### PR TITLE
feat: init `Publish` structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime 2.1.0",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -678,6 +691,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "dotenv",
+ "env_logger 0.10.0",
  "flox-types",
  "fs_extra",
  "futures",
@@ -1016,6 +1030,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1874,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "runix"
 version = "0.1.1"
-source = "git+https://github.com/flox/runix#b6fa4ae25e1229d04a21dc3e76f9089aa9a7a01a"
+source = "git+https://github.com/flox/runix?branch=feat/git-last-modified#889288abd78f54332295bd87b4409c17a24a00ff"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2536,7 +2556,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "lazy_static",
  "log",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "runix"
 version = "0.1.1"
-source = "git+https://github.com/flox/runix?branch=feat/git-last-modified#889288abd78f54332295bd87b4409c17a24a00ff"
+source = "git+https://github.com/flox/runix?branch=feat/git-last-modified#af3ddabb6e5b34281cf913f10eb630a8bc72e2c1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ default-members = ["crates/flox"]
 
 [patch.crates-io]
 bpaf = { git = "https://github.com/ysndr/bpaf", branch = "error/more-suggestions" }
-runix = { git = "https://github.com/flox/runix" }
+runix = { git = "https://github.com/flox/runix", branch = "feat/git-last-modified" }

--- a/crates/flox-rust-sdk/Cargo.toml
+++ b/crates/flox-rust-sdk/Cargo.toml
@@ -27,7 +27,6 @@ regex = "1"
 once_cell = "1.16.0"
 uuid = { version = "1.2", features = ["serde", "v4"] }
 git2 = "0.16.1"
-# async-recursion = "1.0"
 walkdir = "2"
 indoc = "2.0.1"
 itertools = "0.10.5"
@@ -37,6 +36,7 @@ chrono = "0.4.24"
 [dev-dependencies]
 anyhow = "1.0.65"
 dotenv = "0.15.0"
+env_logger = "0.10"
 
 [features]
 extra-tests = ["impure-unit-tests"]

--- a/crates/flox-rust-sdk/src/models/mod.rs
+++ b/crates/flox-rust-sdk/src/models/mod.rs
@@ -9,3 +9,4 @@ pub mod root;
 pub use runix::{flake_ref, registry};
 pub mod floxmeta;
 pub mod project;
+pub mod publish;

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -66,6 +66,11 @@ impl<'flox> Publish<'flox> {
         }
         todo!()
     }
+
+    /// read out the current publish state
+    pub fn analysis(&self) -> Option<&CatalogEntry> {
+        self.analysis.as_ref()
+    }
 }
 
 #[derive(Error, Debug)]

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -67,7 +67,7 @@ impl<'flox> Publish<'flox> {
                     ("target".to_string(), self.publish_ref.clone().into_inner()).into(),
                     (
                         "target/flox-floxpkgs/nixpkgs/nixpkgs".to_string(),
-                        nixpkgs_flakeref,
+                        nixpkgs_flakeref, // stability overide has already been applied, not duplicating that code here
                     )
                         .into(),
                 ]

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -45,19 +45,19 @@ pub struct Publish<'flox, State> {
 }
 
 impl<'flox> Publish<'flox, Empty> {
-    pub async fn new(
+    pub fn new(
         flox: &'flox Flox,
         publish_ref: PublishRef,
         attr_path: AttrPath,
         stability: Stability,
-    ) -> PublishResult<Publish<'flox, Empty>> {
-        Ok(Self {
+    ) -> Publish<'flox, Empty> {
+        Self {
             flox,
             publish_ref,
             attr_path,
             stability,
             analysis: Empty,
-        })
+        }
     }
 
     /// run analysis on the package and switch to next state
