### PR TITLE
ci: cache cargo deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,14 @@ jobs:
     - name: Build
       run: flox nix build .#${{ matrix.package }} -L --print-out-paths
 
-    - name: Cache
+    - name: Cache Runtime
       run: flox nix copy --to "$FLOX_SUBSTITUTER" '.#${{ matrix.package }}^*'
 
-    - name: Test 
+    - name: Cache build deps
+      if: matrix.package == 'flox'
+      run: flox nix copy --to "$FLOX_SUBSTITUTER" '.#flox.cargoDeps'
+
+    - name: Test
       if: ${{ matrix.package == 'flox' }}
       run: |
         flox run flox-tests -- -- --flox $(realpath ./result/bin/flox)

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -98,7 +98,7 @@
   cargoDepsArtifacts = craneLib.buildDepsOnly {
     pname = cargoToml.package.name;
     version = cargoToml.package.version;
-    src = flox-src;
+    src = craneLib.cleanCargoSource (craneLib.path flox-src);
 
     # runtime dependencies of the dependent crates
     buildInputs =


### PR DESCRIPTION
Explicitly copy compiled cargo deps to binary cache - a second try at speeding up CI
