### PR TITLE
fix: repair environment variables displayed with `nix` invocations

### DIFF
--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -328,7 +328,7 @@ function invoke() {
 	trace "$@"
 	local vars=()
 	if [[ "${verbose?}" -ge "$minverbosity" ]]; then
-		for i in ${exported_variables["$1"]:+${exported_variables["$i"]}}; do
+		for i in ${exported_variables["$1"]}; do
 			vars+=($(eval "echo $i=\${$i}"))
 		done
 		pprint "+$colorBold" "${vars[@]}" "$@" "$colorReset" 1>&2

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -329,9 +329,9 @@ function invoke() {
 	local vars=()
 	if [[ "${verbose?}" -ge "$minverbosity" ]]; then
 		for i in ${exported_variables["$1"]}; do
-			vars+=($(eval "echo $i=\${$i}"))
+			vars+=("$i=$(pprint "${!i}")")
 		done
-		pprint "+$colorBold" "${vars[@]}" "$@" "$colorReset" 1>&2
+		echo -e "+$colorBold" "${vars[@]}" "$(pprint "$@")" "$colorReset" 1>&2
 	fi
 	"$@"
 }


### PR DESCRIPTION
The recent cleanup broke reporting of pertinent env variables set during nix invocations. This patch repairs that and also fixes an issue relating to the printing of env variable contents containing spaces.

## Proposed Changes

Revise code which iterates over of `${exported_variables["$1"]}`. Add a `pprint()` call to quote the value of environment variables when necessary.

## Current Behavior

Verbose output (as shown with `flox -v`) no longer displays the pertinent environment variables for `nix` invocations. Invoke `flox -v upgrade` or similar to view a sample `nix build` invocation which should have a number of environment variables displayed, starting with `NIX_REMOTE=`.

## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

N/A