### PR TITLE
fix: skip aws test

### DIFF
--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -935,11 +935,10 @@ function assertAndRemoveFiles {
   popd
 }
 
-@test "flox publish {
+@test "flox publish" {
   for key in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
     if [ ! -v "$key" ]; then
-      echo "This test depends on $key but it is not set"
-      return 1
+      skip "This test depends on $key but it is not set";
     fi
   done
 

--- a/flox-bash/tests/test_support.bash
+++ b/flox-bash/tests/test_support.bash
@@ -17,9 +17,9 @@ setup_file() {
     export FLOX_PACKAGE_FIRST8=$(echo $FLOX_PACKAGE | dd bs=c skip=11 count=8 2>/dev/null)
   fi
   export FLOX_DISABLE_METRICS="true"
+  export TEST_ENVIRONMENT=_testing_
   # Remove any vestiges of previous test runs.
   $FLOX_CLI destroy -e $TEST_ENVIRONMENT --origin -f || :
-  export TEST_ENVIRONMENT=_testing_
   export NIX_SYSTEM=$($FLOX_CLI nix --extra-experimental-features nix-command show-config | awk '/system = / {print $NF}')
   # Simulate pure bootstrapping environment. It is challenging to get
   # the nix, gh, and flox tools to all use the same set of defaults.


### PR DESCRIPTION
## Proposed Changes

Skip AWS test when the necessary variables are unset.


## Current Behavior

This test always fails.


## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A


<!-- Many thanks! -->
