### PR TITLE
fix: support dash shell, add flox activate tests for dash, bash, and zsh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    # FIXME: Change to `uses: flox/install-flox-action@main' when that action
+    #        is fixed.
     - name: Install flox
-      uses: flox/install-flox-action@main
+      uses: flox/install-flox-action@87d4bf1c9567497fe28cb55b411b16c375273219
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    # FIXME: Change to `uses: flox/install-flox-action@main' when that action
-    #        is fixed.
     - name: Install flox
-      uses: flox/install-flox-action@87d4bf1c9567497fe28cb55b411b16c375273219
+      uses: flox/install-flox-action@main
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -359,7 +359,7 @@ function floxActivate() {
 				# profile script and then executing an interactive shell.
 				*dash)
 					exec "$rcShell" -c                                      \
-						   "source '$_etc/flox.bashrc'; exec $rcShell -i";
+					       "source '$_etc/flox.bashrc'; exec $rcShell -i";
 					;;
 			esac
 			;;

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -265,7 +265,7 @@ function floxActivate() {
 	local rcScript
 	rcScript="$(mktemp)" # cleans up after itself, do not use mkTempFile()
 	case "$rcShell" in
-	*bash)
+	*bash|*dash)
 		bashRC "${_environments_to_activate[@]}" >> "$rcScript"
 		;;
 	*zsh)
@@ -349,10 +349,19 @@ function floxActivate() {
 	if [ "$interactive" -eq 1 ]; then
 		# Interactive case - launch subshell.
 		case "$rcShell" in
-		*bash)
+		*bash|*dash)
 			export FLOX_BASH_INIT_SCRIPT="$rcScript"
 			[ "$verbose" -eq 0 ] || pprint "+$colorBold" exec "$rcShell" "--rcfile" "$_etc/flox.bashrc" "$colorReset" 1>&2
-			exec "$rcShell" "--rcfile" "$_etc/flox.bashrc"
+			case "$rcShell" in
+				*bash) exec "$rcShell" "--rcfile" "$_etc/flox.bashrc"; ;;
+				# `dash' lacks an equivalent for `--rcfile' so we have to do
+				# things "the good ol' fashioned way" - manually sourcing the
+				# profile script and then executing an interactive shell.
+				*dash)
+					exec "$rcShell" -c                                      \
+						   "source '$_etc/flox.bashrc'; exec $rcShell -i";
+					;;
+			esac
 			;;
 		*zsh)
 			export FLOX_ZSH_INIT_SCRIPT="$rcScript"
