### PR TITLE
flox-bash: update build to avoid stdenv setup bug

### DIFF
--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -155,7 +155,9 @@ in
 
       # Rewrite /usr/bin/env bash to the full path of bashInteractive.
       # Use --host to resolve using the runtime path.
-      patchShebangs --host $out/libexec/flox/flox $out/libexec/flox/darwin-path-fixer
+      # XXX: run it in a subshell because it otherwise fails with:
+      #   /nix/store/pw17yc3mwmsci4jygwalj8ppg0drz31v-stdenv-linux/setup: line 136: pop_var_context: head of shell_variables not a function context
+      ( patchShebangs --host $out/libexec/flox/flox $out/libexec/flox/darwin-path-fixer )
     '';
 
     doInstallCheck = ! stdenv.isDarwin;


### PR DESCRIPTION
## Proposed Changes

Following the merge of the flox-bash codebase into flox the build started failing as noted below and we found that performing the `patchShebangs` invocation in a subshell works around the problem.

## Current Behavior

The stdenv setup hook is throwing the following build error on x86_64-linux:
```
/nix/store/...-stdenv-linux/setup: line 136: pop_var_context: head of shell_variables not a function context
```

## Checks

- [ ] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A