### PR TITLE
fix: repair broken `flox channels`

### DIFF
--- a/flox-bash/lib/commands/general.sh
+++ b/flox-bash/lib/commands/general.sh
@@ -1,16 +1,5 @@
 ## General commands
 
-# Set utility fallbacks
-: "${_jq:=jq}"
-: "${_nix:=nix}"
-: "${_sed:=sed}"
-: "${_column:=column}"
-: "${_grep:=grep}"
-: "${_sort:=sort}"
-: "${_gum:=gum}"
-: "${_semver:=semver}"
-: "${_xargs:=xargs}"
-
 _general_commands+=("channels")
 _usage["channels"]="list channel subscriptions"
 _usage_options["channels"]="[--json]"
@@ -36,11 +25,11 @@ function floxChannels() {
 		getChannelsJSON
 	else
 		local -a rows;
-		read -ra rows < <( getChannelsJSON | $_jq -r '
+		mapfile -t rows < <(getChannelsJSON | $_jq -r '
 		  to_entries | sort_by(.key) | map(
 			"|\(.key)|\(.value.type)|\(.value.url)|"
-		  )[]'
-		)
+		  )[]
+		')
 		${invoke_gum?} format --type="markdown"                              \
 		               -- "|Channel|Type|URL|" "|---|---|---|" "${rows[@]}"
 	fi

--- a/flox-bash/lib/commands/general.sh
+++ b/flox-bash/lib/commands/general.sh
@@ -25,7 +25,7 @@ function floxChannels() {
 		getChannelsJSON
 	else
 		local -a rows;
-		mapfile -t rows < <(getChannelsJSON | $_jq -r '
+		mapfile -t rows < <( getChannelsJSON | $_jq -r '
 		  to_entries | sort_by(.key) | map(
 			"|\(.key)|\(.value.type)|\(.value.url)|"
 		  )[]'

--- a/flox-bash/lib/commands/general.sh
+++ b/flox-bash/lib/commands/general.sh
@@ -28,8 +28,8 @@ function floxChannels() {
 		mapfile -t rows < <(getChannelsJSON | $_jq -r '
 		  to_entries | sort_by(.key) | map(
 			"|\(.key)|\(.value.type)|\(.value.url)|"
-		  )[]
-		')
+		  )[]'
+		)
 		${invoke_gum?} format --type="markdown"                              \
 		               -- "|Channel|Type|URL|" "|---|---|---|" "${rows[@]}"
 	fi


### PR DESCRIPTION
## Current Behavior

The output of `flox channels` was broken with a recent commit, returning only the first in a list of channels.

## Proposed Changes

This patch replaces the use of `read` with `mapfile` to parse all the channels instead of just the first.

The patch also removes a block of utility command fallback assignments not required for the production version that had temporarily been added for testing.

## Checks

- [ ] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

Fixed bug with `flox channels` command returning only the first in a list of channels.