### PR TITLE
test: update readme/contributing with shorter flox run invocation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ To run them:
 
 ```console
 $ flox develop flox --command 'cargo build';
-$ flox shell '.#flox-tests' --command flox-tests --flox ./target/debug/flox;
+$ flox run '.#flox-tests' -- --flox ./target/debug/flox;
 ```
 By default `flox` CLI is going to be picked from the environment.
 
@@ -185,8 +185,7 @@ every change. In that case run the following:
 
 ```console
 $ flox develop flox --command 'cargo build';
-$ flox shell '.#flox-tests' --command               \
-    flox-tests --flox ./target/debug/flox --watch;
+$ flox run '.#flox-tests' -- --flox ./target/debug/flox --watch;
 ```
 
 
@@ -197,8 +196,8 @@ through to the inner command:
 
 ```console
 $ flox develop flox --command 'cargo build';
-$ flox shell '.#flox-tests' --command                                        \
-    sh -c 'flox-tests --flox ./target/debug/flox -- -j 4 ./tests/run.bats';
+$ flox run '.#flox-tests' --                            \
+  --flox ./target/debug/flox -- -j 4 ./tests/run.bats;
 ```
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@ To run them:
 
 ```console
 $ flox develop flox --command 'cargo build';
-$ flox shell '.#flox-tests' --command flox-tests --flox ./target/debug/flox;
+$ flox run '.#flox-tests' -- --flox ./target/debug/flox;
 ```
 By default `flox` CLI is going to be picked from the environment.
 
@@ -23,8 +23,7 @@ every change. In that case run the following:
 
 ```console
 $ flox develop flox --command 'cargo build';
-$ flox shell '.#flox-tests' --command               \
-    flox-tests --flox ./target/debug/flox --watch;
+$ flox run '.#flox-tests' -- --flox ./target/debug/flox --watch;
 ```
 
 
@@ -35,8 +34,8 @@ through to the inner command:
 
 ```console
 $ flox develop flox --command 'cargo build';
-$ flox shell '.#flox-tests' --command                                        \
-    sh -c 'flox-tests --flox ./target/debug/flox -- -j 4 ./tests/run.bats';
+$ flox run '.#flox-tests' --                            \
+  --flox ./target/debug/flox -- -j 4 ./tests/run.bats;
 ```
 
 


### PR DESCRIPTION
## Proposed Changes

Update CONTRIBUTING.md and README.md files with shorter `flox run '.#flox-tests' ...` invocations.

## Current Behavior

Current docs recommend `flox shell` and are longer/uglier.


## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A


<!-- Many thanks! -->
