### PR TITLE
build: do not include entire repo in build closure of builtfilter-rs

### DIFF
--- a/pkgs/builtfilter-rs/default.nix
+++ b/pkgs/builtfilter-rs/default.nix
@@ -1,22 +1,20 @@
 {
-  inputs,
   pkgs,
   lib,
-  self,
   ...
 }: let
-  cargoToml = lib.importTOML "${self}/builtfilter-rs/Cargo.toml";
+  src = ../../builtfilter-rs;
+  cargoToml = lib.importTOML "${src}/Cargo.toml";
 in
   pkgs.rustPlatform.buildRustPackage
-  rec
   {
     pname = cargoToml.package.name;
     version = cargoToml.package.version;
     cargoLock = {
-      lockFile = src + "/Cargo.lock";
+      lockFile = "${src}/Cargo.lock";
       allowBuiltinFetchGit = true;
     };
-    src = self + "/builtfilter-rs";
+    src = src;
     nativeBuildInputs = [pkgs.pkg-config];
     buildInputs =
       [pkgs.openssl]


### PR DESCRIPTION
## Proposed Changes

Create a separate store path for the builtfilter package, for faster build times.

## Current Behavior

The build closure for the builtfilter output includes `self` so builtfilter will be rebuilt with every commit, regardless of changes to its source.


