### PR TITLE
test: separate multi-env tests to separate file

### DIFF
--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -795,32 +795,6 @@ load test_support.bash
   ! assert_output --partial "stable.nixpkgs-flox.hello"
 }
 
-@test "flox activate on multiple environments" {
-  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}-1"
-  assert_success
-  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}-1" "$FLOX_PACKAGE"
-  assert_success
-  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}-2"
-  assert_success
-  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}-2" "$FLOX_PACKAGE"
-  assert_success
-  run "$FLOX_CLI" activate                                   \
-      -e "${TEST_ENVIRONMENT}-1" -e "${TEST_ENVIRONMENT}-2"  \
-      -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"'
-  assert_success
-  # FLOX_ENV should be set to the first argument
-  assert_output --regexp "^FLOX_ENV: .*${TEST_ENVIRONMENT}-1\$"
-  # Cleanup
-  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e ${TEST_ENVIRONMENT}-1 --origin -f"
-  assert_output --partial "WARNING: you are about to delete the following"
-  assert_output --partial "Deleted branch"
-  assert_output --partial "removed"
-  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e ${TEST_ENVIRONMENT}-2 --origin -f"
-  assert_output --partial "WARNING: you are about to delete the following"
-  assert_output --partial "Deleted branch"
-  assert_output --partial "removed"
-}
-
 @test "flox develop setup" {
   # Note the use of --dereference to copy flake.{nix,lock} as files.
   run sh -c "tar -cf - --dereference --mode u+w -C $TESTS_DIR/develop ./develop | tar -C $FLOX_TEST_HOME -xf -"

--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -4,9 +4,6 @@
 # - unit tests only to be run from within package build
 # - unit and integration tests to be run from command line
 #
-bats_load_library bats-support
-bats_load_library bats-assert
-bats_require_minimum_version 1.5.0
 
 load test_support.bash
 

--- a/flox-bash/tests/multi-env.bats
+++ b/flox-bash/tests/multi-env.bats
@@ -13,8 +13,8 @@ load test_support.bash;
 # ---------------------------------------------------------------------------- #
 
 destroy_envs() {
-  "$FLOX_CLI" destroy -e "${TEST_ENVIRONMENT}1" --origin -f||:;
-  "$FLOX_CLI" destroy -e "${TEST_ENVIRONMENT}2" --origin -f||:;
+  "$FLOX_CLI" destroy -e "${TEST_ENVIRONMENT}_multi_1" --origin -f||:;
+  "$FLOX_CLI" destroy -e "${TEST_ENVIRONMENT}_multi_1" --origin -f||:;
 }
 
 setup_file() {
@@ -29,15 +29,15 @@ teardown_file() {
 
 # ---------------------------------------------------------------------------- #
 
-@test "init flox ${TEST_ENVIRONMENT}{1,2}" {
-  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}1";
+@test "init flox ${TEST_ENVIRONMENT}_multi_{1,2}" {
+  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}_multi_1";
   assert_success;
-  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}1" "$FLOX_PACKAGE";
+  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}_multi_1" "$FLOX_PACKAGE";
   assert_success;
 
-  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}2";
+  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}_multi_2";
   assert_success;
-  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}2" "$FLOX_PACKAGE";
+  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}_multi_2" "$FLOX_PACKAGE";
   assert_success;
 }
 
