### PR TITLE
feat: pass nix flake args to environment subcommands

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1688082682,
-        "narHash": "sha256-nMG/A7qYm9pyHJowKuaNmNYgo748xZrzMJPqtoGozSA=",
+        "lastModified": 1688425221,
+        "narHash": "sha256-DhZnju72DuX9GhOnCOBIE94aCGKC2BOaF+kGxbnP/K0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "4d350bb94fdf8ec9d2e22d68bb13e136d73aa9d8",
+        "rev": "fc6a236548b31aef0be3b0a0377c4459bb39d923",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
         "tracelinks": "tracelinks"
       },
       "locked": {
-        "lastModified": 1688298889,
-        "narHash": "sha256-TTGBzJuvL1JE27tGa0B4+wjO6ORbWL/7pV+fI8cIxmk=",
+        "lastModified": 1688445262,
+        "narHash": "sha256-uX28KY48ZyTczzzvEWnw0eTJqveIYHMbfVZvfrRjQVc=",
         "owner": "flox",
         "repo": "floxpkgs",
-        "rev": "9275bb7fc8e8ba94ce3b87fce1325d0480c56489",
+        "rev": "9b6c0b0397d2e692a7d5f205780b8c244131e4cf",
         "type": "github"
       },
       "original": {
@@ -391,11 +391,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685714850,
-        "narHash": "sha256-OcvbIJq4CGwwFr9m7M/SQcDPZ64hhR4t77oZgEeh7ZY=",
+        "lastModified": 1688221086,
+        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6ffce3d5df7b4c588ce80a0c6e2d2348a611707",
+        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
         "type": "github"
       },
       "original": {
@@ -422,11 +422,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1687654967,
-        "narHash": "sha256-ki8vItcjn8Z8n+QD9NEoCQbbbG7VzWy71hyOkFFwCkM=",
+        "lastModified": 1688259758,
+        "narHash": "sha256-CYVbYQfIm3vwciCf6CCYE+WOOLE3vcfxfEfNHIfKUJQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "b3ec8fb525fc0c8f08eff5ef93c684b4c6d0e777",
+        "rev": "a92befce80a487380ea5e92ae515fe33cebd3ac6",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1687807295,
-        "narHash": "sha256-7TUD0p0m4mZpIi1O+Cyk5NCqpJUnhv/CJOAuHOndjao=",
+        "lastModified": 1688231357,
+        "narHash": "sha256-ZOn16X5jZ6X5ror58gOJAxPfFLAQhZJ6nOUeS4tfFwo=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "6b3d1b1cf13f407fef5e634b224d575eb7211975",
+        "rev": "645ff62e09d294a30de823cb568e9c6d68e92606",
         "type": "github"
       },
       "original": {
@@ -642,11 +642,11 @@
         "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux"
       },
       "locked": {
-        "lastModified": 1688239820,
-        "narHash": "sha256-3X8fV3sZ0DIMvhETxfj/HPJ0WIunetG5lxG2raMtiGw=",
+        "lastModified": 1688442813,
+        "narHash": "sha256-sLQ9/OOgS464JfXHDGn38LNnMqydN19ga3B/zXQGw7E=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "8b6482aa651fe76c40930c7f437fd169e3f28c9a",
+        "rev": "f04b9c97d95664812b3bc100e4d4882edd022ab6",
         "type": "github"
       },
       "original": {
@@ -673,11 +673,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1688239695,
-        "narHash": "sha256-kKXB/QMtr7jTFr/2iblsRv1c3eNKH9KBCGeC7b4HRSg=",
+        "lastModified": 1688442698,
+        "narHash": "sha256-XOQ5euPwDi4Z5sK1IH8Oukp/dftCAPxjfSp7/z2yYOc=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "19833e14f242aa4c61547438cf5ec1c342658f33",
+        "rev": "974acdaffbc02e7362ca09eb45e408353e4700f4",
         "type": "github"
       },
       "original": {
@@ -692,11 +692,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1688239659,
-        "narHash": "sha256-9pKiMHIlqNrg2TDxncajNz7tSuzR1XJuUmzTKSrZnHg=",
+        "lastModified": 1688414073,
+        "narHash": "sha256-PNERhrx0JpjijMScn9O1q+VZnyplbD72pi/47fuPUTI=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "a1679943134e4bb7f0c7a0fb20f32a2704b70be7",
+        "rev": "54cd1273a4da56e9d471e3bc2884983d1623e60e",
         "type": "github"
       },
       "original": {
@@ -711,11 +711,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1688117635,
-        "narHash": "sha256-bn88FPy8AP+Bb8fqSLUWyXfE6NLTN5x/4/W/FjcBQiU=",
+        "lastModified": 1688414430,
+        "narHash": "sha256-Uvd6ljDqNCkDPUStRVptnquGuKkQilM8NF7vPD8hnv8=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "5c9fa2f08bf0b85cd5e001dea40b68e4f828be39",
+        "rev": "0e79bbbd770ff7af93bc11fd498be2ab345e4f19",
         "type": "github"
       },
       "original": {
@@ -730,11 +730,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1688106402,
-        "narHash": "sha256-c26GAVwAaqP9ztS/ZvWdwae7y/yygeA7itEPpY5gEgQ=",
+        "lastModified": 1688414420,
+        "narHash": "sha256-gd7gHHG0cAtbc956rnfwVH6czsT1fDI29oEn4mk0J1o=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "eadd1bf564fa8ac21086c8f904917645718170f2",
+        "rev": "ff0e094fcaaafcc10178bb9f62ed113ff646e45c",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1688117604,
-        "narHash": "sha256-aAsNfsLI82riDgvqoZaP+JL3ig7GRAPszeN5fsIM7kQ=",
+        "lastModified": 1688414398,
+        "narHash": "sha256-1bmG2iTPf7T06AVNvJvwFfMbTdD4qJjlMfLC6zYkJmI=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "916ebaa98732e1bd1d5bdad9d6684a63858ceaff",
+        "rev": "fef6adcaefa98ecc8cfcb9ea0c0ee9a66c613922",
         "type": "github"
       },
       "original": {
@@ -784,11 +784,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685759304,
-        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "lastModified": 1688351637,
+        "narHash": "sha256-CLTufJ29VxNOIZ8UTg0lepsn3X03AmopmaLTTeHDCL4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "rev": "f9b92316727af9e6c7fee4a761242f7f46880329",
         "type": "github"
       },
       "original": {
@@ -857,11 +857,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1688137124,
-        "narHash": "sha256-ramG4s/+A5+t/QG2MplTNPP/lmBWDtbW6ilpwb9sKVo=",
+        "lastModified": 1688386108,
+        "narHash": "sha256-Vffto9QaVonzYAcPlAzd0soqWYpPpKk60dfNLSIXcFA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "522fd47af79b66cdd04b92618e65c7a11504650a",
+        "rev": "42587d3414d1747999a5f71e92a83cf6547b62da",
         "type": "github"
       },
       "original": {

--- a/flox-bash/lib/commands.sh
+++ b/flox-bash/lib/commands.sh
@@ -108,6 +108,43 @@ function parseNixArgs() {
 	done
 }
 
+# This function parses out common flake options used by the flox
+# builders as used by several of the environment builder and
+# development subcommands.
+declare -a _floxFlakeArgs
+function parseFloxFlakeArgs() {
+	_floxFlakeArgs=()
+	_cmdArgs=()
+	while test $# -gt 0; do
+		case "$1" in
+		# Options taking two args.
+		--arg|--argstr|--override-flake|--override-input)
+			_floxFlakeArgs+=("$1"); shift
+			_floxFlakeArgs+=("$1"); shift
+			_floxFlakeArgs+=("$1"); shift
+			;;
+		# Options taking one arg.
+		--priority|--eval-store|--include|-I|--inputs-from|--update-input|--expr|--file|-f)
+			_floxFlakeArgs+=("$1"); shift
+			_floxFlakeArgs+=("$1"); shift
+			;;
+		# Options taking zero args.
+		--debugger|--impure|--commit-lock-file|--no-registries|--no-update-lock-file|--no-write-lock-file|--recreate-lock-file|--derivation)
+			_floxFlakeArgs+=("$1"); shift
+			;;
+		# Consume remaining args
+		--command|-c|--)
+			_cmdArgs+=("$@")
+			break
+			;;
+		# All else are command args.
+		*)
+			_cmdArgs+=("$1"); shift
+			;;
+		esac
+	done
+}
+
 # Import command functions. N.B. the order of imports determines the
 # order that commands appear in the usage() statement.
 

