### PR TITLE
fix: deprecate gitCheckout()

### DIFF
--- a/flox-bash/lib/init.sh
+++ b/flox-bash/lib/init.sh
@@ -135,10 +135,6 @@ fi
 # Path for floxmeta clone for current user (for access to floxmain).
 declare userFloxMetaCloneDir="$FLOX_META/$defaultEnvironmentOwner"
 
-# Define place to store user-specific metadata separate
-# from profile metadata.
-declare OLDfloxUserMeta="$FLOX_CONFIG_HOME/floxUserMeta.json"
-
 # Define location for user-specific flox flake registry.
 declare floxFlakeRegistry="$FLOX_CONFIG_HOME/floxFlakeRegistry.json"
 

--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -150,7 +150,7 @@ function gitInitFloxmeta() {
 	$invoke_git clone --quiet --shared "$repoDir" "$tmpDir"
 	$invoke_git -C "$tmpDir" commit --quiet --allow-empty \
 		-m "$USER created repository"
-	$invoke_git -C "$tmpDir" push --quiet --set-upstream origin $defaultBranch
+	$invoke_git -C "$tmpDir" push --quiet origin $defaultBranch
 }
 
 # XXX TEMPORARY function to convert old-style "1.json" -> "1/manifest.json"

--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -142,12 +142,15 @@ function gitInitFloxmeta() {
 	# Set initial branch with `-c init.defaultBranch=` instead of
 	# `--initial-branch=` to stay compatible with old version of
 	# git, which will ignore unrecognized `-c` options.
-	$invoke_git -c init.defaultBranch="${defaultBranch}" init --quiet "$repoDir"
+	$invoke_git -c init.defaultBranch="${defaultBranch}" init --bare --quiet "$repoDir"
 	$invoke_git -C "$repoDir" config pull.rebase true
 	$invoke_git -C "$repoDir" config receive.denyCurrentBranch updateInstead
 	# A commit is needed in order to make the branch visible.
-	$invoke_git -C "$repoDir" commit --quiet --allow-empty \
+	local tmpDir="$(mkTempDir)"
+	$invoke_git clone --quiet --shared "$repoDir" "$tmpDir"
+	$invoke_git -C "$tmpDir" commit --quiet --allow-empty \
 		-m "$USER created repository"
+	$invoke_git -C "$tmpDir" push --quiet --set-upstream origin $defaultBranch
 }
 
 # XXX TEMPORARY function to convert old-style "1.json" -> "1/manifest.json"

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -667,21 +667,8 @@ function floxUserMetaRegistry() {
 	# the temporary $floxUserMeta file in the local filesystem.
 	if [ ! -s $floxUserMeta ]; then
 		local floxUserMetaTemplate='{"channels":{}, "version":1}'
-		if [ -f $OLDfloxUserMeta ]; then
-			# XXX TEMPORARY: migrate data from ~/.config/floxUserMeta.json.
-			# XXX Delete after 20230331.
-			$_jq -r -S --argjson floxUserMetaTemplate "$floxUserMetaTemplate" '
-				del(.channels."flox") |
-				del(.channels."nixpkgs") |
-				del(.channels."nixpkgs-flox") as $old |
-				( $floxUserMetaTemplate * $old )
-			' $OLDfloxUserMeta |
-				initFloxUserMetaJSON "init: floxUserMeta.json (migrated from <=0.0.9)"
-			$_rm -f $OLDfloxUserMeta
-		else
-			$_jq -n -r -S "$floxUserMetaTemplate" |
-				initFloxUserMetaJSON "init: floxUserMeta.json"
-		fi
+		$_jq -n -r -S "$floxUserMetaTemplate" |
+			initFloxUserMetaJSON "init: floxUserMeta.json"
 		$_git -C "$userFloxMetaCloneDir" show "$defaultBranch:floxUserMeta.json" >$floxUserMeta
 	fi
 

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -648,7 +648,7 @@ function initFloxUserMetaJSON() {
 	$invoke_git -C "$workDir" commit -m "$message" --quiet
 
 	# Push changes back to bare repository.
-	$_git -C $workDir push --quiet --set-upstream origin $defaultBranch
+	$_git -C $workDir push --quiet origin $defaultBranch
 }
 
 #


### PR DESCRIPTION
## Proposed Changes

We are no longer checking out branches of the floxmeta repository in situ and are instead performing all manipulations using a bare repository. With that we no longer need to call gitCheckout() from metaGit(), after which that function is no longer used at all.

Also pared an invocation of metaGit() that was never being performed on account of $_cline never being defined in that scope.

Closes #51 

## Current Behavior

See #51 

## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

Fixed bug preventing `flox export` from working for users who hadn't already been using older versions of flox.