### PR TITLE
fix(gh): allow missing oauth_token

### DIFF
--- a/crates/flox/src/utils/init/mod.rs
+++ b/crates/flox/src/utils/init/mod.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
-use log::{debug, info};
+use indoc::indoc;
+use log::{debug, info, warn};
 use serde::Deserialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -28,16 +29,29 @@ pub fn init_access_tokens(
 
     #[derive(Deserialize)]
     struct GhHost {
-        oauth_token: String,
+        oauth_token: Option<String>,
     }
 
     let gh_config_file = xdg::BaseDirectories::with_prefix("gh")?.get_config_file("hosts.yml");
     let gh_tokens: BTreeMap<String, String> = if gh_config_file.exists() {
-        serde_yaml::from_reader::<_, IndexMap<String, GhHost>>(std::fs::File::open(gh_config_file)?)
-            .context("Could not read `gh` config file")?
-            .into_iter()
-            .map(|(k, v)| (k, v.oauth_token))
-            .collect()
+        serde_yaml::from_reader::<_, IndexMap<String, GhHost>>(std::fs::File::open(
+            &gh_config_file,
+        )?)
+        .context("Could not read `gh` config file")?
+        .into_iter()
+        .filter_map(|(host, v)| {
+            if v.oauth_token.is_none() {
+                warn!(
+                    indoc! {"
+                    gh config ({gh_config_file:?}): {host}: no `oauth_token` specified
+                "},
+                    gh_config_file = gh_config_file,
+                    host = host
+                );
+            }
+            v.oauth_token.map(|token| (host, token))
+        })
+        .collect()
     } else {
         Default::default()
     };


### PR DESCRIPTION
`gh` introduced support for storing credentials in an encrypted keyring about 3 months ago ([1])

If stored in a keyring the `oauth_token` field in the hosts.yml file will remain empty. We previously relied on that field to be present, drawing only from observations due to the lack of documentation on the schema of `hosts.yml`.

Since reading the hosts.yml file is no reliable source for the user's access token anymore, we should either employ

    gh auth token --hostname <host>

or REVISIT THE USE OF `gh` ALTOGETHER.

[1] https://github.com/cli/cli/commit/df83dc2d58f242fc368fa62656d410e5fd820f6e



fixes #44
fixes #22 
