### PR TITLE
fix: sanitize source to minimize rebuild

### DIFF
--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -1,5 +1,6 @@
 {
   self,
+  flox-src,
   inputs,
   stdenv,
   ansifilter,
@@ -83,12 +84,12 @@
   bats = pkgs.bats.withLibraries (p: [p.bats-support p.bats-assert]);
 
   # read commitizen config file as the single source of version
-  czToml = lib.importTOML (self + "/.cz.toml");
+  czToml = lib.importTOML (flox-src + "/.cz.toml");
 in
   stdenv.mkDerivation rec {
     pname = "flox-bash";
     version = "${czToml.tool.commitizen.version}-${inputs.flox-floxpkgs.lib.getRev self}";
-    src = "${self}/flox-bash";
+    src = flox-src + "/flox-bash";
     nativeBuildInputs =
       [bats entr makeWrapper pandoc shellcheck shfmt which]
       # nix-provided expect not working on Darwin (#441)

--- a/pkgs/flox-src/default.nix
+++ b/pkgs/flox-src/default.nix
@@ -1,0 +1,14 @@
+{self}:
+builtins.path {
+  name = "flox-src";
+  path = self;
+  filter = path: type:
+    ! builtins.elem path [
+      (self.outPath + "/flake.nix")
+      (self.outPath + "/flake.lock")
+      (self.outPath + "/pkgs")
+      (self.outPath + "/checks")
+      (self.outPath + "/tests")
+      (self.outPath + "/shells")
+    ];
+}

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -3,6 +3,7 @@
   # self is a flake if this package is built locally, but if it's called as a proto, it's just the
   # source
   self,
+  flox-src,
   inputs,
   lib,
   rustPlatform,
@@ -27,7 +28,7 @@
 }: let
   manpages =
     runCommand "flox-manpages" {
-      src = "${self}/crates/flox/doc";
+      src = flox-src + "/crates/flox/doc";
       buildInputs = [pandoc fd];
     } ''
 
@@ -42,7 +43,7 @@
           {}
     '';
 
-  cargoToml = lib.importTOML (self + "/crates/flox/Cargo.toml");
+  cargoToml = lib.importTOML (flox-src + "/crates/flox/Cargo.toml");
 
   envs =
     {
@@ -76,10 +77,10 @@ in
   rustPlatform.buildRustPackage ({
       pname = cargoToml.package.name;
       version = envs.FLOX_VERSION;
-      src = self;
+      src = flox-src;
 
       cargoLock = {
-        lockFile = self + "/Cargo.lock";
+        lockFile = flox-src + "/Cargo.lock";
         allowBuiltinFetchGit = true;
       };
 


### PR DESCRIPTION
## Proposed Changes

filter the source to be less sensitive to test suite iteration. Note that this will still create a distinction between dirty and clean builds due to the revision count injection, but otherwise should make it easier to work on the tests

## Current Behavior

any change to the repo creates a rebuild

## Checks

- [ ] All tests pass. -  working on it

## Release Notes
N/A
