### PR TITLE
feat: Add semver range parsing to `flox search`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,7 +23,7 @@
     },
     "capacitor": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
@@ -126,6 +126,25 @@
         "type": "github"
       }
     },
+    "floco": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1684245865,
+        "narHash": "sha256-CJSxo7fvAAjdMaQWALyNG6LKMjOGZC/uxlbX1KuegWU=",
+        "owner": "aakropotkin",
+        "repo": "floco",
+        "rev": "e1231f054258f7d62652109725881767765b1efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aakropotkin",
+        "repo": "floco",
+        "rev": "e1231f054258f7d62652109725881767765b1efb",
+        "type": "github"
+      }
+    },
     "flox": {
       "inputs": {
         "flox-floxpkgs": [
@@ -153,7 +172,7 @@
         "builtfilter": "builtfilter",
         "capacitor": "capacitor",
         "flox": "flox",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "tracelinks": "tracelinks"
       },
       "locked": {
@@ -216,18 +235,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679262748,
-        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
-        "owner": "flox",
+        "lastModified": 1674236650,
+        "narHash": "sha256-B4GKL1YdJnII6DQNNJ4wDW1ySJVx2suB1h/v4Ql8J0Q=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "rev": "cfb43ad7b941d9c3606fb35d91228da7ebddbfc5",
         "type": "github"
       },
       "original": {
-        "owner": "flox",
-        "ref": "stable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "nixpkgs-lib": {
@@ -342,6 +359,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1681303793,
         "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
         "owner": "NixOS",
@@ -356,7 +389,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "inputs": {
         "capacitor": "capacitor_2",
         "flox": [
@@ -366,11 +399,7 @@
         "flox-floxpkgs": [
           "flox-floxpkgs"
         ],
-        "nixpkgs": [
-          "flox-floxpkgs",
-          "nixpkgs",
-          "nixpkgs-stable"
-        ],
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixpkgs-staging": "nixpkgs-staging",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -394,7 +423,21 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs-stable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1681303793,
         "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
@@ -507,6 +550,7 @@
     },
     "root": {
       "inputs": {
+        "floco": "floco",
         "flox-floxpkgs": "flox-floxpkgs",
         "shellHooks": "shellHooks_2"
       }
@@ -516,7 +560,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -538,7 +582,7 @@
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_2",
         "gitignore": "gitignore_2",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {

--- a/flake.lock
+++ b/flake.lock
@@ -23,7 +23,7 @@
     },
     "capacitor": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
@@ -128,7 +128,10 @@
     },
     "floco": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "flox-floxpkgs",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1684245865,
@@ -172,7 +175,7 @@
         "builtfilter": "builtfilter",
         "capacitor": "capacitor",
         "flox": "flox",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "tracelinks": "tracelinks"
       },
       "locked": {
@@ -235,16 +238,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674236650,
-        "narHash": "sha256-B4GKL1YdJnII6DQNNJ4wDW1ySJVx2suB1h/v4Ql8J0Q=",
-        "owner": "NixOS",
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "cfb43ad7b941d9c3606fb35d91228da7ebddbfc5",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-lib": {
@@ -359,22 +364,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1679262748,
-        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
-        "owner": "flox",
-        "repo": "nixpkgs",
-        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flox",
-        "ref": "stable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1681303793,
         "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
         "owner": "NixOS",
@@ -389,7 +378,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "inputs": {
         "capacitor": "capacitor_2",
         "flox": [
@@ -399,7 +388,7 @@
         "flox-floxpkgs": [
           "flox-floxpkgs"
         ],
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixpkgs-staging": "nixpkgs-staging",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -423,7 +412,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1679262748,
         "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
@@ -437,7 +426,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1681303793,
         "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
@@ -560,7 +549,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -582,7 +571,7 @@
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_2",
         "gitignore": "gitignore_2",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     owner = "aakropotkin";
     repo = "floco";
     rev = "e1231f054258f7d62652109725881767765b1efb";
+    inputs.nixpkgs.follows = "/flox-floxpkgs/nixpkgs";
   };
 
   outputs = args @ {flox-floxpkgs, ...}: flox-floxpkgs.project args (_: {});

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,12 @@
 
   inputs.flox-floxpkgs.url = "github:flox/floxpkgs";
   inputs.shellHooks.url = "github:cachix/pre-commit-hooks.nix";
+  inputs.floco = {
+    type = "github";
+    owner = "aakropotkin";
+    repo = "floco";
+    rev = "e1231f054258f7d62652109725881767765b1efb";
+  };
 
   outputs = args @ {flox-floxpkgs, ...}: flox-floxpkgs.project args (_: {});
 }

--- a/flox-bash/Makefile
+++ b/flox-bash/Makefile
@@ -74,6 +74,7 @@ LIB = \
 	lib/registry.jq \
 	lib/search.jq \
 	lib/searchJSON.jq \
+	lib/catalog-search.jq \
 	lib/utils.sh \
 	lib/catalog-ingest/flake.nix \
 	lib/catalog-ingest/lib/analysis.nix \

--- a/flox-bash/lib/catalog-search.jq
+++ b/flox-bash/lib/catalog-search.jq
@@ -1,0 +1,81 @@
+# ============================================================================ #
+#
+# Helper module containing several functions used by `flox search'.
+#
+# ---------------------------------------------------------------------------- #
+
+# Convert the JSON representation of a catalog package emitted by `nix search'
+# into an entry used by `flox search'.
+def nixCatalogPkgToSearchEntry:
+  # Discard anything for which version = "latest".
+  select( .key|endswith( ".latest" )|not )|
+  # Start by parsing and enhancing data into fields
+  ( .key|split( "." ) ) as $key|
+  .value.version as $_version|
+  .value.catalog   = $key[0]|
+  .value.system    = $key[1]|
+  .value.stability = $key[2]|
+  .value.channel   = $key[3]|
+  .value.attrPath  = ($key[4:]|join( "." )|rtrimstr( ".\($key[-1])" ) )|
+  .value.floxref   = "\(.value.channel).\(.value.attrPath)"|
+  .value.alias     = (
+    ( if .value.stability == "stable" then (
+        if .value.channel == "nixpkgs-flox" then [] else [.value.channel] end
+      ) else [.value.stability,.value.channel]
+      end ) + $key[4:]|join( "." )|rtrimstr( ".\($key[-1])" )
+  )|.value;
+
+
+# ---------------------------------------------------------------------------- #
+
+# Convert a list of search entries to pretty results grouped by package name.
+# This returns an attrset mapping "floxrefs" to pretty strings.
+def searchEntriesToPrettyBlocks( $showDetail ):
+  reduce .[] as $x (
+    {};
+    # Results are grouped under short headers which might have a description.
+    ( $x.alias + (
+        if ( $x.description == null ) or ( $x.description == "" )
+          then ""
+          else " - " + $x.description
+        end
+      )
+    ) as $header|
+    # When `showDetails' is active, be show multiple lines under each header
+    # as `<stability>.<channel>.<attrPath>@<version>'.
+    ( $x.stability + "." + $x.floxref + "@" + $x.version ) as $line|
+    # The first time seeing a floxref construct an array containing a
+    # header as the previous value, otherwise use the previous array.
+    ( if .[$x.floxref] then .[$x.floxref] else [$header] end ) as $prev|
+    # Only include `$line' when `$showDetail' is enabled.
+    ( if $showDetail then ( $prev + [( "  " + $line )] ) else $prev end
+    ) as $result|
+    # Merge result with existing collection.
+    # This potentially "updates" existing elements.
+    . * { "\($x.floxref)": $result }
+  );
+
+
+# ---------------------------------------------------------------------------- #
+
+# Convert a list of search entries to pretty results by package name.
+# This returns a single string ready for printing.
+def searchEntriesToPretty( $showDetail ):
+  searchEntriesToPrettyBlocks( $showDetail )|
+  # Sort by key.
+  to_entries|sort_by( .key )|
+  # Join floxref arrays by newline.
+  map( .value|join( "\n" ) )|
+  # Our desire is to separate groupings of output with a newline but
+  # unfortunately the Linux version of `column' which supports the
+  # `--keep-empty-lines' option is not available on Darwin, so we
+  # instead place a line with "---" between groupings and then use
+  # `sed' to remove that on the flox.sh end.
+  join( if $showDetail then "\n---\n" else "\n" end );
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/flox-bash/lib/commands/general.sh
+++ b/flox-bash/lib/commands/general.sh
@@ -8,7 +8,8 @@
 : "${_grep:=grep}"
 : "${_sort:=sort}"
 : "${_gum:=gum}"
-if [ -z "${_floco_uri:-}" ]; then
+# TODO: Don't use `nix run' to call `semver'
+if [[ -z "${_floco_uri:-}" ]]; then
   _floco_uri=github:aakropotkin/floco
   _floco_uri="$_floco_uri/e1231f054258f7d62652109725881767765b1efb"
 fi

--- a/flox-bash/lib/commands/general.sh
+++ b/flox-bash/lib/commands/general.sh
@@ -8,12 +8,7 @@
 : "${_grep:=grep}"
 : "${_sort:=sort}"
 : "${_gum:=gum}"
-# TODO: Don't use `nix run' to call `semver'
-if [[ -z "${_floco_uri:-}" ]]; then
-  _floco_uri=github:aakropotkin/floco
-  _floco_uri="$_floco_uri/e1231f054258f7d62652109725881767765b1efb"
-fi
-: "${_semver:=$_nix run $_floco_uri#semver --}"
+: "${_semver:=semver}"
 
 _general_commands+=("channels")
 _usage["channels"]="list channel subscriptions"

--- a/flox-bash/lib/commands/general.sh
+++ b/flox-bash/lib/commands/general.sh
@@ -216,7 +216,7 @@ function floxSearch() {
 	if [[ "$#" -gt 0 ]]; then
 		usage | error "extra arguments \"$*\""
 	fi
-	: "${GREP_COLOR=1;32}"
+	: "${GREP_COLOR:=1;32}"
 	export GREP_COLOR
 
 	runSearch() {

--- a/flox-bash/lib/commands/general.sh
+++ b/flox-bash/lib/commands/general.sh
@@ -190,10 +190,10 @@ function floxSearch() {
 			unset _pkg
 		    ;;
 		*)
-			if [ "${subcommand:-}" = "packages" ]; then
+			if [[ "${subcommand:-}" = "packages" ]]; then
 				# Expecting a channel name (and optionally a jobset).
 				packageregexp="^$1\."
-			elif [ -z "${packageregexp:-}" ]; then
+			elif [[ -z "${packageregexp:-}" ]]; then
 				# Expecting a package name (or part of a package name)
 				packageregexp="$1"
 				# In the event that someone has passed a space or "|"-separated

--- a/flox-bash/lib/search.jq
+++ b/flox-bash/lib/search.jq
@@ -2,55 +2,8 @@
 #   nix search --json "flake:floxpkgs#catalog.$system" "$packageregexp" | \
 #       jq -r --argjson showDetail (true|false) -f <this file>.jq | \
 #       column --keep-empty-lines -t -s "|"
-
-# Start by parsing and enhancing data into fields
-with_entries(
-  # Discard anything for which version = "latest".
-  select(.key | endswith(".latest") | not) |
-  (.key | split(".")) as $key |
-  .value.version as $_version |
-  .value.catalog = $key[0] |
-  .value.system = $key[1] |
-  .value.stability = $key[2] |
-  .value.channel = $key[3] |
-  .value.attrPath = ($key[4:] | join(".") | rtrimstr(".\($key[-1])")) |
-  .value.floxref = "\(.value.channel).\(.value.attrPath)" |
-  .value.alias = (
-    if .value.stability == "stable" then (
-      if .value.channel == "nixpkgs-flox" then [] else [.value.channel] end
-    ) else
-      [.value.stability,.value.channel]
-    end + $key[4:] | join(".") | rtrimstr(".\($key[-1])")
-  )
-) |
-
+include "catalog-search";
+# Convert `nix search' results into extended `flox search' entries.
+to_entries|map( nixCatalogPkgToSearchEntry )|
 # Then create arrays of result lines indexed under floxref.
-reduce .[] as $x (
-  {};
-  "  " as $indent |
-  "\($x.floxref)" as $f |
-  (
-    if $x.description == null or $x.description == ""
-    then "\($x.alias)"
-    else "\($x.alias) - \($x.description)"
-    end
-  ) as $header |
-  "\($x.stability).\($x.floxref)@\($x.version)" as $line |
-  # The first time seeing a floxref construct an array containing a
-  # header as the previous value, otherwise use the previous array.
-  ( if .[$f] then .[$f] else [$header] end ) as $prev |
-  ( if $showDetail then ($prev + [($indent + $line)]) else $prev end ) as $result |
-  . * { "\($f)": $result }
-) |
-
-# Sort by key.
-to_entries | sort_by(.key) |
-# Join floxref arrays by newline.
-map(.value | join("\n")) |
-# Our desire is to separate groupings of output with a newline but
-# unfortunately the Linux version of `column` which supports the
-# `--keep-empty-lines` option is not available on Darwin, so we
-# instead place a line with "---" between groupings and then use
-# `sed` to remove that on the flox.sh end.
-( if $showDetail then "\n---\n" else "\n" end ) as $joinString |
-join($joinString)
+searchEntriesToPretty( $showDetail )

--- a/flox-bash/lib/searchJSON.jq
+++ b/flox-bash/lib/searchJSON.jq
@@ -1,24 +1,6 @@
 # Invoke with:
 #   nix search --json "flake:floxpkgs#catalog.$system" "$packageregexp" | \
 #       jq -r -f <this file>.jq | column --keep-empty-lines -t -s "|"
-
-# Start by parsing and enhancing data into fields
-to_entries | map(
-  # Discard anything for which version = "latest".
-  select(.key | endswith(".latest") | not) |
-  (.key | split(".")) as $key |
-  .value.version as $_version |
-  .value.catalog = $key[0] |
-  .value.system = $key[1] |
-  .value.stability = $key[2] |
-  .value.channel = $key[3] |
-  .value.attrPath = ($key[4:] | join(".") | rtrimstr(".\($key[-1])")) |
-  .value.alias = (
-    if .value.stability == "stable" then (
-      if .value.channel == "nixpkgs-flox" then [] else [.value.channel] end
-    ) else
-      [.value.stability,.value.channel]
-    end + $key[4:] | join(".") | rtrimstr(".\($key[-1])")
-  ) |
-  .value
-)
+include "catalog-search";
+# Convert `nix search' results into extended `flox search' entries.
+to_entries|map( nixCatalogPkgToSearchEntry|del( .floxref ) )

--- a/flox-bash/tests/package.bats
+++ b/flox-bash/tests/package.bats
@@ -46,7 +46,7 @@ load test_support.bash
 }
 
 @test "tear down install test state" {
-  run $FLOX_CLI destroy -e "$TEST_ENVIRONMENT" --origin -f
+  run $FLOX_CLI destroy -e "$TEST_ENVIRONMENT" --origin -f||:
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/flox-bash/tests/semver-search.bats
+++ b/flox-bash/tests/semver-search.bats
@@ -1,0 +1,132 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test the `flox search' command, specifically for use with semver ranges.
+# This test includes a few regular search tests as a baseline to ensure the
+# semver parser isn't wrongly firing.
+#
+# XXX:
+# This test depends on the repo `github:flox-examples/nixpkgs-netlify' and
+# expects certain versions of `nodejs' to be available.
+# If that repo goes down or the versions we expect are removed this test may
+# need an update.
+#
+# TODO:
+# If this feature is to be supported and maintained long term, create a
+# dedicated repo with known versions specifically for this test harness.
+#
+#
+# ---------------------------------------------------------------------------- #
+
+bats_load_library bats-support;
+bats_load_library bats-assert;
+bats_require_minimum_version 1.5.0;
+
+load test_support.bash;
+
+
+# ---------------------------------------------------------------------------- #
+
+setup_file() {
+  common_setup;
+  "$FLOX_CLI" subscribe netlify_test_ github:flox-examples/nixpkgs-netlify/main;
+}
+
+teardown_file() {
+  "$FLOX_CLI" unsubscribe netlify_test_;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# Make sure we haven't broken regular search
+@test "flox search hello" {
+  run "$FLOX_CLI" search hello;
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# Make sure we haven't broken regular search
+@test "flox search -v hello" {
+  run "$FLOX_CLI" search -v hello;
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# Make sure we haven't broken regular search
+@test "flox search --json hello" {
+  run bash -c "{ $FLOX_CLI search --json hello||:; }|jq;";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "flox search node@18" {
+  run "$FLOX_CLI" search node@18;
+  assert_success;
+  assert_output --partial 'netlify_test_.nodejs@18.10.0';
+  assert_output --partial 'netlify_test_.nodejs@18.12.1';
+  assert_output --partial 'netlify_test_.nodejs@18.13.0';
+  assert_output --partial 'netlify_test_.nodejs@18.14.1';
+  assert_output --partial 'netlify_test_.nodejs@18.14.2';
+  refute_output --regexp 'netlify_test_\.nodejs@1[^8]\.';
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "flox search 'node@^16.14'" {
+  run "$FLOX_CLI" search 'node@^16.14';
+  assert_success;
+  refute_output --regexp 'netlify_test_\.nodejs@1[^6]\.';
+  # This is not compatible with 16.14
+  refute_output --partial 'netlify_test_.nodejs@16.13.2';
+  # These are all `>= 16.14' so they should appear.
+  assert_output --partial 'netlify_test_.nodejs@16.14.0'
+  assert_output --partial 'netlify_test_.nodejs@16.15.0'
+  assert_output --partial 'netlify_test_.nodejs@16.16.0'
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "flox search 'node@^16.14 || 18.16.0'" {
+  run "$FLOX_CLI" search 'node@^16.14 || 18.16.0';
+  assert_success;
+  # This is not compatible with 16.14
+  refute_output --partial 'netlify_test_.nodejs@16.13.2';
+  # Don't let other v18s appear
+  refute_output --partial 'netlify_test_.nodejs@18.10.0';
+  refute_output --partial 'netlify_test_.nodejs@18.12.1';
+  refute_output --partial 'netlify_test_.nodejs@18.13.0';
+  refute_output --partial 'netlify_test_.nodejs@18.14.1';
+  refute_output --partial 'netlify_test_.nodejs@18.14.2';
+  # These are all `>= 16.14' so they should appear.
+  assert_output --partial 'netlify_test_.nodejs@16.14.0'
+  assert_output --partial 'netlify_test_.nodejs@16.15.0'
+  assert_output --partial 'netlify_test_.nodejs@16.16.0'
+  # Make sure 18.16.0 appears
+  assert_output --partial 'netlify_test_.nodejs@18.16.0'
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# Make sure we emit valid JSON
+@test "flox search 'node@^16.14' --json" {
+  run bash -c "{ $FLOX_CLI search 'node@^16.14' --json||:; }|jq;";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/flox-bash/tests/test_support.bash
+++ b/flox-bash/tests/test_support.bash
@@ -2,39 +2,50 @@ bats_load_library bats-support
 bats_load_library bats-assert
 bats_require_minimum_version 1.5.0
 
-# setup_file() function run once for a given bats test file.
-setup_file() {
+# Common setup routines are defined in a separate function so this process may
+# be extended.
+# To do so a test file may redefine `setup_file' and call `common_setup' before
+# writing their extensions.
+common_setup() {
   set -x
 
-  if [ -z "$FLOX_CLI" ]; then
-    if [ -L ./result ]; then
-      FLOX_PACKAGE=$(readlink ./result)
+  if [[ -z "${FLOX_CLI:-}" ]]; then
+    if [[ -L ./result ]]; then
+      FLOX_PACKAGE="$(readlink ./result)"
     else
-      FLOX_PACKAGE=$(flox build -A flox --print-out-paths --substituters "")
+      FLOX_PACKAGE="$(flox build -A flox --print-out-paths --substituters "")"
     fi
     export FLOX_PACKAGE
-    export FLOX_CLI=$FLOX_PACKAGE/bin/flox
-    export FLOX_PACKAGE_FIRST8=$(echo $FLOX_PACKAGE | dd bs=c skip=11 count=8 2>/dev/null)
+    export FLOX_CLI="$FLOX_PACKAGE/bin/flox"
+    FLOX_PACKAGE_FIRST8="$(
+      echo $FLOX_PACKAGE | dd bs=c skip=11 count=8 2>/dev/null
+    )"
+    export FLOX_PACKAGE_FIRST8
   fi
-  export FLOX_DISABLE_METRICS="true"
+  export FLOX_DISABLE_METRICS='true'
   export TEST_ENVIRONMENT=_testing_
   # Remove any vestiges of previous test runs.
-  $FLOX_CLI destroy -e $TEST_ENVIRONMENT --origin -f || :
-  export NIX_SYSTEM=$($FLOX_CLI nix --extra-experimental-features nix-command show-config | awk '/system = / {print $NF}')
+  $FLOX_CLI destroy -e "$TEST_ENVIRONMENT" --origin -f || :
+  NIX_SYSTEM="$(
+    $FLOX_CLI nix --extra-experimental-features nix-command show-config  \
+      |awk '/system = / {print $NF}'
+  )"
+  export NIX_SYSTEM
   # Simulate pure bootstrapping environment. It is challenging to get
   # the nix, gh, and flox tools to all use the same set of defaults.
-  export REAL_XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
-  export FLOX_TEST_HOME=$(mktemp -d)
-  export XDG_CACHE_HOME=$FLOX_TEST_HOME/.cache
-  mkdir $XDG_CACHE_HOME
-  ln -s ~/.cache/nix $XDG_CACHE_HOME/nix
-  export XDG_DATA_HOME=$FLOX_TEST_HOME/.local/share
-  export XDG_CONFIG_HOME=$FLOX_TEST_HOME/.config
-  export FLOX_CACHE_HOME=$XDG_CACHE_HOME/flox
-  export FLOX_META=$FLOX_CACHE_HOME/meta
-  export FLOX_DATA_HOME=$XDG_DATA_HOME/flox
-  export FLOX_ENVIRONMENTS=$FLOX_DATA_HOME/environments
-  export FLOX_CONFIG_HOME=$XDG_CONFIG_HOME/flox
+  export REAL_XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+  FLOX_TEST_HOME="$(mktemp -d)"
+  export FLOX_TEST_HOME
+  export XDG_CACHE_HOME="$FLOX_TEST_HOME/.cache"
+  mkdir "$XDG_CACHE_HOME"
+  ln -s ~/.cache/nix "$XDG_CACHE_HOME/nix"
+  export XDG_DATA_HOME="$FLOX_TEST_HOME/.local/share"
+  export XDG_CONFIG_HOME="$FLOX_TEST_HOME/.config"
+  export FLOX_CACHE_HOME="$XDG_CACHE_HOME/flox"
+  export FLOX_META="$FLOX_CACHE_HOME/meta"
+  export FLOX_DATA_HOME="$XDG_DATA_HOME/flox"
+  export FLOX_ENVIRONMENTS="$FLOX_DATA_HOME/environments"
+  export FLOX_CONFIG_HOME="$XDG_CONFIG_HOME/flox"
 
   unset FLOX_PROMPT_ENVIRONMENTS
   unset FLOX_ACTIVE_ENVIRONMENTS
@@ -44,12 +55,13 @@ setup_file() {
   # does it. That is *so* not the right thing to do. (visible with strace)
   # 1121700 renameat(AT_FDCWD, "/home/brantley/.config/gh", AT_FDCWD, "/tmp/nix-shell.dtE4l4/tmp.JD4ki0ZezY/.config/gh") = 0
   # The way to defeat this behavior is by defining GH_CONFIG_DIR.
-  export REAL_GH_CONFIG_DIR=$REAL_XDG_CONFIG_HOME/gh
-  export GH_CONFIG_DIR=$XDG_CONFIG_HOME/gh
+  export REAL_GH_CONFIG_DIR="$REAL_XDG_CONFIG_HOME/gh"
+  export GH_CONFIG_DIR="$XDG_CONFIG_HOME/gh"
   rm -f tests/out/foo tests/out/subdir/bla
   rmdir tests/out/subdir tests/out || :
-  rm -f $FLOX_CONFIG_HOME/{gitconfig,nix.conf}
-  export TESTS_DIR=$(realpath ./tests)
+  rm -f "$FLOX_CONFIG_HOME/"{gitconfig,nix.conf}
+  TESTS_DIR="$(realpath ./tests)"
+  export TESTS_DIR
 
   # Assume that versions:
   # a) start with numbers
@@ -65,4 +77,12 @@ setup_file() {
   export VERSION_REGEX='[0-9]+\.[0-9.]+'
 
   set +x
+}
+
+
+# setup_file() function run once for a given bats test file.
+# This function may be redefined by individual test files, but running
+# `common_setup' is the recommended minimum.
+setup_file() {
+  common_setup
 }

--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -34,6 +34,7 @@
   substituteAll,
   util-linuxMinimal,
   which,
+  semver,
 }: let
   # The getent package can be found in pkgs.unixtools.
   inherit (pkgs.unixtools) getent;
@@ -116,6 +117,7 @@ in
       nixPatched
       nix-editor
       util-linuxMinimal
+      semver
     ];
     makeFlags =
       [

--- a/pkgs/semver/default.nix
+++ b/pkgs/semver/default.nix
@@ -1,0 +1,1 @@
+{inputs}: inputs.floco.packages.semver


### PR DESCRIPTION
## Proposed Changes

Extends `flox search` to support semantic version range filtering such as:
```console
$ flox search hello@2;
hello - A program that produces a familiar, friendly greeting
  stable.nixpkgs-flox.hello@2.10
  stable.nixpkgs-flox.hello@2.12
  stable.nixpkgs-flox.hello@2.12.1
  staging.nixpkgs-flox.hello@2.10
  staging.nixpkgs-flox.hello@2.12
  staging.nixpkgs-flox.hello@2.12.1
  unstable.nixpkgs-flox.hello@2.10
  unstable.nixpkgs-flox.hello@2.12
  unstable.nixpkgs-flox.hello@2.12.1

$ flox search 'hello@^2.12';
hello - A program that produces a familiar, friendly greeting
  stable.nixpkgs-flox.hello@2.12
  stable.nixpkgs-flox.hello@2.12.1
  staging.nixpkgs-flox.hello@2.12
  staging.nixpkgs-flox.hello@2.12.1
  unstable.nixpkgs-flox.hello@2.12
  unstable.nixpkgs-flox.hello@2.12.1
```

## Current Behavior

Users are unable to filter search results by version or version ranges.


## TODO
- [x] Add test cases.
- [x] Don't use `nix run` to invoke `semver`.
- [x] Refactor `jq` snippets for cleanliness.

## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Users may now search for packages using semantic version ranges.
Examples: `flox search hello@2;` or `flox search 'hello@^2.12';` or `flox search 'hello@^2.12 || 1';`