### PR TITLE
fix: avoid gh writing to git config files on user's behalf

### DIFF
--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -490,7 +490,14 @@ function checkGhAuth {
 	while ! $_gh auth status -h $hostname >/dev/null 2>&1; do
 		initialGreeting
 		warn "Invoking 'gh auth login -h $hostname'"
-		$_gh auth login -h $hostname
+
+		# gh auth login will automatically add credential helpers to the users
+		# global git config.
+		# Since flox will set the git credential helper manually where its needed
+		# and we want to avoid writing user files, trick gh to modify a temporary,
+		# discarded file instead
+		stub_git_config_file="$(mkTempFile)"
+		GIT_CONFIG_GLOBAL="$stub_git_config_file" $_gh auth login -h $hostname
 		info ""
 	done
 }

--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -496,8 +496,7 @@ function checkGhAuth {
 		# Since flox will set the git credential helper manually where its needed
 		# and we want to avoid writing user files, trick gh to modify a temporary,
 		# discarded file instead
-		stub_git_config_file="$(mkTempFile)"
-		GIT_CONFIG_GLOBAL="$stub_git_config_file" $_gh auth login -h $hostname
+		GIT_CONFIG_GLOBAL="$(mkTempFile)" $_gh auth login -h $hostname
 		info ""
 	done
 }

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1389,7 +1389,13 @@ function ensureGHRepoExists() {
 	if ! checkGitRepoExists "$origin"; then
 		if [[ "${origin,,}" =~ github ]]; then
 			( $_gh auth status >/dev/null 2>&1 ) ||
-				$_gh auth login
+				# gh auth login will automatically add credential helpers to the users
+				# global git config.
+				# Since flox will set the git credential helper manually where its needed
+				# and we want to avoid writing user files, trick gh to modify a temporary,
+				# discarded file instead
+				stub_git_config_file="$(mkTempFile)"
+				GIT_CONFIG_GLOBAL="$stub_git_config_file" $_gh auth login
 			( $_gh repo view "$origin" >/dev/null 2>&1 ) || (
 				set -x
 				$_gh repo create \

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1394,8 +1394,7 @@ function ensureGHRepoExists() {
 				# Since flox will set the git credential helper manually where its needed
 				# and we want to avoid writing user files, trick gh to modify a temporary,
 				# discarded file instead
-				stub_git_config_file="$(mkTempFile)"
-				GIT_CONFIG_GLOBAL="$stub_git_config_file" $_gh auth login
+				GIT_CONFIG_GLOBAL="$(mkTempFile)" $_gh auth login
 			( $_gh repo view "$origin" >/dev/null 2>&1 ) || (
 				set -x
 				$_gh repo create \


### PR DESCRIPTION
## Proposed Changes

Call `gh auth login` with a stub `$GIT_CONFIG_GLOBAL` to avoid inadvertently writing user config files.

## Current Behavior

We do not want the use of flox to modify anything about the user's personal gitconfig, but we recently found that the mere act of invoking `gh auth login` mutate's the user's own global git config ($GIT_CONFIG_GLOBAL =? ~/.config/git/config or ~/.gitconfig):

```
$ cat ~/.config/git/config
[user]
	name = ""
	email = ""

$ gh auth login
...

$ cat ~/.config/git/config
[user]
	name = ""
	email = ""

[credential "https://github.com"]
	helper = 
	helper = !<path to gh> auth git-credential
[credential "https://gist.github.com"]
	helper = 
	helper = !<path to gh> auth git-credential
```

`gh` does not provide an option to disable this behaviour but obeys to `GIT_CONFIG_GLOBAL`

## Release Notes

Work around behaiour of an internal tool that would otherwise inadvertently modify the user's git config.
