### PR TITLE
fix: wrap rust `flox` executable to use patched `nix`.

### DIFF
--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -148,25 +148,23 @@ in
       #       version advances to the version that supports it.
       #
       mkdir -p $out/libexec
-      makeWrapper ${nixPatched}/bin/nix $out/libexec/flox/nix --argv0 '$0' \
+      makeWrapper ${nixPatched}/bin/nix "$out/libexec/flox/nix" --argv0 '$0' \
         --prefix PATH : "${lib.makeBinPath [git]}"
-      makeWrapper ${gh}/bin/gh $out/libexec/flox/gh --argv0 '$0' \
+      makeWrapper ${gh}/bin/gh "$out/libexec/flox/gh" --argv0 '$0' \
         --prefix PATH : "${lib.makeBinPath [git]}"
 
       # Rewrite /usr/bin/env bash to the full path of bashInteractive.
       # Use --host to resolve using the runtime path.
-      patchShebangs --host $out/libexec/flox/flox $out/libexec/flox/darwin-path-fixer
+      patchShebangs --host "$out/libexec/flox/flox"               \
+                           "$out/libexec/flox/darwin-path-fixer"
     '';
 
-    # XXX: environment setup for the postInstallCheck on Linux is failing
-    #      following the merge of flox + flox-bash repositories. Temporarily
-    #      disable to keep builds flowing while we investigate.
-    doInstallCheck = false; # ! stdenv.isDarwin;
+    doInstallCheck = ! stdenv.isDarwin;
     postInstallCheck = ''
       # Quick unit test to ensure that we are not using any "naked"
       # commands within our scripts. Doesn't hit all codepaths but
       # catches most of them.
-      env -i USER=`id -un` HOME=$PWD $out/bin/flox help > /dev/null
+      env -i USER=`id -un` "HOME=$PWD" "$out/bin/flox" help > /dev/null
     '';
 
     passthru.nixPatched = nixPatched;

--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -161,6 +161,10 @@ in
 
     doInstallCheck = ! stdenv.isDarwin;
     postInstallCheck = ''
+      # Expects to be run from a `git' directory.
+      # FIXME: We need to figure out why `flox' is expecting a `.git' directory.
+      git init;
+
       # Quick unit test to ensure that we are not using any "naked"
       # commands within our scripts. Doesn't hit all codepaths but
       # catches most of them.

--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -89,7 +89,7 @@ in
     version = "${czToml.tool.commitizen.version}-${inputs.flox-floxpkgs.lib.getRev self}";
     src = "${self}/flox-bash";
     nativeBuildInputs =
-      [bats entr makeWrapper pandoc shellcheck shfmt which git]
+      [bats entr makeWrapper pandoc shellcheck shfmt which]
       # nix-provided expect not working on Darwin (#441)
       ++ lib.optionals hostPlatform.isLinux [expect];
     buildInputs = [

--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -89,7 +89,7 @@ in
     version = "${czToml.tool.commitizen.version}-${inputs.flox-floxpkgs.lib.getRev self}";
     src = "${self}/flox-bash";
     nativeBuildInputs =
-      [bats entr makeWrapper pandoc shellcheck shfmt which]
+      [bats entr makeWrapper pandoc shellcheck shfmt which git]
       # nix-provided expect not working on Darwin (#441)
       ++ lib.optionals hostPlatform.isLinux [expect];
     buildInputs = [
@@ -156,8 +156,10 @@ in
 
       # Rewrite /usr/bin/env bash to the full path of bashInteractive.
       # Use --host to resolve using the runtime path.
-      patchShebangs --host "$out/libexec/flox/flox"               \
-                           "$out/libexec/flox/darwin-path-fixer"
+      patchShebangs --host "$out/libexec/flox/flox"
+      if [ -e "$out/libexec/flox/darwin-path-fixer" ]; then
+        patchShebangs --host "$out/libexec/flox/darwin-path-fixer"
+      fi
     '';
 
     doInstallCheck = ! stdenv.isDarwin;

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -100,8 +100,9 @@ in
           --fish <($out/bin/flox --bpaf-complete-style-fish) \
           --zsh <($out/bin/flox --bpaf-complete-style-zsh)
 
-        wrapProgram "$out/bin/flox"                                          \
-                    --prefix PATH : "${flox-bash}/bin:${flox-bash}/libexec"
+        wrapProgram "$out/bin/flox"                                       \
+                    --prefix PATH :                                       \
+                      "${flox-bash}/bin:${flox-bash}/libexec:${git}/bin"
       '';
 
       doInstallCheck = true;


### PR DESCRIPTION
## Proposed Changes

This wraps the `flox` executable produced from Rust code such that it uses our "patched" and wrapped copy of `nix` and `gh`.

This allows `postInstallCheck` scripts to run again.


## Current Behavior

We get a build failure attempting to read a non-existent `.git` directory.


## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A