@@ -46,12 +46,12 @@ teardown_file() {
 
 @test "flox activate on multiple environments" {
   #shellcheck disable=SC2016
-  run "$FLOX_CLI" activate                                 \
-      -e "${TEST_ENVIRONMENT}1" -e "${TEST_ENVIRONMENT}2"  \
+  run "$FLOX_CLI" activate                                               \
+      -e "${TEST_ENVIRONMENT}_multi_1" -e "${TEST_ENVIRONMENT}_multi_2"  \
       -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"';
   assert_success;
   # FLOX_ENV should be set to the first argument
-  assert_output --regexp "^FLOX_ENV: .*${TEST_ENVIRONMENT}1\$";
+  assert_output --regexp "^FLOX_ENV: .*${TEST_ENVIRONMENT}_multi_1\$";
 }
 
 

--- a/flox-bash/tests/multi-env.bats
+++ b/flox-bash/tests/multi-env.bats
@@ -1,0 +1,66 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test the `FLOX_ENV' variable set by `flox activate' is set appropriately when
+# multiple environments are indicated on the CLI.
+#
+# ---------------------------------------------------------------------------- #
+
+bats_load_library bats-support;
+bats_load_library bats-assert;
+bats_require_minimum_version 1.5.0;
+
+load test_support.bash;
+
+
+# ---------------------------------------------------------------------------- #
+
+kill_envs() {
+  "$FLOX_CLI" destroy -e "${TEST_ENVIRONMENT}1" --origin -f||:;
+  "$FLOX_CLI" destroy -e "${TEST_ENVIRONMENT}2" --origin -f||:;
+}
+
+setup_file() {
+  common_setup;
+  kill_envs;
+}
+
+teardown_file() {
+  kill_envs;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "init flox ${TEST_ENVIRONMENT}{1,2}" {
+  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}1";
+  assert_success;
+  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}1" "$FLOX_PACKAGE";
+  assert_success;
+
+  run "$FLOX_CLI" create -e "${TEST_ENVIRONMENT}2";
+  assert_success;
+  run "$FLOX_CLI" install -e "${TEST_ENVIRONMENT}2" "$FLOX_PACKAGE";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "flox activate on multiple environments" {
+  #shellcheck disable=SC2016
+  run "$FLOX_CLI" activate                                 \
+      -e "${TEST_ENVIRONMENT}1" -e "${TEST_ENVIRONMENT}2"  \
+      -- bash -c 'echo "FLOX_ENV: $FLOX_ENV"';
+  assert_success;
+  # FLOX_ENV should be set to the first argument
+  assert_output --regexp "^FLOX_ENV: .*${TEST_ENVIRONMENT}1\$";
+}
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/flox-bash/tests/multi-env.bats
+++ b/flox-bash/tests/multi-env.bats
@@ -16,18 +16,18 @@ load test_support.bash;
 
 # ---------------------------------------------------------------------------- #
 
-kill_envs() {
+destroy_envs() {
   "$FLOX_CLI" destroy -e "${TEST_ENVIRONMENT}1" --origin -f||:;
   "$FLOX_CLI" destroy -e "${TEST_ENVIRONMENT}2" --origin -f||:;
 }
 
 setup_file() {
   common_setup;
-  kill_envs;
+  destroy_envs;
 }
 
 teardown_file() {
-  kill_envs;
+  destroy_envs;
 }
 
 

--- a/flox-bash/tests/multi-env.bats
+++ b/flox-bash/tests/multi-env.bats
@@ -7,10 +7,6 @@
 #
 # ---------------------------------------------------------------------------- #
 
-bats_load_library bats-support;
-bats_load_library bats-assert;
-bats_require_minimum_version 1.5.0;
-
 load test_support.bash;
 
 

--- a/flox-bash/tests/package.bats
+++ b/flox-bash/tests/package.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-bats_load_library bats-assert
-bats_require_minimum_version 1.5.0
-
 load test_support.bash
 
 @test "flox package sanity check" {

--- a/flox-bash/tests/semver-search.bats
+++ b/flox-bash/tests/semver-search.bats
@@ -19,10 +19,6 @@
 #
 # ---------------------------------------------------------------------------- #
 
-bats_load_library bats-support;
-bats_load_library bats-assert;
-bats_require_minimum_version 1.5.0;
-
 load test_support.bash;
 
 


### PR DESCRIPTION
## Proposed Changes

Separate `flox activate -e foo -e bar` "multi-env" tests to separate file.
This largely acts as a model for separating similar test collections.

## Current Behavior

These tests currently reside in `integration.bats`.

## Checks

Failures match existing failures.
No tests are fixed or broken, they are only reorganized.

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A


<!-- Many thanks! -->
