### PR TITLE
fix: 'flox activate' accepts '-s,--system' option

### DIFF
--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -86,23 +86,36 @@ function floxActivate() {
 
 	local -a cmdArgs=()
 	local -i inCmdArgs=0
-	for arg in "${invocation[@]}"; do
-		case "$arg" in
+
+	while [[ "$#" -gt 0 ]]; do
+		case "$1" in
+		# User has explicitly requested a system which differs from the
+		# running system.
+		# This is largely useful for `aarch64-darwin' systems which have the
+		# ability to execute `x86_64-darwin' binaries.
+		-s|--system)
+			shift;
+			if [[ "$#" -lt 1 ]]; then
+				error "option \`--system <SYSTEM>' requires an argument"
+			fi
+			system="$1"
+			;;
 		--)
-			if [ "$inCmdArgs" -eq 1 ]; then
-				cmdArgs+=("$arg")
+			if [[ "$inCmdArgs" -eq 1 ]]; then
+				cmdArgs+=("$1")
 			else
 				inCmdArgs=1
 			fi
 			;;
 		*)
-			if [ "$inCmdArgs" -eq 1 ]; then
-				cmdArgs+=("$arg")
+			if [[ "$inCmdArgs" -eq 1 ]]; then
+				cmdArgs+=("$1")
 			else
-				usage | error "unexpected argument \"$arg\" passed to \"$subcommand\""
+				usage | error "unexpected argument \"$1\" passed to \"$subcommand\""
 			fi
 			;;
 		esac
+		shift;
 	done
 
 	# The $FLOX_ACTIVE_ENVIRONMENTS variable is colon-separated (like $PATH)

--- a/flox-bash/tests/integration.bats
+++ b/flox-bash/tests/integration.bats
@@ -199,6 +199,15 @@ setup_file() {
   assert_output - < tests/hello-cowsay.out
 }
 
+@test "flox activate accepts '-s,--system' options" {
+  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" --system "$NIX_SYSTEM"  \
+                           -- sh -c ':'
+  assert_success
+  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -s "$NIX_SYSTEM"  \
+                           -- sh -c ':'
+  assert_success
+}
+
 @test "flox edit remove hello" {
   EDITOR=./tests/remove-hello run $FLOX_CLI edit -e $TEST_ENVIRONMENT
   assert_success


### PR DESCRIPTION
## Proposed Changes

Fixes arg parser for `flox activate -s,--system <SYSTEM>;`.

## Current Behavior

Help messages and documentation say that this flag is supported, but setting it will cause crashes.


## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Fixed `flox activate --system <SYSTEM>` option which previously crashed with usage information.


<!-- Many thanks! -->
