### PR TITLE
feat: impl copy binaries during publish

### DIFF
--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -13,7 +13,7 @@ use log::debug;
 use runix::arguments::common::NixCommonArgs;
 use runix::arguments::eval::EvaluationArgs;
 use runix::arguments::flake::FlakeArgs;
-use runix::arguments::NixArgs;
+use runix::arguments::{CopyArgs, NixArgs};
 use runix::command::Eval;
 use runix::command_line::{NixCommandLine, NixCommandLineRunError, NixCommandLineRunJsonError};
 use runix::flake_metadata::FlakeMetadata;
@@ -239,15 +239,14 @@ impl<'flox> Publish<'flox, NixAnalysis> {
                 eval_store: Some("auto".to_string().into()),
                 ..Default::default()
             },
-            ..Default::default()
-        };
-
-        let nix_args = NixArgs {
-            common: NixCommonArgs {
-                store: substituter.clone().map(|url| url.to_string().into()),
+            copy_args: CopyArgs {
+                to: substituter.clone().map(|url| url.to_string().into()),
+                ..Default::default()
             },
             ..Default::default()
         };
+
+        let nix_args = Default::default();
 
         copy_command
             .run(&nix, &nix_args)

--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -15,7 +15,7 @@ use runix::arguments::eval::EvaluationArgs;
 use runix::arguments::flake::FlakeArgs;
 use runix::arguments::NixArgs;
 use runix::command::Eval;
-use runix::command_line::{NixCommandLine, NixCommandLineRunJsonError};
+use runix::command_line::{NixCommandLine, NixCommandLineRunError, NixCommandLineRunJsonError};
 use runix::flake_metadata::FlakeMetadata;
 use runix::flake_ref::git::{GitAttributes, GitRef};
 use runix::flake_ref::git_service::{service, GitServiceRef};
@@ -25,7 +25,7 @@ use runix::flake_ref::protocol::{WrappedUrl, WrappedUrlParseError};
 use runix::flake_ref::{protocol, FlakeRef};
 use runix::installable::{AttrPath, FlakeAttribute, Installable};
 use runix::store_path::{StorePath, StorePathError};
-use runix::{RunJson, RunTyped};
+use runix::{Run, RunJson, RunTyped};
 use serde_json::{json, Value};
 use thiserror::Error;
 
@@ -227,8 +227,33 @@ impl<'flox> Publish<'flox, NixAnalysis> {
     }
 
     /// Copy the outputs and dependencies of the package to binary store
-    pub async fn upload_binary(self) -> Result<Publish<'flox, NixAnalysis>, PublishError> {
-        todo!()
+    pub async fn upload_binary(
+        self,
+        substituter: Option<SubstituterUrl>,
+    ) -> Result<(), PublishError> {
+        let nix: NixCommandLine = self.flox.nix(Default::default());
+        let store_paths = self.store_paths()?;
+        let copy_command = runix::command::NixCopy {
+            installables: store_paths.into(),
+            eval: EvaluationArgs {
+                eval_store: Some("auto".to_string().into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let nix_args = NixArgs {
+            common: NixCommonArgs {
+                store: substituter.clone().map(|url| url.to_string().into()),
+            },
+            ..Default::default()
+        };
+
+        copy_command
+            .run(&nix, &nix_args)
+            .map_err(PublishError::Copy)
+            .await?;
+        Ok(())
     }
 
     #[allow(dead_code)] // until consumed by cli
@@ -242,6 +267,36 @@ impl<'flox> Publish<'flox, NixAnalysis> {
         substituter: Option<SubstituterUrl>,
     ) -> Result<CacheMeta, PublishError> {
         let nix: NixCommandLine = self.flox.nix(Default::default());
+        let store_paths = self.store_paths()?;
+        let path_info_command = runix::command::PathInfo {
+            installables: store_paths.into(),
+            eval: EvaluationArgs {
+                eval_store: Some("auto".to_string().into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let nix_args = NixArgs {
+            common: NixCommonArgs {
+                store: substituter.clone().map(|url| url.to_string().into()),
+            },
+            ..Default::default()
+        };
+
+        let narinfos = path_info_command
+            .run_typed(&nix, &nix_args)
+            .map_err(PublishError::PathInfo)
+            .await?;
+
+        Ok(CacheMeta {
+            cache_url: substituter.unwrap_or(SubstituterUrl::parse("file:///nix/store").unwrap()),
+            narinfo: narinfos,
+            _other: BTreeMap::new(),
+        })
+    }
+
+    fn store_paths(&self) -> Result<Vec<Installable>, PublishError> {
         let store_paths = self.analysis()["element"]["store_paths"]
             .as_array()
             // TODO use CatalogEntry and then we don't need to unwrap
@@ -254,29 +309,7 @@ impl<'flox> Publish<'flox, NixAnalysis> {
                     .map(Installable::StorePath)
             })
             .collect::<Result<Vec<Installable>, _>>()?;
-        let path_info_command = runix::command::PathInfo {
-            installables: store_paths.into(),
-            eval: EvaluationArgs {
-                eval_store: Some("auto".to_string().into()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let narinfos = path_info_command
-            .run_typed(&nix, &NixArgs {
-                common: NixCommonArgs {
-                    store: substituter.clone().map(|url| url.to_string().into()),
-                },
-                ..Default::default()
-            })
-            .map_err(PublishError::PathInfo)
-            .await?;
-        Ok(CacheMeta {
-            cache_url: substituter.unwrap_or(SubstituterUrl::parse("file:///nix/store").unwrap()),
-            narinfo: narinfos,
-            _other: BTreeMap::new(),
-        })
+        Ok(store_paths)
     }
 
     /// Write snapshot to catalog and push to origin
@@ -445,12 +478,15 @@ pub enum PublishError {
 
     #[error("Already published")]
     SnapshotExists,
-  
+
     #[error("Failed to parse store path {0}")]
     ParseStorePath(StorePathError),
 
     #[error("Failed to invoke path-info: {0}")]
     PathInfo(NixCommandLineRunJsonError),
+
+    #[error("Failed to invoke copy: {0}")]
+    Copy(NixCommandLineRunError),
 }
 
 /// Publishable FlakeRefs
@@ -739,6 +775,7 @@ mod tests {
 
     use super::*;
     use crate::flox::tests::flox_instance;
+    use crate::prelude::Channel;
 
     #[cfg(feature = "impure-unit-tests")] // /nix/store is not accessible in the sandbox
     #[tokio::test]


### PR DESCRIPTION
Add a method on `Publish<NixAnalysis>` that can be used to copy binaries to a cache.

* feat: impl copy binaries during publish
* refactor: extract `store_paths` method
