### PR TITLE
fix: cleaner output for flox search

### DIFF
--- a/crates/flox/src/utils/init/mod.rs
+++ b/crates/flox/src/utils/init/mod.rs
@@ -41,7 +41,7 @@ pub fn init_access_tokens(
         .into_iter()
         .filter_map(|(host, v)| {
             if v.oauth_token.is_none() {
-                warn!(
+                debug!(
                     indoc! {"
                     gh config ({gh_config_file:?}): {host}: no `oauth_token` specified
                 "},

--- a/flox-bash/lib/commands/general.sh
+++ b/flox-bash/lib/commands/general.sh
@@ -215,8 +215,8 @@ function floxSearch() {
 	if [[ "$#" -gt 0 ]]; then
 		usage | error "extra arguments \"$*\""
 	fi
-	: "${GREP_COLOR:=1;32}"
-	export GREP_COLOR
+	: "${GREP_COLORS:=mt=1;32}"
+	export GREP_COLORS
 
 	# TODO: handle lines which contain `|' in their descriptions
 	if [[ "$showDetail" = true ]]; then

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1259,6 +1259,7 @@ function searchChannels() {
 	  -e ".sqlite' is busy" \
 	  -e " Added input " \
 	  -e " follows " \
+	  -e " does not provide attribute " \
 	  -e "\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\)" \
 	  ${_stderrFiles[@]} 1>&2 || true
 	#shellcheck disable=SC2016


### PR DESCRIPTION
This fixes a few stray messages in the flox search (and other) output.

* We now use `GREP_COLORS` instead of the obsolete `GREP_COLOR`
* Errors about non-existent attribute (caused by searching stabilities that don't exist) are filtered out
* The message about missing `oauth_token` in gh hosts.yml is now at debug level instead of warn, as it doesn't represent a problem and there's nothing the user can do about it (this one affects _every_ flox invocation, not just search)