### PR TITLE
fix(publish): add `allRefs=true` to all built flakerefs

### DIFF
--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -310,7 +310,7 @@ function floxPublish() {
 				fi
 			fi
 		fi
-		canonicalFlakeRef="${buildRepositoryBase}?rev=${upstreamRev}"
+		canonicalFlakeRef="${buildRepositoryBase}?rev=${upstreamRev}&allRefs=1"
 		;;
 	esac
 


### PR DESCRIPTION
When publishing from branches other than the default branch, the flakeref url constructed within `floxPublish` will contain a `?rev` pointing to a revision outside the main branch.
In these cases nix requires that a either `?ref=67e0617635fae9779247e9a5d660285bb92afe24` or `?allRefs=1` is specified.