### PR TITLE
fix(search): don't overwrite stability entries

### DIFF
--- a/flox-bash/lib/catalog-search.jq
+++ b/flox-bash/lib/catalog-search.jq
@@ -19,7 +19,7 @@ def nixPkgToCatalogPkg( $channel ):
   $key[1] as $system|
   $key[2] as $stability|
   ( $key[3:]|join( "." ) ) as $attrPathVersion|
-  .key    = $catalog + "." + $system + "." + $channel + "." + $attrPathVersion|
+  .key    = $catalog + "." + $system + "." + $stability + "." + $channel + "." + $attrPathVersion|
   .value += {
     catalog:         $catalog
   , system:          $system


### PR DESCRIPTION
The key returned by nixPkgToCatalogPkg is used as the key in a $_jq -r -s add invocation. Because add overwrites the value for previous keys, this overwrites values for previous stabilities.

Based on comments, this bug was likely just a typo.