@@ -73,8 +73,10 @@ impl<'flox> Publish<'flox, Empty> {
         let nixpkgs_flakeref =
             FlakeRef::Indirect(IndirectRef::new("nixpkgs-flox".into(), Default::default()));
 
-        let analyzer_flakeref =
-            FlakeRef::Path(PathRef::new(PathBuf::from("asd"), Default::default()));
+        let analyzer_flakeref = FlakeRef::Path(PathRef::new(
+            PathBuf::from(env!("FLOX_ANALYZER_SRC")),
+            Default::default(),
+        ));
 
         let eval_analysis_command = Eval {
             flake: FlakeArgs {

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -50,13 +50,8 @@ impl<'flox> Publish<'flox> {
         let nix: NixCommandLine = self.flox.nix(Default::default());
 
         let analysis_attr_path = {
-            let mut attrpath = AttrPath::default();
-            attrpath
-                .push_attr("")
-                .and_then(|path| path.push_attr("analysis"))
-                .and_then(|path| path.push_attr("eval"))
-                .unwrap();
-            attrpath.extend(self.attr_path);
+            let mut attrpath = AttrPath::try_from(["", "analysis", "eval"]).unwrap();
+            attrpath.extend(self.attr_path.clone());
             attrpath
         };
 

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -250,6 +250,8 @@ mod tests {
 
     #[tokio::test]
     async fn creates_catalog_entry() {
+        env_logger::init();
+
         let (mut flox, _temp_dir_handle) = flox_instance();
 
         flox.channels.register_channel(

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -1,0 +1,117 @@
+use flox_types::catalog::CatalogEntry;
+use runix::flake_ref::git::GitRef;
+use runix::flake_ref::{protocol, FlakeRef};
+use runix::installable::AttrPath;
+use thiserror::Error;
+
+use crate::flox::Flox;
+use crate::providers::git::{GitCommandProvider as Git, GitProvider};
+
+/// State for the publish algorihm
+#[allow(dead_code)] // until we implement methods for Publish
+pub struct Publish<'flox> {
+    flox: &'flox Flox,
+    publish_ref: PublishRef,
+    attr_path: AttrPath,
+    catalog: Git,
+    analysis: Option<CatalogEntry>, // model as type state?
+}
+
+impl<'flox> Publish<'flox> {
+    pub async fn new(
+        flox: &'flox Flox,
+        publish_ref: PublishRef,
+        attr_path: AttrPath,
+    ) -> PublishResult<Publish<'flox>> {
+        let url = match publish_ref {
+            PublishRef::Ssh(ref ssh_ref) => ssh_ref.url.as_str().to_owned(),
+
+            PublishRef::Https(ref https_ref) => https_ref.url.as_str().to_owned(),
+        };
+
+        let repo_dir = tempfile::tempdir_in(&flox.temp_dir).unwrap().into_path(); // todo catch error
+        let catalog = <Git as GitProvider>::clone(url, &repo_dir, false)
+            .await
+            .unwrap(); // todo: catch error
+
+        if catalog.list_branches().await.unwrap() // todo: catch error
+            .into_iter().any(|info| info.name == "catalog")
+        {
+            catalog.checkout("catalog", false).await.unwrap(); // todo: catch error
+        } else {
+            todo!();
+            // catalog.checkout("catalog", true).await.unwrap(); // todo: catch error
+
+            // catalog.set_upstream("origin", "catalog").await.unwrap();  // todo: implement
+            //                                                               todo: catch error
+        }
+
+        Ok(Self {
+            flox,
+            publish_ref,
+            attr_path,
+            catalog,
+            analysis: None,
+        })
+    }
+
+    /// run analysis on the package and add to state
+    pub async fn analyze(self) -> PublishResult<Publish<'flox>> {
+        todo!()
+    }
+
+    /// copy the outputs and dependencies of the package to binary store
+    pub async fn upload_binary(&self) -> PublishResult<()> {
+        todo!()
+    }
+
+    /// write snapshot to catalog and push to origin
+    pub async fn push_catalog(self) -> PublishResult<()> {
+        todo!()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum PublishError {}
+
+type PublishResult<T> = Result<T, PublishError>;
+
+/// Publishable FlakeRefs
+///
+/// `publish` modifies branches of the source repository.
+/// Thus we can only publish to repositories in (remote*) git repositories.
+/// This enum represents the subset of flakerefs we can use,
+/// so we can avoid parsing and converting flakerefs within publish.
+/// [GitRef<protocol::File>] should in most cases be resolved to a remote type.
+#[derive(PartialEq, Eq, Clone)]
+pub enum PublishRef {
+    Ssh(GitRef<protocol::SSH>),
+    Https(GitRef<protocol::HTTPS>),
+    // File(GitRef<protocol::File>),
+}
+
+impl TryFrom<FlakeRef> for PublishRef {
+    type Error = ConvertFlakeRefError;
+
+    fn try_from(value: FlakeRef) -> Result<Self, Self::Error> {
+        let publish_ref = match value {
+            FlakeRef::GitSsh(ssh_ref) => Self::Ssh(ssh_ref),
+            FlakeRef::GitHttps(https_ref) => Self::Https(https_ref),
+            // resolve upstream for local git repo
+            FlakeRef::GitPath(_) => todo!(),
+            // resolve indirect ref to direct ref (recursively)
+            FlakeRef::Indirect(_) => todo!(),
+            FlakeRef::Github(_) => todo!(),
+            FlakeRef::Gitlab(_) => todo!(),
+            _ => Err(ConvertFlakeRefError::UnsupportedTarget(value))?,
+        };
+        Ok(publish_ref)
+    }
+}
+
+/// Errors arising from convert
+#[derive(Error, Debug)]
+pub enum ConvertFlakeRefError {
+    #[error("Unsupported flakeref for publish: {0}")]
+    UnsupportedTarget(FlakeRef),
+}

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -296,6 +296,7 @@ mod tests {
     use crate::flox::tests::flox_instance;
     use crate::prelude::Channel;
 
+    #[cfg(feature = "impure-unit-tests")] // disabled for offline builds, TODO fix tests to work with local repos
     #[tokio::test]
     async fn creates_catalog_entry() {
         env_logger::init();

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -61,6 +61,14 @@ impl<'flox> Publish<'flox, Empty> {
     }
 
     /// run analysis on the package and switch to next state
+    ///
+    /// It uses an analyzer flake to extract eval metadata of the derivation.
+    /// The analyzer applies a function to all packages in a `target` flake
+    /// and provides the result under `#analysis.eval.<full attrpath of the package>`.
+    ///
+    /// We evalaute this analysis as json, to which we add
+    /// * source urls for reproducibility
+    /// * the nixpkgs stability being used to create the package
     pub async fn analyze(self) -> PublishResult<Publish<'flox, NixAnalysis>> {
         let nix: NixCommandLine = self.flox.nix(Default::default());
 

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -112,8 +112,10 @@ impl<'flox> Publish<'flox, Empty> {
             attrpath
         };
 
-        let nixpkgs_flakeref =
-            FlakeRef::Indirect(IndirectRef::new("nixpkgs-flox".into(), Default::default()));
+        let nixpkgs_flakeref = FlakeRef::Indirect(IndirectRef::new(
+            format!("nixpkgs-{}", self.stability),
+            Default::default(),
+        ));
 
         let analyzer_flakeref = FlakeRef::Path(PathRef::new(
             PathBuf::from(env!("FLOX_ANALYZER_SRC")),
@@ -126,7 +128,7 @@ impl<'flox> Publish<'flox, Empty> {
                     ("target".to_string(), self.publish_ref.clone().into_inner()).into(),
                     (
                         "target/flox-floxpkgs/nixpkgs/nixpkgs".to_string(),
-                        nixpkgs_flakeref, // stability overide has already been applied, not duplicating that code here
+                        nixpkgs_flakeref,
                     )
                         .into(),
                 ]
@@ -301,7 +303,7 @@ mod tests {
         let (mut flox, _temp_dir_handle) = flox_instance();
 
         flox.channels.register_channel(
-            "nixpkgs-flox",
+            "nixpkgs-stable",
             Channel::from("github:flox/nixpkgs/stable".parse::<FlakeRef>().unwrap()),
         );
 

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use flox_types::stability::Stability;
 use runix::arguments::flake::FlakeArgs;
 use runix::command::Eval;
 use runix::command_line::NixCommandLine;
@@ -24,6 +25,7 @@ pub struct Publish<'flox> {
     /// The published attrpath
     /// Should be fully resolved to avoid ambiguity
     attr_path: AttrPath,
+    stability: Stability,
     analysis: Option<Value>, // model as type state?
 }
 
@@ -32,11 +34,13 @@ impl<'flox> Publish<'flox> {
         flox: &'flox Flox,
         publish_ref: PublishRef,
         attr_path: AttrPath,
+        stability: Stability,
     ) -> PublishResult<Publish<'flox>> {
         Ok(Self {
             flox,
             publish_ref,
             attr_path,
+            stability,
             analysis: None,
         })
     }

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -170,12 +170,15 @@ impl<'flox> Publish<'flox, Empty> {
 
 impl<'flox> Publish<'flox, NixAnalysis> {
     /// copy the outputs and dependencies of the package to binary store
-    pub async fn upload_binary(&self) -> PublishResult<()> {
+    pub async fn upload_binary(self) -> PublishResult<Publish<'flox, NixAnalysis>> {
         todo!()
     }
 
     #[allow(unused)] // until implemented
-    async fn check_binary_cache(&self, substituter: SubstituterUrl) -> PublishResult<CacheMeta> {
+    async fn get_binary_cache_metadata(
+        &self,
+        substituter: SubstituterUrl,
+    ) -> PublishResult<CacheMeta> {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -28,7 +28,7 @@ pub struct Empty;
 
 /// Publish state after collecting nix metadata
 ///
-/// Json value (ideally a [flox_types::catalog::CatalogEntry],
+/// JSON value (ideally a [flox_types::catalog::CatalogEntry],
 /// but that's currently broken on account of some flakerefs)
 #[derive(Debug, Deref, DerefMut)]
 pub struct NixAnalysis(Value);
@@ -39,7 +39,7 @@ pub struct NixAnalysis(Value);
 pub struct Publish<'flox, State> {
     /// A shared flox session
     ///
-    /// Nearly all comands require shared state from the [Flox] object.
+    /// Nearly all commands require shared state from the [Flox] object.
     /// Save a reference to it to simplify the method signatures.
     flox: &'flox Flox,
     /// The published _upstream_ source
@@ -74,8 +74,8 @@ impl<'flox> Publish<'flox, Empty> {
 
     /// Run analysis on the package and switch to next state.
     ///
-    /// We evalaute pacakge metadata as json, to which we add
-    /// * source urls for reproducibility
+    /// We evaluate package metadata as JSON, to which we add
+    /// * source URLs for reproducibility
     /// * the nixpkgs stability being used to create the package
     pub async fn analyze(self) -> Result<Publish<'flox, NixAnalysis>, PublishError> {
         let mut drv_metadata_json = self.get_drv_metadata().await?;
@@ -104,14 +104,14 @@ impl<'flox> Publish<'flox, Empty> {
 
     /// Extract metadata of the published derivation using the analyzer flake.
     ///
-    ///  It uses an analyzer flake to extract eval metadata of the derivation.
+    /// It uses an analyzer flake to extract eval metadata of the derivation.
     /// The analyzer applies a function to all packages in a `target` flake
     /// and provides the result under `#analysis.eval.<full attrpath of the package>`.
     async fn get_drv_metadata(&self) -> Result<Value, PublishError> {
         let nix: NixCommandLine = self.flox.nix(Default::default());
 
-        // create the analysis.eval.<full attrpath of the package> attr path
-        // take care to remove any leading `""` from the original attri_path
+        // Create the analysis.eval.<full attrpath of the package> attr path
+        // taking care to remove any leading `""` from the original attr_path
         // used to signal strict paths (a flox concept, to be upstreamed)
         let analysis_attr_path = {
             let mut attrpath = AttrPath::try_from(["", "analysis", "eval"]).unwrap();
@@ -158,7 +158,7 @@ impl<'flox> Publish<'flox, Empty> {
                         .into(),
                 ]
                 .to_vec(),
-                // The analyzer flake is bundles with flox as a nix store path and thus read-only.
+                // The analyzer flake is bundled with flox as a nix store path and thus read-only.
                 no_write_lock_file: true.into(),
             },
             eval_args: runix::arguments::EvalArgs {
@@ -266,12 +266,12 @@ pub enum PublishError {
 /// [GitRef<protocol::File>] should in most cases be resolved to a remote type.
 ///
 /// \* A publish allows other users to substitute or build a package
-/// (as log as repo name and references remain available).
+/// (as long as repo name and references remain available).
 /// If you publish a local repository, all urls will refer to local paths,
-/// a snapshot cant be reproduced anywhere but the locla machine.
+/// so a snapshot can't be reproduced anywhere but the local machine.
 ///
 /// `flox publish git+file:///somewhere/local#package` would actually resolve git+file:///somewhere/local
-/// to the upstream repo defined by the current branche's remote.
+/// to the upstream repo defined by the current branch's remote.
 #[derive(PartialEq, Eq, Clone, Debug, Display)]
 pub enum PublishFlakeRef {
     Ssh(GitRef<protocol::SSH>),

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -24,14 +24,14 @@ use crate::providers::git::{GitCommandProvider as Git, GitProvider};
 /// Publish state before analyzing
 ///
 /// Prevents other actions to commence without analyzing the package first
-struct Empty;
+pub struct Empty;
 
 /// Publish state after collecting nix metadata
 ///
 /// Json value (ideally a [flox_types::catalog::CatalogEntry],
 /// but that's currently broken on account of some flakerefs)
 #[derive(Debug, Deref, DerefMut)]
-struct NixAnalysis(Value);
+pub struct NixAnalysis(Value);
 
 /// State for the publish algorihm
 ///

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -102,7 +102,13 @@ impl<'flox> Publish<'flox, Empty> {
 
         let analysis_attr_path = {
             let mut attrpath = AttrPath::try_from(["", "analysis", "eval"]).unwrap();
-            attrpath.extend(self.attr_path.clone());
+            attrpath.extend(
+                self.attr_path
+                    .clone()
+                    .into_iter()
+                    .peekable()
+                    .skip_while(|attr| attr.as_ref() == ""),
+            );
             attrpath
         };
 
@@ -305,7 +311,9 @@ mod tests {
             .try_into()
             .unwrap();
 
-        let attr_path = ["packages", "aarch64-darwin", "flox"].try_into().unwrap();
+        let attr_path = ["", "packages", "aarch64-darwin", "flox"]
+            .try_into()
+            .unwrap();
         let stability = Stability::Stable;
         let publish = Publish::new(&flox, publish_ref, attr_path, stability);
 

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -264,6 +264,14 @@ pub enum PublishError {
 /// This enum represents the subset of flakerefs we can use,
 /// so we can avoid parsing and converting flakerefs within publish.
 /// [GitRef<protocol::File>] should in most cases be resolved to a remote type.
+///
+/// \* A publish allows other users to substitute or build a package
+/// (as log as repo name and references remain available).
+/// If you publish a local repository, all urls will refer to local paths,
+/// a snapshot cant be reproduced anywhere but the locla machine.
+///
+/// `flox publish git+file:///somewhere/local#package` would actually resolve git+file:///somewhere/local
+/// to the upstream repo defined by the current branche's remote.
 #[derive(PartialEq, Eq, Clone, Debug, Display)]
 pub enum PublishFlakeRef {
     Ssh(GitRef<protocol::SSH>),

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -46,8 +46,9 @@
       NIX_BASH_COMPLETION_SCRIPT = ../../crates/flox/src/static/nix_bash_completion.sh;
       NIX_ZSH_COMPLETION_SCRIPT = ../../crates/flox/src/static/nix_zsh_completion.sh;
 
-      # bundling of an internally used nix script
+      # bundling of an internally used nix scripts
       FLOX_RESOLVER_SRC = ../../resolver;
+      FLOX_ANALYZER_SRC = ../../flox-bash/lib/catalog-ingest;
 
       # Metrics subsystem configuration
       METRICS_EVENTS_URL = "https://events.floxdev.com/capture";

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -46,7 +46,7 @@
       NIX_BASH_COMPLETION_SCRIPT = ../../crates/flox/src/static/nix_bash_completion.sh;
       NIX_ZSH_COMPLETION_SCRIPT = ../../crates/flox/src/static/nix_zsh_completion.sh;
 
-      # bundling of an internally used nix scripts
+      # bundling of internally used nix scripts
       FLOX_RESOLVER_SRC = ../../resolver;
       FLOX_ANALYZER_SRC = ../../flox-bash/lib/catalog-ingest;
 


### PR DESCRIPTION
Implement scaffolding for the `Publish` command and provides eval time analysis.

`Publish<State>` holds common data required during all phases of the publish,
as well as a typestate that contains phase specific data, ie.e (partial) snapshots.

Additionally we introduce a custom flakeref group; `PublishFlakeRef`s.
A `PublishFlakeRef` is a reference to an upstream git repo.
It is indirectly created by resolving `FlakeRefs` to `git+_` flakerefs if possible.
The current implementation provides trivial conversions for `git+{https,ssh}.
More are being worked on separately as part of the publish efforts.