### PR TITLE
fix: remove spurious print-build-logs

### DIFF
--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -470,7 +470,7 @@ EOF
 		$_git -C $workDir add $nextGen/pkgs/default/flox.nix
 
 		local envPackage
-		if ! envPackage=$($invoke_nix "${_nixArgs[@]}" build --impure --no-link --print-out-paths -L "$workDir/$nextGen#.floxEnvs.$system.default" "${_floxFlakeArgs[@]}"); then
+		if ! envPackage=$($invoke_nix "${_nixArgs[@]}" build --impure --no-link --print-out-paths "$workDir/$nextGen#.floxEnvs.$system.default" "${_floxFlakeArgs[@]}"); then
 			error "failed to install packages: ${pkgArgs[@]}" < /dev/null
 		fi
 


### PR DESCRIPTION
## Proposed Changes

Removes the printing of builds that occur during install.

## Current Behavior

Verbose output of the buildEnv wrappers.

## Checks

- [ ] All tests pass.
- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes
N/A