### PR TITLE
test: avoid non-determinism in develop tests

### DIFF
--- a/tests/develop.bats
+++ b/tests/develop.bats
@@ -63,6 +63,10 @@ loadHarness() {
     |tar -C "$FLOX_TEST_HOME" -xf -;
   cd "$FLOX_TEST_HOME/$1"||return;
   export HARNESS="$1";
+  # Prefetch all inputs to avoid non-determinism in `expect' timeouts later.
+  $FLOX_CLI nix flake archive;
+  # Pre-evaluate targets to avoid non-determinism in `expect' timeouts later.
+  $FLOX_CLI nix flake show >/dev/null 2>&1;
 }
 
 

--- a/tests/develop.bats
+++ b/tests/develop.bats
@@ -63,8 +63,6 @@ loadHarness() {
     |tar -C "$FLOX_TEST_HOME" -xf -;
   cd "$FLOX_TEST_HOME/$1"||return;
   export HARNESS="$1";
-  # Prefetch all inputs to avoid non-determinism in `expect' timeouts later.
-  $FLOX_CLI nix flake archive;
   # Pre-evaluate targets to avoid non-determinism in `expect' timeouts later.
   $FLOX_CLI nix flake show >/dev/null 2>&1;
 }

--- a/tests/develop/devShell.exp
+++ b/tests/develop/devShell.exp
@@ -1,8 +1,10 @@
 set attr [lindex $argv 0]
 set flox $env(FLOX_CLI)
 if {$attr eq ""} {
+    set cmd "$flox -v develop"
     spawn $flox -v develop
 } else {
+    set cmd "$flox -v develop $attr"
     spawn $flox -v develop $attr
 }
 set timeout 30
@@ -12,21 +14,43 @@ expect {
         set timeout 90
         expect {
             "developing package" {}
-            timeout { exit 1 }
+            timeout {
+              puts stderr "Reached timeout running '$cmd'"
+              exit 1
+            }
         }
         set timeout 30
     }
     "developing package" {}
-    timeout { exit 1 }
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
 }
 expect {
-    -re "\$" {}
-    timeout { exit 1 }
+    -re "\$" {
+        send "{ command -v rg||which rg||type -P rg; } 2>&1\n"
+        expect {
+            -re "/nix/store/.*-ripgrep-13.0.0/bin/rg" {}
+            timeout {
+              puts stderr "Reached timeout locating 'rg'"
+              exit 1
+            }
+        }
+    }
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
 }
-send "which rg\n"
 expect {
-    -re "/nix/store/.*-ripgrep-13.0.0/bin/rg" {}
-    timeout { exit 1 }
+    -re "\$" {
+        send "exit\r"
+        expect eof
+    }
+    timeout {
+      puts stderr "Reached timeout locating 'rg'"
+      exit 1
+    }
 }
-send "exit\r"
-expect eof
+exit 0

--- a/tests/develop/develop-fail.exp
+++ b/tests/develop/develop-fail.exp
@@ -1,11 +1,17 @@
 set attr [lindex $argv 0]
 set flox $env(FLOX_CLI)
 if {$attr eq ""} {
+    set cmd "$flox -v develop"
     spawn $flox -v develop
 } else {
+    set cmd "$flox -v develop $attr"
     spawn $flox -v develop $attr
 }
 expect {
     "ERROR: could not determine toplevel directory" {}
-    timeout { exit 1 }
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
 }
+exit 0

--- a/tests/develop/develop.exp
+++ b/tests/develop/develop.exp
@@ -1,8 +1,10 @@
 set attr [lindex $argv 0]
 set flox $env(FLOX_CLI)
 if {$attr eq ""} {
+    set cmd "$flox -v develop"
     spawn $flox -v develop
 } else {
+    set cmd "$flox -v develop $attr"
     spawn $flox -v develop $attr
 }
 set timeout 30
@@ -12,30 +14,66 @@ expect {
         set timeout 90
         expect {
             "activating floxEnv" {}
-            timeout { exit 1 }
+            timeout {
+              puts stderr "Reached timeout running '$cmd'"
+              exit 1
+            }
         }
         set timeout 30
     }
     "activating floxEnv" {}
