### PR TITLE
ci: configure binary cache url as env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+env:
+  FLOX_SUBSTITUTER: "s3://flox-store"
+
 jobs:
 
   build:
@@ -30,7 +33,7 @@ jobs:
       uses: flox/install-flox-action@main
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
-        substituter: s3://flox-store
+        substituter: ${{ env.FLOX_SUBSTITUTER }}
         substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -39,9 +42,9 @@ jobs:
       run: flox nix build .#${{ matrix.package }} -L --print-out-paths
 
     - name: Cache
-      run: flox nix copy --to "$FLOX_SUBSTITUTER" '.#${{ matrix.package }}^*'
+      run: flox nix copy --to "${{ env.FLOX_SUBSTITUTER }}" '.#${{ matrix.package }}^*'
 
-    - name: Test 
+    - name: Test
       if: ${{ matrix.package == 'flox' }}
       run: |
         flox run flox-tests -- -- --flox $(realpath ./result/bin/flox)


### PR DESCRIPTION
The CI script currently runs 

```shell
flox nix copy --to "$FLOX_SUBSTITUTER" '.#${{ matrix.package }}^*'
```

but `FLOX_SUBSTITUTER` is never set anywhere.

This PR adds a new env variable `FLOX_SUBSTITUTER` and uses it for both the `install-flox-action` and populating the binary cache