### PR TITLE
build(dep): update runix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "runix"
 version = "0.1.1"
-source = "git+https://github.com/flox/runix?branch=feat/git-last-modified#af3ddabb6e5b34281cf913f10eb630a8bc72e2c1"
+source = "git+https://github.com/flox/runix#17dc209e211001f21f22102dcb3f70c921308f23"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ default-members = ["crates/flox"]
 
 [patch.crates-io]
 bpaf = { git = "https://github.com/ysndr/bpaf", branch = "error/more-suggestions" }
-runix = { git = "https://github.com/flox/runix", branch = "feat/git-last-modified" }
+runix = { git = "https://github.com/flox/runix" }


### PR DESCRIPTION
https://github.com/flox/runix/pull/28 introduced important fixes to the flakeref parser required for publish and improving convenience for users across nix'y commands.