### PR TITLE
fix: allowSubstitutes for semver

### DIFF
--- a/pkgs/semver/default.nix
+++ b/pkgs/semver/default.nix
@@ -1,1 +1,4 @@
-{inputs}: inputs.floco.packages.semver
+{inputs}:
+inputs.floco.packages.semver.overrideAttrs (_: {
+  allowSubstitutes = true;
+})


### PR DESCRIPTION
## Proposed Changes

Force `allowSubstitutes` for `semver` dependency.


## Current Behavior

This derivation sets `allowSubstitutes` based on `currentSystem` when `--impure` is active.


## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
