### PR TITLE
feat: convert `github:` references to `git+https`

### DIFF
--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -414,7 +414,7 @@ mod tests {
     fn convert_github_ref() {
         // simple github references
         let flake_ref = GitServiceRef::<service::Github>::from_str("github:flox/flox").unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
             "git+https://github.com/flox/flox"
@@ -425,7 +425,7 @@ mod tests {
             "github:flox/flox?host=github.myenterprise.com",
         )
         .unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
             "git+https://github.myenterprise.com/flox/flox"
@@ -435,7 +435,7 @@ mod tests {
         let flake_ref =
             GitServiceRef::<service::Github>::from_str("github:flox/flox?dir=somwhere/inside")
                 .unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
             "git+https://github.com/flox/flox?dir=somwhere%2Finside"
@@ -444,7 +444,7 @@ mod tests {
         // github references with git ref
         let flake_ref =
             GitServiceRef::<service::Github>::from_str("github:flox/flox/feat/test").unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
             "git+https://github.com/flox/flox?ref=feat%2Ftest"
@@ -455,7 +455,7 @@ mod tests {
             "github:flox/flox/49335c4bade5b3feb7378f9af8e9a528d9c4103e",
         )
         .unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
             "git+https://github.com/flox/flox?allRefs=1&rev=49335c4bade5b3feb7378f9af8e9a528d9c4103e"

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -299,6 +299,18 @@ impl PublishFlakeRef {
         }
     }
 
+    /// Resolve `github:` flakerefs to a "proper" git url.
+    ///
+    /// Unlike nix operations publish is writing to the targeted git repository.
+    /// To allow native git operations on the remote,
+    /// the `github:` shorthand must be exanded to an `ssh` or `https` url.
+    ///
+    /// By default we resolve ssh urls,
+    /// since (publishing) users will more likely have ssh configured,
+    /// rather than (often insecure) token access.
+    /// In cases where https token access is granted by another tool (e.g. gh),
+    /// or within github actions we can prefer https URLs,
+    /// so not to require an ssh setup to be present.
     #[allow(unused)]
     fn from_github_ref(
         GitServiceRef {
@@ -317,6 +329,7 @@ impl PublishFlakeRef {
             rev: attributes.rev,
             reference: attributes.reference,
             dir: attributes.dir,
+            // Nix needs either a `?ref=` or `allRefs=1` set to fetch a revision
             all_refs: only_rev.then_some(true),
             ..Default::default()
         };

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -339,7 +339,7 @@ impl PublishFlakeRef {
             let url = WrappedUrl::from_str(&url_str)
                 .map_err(|e| ConvertFlakeRefError::InvalidResultUrl(url_str, e))?;
 
-            Self::Ssh(GitRef {
+            Self::Https(GitRef {
                 url,
                 attributes: git_attributes,
             })
@@ -427,10 +427,10 @@ mod tests {
     fn convert_github_ref() {
         // simple github references
         let flake_ref = GitServiceRef::<service::Github>::from_str("github:flox/flox").unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, false).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
-            "git+https://github.com/flox/flox"
+            "git+ssh://git@github.com/flox/flox"
         );
 
         // github references with explicit host param
@@ -438,29 +438,29 @@ mod tests {
             "github:flox/flox?host=github.myenterprise.com",
         )
         .unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, false).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
-            "git+https://github.myenterprise.com/flox/flox"
+            "git+ssh://git@github.myenterprise.com/flox/flox"
         );
 
         // github references with dir param
         let flake_ref =
             GitServiceRef::<service::Github>::from_str("github:flox/flox?dir=somwhere/inside")
                 .unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, false).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
-            "git+https://github.com/flox/flox?dir=somwhere%2Finside"
+            "git+ssh://git@github.com/flox/flox?dir=somwhere%2Finside"
         );
 
         // github references with git ref
         let flake_ref =
             GitServiceRef::<service::Github>::from_str("github:flox/flox/feat/test").unwrap();
-        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, false).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
-            "git+https://github.com/flox/flox?ref=feat%2Ftest"
+            "git+ssh://git@github.com/flox/flox?ref=feat%2Ftest"
         );
 
         // github references with git rev
@@ -468,10 +468,18 @@ mod tests {
             "github:flox/flox/49335c4bade5b3feb7378f9af8e9a528d9c4103e",
         )
         .unwrap();
+        let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, false).unwrap();
+        assert_eq!(
+            publish_flake_ref.to_string(),
+            "git+ssh://git@github.com/flox/flox?allRefs=1&rev=49335c4bade5b3feb7378f9af8e9a528d9c4103e"
+        );
+
+        // simple github references
+        let flake_ref = GitServiceRef::<service::Github>::from_str("github:flox/flox").unwrap();
         let publish_flake_ref = PublishFlakeRef::from_github_ref(flake_ref, true).unwrap();
         assert_eq!(
             publish_flake_ref.to_string(),
-            "git+https://github.com/flox/flox?allRefs=1&rev=49335c4bade5b3feb7378f9af8e9a528d9c4103e"
+            "git+https://github.com/flox/flox"
         );
     }
 }

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -310,7 +310,7 @@ impl PublishFlakeRef {
     ) -> Result<Self, ConvertFlakeRefError> {
         let host = attributes.host.unwrap_or("github.com".to_string());
 
-        let url_str = format!("https://{host}/{owner}/{repo}");
+        let url_str = format!("ssh://git@{host}/{owner}/{repo}");
         let url = WrappedUrl::from_str(&url_str)
             .map_err(|e| ConvertFlakeRefError::InvalidResultUrl(url_str, e))?;
 
@@ -329,7 +329,7 @@ impl PublishFlakeRef {
             attributes: git_attributes,
         };
 
-        Ok(Self::Https(git_ref))
+        Ok(Self::Ssh(git_ref))
     }
 }
 


### PR DESCRIPTION
Converts `github:<owner>/<repo>` flake refs to `git+https` references as inspired by [`GithubInputScheme::clone`](https://github.com/NixOS/nix/blob/fe1fbdb5a14a059763fcc7434f2cd1e483dc00e6/src/libfetchers/github.cc#L299C6-L299C6).

May eventually support ssh as well as through a toggle.

- [x] accept `?host=...` param
- [x] accept inline reference
- [x] accept inline revision (sets `allRefs=1`)
- [x] accept `?dir=...` param