--- a/flox-bash/lib/commands/development.sh
+++ b/flox-bash/lib/commands/development.sh
@@ -89,13 +89,13 @@ function floxBuild() {
 		# All remaining options are `nix build` args.
 
 		# Options taking two args.
-		-o|--profile|--override-flake|--override-input)
+		-o|--profile)
 			buildArgs+=("$1"); shift
 			buildArgs+=("$1"); shift
 			buildArgs+=("$1"); shift
 			;;
 		# Options taking one arg.
-		--out-link|--eval-store|--include|-I|--inputs-from|--update-input|--expr|--file|-f)
+		--out-link)
 			buildArgs+=("$1"); shift
 			buildArgs+=("$1"); shift
 			;;
@@ -262,13 +262,13 @@ function floxDevelop() {
 		# All remaining options are `nix build` args.
 
 		# Options taking two args.
-		--redirect|--arg|--argstr|--override-flake|--override-input)
+		--redirect)
 			developArgs+=("$1"); shift
 			developArgs+=("$1"); shift
 			developArgs+=("$1"); shift
 			;;
 		# Options taking one arg.
-		--keep|-k|--phase|--profile|--unset|-u|--eval-store|--include|-I|--inputs-from|--update-input|--expr|--file|-f)
+		--keep|-k|--phase|--profile|--unset|-u)
 			developArgs+=("$1"); shift
 			developArgs+=("$1"); shift
 			;;
