### PR TITLE
fix(flox-bash): make  `selectAttrPath` more resilient

### DIFF
--- a/flox-bash/flox.sh
+++ b/flox-bash/flox.sh
@@ -14,6 +14,7 @@ declare -i debug=0
 # Declare global variables
 declare -i educatePublish=0
 declare -i interactive=0
+declare -i spawnMode=0
 
 # set -x if debugging, can never remember which way this goes so do both.
 # Note need to do this here in addition to "-d" flag to be able to debug

--- a/flox-bash/lib/bootstrap.sh
+++ b/flox-bash/lib/bootstrap.sh
@@ -25,8 +25,13 @@ function bootstrap() {
 	floxUserMetaRegistry get floxClientUUID >/dev/null || \
 		floxUserMetaRegistry set floxClientUUID $($_uuid)
 	floxClientUUID=$(floxUserMetaRegistry get floxClientUUID)
+	if [ -t 1 ]; then
+		# Spawn mode indicates that flox activate should launch subshell instead
+		# of emitting statements (to stdout) to be sourced by current shell.
+		spawnMode=1
+	fi
 	if [ -t 0 -a -t 2 ]; then
-		# Interactive mode
+		# Interactive mode indicates the ability to prompt users for input.
 		interactive=1
 
 		# Note whether user has seen various educational/informational messages.

--- a/flox-bash/lib/bootstrap.sh
+++ b/flox-bash/lib/bootstrap.sh
@@ -25,7 +25,7 @@ function bootstrap() {
 	floxUserMetaRegistry get floxClientUUID >/dev/null || \
 		floxUserMetaRegistry set floxClientUUID $($_uuid)
 	floxClientUUID=$(floxUserMetaRegistry get floxClientUUID)
-	if [ -t 1 ]; then
+	if [ -t 0 -a -t 2 ]; then
 		# Interactive mode
 		interactive=1
 

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -193,10 +193,11 @@ function floxActivate() {
 	local rcShell
 	if [ "${#cmdArgs[@]}" -gt 0 ]; then
 		rcShell="$_bash" # i.e. language of this script
-	elif [ -t 1 ]; then
+	elif [ "$spawnMode" -eq 1 ]; then
+		# "Spawn" mode. Configure environment using bash then exec $rcShell.
 		rcShell="$SHELL" # i.e. the shell we will be invoking
 	else
-		# Non-interactive. In this case it's really important to emit commands
+		# "Source" mode. In this case it's really important to emit commands
 		# using the correct syntax, so start by doing everything possible to
 		# accurately identify the currently-running (parent) shell.
 		rcShell="$(identifyParentShell)";
@@ -251,7 +252,7 @@ function floxActivate() {
 	# https://discourse.floxdev.com/t/losing-part-of-my-shell-environment-when-using-flox-develop/556/2
 	if [[ -x /usr/libexec/path_helper ]] && [[ "$PATH" =~ ^/usr/local/bin: ]]
 	then
-		if [[ "${#cmdArgs[@]}" -eq 0 ]] && ! [[ -t 1 ]]; then
+		if [[ "${#cmdArgs[@]}" -eq 0 ]] && [[ "$spawnMode" -eq 0 ]]; then
 			case "$rcShell" in
 			*bash|*zsh)
 				PATH="$(echo "$PATH" | $_awk -v shellDialect=bash -f "$_libexec/flox/darwin-path-fixer.awk")"
@@ -346,8 +347,8 @@ function floxActivate() {
 	[ "$($_uname -s)" != "Darwin" ] || darwinRepairFiles
 
 	# Activate.
-	if [ -t 1 ]; then
-		# Interactive case - launch subshell.
+	if [ "$spawnMode" -eq 1 ]; then
+		# Spawn mode - launch subshell.
 		case "$rcShell" in
 		*bash|*dash)
 			export FLOX_BASH_INIT_SCRIPT="$rcScript"
@@ -382,7 +383,7 @@ function floxActivate() {
 			;;
 		esac
 	else
-		# Non-interactive case - print out commands to be sourced.
+		# Source mode - print out commands to be sourced.
 		local _flox_activate_verbose=/dev/null
 		[ "$verbose" -eq 0 ] || _flox_activate_verbose=/dev/stderr
 		case "$rcShell" in

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -193,7 +193,7 @@ function floxActivate() {
 	local rcShell
 	if [ "${#cmdArgs[@]}" -gt 0 ]; then
 		rcShell="$_bash" # i.e. language of this script
-	elif [ "$interactive" -eq 1 ]; then
+	elif [ -t 1 ]; then
 		rcShell="$SHELL" # i.e. the shell we will be invoking
 	else
 		# Non-interactive. In this case it's really important to emit commands
@@ -251,7 +251,7 @@ function floxActivate() {
 	# https://discourse.floxdev.com/t/losing-part-of-my-shell-environment-when-using-flox-develop/556/2
 	if [[ -x /usr/libexec/path_helper ]] && [[ "$PATH" =~ ^/usr/local/bin: ]]
 	then
-		if [[ "${#cmdArgs[@]}" -eq 0 ]] && [[ "$interactive" -eq 0 ]]; then
+		if [[ "${#cmdArgs[@]}" -eq 0 ]] && ! [[ -t 1 ]]; then
 			case "$rcShell" in
 			*bash|*zsh)
 				PATH="$(echo "$PATH" | $_awk -v shellDialect=bash -f "$_libexec/flox/darwin-path-fixer.awk")"
@@ -346,7 +346,7 @@ function floxActivate() {
 	[ "$($_uname -s)" != "Darwin" ] || darwinRepairFiles
 
 	# Activate.
-	if [ "$interactive" -eq 1 ]; then
+	if [ -t 1 ]; then
 		# Interactive case - launch subshell.
 		case "$rcShell" in
 		*bash|*dash)

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1361,8 +1361,10 @@ function selectAttrPath() {
 			error "Can't select package for 'flox $subcommand' in non-interactive mode." </dev/null
 		fi
 
-		warn "Select package for flox $subcommand"
-		attrPath=$($_gum choose ${attrPaths[*]})
+		warn "Select package for 'flox $subcommand'"
+
+		# don't continue if prompting failed (e.g. interrupted)
+		attrPath=$($_gum choose ${attrPaths[*]}) ||	error "Selection failed" </dev/null
 
 		local hintCommandArgs
 		case "$subcommand" in

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1356,6 +1356,11 @@ function selectAttrPath() {
 	elif [ ${#attrPaths[@]} -eq 1 ]; then
 		echo "${attrPaths[0]}"
 	else
+		# don't attempt to prompt if not interactive
+		if [ ! -t 0 ] || [ ! -t 2 ]; then
+			error "Can't select package for 'flox $subcommand' in non-interactive mode." </dev/null
+		fi
+
 		warn "Select package for flox $subcommand"
 		attrPath=$($_gum choose ${attrPaths[*]})
 

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1357,9 +1357,8 @@ function selectAttrPath() {
 		echo "${attrPaths[0]}"
 	else
 		# don't attempt to prompt if not interactive
-		if [ ! -t 0 ] || [ ! -t 2 ]; then
+		[ $interactive -eq 1 ] || \
 			error "Can't select package for 'flox $subcommand' in non-interactive mode." </dev/null
-		fi
 
 		warn "Select package for 'flox $subcommand'"
 


### PR DESCRIPTION
## Proposed Changes

* exit if selection required without tty

Let `selectAttrPath` raise an error if more than one option exist but we can't prompt users.
 
* exit if choosing a package 

Fail `selectAttrPath` if `gum choose` command failed.

This can be either due to an error in gum or (more importantly) an explicit interrupt by the user.


This change was originally motivated by providing better errors for `flox activate`, but since `selectAttrPath` is used by several commands all of them will benefit from it.