### PR TITLE
fix: publish non-interactively

### DIFF
--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -471,9 +471,9 @@ function floxPublish() {
 	mapfile -t outpaths < <(
 		floxBuild "${_nixArgs[@]}" --no-link --print-out-paths  \
 		          "$canonicalFlakeURL^"'*' "${buildArgs[@]}"
-    )
+    ) || error "could not build $canonicalFlakeURL" < /dev/null
 	if [[ "${#outpaths[@]}" -le 0 ]]; then
-		error "could not build $canonicalFlakeURL" < /dev/null
+		error "no outputs created from build of $canonicalFlakeURL" < /dev/null
 	fi
 
 	# TODO Make content addressable (uncomment "XXX" lines below).

--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -79,10 +79,11 @@ _usage_options["publish"]="[--build-repo <URL>] [--channel-repo <URL>] \\
 function floxPublish() {
 	trace "$@"
 	parseNixArgs "$@" && set -- "${_cmdArgs[@]}"
+	parseFloxFlakeArgs "$@" && set -- "${_cmdArgs[@]}"
 
 	# Publish takes the same args as build, plus a few more.
 	# Split out the publish args from the build args.
-	local -a buildArgs=()
+	local -a buildArgs=( "${_floxFlakeArgs[@]}" )
 	local -a installables
 	local packageAttrPath
 	local packageFlakeRef
@@ -149,13 +150,8 @@ function floxPublish() {
 		# All remaining options are `nix build` args.
 
 		# Options taking two args.
-		--out-link|-o|--profile|--override-flake|--override-input)
+		--out-link|-o|--profile)
 			buildArgs+=("$1"); shift
-			buildArgs+=("$1"); shift
-			buildArgs+=("$1"); shift
-			;;
-		# Options taking one arg.
-		--eval-store|--include|-I|--inputs-from|--update-input|--expr|--file|-f)
 			buildArgs+=("$1"); shift
 			buildArgs+=("$1"); shift
 			;;

