### PR TITLE
fix: pull in builtfilter from the capacitated context

### DIFF
--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -2,6 +2,7 @@
   self,
   flox-src,
   inputs,
+  capacitated,
   stdenv,
   ansifilter,
   bashInteractive,
@@ -115,7 +116,7 @@ in
       nix-editor
       util-linuxMinimal
       semver
-      inputs.flox-floxpkgs.packages.builtfilter
+      capacitated.flox-floxpkgs.packages.builtfilter
     ];
     makeFlags =
       [


### PR DESCRIPTION
Pull in builtfilter from the shared capacitated context rather than as an independent input.