### PR TITLE
refactor: use FlakeAttribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "runix"
 version = "0.1.1"
-source = "git+https://github.com/flox/runix#17dc209e211001f21f22102dcb3f70c921308f23"
+source = "git+https://github.com/flox/runix#2f385000053b5c6b8e972f6b98a8a26ec7c18b21"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/flox-rust-sdk/src/actions/environment.rs
+++ b/crates/flox-rust-sdk/src/actions/environment.rs
@@ -6,7 +6,7 @@ use runix::arguments::eval::EvaluationArgs;
 use runix::arguments::NixArgs;
 use runix::command::Build;
 use runix::flake_ref::path::PathRef;
-use runix::installable::{AttrPath, Installable, ParseInstallableError};
+use runix::installable::{AttrPath, FlakeAttribute, ParseInstallableError};
 use runix::{NixBackend, Run};
 use thiserror::Error;
 use {fs_extra, nix_editor, tempfile};
@@ -270,13 +270,14 @@ impl<'flox> Environment<'flox> {
 
         let nix_args = NixArgs::default();
 
-        let temp_installable = Installable {
+        let temp_installable = FlakeAttribute {
             flakeref: runix::flake_ref::FlakeRef::Path(PathRef::new(
                 temp_flake_dir,
                 Default::default(),
             )),
             attr_path: self.attr_path.parse::<AttrPath>().unwrap(),
-        };
+        }
+        .into();
         let command = Build {
             installables: [temp_installable].into(),
             eval: EvaluationArgs {

--- a/crates/flox-rust-sdk/src/actions/package.rs
+++ b/crates/flox-rust-sdk/src/actions/package.rs
@@ -125,7 +125,7 @@ impl Package<'_> {
 
         let command = Develop {
             flake: self.flake_args().map_err(PackageError::FlakeArgs)?,
-            installable: Installable::FlakeAttribute(self.flake_attribute.clone()).into(),
+            installable: self.flake_attribute.clone().into(),
             ..Default::default()
         };
 
@@ -149,7 +149,7 @@ impl Package<'_> {
 
         let command = RunCommand {
             flake: self.flake_args().map_err(PackageError::FlakeArgs)?,
-            installable: Installable::FlakeAttribute(self.flake_attribute.clone()).into(),
+            installable: self.flake_attribute.clone().into(),
             ..Default::default()
         };
 
@@ -200,7 +200,7 @@ impl Package<'_> {
 
         let command = Bundle {
             flake: self.flake_args().map_err(PackageError::FlakeArgs)?,
-            installable: Installable::FlakeAttribute(self.flake_attribute.clone()).into(),
+            installable: self.flake_attribute.clone().into(),
             bundle_args: BundleArgs {
                 bundler: Some(bundler.into()),
             },

--- a/crates/flox-rust-sdk/src/actions/package.rs
+++ b/crates/flox-rust-sdk/src/actions/package.rs
@@ -3,7 +3,7 @@ use flox_types::stability::Stability;
 use runix::arguments::flake::FlakeArgs;
 use runix::arguments::{BundleArgs, NixArgs};
 use runix::command::{Build, Bundle, Develop, Run as RunCommand, Shell};
-use runix::installable::Installable;
+use runix::installable::{FlakeAttribute, Installable};
 use runix::{NixBackend, Run};
 use thiserror::Error;
 
@@ -12,7 +12,7 @@ use crate::flox::{Flox, FloxNixApi};
 #[derive(Constructor)]
 pub struct Package<'flox> {
     flox: &'flox Flox,
-    installable: Installable,
+    flake_attribute: FlakeAttribute,
     stability: Stability,
     nix_arguments: Vec<String>,
 }
@@ -101,7 +101,7 @@ impl Package<'_> {
 
         let command = Build {
             flake: self.flake_args().map_err(PackageError::FlakeArgs)?,
-            installables: [self.installable.clone()].into(),
+            installables: [self.flake_attribute.clone().into()].into(),
             ..Default::default()
         };
 
@@ -125,7 +125,7 @@ impl Package<'_> {
 
         let command = Develop {
             flake: self.flake_args().map_err(PackageError::FlakeArgs)?,
-            installable: self.installable.clone().into(),
+            installable: Installable::FlakeAttribute(self.flake_attribute.clone()).into(),
             ..Default::default()
         };
 
@@ -149,7 +149,7 @@ impl Package<'_> {
 
         let command = RunCommand {
             flake: self.flake_args().map_err(PackageError::FlakeArgs)?,
-            installable: self.installable.clone().into(),
+            installable: Installable::FlakeAttribute(self.flake_attribute.clone()).into(),
             ..Default::default()
         };
 
@@ -173,7 +173,7 @@ impl Package<'_> {
 
         let command = Shell {
             flake: self.flake_args().map_err(PackageError::FlakeArgs)?,
-            installables: [self.installable.clone()].into(),
+            installables: [self.flake_attribute.clone().into()].into(),
             ..Default::default()
         };
 
@@ -200,7 +200,7 @@ impl Package<'_> {
 
         let command = Bundle {
             flake: self.flake_args().map_err(PackageError::FlakeArgs)?,
-            installable: self.installable.clone().into(),
+            installable: Installable::FlakeAttribute(self.flake_attribute.clone()).into(),
             bundle_args: BundleArgs {
                 bundler: Some(bundler.into()),
             },

--- a/crates/flox-rust-sdk/src/flox.rs
+++ b/crates/flox-rust-sdk/src/flox.rs
@@ -15,7 +15,7 @@ use runix::arguments::{EvalArgs, NixArgs};
 use runix::command::{Eval, FlakeMetadata};
 use runix::command_line::{DefaultArgs, NixCommandLine};
 use runix::flake_ref::path::PathRef;
-use runix::installable::{AttrPath, FlakeAttribute, Installable};
+use runix::installable::{AttrPath, FlakeAttribute};
 use runix::{NixBackend, RunJson};
 use serde::Deserialize;
 use thiserror::Error;
@@ -404,7 +404,7 @@ impl Flox {
             },
             // Use the super resolver as the installable (which we use as this only takes one)
             eval_args: EvalArgs {
-                installable: Some(Installable::FlakeAttribute(resolve_flake_attribute).into()),
+                installable: Some(resolve_flake_attribute.into()),
                 apply: Some(eval_apply.into()),
             },
             ..Default::default()

--- a/crates/flox-rust-sdk/src/lib.rs
+++ b/crates/flox-rust-sdk/src/lib.rs
@@ -8,7 +8,7 @@ pub mod environment;
 pub mod prelude {
     pub use crate::models::channels::{Channel, ChannelRegistry};
     pub use crate::models::flox_package;
-    pub use crate::nix::installable::Installable;
+    pub use crate::nix::installable::{FlakeAttribute, Installable};
 }
 
 pub mod actions;

--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use runix::installable::{Installable, ParseInstallableError};
+use runix::installable::{FlakeAttribute, ParseInstallableError};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -22,17 +22,17 @@ pub enum CommonEnvironment<'flox, Git: GitProvider> {
 }
 
 impl<'flox, Git: GitProvider> CommonEnvironment<'flox, Git> {
-    /// get an installbale for the environment
-    /// todo installable should be constructed earlier
-    pub async fn installable(
+    /// get a flake attribute for the environment
+    /// todo flake_attribute should be constructed earlier
+    pub async fn flake_attribute(
         &self,
-    ) -> Result<Installable, EnvironmentError<GenerationError<Git>, ParseInstallableError>> {
+    ) -> Result<FlakeAttribute, EnvironmentError<GenerationError<Git>, ParseInstallableError>> {
         match self {
             CommonEnvironment::Named(n) => n
-                .installable(Default::default())
+                .flake_attribute(Default::default())
                 .await
                 .map_err(EnvironmentError::Named),
-            CommonEnvironment::Project(p) => p.installable().map_err(EnvironmentError::Project),
+            CommonEnvironment::Project(p) => p.flake_attribute().map_err(EnvironmentError::Project),
         }
     }
 

--- a/crates/flox-rust-sdk/src/models/floxmeta/environment.rs
+++ b/crates/flox-rust-sdk/src/models/floxmeta/environment.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use log::debug;
 use runix::flake_ref::git::{GitAttributes, GitRef};
 use runix::flake_ref::FlakeRef;
-use runix::installable::Installable;
+use runix::installable::FlakeAttribute;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
@@ -315,10 +315,10 @@ impl<'flox, Git: GitProvider> Environment<'flox, Git, ReadOnly<Git>> {
         })
     }
 
-    pub async fn installable(
+    pub async fn flake_attribute(
         &self,
         generation: Option<&str>,
-    ) -> Result<Installable, GenerationError<Git>> {
+    ) -> Result<FlakeAttribute, GenerationError<Git>> {
         let git = &self.floxmeta.access.git();
         let metadata = self.metadata().await?;
 
@@ -337,7 +337,7 @@ impl<'flox, Git: GitProvider> Environment<'flox, Git, ReadOnly<Git>> {
             },
         });
 
-        Ok(Installable {
+        Ok(FlakeAttribute {
             flakeref,
             attr_path: ["", "floxEnvs", "default"].try_into().unwrap(),
         })

--- a/crates/flox-rust-sdk/src/models/project/environment.rs
+++ b/crates/flox-rust-sdk/src/models/project/environment.rs
@@ -82,7 +82,7 @@ impl<Git: GitProvider, A: GitAccess<Git>> Environment<'_, Git, A> {
                 impure: true.into(),
             },
             eval_args: EvalArgs {
-                installable: Some(Installable::FlakeAttribute(flake_attribute).into()),
+                installable: Some(flake_attribute.into()),
                 apply: None,
             },
             ..Eval::default()
@@ -108,7 +108,7 @@ impl<Git: GitProvider, A: GitAccess<Git>> Environment<'_, Git, A> {
                 impure: true.into(),
             },
             eval_args: EvalArgs {
-                installable: Some(Installable::FlakeAttribute(flake_attribute).into()),
+                installable: Some(flake_attribute.into()),
                 apply: None,
             },
             ..Eval::default()

--- a/crates/flox-rust-sdk/src/models/project/environment.rs
+++ b/crates/flox-rust-sdk/src/models/project/environment.rs
@@ -7,7 +7,7 @@ use runix::arguments::eval::EvaluationArgs;
 use runix::arguments::{BuildArgs, EvalArgs};
 use runix::command::{Build, Eval};
 use runix::command_line::{NixCommandLine, NixCommandLineRunJsonError};
-use runix::installable::{FlakeAttribute, Installable, ParseInstallableError};
+use runix::installable::{FlakeAttribute, ParseInstallableError};
 use runix::{NixBackend, Run, RunJson, RunTyped};
 use thiserror::Error;
 
@@ -60,12 +60,6 @@ impl<Git: GitProvider, A: GitAccess<Git>> Environment<'_, Git, A> {
             flakeref: self.project.flakeref(),
             attr_path: ["", "floxEnvs", &self.system, &self.name].try_into()?,
         })
-    }
-
-    /// get an installable for this environment
-    // todo: share with named env
-    pub fn installable(&self) -> Result<Installable, ParseInstallableError> {
-        Ok(self.flake_attribute()?.into())
     }
 
     pub async fn installed_store_paths(
@@ -151,7 +145,7 @@ impl<Git: GitProvider, A: GitAccess<Git>> Environment<'_, Git, A> {
         let nix: Nix = self.project.flox.nix([].to_vec());
 
         let build = Build {
-            installables: [self.installable()?].into(),
+            installables: [self.flake_attribute()?.into()].into(),
             eval: runix::arguments::eval::EvaluationArgs {
                 impure: true.into(),
             },

--- a/crates/flox-rust-sdk/src/models/project/mod.rs
+++ b/crates/flox-rust-sdk/src/models/project/mod.rs
@@ -110,10 +110,10 @@ impl<'flox, Git: GitProvider> Guard<Project<'flox, Git, ReadOnly<Git>>, Root<'fl
 
         FlakeInit {
             template: Some(
-                Installable::FlakeAttribute(FlakeAttribute {
+                FlakeAttribute {
                     flakeref: IndirectRef::new("flox".to_string(), Default::default()).into(),
                     attr_path: ["", "templates", "_init"].try_into().unwrap(),
-                })
+                }
                 .into(),
             ),
             ..Default::default()
@@ -300,10 +300,10 @@ impl<'flox, Git: GitProvider, Access: GitAccess<Git>> Project<'flox, Git, Access
             eval_args: EvalArgs {
                 apply: Some(nix_apply_expr.into()),
                 installable: Some(
-                    Installable::FlakeAttribute(FlakeAttribute {
+                    FlakeAttribute {
                         flakeref: self.flakeref(),
                         attr_path: ["floxEnvs".to_string()].try_into().unwrap(),
-                    })
+                    }
                     .into(),
                 ),
             },
@@ -346,10 +346,10 @@ impl<'flox, Git: GitProvider, Access: GitAccess<Git>> Project<'flox, Git, Access
             eval_args: EvalArgs {
                 apply: Some(nix_apply_expr.into()),
                 installable: Some(
-                    Installable::FlakeAttribute(FlakeAttribute {
+                    FlakeAttribute {
                         flakeref: self.flakeref(),
                         attr_path: ["floxEnvs".to_string()].try_into().unwrap(),
-                    })
+                    }
                     .into(),
                 ),
             },

--- a/crates/flox-rust-sdk/src/models/project/mod.rs
+++ b/crates/flox-rust-sdk/src/models/project/mod.rs
@@ -8,7 +8,7 @@ use runix::command::{Eval, FlakeInit};
 use runix::flake_ref::git::{GitAttributes, GitRef};
 use runix::flake_ref::indirect::IndirectRef;
 use runix::flake_ref::FlakeRef;
-use runix::installable::Installable;
+use runix::installable::{FlakeAttribute, Installable};
 use runix::{NixBackend, Run, RunJson};
 use tempfile::TempDir;
 use thiserror::Error;
@@ -110,10 +110,10 @@ impl<'flox, Git: GitProvider> Guard<Project<'flox, Git, ReadOnly<Git>>, Root<'fl
 
         FlakeInit {
             template: Some(
-                Installable {
+                Installable::FlakeAttribute(FlakeAttribute {
                     flakeref: IndirectRef::new("flox".to_string(), Default::default()).into(),
                     attr_path: ["", "templates", "_init"].try_into().unwrap(),
-                }
+                })
                 .into(),
             ),
             ..Default::default()
@@ -300,10 +300,10 @@ impl<'flox, Git: GitProvider, Access: GitAccess<Git>> Project<'flox, Git, Access
             eval_args: EvalArgs {
                 apply: Some(nix_apply_expr.into()),
                 installable: Some(
-                    Installable {
+                    Installable::FlakeAttribute(FlakeAttribute {
                         flakeref: self.flakeref(),
                         attr_path: ["floxEnvs".to_string()].try_into().unwrap(),
-                    }
+                    })
                     .into(),
                 ),
             },
@@ -346,10 +346,10 @@ impl<'flox, Git: GitProvider, Access: GitAccess<Git>> Project<'flox, Git, Access
             eval_args: EvalArgs {
                 apply: Some(nix_apply_expr.into()),
                 installable: Some(
-                    Installable {
+                    Installable::FlakeAttribute(FlakeAttribute {
                         flakeref: self.flakeref(),
                         attr_path: ["floxEnvs".to_string()].try_into().unwrap(),
-                    }
+                    })
                     .into(),
                 ),
             },

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -13,7 +13,7 @@ use runix::flake_ref::git::GitRef;
 use runix::flake_ref::indirect::IndirectRef;
 use runix::flake_ref::path::PathRef;
 use runix::flake_ref::{protocol, FlakeRef};
-use runix::installable::{AttrPath, Installable};
+use runix::installable::{AttrPath, FlakeAttribute, Installable};
 use runix::{RunJson, RunTyped};
 use serde_json::{json, Value};
 use thiserror::Error;
@@ -163,10 +163,10 @@ impl<'flox> Publish<'flox, Empty> {
             },
             eval_args: runix::arguments::EvalArgs {
                 installable: Some(
-                    Installable {
+                    Installable::FlakeAttribute(FlakeAttribute {
                         flakeref: analyzer_flakeref,
                         attr_path: analysis_attr_path,
-                    }
+                    })
                     .into(),
                 ),
                 ..Default::default()

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -13,7 +13,7 @@ use runix::flake_ref::git::GitRef;
 use runix::flake_ref::indirect::IndirectRef;
 use runix::flake_ref::path::PathRef;
 use runix::flake_ref::{protocol, FlakeRef};
-use runix::installable::{AttrPath, FlakeAttribute, Installable};
+use runix::installable::{AttrPath, FlakeAttribute};
 use runix::{RunJson, RunTyped};
 use serde_json::{json, Value};
 use thiserror::Error;
@@ -163,10 +163,10 @@ impl<'flox> Publish<'flox, Empty> {
             },
             eval_args: runix::arguments::EvalArgs {
                 installable: Some(
-                    Installable::FlakeAttribute(FlakeAttribute {
+                    FlakeAttribute {
                         flakeref: analyzer_flakeref,
                         attr_path: analysis_attr_path,
-                    })
+                    }
                     .into(),
                 ),
                 ..Default::default()

--- a/crates/flox-types/src/catalog/cache.rs
+++ b/crates/flox-types/src/catalog/cache.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use runix::narinfo::Narinfo;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -61,21 +62,4 @@ pub struct CacheMeta {
     pub narinfo: Vec<Narinfo>,
     #[serde(flatten)]
     pub _other: BTreeMap<String, Value>,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-/// Narinfo stores information output by `nix path-info --json`
-#[derive(Serialize, Deserialize, Clone)]
-pub struct Narinfo {
-    pub path: DerivationPath,
-    // TODO remove this default once https://github.com/NixOS/nix/pull/7924 has
-    // made it's way into our version of Nix
-    #[serde(default = "default_true")]
-    pub valid: bool,
-    // TODO add other fields
-    #[serde(flatten)]
-    _other: HashMap<String, Value>,
 }

--- a/crates/flox-types/src/catalog/element.rs
+++ b/crates/flox-types/src/catalog/element.rs
@@ -1,3 +1,4 @@
+use runix::types::DerivationPath;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/flox-types/src/catalog/element.rs
+++ b/crates/flox-types/src/catalog/element.rs
@@ -1,4 +1,4 @@
-use runix::types::DerivationPath;
+use runix::DerivationPath;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 

--- a/crates/flox-types/src/catalog/eval.rs
+++ b/crates/flox-types/src/catalog/eval.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use runix::DerivationPath;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;

--- a/crates/flox-types/src/catalog/mod.rs
+++ b/crates/flox-types/src/catalog/mod.rs
@@ -20,7 +20,6 @@ pub use eval::Eval;
 mod source;
 pub use source::Source;
 
-pub type DerivationPath = PathBuf;
 pub type StorePath = PathBuf;
 pub type AttrPath = Vec<String>;
 /// The "meaningful" component of an AttrPath. This excludes derivation type,

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -16,7 +16,7 @@ use flox_rust_sdk::nix::arguments::NixArgs;
 use flox_rust_sdk::nix::command::{Build, BuildOut, Eval as EvalComm};
 use flox_rust_sdk::nix::command_line::{Group, NixCliCommand, NixCommandLine, ToArgs};
 use flox_rust_sdk::nix::{Run as RunC, RunTyped};
-use flox_rust_sdk::prelude::Installable;
+use flox_rust_sdk::prelude::FlakeAttribute;
 use flox_rust_sdk::providers::git::{GitCommandProvider, GitProvider};
 use flox_types::stability::Stability;
 use indoc::indoc;
@@ -30,24 +30,24 @@ use crate::utils::dialog::{Dialog, Text};
 use crate::utils::resolve_environment_ref;
 use crate::{flox_forward, subcommand_metric};
 
-async fn env_ref_to_installable<Git: GitProvider + 'static>(
+async fn env_ref_to_flake_attribute<Git: GitProvider + 'static>(
     flox: &Flox,
     subcommand: &str,
     environment_name: &str,
-) -> anyhow::Result<Installable> {
+) -> anyhow::Result<FlakeAttribute> {
     let env_ref = resolve_environment_ref::<Git>(flox, subcommand, Some(environment_name)).await?;
-    Ok(env_ref.get_latest_installable::<Git>(flox).await?)
+    Ok(env_ref.get_latest_flake_attribute::<Git>(flox).await?)
 }
 
 pub(crate) mod interface {
     use async_trait::async_trait;
     use bpaf::{Bpaf, Parser};
     use flox_rust_sdk::flox::Flox;
-    use flox_rust_sdk::prelude::Installable;
+    use flox_rust_sdk::prelude::FlakeAttribute;
     use flox_rust_sdk::providers::git::GitProvider;
 
     use super::parseable_macro::parseable;
-    use super::{env_ref_to_installable, Parseable, WithPassthru};
+    use super::{env_ref_to_flake_attribute, Parseable, WithPassthru};
     use crate::utils::installables::{
         BuildInstallable,
         BundleInstallable,
@@ -80,17 +80,19 @@ pub(crate) mod interface {
 
     #[async_trait(?Send)]
     pub trait ResolveInstallable<Git: GitProvider> {
-        async fn installable(&self, flox: &Flox) -> anyhow::Result<Installable>;
+        async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute>;
     }
 
     #[async_trait(?Send)]
     impl<T: InstallableDef + 'static, Git: GitProvider + 'static> ResolveInstallable<Git>
         for PosOrEnv<T>
     {
-        async fn installable(&self, flox: &Flox) -> anyhow::Result<Installable> {
+        async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute> {
             Ok(match self {
-                PosOrEnv::Pos(i) => i.resolve_installable(flox).await?,
-                PosOrEnv::Env(n) => env_ref_to_installable::<Git>(flox, T::SUBCOMMAND, n).await?,
+                PosOrEnv::Pos(i) => i.resolve_flake_attribute(flox).await?,
+                PosOrEnv::Env(n) => {
+                    env_ref_to_flake_attribute::<Git>(flox, T::SUBCOMMAND, n).await?
+                },
             })
         }
     }
@@ -99,7 +101,7 @@ pub(crate) mod interface {
     impl<T: InstallableDef + 'static, Git: GitProvider + 'static> ResolveInstallable<Git>
         for Option<PosOrEnv<T>>
     {
-        async fn installable(&self, flox: &Flox) -> anyhow::Result<Installable> {
+        async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute> {
             Ok(match self {
                 Some(x) => ResolveInstallable::<Git>::installable(x, flox).await?,
                 None => {
@@ -348,14 +350,14 @@ impl PackageCommands {
             },
 
             PackageCommands::Publish2(args) => {
-                let Installable {
+                let FlakeAttribute {
                     flakeref,
                     attr_path,
                 } = args
                     .inner
                     .installable_arg
                     .unwrap_or_default()
-                    .resolve_installable(&flox)
+                    .resolve_flake_attribute(&flox)
                     .await?;
 
                 let publish_ref = flakeref.try_into()?;
@@ -382,8 +384,9 @@ impl PackageCommands {
                     .inner
                     .template
                     .unwrap_or_default()
-                    .resolve_installable(&flox)
-                    .await?;
+                    .resolve_flake_attribute(&flox)
+                    .await?
+                    .into();
 
                 let name = match command.inner.name {
                     Some(n) => n,
@@ -422,7 +425,7 @@ impl PackageCommands {
                     .inner
                     .installable_arg
                     .unwrap_or_default()
-                    .resolve_installable(&flox)
+                    .resolve_flake_attribute(&flox)
                     .await?;
 
                 flox.package(installable_arg, config.flox.stability, command.nix_args)
@@ -434,7 +437,7 @@ impl PackageCommands {
                     .inner
                     .installable_arg
                     .unwrap_or_default()
-                    .resolve_installable(&flox)
+                    .resolve_flake_attribute(&flox)
                     .await?;
 
                 flox.package(installable_arg, config.flox.stability, command.nix_args)
@@ -446,7 +449,7 @@ impl PackageCommands {
                     .inner
                     .installable_arg
                     .unwrap_or_default()
-                    .resolve_installable(&flox)
+                    .resolve_flake_attribute(&flox)
                     .await?;
 
                 flox.package(installable_arg, config.flox.stability, command.nix_args)
@@ -458,7 +461,7 @@ impl PackageCommands {
                     .inner
                     .installable_arg
                     .unwrap_or_default()
-                    .resolve_installable(&flox)
+                    .resolve_flake_attribute(&flox)
                     .await?;
 
                 flox.package(installable_arg, config.flox.stability, command.nix_args)
@@ -488,15 +491,15 @@ impl PackageCommands {
                     .inner
                     .bundler_arg
                     .unwrap_or_default()
-                    .resolve_installable(&flox)
+                    .resolve_flake_attribute(&flox)
                     .await?;
 
                 flox.package(installable_arg, config.flox.stability, command.nix_args)
-                    .bundle::<NixCommandLine>(bundler)
+                    .bundle::<NixCommandLine>(bundler.into())
                     .await?
             },
             PackageCommands::Containerize(command) => {
-                let mut installable = env_ref_to_installable::<GitCommandProvider>(
+                let mut installable = env_ref_to_flake_attribute::<GitCommandProvider>(
                     &flox,
                     "containerize",
                     &command.inner.environment_name.unwrap_or_default(),
@@ -528,7 +531,7 @@ impl PackageCommands {
                 info!("Building container...");
 
                 let command = Build {
-                    installables: [installable].into(),
+                    installables: [installable.into()].into(),
                     eval: EvaluationArgs {
                         impure: true.into(),
                     },


### PR DESCRIPTION
runix split Installable into an enum with FlakeAttribute and StorePath.
Refactor all occurrences of Installable to instead be a FlakeAttribute.

Depends on https://github.com/flox/runix/pull/30