--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -386,7 +386,7 @@ function floxPublish() {
 	# Prompt for location(s) TO and FROM which we can (optionally) copy the
 	# built package store path(s). By default these will refer to the same
 	# URL, but can be overridden with --download-from.
-	if [[ -z "${uploadTo+1}" ]]; then
+	if [[ -z "${uploadTo}" ]]; then
 		doEducatePublish
 		# Load previous answer (if applicable).
 		uploadTo="$(registry "$gitCloneRegistry" 1 get uploadTo || :)"
@@ -402,7 +402,7 @@ function floxPublish() {
 	: "${uploadTo:=}"
 	[[ -z "${uploadTo:-}" ]] || warn "upload to: $uploadTo"
 
-	if [[ -z "${downloadFrom+1}" ]]; then
+	if [[ -z "${downloadFrom}" ]]; then
 		# Load previous answer (if applicable).
 		downloadFrom="$(registry "$gitCloneRegistry" 1 get downloadFrom || :)"
 		if [[ -z "$downloadFrom" ]] && [[ "${interactive:-0}" -eq 1 ]]; then

--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -423,7 +423,7 @@ function floxPublish() {
 	# Construct string encapsulating entire command invocation.
 	local entirePublishCommand
 	entirePublishCommand="flox publish -A '$packageAttrPath'"
-    entirePublishCommand+=" --build-repo '$buildRepository'"
+	entirePublishCommand+=" --build-repo '$buildRepository'"
 	entirePublishCommand+=" --channel-repo '$channelRepository'"
 
 	if [[ -n "$uploadTo" ]]; then

--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -470,12 +470,14 @@ function floxPublish() {
 	declare -a outpaths
 	mapfile -t outpaths < <(
 		floxBuild "${_nixArgs[@]}" --no-link --print-out-paths  \
-		          "$canonicalFlakeURL" "${buildArgs[@]}"
+		          "$canonicalFlakeURL^"'*' "${buildArgs[@]}"
     )
 	if [[ "${#outpaths[@]}" -le 0 ]]; then
 		error "could not build $canonicalFlakeURL" < /dev/null
 	fi
 
+	# TODO Make content addressable (uncomment "XXX" lines below).
+	if false; then # XXX
 	declare -a ca_out
 	mapfile -t ca_out < <(
 		$invoke_nix "${_nixArgs[@]}" store make-content-addressed             \
@@ -486,6 +488,7 @@ function floxPublish() {
 		warn "Replacing with content-addressable package: $ca_out"
 		outpaths=( "${ca_out[@]}" )
 	fi
+	fi # /XXX
 
 	# Sign the package outpaths (optional). Sign by default?
 	if [[ -z "${keyFile:-}" ]] && [[ -f "$FLOX_CONFIG_HOME/secret-key" ]]; then

--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -223,6 +223,8 @@ function floxPublish() {
 		cloneRemote="$($_git remote get-url ${upstreamRemote:-origin})"
 		cloneBranch="$($_git rev-parse --abbrev-ref --symbolic-full-name @)"
 		cloneRev="$($_git rev-parse @)"
+		# Create the project registry before proceeding.
+		initProjectRegistry
 	fi
 
 	# The --build-repo argument specifies the repository of the flake used
@@ -235,8 +237,6 @@ function floxPublish() {
 			# Derive the default flakeRef from the current git clone.
 			if [ "$packageFlakeRef" = "." ]; then
 				buildRepository="$cloneRemote"
-				# Create the project registry before proceeding.
-				initProjectRegistry
 			else
 				buildRepository="$packageFlakeRef"
 			fi

--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -242,16 +242,15 @@ function floxPublish() {
 			fi
 		fi
 		while true; do
+			if checkGitRepoExists "$buildRepository"; then
+				[ -z "$buildRepository" ] || break
+			fi
+			warn "repository '$buildRepository' does not exist"
+			warn "please enter a valid URL from which to 'flox build' a package"
 			buildRepository=$(promptInput \
 				"Enter git URL (required)" \
 				"build repository:" \
 				"$buildRepository")
-			if checkGitRepoExists "$buildRepository"; then
-				[ -z "$buildRepository" ] || break
-			else
-				warn "repository '$buildRepository' does not exist"
-			fi
-			warn "please enter a valid URL from which to 'flox build' a package"
 		done
 	fi
 	warn "build repository: $buildRepository"

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1381,7 +1381,7 @@ function selectAttrPath() {
 
 function checkGitRepoExists() {
 	trace "$@"
-	local origin="$1"
+	local origin="${1/\?*/}"
 	githubHelperGit ls-remote "$origin" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
## Proposed Changes

Minimal changes were made since I anticipate a lot of work in the near future surrounding publish; but this at least enables non-interactive usage of `flox publish` which is a necessary prerequisite for automated testing.

This change causes `flox publish` to throw an error rather than hang waiting for an interactive prompt in cases where mandatory arguments were omitted, or there is a dirty git tree.

Additionally it is possible to omit certain arguments by passing the empty string; specifically `--upload-to` and `--download-from`.

Minor fixes to fallback variable expansion and the use of `mapfile` instead of `array=( $(...) )` were also made.


## Current Behavior

Currently prompts prevent the user from publishing without certain optional args.
Additionally if there is a dirty git repo prompts will be launched without trying to detect interactive mode.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

Since we lack tests cases for publishing ( we don't currently have a good harness that enables this ), the following invocation shows that it is possible to publish with no prompts.

```console
$ "$HOME/src/flox/result/bin/flox" publish  \
  --attr "packages.x86_64-linux.gym"  \
  --publish-system x86_64-linux  \
  --channel-repo 'git@github.com:flox-examples/floxpkgs-python.git'  \
  --build-repo 'git@github.com:flox/py-roberto.git'  \
  --upload-to ''  \
  --download-from '';
build repository: git@github.com:flox/py-roberto.git
package name: gym
channel repository: git@github.com:flox-examples/floxpkgs-python.git
Cloning git@github.com:flox-examples/floxpkgs-python.git ...
Cloning into '/tmp/nix-shell.dGryc7/nix-shell.spWZvw/tmp.9SQU3NYG1c'...
remote: Enumerating objects: 139, done.
remote: Counting objects: 100% (139/139), done.
remote: Compressing objects: 100% (82/82), done.
remote: Total 139 (delta 53), reused 99 (delta 16), pack-reused 0
Receiving objects: 100% (139/139), 17.42 KiB | 8.71 MiB/s, done.
Resolving deltas: 100% (53/53), done.
Building gym ...
warning: not writing modified lock file of flake 'git+ssh://git@github.com/flox/py-roberto.git?rev=0676b3ac47deb96e7a7230ed5ec3501cfbbb936b':
• Updated input 'flox-floxpkgs/nixpkgs/nixpkgs':
    follows 'flox-floxpkgs/nixpkgs/nixpkgs-stable'
  → 'github:flox/nixpkgs/7084250df3d7f9735087d3234407f3c1fc2400e3' (2023-05-22)
Replacing with content-addressable package: "/nix/store/qaqhb3a4w21y0afdj680xxl655xs17cb-python3.10-gym-0.26.2"
publishing render to catalog ...
flox publish completed
[main e1b1cba] published x86_64-linux/stable/gym/0.26.2.json
 1 file changed, 117 insertions(+)
 create mode 100644 catalog/x86_64-linux/stable/gym/0.26.2.json
Current branch main is up to date.
Enumerating objects: 10, done.
Counting objects: 100% (10/10), done.
Delta compression using up to 16 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (7/7), 1.54 KiB | 1.54 MiB/s, done.
Total 7 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:flox-examples/floxpkgs-python.git
   01dab5c..e1b1cba  main -> main
```


## Release Notes

It is now possible to use `flox publish` non-interactively by passing `--upload-to '' --download-from ''` ( empty strings ).

<!-- Many thanks! -->
