### PR TITLE
fix: harden release ci script

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -euxo pipefail
+
 fork_point="$(git merge-base --fork-point main)"
 main_head="$(git show-ref -s --heads main)"
 


### PR DESCRIPTION
## Proposed Changes

add `set -euxo pipefail` to the release ci script to correctly fail early in CI.

## Current Behavior

If the nix command inside the release script fails, the script still exits successfully causing  falsely positive releases.