@@ -377,7 +386,7 @@ function floxActivate() {
 		local _flox_activate_verbose=/dev/null
 		[ "$verbose" -eq 0 ] || _flox_activate_verbose=/dev/stderr
 		case "$rcShell" in
-		*bash|*zsh)
+		*bash|*zsh|*dash)
 			$_cat "$rcScript" | $_tee "$_flox_activate_verbose"
 			;;
 		*)

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1470,12 +1470,12 @@ function darwinRepairFiles() {
 #
 function identifyParentShell() {
 	trace "$@"
-	local parentShell="$SHELL" # default
-	local shellCmd="${SHELL/*\//}" # aka basename
+	local parentShell="${SHELL:-}" # default
+	local shellCmd="${parentShell/*\//}" # aka basename
 	local parentShellCmd="$shellCmd" # default
 
 	# Only attempt a guess if we know our parent PID.
-	if [ -n "$FLOX_PARENT_PID" ]; then
+	if [ -n "${FLOX_PARENT_PID:-}" ]; then
 		# First attempt to identify details of parent shell process.
 		if [ -L "/proc/$FLOX_PARENT_PID/exe" -a \
 			 -r "/proc/$FLOX_PARENT_PID/exe" ]; then
@@ -1494,14 +1494,14 @@ function identifyParentShell() {
 		# Compare $SHELL and $parentShell to see if the command names match.
 		if [ "$shellCmd" == "$parentShellCmd" ]; then
 			# Respect $SHELL over $parentShell (which is usually its realpath).
-			echo "$SHELL"
+			echo "${SHELL:-$shellCmd}"
 		else
 			# Return parent shell.
 			echo "$parentShell"
 		fi
 	else
 		# We don't know our parent PID so don't even guess.
-		echo "$SHELL"
+		echo "${SHELL:-$shellCmd}"
 	fi
 }
 

--- a/pkgs/flox-tests/default.nix
+++ b/pkgs/flox-tests/default.nix
@@ -2,6 +2,8 @@
   self,
   lib,
   bash,
+  zsh,
+  dash,
   bats,
   coreutils,
   entr,
@@ -28,6 +30,8 @@
 
   paths = [
     bash
+    zsh
+    dash
     batsWith
     coreutils
     entr

--- a/tests/activate.bats
+++ b/tests/activate.bats
@@ -114,6 +114,18 @@ teardown_file() {
 
 
 # ---------------------------------------------------------------------------- #
+
+@test "'flox activate' accepts '-s,--system' options" {
+  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" --system "$NIX_SYSTEM"  \
+                           -- sh -c ':'
+  assert_success
+  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -s "$NIX_SYSTEM"  \
+                           -- sh -c ':'
+  assert_success
+}
+
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/tests/activate.bats
+++ b/tests/activate.bats
@@ -1,0 +1,73 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test the `flox activate' subcommand.
+# We are especially interested in ensuring that the activation script works
+# with most common shells, since that routine will be executed using the users
+# running shell.
+#
+# TODO: Test multiple versions of `bash'. Specifically v{3,4,5}.x
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash;
+
+
+# ---------------------------------------------------------------------------- #
+
+destroy_envs() {
+  "$FLOX_CLI" destroy -e "$TEST_ENVIRONMENT" --origin -f||:;
+}
+
+setup_file() {
+  common_setup;
+  TEST_ENVIRONMENT='_testing_activate'
+  destroy_envs;
+  "$FLOX_CLI" create -e "$TEST_ENVIRONMENT";
+  "$FLOX_CLI" install -e "$TEST_ENVIRONMENT" hello cowsay;
+}
+
+teardown_file() {
+  destroy_envs;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox activate' can invoke hello and cowsay" {
+  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -- sh -c 'hello|cowsay;';
+  assert_success;
+  assert_output --partial - < tests/hello-cowsay.out;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox activate' works with 'bash'" {
+  run bash -c "$FLOX_CLI activate -e '$TEST_ENVIRONMENT' -- bash -c ':';";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox activate' works with 'dash'" {
+  run bash -c "$FLOX_CLI activate -e '$TEST_ENVIRONMENT' -- dash -c ':';";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox activate' works with 'zsh'" {
+  run bash -c "$FLOX_CLI activate -e '$TEST_ENVIRONMENT' -- zsh -c ':';";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/tests/activate.bats
+++ b/tests/activate.bats
@@ -7,7 +7,6 @@
 # with most common shells, since that routine will be executed using the users
 # running shell.
 #
-# TODO: Test multiple versions of `bash'. Specifically v{3,4,5}.x
 #
 # ---------------------------------------------------------------------------- #
 
@@ -22,21 +21,39 @@ destroy_envs() {
 
 setup_file() {
   common_setup;
-  TEST_ENVIRONMENT='_testing_activate'
+  export TEST_ENVIRONMENT='_testing_activate'
   destroy_envs;
   "$FLOX_CLI" create -e "$TEST_ENVIRONMENT";
   "$FLOX_CLI" install -e "$TEST_ENVIRONMENT" hello cowsay;
+
+  # Run by various shells to test that `flox activate ... -- ...;' works.
+  _inline_cmd="$FLOX_CLI activate -e '$TEST_ENVIRONMENT'";
+  _inline_cmd="$_inline_cmd -- sh -c 'hello|cowsay'";
+  export _inline_cmd;
+
+  # Run by various shells to test that `eval "$( flox activate ...; )";' works.
+  _eval_cmd="eval \"\$( $FLOX_CLI activate -e '$TEST_ENVIRONMENT'; )\"";
+  _eval_cmd="$_eval_cmd; hello|cowsay;";
+  export _eval_cmd;
 }
 
 teardown_file() {
   destroy_envs;
 }
 
-
 # ---------------------------------------------------------------------------- #
 
 @test "'flox activate' can invoke hello and cowsay" {
-  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -- sh -c 'hello|cowsay;';
+  run sh -c "$_inline_cmd";
+  assert_success;
+  assert_output --partial - < tests/hello-cowsay.out;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox activate' with eval can invoke hello and cowsay" {
+  run sh -c "$_eval_cmd";
   assert_success;
   assert_output --partial - < tests/hello-cowsay.out;
 }
@@ -45,24 +62,54 @@ teardown_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox activate' works with 'bash'" {
-  run bash -c "$FLOX_CLI activate -e '$TEST_ENVIRONMENT' -- bash -c ':';";
+  run bash -c "$_inline_cmd";
   assert_success;
+  assert_output --partial - < tests/hello-cowsay.out;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox activate' with eval works with 'bash'" {
+  run bash -c "$_eval_cmd";
+  assert_success;
+  assert_output --partial - < tests/hello-cowsay.out;
 }
 
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox activate' works with 'dash'" {
-  run bash -c "$FLOX_CLI activate -e '$TEST_ENVIRONMENT' -- dash -c ':';";
+  run dash -c "$_inline_cmd";
   assert_success;
+  assert_output --partial - < tests/hello-cowsay.out;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox activate' with eval works with 'dash'" {
+  run dash -c "$_eval_cmd";
+  assert_success;
+  assert_output --partial - < tests/hello-cowsay.out;
 }
 
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox activate' works with 'zsh'" {
-  run bash -c "$FLOX_CLI activate -e '$TEST_ENVIRONMENT' -- zsh -c ':';";
+  run zsh -c "$_inline_cmd";
   assert_success;
+  assert_output --partial - < tests/hello-cowsay.out;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox activate' with eval works with 'zsh'" {
+  run zsh -c "$_eval_cmd";
+  assert_success;
+  assert_output --partial - < tests/hello-cowsay.out;
 }
 
 

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -184,12 +184,6 @@ setup_file() {
   assert_output --regexp "3  stable.nixpkgs-flox.jq +"$VERSION_REGEX
 }
 
-@test "flox activate can invoke hello and cowsay" {
-  run $FLOX_CLI activate -e $TEST_ENVIRONMENT -- sh -c 'hello | cowsay'
-  assert_success
-  assert_output --partial - < tests/hello-cowsay.out
-}
-
 @test "flox edit remove hello" {
   EDITOR=./tests/remove-hello run $FLOX_CLI edit -e $TEST_ENVIRONMENT
   assert_success

--- a/tests/progs.bats
+++ b/tests/progs.bats
@@ -19,6 +19,21 @@ setup_file() {
   common_setup;
   export TEST_ENVIRONMENT='_testing_progs';
   destroy_envs;
+
+  # Perform a minimal form of `flox-bash/lib/init.sh' required to support
+  # using internal `flox-bash/lib/utils.sh' routines.
+  _prefix="$( $FLOX_CLI --bash-passthru --prefix; )";
+  _lib="$_prefix/lib";
+  _libexec="$_prefix/libexec";
+  _etc="$_prefix/etc";
+
+  # Used to reset `PATH' to conventional UNIX system default.
+  # This ensures that the `PATH' used by the test environment does not pollute
+  # our results.
+  _progs_PATH='/bin:/sbin:/usr/bin:/usr/local/bin';
+  _progs_PATH="$_progs_PATH:/run/wrappers/bin:/run/current-system/sw/bin";
+
+  export _prefix _lib _libexec _etc _progs_PATH;
 }
 
 teardown_file() {
@@ -32,20 +47,12 @@ teardown_file() {
 # This file handles resolution of runtime dependencies, so we only care about
 # testing past that point of initialization.
 util() {
-  # Perform a minimal form of `flox-bash/lib/init.sh' required to support
-  # using internal `flox-bash/lib/utils.sh' routines.
-  _prefix="$( $FLOX_CLI --bash-passthru --prefix; )";
-  _lib="$_prefix/lib";
-  _libexec="$_prefix/libexec";
-  _etc="$_prefix/etc";
-
   # push current options
   _old_opts="$( shopt -p; )";
   shopt -s extglob;
   shopt -s nullglob;
   _OLD_PATH="$PATH";
-  PATH='/bin:/sbin:/usr/bin:/usr/local/bin'
-  PATH="$PATH:/run/wrappers/bin:/run/current-system/sw/bin"
+  export PATH="$_progs_PATH";
 
   # Run utils setup
   #shellcheck source-path=SCRIPTDIR

--- a/tests/progs.bats
+++ b/tests/progs.bats
@@ -17,7 +17,7 @@ destroy_envs() {
 
 setup_file() {
   common_setup;
-  TEST_ENVIRONMENT='_testing_progs';
+  export TEST_ENVIRONMENT='_testing_progs';
   destroy_envs;
 }
 
@@ -34,7 +34,7 @@ teardown_file() {
 util() {
   # Perform a minimal form of `flox-bash/lib/init.sh' required to support
   # using internal `flox-bash/lib/utils.sh' routines.
-  _prefix="$FLOX_PACKAGE";
+  _prefix="$( $FLOX_CLI --bash-passthru --prefix; )";
   _lib="$_prefix/lib";
   _libexec="$_prefix/libexec";
   _etc="$_prefix/etc";
@@ -49,7 +49,7 @@ util() {
 
   # Run utils setup
   #shellcheck source-path=SCRIPTDIR
-  #shellcheck source=../lib/utils.sh
+  #shellcheck source=../flox-bash/lib/utils.sh
   . "$_lib/utils.sh";
 
   # Run the given command and stash the exit code
@@ -74,14 +74,14 @@ cmds=(
 
 # ---------------------------------------------------------------------------- #
 
-#@test "runtime dependencies in '/nix/store'" {
-#  for p in "${cmds[@]}"; do
-#    run util echo "\$_$p";
-#    assert_output --regexp "^/nix/store/.*/$p\$";
-#    run util echo "\$invoke_$p";
-#    assert_output --regexp "^invoke /nix/store/.*/$p\$";
-#  done
-#}
+@test "runtime dependencies in '/nix/store'" {
+  for p in "${cmds[@]}"; do
+    run util echo "\$_$p";
+    assert_output --regexp "^/nix/store/.*/$p\$";
+    run util echo "\$invoke_$p";
+    assert_output --regexp "^invoke /nix/store/.*/$p\$";
+  done
+}
 
 
 # ---------------------------------------------------------------------------- #
@@ -91,7 +91,8 @@ cmds=(
   assert_success;
   run "$FLOX_CLI" install -e "$TEST_ENVIRONMENT" hello bash;
   assert_success;
-  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -- bash -c "echo \"\${_${cmds[1]}:-NOPE}\";";
+  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" --  \
+        bash -c "echo \"\${_${cmds[1]}:-NOPE}\";";
   assert_output --partial NOPE;
 }
 


### PR DESCRIPTION
## Proposed Changes

Adds support for `dash` shell.
Adds tests for `flox activate` run with `zsh`, `bash`, and `dash`.

TODO: test `bash` v{3,4,5}.x explicitly.


## Current Behavior

Tests currently adopt whatever the running shell is, in CI this is often `bash`.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Adds support for `dash` shell.

The recommended invocation of `flox activate` and `flox print-dev-env` non-interactively has been changed in order to support shells such as `dash` and `zsh`.
The recommended way to activate environments from a script is now:
```shell
# For a "named environment":
eval "$( flox activate -e <NAME>; )";
# For the default environment:
eval "$( flox activate -e default; )";

# For a "project environment":
eval "$( flox print-dev-env '.#<NAME>'; )";
# For the default target:
eval "$( flox print-dev-env '.#default'; )";
```

<!-- Many thanks! -->
