### PR TITLE
feat(publish): sign published package

### DIFF
--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -234,6 +234,9 @@ impl<'flox> Publish<'flox, NixAnalysis> {
 
     /// Sign the binary
     ///
+    /// The current implementation does not involve any state transition,
+    /// making signing an optional operation.
+    ///
     /// Requires a valid signing key
     pub async fn sign_binary(
         self,


### PR DESCRIPTION
Add library function to sign the published package before uploading to binary cache.
Leaves validation of the signing key and package to the nix call.