### PR TITLE
feat: source floxEnv `etc/profile` upon activation

### DIFF
--- a/crates/flox/doc/flox-activate.md
+++ b/crates/flox/doc/flox-activate.md
@@ -53,6 +53,38 @@ or with a command and arguments to be invoked directly.
     will search these directories to locate files and resources from
     the environment.
 
+    **N.B.** the default shell hook for newly-created environments will
+    source the `$FLOX_ENV/etc/profile` file at activation if it exists.
+    This behavior can be viewed/modified with `flox edit`.
+
+## Language packs _(**experimental**)_
+
+Language packs help you develop with flox the way **you** work, making it
+possible to install and use compilers, interpreters, libraries and modules
+in much the way you would on any other operating system.
+
+Language packs are activated by way of `$FLOX_ENV/etc/profile` as described
+above, and the `flox.etc-profiles` package provides a version of this script
+along with "language packs" providing environment variables and hooks that
+support developing in a variety of languages.
+
+Install a bundle of all language packs with the command:
+
+```
+flox install flox.etc-profiles
+```
+
+To restrict the installation to individual language packs, invoke `flox edit`
+and update the installation stanza as follows:
+
+```
+packages.flox.etc-profiles = {
+  meta.outputsToInstall = [ "base" "common_paths" "python3" ];
+};
+```
+
+Please note that the `base` and `common_paths` language packs are required
+when installing individual language packs.
 
 # EXAMPLES:
 

--- a/flox-bash/lib/templateFloxEnv/pkgs/default/flox.nix
+++ b/flox-bash/lib/templateFloxEnv/pkgs/default/flox.nix
@@ -4,16 +4,31 @@
   # packages.nixpkgs-flox.figlet = {};
   # packages.nixpkgs-flox.bat = { version = "0.22.1"; };
 
+  # Activation Extensions
+  # Provides an extensible `<env>/etc/profile` script.
+  # packages.flox.etc-profiles = {
+  #   # All language packs are installed by default, but you can also
+  #   # select individual packs by uncommenting the line below.
+  #   # Invoke `flox search -c flox etc-profiles -l` to see
+  #   # a list of all supported language pack outputs.
+  #   # Please note that all/most language packs depend on including
+  #   # the "base" and "common_paths" output.
+  #   # meta.outputsToInstall = [ "base" "common_paths" "python3" ];
+  # };
+
   # Aliases available when environment is active
   # shell.aliases.cat = "bat";
 
   # Script run upon environment activation
   # Warning: Be careful when using `${}` in shell hook.
-  #          Due to conflicts with Nix language you have to escape it with '' (two single quotes)
+  #          Due to conflicts with Nix language you have to
+  #          first escape it with '' (two single quotes).
   #          Example: ` ''${ENV_VARIABLE} `
-  # shell.hook = ''
-  #   echo Flox Environment | figlet
-  # '';
+  shell.hook = ''
+    # Source `<env>/etc/profile` if it exists.
+    [ -r "$FLOX_ENV/etc/profile" ] && . "$FLOX_ENV/etc/profile";
+    # echo Flox Environment | figlet
+  '';
 
   # Environment variables
   # environmentVariables.LANG = "en_US.UTF-8";

--- a/flox-bash/lib/templateFloxEnv/pkgs/default/flox.nix
+++ b/flox-bash/lib/templateFloxEnv/pkgs/default/flox.nix
@@ -14,7 +14,7 @@
   #   # a list of all supported language pack outputs.
   #   # Please note that all/most language packs depend on including
   #   # the "base" and "common_paths" output.
-  #   # meta.outputsToInstall = [ "base" "common_paths" "python3" ];
+  #   meta.outputsToInstall = [ "base" "common_paths" "python3" ];
   # };
 
   # Aliases available when environment is active

--- a/flox-bash/lib/templateFloxEnv/pkgs/default/flox.nix
+++ b/flox-bash/lib/templateFloxEnv/pkgs/default/flox.nix
@@ -6,6 +6,7 @@
 
   # Activation Extensions
   # Provides an extensible `<env>/etc/profile` script.
+  # see 'man flox-activate' for more information on Language Packs.
   # packages.flox.etc-profiles = {
   #   # All language packs are installed by default, but you can also
   #   # select individual packs by uncommenting the line below.

--- a/flox-bash/lib/templateFloxEnv/pkgs/default/flox.nix
+++ b/flox-bash/lib/templateFloxEnv/pkgs/default/flox.nix
@@ -9,7 +9,7 @@
   # packages.flox.etc-profiles = {
   #   # All language packs are installed by default, but you can also
   #   # select individual packs by uncommenting the line below.
-  #   # Invoke `flox search -c flox etc-profiles -l` to see
+  #   # Invoke `flox search -l -c flox etc-profiles` to see
   #   # a list of all supported language pack outputs.
   #   # Please note that all/most language packs depend on including
   #   # the "base" and "common_paths" output.


### PR DESCRIPTION
This commit updates the default floxEnv template to enable logic to source the etc/profile file if it exists within the flox environment, and adds instructions for installing the "etc-profiles" package that provides the language-specific modules which drive the process of configuring the environment.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

Updated default flox environment template in support of new environment initialization features.