### PR TITLE
build: fix flox package versions

### DIFF
--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -84,7 +84,7 @@
   czToml = lib.importTOML (self + "/.cz.toml");
 in
   stdenv.mkDerivation rec {
-    pname = "flox";
+    pname = "flox-bash";
     version = "${czToml.tool.commitizen.version}-${self.lib.getRev self}";
     src = "${self}/flox-bash";
     nativeBuildInputs =

--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -33,7 +33,6 @@
   substituteAll,
   util-linuxMinimal,
   which,
-  writeText,
 }: let
   # The getent package can be found in pkgs.unixtools.
   inherit (pkgs.unixtools) getent;
@@ -80,10 +79,13 @@
     else throw "unsupported system variant";
 
   bats = pkgs.bats.withLibraries (p: [p.bats-support p.bats-assert]);
+
+  # read commitizen config file as the single source of version
+  czToml = lib.importTOML (self + "/.cz.toml");
 in
   stdenv.mkDerivation rec {
     pname = "flox";
-    version = "0.0.10-${self.lib.getRev src}";
+    version = "${czToml.tool.commitizen.version}-${self.lib.getRev self}";
     src = "${self}/flox-bash";
     nativeBuildInputs =
       [bats entr makeWrapper pandoc shellcheck shfmt which]

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -50,9 +50,7 @@
       FLOX_SH = "${flox-bash}/libexec/flox/flox";
       FLOX_SH_PATH = "${flox-bash}";
       FLOX_SH_FLAKE = flox-bash.src; # For bats tests
-      FLOX_VERSION = "${envs.FLOX_RS_VERSION}-${envs.FLOX_SH_VERSION}";
-      FLOX_SH_VERSION = flox-bash.version;
-      FLOX_RS_VERSION = "${cargoToml.package.version}-r${toString self.revCount or "dirty"}";
+      FLOX_VERSION = "${cargoToml.package.version}-r${self.lib.getRev self}";
       NIXPKGS_CACERT_BUNDLE_CRT = "${cacert}/etc/ssl/certs/ca-bundle.crt";
       NIX_TARGET_SYSTEM = targetPlatform.system;
 


### PR DESCRIPTION
The rust flox reads the version from cargo.toml, which in turn is updated by commitizen on release

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Current Behavior

<!-- Describe the current behavior before applying this pull request. -->


## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Flox package version changes from `flox-A.B.C-rXXX-U.V.W-rYYY` and `flox-U.V.W-rYYY` to `flox-A.B.C-rXXX` and `flox-bash-A.B.C-rXXX` respectively.

<!-- Many thanks! -->
