### PR TITLE
style: sort generations numerically

### DIFF
--- a/flox-bash/lib/registry.jq
+++ b/flox-bash/lib/registry.jq
@@ -129,6 +129,7 @@ def listGenerations(args):
   (args | length) as $argc |
   if $argc == 0 then
     $registry | .generations | to_entries |
+      sort_by(.key|tonumber) |
       map(listGeneration) | flatten | .[]
   elif args[0] == "--json" then
     $registry | .generations


### PR DESCRIPTION
## Proposed Changes

Sorts generations numerically.


## Current Behavior

Generations are sort lexicographically so you get `[1, 11, 2]` not `[1, 2, 11]`.


## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

`flox generations` command now sorts results numerically.

<!-- Many thanks! -->
