### PR TITLE
trace(): remove unnecessary quotes from echo invocation

### DIFF
--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -113,7 +113,7 @@ function trace() {
 	exec 9>/dev/null
 	local BASH_XTRACEFD=9
 	[ ${debug:-0} -gt 0 ] || return 0
-	echo -e "trace:${filecolor}${BASH_SOURCE[2]}:${BASH_LINENO[1]}${colorReset} ${funccolor}${FUNCNAME[1]}${colorReset}( ${argscolor}"$(pprint "$@")"${colorReset} )" 1>&2
+	echo -e "trace:${filecolor}${BASH_SOURCE[2]}:${BASH_LINENO[1]}${colorReset} ${funccolor}${FUNCNAME[1]}${colorReset}( ${argscolor}$(pprint "$@")${colorReset} )" 1>&2
 }
 
 # Track exported environment variables for use in verbose output.


### PR DESCRIPTION
## Current Behavior

The trace() function was echoing a string containing an unquoted embedded pprint() invocation, and the resulting string was being globbed to the empty string on account of `shopt -s extglob`. This problem was evident when running `flox --debug --debug` as in the following example (look at the end of the line beginning `trace:`):

    $ flox --debug --debug destroy -e foo |& grep "Are you"
    + boolPrompt 'Are you sure?' no
    + trace 'Are you sure?' no
    trace:/nix/store/8x517fn3ckdgj4p013hnbyl91wsg9g0f-flox-bash-0.2.3-r532/lib/commands/environment.sh:1365 boolPrompt( 'Are you no )
    + local 'prompt=Are you sure?'

## Proposed Changes

This patch removes a pair of quotes so that the output of pprint() is quoted, thus preventing the glob'ing from removing arguments. With this patch in place the above example shows:

    $ flox --debug --debug destroy -e foo |& grep "Are you"
    + boolPrompt 'Are you sure?' no
    + trace 'Are you sure?' no
    trace:/nix/store/fgz91ycj7qzz76d9snwp4vdg4c5g6kla-flox-bash-0.2.3-dirty/lib/commands/environment.sh:1365 boolPrompt( 'Are you sure?' no )
    + local 'prompt=Are you sure?'

## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

None.