@@ -432,17 +432,6 @@ function floxRun() {
 
 		# All remaining options are `nix run` args.
 
-		# Options taking two args.
-		--arg|--argstr|--override-flake|--override-input)
-			runArgs+=("$1"); shift
-			runArgs+=("$1"); shift
-			runArgs+=("$1"); shift
-			;;
-		# Options taking one arg.
-		--eval-store|--include|-I|--inputs-from|--update-input|--expr|--file|-f)
-			runArgs+=("$1"); shift
-			runArgs+=("$1"); shift
-			;;
 		# Options that consume remaining arguments
 		--)
 			remainingArgs+=("$@")
@@ -500,14 +489,8 @@ function floxShell() {
 
 		# All remaining options are `nix run` args.
 
-		# Options taking two args.
-		--arg|--argstr|--override-flake|--override-input)
-			shellArgs+=("$1"); shift
-			shellArgs+=("$1"); shift
-			shellArgs+=("$1"); shift
-			;;
 		# Options taking one arg.
-		--keep|-k|--unset|-u|--eval-store|--include|-I|--inputs-from|--update-input|--expr|--file|-f)
+		--keep|-k|--unset|-u)
 			shellArgs+=("$1"); shift
 			shellArgs+=("$1"); shift
 			;;

--- a/flox-bash/lib/commands/development.sh
+++ b/flox-bash/lib/commands/development.sh
@@ -6,6 +6,7 @@ _usage["init"]="initialize flox expressions for current project"
 function floxInit() {
 	trace "$@"
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	local template
 	local pname
@@ -73,6 +74,7 @@ _usage["build"]="build package from current project"
 function floxBuild() {
 	trace "$@"
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	local -a buildArgs=()
 	local -a installables=()
@@ -128,6 +130,7 @@ _usage["eval"]="evaluate a Nix expression"
 function floxEval() {
 	trace "$@"
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	local -a evalArgs=()
 	local -a installables=()
@@ -243,6 +246,7 @@ _usage["print-dev-env"]="print shell code that can be sourced by bash to reprodu
 function floxDevelop() {
 	trace "$@"
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	local -a developArgs=()
 	local -a installables=()
@@ -413,6 +417,7 @@ _usage["run"]="run app from current project"
 function floxRun() {
 	trace "$@"
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	local -a runArgs=()
 	local -a installables=()
@@ -480,6 +485,7 @@ _usage["shell"]="run a shell in which the current project is available"
 function floxShell() {
 	trace "$@"
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	local -a shellArgs=()
 	local -a installables=()

--- a/flox-bash/lib/commands/development.sh
+++ b/flox-bash/lib/commands/development.sh
@@ -53,11 +53,11 @@ function floxInit() {
 	# Extract flox _init template if it hasn't already.
 	[ -f flox.nix ] || {
 		# Start by extracting "_init" template to floxify project.
-		$invoke_nix flake init --template "flox#templates._init" "$@"
+		$invoke_nix flake init --template "flox#templates._init" "${_floxFlakeArgs[@]}" "$@"
 	}
 
 	# Extract requested template.
-	$invoke_nix "${_nixArgs[@]}" flake init --template "flox#templates.$template" "$@"
+	$invoke_nix "${_nixArgs[@]}" flake init --template "flox#templates.$template" "${_floxFlakeArgs[@]}" "$@"
 	if [ -f pkgs/default.nix ]; then
 		$invoke_mkdir -p "pkgs/$pname"
 		$invoke_git mv pkgs/default.nix "pkgs/$pname/default.nix"
@@ -76,7 +76,7 @@ function floxBuild() {
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
 	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
-	local -a buildArgs=()
+	local -a buildArgs=( "${_floxFlakeArgs[@]}" )
 	local -a installables=()
 	while test $# -gt 0; do
 		case "$1" in
@@ -132,7 +132,7 @@ function floxEval() {
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
 	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
-	local -a evalArgs=()
+	local -a evalArgs=( "${_floxFlakeArgs[@]}" )
 	local -a installables=()
 	while test $# -gt 0; do
 		case "$1" in
@@ -248,7 +248,7 @@ function floxDevelop() {
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
 	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
-	local -a developArgs=()
+	local -a developArgs=( "${_floxFlakeArgs[@]}" )
 	local -a installables=()
 	local -a remainingArgs=()
 	while test $# -gt 0; do
@@ -419,7 +419,7 @@ function floxRun() {
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
 	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
-	local -a runArgs=()
+	local -a runArgs=( "${_floxFlakeArgs[@]}" )
 	local -a installables=()
 	local -a remainingArgs=()
 	while test $# -gt 0; do
@@ -487,7 +487,7 @@ function floxShell() {
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
 	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
-	local -a shellArgs=()
+	local -a shellArgs=( "${_floxFlakeArgs[@]}" )
 	local -a installables=()
 	local -a remainingArgs=()
 	while test $# -gt 0; do

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -61,8 +61,6 @@ function floxList() {
 	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
-	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
-	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local -a invocation=("$@")
 
 	local -a listArgs=()

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -1131,8 +1131,6 @@ function floxExport() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
-	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
-	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 	# This is the easy one; just export all the generations. It's up to the
@@ -1147,8 +1145,6 @@ function floxHistory() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
-	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
-	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 
@@ -1191,8 +1187,6 @@ function floxGenerations() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
-	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
-	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	local -i displayJSON=0
 	while test $# -gt 0; do
@@ -1230,8 +1224,6 @@ function floxRollback() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
-	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
-	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local subcommand="$1"; shift
 	local -a invocation=("$@")
 
@@ -1309,8 +1301,6 @@ function floxDestroy() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
-	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
-	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 	local originArg=
@@ -1431,8 +1421,6 @@ function floxPushPull() {
 	local action="$1"; shift
 	local environment="$1"; shift
 	local system="$1"; shift
-	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
-	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 	local forceArg=

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -858,10 +858,13 @@ function floxEdit() {
 	local environment="$1"; shift
 	local system="$1"; shift
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
-	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
-	local -a invocation=("$@")
 
 	local inputFile
+
+	# Our -f|--file arg collides with the same argument as used
+	# by nix (build|eval|develop), so parse this out of $@ before
+	# calling parseFloxFlakeArgs.
+	local -a otherArgs=()
 	while [[ "$#" -gt 0 ]]; do
 		# 'flox edit' args.
 		case "$1" in
@@ -869,6 +872,17 @@ function floxEdit() {
 			shift
 			inputFile="$1"; shift
 			;;
+		*)
+			otherArgs+=("$1"); shift
+			;;
+		esac
+	done
+
+	parseFloxFlakeArgs "${otherArgs[@]}" && set -- "${_cmdArgs[@]}"
+	local -a invocation=("$@")
+
+	while [[ "$#" -gt 0 ]]; do
+		case "$1" in
 		# Any other options are unrecognised.
 		*)
 			usage | error "unknown option '$1'"

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -8,6 +8,8 @@ function floxListProject() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local displayOutPath="$1"; shift
 	local displayJSON="$1"; shift
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
@@ -55,9 +57,12 @@ function floxList() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local -a invocation=("$@")
 
 	local -a listArgs=()
@@ -186,7 +191,7 @@ function floxList() {
 		# Otherwise Nix eval won't be able to find any of the files.
 		$_git -C $workDir add $nextGen
 
-		if $invoke_nix eval "$workDir/$nextGen#floxEnvs.$environmentSystem.default.catalog" --impure --json > $newCatalogJSON; then
+		if $invoke_nix "${_nixArgs[@]}" eval "$workDir/$nextGen#floxEnvs.$environmentSystem.default.catalog" --impure --json "${_floxFlakeArgs[@]}" > $newCatalogJSON; then
 			$invoke_jq -n -f $_lib/diff-catalogs.jq \
 				--slurpfile c1 $oldCatalogJSON --slurpfile c2 $newCatalogJSON > $upgradeDiffs
 		else
@@ -229,6 +234,8 @@ function floxCreate() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local -a invocation=("$@")
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
@@ -266,7 +273,7 @@ deleted if you build \`flox' from source and/or run the test suite.";
 	$_git -C $workDir add $nextGen
 
 	local envPackage
-	if ! envPackage=$($invoke_nix build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default"); then
+	if ! envPackage=$($invoke_nix "${_nixArgs[@]}" build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default" "${_floxFlakeArgs[@]}"); then
 		error "failed to create environment: ${invocation[*]}" < /dev/null
 	fi
 
@@ -292,9 +299,9 @@ function floxInstall() {
 	local environment="$1"; shift
 	local system="$1"; shift
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local -a invocation=("$@")
 
-	local -a installArgs=()
 	local -a installables=()
 	while test $# -gt 0; do
 		# 'flox install' args.
@@ -303,24 +310,6 @@ function floxInstall() {
 			# legacy nix-build option; convert to flakeref
 			shift
 			installables+=(".#$1"); shift
-			;;
-
-		# All remaining options are 'nix profile install' args.
-
-		# Options taking two args.
-		--arg|--argstr|--override-flake|--override-input)
-			installArgs+=("$1"); shift
-			installArgs+=("$1"); shift
-			installArgs+=("$1"); shift
-			;;
-		# Options taking one arg.
-		--priority|--eval-store|--include|-I|--inputs-from|--update-input|--expr|--file|-f)
-			installArgs+=("$1"); shift
-			installArgs+=("$1"); shift
-			;;
-		# Options taking zero args.
-		--debugger|--impure|--commit-lock-file|--no-registries|--no-update-lock-file|--no-write-lock-file|--recreate-lock-file|--derivation)
-			installArgs+=("$1"); shift
 			;;
 		# Any other options are unrecognised.
 		-*)
@@ -387,14 +376,14 @@ function floxInstall() {
 		# do that is to just install them to an ephemeral profile.
 		local environmentWorkDir
 		environmentWorkDir=$(mkTempDir)
-		if ! $invoke_nix profile install --profile "$environmentWorkDir/x" --impure "${pkgArgs[@]}"; then
+		if ! $invoke_nix "${_nixArgs[@]}" profile install --profile "$environmentWorkDir/x" --impure "${pkgArgs[@]}" "${_floxFlakeArgs[@]}"; then
 			# If that failed then repeat the build of each pkgArg individually
 			# to report which one(s) failed.
 			local -a failedPkgArgs=()
 			local _stderr
 			_stderr=$(mkTempFile)
 			for pkgArg in ${pkgArgs[@]}; do
-				if ! $invoke_nix build --no-link --impure "$pkgArg" >$_stderr 2>&1; then
+				if ! $invoke_nix "${_nixArgs[@]}" build --no-link --impure "$pkgArg" "${_floxFlakeArgs[@]}" >$_stderr 2>&1; then
 					failedPkgArgs+=("$pkgArg")
 					local pkgName
 					case "$pkgArg" in
@@ -439,7 +428,7 @@ function floxInstall() {
 		else
 			# Invoke 'nix profile build' to turn the manifest into a package.
 			# Derive the environment package from the newly-rendered link.
-			envPackage=$($invoke_nix profile build $workDir/$nextGen/manifest.json)
+			envPackage=$($invoke_nix "${_nixArgs[@]}" profile build $workDir/$nextGen/manifest.json "${_floxFlakeArgs[@]}")
 		fi
 
 		# Generate declarative manifest.
@@ -482,7 +471,7 @@ EOF
 		$_git -C $workDir add $nextGen/pkgs/default/flox.nix
 
 		local envPackage
-		if ! envPackage=$($invoke_nix build --impure --no-link --print-out-paths -L "$workDir/$nextGen#.floxEnvs.$system.default"); then
+		if ! envPackage=$($invoke_nix "${_nixArgs[@]}" build --impure --no-link --print-out-paths -L "$workDir/$nextGen#.floxEnvs.$system.default" "${_floxFlakeArgs[@]}"); then
 			error "failed to install packages: ${pkgArgs[@]}" < /dev/null
 		fi
 
@@ -522,6 +511,8 @@ function floxRemove() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local -a invocation=("$@")
 
 	local -a removeArgs=()
@@ -603,7 +594,7 @@ function floxRemove() {
 	case $currentGenVersion in
 	1)
 		# Render a new environment with 'nix profile remove'.
-		$invoke_nix profile remove --profile $environmentWorkDir/x "${pkgPositionArgs[@]}"
+		$invoke_nix "${_nixArgs[@]}" profile remove --profile $environmentWorkDir/x "${pkgPositionArgs[@]}" "${_floxFlakeArgs[@]}"
 		envPackage=$($_realpath $environmentWorkDir/x/.)
 
 		# That went well, update metadata accordingly.
@@ -646,7 +637,7 @@ EOF
 		$_git -C $workDir add $nextGen/pkgs/default/flox.nix
 
 		local envPackage
-		if ! envPackage=$($invoke_nix build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default"); then
+		if ! envPackage=$($invoke_nix "${_nixArgs[@]}" build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default" "${_floxFlakeArgs[@]}"); then
 			error "failed to remove ${pkgNames[@]}" </dev/null
 		fi
 
@@ -685,6 +676,8 @@ function floxUpgrade() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local -a invocation=("$@")
 
 	local -a upgradeArgs=()
@@ -769,9 +762,9 @@ function floxUpgrade() {
 
 		# Render a new environment with 'nix profile upgrade'.
 		if [ ${#pkgArgs[@]} -gt 0 ]; then
-			$invoke_nix profile upgrade --impure --profile $environmentWorkDir/x "${pkgArgs[@]}"
+			$invoke_nix "${_nixArgs[@]}" profile upgrade --impure --profile $environmentWorkDir/x "${pkgArgs[@]}" "${_floxFlakeArgs[@]}"
 		else
-			$invoke_nix profile upgrade --impure --profile $environmentWorkDir/x '.*'
+			$invoke_nix "${_nixArgs[@]}" profile upgrade --impure --profile $environmentWorkDir/x '.*' "${_floxFlakeArgs[@]}"
 		fi
 		envPackage=$($_realpath $environmentWorkDir/x/.)
 
@@ -825,7 +818,7 @@ EOF
 		fi
 
 		local envPackage
-		if ! envPackage=$($invoke_nix build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default"); then
+		if ! envPackage=$($invoke_nix "${_nixArgs[@]}" build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default" "${_floxFlakeArgs[@]}"); then
 			# TODO: be more specific?
 			error "failed to upgrade packages" < /dev/null
 		fi
@@ -864,6 +857,8 @@ function floxEdit() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local -a invocation=("$@")
 
 	local inputFile
@@ -984,7 +979,7 @@ EOF
 			)
 
 			# TODO: return early if no changes have been made instead of rebuilding?
-			if envPackage=$($invoke_nix build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default"); then
+			if envPackage=$($invoke_nix "${_nixArgs[@]}" build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default" "${_floxFlakeArgs[@]}"); then
 				: confirmed valid config
 				break
 			else
@@ -1039,6 +1034,8 @@ function floxImport() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local -a invocation=("$@")
 
 	# Create shared clone for importing new generation.
@@ -1083,7 +1080,7 @@ function floxImport() {
 		[ -n "$envPackage" ] || error "failed to render new environment" </dev/null
 		;;
 	2)
-		envPackage=$($invoke_nix build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default")
+		envPackage=$($invoke_nix "${_nixArgs[@]}" build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default" "${_floxFlakeArgs[@]}")
 		;;
 	*)
 		error "unknown version: $currentGenVersion" </dev/null
@@ -1120,6 +1117,8 @@ function floxExport() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 	# This is the easy one; just export all the generations. It's up to the
@@ -1134,6 +1133,8 @@ function floxHistory() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 
@@ -1176,6 +1177,8 @@ function floxGenerations() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	local -i displayJSON=0
 	while test $# -gt 0; do
@@ -1213,6 +1216,8 @@ function floxRollback() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	local subcommand="$1"; shift
 	local -a invocation=("$@")
 
@@ -1290,6 +1295,8 @@ function floxDestroy() {
 	trace "$@"
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 	local originArg=
@@ -1410,6 +1417,8 @@ function floxPushPull() {
 	local action="$1"; shift
 	local environment="$1"; shift
 	local system="$1"; shift
+	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 	# set $branchName,$floxNixDir,$environment{Name,Alias,Owner,System,BaseDir,BinDir,ParentDir,MetaDir}
 	eval $(decodeEnvironment "$environment")
 	local forceArg=


### PR DESCRIPTION
## Proposed Changes

Enable parsing and passing of nix flake related options to flox environment-related commands. In particular this facilitates the testing of flox-floxpkgs library changes with:

$ flox install foo --override-input flox-floxpkgs ~/wherever

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

flox subcommands updated to accept flake-related options for the building of flox environment packages.