### PR TITLE
[BUG] repair `flox destroy` ability to fully remove branch metadata

### DIFF
--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -1333,6 +1333,14 @@ function floxDestroy() {
 	done
 	if [ $force -gt 0 ] || boolPrompt "Are you sure?" "no"; then
 		if [ -n "$localBranch" ]; then
+
+			# TODO: remove once we move exclusively to the use of bare clones.
+			# Start by changing to the (default) floxmain branch to ensure
+			# we're not attempting to delete the current branch.
+			[ "$($_git -C "$environmentMetaDir" rev-parse --is-bare-repository)" == "true" ] || \
+				$invoke_git -C "$environmentMetaDir" checkout --quiet "$defaultBranch" 2>/dev/null || true
+			# /TODO
+
 			# Ensure following commands always succeed so that subsequent
 			# invocations can reach the --origin remote removal below.
 			$invoke_git -C "$environmentMetaDir" branch -D "$branchName" || true

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -1332,8 +1332,6 @@ function floxDestroy() {
 		warn "$i"
 	done
 	if [ $force -gt 0 ] || boolPrompt "Are you sure?" "no"; then
-		# Start by changing to the (default) floxmain branch to ensure
-		# we're not attempting to delete the current branch.
 		if [ -n "$localBranch" ]; then
 			# Ensure following commands always succeed so that subsequent
 			# invocations can reach the --origin remote removal below.

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -1335,11 +1335,9 @@ function floxDestroy() {
 		# Start by changing to the (default) floxmain branch to ensure
 		# we're not attempting to delete the current branch.
 		if [ -n "$localBranch" ]; then
-			if $invoke_git -C "$environmentMetaDir" checkout --quiet "$defaultBranch" 2>/dev/null; then
-				# Ensure following commands always succeed so that subsequent
-				# invocations can reach the --origin remote removal below.
-				$invoke_git -C "$environmentMetaDir" branch -D "$branchName" || true
-			fi
+			# Ensure following commands always succeed so that subsequent
+			# invocations can reach the --origin remote removal below.
+			$invoke_git -C "$environmentMetaDir" branch -D "$branchName" || true
 		fi
 		if [ -n "$origin" ]; then
 			$invoke_git -C "$environmentMetaDir" branch -rd origin/"$branchName" || true


### PR DESCRIPTION
## Current Behavior

The move to bare repositories broke the ability to checkout the floxmain branch, and that in turn broke the logic in `flox destroy` to delete environment branches.

## Proposed Changes

This patch fixes the issue by removing the requirement to check out the "floxmain" branch prior to destroying the environment branch. In previous versions we performed this checkout as a way of guaranteeing we would never attempt to delete the currently-checked-out branch.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

Fixed bug which prevented `flox destroy` from fully deleting environment metadata.