### PR TITLE
ci: escape newline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           # so pusing to latest is just forwarding the branch
           git push --atomic origin \
             ${{ steps.tag.outputs.TAG }} \
-            +${{ steps.tag.outputs.TAG }}~0:refs/heads/main
+            +${{ steps.tag.outputs.TAG }}~0:refs/heads/main \
             +${{ steps.tag.outputs.TAG }}~0:refs/heads/latest 
           
           # update the PR branch so github will close the PR


### PR DESCRIPTION
Atomic push to version tag, main and latest did not include the push to latest due to a missing `\` to escape the new line separating the arguments to `git push`.