### PR TITLE
fix: don't invoke nix build with --impure flag when publishing

### DIFF
--- a/flox-bash/lib/commands/development.sh
+++ b/flox-bash/lib/commands/development.sh
@@ -119,7 +119,7 @@ function floxBuild() {
 	if [ -n "$FLOX_ORIGINAL_NIX_GET_COMPLETIONS" ]; then
 		export NIX_GET_COMPLETIONS="$(( FLOX_ORIGINAL_NIX_GET_COMPLETIONS + 1 ))"
 	fi
-	$invoke_nix "${_nixArgs[@]}" build --impure "${buildArgs[@]}" "${installables[@]}" --override-input flox-floxpkgs/nixpkgs/nixpkgs flake:nixpkgs-$FLOX_STABILITY
+	$invoke_nix "${_nixArgs[@]}" build "${buildArgs[@]}" "${installables[@]}" --override-input flox-floxpkgs/nixpkgs/nixpkgs flake:nixpkgs-$FLOX_STABILITY
 }
 
 # flox eval
@@ -378,7 +378,7 @@ function floxDevelop() {
 			floxNixDir="$($_dirname "$floxNixDir")"
 			# Try to build the floxEnv if there is one.
 			# The following build could fail; let it.
-			floxBuild "${_nixArgs[@]}" --out-link "$floxEnvGCRoot" "$floxEnvFlakeURL" "${developArgs[@]}" || \
+			floxBuild "${_nixArgs[@]}" --impure --out-link "$floxEnvGCRoot" "$floxEnvFlakeURL" "${developArgs[@]}" || \
 				error "failed to build floxEnv from $floxNixDir/flox.nix" < /dev/null
 
 			# The build was successful so copy the newly rendered catalog and


### PR DESCRIPTION
The placement of --impure within the floxBuild() function meant that it also applied to nix builds happening by way of flox publish invocations. This patch moves the flag to the [1] place where we are calling floxBuild to build flox environments, which do require the use of --impure.

Note that flox build as called from the top-level flox-bash/flox.sh is handled by rust, so that use of the floxBuild() function is not relevant.

## Checks

- [ ] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

Fixed obscure bug affecting the correctness of flox publish when working with impure inputs.