### PR TITLE
fix: typo in template description

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -12,3 +12,4 @@ yes,stavares843,Sara Tavares,<saratavares843@gmail.com>
 yes,networkhermit,vac,<dot.fun@protonmail.com>
 yes,q5sys,JT Pennington,<jt@obs-sec.com>
 yes,ghudgins,Graham Hudgins,<graham@floxdev.com>
+yes,jennymahmoudi,Jenny Mahmoudi,<jenny@floxdev.com>

--- a/crates/flox/doc/flox-init.md
+++ b/crates/flox/doc/flox-init.md
@@ -39,4 +39,4 @@ to a generic builder for `<template>`.
     Queried interactively if controlling TTY is attached
 
 [ \--template `<template>` | -t `<template>` ]
-:   Template to creat new package definition from.
+:   Template to create new package definition from.


### PR DESCRIPTION
## Proposed Changes

Fix spelling typo: change "creat" to "create" in the template description. 


## Current Behavior

Spelling error: "creat"


## Checks

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A