-    timeout { exit 1 }
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
 }
 expect {
     "developing package" {}
-    timeout { exit 1 }
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
 }
 expect {
-    -re "\$" {}
-    timeout { exit 1 }
+    -re "\$" {
+        send "{ command -v rg||which rg||type -P rg; } 2>&1\n"
+        expect {
+            -re "/nix/store/.*-ripgrep-13.0.0/bin/rg" {}
+            timeout {
+              puts stderr "Reached timeout locating 'rg'"
+              exit 1
+            }
+        }
+    }
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
 }
-send "which rg\n"
 expect {
-    -re "/nix/store/.*-ripgrep-13.0.0/bin/rg" {}
-    timeout { exit 1 }
+    -re "\$" {
+        send "{ command -v curl||which curl||type -P curl; } 2>&1\n"
+        expect {
+            -re ".*/(develop|toplevel-flox-nix-with-pkg)/.flox/envs/.*(my-pkg|default)/bin/curl" {}
+            timeout {
+              puts stderr "Reached timeout locating 'curl'"
+              exit 1
+            }
+        }
+    }
+    timeout {
+      puts stderr "Reached timeout locating 'rg'"
+      exit 1
+    }
 }
-send "which curl\n"
 expect {
-    -re ".*/(develop|toplevel-flox-nix-with-pkg)/.flox/envs/.*(my-pkg|default)/bin/curl" {}
-    timeout { exit 1 }
+    -re "\$" {
+        send "exit\r"
+        expect eof
+    }
+    timeout {
+      puts stderr "Reached timeout locating 'curl'"
+      exit 0
+    }
 }
-send "exit\r"
-expect eof
+exit 0

--- a/tests/develop/toplevel-flox-nix.exp
+++ b/tests/develop/toplevel-flox-nix.exp
@@ -1,32 +1,56 @@
 set attr [lindex $argv 0]
 set flox $env(FLOX_CLI)
 if {$attr eq ""} {
+    set cmd "$flox -v develop"
     spawn $flox -v develop
 } else {
+    set cmd "$flox -v develop $attr"
     spawn $flox -v develop $attr
 }
-set timeout 30
+set timeout 60
 expect {
     -re "(fetching|downloading)" {
         # fetching needs a higher timeout
         set timeout 90
         expect {
             "activating floxEnv" {}
-            timeout { exit 1 }
+            timeout {
+              puts stderr "Reached timeout running '$cmd'"
+              exit 1
+            }
         }
         set timeout 30
     }
     "activating floxEnv" {}
-    timeout { exit 1 }
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
 }
 expect {
-    -re "\$" {}
-    timeout { exit 1 }
+    -re "\$" {
+        send "{ command -v hello||which hello||type -P hello; } 2>&1\n"
+        expect {
+            -re ".*/toplevel-flox-nix/.flox/envs/.*default/bin/hello" {}
+            timeout {
+              puts stderr "Reached timeout locating 'hello'"
+              exit 1
+            }
+        }
+    }
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
 }
-send "which hello\n"
 expect {
-    -re ".*/toplevel-flox-nix/.flox/envs/.*default/bin/hello" {}
-    timeout { exit 1 }
+    -re "\$" {
+        send "exit\r"
+        expect eof
+    }
+    timeout {
+      puts stderr "Reached timeout locating 'hello'"
+      exit 0
+    }
 }
-send "exit\r"
-expect eof
+exit 0


### PR DESCRIPTION
## Proposed Changes

Fetch and eval `flox develop` work-spaces before running `expect`.

More portable form of "find absolute path to my executable": `which foo` -> `command -v foo||which foo||type -P foo`.

## Current Behavior

Tests fail in a non-deterministic fashion based on cache warmth and network connection speed by timing out `expect` sleeps.

Some tests fail when the user's shell is `zsh` or `dash`.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A

<!-- Many thanks! -->
