### PR TITLE
fix: disable inputs.nixpkgs.follows in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,8 @@
     owner = "aakropotkin";
     repo = "floco";
     rev = "e1231f054258f7d62652109725881767765b1efb";
-    inputs.nixpkgs.follows = "/flox-floxpkgs/nixpkgs";
+    # MFB: commented 20230527, breaks the floxpkgs-internal pkgset.
+    # inputs.nixpkgs.follows = "/flox-floxpkgs/nixpkgs";
   };
 
   outputs = args @ {flox-floxpkgs, ...}: flox-floxpkgs.project args (_: {});


### PR DESCRIPTION
## Current Behavior

The nixpkgs "follows" statement in flake.nix was breaking flake updates of
the floxpkgs-internal pkgset, and is not necessary when building with flox.

## Proposed Changes

Comment out the "follows" statement to get other updates flowing over the
long weekend and we'll revisit this next week.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A