### PR TITLE
fix(nix): lower verbosity of nix subprocesses

### DIFF
--- a/crates/flox-rust-sdk/src/flox.rs
+++ b/crates/flox-rust-sdk/src/flox.rs
@@ -445,7 +445,7 @@ impl Flox {
     ///
     /// The constructor will perform backend specific configuration measures
     /// and return a fresh initialized backend.
-    pub fn nix<Nix: FloxNixApi>(&self, extra_args: Vec<String>) -> Nix {
+    pub fn nix<Nix: FloxNixApi>(&self, mut caller_extra_args: Vec<String>) -> Nix {
         use std::io::Write;
         use std::os::unix::prelude::OpenOptionsExt;
 
@@ -542,6 +542,9 @@ impl Flox {
         let common_args = NixCommonArgs {
             ..Default::default()
         };
+
+        let mut extra_args = vec!["--quiet".to_string(), "--quiet".to_string()];
+        extra_args.append(&mut caller_extra_args);
 
         let default_nix_args = DefaultArgs {
             environment,


### PR DESCRIPTION

Since we run nix with stderr attached to the user terminal, with the current verbosity levels users face unnecessary amounts of (internal) logs emitted by nix.
In particular resolving package targets is noisy and to the detriment of the user experience.

This PR lowers the default verbosity level for _all_ nix calls by two levels (`nix --quiet --quiet`) which suppresses warnings informing about flake overrides.

This change should be revisited if it turns out we are losing too much information by suppressing certain levels of logging output or we want to approach more fine grained nix output parsing.