### PR TITLE
fix: (temporarily) patch `flox publish`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /result*
 .env
 .pre-commit-config.yaml
+/.flox

--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -466,18 +466,18 @@ function floxPublish() {
 		error "eval of $analyzer#analysis.eval.packages.$publishSystem.$packageAttrPath failed - see above" < /dev/null
 	}
 	local evalOutputs
-	evalOutputs="$($_jq -r '.eval.outputs | map(values)[]' <<< "$evalAndBuild")"
+	evalOutputs=$($_jq -r '.eval.outputs | map(values)[]' <<< "$evalAndBuild")
 	# Filter eval outputs to return only the ones that exist.
 	local outpaths
-	outpaths="$(for i in "$evalOutputs"; do [ -e "$i" ] && echo $i; done)"
+	outpaths="$(for i in $evalOutputs; do [ -e "$i" ] && echo $i; done)"
 
 	# TODO Make content addressable (remove "false" below).
 	local ca_out
-	if false ca_out="$($invoke_nix "${_nixArgs[@]}" store make-content-addressed $outpaths --json | $_jq '.rewrites[]')"; then
-		# Replace package outpaths with CA versions.
-		warn "Replacing with content-addressable package: $ca_out"
-		outpaths="$ca_out"
-	fi
+#	if false ca_out="$($invoke_nix "${_nixArgs[@]}" store make-content-addressed $outpaths --json | $_jq '.rewrites[]')"; then
+#		# Replace package outpaths with CA versions.
+#		warn "Replacing with content-addressable package: $ca_out"
+#		outpaths="$ca_out"
+#	fi
 
 	# Sign the package outpaths (optional). Sign by default?
 	if [ -z "$keyFile" -a -f "$FLOX_CONFIG_HOME/secret-key" ]; then
@@ -485,7 +485,7 @@ function floxPublish() {
 	fi
 	if [ -n "$keyFile" ]; then
 		if [ -f "$keyFile" ]; then
-			$invoke_nix "${_nixArgs[@]}" store sign -r --key-file "$keyFile" "$outpaths"
+			$invoke_nix "${_nixArgs[@]}" store sign -r --key-file "$keyFile" $outpaths
 		else
 			error "could not read $keyFile: $!" < /dev/null
 		fi

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1381,7 +1381,8 @@ function selectAttrPath() {
 
 function checkGitRepoExists() {
 	trace "$@"
-	local origin="$1"
+	# Remove any rev/ref tags before attempting to verify repo exists.
+	local origin="${1/\?*/}"
 	githubHelperGit ls-remote "$origin" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR optimizes the `flox publish` flow to address a few specific high-value use cases. Most of the publish logic is due to be overhauled in the near term, so this should be viewed as a short-term repair while we wait for the ultimate fix.

## Current Behavior

`flox publish` currently prompts to reconfirm all parameters on every invocation unless they are explicitly provided as command-line options. This PR updates the flow to be more streamlined, prompting only when a default value is not available by way of the `.flox/metadata.json` project state file.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

Updated `flox publish` to optimize the workflow when repeatedly publishing the same package.