### PR TITLE
fix: pushing tag as "latest" branch

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -1,18 +1,32 @@
 #!/usr/bin/env sh
 
+set -euxo pipefail
+
+# The common ancestor to the release branch and main
+#
+#   ... -- A -- (B) -- ...       main
+#                 \ 
+#                  \ - C -- ...  release/*
 fork_point="$(git merge-base --fork-point main)"
+
+# The current "head" commit pointed to by "main"
+#
+#   ... -- A -- (B) -- ... -- (X)   main
 main_head="$(git show-ref -s --heads main)"
 
 
 if [[ -z "$fork_point" ]]; then
+    echo "::error::main and release branch do not share a common ancestor"
     exit 2
 fi
 
 if [[ -z "$main_head" ]]; then
+    echo "::error::couldn't determine head commit of main"
     exit 3
 fi
 
 if [[ "$fork_point" != "$main_head" ]]; then
+    echo "::error::release branch needs to be rebased onto main"
     exit 4
 fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           # push release and latest tag and update main branch
           git push --atomic origin \
             ${{ steps.tag.outputs.TAG }} \
-            refs/tags/${{ steps.tag.outputs.TAG }}:main
+            +${{ steps.tag.outputs.TAG }}~0:refs/heads/main
+          # push "latest" branch
+          git push --force origin +${{ steps.tag.outputs.TAG }}~0:refs/heads/latest
 
-          git push --force origin refs/tags/${{ steps.tag.outputs.TAG }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,8 @@ jobs:
             +${{ steps.tag.outputs.TAG }}~0:refs/heads/main
           # push "latest" branch
           git push --force origin +${{ steps.tag.outputs.TAG }}~0:refs/heads/latest
+          
+          # update the PR branch so github will close the PR
+          # todo: close pr as a separate step through API?
+          git push --force origin HEAD
 


### PR DESCRIPTION
* Harden release script

add set -euxo pipefail to the release ci script to correctly fail early in CI.

* Fixes regarding pushing of "latest" branch.

Since we push a "tag" to a branch we have to "unpeel" the tag
to get to the referenced commit, which is what we push to the branch ref.

unpeeling looks like the following:

  given a tag `v0.2.0`, unpeel to commit as `+v0.2.0~0`


* Push to release pr branch to close the PR

There is likely a way to properly show the PR as merged (i've seen it before)
but for now we keep on closing the PR instead.

The new order of closing PR branches should also make error recovery easier.

* Add some documentation to the release script

