### PR TITLE
docs: use `eval` to `flox activate` in the current shell

### DIFF
--- a/crates/flox/doc/flox-activate.md
+++ b/crates/flox/doc/flox-activate.md
@@ -35,8 +35,8 @@ or with a command and arguments to be invoked directly.
 :   Command to run in the environment.
     Spawns the command in a subshell
     that does not leak into the calling process.
-    
-    
+
+
 # ENVIRONMENT VARIABLES
 
 `$FLOX_ENV`
@@ -60,7 +60,7 @@ or with a command and arguments to be invoked directly.
     (add to the relevant "rc" file, e.g. `~/.bashrc` or `~/.zprofile`)
 
     ```
-    . <(flox activate)
+    eval "$(flox activate)"
     ```
 
 -   activate "foo" and "default" flox environments in a new subshell

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -200,7 +200,7 @@ pub enum EnvironmentCommands {
 
     /// activate environment:
     ///
-    /// * in current shell: . <(flox activate)
+    /// * in current shell: eval "$(flox activate)"
     /// * in subshell: flox activate
     /// * for command: flox activate -- <command> <args>
     #[bpaf(command)]

--- a/flox-bash/.github/workflows/gpg-test.yml
+++ b/flox-bash/.github/workflows/gpg-test.yml
@@ -87,7 +87,7 @@ jobs:
           set -o pipefail;
           flox create -e foo;
           flox install -e foo cowsay;
-          . <( flox activate -e foo; );
+          eval "$( flox activate -e foo; )";
           cowsay "No Signature" >&2;
 
       - name: Create Env (Global Signing)
@@ -97,7 +97,7 @@ jobs:
           git config --global commit.gpgsign true;
           flox create -e bar;
           flox install -e bar cowsay;
-          . <( flox activate -e bar; );
+          eval "$( flox activate -e bar; )";
           cowsay "Signature set in Global Config" >&2;
           git config --global --unset commit.gpgsign;
 
@@ -108,7 +108,7 @@ jobs:
           git config commit.gpgsign true;
           flox create -e quux;
           flox install -e quux cowsay;
-          . <( flox activate -e quux; );
+          eval "$( flox activate -e quux; )";
           cowsay "Signature set in User Config" >&2;
           git config --unset commit.gpgsign;
 

--- a/flox-bash/flox.1.md
+++ b/flox-bash/flox.1.md
@@ -160,7 +160,7 @@ The following options are supported by the commands below.
     - activate "default" flox environment only within the current shell
     (add to the relevant "rc" file, e.g. `~/.bashrc` or `~/.zprofile`)
     ```
-    . <(flox activate)
+    eval "$(flox activate)"
     ```
 
     - activate "foo" and "default" flox environments in a new subshell

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -68,7 +68,7 @@ function bashRC() {
 
 _environment_commands+=("activate")
 _usage["activate"]="activate environment:
-        in current shell: . <(flox activate)
+        in current shell: eval "$(flox activate)"
         in subshell: flox activate
         for command: flox activate -- <command> <args>"
 
@@ -313,7 +313,7 @@ function floxActivate() {
 	# both of the following:
 	#
 	# - invoke 'flox activate -e foo'
-	# - have '. <(flox activate)' in .zshrc
+	# - have 'eval "$(flox activate)"' in .zshrc
 	#
 	# Our only real defense against this sort of "double activation"
 	# is to put guards around our configuration, just as C include

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -68,7 +68,7 @@ function bashRC() {
 
 _environment_commands+=("activate")
 _usage["activate"]="activate environment:
-        in current shell: eval \"$(flox activate)\"
+        in current shell: eval \"\$(flox activate)\"
         in subshell: flox activate
         for command: flox activate -- <command> <args>"
 

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -68,7 +68,7 @@ function bashRC() {
 
 _environment_commands+=("activate")
 _usage["activate"]="activate environment:
-        in current shell: eval "$(flox activate)"
+        in current shell: eval \"$(flox activate)\"
         in subshell: flox activate
         for command: flox activate -- <command> <args>"
 

--- a/flox-bash/tests/usage.out
+++ b/flox-bash/tests/usage.out
@@ -23,7 +23,7 @@ environment commands:
     flox <command> [(-e|--environment) <env>] [<args>]
     ----
     flox activate - activate environment:
-        in current shell: . <(flox activate)
+        in current shell: eval "$(flox activate)"
         in subshell: flox activate
         for command: flox activate -- <command> <args>
     flox list [--out-path] [--json]
@@ -67,4 +67,3 @@ development commands:
                  [--render-path <dir>] [--key-file <file>] \
                  [(-A|--attr) <package>] [--publish-system <system>]
          - build and publish project to flox channel
-

--- a/shells/flox/default.nix
+++ b/shells/flox/default.nix
@@ -1,0 +1,40 @@
+{
+  mkShell,
+  self,
+  lib,
+  rustfmt,
+  clippy,
+  rust-analyzer,
+  darwin,
+  glibcLocales,
+  hostPlatform,
+  nix,
+  rustPlatform,
+  cargo,
+  rustc,
+  rust,
+  hivemind,
+  cargo-watch,
+  commitizen,
+}:
+mkShell ({
+    inputsFrom = [
+      self.packages.flox
+      self.packages.flox.passthru.flox-bash
+    ];
+    RUST_SRC_PATH = "${self.packages.flox.passthru.rustPlatform.rustLibSrc}";
+    RUSTFMT = "${self.checks.pre-commit-check.passthru.rustfmt}/bin/rustfmt";
+    packages = [
+      commitizen
+      self.checks.pre-commit-check.passthru.rustfmt
+      hivemind
+      # cargo-watch
+      clippy
+      rust-analyzer
+      rust.packages.stable.rustPlatform.rustLibSrc
+    ];
+    shellHook = ''
+      ${self.checks.pre-commit-check.shellHook}
+    '';
+  }
+  // self.packages.flox.envs)


### PR DESCRIPTION
Using `source <(flox activate)` breaks in zsh shells.

flox checks for updates of the current environment and issue an interactive prompt to apply possible updates.

In zsh `<(_)` attempts to read from stdin will block forever:

> The = form is useful as both the /dev/fd and the named pipe implementation of <(...) have drawbacks. [..]
> In the second case, if the programme does not actually open the file,
> the subshell attempting to read from or write to the pipe will
> (in a typical implementation, different operating systems may have different behaviour)
> block for ever and have to be killed explicitly. In both cases,
> the shell actually supplies the information using a pipe,
> so that programmes that expect to lseek (see lseek(2)) on the file will not work.

https://zsh.sourceforge.io/Doc/Release/Expansion.html#Process-Substitution
