### PR TITLE
fix: stop parsing activate args at "--" delimiter

### DIFF
--- a/flox-bash/flox.sh
+++ b/flox-bash/flox.sh
@@ -161,6 +161,10 @@ activate | history | create | install | list | remove | rollback | \
 			export FLOX_SYSTEM="$1"
 			shift
 			;;
+		--)
+			args+=("$@")
+			break
+			;;
 		*)
 			args+=("$1")
 			shift


### PR DESCRIPTION
## Current Behavior

Invocations of `flox activate` where the invoked command contained an `-e` argument were failing as in the following example:

    $ flox activate -e foo -- python -e 'import foo'
    
    ERROR: environment "import foo" cannot contain whitespace

## Proposed Changes

This patch adds logic to stop parsing args at the "--" delimiter as found in argv.

## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

Fixed bug in the parsing of command arguments passed to `flox activate`.