### PR TITLE
flox-bash: fix FLOX_ENV for multiple envs

### DIFF
--- a/crates/flox/doc/flox-activate.md
+++ b/crates/flox/doc/flox-activate.md
@@ -44,6 +44,10 @@ or with a command and arguments to be invoked directly.
 
     Set by `flox activate` before executing `shell.hook`.
 
+    If multiple environments are indicated, each `shell.hook` will run with
+    its associated `FLOX_ENV` set properly, and the activated environment
+    will have `FLOX_ENV` set to the first environment indicated on the CLI.
+
     This variable may be used to set other environment variables such as
     `MANPATH`, `PKG_CONFIG_PATH`, `PYTHONPATH`, etc so that relevant tooling
     will search these directories to locate files and resources from

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -291,7 +291,7 @@ function floxActivate() {
 	# interspersed between `shell.hook' bodies.
 	# Because the "target" environment may not be the last to activate, we
 	# explicitly set `FLOX_ENV' here so that once activated the variable will
-	# point to the environment indicated on the command line.
+	# point to the first environment indicated on the command line.
 	eval "$(decodeEnvironment "$_target_environment")"
 	echo "export FLOX_ENV='$environmentBaseDir'" >> "$rcScript"
 

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -13,7 +13,7 @@ function bashRC() {
 	# Add computed environment variables.
 	for i in PATH XDG_DATA_DIRS FLOX_ACTIVE_ENVIRONMENTS                    \
 			FLOX_PROMPT_ENVIRONMENTS FLOX_PROMPT_COLOR_{1,2}; do
-		printf 'export %s="%s"\n' $i "${!i}"
+		printf 'export %s="%s"\n' "$i" "${!i}"
 	done
 	# Add environment-specific activation commands.
 	for i in "$@"; do
@@ -74,8 +74,9 @@ _usage["activate"]="activate environment:
 
 function floxActivate() {
 	trace "$@"
-	local _target_environment="$1";
-	local -a environments=("$1"); shift
+	local -a environments
+	read -ra environments <<< "$1"; shift
+	local _target_environment="${environments[0]}"
 	local system="$1"; shift
 	local -a invocation=("$@")
 	local -A _flox_active_environments_hash

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -19,7 +19,7 @@ function bashRC() {
 	for i in "$@"; do
 		# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 		eval "$(decodeEnvironment "$i")"
-	    echo "export FLOX_ENV='$environmentBaseDir'"
+		echo "export FLOX_ENV='$environmentBaseDir'"
 		if [ -f "$environmentBaseDir/activate" ]; then
 			$invoke_cat "$environmentBaseDir/activate"
 		elif [ -f "$environmentBaseDir/manifest.toml" ]; then

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -292,8 +292,8 @@ function floxActivate() {
 	# Because the "target" environment may not be the last to activate, we
 	# explicitly set `FLOX_ENV' here so that once activated the variable will
 	# point to the environment indicated on the command line.
-	eval "$(decodeEnvironment "$environment")"
-	echo "export FLOX_ENV='$FLOX_ENV'" >> "$rcScript"
+	eval "$(decodeEnvironment "$_target_environment")"
+	echo "export FLOX_ENV='$environmentBaseDir'" >> "$rcScript"
 
 	# Set the init script to self-destruct upon activation (unless debugging).
 	# Very James Bond.

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -12,13 +12,14 @@ function bashRC() {
 	$_grep -v '^#' "$_lib/commands/shells/activate.bash" | $_grep -v '^$'
 	# Add computed environment variables.
 	for i in PATH XDG_DATA_DIRS FLOX_ACTIVE_ENVIRONMENTS                    \
-			FLOX_PROMPT_ENVIRONMENTS FLOX_PROMPT_COLOR_{1,2} FLOX_ENV; do
+			FLOX_PROMPT_ENVIRONMENTS FLOX_PROMPT_COLOR_{1,2}; do
 		printf 'export %s="%s"\n' $i "${!i}"
 	done
 	# Add environment-specific activation commands.
 	for i in "$@"; do
 		# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 		eval "$(decodeEnvironment "$i")"
+	    echo "export FLOX_ENV='$environmentBaseDir'"
 		if [ -f "$environmentBaseDir/activate" ]; then
 			$invoke_cat "$environmentBaseDir/activate"
 		elif [ -f "$environmentBaseDir/manifest.toml" ]; then
@@ -73,7 +74,8 @@ _usage["activate"]="activate environment:
 
 function floxActivate() {
 	trace "$@"
-	local -a environments=($1); shift
+	local _target_environment="$1";
+	local -a environments=("$1"); shift
 	local system="$1"; shift
 	local -a invocation=("$@")
 	local -A _flox_active_environments_hash
@@ -221,8 +223,6 @@ function floxActivate() {
 	FLOX_ACTIVE_ENVIRONMENTS="$(joinString ':' "${flox_active_environments_prepend[@]}" "$FLOX_ACTIVE_ENVIRONMENTS")"
 	FLOX_PROMPT_ENVIRONMENTS="$(joinString ' ' "${flox_prompt_environments_prepend[@]}" "$FLOX_PROMPT_ENVIRONMENTS")"
 	export PATH XDG_DATA_DIRS FLOX_ACTIVE_ENVIRONMENTS FLOX_PROMPT_ENVIRONMENTS
-	FLOX_ENV="$environmentBaseDir"
-	export FLOX_ENV
 
 	# Darwin has a "path_helper" which indiscriminately reorders the path to
 	# put the Apple-preferred items first in the PATH, which completely breaks
@@ -285,6 +285,14 @@ function floxActivate() {
 		error "unknown shell: $rcShell" < /dev/null
 		;;
 	esac
+
+	# Earlier parts of the activation script set individual `FLOX_ENV' vars
+	# interspersed between `shell.hook' bodies.
+	# Because the "target" environment may not be the last to activate, we
+	# explicitly set `FLOX_ENV' here so that once activated the variable will
+	# point to the environment indicated on the command line.
+	eval "$(decodeEnvironment "$environment")"
+	echo "export FLOX_ENV='$FLOX_ENV'" >> "$rcScript"
 
 	# Set the init script to self-destruct upon activation (unless debugging).
 	# Very James Bond.

--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -802,6 +802,7 @@ load test_support.bash
   (
     run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -e "${TEST_ENVIRONMENT}-2" \
         -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"'
+    assert_success
     # FLOX_ENV should be set to the first argument
     assert_output --regexp "^FLOX_ENV: .*$TEST_ENVIRONMENT\$"
   )

--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -802,7 +802,8 @@ load test_support.bash
   (
     run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -e "${TEST_ENVIRONMENT}-2" \
         -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"'
-    assert_output --partial "FLOX_ENV: /"
+    # FLOX_ENV should be set to the first argument
+    assert_output --regexp "^FLOX_ENV: .*$TEST_ENVIRONMENT\$"
   )
 }
 

--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -809,6 +809,15 @@ load test_support.bash
   assert_success
   # FLOX_ENV should be set to the first argument
   assert_output --regexp "^FLOX_ENV: .*${TEST_ENVIRONMENT}-1\$"
+  # Cleanup
+  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e ${TEST_ENVIRONMENT}-1 --origin -f"
+  assert_output --partial "WARNING: you are about to delete the following"
+  assert_output --partial "Deleted branch"
+  assert_output --partial "removed"
+  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e ${TEST_ENVIRONMENT}-2 --origin -f"
+  assert_output --partial "WARNING: you are about to delete the following"
+  assert_output --partial "Deleted branch"
+  assert_output --partial "removed"
 }
 
 @test "flox develop setup" {
@@ -970,14 +979,6 @@ function assertAndRemoveFiles {
 
 @test "tear down install test state" {
   run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e $TEST_ENVIRONMENT --origin -f"
-  assert_output --partial "WARNING: you are about to delete the following"
-  assert_output --partial "Deleted branch"
-  assert_output --partial "removed"
-  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e ${TEST_ENVIRONMENT}-1 --origin -f"
-  assert_output --partial "WARNING: you are about to delete the following"
-  assert_output --partial "Deleted branch"
-  assert_output --partial "removed"
-  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e ${TEST_ENVIRONMENT}-2 --origin -f"
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -804,7 +804,7 @@ load test_support.bash
         -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"'
     assert_success
     # FLOX_ENV should be set to the first argument
-    assert_output --regexp "^FLOX_ENV: .*$TEST_ENVIRONMENT\$"
+    assert_output --regexp "FLOX_ENV: .*$TEST_ENVIRONMENT"
   )
 }
 

--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -795,17 +795,20 @@ load test_support.bash
 }
 
 @test "flox activate on multiple environments" {
+  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}-1"
+  assert_success
+  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}-1" "$FLOX_PACKAGE"
+  assert_success
   run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}-2"
   assert_success
   run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}-2" "$FLOX_PACKAGE"
   assert_success
-  (
-    run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -e "${TEST_ENVIRONMENT}-2" \
-        -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"'
-    assert_success
-    # FLOX_ENV should be set to the first argument
-    assert_output --regexp "FLOX_ENV: .*$TEST_ENVIRONMENT"
-  )
+  run "$FLOX_CLI" activate                                   \
+      -e "${TEST_ENVIRONMENT}-1" -e "${TEST_ENVIRONMENT}-2"  \
+      -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"'
+  assert_success
+  # FLOX_ENV should be set to the first argument
+  assert_output --regexp "^FLOX_ENV: .*${TEST_ENVIRONMENT}-1\$"
 }
 
 @test "flox develop setup" {
@@ -970,7 +973,11 @@ function assertAndRemoveFiles {
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"
-  run $FLOX_CLI destroy -e "${TEST_ENVIRONMENT}-2" --origin -f
+  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e ${TEST_ENVIRONMENT}-1 --origin -f"
+  assert_output --partial "WARNING: you are about to delete the following"
+  assert_output --partial "Deleted branch"
+  assert_output --partial "removed"
+  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e ${TEST_ENVIRONMENT}-2 --origin -f"
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/flox-bash/tests/package.bats
+++ b/flox-bash/tests/package.bats
@@ -45,24 +45,8 @@ load test_support.bash
   assert_output --partial "0  $FLOX_PACKAGE  $FLOX_PACKAGE_FIRST8"
 }
 
-@test "flox activate on multiple environments" {
-  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}-2"
-  assert_success
-  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}-2" "$FLOX_PACKAGE"
-  assert_success
-  (
-    run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -e "${TEST_ENVIRONMENT}-2" \
-        -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"'
-    assert_output --partial "FLOX_ENV: /"
-  )
-}
-
 @test "tear down install test state" {
   run $FLOX_CLI destroy -e "$TEST_ENVIRONMENT" --origin -f
-  assert_output --partial "WARNING: you are about to delete the following"
-  assert_output --partial "Deleted branch"
-  assert_output --partial "removed"
-  run $FLOX_CLI destroy -e "${TEST_ENVIRONMENT}-2" --origin -f
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/flox-bash/tests/package.bats
+++ b/flox-bash/tests/package.bats
@@ -7,46 +7,62 @@ load test_support.bash
 
 @test "flox package sanity check" {
   # directories
-  [ -d $FLOX_PACKAGE/bin ]
-  [ -d $FLOX_PACKAGE/libexec ]
-  [ -d $FLOX_PACKAGE/libexec/flox ]
-  [ -d $FLOX_PACKAGE/etc ]
-  [ -d $FLOX_PACKAGE/etc/flox.zdotdir ]
-  [ -d $FLOX_PACKAGE/lib ]
-  [ -d $FLOX_PACKAGE/share ]
-  [ -d $FLOX_PACKAGE/share/man ]
-  [ -d $FLOX_PACKAGE/share/man/man1 ]
-  [ -d $FLOX_PACKAGE/share/bash-completion ]
-  [ -d $FLOX_PACKAGE/share/bash-completion/completions ]
+  [ -d "$FLOX_PACKAGE/bin" ]
+  [ -d "$FLOX_PACKAGE/libexec" ]
+  [ -d "$FLOX_PACKAGE/libexec/flox" ]
+  [ -d "$FLOX_PACKAGE/etc" ]
+  [ -d "$FLOX_PACKAGE/etc/flox.zdotdir" ]
+  [ -d "$FLOX_PACKAGE/lib" ]
+  [ -d "$FLOX_PACKAGE/share" ]
+  [ -d "$FLOX_PACKAGE/share/man" ]
+  [ -d "$FLOX_PACKAGE/share/man/man1" ]
+  [ -d "$FLOX_PACKAGE/share/bash-completion" ]
+  [ -d "$FLOX_PACKAGE/share/bash-completion/completions" ]
   # executables
-  [ -x $FLOX_CLI ]
-  [ -x $FLOX_PACKAGE/libexec/flox/gh ]
-  [ -x $FLOX_PACKAGE/libexec/flox/nix ]
-  [ -x $FLOX_PACKAGE/libexec/flox/flox ]
+  [ -x "$FLOX_CLI" ]
+  [ -x "$FLOX_PACKAGE/libexec/flox/gh" ]
+  [ -x "$FLOX_PACKAGE/libexec/flox/nix" ]
+  [ -x "$FLOX_PACKAGE/libexec/flox/flox" ]
   # Could go on ...
 }
 
 @test "flox --prefix" {
-  run $FLOX_CLI --prefix
+  run "$FLOX_CLI" --prefix
   assert_success
-  assert_output $FLOX_PACKAGE
+  assert_output "$FLOX_PACKAGE"
 }
 
 @test "flox install by /nix/store path" {
-  run $FLOX_CLI install -e $TEST_ENVIRONMENT $FLOX_PACKAGE
+  run "$FLOX_CLI" install -e "$TEST_ENVIRONMENT" "$FLOX_PACKAGE"
   assert_success
   assert_output --partial "Installed '$FLOX_PACKAGE' package(s) into '$TEST_ENVIRONMENT' environment."
 }
 
 @test "flox list after installing by store path should contain package" {
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT
+  run "$FLOX_CLI" list -e "$TEST_ENVIRONMENT"
   assert_success
   assert_output --partial "Curr Gen  1"
   assert_output --partial "0  $FLOX_PACKAGE  $FLOX_PACKAGE_FIRST8"
 }
 
+@test "flox activate on multiple environments" {
+  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}-2"
+  assert_success
+  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}-2" "$FLOX_PACKAGE"
+  assert_success
+  (
+    run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -e "${TEST_ENVIRONMENT}-2" \
+        -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"'
+    assert_output --partial "FLOX_ENV: /"
+  )
+}
+
 @test "tear down install test state" {
-  run $FLOX_CLI destroy -e $TEST_ENVIRONMENT --origin -f
+  run $FLOX_CLI destroy -e "$TEST_ENVIRONMENT" --origin -f
+  assert_output --partial "WARNING: you are about to delete the following"
+  assert_output --partial "Deleted branch"
+  assert_output --partial "removed"
+  run $FLOX_CLI destroy -e "${TEST_ENVIRONMENT}-2" --origin -f
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -104,6 +104,7 @@ in
         # Quick unit test to ensure that we are not using any "naked"
         # commands within our scripts. Doesn't hit all codepaths but
         # catches most of them.
+        git init;
         env -i USER=`id -un` HOME=$PWD $out/bin/flox --debug envs > /dev/null
       '';
 


### PR DESCRIPTION
## Proposed Change
`FLOX_ENV` is now set properly while each activation script is run, and after activation completes `FLOX_ENV` is set to the path associated with the "target" environment indicated on the CLI.


## Current Behavior

Currently all activation scripts run with `FLOX_ENV` set to the default environment.


## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A