### PR TITLE
fix: enforce using system ssl for rust ssl bindings

### DIFF
--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -115,6 +115,8 @@
     nativeBuildInputs = [
       pkg-config # for openssl
     ];
+
+    inherit (envs) LIBSSH2_SYS_USE_PKG_CONFIG;
   };
 in
   craneLib.buildPackage ({


### PR DESCRIPTION
Add `LIBSSH2_SYS_USE_PKG_CONFIG=1` to the `cargoArtifacts` build.

Missing this causes build failure as cargo tries to build libssh from source which involves cloning git submodules into the r/o nix store path.
