### PR TITLE
feat: add --file|-f option to flox edit

### DIFF
--- a/crates/flox/doc/flox-edit.md
+++ b/crates/flox/doc/flox-edit.md
@@ -7,7 +7,7 @@ header: "flox User Manuals"
 
 # NAME
 
-flox-edit - build package from current project
+flox-edit - edit declarative format of an environment
 
 # SYNOPSIS
 
@@ -15,7 +15,7 @@ flox [ `<general-options>` ] edit [ `<options>` ]
 
 # DESCRIPTION
 
-Edit declarative environment manifest. Has the effect of creating the
+Edit environment declaratively. Has the effect of creating the
 environment if it does not exist.
 
 # OPTIONS
@@ -24,3 +24,9 @@ environment if it does not exist.
 ./include/general-options.md
 ./include/environment-options.md
 ```
+
+## Edit Options
+
+[ (\--file|-f) `<file>` ]
+:   Replace environment declaration with that in `<file>`.
+    If `<file>` is `-`, reads from stdin.

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -249,6 +249,10 @@ pub enum EnvironmentCommands {
 
         #[bpaf(long, short, argument("ENV"))]
         environment: Option<EnvironmentRef>,
+
+        /// Replace environment declaration with that in FILE
+        #[bpaf(long, short, argument("FILE"))]
+        file: Option<PathBuf>,
     },
 
     /// export declarative environment manifest to STDOUT

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -856,7 +856,7 @@ function floxEdit() {
 	local -a invocation=("$@")
 
 	local inputFile
-	while test $# -gt 0; do
+	while [[ "$#" -gt 0 ]]; do
 		# 'flox edit' args.
 		case "$1" in
 		-f | --file) # takes one arg
@@ -964,7 +964,7 @@ EOF
 				# cat will read from stdin if $inputFile is -
 				$_cat "$inputFile" > "$workDir/$nextGen/pkgs/default/flox.nix"
 			else
-				$editorCommand $workDir/$nextGen/pkgs/default/flox.nix
+				$editorCommand "$workDir/$nextGen/pkgs/default/flox.nix"
 			fi
 
 			[ -s $workDir/$nextGen/pkgs/default/flox.nix ] || (

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -855,6 +855,21 @@ function floxEdit() {
 	local system="$1"; shift
 	local -a invocation=("$@")
 
+	local inputFile
+	while test $# -gt 0; do
+		# 'flox edit' args.
+		case "$1" in
+		-f | --file) # takes one arg
+			shift
+			inputFile="$1"; shift
+			;;
+		# Any other options are unrecognised.
+		*)
+			usage | error "unknown option '$1'"
+			;;
+		esac
+	done
+
 	# Create shared clone for importing new generation.
 	local workDir
 	workDir=$(mkTempDir)
@@ -945,7 +960,12 @@ EOF
 
 		# Edit nextGen manifest.toml file.
 		while true; do
-			$editorCommand $workDir/$nextGen/pkgs/default/flox.nix
+			if [ -n "$inputFile" ]; then
+				# cat will read from stdin if $inputFile is -
+				$_cat "$inputFile" > "$workDir/$nextGen/pkgs/default/flox.nix"
+			else
+				$editorCommand $workDir/$nextGen/pkgs/default/flox.nix
+			fi
 
 			[ -s $workDir/$nextGen/pkgs/default/flox.nix ] || (
 				$_rm -rf $workDir/$nextGen

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -32,8 +32,8 @@ EDIT_ENVIRONMENT=_edit_testing_
   assert_output --partial 'environmentVariables.test = "file"'
 
   # test reading from stdin
-  run sh -c "echo '{ environmentVariables.test = \"stdin\"; }'
-              |$FLOX_CLI edit -e '$EDIT_ENVIRONMENT' --file -;";
+  run sh -c "echo '{ environmentVariables.test = \"stdin\"; }' |
+              $FLOX_CLI edit -e '$EDIT_ENVIRONMENT' --file -;";
   assert_success
   assert_output --partial "Environment '$EDIT_ENVIRONMENT' modified."
   EDITOR=cat run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT"

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -1,0 +1,56 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test flox edit
+# TODO move other edit tests from integration.bats
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash;
+
+# bats file_tags=edit
+
+# ---------------------------------------------------------------------------- #
+
+EDIT_ENVIRONMENT=_edit_testing_
+
+# ---------------------------------------------------------------------------- #
+
+@test "flox edit -f" {
+  run $FLOX_CLI destroy --force -e "$EDIT_ENVIRONMENT"
+  run $FLOX_CLI create -e "$EDIT_ENVIRONMENT"
+  assert_success
+
+  # test reading from a file
+  run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT" -f "$TESTS_DIR/test-flox.nix"
+  assert_success
+  assert_output --partial "Environment '$EDIT_ENVIRONMENT' modified."
+
+  EDITOR=cat run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT"
+  assert_success
+  assert_output --partial 'environmentVariables.test = "file"'
+
+  # test reading from stdin
+  contentsStdin=$(cat <<'EOF'
+{
+  environmentVariables.test = "stdin";
+}
+EOF
+)
+  run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT" --file - <<<"$contentsStdin"
+  assert_success
+  assert_output --partial "Environment '$EDIT_ENVIRONMENT' modified."
+  EDITOR=cat run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT"
+  assert_success
+  assert_output --partial "$contentsStdin"
+
+  run $FLOX_CLI destroy --force -e "$EDIT_ENVIRONMENT"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -38,12 +38,13 @@ EDIT_ENVIRONMENT=_edit_testing_
 }
 EOF
 )
-  run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT" --file - <<<"$contentsStdin"
+  run sh -c "echo '{ environmentVariables.test = \"stdin\"; }'
+              |$FLOX_CLI edit -e '$EDIT_ENVIRONMENT' --file -;";
   assert_success
   assert_output --partial "Environment '$EDIT_ENVIRONMENT' modified."
   EDITOR=cat run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT"
   assert_success
-  assert_output --partial "$contentsStdin"
+  assert_output --partial 'environmentVariables.test = "stdin";'
 
   run $FLOX_CLI destroy --force -e "$EDIT_ENVIRONMENT"
   assert_success

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -32,12 +32,6 @@ EDIT_ENVIRONMENT=_edit_testing_
   assert_output --partial 'environmentVariables.test = "file"'
 
   # test reading from stdin
-  contentsStdin=$(cat <<'EOF'
-{
-  environmentVariables.test = "stdin";
-}
-EOF
-)
   run sh -c "echo '{ environmentVariables.test = \"stdin\"; }'
               |$FLOX_CLI edit -e '$EDIT_ENVIRONMENT' --file -;";
   assert_success

--- a/tests/test-flox.nix
+++ b/tests/test-flox.nix
@@ -1,0 +1,3 @@
+{
+  environmentVariables.test = "file";
+}


### PR DESCRIPTION
--file allows replacing the environment declaration with the contents of a file, or it reads from stdin if - is passed