### PR TITLE
feat: no stability override by default

### DIFF
--- a/crates/flox-rust-sdk/src/actions/package.rs
+++ b/crates/flox-rust-sdk/src/actions/package.rs
@@ -84,7 +84,11 @@ where
 impl Package<'_> {
     fn flake_args(&self) -> Result<FlakeArgs, ()> {
         Ok(FlakeArgs {
-            override_inputs: vec![self.stability.as_override()],
+            override_inputs: if self.stability == Default::default() {
+                vec![]
+            } else {
+                vec![self.stability.as_override()]
+            },
             ..Default::default()
         })
     }

--- a/crates/flox-types/src/stability.rs
+++ b/crates/flox-types/src/stability.rs
@@ -10,8 +10,9 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(rename_all = "camelCase")]
 pub enum Stability {
-    #[display(fmt = "stable")]
     #[default]
+    Unspecified,
+    #[display(fmt = "stable")]
     Stable,
     #[display(fmt = "unstable")]
     Unstable,

--- a/crates/flox/src/commands/general.rs
+++ b/crates/flox/src/commands/general.rs
@@ -52,10 +52,15 @@ impl GeneralCommands {
                     }
                 };
 
-                flox.channels.register_channel(
-                    "nixpkgs",
-                    Channel::from_str(&format!("github:flox/nixpkgs/{}", config.flox.stability))?,
-                );
+                if config.flox.stability != Default::default() {
+                    flox.channels.register_channel(
+                        "nixpkgs",
+                        Channel::from_str(&format!(
+                            "github:flox/nixpkgs/{}",
+                            config.flox.stability
+                        ))?,
+                    );
+                }
 
                 let nix: NixCommandLine = flox.nix(Default::default());
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -199,10 +199,15 @@ impl FloxArgs {
 
                 let mut flox = flox;
                 // more mutable state hurray :/
-                flox.channels.register_channel(
-                    "nixpkgs",
-                    Channel::from_str(&format!("github:flox/nixpkgs/{}", config.flox.stability))?,
-                );
+                if config.flox.stability != Default::default() {
+                    flox.channels.register_channel(
+                        "nixpkgs",
+                        Channel::from_str(&format!(
+                            "github:flox/nixpkgs/{}",
+                            config.flox.stability
+                        ))?,
+                    );
+                }
                 command.handle(config, flox).await?
             },
             Commands::Environment(ref environment) => environment.handle(flox).await?,

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -472,7 +472,11 @@ impl PackageCommands {
                 let nix = flox.nix::<NixCommandLine>(command.nix_args);
                 let command = EvalComm {
                     flake: FlakeArgs {
-                        override_inputs: [config.flox.stability.as_override()].into(),
+                        override_inputs: if config.flox.stability == Default::default() {
+                            vec![]
+                        } else {
+                            vec![config.flox.stability.as_override()]
+                        },
                         ..FlakeArgs::default()
                     },
                     ..Default::default()
@@ -601,7 +605,11 @@ impl PackageCommands {
                 FlakeCommand {
                     subcommand: command.inner.subcommand.to_owned(),
                     default_flake_args: FlakeArgs {
-                        override_inputs: [config.flox.stability.as_override()].into(),
+                        override_inputs: if config.flox.stability == Default::default() {
+                            vec![]
+                        } else {
+                            vec![config.flox.stability.as_override()]
+                        },
                         ..Default::default()
                     },
                     args: command.nix_args,

--- a/tests/reliability.bats
+++ b/tests/reliability.bats
@@ -27,14 +27,31 @@ setup() {
 
 # ---------------------------------------------------------------------------- #
 
-@test "flox should reliably use a lock in a repo" {
+@test "flox should reliably use a lock in a repo without specifying a stability" {
   $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230603;
   before=$($FLOX_CLI eval .#hello --json )
-  # simulate 30 days have passed
+  # simulate 30 days have passed and the lockfile updated
   $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230701;
   after=$($FLOX_CLI eval .#hello --json)
   echo "$before and $after should be different"
   [ "$before" != "$after" ]
+}
+
+@test "flox should use stability when specified" {
+  $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230603;
+  before=$($FLOX_CLI eval .#hello --json )
+  after=$($FLOX_CLI eval .#hello --stability unstable --json)
+  echo "$before and $after should be different"
+  [ "$before" != "$after" ]
+}
+
+@test "flox should use only use stability when specified" {
+  $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230603;
+  before=$($FLOX_CLI eval --stability stable -v .#hello --json )
+  $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230701;
+  after=$($FLOX_CLI eval --stability stable -v .#hello --json)
+  echo "$before and $after should be the same"
+  [ "$before" == "$after" ]
 }
 
 # ---------------------------------------------------------------------------- #

--- a/tests/reliability.bats
+++ b/tests/reliability.bats
@@ -1,0 +1,44 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test the `flox run' subcommand.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash;
+
+# bats file_tags=run
+
+
+# ---------------------------------------------------------------------------- #
+
+# Suppress the creation of file/suite homedirs.
+setup_file() { common_file_setup test; }
+
+setup() {
+  # Note the use of `-L' to copy flake.{nix,lock} as files.
+  home_setup test;
+  cp -LTpr -- "$TESTS_DIR/run/hello" "$FLOX_TEST_HOME/hello";
+  chmod -R u+w "$FLOX_TEST_HOME/hello";
+  cd "$FLOX_TEST_HOME/hello"||return;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "flox should reliably use a lock in a repo" {
+  $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230603;
+  before=$($FLOX_CLI eval .#hello --json )
+  # simulate 30 days have passed
+  $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230701;
+  after=$($FLOX_CLI eval .#hello --json)
+  echo "$before and $after should be different"
+  [ "$before" != "$after" ]
+}
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/tests/reliability.bats
+++ b/tests/reliability.bats
@@ -2,13 +2,13 @@
 # -*- mode: bats; -*-
 # ============================================================================ #
 #
-# Test the `flox run' subcommand.
+# Test the `flox' usage of stabilities.
 #
 # ---------------------------------------------------------------------------- #
 
 load test_support.bash;
 
-# bats file_tags=run
+# bats file_tags=stability
 
 
 # ---------------------------------------------------------------------------- #
@@ -45,7 +45,7 @@ setup() {
   [ "$before" != "$after" ]
 }
 
-@test "flox should use only use stability when specified" {
+@test "flox should use only use stability when specified and not the lock" {
   $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230603;
   before=$($FLOX_CLI eval --stability stable -v .#hello --json )
   $FLOX_CLI flake lock --override-input flox-floxpkgs/nixpkgs/nixpkgs github:flox/nixpkgs/stable.20230701;


### PR DESCRIPTION
## Proposed Changes

Do not perform a stability override by default.

## Current Behavior

Simple commands perform a speculative nixpkgs update, ignoring existing lockfiles and making it difficult to replicate behavior.

Fixes: https://github.com/flox/product/issues/301


## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes
Note: stability overrides now require the use of `--stability` instead of always overriding to "stable".