### PR TITLE
build: push all release branches in a single atomic operation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,13 @@ jobs:
 
       - name: "Push `${{ steps.tag.outputs.TAG }} (tag), main (branch)"
         run: |
-          # push release and latest tag and update main branch
+          # push (1) the release tag (2) main branch (3) release "pointer" branch
+          # the "latest" branch must not divert from the history of "main" anyway
+          # so pusing to latest is just forwarding the branch
           git push --atomic origin \
             ${{ steps.tag.outputs.TAG }} \
             +${{ steps.tag.outputs.TAG }}~0:refs/heads/main
-          # push "latest" branch
-          git push --force origin +${{ steps.tag.outputs.TAG }}~0:refs/heads/latest
+            +${{ steps.tag.outputs.TAG }}~0:refs/heads/latest 
           
           # update the PR branch so github will close the PR
           # todo: close pr as a separate step through API?


### PR DESCRIPTION

## Proposed Changes

Include the "latest" branch in the atomic push operation that pushes the version tag and "main" branch. latest must not divert from main anyway, and can be fast-forwarded


## Current Behavior

We currently do 3 pushes to github

1. for version tag and main
2. for the latest branch (force)
3. for to close the release PR

Since were fast-forwarding anyway, the latest branch can be pushed atomically with main and the version tag


