### PR TITLE
feat: determine interactive session using `PS1`

### DIFF
--- a/crates/flox/src/utils/dialog.rs
+++ b/crates/flox/src/utils/dialog.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fmt::Display;
 
 use crossterm::tty::IsTty;
@@ -124,7 +125,14 @@ impl<'a, T: Display + Send + 'static> Dialog<'a, Select<T>> {
 impl Dialog<'_, ()> {
     /// True if stderr and stdin are ttys
     pub fn can_prompt() -> bool {
-        std::io::stderr().is_tty() && std::io::stdin().is_tty()
+        // able to prompt user
+        let open_stderr = std::io::stderr().is_tty();
+        // able to receive input
+        let open_stdin = std::io::stdin().is_tty();
+        // "probably" an interactive shell session
+        let shell_prompt_present = env::var("PS1").is_ok();
+
+        open_stderr && open_stdin && shell_prompt_present
     }
 }
 

--- a/flox-bash/lib/bootstrap.sh
+++ b/flox-bash/lib/bootstrap.sh
@@ -25,7 +25,7 @@ function bootstrap() {
 	floxUserMetaRegistry get floxClientUUID >/dev/null || \
 		floxUserMetaRegistry set floxClientUUID $($_uuid)
 	floxClientUUID=$(floxUserMetaRegistry get floxClientUUID)
-	if [ -t 1 ]; then
+	if [ -t 1 ] && [ -z "$PS1" ]; then
 		# Interactive mode
 		interactive=1
 

--- a/flox-bash/lib/bootstrap.sh
+++ b/flox-bash/lib/bootstrap.sh
@@ -25,12 +25,12 @@ function bootstrap() {
 	floxUserMetaRegistry get floxClientUUID >/dev/null || \
 		floxUserMetaRegistry set floxClientUUID $($_uuid)
 	floxClientUUID=$(floxUserMetaRegistry get floxClientUUID)
-	if [ -t 1 ] && [ -z "$PS1" ]; then
+	if [ -t 1 ] && [ -z "${PS1:-}" ]; then
 		# Interactive mode
 		interactive=1
 
 		# Collect the user's express consent to submit telemetry data.
-		if [ -z "$FLOX_DISABLE_METRICS" ]; then
+		if [ -z "${FLOX_DISABLE_METRICS:-}" ]; then
 			if ! floxMetricsConsent=$(floxUserMetaRegistry get floxMetricsConsent); then
 				info ""
 				info "flox collects basic usage metrics in order to improve the user experience,"
@@ -62,7 +62,7 @@ function bootstrap() {
 		#
 		# Non-interactive mode. Use all defaults if not found in registry.
 		#
-		if [ -z "$FLOX_DISABLE_METRICS" ]; then
+		if [ -z "${FLOX_DISABLE_METRICS:-}" ]; then
 			floxMetricsConsent=$(floxUserMetaRegistry get floxMetricsConsent) || \
 				floxMetricsConsent=0
 		fi


### PR DESCRIPTION
## Current Behavior

Before attempting any user prompts we check whether the current session is interactive, i.e. can communicate with the user.

In the bash implementation we check whether `stdout` is a tty or redirected.
If it's not redirected we assume the session is interactive. [1]

The rust implementation does not check `stdout` but proves whether it can send output to `stderr` on a terminal and receive answers through `stdin` from a terminal. [2]

~However, there were apparently cases where checking for the attached terminals is not equivalent to the presence of a _user_ to answer prompts.~

[1]: https://github.com/flox/flox/blob/284cfff77c934122f27057e49d1df6ec57cfee3f/flox-bash/lib/bootstrap.sh#L28
[2]: https://github.com/flox/flox/blob/284cfff77c934122f27057e49d1df6ec57cfee3f/crates/flox/src/utils/dialog.rs#L127

## Proposed Changes

Additionally to the existing checks this PR introduces a check for the presence of `$PS1`, which is used as another cue proving user presence in cases where terminals are attached to stdio but no controlling _user_ accesses the terminal.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
