### PR TITLE
refactor: clean up usage and command definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,8 +168,7 @@ dependencies = [
 [[package]]
 name = "bpaf"
 version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c359c5e742f51d3238e83af24b289903591fbce38990eb9fcc903c7f8d5d95f9"
+source = "git+https://github.com/pacak/bpaf?branch=derive-alias#f2173336bb6dcd5f9053bcaf345f35e3ed98ea67"
 dependencies = [
  "bpaf_derive",
 ]
@@ -177,8 +176,7 @@ dependencies = [
 [[package]]
 name = "bpaf_derive"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1184f80d42a8fa311570a1458e54e2e9f5537fbd19b4d2fba04110e30307"
+source = "git+https://github.com/pacak/bpaf?branch=derive-alias#f2173336bb6dcd5f9053bcaf345f35e3ed98ea67"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,16 +167,18 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.9.4"
-source = "git+https://github.com/pacak/bpaf?branch=derive-alias#f2173336bb6dcd5f9053bcaf345f35e3ed98ea67"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dc3b1bd654a8d16eea03586c3eee8ffd25c7f242b9eae9730cc442834fe56d9"
 dependencies = [
  "bpaf_derive",
 ]
 
 [[package]]
 name = "bpaf_derive"
-version = "0.5.3"
-source = "git+https://github.com/pacak/bpaf?branch=derive-alias#f2173336bb6dcd5f9053bcaf345f35e3ed98ea67"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cbaba260bbcbb69b0d54e9f0d83038a4568f3a5d1c95591fed5e8fee964539"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ default-members = ["crates/flox"]
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1.52"
-bpaf = { version = "0.9.4", features = ["derive", "autocomplete"] }
+bpaf = { version = "0.9.5", features = ["derive", "autocomplete"] }
 chrono = "0.4.24"
 config = "0.13.1"
 crossterm = "0.26"
@@ -59,4 +59,3 @@ xdg = "2.4"
 
 
 [patch.crates-io]
-bpaf = { git = "https://github.com/pacak/bpaf", branch = "derive-alias" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ xdg = "2.4"
 
 
 [patch.crates-io]
-# bpaf = { git = "https://github.com/ysndr/bpaf", branch = "error/more-suggestions" }
+bpaf = { git = "https://github.com/pacak/bpaf", branch = "derive-alias" }

--- a/crates/flox-rust-sdk/src/actions/package.rs
+++ b/crates/flox-rust-sdk/src/actions/package.rs
@@ -13,7 +13,7 @@ use crate::flox::{Flox, FloxNixApi};
 pub struct Package<'flox> {
     flox: &'flox Flox,
     flake_attribute: FlakeAttribute,
-    stability: Stability,
+    stability: Option<Stability>,
     nix_arguments: Vec<String>,
 }
 
@@ -83,12 +83,9 @@ where
 
 impl Package<'_> {
     fn flake_args(&self) -> Result<FlakeArgs, ()> {
+        let override_inputs = self.stability.as_ref().map(Stability::as_override);
         Ok(FlakeArgs {
-            override_inputs: if self.stability == Default::default() {
-                vec![]
-            } else {
-                vec![self.stability.as_override()]
-            },
+            override_inputs: Vec::from_iter(override_inputs),
             ..Default::default()
         })
     }

--- a/crates/flox-rust-sdk/src/flox.rs
+++ b/crates/flox-rust-sdk/src/flox.rs
@@ -152,7 +152,7 @@ impl Flox {
     pub fn package(
         &self,
         flake_attribute: FlakeAttribute,
-        stability: Stability,
+        stability: Option<Stability>,
         nix_arguments: Vec<String>,
     ) -> Package {
         Package::new(self, flake_attribute, stability, nix_arguments)

--- a/crates/flox-rust-sdk/src/models/flox_package.rs
+++ b/crates/flox-rust-sdk/src/models/flox_package.rs
@@ -127,14 +127,7 @@ impl FloxTriple {
         };
 
         // try to interpret an attribute as a stability
-        let as_stability = |attr: &Attribute| -> Option<Stability> {
-            let stability = attr.as_ref().parse().unwrap();
-            if matches!(stability, Stability::Other(_)) {
-                None
-            } else {
-                Some(stability)
-            }
-        };
+        let as_stability = |attr: &Attribute| -> Option<Stability> { attr.as_ref().parse().ok() };
 
         // FloxTriple constructor private to the parse() function
         // - insert default channel and/or stability

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -12,6 +12,7 @@ use itertools::Itertools;
 use regex::Regex;
 use serde_json::json;
 
+use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select, Text};
 use crate::utils::init::{DEFAULT_CHANNELS, HIDDEN_CHANNELS};
 
@@ -55,6 +56,7 @@ pub struct Search {
 
 impl Search {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("search");
         let channels = flox
             .channels
             .iter()
@@ -131,6 +133,7 @@ pub struct Subscribe {
 }
 impl Subscribe {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("subscribe");
         // query name interactively if not provided
         let name = match &self.args {
             None => {
@@ -245,6 +248,7 @@ pub struct Unsubscribe {
 
 impl Unsubscribe {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("unsubscribe");
         let floxmeta = flox
             .floxmeta::<GitCommandProvider>(DEFAULT_OWNER)
             .await
@@ -300,6 +304,7 @@ pub struct Channels {
 
 impl Channels {
     pub fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("channels");
         let channels = flox
             .channels
             .iter()

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -28,7 +28,6 @@ enum ChannelType {
 
 /// Search packages in subscribed channels
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Search {
     #[bpaf(short, long, argument("channel"))]
     pub channel: Vec<ChannelRef>,
@@ -126,7 +125,6 @@ pub enum SubscribeArgs {
 
 /// Subscribe to channel URL
 #[derive(Bpaf, Clone)]
-#[bpaf(command("subscribe"))]
 pub struct Subscribe {
     #[bpaf(external(subscribe_args), optional)]
     args: Option<SubscribeArgs>,
@@ -237,7 +235,6 @@ impl Subscribe {
 
 /// Unsubscribe from a channel
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Unsubscribe {
     /// Channel name to unsubscribe.
     ///
@@ -295,7 +292,6 @@ impl Unsubscribe {
 
 /// List all subscribed channels
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Channels {
     /// print channels as JSON
     #[bpaf(long)]

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -12,10 +12,8 @@ use itertools::Itertools;
 use regex::Regex;
 use serde_json::json;
 
-use crate::config::features::Feature;
 use crate::utils::dialog::{Dialog, Select, Text};
 use crate::utils::init::{DEFAULT_CHANNELS, HIDDEN_CHANNELS};
-use crate::{flox_forward, subcommand_metric};
 
 #[derive(Bpaf, Clone)]
 pub struct ChannelArgs {}
@@ -26,216 +24,6 @@ enum ChannelType {
     User,
     #[display(fmt = "flox")]
     Flox,
-}
-
-impl ChannelCommands {
-    pub async fn handle(&self, flox: Flox) -> Result<()> {
-        match self {
-            ChannelCommands::Subscribe(_) => subcommand_metric!("subscribe"),
-            ChannelCommands::Unsubscribe { .. } => subcommand_metric!("unsubscribe"),
-            ChannelCommands::Channels { .. } => subcommand_metric!("channels"),
-        }
-
-        match self {
-            _ if Feature::Channels.is_forwarded()? => flox_forward(&flox).await?,
-            ChannelCommands::Channels { json } => {
-                let channels = flox
-                    .channels
-                    .iter()
-                    .filter_map(|entry| {
-                        if HIDDEN_CHANNELS.contains_key(&*entry.from.id) {
-                            None
-                        } else if DEFAULT_CHANNELS.contains_key(&*entry.from.id) {
-                            Some((ChannelType::Flox, entry))
-                        } else {
-                            Some((ChannelType::User, entry))
-                        }
-                    })
-                    .sorted_by(|a, b| Ord::cmp(a, b));
-
-                if *json {
-                    let mut map = serde_json::Map::new();
-                    for (channel, entry) in channels {
-                        map.insert(
-                            entry.from.id.to_string(),
-                            json!({
-                                "type": channel.to_string(),
-                                "url": entry.to.to_string()
-                            }),
-                        );
-                    }
-
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&serde_json::Value::Object(map))?
-                    )
-                } else {
-                    let width = channels
-                        .clone()
-                        .map(|(_, entry)| entry.from.id.len())
-                        .reduce(|acc, e| acc.max(e))
-                        .unwrap_or(8);
-
-                    println!("{ch:<width$}   TYPE   URL", ch = "CHANNEL");
-                    for (channel, entry) in channels {
-                        println!(
-                            "{from:<width$} | {ty} | {url}",
-                            from = entry.from.id,
-                            ty = channel,
-                            url = entry.to
-                        )
-                    }
-                }
-            },
-
-            ChannelCommands::Subscribe(args) => {
-                // query name interactively if not provided
-                let name = match args {
-                    None => {
-                        Dialog {
-                            help_message: None,
-                            message: "Enter channel name to be added:",
-                            typed: Text { default: None },
-                        }
-                        .prompt()
-                        .await?
-                    },
-                    Some(SubscribeArgs::Name { name })
-                    | Some(SubscribeArgs::NameUrl { name, .. }) => name.to_string(),
-                };
-
-                // return if name invalid
-                if [HIDDEN_CHANNELS.keys(), DEFAULT_CHANNELS.keys()]
-                    .into_iter()
-                    .flatten()
-                    .contains(&name.as_str())
-                {
-                    bail!("'{name}' is a reserved channel name");
-                }
-
-                // return if name is invalid
-                if !Regex::new("^[a-zA-Z][a-zA-Z0-9_-]*$")
-                    .unwrap()
-                    .is_match(&name)
-                {
-                    bail!("invalid channel name '{name}', valid regexp: ^[a-zA-Z][a-zA-Z0-9_-]*$");
-                }
-
-                // query url interactively if not provided
-                let url = match args {
-                    None | Some(SubscribeArgs::Name { .. }) => {
-                        let default = FlakeRef::Github(GitServiceRef::new(
-                            name.to_string(),
-                            "floxpkgs".to_string(),
-                            GitServiceAttributes {
-                                reference: Some("master".to_string()),
-                                ..Default::default()
-                            },
-                        ));
-
-                        Dialog {
-                            help_message: None,
-                            message: &format!("Enter URL for '{name}' channel:"),
-                            typed: Text {
-                                default: Some(&default.to_string()),
-                            },
-                        }
-                        .prompt()
-                        .await?
-                    },
-                    Some(SubscribeArgs::NameUrl { url, .. }) => url.to_string(),
-                };
-
-                // attempt parsing url as flakeref (validation)
-                let url = url
-                    .parse::<FlakeRef>()
-                    .with_context(|| format!("'{url}' is not a valid url"))?;
-
-                // read user channels
-                let floxmeta = flox
-                    .floxmeta::<GitCommandProvider>(DEFAULT_OWNER)
-                    .await
-                    .context("Could not get default floxmeta")?;
-
-                let mut user_meta = floxmeta
-                    .user_meta()
-                    .await
-                    .context("Could not read user metadata")?;
-                let user_meta_channels = user_meta.channels.get_or_insert(Default::default());
-
-                // ensure channel does not yet exist
-                if user_meta_channels.contains_key(&name) {
-                    bail!("A channel subscription '{name}' already exists");
-                }
-
-                // validate the existence of the flake behind `url`
-                // candidate for a flakeref extension?
-                let nix = flox.nix::<NixCommandLine>(Default::default());
-                let command = FlakeMetadata {
-                    flake_ref: Some(url.clone().into()),
-                    ..Default::default()
-                };
-                let _ = command
-                    .run_json(&nix, &Default::default())
-                    .await
-                    .map_err(|_| anyhow::anyhow!("Could not verify channel URL: '{url}'"))?;
-
-                user_meta_channels.insert(name.to_string(), url.to_string());
-
-                // tansactionally update user meta file
-                floxmeta
-                    .set_user_meta(&user_meta, &format!("Subscribed to {url} as '{name}'"))
-                    .await?;
-            },
-
-            ChannelCommands::Unsubscribe { channel } => {
-                let floxmeta = flox
-                    .floxmeta::<GitCommandProvider>(DEFAULT_OWNER)
-                    .await
-                    .context("Could not get default floxmeta")?;
-
-                let mut user_meta = floxmeta
-                    .user_meta()
-                    .await
-                    .context("Could not read user metadata")?;
-                let user_meta_channels = user_meta.channels.get_or_insert(Default::default());
-
-                let channel = match channel {
-                    Some(channel) => channel.to_owned(),
-                    None => {
-                        let dialog = Dialog {
-                            help_message: None,
-                            message: "Enter channel name to be added:",
-                            typed: Select {
-                                options: user_meta_channels.keys().cloned().collect_vec(),
-                            },
-                        };
-
-                        dialog.prompt().await?
-                    },
-                };
-
-                if HIDDEN_CHANNELS
-                    .keys()
-                    .chain(DEFAULT_CHANNELS.keys())
-                    .contains(&channel.as_str())
-                {
-                    bail!("'{channel}' is a reserved channel name and can't be unsubscribed from");
-                }
-
-                if user_meta_channels.remove(&channel).is_none() {
-                    bail!("No subscription found for '{channel}'");
-                }
-
-                floxmeta
-                    .set_user_meta(&user_meta, &format!("Unsubscribed from '{channel}'"))
-                    .await?;
-            },
-            _ => todo!(),
-        }
-
-        Ok(())
-    }
 }
 
 /// Search packages in subscribed channels
@@ -320,30 +108,6 @@ impl Search {
 }
 
 #[derive(Bpaf, Clone)]
-pub enum ChannelCommands {
-    /// subscribe to channel URL
-    #[bpaf(command)]
-    Subscribe(#[bpaf(external(subscribe_args), optional)] Option<SubscribeArgs>),
-
-    /// unsubscribe from a channel
-    #[bpaf(command)]
-    Unsubscribe {
-        /// channel name to unsubscribe.
-        /// If omitted, flow will prompt for the name interactively
-        #[bpaf(positional("channel"), optional)]
-        channel: Option<ChannelRef>,
-    },
-
-    /// list all subscribed channels
-    #[bpaf(command)]
-    Channels {
-        /// print channels as JSON
-        #[bpaf(long)]
-        json: bool,
-    },
-}
-
-#[derive(Bpaf, Clone)]
 pub enum SubscribeArgs {
     NameUrl {
         /// Name of the subscribed channel
@@ -358,6 +122,237 @@ pub enum SubscribeArgs {
         #[bpaf(positional("name"))]
         name: ChannelRef,
     },
+}
+
+/// Subscribe to channel URL
+#[derive(Bpaf, Clone)]
+#[bpaf(command("subscribe"))]
+pub struct Subscribe {
+    #[bpaf(external(subscribe_args), optional)]
+    args: Option<SubscribeArgs>,
+}
+impl Subscribe {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        // query name interactively if not provided
+        let name = match &self.args {
+            None => {
+                Dialog {
+                    help_message: None,
+                    message: "Enter channel name to be added:",
+                    typed: Text { default: None },
+                }
+                .prompt()
+                .await?
+            },
+            Some(SubscribeArgs::Name { name }) | Some(SubscribeArgs::NameUrl { name, .. }) => {
+                name.to_string()
+            },
+        };
+
+        // return if name invalid
+        if [HIDDEN_CHANNELS.keys(), DEFAULT_CHANNELS.keys()]
+            .into_iter()
+            .flatten()
+            .contains(&name.as_str())
+        {
+            bail!("'{name}' is a reserved channel name");
+        }
+
+        // return if name is invalid
+        if !Regex::new("^[a-zA-Z][a-zA-Z0-9_-]*$")
+            .unwrap()
+            .is_match(&name)
+        {
+            bail!("invalid channel name '{name}', valid regexp: ^[a-zA-Z][a-zA-Z0-9_-]*$");
+        }
+
+        // query url interactively if not provided
+        let url = match self.args {
+            None | Some(SubscribeArgs::Name { .. }) => {
+                let default = FlakeRef::Github(GitServiceRef::new(
+                    name.to_string(),
+                    "floxpkgs".to_string(),
+                    GitServiceAttributes {
+                        reference: Some("master".to_string()),
+                        ..Default::default()
+                    },
+                ));
+
+                Dialog {
+                    help_message: None,
+                    message: &format!("Enter URL for '{name}' channel:"),
+                    typed: Text {
+                        default: Some(&default.to_string()),
+                    },
+                }
+                .prompt()
+                .await?
+            },
+            Some(SubscribeArgs::NameUrl { url, .. }) => url.to_string(),
+        };
+
+        // attempt parsing url as flakeref (validation)
+        let url = url
+            .parse::<FlakeRef>()
+            .with_context(|| format!("'{url}' is not a valid url"))?;
+
+        // read user channels
+        let floxmeta = flox
+            .floxmeta::<GitCommandProvider>(DEFAULT_OWNER)
+            .await
+            .context("Could not get default floxmeta")?;
+
+        let mut user_meta = floxmeta
+            .user_meta()
+            .await
+            .context("Could not read user metadata")?;
+        let user_meta_channels = user_meta.channels.get_or_insert(Default::default());
+
+        // ensure channel does not yet exist
+        if user_meta_channels.contains_key(&name) {
+            bail!("A channel subscription '{name}' already exists");
+        }
+
+        // validate the existence of the flake behind `url`
+        // candidate for a flakeref extension?
+        let nix = flox.nix::<NixCommandLine>(Default::default());
+        let command = FlakeMetadata {
+            flake_ref: Some(url.clone().into()),
+            ..Default::default()
+        };
+        let _ = command
+            .run_json(&nix, &Default::default())
+            .await
+            .map_err(|_| anyhow::anyhow!("Could not verify channel URL: '{url}'"))?;
+
+        user_meta_channels.insert(name.to_string(), url.to_string());
+
+        // tansactionally update user meta file
+        floxmeta
+            .set_user_meta(&user_meta, &format!("Subscribed to {url} as '{name}'"))
+            .await?;
+        Ok(())
+    }
+}
+
+/// Unsubscribe from a channel
+#[derive(Bpaf, Clone)]
+#[bpaf(command)]
+pub struct Unsubscribe {
+    /// Channel name to unsubscribe.
+    ///
+    /// If omitted, flow will prompt for the name interactively
+    #[bpaf(positional("channel"), optional)]
+    channel: Option<ChannelRef>,
+}
+
+impl Unsubscribe {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        let floxmeta = flox
+            .floxmeta::<GitCommandProvider>(DEFAULT_OWNER)
+            .await
+            .context("Could not get default floxmeta")?;
+
+        let mut user_meta = floxmeta
+            .user_meta()
+            .await
+            .context("Could not read user metadata")?;
+        let user_meta_channels = user_meta.channels.get_or_insert(Default::default());
+
+        let channel = match self.channel {
+            Some(channel) => channel.to_owned(),
+            None => {
+                let dialog = Dialog {
+                    help_message: None,
+                    message: "Enter channel name to be added:",
+                    typed: Select {
+                        options: user_meta_channels.keys().cloned().collect_vec(),
+                    },
+                };
+
+                dialog.prompt().await?
+            },
+        };
+
+        if HIDDEN_CHANNELS
+            .keys()
+            .chain(DEFAULT_CHANNELS.keys())
+            .contains(&channel.as_str())
+        {
+            bail!("'{channel}' is a reserved channel name and can't be unsubscribed from");
+        }
+
+        if user_meta_channels.remove(&channel).is_none() {
+            bail!("No subscription found for '{channel}'");
+        }
+
+        floxmeta
+            .set_user_meta(&user_meta, &format!("Unsubscribed from '{channel}'"))
+            .await?;
+        Ok(())
+    }
+}
+
+/// List all subscribed channels
+#[derive(Bpaf, Clone)]
+#[bpaf(command)]
+pub struct Channels {
+    /// print channels as JSON
+    #[bpaf(long)]
+    json: bool,
+}
+
+impl Channels {
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        let channels = flox
+            .channels
+            .iter()
+            .filter_map(|entry| {
+                if HIDDEN_CHANNELS.contains_key(&*entry.from.id) {
+                    None
+                } else if DEFAULT_CHANNELS.contains_key(&*entry.from.id) {
+                    Some((ChannelType::Flox, entry))
+                } else {
+                    Some((ChannelType::User, entry))
+                }
+            })
+            .sorted_by(|a, b| Ord::cmp(a, b));
+
+        if self.json {
+            let mut map = serde_json::Map::new();
+            for (channel, entry) in channels {
+                map.insert(
+                    entry.from.id.to_string(),
+                    json!({
+                        "type": channel.to_string(),
+                        "url": entry.to.to_string()
+                    }),
+                );
+            }
+
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::Value::Object(map))?
+            )
+        } else {
+            let width = channels
+                .clone()
+                .map(|(_, entry)| entry.from.id.len())
+                .reduce(|acc, e| acc.max(e))
+                .unwrap_or(8);
+
+            println!("{ch:<width$}   TYPE   URL", ch = "CHANNEL");
+            for (channel, entry) in channels {
+                println!(
+                    "{from:<width$} | {ty} | {url}",
+                    from = entry.from.id,
+                    ty = channel,
+                    url = entry.to
+                )
+            }
+        }
+        Ok(())
+    }
 }
 
 pub type ChannelRef = String;

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -238,7 +238,7 @@ impl ChannelCommands {
     }
 }
 
-/// search packages in subscribed channels
+/// Search packages in subscribed channels
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Search {

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -165,10 +165,12 @@ impl Delete {
     }
 }
 
-/// activate environment:
+/// Activate environment
 ///
 /// * in current shell: eval "$(flox activate)"
+///
 /// * in subshell: flox activate
+///
 /// * for command: flox activate -- <command> <args>
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -59,6 +59,7 @@ pub type EnvironmentRef = String;
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Edit {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -146,6 +147,7 @@ pub struct Delete {
     #[bpaf(short, long)]
     origin: bool,
 
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -175,6 +177,7 @@ impl Delete {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Activate {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -209,6 +212,7 @@ impl Activate {
 #[derive(Bpaf, Clone)]
 #[bpaf(command, long("create"))]
 pub struct Init {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -254,6 +258,7 @@ impl Init {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct List {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -333,6 +338,7 @@ impl Envs {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Install {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -384,6 +390,7 @@ impl Install {
 #[derive(Bpaf, Clone)]
 #[bpaf(command, long("remove"), long("rm"))]
 pub struct Uninstall {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -423,6 +430,7 @@ impl Uninstall {
 #[derive(Bpaf, Clone)]
 #[bpaf(command("wipe-history"))]
 pub struct WipeHistory {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -470,6 +478,7 @@ impl WipeHistory {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Export {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -487,6 +496,7 @@ impl Export {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Generations {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -505,6 +515,7 @@ impl Generations {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Git {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -527,6 +538,7 @@ pub struct History {
     #[bpaf(long, short)]
     oneline: bool,
 
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -543,6 +555,7 @@ impl History {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Import {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -584,6 +597,7 @@ impl ImportFile {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Push {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -616,6 +630,7 @@ pub enum PushFloxmainOrEnv {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Pull {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -651,6 +666,7 @@ pub enum PullFloxmainOrEnv {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Rollback {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -673,6 +689,7 @@ impl Rollback {
 #[derive(Bpaf, Clone)]
 #[bpaf(command("switch-generation"))]
 pub struct SwitchGeneration {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
@@ -693,6 +710,7 @@ impl SwitchGeneration {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Upgrade {
+    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -325,10 +325,8 @@ impl List {
 pub struct Envs;
 impl Envs {
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = PathEnvironment::<Original>::discover(
-            std::env::current_dir().unwrap(),
-            flox.temp_dir.clone(),
-        )?;
+        let env =
+            PathEnvironment::<Original>::discover(std::env::current_dir().unwrap(), flox.temp_dir)?;
 
         if let Some(env) = env {
             println!("{}", env.environment_ref());

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -431,15 +431,8 @@ pub struct WipeHistory {
 }
 
 impl WipeHistory {
-    pub async fn handle(
-        Self {
-            // TODO use environment_args.system?
-            environment_args: _,
-            environment,
-        }: Self,
-        flox: Flox,
-    ) -> Result<()> {
-        let environment_name = environment.as_deref();
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        let environment_name = self.environment.as_deref();
         let environment_ref: environment_ref::EnvironmentRef =
             resolve_environment_ref(&flox, "wipe-history", environment_name).await?;
 

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -248,7 +248,7 @@ impl Init {
     }
 }
 
-/// list packages installed in an environment
+/// List (status?) packages installed in an environment
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct List {

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -57,7 +57,6 @@ pub type EnvironmentRef = String;
 
 /// Edit declarative environment configuration
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Edit {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -139,7 +138,6 @@ impl Edit {
 
 /// Delete an environment
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Delete {
     #[allow(dead_code)] // not yet handled in impl
     #[bpaf(short, long)]
@@ -171,13 +169,12 @@ impl Delete {
 
 /// Activate environment
 ///
-/// * in current shell: eval "$(flox activate)"
 ///
-/// * in subshell: flox activate
-///
-/// * for command: flox activate -- <command> <args>
+/// Modes:
+///  * in current shell: eval "$(flox activate)"
+///  * in subshell: flox activate
+///  * for command: flox activate -- <command> <args>
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Activate {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -213,7 +210,6 @@ impl Activate {
 
 /// Create an environment in the current directory
 #[derive(Bpaf, Clone)]
-#[bpaf(command, long("create"))]
 pub struct Init {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -259,7 +255,6 @@ impl Init {
 
 /// List (status?) packages installed in an environment
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct List {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -321,7 +316,6 @@ impl List {
 /// Aliases:
 ///   environments, envs
 #[derive(Bpaf, Clone)]
-#[bpaf(command, long("environments"))]
 pub struct Envs;
 impl Envs {
     pub async fn handle(self, flox: Flox) -> Result<()> {
@@ -339,7 +333,6 @@ impl Envs {
 
 /// Install a package into an environment
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Install {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -391,7 +384,6 @@ impl Install {
 
 /// Uninstall installed packages from an environment
 #[derive(Bpaf, Clone)]
-#[bpaf(command, long("remove"), long("rm"))]
 pub struct Uninstall {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -431,7 +423,6 @@ impl Uninstall {
 
 /// delete builds of non-current versions of an environment
 #[derive(Bpaf, Clone)]
-#[bpaf(command("wipe-history"))]
 pub struct WipeHistory {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -479,7 +470,6 @@ impl WipeHistory {
 
 /// export declarative environment manifest to STDOUT
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Export {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -498,7 +488,6 @@ impl Export {
 
 /// list environment generations with contents
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Generations {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -519,7 +508,6 @@ impl Generations {
 }
 /// access to the git CLI for floxmeta repository
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Git {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -541,7 +529,6 @@ impl Git {
 
 /// show all versions of an environment
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct History {
     #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short)]
@@ -563,7 +550,6 @@ impl History {
 
 /// import declarative environment manifest from STDIN as new generation
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Import {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -607,7 +593,6 @@ impl ImportFile {
 
 /// Send environment to flox hub
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Push {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -642,7 +627,6 @@ pub enum PushFloxmainOrEnv {
 
 /// Pull environment from flox hub
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Pull {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -680,7 +664,6 @@ pub enum PullFloxmainOrEnv {
 
 /// rollback to the previous generation of an environment
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Rollback {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -705,7 +688,6 @@ impl Rollback {
 
 /// switch to a specific generation of an environment
 #[derive(Bpaf, Clone)]
-#[bpaf(command("switch-generation"))]
 pub struct SwitchGeneration {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]
@@ -728,7 +710,6 @@ impl SwitchGeneration {
 
 /// upgrade packages using their most recent flake
 #[derive(Bpaf, Clone)]
-#[bpaf(command)]
 pub struct Upgrade {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
     #[bpaf(external(environment_args), group_help("Environment Options"))]

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -377,7 +377,8 @@ impl Install {
         Ok(())
     }
 }
-/// remove packages from an environment
+
+/// Uninstall installed packages from an environment
 #[derive(Bpaf, Clone)]
 #[bpaf(command, long("remove"), long("rm"))]
 pub struct Uninstall {

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -136,7 +136,7 @@ impl Edit {
     }
 }
 
-/// remove all data pertaining to an environment
+/// Delete an environment
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Delete {

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -55,7 +55,7 @@ pub type EnvironmentRef = String;
 //             EnvironmentCommands::WipeHistory { .. } => subcommand_metric!("wipe-history"),
 //         }
 
-/// edit declarative environment configuration
+/// Edit declarative environment configuration
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Edit {

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -583,7 +583,7 @@ impl ImportFile {
     }
 }
 
-/// send environment metadata to remote registry
+/// Send environment to flox hub
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Push {
@@ -615,7 +615,7 @@ pub enum PushFloxmainOrEnv {
     },
 }
 
-/// pull environment metadata from remote registry
+/// Pull environment from flox hub
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Pull {

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -327,7 +327,7 @@ impl List {
 /// Aliases:
 ///   environments, envs
 #[derive(Bpaf, Clone)]
-pub struct Envs;
+pub struct Envs {}
 impl Envs {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("envs");

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -139,7 +139,7 @@ impl Edit {
 /// remove all data pertaining to an environment
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
-pub struct Destroy {
+pub struct Delete {
     #[bpaf(short, long)]
     force: bool,
 
@@ -153,9 +153,10 @@ pub struct Destroy {
     environment: Option<EnvironmentRef>,
 }
 
-impl Destroy {
-    pub async fn handle(Self { environment, .. }: Self, flox: Flox) -> Result<()> {
-        let environment = resolve_environment(&flox, environment.as_deref(), "install").await?;
+impl Delete {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        let environment =
+            resolve_environment(&flox, self.environment.as_deref(), "install").await?;
 
         environment
             .delete()

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -327,7 +327,7 @@ impl Envs {
     }
 }
 
-/// install a package into an environment
+/// Install a package into an environment
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Install {

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -141,9 +141,11 @@ impl Edit {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct Delete {
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(short, long)]
     force: bool,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(short, long)]
     origin: bool,
 
@@ -184,6 +186,7 @@ pub struct Activate {
     #[bpaf(long, short, argument("ENV"))]
     environment: Vec<EnvironmentRef>,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(external(activate_run_args))]
     arguments: Option<(String, Vec<String>)>,
 }
@@ -265,10 +268,12 @@ pub struct List {
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(external(list_output), optional)]
     json: Option<ListOutput>,
 
     /// The generation to list, if not specified defaults to the current one
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(positional("GENERATION"))]
     generation: Option<u32>,
 }
@@ -482,6 +487,7 @@ pub struct Export {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 }
@@ -500,9 +506,11 @@ pub struct Generations {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long)]
     json: bool,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 }
@@ -519,9 +527,11 @@ pub struct Git {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(any("Git Arguments", Some))]
     git_arguments: Vec<String>,
 }
@@ -535,6 +545,7 @@ impl Git {
 #[derive(Bpaf, Clone)]
 #[bpaf(command)]
 pub struct History {
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short)]
     oneline: bool,
 
@@ -542,6 +553,7 @@ pub struct History {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 }
@@ -559,9 +571,11 @@ pub struct Import {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(external(ImportFile::parse), fallback(ImportFile::Stdin))]
     file: ImportFile,
 }
@@ -601,10 +615,12 @@ pub struct Push {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(external(push_floxmain_or_env), optional)]
     target: Option<PushFloxmainOrEnv>,
 
     /// forceably overwrite the remote copy of the environment
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short)]
     force: bool,
 }
@@ -634,10 +650,12 @@ pub struct Pull {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(external(pull_floxmain_or_env), optional)]
     target: Option<PullFloxmainOrEnv>,
 
     /// forceably overwrite the local copy of the environment
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short)]
     force: bool,
 }
@@ -671,11 +689,13 @@ pub struct Rollback {
     environment_args: EnvironmentArgs,
 
     #[bpaf(long, short, argument("ENV"))]
+    #[allow(dead_code)] // not yet handled in impl
     environment: Option<EnvironmentRef>,
 
     /// Generation to roll back to.
     ///
     /// If omitted, defaults to the previous generation.
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(argument("GENERATION"))]
     to: Option<u32>,
 }
@@ -693,9 +713,11 @@ pub struct SwitchGeneration {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(positional("GENERATION"))]
     generation: u32,
 }
@@ -714,9 +736,11 @@ pub struct Upgrade {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(positional("PACKAGES"))]
     packages: Vec<String>,
 }

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -19,9 +19,9 @@ use flox_types::constants::{DEFAULT_CHANNEL, LATEST_VERSION};
 use itertools::Itertools;
 use log::{error, info};
 
-use crate::flox_forward;
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::resolve_environment_ref;
+use crate::{flox_forward, subcommand_metric};
 
 #[derive(Bpaf, Clone)]
 pub struct EnvironmentArgs {
@@ -33,6 +33,7 @@ pub type EnvironmentRef = String;
 
 // impl EnvironmentCommands {
 //     pub async fn handle(&self, flox: Flox) -> Result<()> {
+
 //         match self {
 //             EnvironmentCommands::List { .. } => subcommand_metric!("list"),
 //             EnvironmentCommands::Envs => subcommand_metric!("envs"),
@@ -71,6 +72,8 @@ pub struct Edit {
 }
 impl Edit {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("edit");
+
         let mut environment =
             resolve_environment(&flox, self.environment.as_deref(), "install").await?;
         let mut temporary_environment = environment.make_temporary().await?;
@@ -157,6 +160,8 @@ pub struct Delete {
 
 impl Delete {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("delete");
+
         let environment =
             resolve_environment(&flox, self.environment.as_deref(), "install").await?;
 
@@ -190,6 +195,8 @@ pub struct Activate {
 
 impl Activate {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("activate");
+
         let environment = self.environment.first().map(|e| e.as_ref());
         let environment = resolve_environment(&flox, environment, "install").await?;
 
@@ -220,6 +227,8 @@ pub struct Init {
 }
 impl Init {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("init");
+
         let current_dir = std::env::current_dir().unwrap();
         let home_dir = dirs::home_dir().unwrap();
 
@@ -285,6 +294,8 @@ pub enum ListOutput {
 
 impl List {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("list");
+
         let env = resolve_environment(&flox, self.environment.as_deref(), "install").await?;
 
         let catalog = env
@@ -319,6 +330,8 @@ impl List {
 pub struct Envs;
 impl Envs {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("envs");
+
         let env =
             PathEnvironment::<Original>::discover(std::env::current_dir().unwrap(), flox.temp_dir)?;
 
@@ -346,6 +359,8 @@ pub struct Install {
 }
 impl Install {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("install");
+
         let mut packages: Vec<_> = self
             .packages
             .iter()
@@ -397,6 +412,8 @@ pub struct Uninstall {
 }
 impl Uninstall {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("uninstall");
+
         let mut packages: Vec<_> = self
             .packages
             .iter()
@@ -434,6 +451,8 @@ pub struct WipeHistory {
 
 impl WipeHistory {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("wipe-history");
+
         let environment_name = self.environment.as_deref();
         let environment_ref: environment_ref::EnvironmentRef =
             resolve_environment_ref(&flox, "wipe-history", environment_name).await?;
@@ -482,6 +501,8 @@ pub struct Export {
 
 impl Export {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("export");
+
         flox_forward(&flox).await
     }
 }
@@ -503,6 +524,8 @@ pub struct Generations {
 }
 impl Generations {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("generations");
+
         flox_forward(&flox).await
     }
 }
@@ -523,6 +546,8 @@ pub struct Git {
 }
 impl Git {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("git");
+
         flox_forward(&flox).await
     }
 }
@@ -544,6 +569,8 @@ pub struct History {
 }
 impl History {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("history");
+
         flox_forward(&flox).await
     }
 }
@@ -566,6 +593,8 @@ pub struct Import {
 
 impl Import {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("import");
+
         flox_forward(&flox).await
     }
 }
@@ -610,6 +639,8 @@ pub struct Push {
 
 impl Push {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("push");
+
         flox_forward(&flox).await
     }
 }
@@ -643,6 +674,8 @@ pub struct Pull {
 }
 impl Pull {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("pull");
+
         flox_forward(&flox).await
     }
 }
@@ -682,6 +715,8 @@ pub struct Rollback {
 }
 impl Rollback {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("rollback");
+
         flox_forward(&flox).await
     }
 }
@@ -704,6 +739,8 @@ pub struct SwitchGeneration {
 
 impl SwitchGeneration {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("switch-generation");
+
         flox_forward(&flox).await
     }
 }
@@ -725,6 +762,8 @@ pub struct Upgrade {
 }
 impl Upgrade {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("upgrade");
+
         flox_forward(&flox).await
     }
 }

--- a/crates/flox/src/commands/general.rs
+++ b/crates/flox/src/commands/general.rs
@@ -123,30 +123,10 @@ impl ConfigArgs {
                 update_config(&flox.config_dir, &flox.temp_dir, key, Some(value)).await?
             },
             ConfigArgs::SetNumber(ConfigSetNumber { key, value, .. }) => {
-                update_config(
-                    &flox.config_dir,
-                    &flox.temp_dir,
-                    key,
-                    Some(
-                        value
-                            .parse::<i32>()
-                            .context(format!("could not parse '{value}' as number"))?,
-                    ),
-                )
-                .await?
+                update_config(&flox.config_dir, &flox.temp_dir, key, Some(value)).await?
             },
             ConfigArgs::SetBool(ConfigSetBool { key, value, .. }) => {
-                update_config(
-                    &flox.config_dir,
-                    &flox.temp_dir,
-                    key,
-                    Some(
-                        value
-                            .parse::<bool>()
-                            .context(format!("could not parse '{value}' as bool"))?,
-                    ),
-                )
-                .await?
+                update_config(&flox.config_dir, &flox.temp_dir, key, Some(value)).await?
             },
             ConfigArgs::Delete(ConfigDelete { key, .. }) => {
                 update_config::<()>(&flox.config_dir, &flox.temp_dir, key, None).await?
@@ -181,11 +161,8 @@ pub struct ConfigSetNumber {
     #[bpaf(positional("key"))]
     key: String,
     /// Configuration Value (i32)
-    // we have to parse to int ourselves after reading the argument,
-    // as the bpaf error for parse failures here is not descriptive enough
-    // (<https://github.com/pacak/bpaf/issues/172>)
     #[bpaf(positional("number"))]
-    value: String,
+    value: i32,
 }
 
 #[derive(Debug, Clone, Bpaf)]
@@ -200,17 +177,8 @@ pub struct ConfigSetBool {
     key: String,
     /// Configuration Value (bool)
     #[bpaf(positional("bool"))]
-    // #[bpaf(external(parse_bool))]
-    // we have to parse to int ourselves after reading the argument,
-    // as the bpaf error for parse failures here is not descriptive enough
-    // (<https://github.com/pacak/bpaf/issues/172>)
-    value: String,
+    value: bool,
 }
-
-// / bug in bpaf (<https://github.com/pacak/bpaf/issues/171>)
-// fn parse_bool() -> impl Parser<String> {
-//     bpaf::positional::<String>("bool")
-// }
 
 #[derive(Debug, Clone, Bpaf)]
 #[allow(unused)]

--- a/crates/flox/src/commands/general.rs
+++ b/crates/flox/src/commands/general.rs
@@ -281,9 +281,6 @@ pub fn parse_nix_passthru() -> impl Parser<WrappedNix> {
     };
 
     bpaf::construct!([without_stability, with_stability])
-        .to_options()
-        .command("nix")
-        .help("Access to the nix CLI")
 }
 
 fn complete_nix_shell(offset: u8) -> bpaf::ShellComp {

--- a/crates/flox/src/commands/general.rs
+++ b/crates/flox/src/commands/general.rs
@@ -17,6 +17,7 @@ use toml_edit::Key;
 
 use crate::commands::not_help;
 use crate::config::{Config, ReadWriteError, FLOX_CONFIG_FILE};
+use crate::subcommand_metric;
 use crate::utils::metrics::{
     METRICS_EVENTS_FILE_NAME,
     METRICS_LOCK_FILE_NAME,
@@ -28,6 +29,7 @@ use crate::utils::metrics::{
 pub struct ResetMetrics {}
 impl ResetMetrics {
     pub async fn handle(self, _config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("reset-metrics");
         let mut metrics_lock = LockFile::open(&flox.cache_dir.join(METRICS_LOCK_FILE_NAME))?;
         tokio::task::spawn_blocking(move || metrics_lock.lock()).await??;
 
@@ -86,6 +88,8 @@ pub enum ConfigArgs {
 impl ConfigArgs {
     /// handle config flags like commands
     pub async fn handle(&self, config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("config");
+
         /// wrapper around [Config::write_to]
         async fn update_config<V: Serialize>(
             config_dir: &Path,
@@ -225,6 +229,7 @@ pub struct WrappedNix {
 
 impl WrappedNix {
     pub async fn handle(self, mut config: Config, mut flox: Flox) -> Result<()> {
+        subcommand_metric!("nix");
         // mutable state hurray :/
         let stability = config.override_stability(self.stability);
 

--- a/crates/flox/src/commands/general.rs
+++ b/crates/flox/src/commands/general.rs
@@ -268,6 +268,7 @@ pub struct ConfigDelete {
     key: String,
 }
 
+/// Access to the nix CLI
 #[derive(Clone, Debug)]
 pub struct WrappedNix {
     stability: Option<Stability>,

--- a/crates/flox/src/commands/general.rs
+++ b/crates/flox/src/commands/general.rs
@@ -67,15 +67,19 @@ impl ResetMetrics {
 #[derive(Bpaf, Clone)]
 #[bpaf(fallback(ConfigArgs::List))]
 pub enum ConfigArgs {
-    /// list the current values of all configurable paramers
+    /// List the current values of all configurable paramers
     #[bpaf(short, long)]
     List,
-    /// reset all configurable parameters to their default values without further confirmation.
+    /// Reset all configurable parameters to their default values without further confirmation.
     #[bpaf(short, long)]
     Reset,
+    /// Set a config value
     Set(#[bpaf(external(config_set))] ConfigSet),
+    /// Set a numeric config value
     SetNumber(#[bpaf(external(config_set_number))] ConfigSetNumber),
+    /// Set a boolean config value
     SetBool(#[bpaf(external(config_set_bool))] ConfigSetBool),
+    /// Delete a config value
     Delete(#[bpaf(external(config_delete))] ConfigDelete),
 }
 
@@ -148,7 +152,6 @@ impl ConfigArgs {
     }
 }
 
-/// Arguments for `flox config --set`
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(adjacent)]
 #[allow(unused)]
@@ -163,7 +166,6 @@ pub struct ConfigSet {
     value: String,
 }
 
-/// Arguments for `flox config --setNumber`
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(adjacent)]
 #[allow(unused)]
@@ -182,7 +184,6 @@ pub struct ConfigSetNumber {
     value: String,
 }
 
-/// Arguments for `flox config --setNumber`
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(adjacent)]
 #[allow(unused)]
@@ -202,16 +203,13 @@ pub struct ConfigSetBool {
     value: String,
 }
 
-/// bug in bpaf (<https://github.com/pacak/bpaf/issues/171>)
+// / bug in bpaf (<https://github.com/pacak/bpaf/issues/171>)
 // fn parse_bool() -> impl Parser<String> {
 //     bpaf::positional::<String>("bool")
 // }
 
-/// Arguments for `flox config --delete`
 #[derive(Debug, Clone, Bpaf)]
-#[bpaf(adjacent)]
 #[allow(unused)]
-/// delete <key> from config
 pub struct ConfigDelete {
     /// Configuration key
     #[bpaf(long("delete"), argument("key"))]

--- a/crates/flox/src/commands/general.rs
+++ b/crates/flox/src/commands/general.rs
@@ -17,12 +17,12 @@ use toml_edit::Key;
 
 use crate::commands::not_help;
 use crate::config::{Config, ReadWriteError, FLOX_CONFIG_FILE};
-use crate::subcommand_metric;
 use crate::utils::metrics::{
     METRICS_EVENTS_FILE_NAME,
     METRICS_LOCK_FILE_NAME,
     METRICS_UUID_FILE_NAME,
 };
+use crate::{flox_forward, subcommand_metric};
 
 /// reset the metrics queue (if any), reset metrics ID, and re-prompt for consent
 #[derive(Bpaf, Clone)]
@@ -212,6 +212,19 @@ impl WrappedNix {
             .run(&nix, &Default::default())
             .await?;
         Ok(())
+    }
+}
+
+/// Access to the nix CLI
+#[derive(Clone, Debug, Bpaf)]
+pub struct Gh {
+    #[bpaf(any("gh arguments and options", not_help))]
+    _gh_args: Vec<String>,
+}
+impl Gh {
+    pub async fn handle(self, _config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("gh");
+        flox_forward(&flox).await
     }
 }
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -232,22 +232,22 @@ enum Commands {
 #[derive(Bpaf, Clone)]
 enum LocalDevelopmentCommands {
     /// Create an environment in the current directory
-    #[bpaf(command, short('i'), long("create"), short('c'))]
+    #[bpaf(command, long("create"))]
     Init(#[bpaf(external(environment::init))] environment::Init),
     /// Activate environment
-    #[bpaf(command, short('a'), long("develop"))]
+    #[bpaf(command, long("develop"))]
     Activate(#[bpaf(external(environment::activate))] environment::Activate),
     /// Search packages in subscribed channels
     #[bpaf(command)]
     Search(#[bpaf(external(channel::search))] channel::Search),
     /// Install a package into an environment
-    #[bpaf(command, short('i'))]
+    #[bpaf(command)]
     Install(#[bpaf(external(environment::install))] environment::Install),
     /// Uninstall installed packages from an environment
-    #[bpaf(command, short('u'), long("remove"), long("rm"))]
+    #[bpaf(command, long("remove"), long("rm"))]
     Uninstall(#[bpaf(external(environment::uninstall))] environment::Uninstall),
     /// Edit declarative environment configuration
-    #[bpaf(command, short('e'))]
+    #[bpaf(command)]
     Edit(#[bpaf(external(environment::edit))] environment::Edit),
     /// Run app from current project
     #[bpaf(command)]

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -411,6 +411,14 @@ impl AdditionalCommands {
                 subcommand_metric!("channels");
                 flox_forward(&flox).await?
             },
+            AdditionalCommands::Subscribe(_) if Feature::Channels.is_forwarded()? => {
+                subcommand_metric!("channels");
+                flox_forward(&flox).await?
+            },
+            AdditionalCommands::Unsubscribe(_) if Feature::Channels.is_forwarded()? => {
+                subcommand_metric!("channels");
+                flox_forward(&flox).await?
+            },
 
             AdditionalCommands::Documentation(args) => args.handle(),
             AdditionalCommands::Build(args) => args.handle(config, flox).await?,

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -230,6 +230,7 @@ enum LocalDevelopmentCommands {
     Run(#[bpaf(external(WithPassthru::parse))] WithPassthru<Run>),
     List(#[bpaf(external(environment::list))] environment::List),
     Nix(#[bpaf(external(general::parse_nix_passthru))] general::WrappedNix),
+    Delete(#[bpaf(external(environment::delete))] environment::Delete),
 }
 
 impl LocalDevelopmentCommands {
@@ -244,6 +245,7 @@ impl LocalDevelopmentCommands {
             LocalDevelopmentCommands::Nix(args) => args.handle(config, flox).await?,
             LocalDevelopmentCommands::Search(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::Run(args) => args.handle(config, flox).await?,
+            LocalDevelopmentCommands::Delete(args) => args.handle(flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -28,6 +28,9 @@ use crate::utils::init::{
 };
 use crate::utils::metrics::METRICS_UUID_FILE_NAME;
 
+use self::package::{WithPassthru, Parseable};
+use self::package::interface::Run;
+
 static FLOX_WELCOME_MESSAGE: Lazy<String> = Lazy::new(|| {
     formatdoc! {r#"
     flox version {FLOX_VERSION}
@@ -223,6 +226,7 @@ enum LocalDevelopmentCommands {
     Install(#[bpaf(external(environment::install))] environment::Install),
     Uninstall(#[bpaf(external(environment::uninstall))] environment::Uninstall),
     Edit(#[bpaf(external(environment::edit))] environment::Edit),
+    Run(#[bpaf(external(WithPassthru::parse))] WithPassthru<Run>),
     List(#[bpaf(external(environment::list))] environment::List),
     Nix(#[bpaf(external(general::parse_nix_passthru))] general::WrappedNix),
 }
@@ -239,6 +243,7 @@ impl LocalDevelopmentCommands {
 
             LocalDevelopmentCommands::Nix(args) => args.handle(config, flox).await?,
             LocalDevelopmentCommands::Search(args) => args.handle(flox).await?,
+            LocalDevelopmentCommands::Run(_) => todo!(),
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -273,8 +273,13 @@ impl LocalDevelopmentCommands {
             | LocalDevelopmentCommands::Uninstall(_)
             | LocalDevelopmentCommands::List(_)
             | LocalDevelopmentCommands::Delete(_)
+            | LocalDevelopmentCommands::Search(_)
                 if Feature::Env.is_forwarded()? =>
             {
+                flox_forward(&flox).await?
+            },
+
+            LocalDevelopmentCommands::Search(_) if Feature::Channels.is_forwarded()? => {
                 flox_forward(&flox).await?
             },
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -211,11 +211,34 @@ impl FloxArgs {
 #[allow(clippy::large_enum_variant)] // there's only a single instance of this enum
 #[derive(Bpaf, Clone)]
 enum Commands {
-    Development,
-    General,
-    // Development(#[bpaf(external(local_development_commands))] LocalDevelopmentCommands),
+    Development(#[bpaf(external(local_development_commands))]LocalDevelopmentCommands),
 }
 
+/// Local Development Commands
+#[derive(Bpaf, Clone)]
+enum LocalDevelopmentCommands {
+
+    Init(#[bpaf(external(environment::init))] environment::Init),
+    Activate(#[bpaf(external(environment::activate))] environment::Activate),
+    Install(#[bpaf(external(environment::install))] environment::Install),
+    Uninstall(#[bpaf(external(environment::uninstall))] environment::Uninstall),
+    Edit(#[bpaf(external(environment::edit))] environment::Edit),
+    List(#[bpaf(external(environment::list))] environment::List),
+}
+
+impl LocalDevelopmentCommands {
+    async fn handle(self, flox: Flox) -> Result<()> {
+        match self {
+            LocalDevelopmentCommands::Init(args) => args.handle(flox).await?,
+            LocalDevelopmentCommands::Activate(args) => args.handle(flox).await?,
+            LocalDevelopmentCommands::Edit(args) => args.handle(flox).await?,
+            LocalDevelopmentCommands::Install(args) => args.handle(flox).await?,
+            LocalDevelopmentCommands::Uninstall(args) => args.handle(flox).await?,
+            LocalDevelopmentCommands::List(args) => args.handle(flox).await?,
+        }
+        Ok(())
+    }
+}
 /// Special command to check for the presence of the `--prefix` flag.
 ///
 /// With `--prefix` the application will print the prefix of the program

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -217,9 +217,9 @@ enum Commands {
 /// Local Development Commands
 #[derive(Bpaf, Clone)]
 enum LocalDevelopmentCommands {
-
     Init(#[bpaf(external(environment::init))] environment::Init),
     Activate(#[bpaf(external(environment::activate))] environment::Activate),
+    Search(#[bpaf(external(channel::search))] channel::Search),
     Install(#[bpaf(external(environment::install))] environment::Install),
     Uninstall(#[bpaf(external(environment::uninstall))] environment::Uninstall),
     Edit(#[bpaf(external(environment::edit))] environment::Edit),
@@ -238,6 +238,7 @@ impl LocalDevelopmentCommands {
             LocalDevelopmentCommands::List(args) => args.handle(flox).await?,
 
             LocalDevelopmentCommands::Nix(args) => args.handle(config, flox).await?,
+            LocalDevelopmentCommands::Search(args) => args.handle(flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -350,6 +350,7 @@ enum InternalCommands {
     ),
     Rollback(#[bpaf(external(environment::rollback))] environment::Rollback),
     Envs(#[bpaf(external(environment::envs))] environment::Envs),
+    Git(#[bpaf(external(environment::git))] environment::Git),
 }
 
 impl InternalCommands {
@@ -360,6 +361,7 @@ impl InternalCommands {
             InternalCommands::SwitchGeneration(args) => args.handle(flox).await?,
             InternalCommands::Rollback(args) => args.handle(flox).await?,
             InternalCommands::Envs(args) => args.handle(flox).await?,
+            InternalCommands::Git(args) => args.handle(flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -224,10 +224,11 @@ enum LocalDevelopmentCommands {
     Uninstall(#[bpaf(external(environment::uninstall))] environment::Uninstall),
     Edit(#[bpaf(external(environment::edit))] environment::Edit),
     List(#[bpaf(external(environment::list))] environment::List),
+    Nix(#[bpaf(external(general::parse_nix_passthru))] general::WrappedNix),
 }
 
 impl LocalDevelopmentCommands {
-    async fn handle(self, flox: Flox) -> Result<()> {
+    async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
             LocalDevelopmentCommands::Init(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::Activate(args) => args.handle(flox).await?,
@@ -235,6 +236,8 @@ impl LocalDevelopmentCommands {
             LocalDevelopmentCommands::Install(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::Uninstall(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::List(args) => args.handle(flox).await?,
+
+            LocalDevelopmentCommands::Nix(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -329,29 +329,29 @@ enum AdditionalCommands {
         #[bpaf(external(AdditionalCommands::documentation))] AdditionalCommandsDocumentation,
     ),
     #[bpaf(command, hide)]
-    Build(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::Build>),
+    Build(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Build>),
     #[bpaf(command, hide)]
-    Upgrade(#[bpaf(external(environment::upgrade), hide)] environment::Upgrade),
+    Upgrade(#[bpaf(external(environment::upgrade))] environment::Upgrade),
     #[bpaf(command, hide)]
-    Import(#[bpaf(external(environment::import), hide)] environment::Import),
+    Import(#[bpaf(external(environment::import))] environment::Import),
     #[bpaf(command, hide)]
-    Export(#[bpaf(external(environment::export), hide)] environment::Export),
+    Export(#[bpaf(external(environment::export))] environment::Export),
     #[bpaf(command, hide)]
-    Config(#[bpaf(external(general::config_args), hide)] general::ConfigArgs),
+    Config(#[bpaf(external(general::config_args))] general::ConfigArgs),
     #[bpaf(command("wipe-history"), hide)]
-    WipeHistory(#[bpaf(external(environment::wipe_history), hide)] environment::WipeHistory),
+    WipeHistory(#[bpaf(external(environment::wipe_history))] environment::WipeHistory),
     #[bpaf(command, hide)]
-    Subscribe(#[bpaf(external(channel::subscribe), hide)] channel::Subscribe),
+    Subscribe(#[bpaf(external(channel::subscribe))] channel::Subscribe),
     #[bpaf(command, hide)]
-    Unsubscribe(#[bpaf(external(channel::unsubscribe), hide)] channel::Unsubscribe),
+    Unsubscribe(#[bpaf(external(channel::unsubscribe))] channel::Unsubscribe),
     #[bpaf(command, hide)]
-    Channels(#[bpaf(external(channel::channels), hide)] channel::Channels),
+    Channels(#[bpaf(external(channel::channels))] channel::Channels),
     #[bpaf(command, hide)]
-    History(#[bpaf(external(environment::history), hide)] environment::History),
+    History(#[bpaf(external(environment::history))] environment::History),
     #[bpaf(command, hide)]
-    PrintDevEnv(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::PrintDevEnv>),
+    PrintDevEnv(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::PrintDevEnv>),
     #[bpaf(command, hide)]
-    Shell(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::Shell>),
+    Shell(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Shell>),
 }
 
 impl AdditionalCommands {

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -17,8 +17,7 @@ use once_cell::sync::Lazy;
 use tempfile::TempDir;
 use toml_edit::Key;
 
-use self::package::interface::Run;
-use self::package::{Parseable, WithPassthru};
+use self::package::{Parseable, Run, WithPassthru};
 use crate::config::{Config, FLOX_CONFIG_FILE};
 use crate::utils::init::{
     init_access_tokens,
@@ -254,9 +253,7 @@ impl LocalDevelopmentCommands {
 enum SharingCommands {
     Push(#[bpaf(external(environment::push))] environment::Push),
     Pull(#[bpaf(external(environment::pull))] environment::Pull),
-    Containerize(
-        #[bpaf(external(package::interface::containerize))] package::interface::Containerize,
-    ),
+    Containerize(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Containerize>),
 }
 impl SharingCommands {
     async fn handle(self, config: Config, flox: Flox) -> Result<()> {

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -355,6 +355,8 @@ enum InternalCommands {
     InitPackage(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::InitPackage>),
     #[bpaf(command)]
     Publish(#[bpaf(external(package::publish))] package::Publish),
+    #[bpaf(command)]
+    Bundle(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Bundle>),
 }
 
 impl InternalCommands {
@@ -368,6 +370,7 @@ impl InternalCommands {
             InternalCommands::Git(args) => args.handle(flox).await?,
             InternalCommands::InitPackage(args) => args.handle(flox).await?,
             InternalCommands::Publish(args) => args.handle(config, flox).await?,
+            InternalCommands::Bundle(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -285,7 +285,7 @@ enum AdditionalCommands {
     Documentation(
         #[bpaf(external(AdditionalCommands::documentation))] AdditionalCommandsDocumentation,
     ),
-    #[bpaf(command)]
+    #[bpaf(command, hide)]
     Build(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::Build>),
     Upgrade(#[bpaf(external(environment::upgrade), hide)] environment::Upgrade),
     Import(#[bpaf(external(environment::import), hide)] environment::Import),
@@ -296,9 +296,9 @@ enum AdditionalCommands {
     Unsubscribe(#[bpaf(external(channel::unsubscribe), hide)] channel::Unsubscribe),
     Channels(#[bpaf(external(channel::channels), hide)] channel::Channels),
     History(#[bpaf(external(environment::history), hide)] environment::History),
-    #[bpaf(command)]
+    #[bpaf(command, hide)]
     PrintDevEnv(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::PrintDevEnv>),
-    #[bpaf(command)]
+    #[bpaf(command, hide)]
     Shell(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::Shell>),
 }
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -423,6 +423,10 @@ enum InternalCommands {
     ),
     #[bpaf(command)]
     Rollback(#[bpaf(external(environment::rollback))] environment::Rollback),
+    /// List all available environments
+    ///
+    /// Aliases:
+    ///   environments, envs
     #[bpaf(command, long("environments"))]
     Envs(#[bpaf(external(environment::envs))] environment::Envs),
     #[bpaf(command)]

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -357,6 +357,8 @@ enum InternalCommands {
     Publish(#[bpaf(external(package::publish))] package::Publish),
     #[bpaf(command)]
     Bundle(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Bundle>),
+    #[bpaf(command)]
+    Flake(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Flake>),
 }
 
 impl InternalCommands {
@@ -371,6 +373,7 @@ impl InternalCommands {
             InternalCommands::InitPackage(args) => args.handle(flox).await?,
             InternalCommands::Publish(args) => args.handle(config, flox).await?,
             InternalCommands::Bundle(args) => args.handle(config, flox).await?,
+            InternalCommands::Flake(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -211,6 +211,7 @@ impl FloxArgs {
             Commands::Development(group) => group.handle(config, flox).await?,
             Commands::Sharing(group) => group.handle(config, flox).await?,
             Commands::Additional(group) => group.handle(config, flox).await?,
+            Commands::Internal(group) => group.handle(config, flox).await?,
         }
         Ok(())
     }
@@ -222,6 +223,7 @@ enum Commands {
     Development(#[bpaf(external(local_development_commands))] LocalDevelopmentCommands),
     Sharing(#[bpaf(external(sharing_commands))] SharingCommands),
     Additional(#[bpaf(external(additional_commands))] AdditionalCommands),
+    Internal(#[bpaf(external(internal_commands))] InternalCommands),
 }
 
 /// Local Development Commands
@@ -334,6 +336,30 @@ struct AdditionalCommandsDocumentation;
 impl AdditionalCommandsDocumentation {
     fn handle(self) {
         println!("🥚");
+    }
+}
+
+/// Additional Commands. Use "flox COMMAND --help" for more info
+#[derive(Bpaf, Clone)]
+#[bpaf(hide)]
+enum InternalCommands {
+    ResetMetrics(#[bpaf(external(general::reset_metrics))] general::ResetMetrics),
+    Generations(#[bpaf(external(environment::generations))] environment::Generations),
+    SwitchGeneration(
+        #[bpaf(external(environment::switch_generation))] environment::SwitchGeneration,
+    ),
+    Rollback(#[bpaf(external(environment::rollback))] environment::Rollback),
+}
+
+impl InternalCommands {
+    async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        match self {
+            InternalCommands::ResetMetrics(args) => args.handle(config, flox).await?,
+            InternalCommands::Generations(args) => args.handle(flox).await?,
+            InternalCommands::SwitchGeneration(args) => args.handle(flox).await?,
+            InternalCommands::Rollback(args) => args.handle(flox).await?,
+        }
+        Ok(())
     }
 }
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -349,6 +349,7 @@ enum InternalCommands {
         #[bpaf(external(environment::switch_generation))] environment::SwitchGeneration,
     ),
     Rollback(#[bpaf(external(environment::rollback))] environment::Rollback),
+    Envs(#[bpaf(external(environment::envs))] environment::Envs),
 }
 
 impl InternalCommands {
@@ -358,6 +359,7 @@ impl InternalCommands {
             InternalCommands::Generations(args) => args.handle(flox).await?,
             InternalCommands::SwitchGeneration(args) => args.handle(flox).await?,
             InternalCommands::Rollback(args) => args.handle(flox).await?,
+            InternalCommands::Envs(args) => args.handle(flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -480,6 +480,8 @@ enum InternalCommands {
     Eval(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Eval>),
     #[bpaf(command)]
     Develop(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Develop>),
+    #[bpaf(command)]
+    Gh(#[bpaf(external(general::gh))] general::Gh),
 }
 
 impl InternalCommands {
@@ -519,6 +521,7 @@ impl InternalCommands {
             InternalCommands::Flake(args) => args.handle(config, flox).await?,
             InternalCommands::Eval(args) => args.handle(config, flox).await?,
             InternalCommands::Develop(args) => args.handle(config, flox).await?,
+            InternalCommands::Gh(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -353,6 +353,8 @@ enum InternalCommands {
     Git(#[bpaf(external(environment::git))] environment::Git),
     #[bpaf(command("init-package"))]
     InitPackage(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::InitPackage>),
+    #[bpaf(command)]
+    Publish(#[bpaf(external(package::publish))] package::Publish),
 }
 
 impl InternalCommands {
@@ -365,6 +367,7 @@ impl InternalCommands {
             InternalCommands::Envs(args) => args.handle(flox).await?,
             InternalCommands::Git(args) => args.handle(flox).await?,
             InternalCommands::InitPackage(args) => args.handle(flox).await?,
+            InternalCommands::Publish(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -478,6 +478,8 @@ enum InternalCommands {
     Flake(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Flake>),
     #[bpaf(command)]
     Eval(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Eval>),
+    #[bpaf(command)]
+    Develop(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Develop>),
 }
 
 impl InternalCommands {
@@ -516,6 +518,7 @@ impl InternalCommands {
             InternalCommands::Bundle(args) => args.handle(config, flox).await?,
             InternalCommands::Flake(args) => args.handle(config, flox).await?,
             InternalCommands::Eval(args) => args.handle(config, flox).await?,
+            InternalCommands::Develop(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -285,8 +285,21 @@ enum AdditionalCommands {
     Documentation(
         #[bpaf(external(AdditionalCommands::documentation))] AdditionalCommandsDocumentation,
     ),
-    Push(#[bpaf(external(environment::push), hide)] environment::Push),
-    Pull(#[bpaf(external(environment::pull), hide)] environment::Pull),
+    #[bpaf(command)]
+    Build(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::Build>),
+    Upgrade(#[bpaf(external(environment::upgrade), hide)] environment::Upgrade),
+    Import(#[bpaf(external(environment::import), hide)] environment::Import),
+    Export(#[bpaf(external(environment::export), hide)] environment::Export),
+    Config(#[bpaf(external(general::config_args), hide)] general::ConfigArgs),
+    WipeHistory(#[bpaf(external(environment::wipe_history), hide)] environment::WipeHistory),
+    Subscribe(#[bpaf(external(channel::subscribe), hide)] channel::Subscribe),
+    Unsubscribe(#[bpaf(external(channel::unsubscribe), hide)] channel::Unsubscribe),
+    Channels(#[bpaf(external(channel::channels), hide)] channel::Channels),
+    History(#[bpaf(external(environment::history), hide)] environment::History),
+    #[bpaf(command)]
+    PrintDevEnv(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::PrintDevEnv>),
+    #[bpaf(command)]
+    Shell(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::Shell>),
 }
 
 impl AdditionalCommands {
@@ -299,8 +312,18 @@ impl AdditionalCommands {
     async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
             AdditionalCommands::Documentation(args) => args.handle(),
-            AdditionalCommands::Push(args) => args.handle(flox).await?,
-            AdditionalCommands::Pull(args) => args.handle(flox).await?,
+            AdditionalCommands::Build(args) => args.handle(config, flox).await?,
+            AdditionalCommands::Upgrade(args) => args.handle(flox).await?,
+            AdditionalCommands::Import(args) => args.handle(flox).await?,
+            AdditionalCommands::Export(args) => args.handle(flox).await?,
+            AdditionalCommands::Config(args) => args.handle(config, flox).await?,
+            AdditionalCommands::WipeHistory(args) => args.handle(flox).await?,
+            AdditionalCommands::Subscribe(args) => args.handle(flox).await?,
+            AdditionalCommands::Unsubscribe(args) => args.handle(flox).await?,
+            AdditionalCommands::Channels(args) => args.handle(flox)?,
+            AdditionalCommands::History(args) => args.handle(flox).await?,
+            AdditionalCommands::PrintDevEnv(args) => args.handle(config, flox).await?,
+            AdditionalCommands::Shell(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -351,6 +351,8 @@ enum InternalCommands {
     Rollback(#[bpaf(external(environment::rollback))] environment::Rollback),
     Envs(#[bpaf(external(environment::envs))] environment::Envs),
     Git(#[bpaf(external(environment::git))] environment::Git),
+    #[bpaf(command("init-package"))]
+    InitPackage(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::InitPackage>),
 }
 
 impl InternalCommands {
@@ -362,6 +364,7 @@ impl InternalCommands {
             InternalCommands::Rollback(args) => args.handle(flox).await?,
             InternalCommands::Envs(args) => args.handle(flox).await?,
             InternalCommands::Git(args) => args.handle(flox).await?,
+            InternalCommands::InitPackage(args) => args.handle(flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -484,14 +484,25 @@ impl InternalCommands {
     async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
             // Environment Commands feature gate
-            InternalCommands::Generations(_)
-            | InternalCommands::SwitchGeneration(_)
-            | InternalCommands::Rollback(_)
-            | InternalCommands::Envs(_)
-            | InternalCommands::Git(_)
-                if Feature::Env.is_forwarded()? =>
-            {
-                flox_forward(&flox).await?
+            InternalCommands::Generations(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("generations");
+                flox_forward(&flox).await?;
+            },
+            InternalCommands::SwitchGeneration(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("switch-generation");
+                flox_forward(&flox).await?;
+            },
+            InternalCommands::Rollback(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("rollback");
+                flox_forward(&flox).await?;
+            },
+            InternalCommands::Envs(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("envs");
+                flox_forward(&flox).await?;
+            },
+            InternalCommands::Git(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("git");
+                flox_forward(&flox).await?;
             },
 
             InternalCommands::ResetMetrics(args) => args.handle(config, flox).await?,

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -225,6 +225,8 @@ enum LocalDevelopmentCommands {
     Install(#[bpaf(external(environment::install))] environment::Install),
     Uninstall(#[bpaf(external(environment::uninstall))] environment::Uninstall),
     Edit(#[bpaf(external(environment::edit))] environment::Edit),
+    /// Run app from current project
+    #[bpaf(command)]
     Run(#[bpaf(external(WithPassthru::parse))] WithPassthru<Run>),
     List(#[bpaf(external(environment::list))] environment::List),
     Nix(#[bpaf(external(general::parse_nix_passthru))] general::WrappedNix),
@@ -239,10 +241,9 @@ impl LocalDevelopmentCommands {
             LocalDevelopmentCommands::Install(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::Uninstall(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::List(args) => args.handle(flox).await?,
-
             LocalDevelopmentCommands::Nix(args) => args.handle(config, flox).await?,
             LocalDevelopmentCommands::Search(args) => args.handle(flox).await?,
-            LocalDevelopmentCommands::Run(_) => todo!(),
+            LocalDevelopmentCommands::Run(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }
@@ -253,6 +254,8 @@ impl LocalDevelopmentCommands {
 enum SharingCommands {
     Push(#[bpaf(external(environment::push))] environment::Push),
     Pull(#[bpaf(external(environment::pull))] environment::Pull),
+    /// Containerize an environment
+    #[bpaf(command)]
     Containerize(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Containerize>),
 }
 impl SharingCommands {
@@ -260,7 +263,7 @@ impl SharingCommands {
         match self {
             SharingCommands::Push(args) => args.handle(flox).await?,
             SharingCommands::Pull(args) => args.handle(flox).await?,
-            SharingCommands::Containerize(_) => todo!(),
+            SharingCommands::Containerize(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -259,7 +259,7 @@ enum LocalDevelopmentCommands {
     #[bpaf(command)]
     Nix(#[bpaf(external(general::parse_nix_passthru))] general::WrappedNix),
     /// Delete an environment
-    #[bpaf(command)]
+    #[bpaf(command, long("destroy"))]
     Delete(#[bpaf(external(environment::delete))] environment::Delete),
 }
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -20,7 +20,6 @@ use toml_edit::Key;
 use self::package::{Parseable, Run, WithPassthru};
 use crate::config::features::Feature;
 use crate::config::{Config, FLOX_CONFIG_FILE};
-use crate::flox_forward;
 use crate::utils::init::{
     init_access_tokens,
     init_channels,
@@ -30,6 +29,7 @@ use crate::utils::init::{
     telemetry_opt_out_needs_migration,
 };
 use crate::utils::metrics::METRICS_UUID_FILE_NAME;
+use crate::{flox_forward, subcommand_metric};
 
 static FLOX_WELCOME_MESSAGE: Lazy<String> = Lazy::new(|| {
     formatdoc! {r#"
@@ -266,19 +266,37 @@ enum LocalDevelopmentCommands {
 impl LocalDevelopmentCommands {
     async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
-            LocalDevelopmentCommands::Init(_)
-            | LocalDevelopmentCommands::Activate(_)
-            | LocalDevelopmentCommands::Edit(_)
-            | LocalDevelopmentCommands::Install(_)
-            | LocalDevelopmentCommands::Uninstall(_)
-            | LocalDevelopmentCommands::List(_)
-            | LocalDevelopmentCommands::Delete(_)
-                if Feature::Env.is_forwarded()? =>
-            {
-                flox_forward(&flox).await?
+            LocalDevelopmentCommands::Init(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("init");
+                flox_forward(&flox).await?;
             },
-
+            LocalDevelopmentCommands::Activate(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("activate");
+                flox_forward(&flox).await?;
+            },
+            LocalDevelopmentCommands::Edit(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("edit");
+                flox_forward(&flox).await?;
+            },
+            LocalDevelopmentCommands::Install(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("install");
+                flox_forward(&flox).await?;
+            },
+            LocalDevelopmentCommands::Uninstall(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("uninstall");
+                flox_forward(&flox).await?;
+            },
+            LocalDevelopmentCommands::List(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("list");
+                flox_forward(&flox).await?;
+            },
+            LocalDevelopmentCommands::Delete(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("delete");
+                flox_forward(&flox).await?;
+            },
             LocalDevelopmentCommands::Search(_) if Feature::Channels.is_forwarded()? => {
+                subcommand_metric!("search");
+
                 flox_forward(&flox).await?
             },
 
@@ -313,10 +331,13 @@ enum SharingCommands {
 impl SharingCommands {
     async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
-            SharingCommands::Push(_) | SharingCommands::Pull(_)
-                if Feature::Env.is_forwarded()? =>
-            {
-                flox_forward(&flox).await?
+            SharingCommands::Push(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("push");
+                flox_forward(&flox).await?;
+            },
+            SharingCommands::Pull(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("pull");
+                flox_forward(&flox).await?;
             },
             SharingCommands::Push(args) => args.handle(flox).await?,
             SharingCommands::Pull(args) => args.handle(flox).await?,
@@ -368,22 +389,26 @@ impl AdditionalCommands {
     async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
             // Environment commands feature gate
-            AdditionalCommands::Upgrade(_)
-            | AdditionalCommands::Import(_)
-            | AdditionalCommands::Export(_)
-            | AdditionalCommands::History(_)
-            | AdditionalCommands::PrintDevEnv(_)
-                if Feature::Env.is_forwarded()? =>
-            {
-                flox_forward(&flox).await?
+            AdditionalCommands::Upgrade(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("upgrade");
+                flox_forward(&flox).await?;
+            },
+            AdditionalCommands::Import(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("import");
+                flox_forward(&flox).await?;
+            },
+            AdditionalCommands::Export(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("export");
+                flox_forward(&flox).await?;
+            },
+            AdditionalCommands::History(_) if Feature::Env.is_forwarded()? => {
+                subcommand_metric!("history");
+                flox_forward(&flox).await?;
             },
 
             // Channel Commands feature gate
-            AdditionalCommands::Channels(_)
-            | AdditionalCommands::Subscribe(_)
-            | AdditionalCommands::Unsubscribe(_)
-                if Feature::Channels.is_forwarded()? =>
-            {
+            AdditionalCommands::Channels(_) if Feature::Channels.is_forwarded()? => {
+                subcommand_metric!("channels");
                 flox_forward(&flox).await?
             },
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -273,7 +273,6 @@ impl LocalDevelopmentCommands {
             | LocalDevelopmentCommands::Uninstall(_)
             | LocalDevelopmentCommands::List(_)
             | LocalDevelopmentCommands::Delete(_)
-            | LocalDevelopmentCommands::Search(_)
                 if Feature::Env.is_forwarded()? =>
             {
                 flox_forward(&flox).await?

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -231,17 +231,35 @@ enum Commands {
 /// Local Development Commands
 #[derive(Bpaf, Clone)]
 enum LocalDevelopmentCommands {
+    /// Create an environment in the current directory
+    #[bpaf(command, long("create"))]
     Init(#[bpaf(external(environment::init))] environment::Init),
+    /// Activate environment
+    #[bpaf(command)]
     Activate(#[bpaf(external(environment::activate))] environment::Activate),
+    /// Search packages in subscribed channels
+    #[bpaf(command)]
     Search(#[bpaf(external(channel::search))] channel::Search),
+    /// Install a package into an environment
+    #[bpaf(command)]
     Install(#[bpaf(external(environment::install))] environment::Install),
+    /// Uninstall installed packages from an environment
+    #[bpaf(command, long("remove"), long("rm"))]
     Uninstall(#[bpaf(external(environment::uninstall))] environment::Uninstall),
+    /// Edit declarative environment configuration
+    #[bpaf(command)]
     Edit(#[bpaf(external(environment::edit))] environment::Edit),
     /// Run app from current project
     #[bpaf(command)]
     Run(#[bpaf(external(WithPassthru::parse))] WithPassthru<Run>),
+    /// List (status?) packages installed in an environment
+    #[bpaf(command)]
     List(#[bpaf(external(environment::list))] environment::List),
+    /// Access to the nix CLI
+    #[bpaf(command)]
     Nix(#[bpaf(external(general::parse_nix_passthru))] general::WrappedNix),
+    /// Delete an environment
+    #[bpaf(command)]
     Delete(#[bpaf(external(environment::delete))] environment::Delete),
 }
 
@@ -278,7 +296,11 @@ impl LocalDevelopmentCommands {
 /// Sharing Commands
 #[derive(Bpaf, Clone)]
 enum SharingCommands {
+    /// Send environment to flox hub
+    #[bpaf(command)]
     Push(#[bpaf(external(environment::push))] environment::Push),
+    #[bpaf(command)]
+    /// Pull environment from flox hub
     Pull(#[bpaf(external(environment::pull))] environment::Pull),
     /// Containerize an environment
     #[bpaf(command)]
@@ -308,14 +330,23 @@ enum AdditionalCommands {
     ),
     #[bpaf(command, hide)]
     Build(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::Build>),
+    #[bpaf(command, hide)]
     Upgrade(#[bpaf(external(environment::upgrade), hide)] environment::Upgrade),
+    #[bpaf(command, hide)]
     Import(#[bpaf(external(environment::import), hide)] environment::Import),
+    #[bpaf(command, hide)]
     Export(#[bpaf(external(environment::export), hide)] environment::Export),
+    #[bpaf(command, hide)]
     Config(#[bpaf(external(general::config_args), hide)] general::ConfigArgs),
+    #[bpaf(command("wipe-history"), hide)]
     WipeHistory(#[bpaf(external(environment::wipe_history), hide)] environment::WipeHistory),
+    #[bpaf(command, hide)]
     Subscribe(#[bpaf(external(channel::subscribe), hide)] channel::Subscribe),
+    #[bpaf(command, hide)]
     Unsubscribe(#[bpaf(external(channel::unsubscribe), hide)] channel::Unsubscribe),
+    #[bpaf(command, hide)]
     Channels(#[bpaf(external(channel::channels), hide)] channel::Channels),
+    #[bpaf(command, hide)]
     History(#[bpaf(external(environment::history), hide)] environment::History),
     #[bpaf(command, hide)]
     PrintDevEnv(#[bpaf(external(WithPassthru::parse), hide)] WithPassthru<package::PrintDevEnv>),
@@ -382,13 +413,19 @@ impl AdditionalCommandsDocumentation {
 #[derive(Bpaf, Clone)]
 #[bpaf(hide)]
 enum InternalCommands {
+    #[bpaf(command("reset-metrics"))]
     ResetMetrics(#[bpaf(external(general::reset_metrics))] general::ResetMetrics),
+    #[bpaf(command)]
     Generations(#[bpaf(external(environment::generations))] environment::Generations),
+    #[bpaf(command("switch-generation"))]
     SwitchGeneration(
         #[bpaf(external(environment::switch_generation))] environment::SwitchGeneration,
     ),
+    #[bpaf(command)]
     Rollback(#[bpaf(external(environment::rollback))] environment::Rollback),
+    #[bpaf(command, long("environments"))]
     Envs(#[bpaf(external(environment::envs))] environment::Envs),
+    #[bpaf(command)]
     Git(#[bpaf(external(environment::git))] environment::Git),
     #[bpaf(command("init-package"))]
     InitPackage(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::InitPackage>),

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -359,6 +359,8 @@ enum InternalCommands {
     Bundle(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Bundle>),
     #[bpaf(command)]
     Flake(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Flake>),
+    #[bpaf(command)]
+    Eval(#[bpaf(external(WithPassthru::parse))] WithPassthru<package::Eval>),
 }
 
 impl InternalCommands {
@@ -374,6 +376,7 @@ impl InternalCommands {
             InternalCommands::Publish(args) => args.handle(config, flox).await?,
             InternalCommands::Bundle(args) => args.handle(config, flox).await?,
             InternalCommands::Flake(args) => args.handle(config, flox).await?,
+            InternalCommands::Eval(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -232,22 +232,22 @@ enum Commands {
 #[derive(Bpaf, Clone)]
 enum LocalDevelopmentCommands {
     /// Create an environment in the current directory
-    #[bpaf(command, long("create"))]
+    #[bpaf(command, short('i'), long("create"), short('c'))]
     Init(#[bpaf(external(environment::init))] environment::Init),
     /// Activate environment
-    #[bpaf(command)]
+    #[bpaf(command, short('a'), long("develop"))]
     Activate(#[bpaf(external(environment::activate))] environment::Activate),
     /// Search packages in subscribed channels
     #[bpaf(command)]
     Search(#[bpaf(external(channel::search))] channel::Search),
     /// Install a package into an environment
-    #[bpaf(command)]
+    #[bpaf(command, short('i'))]
     Install(#[bpaf(external(environment::install))] environment::Install),
     /// Uninstall installed packages from an environment
-    #[bpaf(command, long("remove"), long("rm"))]
+    #[bpaf(command, short('u'), long("remove"), long("rm"))]
     Uninstall(#[bpaf(external(environment::uninstall))] environment::Uninstall),
     /// Edit declarative environment configuration
-    #[bpaf(command)]
+    #[bpaf(command, short('e'))]
     Edit(#[bpaf(external(environment::edit))] environment::Edit),
     /// Run app from current project
     #[bpaf(command)]

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -215,7 +215,7 @@ pub struct PrintDevEnv {
 }
 parseable!(PrintDevEnv, print_dev_env);
 impl WithPassthru<PrintDevEnv> {
-    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, _config: Config, flox: Flox) -> Result<()> {
         flox_forward(&flox).await
     }
 }
@@ -384,10 +384,12 @@ impl WithPassthru<Shell> {
 #[derive(Bpaf, Clone, Debug)]
 pub struct Bundle {
     /// Bundler to use
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(external)]
     pub(crate) bundler_arg: Option<InstallableArgument<Parsed, BundlerInstallable>>,
 
     /// Package or environment to bundle
+    #[allow(dead_code)] // not yet handled in impl
     #[bpaf(external(PosOrEnv::parse), optional, catch)]
     pub(crate) installable_arg: Option<PosOrEnv<BundleInstallable>>,
 
@@ -433,7 +435,7 @@ pub struct Containerize {
 }
 parseable!(Containerize, containerize);
 impl WithPassthru<Containerize> {
-    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, _config: Config, flox: Flox) -> Result<()> {
         let mut installable = env_ref_to_flake_attribute::<GitCommandProvider>(
             &flox,
             "containerize",

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -123,7 +123,7 @@ pub(crate) fn template_arg() -> impl Parser<Option<InstallableArgument<Parsed, T
 }
 parseable!(InitPackage, init_package);
 impl WithPassthru<InitPackage> {
-    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
         let cwd = std::env::current_dir()?;
         let basename = cwd
             .file_name()

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -713,11 +713,9 @@ impl<T> WithPassthru<T> {
             // .strict()
             .many();
 
-        construct!(nix_args, inner, fake_args).map(|(mut nix_args, inner, mut fake_args)| {
+        construct!(inner, fake_args, nix_args).map(|(inner, mut fake_args, mut nix_args)| {
             // dbg!(&nix_args, &inner, &fake_args);
-
             nix_args.append(&mut fake_args);
-
             WithPassthru { inner, nix_args }
         })
     }

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -203,18 +203,6 @@ impl WithPassthru<Build> {
     }
 }
 
-/// launch development shell for current project
-#[derive(Bpaf, Clone, Debug)]
-pub struct Develop {
-    #[bpaf(short('A'), hide)]
-    pub _attr_flag: bool,
-
-    /// Shell or package to develop on
-    #[bpaf(external(InstallableArgument::positional), optional, catch)]
-    pub(crate) installable_arg: Option<InstallableArgument<Parsed, DevelopInstallable>>,
-}
-parseable!(Develop, develop);
-
 /// print shell code that can be sourced by bash to reproduce the development environment
 #[derive(Bpaf, Clone, Debug)]
 pub struct PrintDevEnv {

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -289,10 +289,7 @@ impl Publish {
 
         // validate arguments
 
-        let stability = config.override_stability(self.stability).context(indoc! {"
-            Stability is required!
-            Provide using `--stability` or the `stability` config key
-        "})?;
+        let stability = config.override_stability(self.stability);
 
         let sign_key = self
             .signing_key

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -243,7 +243,9 @@ pub(crate) mod interface {
             .optional()
     }
 
+    /// Containerize an environment
     #[derive(Bpaf, Clone, Debug)]
+    #[bpaf(command)]
     pub struct Containerize {
         /// Environment to containerize
         #[bpaf(long("environment"), short('e'), argument("ENV"))]

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -207,6 +207,18 @@ impl WithPassthru<Build> {
     }
 }
 
+/// launch development shell for current project
+#[derive(Bpaf, Clone, Debug)]
+pub struct Develop {
+    #[bpaf(short('A'), hide)]
+    pub _attr_flag: bool,
+
+    /// Shell or package to develop on
+    #[bpaf(external(InstallableArgument::positional), optional, catch)]
+    pub(crate) installable_arg: Option<InstallableArgument<Parsed, DevelopInstallable>>,
+}
+parseable!(Develop, develop);
+
 /// print shell code that can be sourced by bash to reproduce the development environment
 #[derive(Bpaf, Clone, Debug)]
 pub struct PrintDevEnv {

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -7,13 +7,13 @@ use bpaf::{construct, Bpaf, Parser};
 use crossterm::tty::IsTty;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::project::Project;
-use flox_rust_sdk::models::publish::{Publish, PublishFlakeRef};
+use flox_rust_sdk::models::publish::{Publish as PublishComm, PublishFlakeRef};
 use flox_rust_sdk::models::root::transaction::ReadOnly;
 use flox_rust_sdk::models::root::{self, Closed, Root};
 use flox_rust_sdk::nix::arguments::eval::EvaluationArgs;
 use flox_rust_sdk::nix::arguments::flake::FlakeArgs;
 use flox_rust_sdk::nix::arguments::NixArgs;
-use flox_rust_sdk::nix::command::{Build, BuildOut, Eval as EvalComm};
+use flox_rust_sdk::nix::command::{Build as BuildComm, BuildOut, Eval as EvalComm};
 use flox_rust_sdk::nix::command_line::{Group, NixCliCommand, NixCommandLine, ToArgs};
 use flox_rust_sdk::nix::{Run as RunC, RunTyped};
 use flox_rust_sdk::prelude::FlakeAttribute;
@@ -23,12 +23,10 @@ use indoc::indoc;
 use itertools::Itertools;
 use log::{debug, info};
 
-use crate::commands::package::interface::{PackageCommands, ResolveInstallable};
-use crate::config::features::Feature;
 use crate::config::Config;
+use crate::flox_forward;
 use crate::utils::dialog::{Dialog, Text};
 use crate::utils::resolve_environment_ref;
-use crate::{flox_forward, subcommand_metric};
 
 async fn env_ref_to_flake_attribute<Git: GitProvider + 'static>(
     flox: &Flox,
@@ -39,668 +37,596 @@ async fn env_ref_to_flake_attribute<Git: GitProvider + 'static>(
     Ok(env_ref.get_latest_flake_attribute::<Git>(flox).await?)
 }
 
-pub(crate) mod interface {
-    use std::path::PathBuf;
+use async_trait::async_trait;
+use flox_types::catalog::cache::SubstituterUrl;
 
-    use async_trait::async_trait;
-    use bpaf::{Bpaf, Parser};
-    use flox_rust_sdk::flox::Flox;
-    use flox_rust_sdk::prelude::FlakeAttribute;
-    use flox_rust_sdk::providers::git::GitProvider;
-    use flox_types::catalog::cache::SubstituterUrl;
+use self::parseable_macro::parseable;
+use crate::utils::installables::{
+    BuildInstallable,
+    BundleInstallable,
+    BundlerInstallable,
+    DevelopInstallable,
+    PublishInstallable,
+    RunInstallable,
+    ShellInstallable,
+    TemplateInstallable,
+};
+use crate::utils::{InstallableArgument, InstallableDef, Parsed};
 
-    use super::parseable_macro::parseable;
-    use super::{env_ref_to_flake_attribute, Parseable, WithPassthru};
-    use crate::utils::installables::{
-        BuildInstallable,
-        BundleInstallable,
-        BundlerInstallable,
-        DevelopInstallable,
-        PublishInstallable,
-        RunInstallable,
-        ShellInstallable,
-        TemplateInstallable,
-    };
-    use crate::utils::{InstallableArgument, InstallableDef, Parsed};
+#[derive(Clone, Debug)]
+pub enum PosOrEnv<T: InstallableDef> {
+    Pos(InstallableArgument<Parsed, T>),
+    Env(String),
+}
+impl<T: 'static + InstallableDef> Parseable for PosOrEnv<T> {
+    fn parse() -> Box<dyn bpaf::Parser<Self>> {
+        let installable = InstallableArgument::positional().map(PosOrEnv::Pos);
+        let environment = bpaf::long("environment")
+            .short('e')
+            .argument("environment")
+            .map(PosOrEnv::Env);
 
-    #[derive(Clone, Debug)]
-    pub enum PosOrEnv<T: InstallableDef> {
-        Pos(InstallableArgument<Parsed, T>),
-        Env(String),
-    }
-    impl<T: 'static + InstallableDef> Parseable for PosOrEnv<T> {
-        fn parse() -> Box<dyn bpaf::Parser<Self>> {
-            let installable = InstallableArgument::positional().map(PosOrEnv::Pos);
-            let environment = bpaf::long("environment")
-                .short('e')
-                .argument("environment")
-                .map(PosOrEnv::Env);
-
-            let parser = bpaf::construct!([installable, environment]);
-            bpaf::construct!(parser) // turn into a box
-        }
-    }
-
-    #[async_trait(?Send)]
-    pub trait ResolveInstallable<Git: GitProvider> {
-        async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute>;
-    }
-
-    #[async_trait(?Send)]
-    impl<T: InstallableDef + 'static, Git: GitProvider + 'static> ResolveInstallable<Git>
-        for PosOrEnv<T>
-    {
-        async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute> {
-            Ok(match self {
-                PosOrEnv::Pos(i) => i.resolve_flake_attribute(flox).await?,
-                PosOrEnv::Env(n) => {
-                    env_ref_to_flake_attribute::<Git>(flox, T::SUBCOMMAND, n).await?
-                },
-            })
-        }
-    }
-
-    #[async_trait(?Send)]
-    impl<T: InstallableDef + 'static, Git: GitProvider + 'static> ResolveInstallable<Git>
-        for Option<PosOrEnv<T>>
-    {
-        async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute> {
-            Ok(match self {
-                Some(x) => ResolveInstallable::<Git>::installable(x, flox).await?,
-                None => {
-                    ResolveInstallable::<Git>::installable(
-                        &PosOrEnv::Pos(InstallableArgument::<Parsed, T>::default()),
-                        flox,
-                    )
-                    .await?
-                },
-            })
-        }
-    }
-
-    #[derive(Debug, Clone, Bpaf)]
-    pub struct Nix {}
-
-    #[derive(Debug, Clone, Bpaf)]
-    pub struct Init {
-        // [sic]
-        // template does NOT support package args
-        // - e.g. `stability`
-        #[bpaf(external(template_arg))]
-        pub(crate) template: Option<InstallableArgument<Parsed, TemplateInstallable>>,
-        #[bpaf(long("name"), short('n'), argument("name"))]
-        pub(crate) name: Option<String>,
-    }
-    pub(crate) fn template_arg(
-    ) -> impl Parser<Option<InstallableArgument<Parsed, TemplateInstallable>>> {
-        InstallableArgument::parse_with(bpaf::long("template").short('t').argument("template"))
-            .optional()
-    }
-
-    parseable!(Init, init);
-
-    #[derive(Debug, Clone, Bpaf)]
-    pub struct Build {
-        #[bpaf(short('A'), hide)]
-        pub(crate) _attr_flag: bool,
-
-        #[bpaf(external(InstallableArgument::positional), optional, catch)]
-        pub(crate) installable_arg: Option<InstallableArgument<Parsed, BuildInstallable>>,
-    }
-    parseable!(Build, build);
-
-    #[derive(Bpaf, Clone, Debug)]
-    /// launch development shell for current project
-    pub struct Develop {
-        #[bpaf(short('A'), hide)]
-        pub _attr_flag: bool,
-
-        /// Shell or package to develop on
-        #[bpaf(external(InstallableArgument::positional), optional, catch)]
-        pub(crate) installable_arg: Option<InstallableArgument<Parsed, DevelopInstallable>>,
-    }
-    parseable!(Develop, develop);
-
-    #[derive(Bpaf, Clone, Debug)]
-    /// print shell code that can be sourced by bash to reproduce the development environment
-    pub struct PrintDevEnv {
-        #[bpaf(short('A'), hide)]
-        pub _attr_flag: bool,
-
-        /// Shell or package to develop on
-        #[bpaf(external(InstallableArgument::positional), optional, catch)]
-        pub(crate) _installable_arg: Option<InstallableArgument<Parsed, DevelopInstallable>>,
-    }
-    parseable!(PrintDevEnv, print_dev_env);
-
-    #[derive(Bpaf, Clone, Debug)]
-    pub struct Publish {
-        /// Signing key file to sign the binary with
-        ///
-        /// When omitted, reads from the config.
-        /// See flox-config(1) for more details.
-        #[bpaf(long, short('k'))]
-        pub signing_key: Option<PathBuf>,
-
-        /// Url of a binary cache to push binaries _to_
-        ///
-        /// When omitted, reads from the config.
-        /// See flox-config(1) for more details.
-        #[bpaf(long, short('c'))]
-        pub cache_url: Option<SubstituterUrl>,
-
-        /// URL of a substituter to pull binaries _from_
-        ///
-        /// When ommitted, falls back to the config or uses the value for cache-url.
-        /// See flox-config(1) for more details.
-        #[bpaf(long, short('s'))]
-        pub public_cache_url: Option<SubstituterUrl>,
-
-        /// Print snapshot JSON to stdout instead of uploading it to the catalog
-        #[bpaf(long, hide)]
-        pub json: bool,
-
-        /// Prefer https access to repositories published with a `github:` reference
-        ///
-        /// `ssh` is used by default.
-        #[bpaf(long)]
-        pub prefer_https: bool,
-
-        /// Package to publish
-        #[bpaf(external(InstallableArgument::positional), optional, catch)]
-        pub installable_arg: Option<InstallableArgument<Parsed, PublishInstallable>>,
-    }
-    parseable!(Publish, publish);
-
-    #[derive(Bpaf, Clone, Debug)]
-    pub struct Shell {
-        #[bpaf(short('A'), hide)]
-        pub _attr_flag: bool,
-
-        /// Package to provide in a shell
-        #[bpaf(external(InstallableArgument::positional), optional, catch)]
-        pub(crate) installable_arg: Option<InstallableArgument<Parsed, ShellInstallable>>,
-    }
-    parseable!(Shell, shell);
-
-    #[derive(Bpaf, Clone, Debug)]
-    pub struct Bundle {
-        /// Bundler to use
-        #[bpaf(external)]
-        pub(crate) bundler_arg: Option<InstallableArgument<Parsed, BundlerInstallable>>,
-
-        /// Package or environment to bundle
-        #[bpaf(external(PosOrEnv::parse), optional, catch)]
-        pub(crate) installable_arg: Option<PosOrEnv<BundleInstallable>>,
-
-        #[bpaf(short('A'), hide)]
-        pub _attr_flag: bool,
-    }
-    parseable!(Bundle, bundle);
-    pub(crate) fn bundler_arg(
-    ) -> impl Parser<Option<InstallableArgument<Parsed, BundlerInstallable>>> {
-        InstallableArgument::parse_with(bpaf::long("bundler").short('b').argument("bundler"))
-            .optional()
-    }
-
-    /// Containerize an environment
-    #[derive(Bpaf, Clone, Debug)]
-    #[bpaf(command)]
-    pub struct Containerize {
-        /// Environment to containerize
-        #[bpaf(long("environment"), short('e'), argument("ENV"))]
-        pub(crate) environment_name: Option<String>,
-
-        #[bpaf(short('A'), hide)]
-        pub _attr_flag: bool,
-    }
-    parseable!(Containerize, containerize);
-
-    #[derive(Bpaf, Clone, Debug)]
-    pub struct Run {
-        #[bpaf(short('A'), hide)]
-        pub(crate) _attr_flag: bool,
-        #[bpaf(external(InstallableArgument::positional), optional, catch)]
-        pub(crate) installable_arg: Option<InstallableArgument<Parsed, RunInstallable>>,
-    }
-    parseable!(Run, run);
-
-    #[derive(Bpaf, Clone, Debug)]
-    pub struct Eval {}
-    parseable!(Eval, eval);
-
-    #[derive(Bpaf, Clone, Debug)]
-    pub struct Flake {
-        #[bpaf(positional("NIX FLAKE COMMAND"))]
-        pub subcommand: String,
-    }
-    parseable!(Flake, flake);
-
-    #[derive(Bpaf, Clone, Debug)]
-    pub enum PackageCommands {
-        // [c1]: only one init command
-        /// initialize flox expressions for current project
-        #[bpaf(command("init-package"), hide)]
-        InitPackage(#[bpaf(external(WithPassthru::parse))] WithPassthru<Init>),
-
-        /// build package from current project
-        #[bpaf(command)]
-        Build(#[bpaf(external(WithPassthru::parse))] WithPassthru<Build>),
-        /// launch development shell for current project
-        #[bpaf(command)]
-        Develop(#[bpaf(external(WithPassthru::parse))] WithPassthru<Develop>),
-        /// print shell code that can be sourced by bash to reproduce the development environment
-        #[bpaf(command("print-dev-env"))]
-        PrintDevEnv(#[bpaf(external(WithPassthru::parse))] WithPassthru<PrintDevEnv>),
-        /// build package and publish to flox channel
-        #[bpaf(command)]
-        Publish(#[bpaf(external(WithPassthru::parse))] WithPassthru<Publish>),
-        /// run app from current project
-        #[bpaf(command)]
-        Run(#[bpaf(external(WithPassthru::parse))] WithPassthru<Run>),
-        /// run a shell in which the current project is available
-        #[bpaf(command)]
-        Shell(#[bpaf(external(WithPassthru::parse))] WithPassthru<Shell>),
-        /// evaluate a Nix expression
-        #[bpaf(command)]
-        Eval(#[bpaf(external(WithPassthru::parse))] WithPassthru<Eval>),
-        /// run a bundler for current project
-        #[bpaf(command)]
-        Bundle(#[bpaf(external(WithPassthru::parse))] WithPassthru<Bundle>),
-        /// containerize an environment
-        #[bpaf(command)]
-        Containerize(#[bpaf(external(WithPassthru::parse))] WithPassthru<Containerize>),
-        /// run `nix flake` commands
-        #[bpaf(command)]
-        Flake(#[bpaf(external(WithPassthru::parse))] WithPassthru<Flake>),
+        let parser = bpaf::construct!([installable, environment]);
+        bpaf::construct!(parser) // turn into a box
     }
 }
 
-impl PackageCommands {
+#[async_trait(?Send)]
+pub trait ResolveInstallable<Git: GitProvider> {
+    async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute>;
+}
+
+#[async_trait(?Send)]
+impl<T: InstallableDef + 'static, Git: GitProvider + 'static> ResolveInstallable<Git>
+    for PosOrEnv<T>
+{
+    async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute> {
+        Ok(match self {
+            PosOrEnv::Pos(i) => i.resolve_flake_attribute(flox).await?,
+            PosOrEnv::Env(n) => env_ref_to_flake_attribute::<Git>(flox, T::SUBCOMMAND, n).await?,
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl<T: InstallableDef + 'static, Git: GitProvider + 'static> ResolveInstallable<Git>
+    for Option<PosOrEnv<T>>
+{
+    async fn installable(&self, flox: &Flox) -> anyhow::Result<FlakeAttribute> {
+        Ok(match self {
+            Some(x) => ResolveInstallable::<Git>::installable(x, flox).await?,
+            None => {
+                ResolveInstallable::<Git>::installable(
+                    &PosOrEnv::Pos(InstallableArgument::<Parsed, T>::default()),
+                    flox,
+                )
+                .await?
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, Bpaf)]
+pub struct InitPackage {
+    // [sic]
+    // template does NOT support package args
+    // - e.g. `stability`
+    #[bpaf(external(template_arg))]
+    pub(crate) template: Option<InstallableArgument<Parsed, TemplateInstallable>>,
+    #[bpaf(long("name"), short('n'), argument("name"))]
+    pub(crate) name: Option<String>,
+}
+pub(crate) fn template_arg() -> impl Parser<Option<InstallableArgument<Parsed, TemplateInstallable>>>
+{
+    InstallableArgument::parse_with(bpaf::long("template").short('t').argument("template"))
+        .optional()
+}
+parseable!(InitPackage, init_package);
+impl WithPassthru<InitPackage> {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
-        match self {
-            PackageCommands::InitPackage(_) => subcommand_metric!("init-package"),
-            PackageCommands::Develop(_) => subcommand_metric!("develop"),
-            PackageCommands::Build(_) => subcommand_metric!("build"),
-            PackageCommands::PrintDevEnv(_) => subcommand_metric!("print-dev-env"),
-            PackageCommands::Publish(_) => subcommand_metric!("publish"),
-            PackageCommands::Run(_) => subcommand_metric!("run"),
-            PackageCommands::Shell(_) => subcommand_metric!("shell"),
-            PackageCommands::Eval(_) => subcommand_metric!("eval"),
-            PackageCommands::Bundle(_) => subcommand_metric!("bundle"),
-            PackageCommands::Containerize(_) => subcommand_metric!("containerize"),
-            PackageCommands::Flake(_) => subcommand_metric!("flake"),
+        let cwd = std::env::current_dir()?;
+        let basename = cwd
+            .file_name()
+            .and_then(|x| x.to_str())
+            .unwrap_or("NAME")
+            .to_owned();
+
+        let git_repo = ensure_project_repo(&flox, cwd).await?;
+        let project = ensure_project(git_repo, &self).await?;
+
+        // Check if template exists before asking for project's name
+        let template = self
+            .inner
+            .template
+            .unwrap_or_default()
+            .resolve_flake_attribute(&flox)
+            .await?
+            .into();
+
+        let name = match self.inner.name {
+            Some(n) => n,
+            None => {
+                // Comment this out since we're using mkShell instead of
+                // root-level flox.nix
+                // TODO: find a better way to not hardcode this
+                // if template.to_string() == "flake:flox#.templates.project" {
+                //     "default".to_string()
+                // } else {
+                let dialog = Dialog {
+                    message: "Enter package name",
+                    help_message: None,
+                    typed: Text {
+                        default: Some(&basename),
+                    },
+                };
+
+                dialog.prompt().await.context("Failed to prompt for name")?
+                // }
+            },
+        };
+
+        let name = name.trim();
+
+        if !name.is_empty() {
+            project
+                .init_flox_package::<NixCommandLine>(self.nix_args, template, name)
+                .await?;
         }
 
-        match self {
-            _ if Feature::Nix.is_forwarded()? => flox_forward(&flox).await?,
+        info!("Run 'flox develop' to enter the project environment.");
+        Ok(())
+    }
+}
 
-            // Unification implementation of Develop is not yet implemented in rust
-            PackageCommands::Develop(_) if Feature::Develop.is_forwarded()? => {
-                flox_forward(&flox).await?
-            },
+#[derive(Debug, Clone, Bpaf)]
+pub struct Build {
+    #[bpaf(short('A'), hide)]
+    pub(crate) _attr_flag: bool,
 
-            // Unification implementation of print-dev-env is not yet implemented in rust
-            PackageCommands::PrintDevEnv(_) if Feature::Develop.is_forwarded()? => {
-                flox_forward(&flox).await?
-            },
+    #[bpaf(external(InstallableArgument::positional), optional, catch)]
+    pub(crate) installable_arg: Option<InstallableArgument<Parsed, BuildInstallable>>,
+}
+parseable!(Build, build);
+impl WithPassthru<Build> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        let installable_arg = self
+            .inner
+            .installable_arg
+            .unwrap_or_default()
+            .resolve_flake_attribute(&flox)
+            .await?;
 
-            PackageCommands::Publish(args) => {
-                let installable = args
-                    .inner
-                    .installable_arg
-                    .unwrap_or_default()
-                    .resolve_flake_attribute(&flox)
-                    .await?;
+        flox.package(installable_arg, config.flox.stability, self.nix_args)
+            .build::<NixCommandLine>()
+            .await?;
+        Ok(())
+    }
+}
 
-                let original_flakeref = &installable.flakeref;
-                let publish_flakeref = PublishFlakeRef::from_flake_ref(
-                    installable.flakeref.clone(),
-                    &flox,
-                    args.inner.prefer_https,
-                )
-                .await?;
+/// launch development shell for current project
+#[derive(Bpaf, Clone, Debug)]
+pub struct Develop {
+    #[bpaf(short('A'), hide)]
+    pub _attr_flag: bool,
 
-                if &publish_flakeref != original_flakeref {
-                    info!("Resolved {} to {}", original_flakeref, publish_flakeref);
-                }
+    /// Shell or package to develop on
+    #[bpaf(external(InstallableArgument::positional), optional, catch)]
+    pub(crate) installable_arg: Option<InstallableArgument<Parsed, DevelopInstallable>>,
+}
+parseable!(Develop, develop);
 
-                // validate arguments
+/// print shell code that can be sourced by bash to reproduce the development environment
+#[derive(Bpaf, Clone, Debug)]
+pub struct PrintDevEnv {
+    #[bpaf(short('A'), hide)]
+    pub _attr_flag: bool,
 
-                let sign_key = args
-                    .inner
-                    .signing_key
-                    .or(config.flox.signing_key)
-                    .ok_or_else(|| {
-                        anyhow!(indoc! {"
+    /// Shell or package to develop on
+    #[bpaf(external(InstallableArgument::positional), optional, catch)]
+    pub(crate) _installable_arg: Option<InstallableArgument<Parsed, DevelopInstallable>>,
+}
+parseable!(PrintDevEnv, print_dev_env);
+impl WithPassthru<PrintDevEnv> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        flox_forward(&flox).await
+    }
+}
+
+#[derive(Bpaf, Clone, Debug)]
+pub struct Publish {
+    /// Signing key file to sign the binary with
+    ///
+    /// When omitted, reads from the config.
+    /// See flox-config(1) for more details.
+    #[bpaf(long, short('k'))]
+    pub signing_key: Option<PathBuf>,
+
+    /// Url of a binary cache to push binaries _to_
+    ///
+    /// When omitted, reads from the config.
+    /// See flox-config(1) for more details.
+    #[bpaf(long, short('c'))]
+    pub cache_url: Option<SubstituterUrl>,
+
+    /// URL of a substituter to pull binaries _from_
+    ///
+    /// When ommitted, falls back to the config or uses the value for cache-url.
+    /// See flox-config(1) for more details.
+    #[bpaf(long, short('s'))]
+    pub public_cache_url: Option<SubstituterUrl>,
+
+    /// Print snapshot JSON to stdout instead of uploading it to the catalog
+    #[bpaf(long, hide)]
+    pub json: bool,
+
+    /// Prefer https access to repositories published with a `github:` reference
+    ///
+    /// `ssh` is used by default.
+    #[bpaf(long)]
+    pub prefer_https: bool,
+
+    /// Package to publish
+    #[bpaf(external(InstallableArgument::positional), optional, catch)]
+    pub installable_arg: Option<InstallableArgument<Parsed, PublishInstallable>>,
+}
+parseable!(Publish, publish);
+impl WithPassthru<Publish> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        let installable = self
+            .inner
+            .installable_arg
+            .unwrap_or_default()
+            .resolve_flake_attribute(&flox)
+            .await?;
+
+        let original_flakeref = &installable.flakeref;
+        let publish_flakeref = PublishFlakeRef::from_flake_ref(
+            installable.flakeref.clone(),
+            &flox,
+            self.inner.prefer_https,
+        )
+        .await?;
+
+        if &publish_flakeref != original_flakeref {
+            info!("Resolved {} to {}", original_flakeref, publish_flakeref);
+        }
+
+        // validate arguments
+
+        let sign_key = self
+            .inner
+            .signing_key
+            .or(config.flox.signing_key)
+            .ok_or_else(|| {
+                anyhow!(indoc! {"
                             Signing key is required!
                             Provide using `--sign-key` or the `sign_key` config key
                         "})
-                    })?;
+            })?;
 
-                let cache_url =
-                    args.inner
-                        .cache_url
-                        .or(config.flox.cache_url)
-                        .ok_or_else(|| {
-                            anyhow!(indoc! {"
+        let cache_url = self
+            .inner
+            .cache_url
+            .or(config.flox.cache_url)
+            .ok_or_else(|| {
+                anyhow!(indoc! {"
                             Cache url is required!
                             Provide using `--cache-url` or the `cache_url` config key
                         "})
-                        })?;
+            })?;
 
-                let substituter_url = args
-                    .inner
-                    .public_cache_url
-                    .or(config.flox.public_cache_url)
-                    .unwrap_or(cache_url.clone());
+        let substituter_url = self
+            .inner
+            .public_cache_url
+            .or(config.flox.public_cache_url)
+            .unwrap_or(cache_url.clone());
 
-                // run publish steps
+        // run publish steps
 
-                let publish = Publish::new(
-                    &flox,
-                    publish_flakeref.clone(),
-                    installable.attr_path.clone(),
-                    config.flox.stability,
-                );
+        let publish = PublishComm::new(
+            &flox,
+            publish_flakeref.clone(),
+            installable.attr_path.clone(),
+            config.flox.stability,
+        );
 
-                // retrieve eval metadata
-                info!("Getting metadata for {installable}...");
-                let mut publish = publish.analyze().await?;
+        // retrieve eval metadata
+        info!("Getting metadata for {installable}...");
+        let mut publish = publish.analyze().await?;
 
-                // build binary
-                info!("Building {installable}...");
-                publish.build().await?;
-                info!("done!");
+        // build binary
+        info!("Building {installable}...");
+        publish.build().await?;
+        info!("done!");
 
-                // sign binary
+        // sign binary
 
-                info!("Signing binary...");
-                publish
-                    .sign_binary(&sign_key)
-                    .await
-                    .with_context(|| format!("Could not sign binary with sign-key {sign_key:?}"))?;
-                info!("done!");
+        info!("Signing binary...");
+        publish
+            .sign_binary(&sign_key)
+            .await
+            .with_context(|| format!("Could not sign binary with sign-key {sign_key:?}"))?;
+        info!("done!");
 
-                // cache binary
-                info!("Uploading binary to {cache_url}...");
-                publish
-                    .upload_binary(Some(cache_url))
-                    .await
-                    .context("Failed uploading binary")?;
-                info!("done!");
+        // cache binary
+        info!("Uploading binary to {cache_url}...");
+        publish
+            .upload_binary(Some(cache_url))
+            .await
+            .context("Failed uploading binary")?;
+        info!("done!");
 
-                info!("Checking binary can be downloaded from {substituter_url}...");
-                publish
-                    .check_substituter(substituter_url)
-                    .await
-                    .context("Binary cannot be downloaded")?;
-                info!("done!");
+        info!("Checking binary can be downloaded from {substituter_url}...");
+        publish
+            .check_substituter(substituter_url)
+            .await
+            .context("Binary cannot be downloaded")?;
+        info!("done!");
 
-                if args.inner.json {
-                    let analysis = publish.analysis();
+        if self.inner.json {
+            let analysis = publish.analysis();
 
-                    println!("{}", serde_json::to_string(analysis)?);
-                } else {
-                    info!("Uploading snapshot to {}...", publish_flakeref.clone_url());
-                    publish.push_snapshot().await.context("Failed to upload")?;
-                    info!("done!");
-                    info!("Publish complete");
-                }
-            },
+            println!("{}", serde_json::to_string(analysis)?);
+        } else {
+            info!("Uploading snapshot to {}...", publish_flakeref.clone_url());
+            publish.push_snapshot().await.context("Failed to upload")?;
+            info!("done!");
+            info!("Publish complete");
+        }
+        Ok(())
+    }
+}
 
-            PackageCommands::InitPackage(command) => {
-                let cwd = std::env::current_dir()?;
-                let basename = cwd
-                    .file_name()
-                    .and_then(|x| x.to_str())
-                    .unwrap_or("NAME")
-                    .to_owned();
+#[derive(Bpaf, Clone, Debug)]
+pub struct Shell {
+    #[bpaf(short('A'), hide)]
+    pub _attr_flag: bool,
 
-                let git_repo = ensure_project_repo(&flox, cwd).await?;
-                let project = ensure_project(git_repo, &command).await?;
+    /// Package to provide in a shell
+    #[bpaf(external(InstallableArgument::positional), optional, catch)]
+    pub(crate) installable_arg: Option<InstallableArgument<Parsed, ShellInstallable>>,
+}
+parseable!(Shell, shell);
+impl WithPassthru<Shell> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        let installable_arg = self
+            .inner
+            .installable_arg
+            .unwrap_or_default()
+            .resolve_flake_attribute(&flox)
+            .await?;
 
-                // Check if template exists before asking for project's name
-                let template = command
-                    .inner
-                    .template
-                    .unwrap_or_default()
-                    .resolve_flake_attribute(&flox)
-                    .await?
-                    .into();
+        flox.package(installable_arg, config.flox.stability, self.nix_args)
+            .shell::<NixCommandLine>()
+            .await?;
+        Ok(())
+    }
+}
 
-                let name = match command.inner.name {
-                    Some(n) => n,
-                    None => {
-                        // Comment this out since we're using mkShell instead of
-                        // root-level flox.nix
-                        // TODO: find a better way to not hardcode this
-                        // if template.to_string() == "flake:flox#.templates.project" {
-                        //     "default".to_string()
-                        // } else {
-                        let dialog = Dialog {
-                            message: "Enter package name",
-                            help_message: None,
-                            typed: Text {
-                                default: Some(&basename),
-                            },
-                        };
+#[derive(Bpaf, Clone, Debug)]
+pub struct Bundle {
+    /// Bundler to use
+    #[bpaf(external)]
+    pub(crate) bundler_arg: Option<InstallableArgument<Parsed, BundlerInstallable>>,
 
-                        dialog.prompt().await.context("Failed to prompt for name")?
-                        // }
-                    },
-                };
+    /// Package or environment to bundle
+    #[bpaf(external(PosOrEnv::parse), optional, catch)]
+    pub(crate) installable_arg: Option<PosOrEnv<BundleInstallable>>,
 
-                let name = name.trim();
+    #[bpaf(short('A'), hide)]
+    pub _attr_flag: bool,
+}
+parseable!(Bundle, bundle);
+pub(crate) fn bundler_arg() -> impl Parser<Option<InstallableArgument<Parsed, BundlerInstallable>>>
+{
+    InstallableArgument::parse_with(bpaf::long("bundler").short('b').argument("bundler")).optional()
+}
+impl WithPassthru<Bundle> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        let installable_arg = ResolveInstallable::<GitCommandProvider>::installable(
+            &self.inner.installable_arg,
+            &flox,
+        )
+        .await?;
 
-                if !name.is_empty() {
-                    project
-                        .init_flox_package::<NixCommandLine>(command.nix_args, template, name)
-                        .await?;
-                }
+        let bundler = self
+            .inner
+            .bundler_arg
+            .unwrap_or_default()
+            .resolve_flake_attribute(&flox)
+            .await?;
 
-                info!("Run 'flox develop' to enter the project environment.")
-            },
-            PackageCommands::Build(command) => {
-                let installable_arg = command
-                    .inner
-                    .installable_arg
-                    .unwrap_or_default()
-                    .resolve_flake_attribute(&flox)
-                    .await?;
+        flox.package(installable_arg, config.flox.stability, self.nix_args)
+            .bundle::<NixCommandLine>(bundler.into())
+            .await?;
+        Ok(())
+    }
+}
 
-                flox.package(installable_arg, config.flox.stability, command.nix_args)
-                    .build::<NixCommandLine>()
-                    .await?;
-            },
-            PackageCommands::Develop(command) => {
-                let installable_arg = command
-                    .inner
-                    .installable_arg
-                    .unwrap_or_default()
-                    .resolve_flake_attribute(&flox)
-                    .await?;
+/// Containerize an environment
+#[derive(Bpaf, Clone, Debug)]
+#[bpaf(command)]
+pub struct Containerize {
+    /// Environment to containerize
+    #[bpaf(long("environment"), short('e'), argument("ENV"))]
+    pub(crate) environment_name: Option<String>,
 
-                flox.package(installable_arg, config.flox.stability, command.nix_args)
-                    .develop::<NixCommandLine>()
-                    .await?
-            },
-            PackageCommands::Run(command) => {
-                let installable_arg = command
-                    .inner
-                    .installable_arg
-                    .unwrap_or_default()
-                    .resolve_flake_attribute(&flox)
-                    .await?;
+    #[bpaf(short('A'), hide)]
+    pub _attr_flag: bool,
+}
+parseable!(Containerize, containerize);
+impl WithPassthru<Containerize> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        let mut installable = env_ref_to_flake_attribute::<GitCommandProvider>(
+            &flox,
+            "containerize",
+            &self.inner.environment_name.unwrap_or_default(),
+        )
+        .await?;
 
-                flox.package(installable_arg, config.flox.stability, command.nix_args)
-                    .run::<NixCommandLine>()
-                    .await?
-            },
-            PackageCommands::Shell(command) => {
-                let installable_arg = command
-                    .inner
-                    .installable_arg
-                    .unwrap_or_default()
-                    .resolve_flake_attribute(&flox)
-                    .await?;
+        installable
+            .attr_path
+            .extend(["passthru", "streamLayeredImage"].map(|attr| attr.parse().unwrap()));
 
-                flox.package(installable_arg, config.flox.stability, command.nix_args)
-                    .shell::<NixCommandLine>()
-                    .await?
-            },
-            PackageCommands::Eval(command) => {
-                let nix = flox.nix::<NixCommandLine>(command.nix_args);
-                let command = EvalComm {
-                    flake: FlakeArgs {
-                        override_inputs: if config.flox.stability == Default::default() {
-                            vec![]
-                        } else {
-                            vec![config.flox.stability.as_override()]
-                        },
-                        ..FlakeArgs::default()
-                    },
-                    ..Default::default()
-                };
-
-                command.run(&nix, &NixArgs::default()).await?
-            },
-            PackageCommands::Bundle(command) => {
-                let installable_arg = ResolveInstallable::<GitCommandProvider>::installable(
-                    &command.inner.installable_arg,
-                    &flox,
-                )
-                .await?;
-
-                let bundler = command
-                    .inner
-                    .bundler_arg
-                    .unwrap_or_default()
-                    .resolve_flake_attribute(&flox)
-                    .await?;
-
-                flox.package(installable_arg, config.flox.stability, command.nix_args)
-                    .bundle::<NixCommandLine>(bundler.into())
-                    .await?
-            },
-            PackageCommands::Containerize(command) => {
-                let mut installable = env_ref_to_flake_attribute::<GitCommandProvider>(
-                    &flox,
-                    "containerize",
-                    &command.inner.environment_name.unwrap_or_default(),
-                )
-                .await?;
-
-                installable
-                    .attr_path
-                    .extend(["passthru", "streamLayeredImage"].map(|attr| attr.parse().unwrap()));
-
-                if std::io::stdout().is_tty() {
-                    bail!(
-                        indoc! {"
+        if std::io::stdout().is_tty() {
+            bail!(
+                indoc! {"
                         'flox containerize' pipes a container image to stdout, but stdout is
                         attached to the terminal. Instead, run this command as:
 
                             $ {command} | docker load
                     "},
-                        command = env::args()
-                            .map(|arg| shell_escape::escape(arg.into()))
-                            .join(" ")
-                    );
-                }
-
-                let nix = flox.nix::<NixCommandLine>(command.nix_args);
-
-                let nix_args = NixArgs::default();
-
-                info!("Building container...");
-
-                let command = Build {
-                    installables: [installable.into()].into(),
-                    eval: EvaluationArgs {
-                        impure: true.into(),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                };
-
-                let mut out: BuildOut = command.run_typed(&nix, &nix_args).await?;
-
-                info!("Done.");
-
-                let script = out
-                    .pop()
-                    .context("Container script not built")?
-                    .outputs
-                    .remove("out")
-                    .context("Container script output not found")?;
-
-                debug!("Got container script: {:?}", script);
-
-                tokio::process::Command::new(script)
-                    .spawn()
-                    .context("Failed to start container script")?
-                    .wait()
-                    .await
-                    .context("Container script failed to run")?;
-            },
-            PackageCommands::Flake(command) => {
-                /// A custom nix command that passes its arguments to `nix flake`
-                #[derive(Debug, Clone)]
-                pub struct FlakeCommand {
-                    subcommand: String,
-                    default_flake_args: FlakeArgs,
-                    args: Vec<String>,
-                }
-                impl ToArgs for FlakeCommand {
-                    fn to_args(&self) -> Vec<String> {
-                        let mut args = vec![self.subcommand.clone()];
-                        args.append(&mut self.default_flake_args.to_args());
-                        args.append(&mut self.args.clone());
-                        args
-                    }
-                }
-                impl NixCliCommand for FlakeCommand {
-                    type Own = Self;
-
-                    const FLAKE_ARGS: Group<Self, FlakeArgs> = Some(|_| Default::default());
-                    const OWN_ARGS: Group<Self, Self::Own> = Some(|s| s.to_owned());
-                    const SUBCOMMAND: &'static [&'static str] = &["flake"];
-                }
-
-                // currently Flox::package requires _a package_.
-                // since flake commands can't provide this flox.
-                // we need to create a custom nix instance.
-                // TODO: decide whether `flox flake` should be a "development command"
-                //       It is currently implemented as such because it is influenced by `--stability`.
-                //       Yet, it could be implemented as a different group altogether (more cleanly?).
-                let nix: NixCommandLine = flox.nix(Default::default());
-
-                // Flake commands should take `--stability`
-                // Can't be a default on the `nix` instance, because that will apply it as a flag
-                // on `nix flake` rather than `nix flake <subcommand>`.
-                // Even though documented as "Common flake-related options",
-                // flake args such as `--override-inputs` can not be applied to `nix flake`.
-                // Inform [FlakeCommand] about the issued subcommand
-                // and inject the flake args through its `ToArgs` implementation.
-                FlakeCommand {
-                    subcommand: command.inner.subcommand.to_owned(),
-                    default_flake_args: FlakeArgs {
-                        override_inputs: if config.flox.stability == Default::default() {
-                            vec![]
-                        } else {
-                            vec![config.flox.stability.as_override()]
-                        },
-                        ..Default::default()
-                    },
-                    args: command.nix_args,
-                }
-                .run(&nix, &Default::default())
-                .await?;
-            },
-            _ => todo!(),
+                command = env::args()
+                    .map(|arg| shell_escape::escape(arg.into()))
+                    .join(" ")
+            );
         }
 
+        let nix = flox.nix::<NixCommandLine>(self.nix_args);
+
+        let nix_args = NixArgs::default();
+
+        info!("Building container...");
+
+        let command = BuildComm {
+            installables: [installable.into()].into(),
+            eval: EvaluationArgs {
+                impure: true.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut out: BuildOut = command.run_typed(&nix, &nix_args).await?;
+
+        info!("Done.");
+
+        let script = out
+            .pop()
+            .context("Container script not built")?
+            .outputs
+            .remove("out")
+            .context("Container script output not found")?;
+
+        debug!("Got container script: {:?}", script);
+
+        tokio::process::Command::new(script)
+            .spawn()
+            .context("Failed to start container script")?
+            .wait()
+            .await
+            .context("Container script failed to run")?;
+        Ok(())
+    }
+}
+
+#[derive(Bpaf, Clone, Debug)]
+pub struct Run {
+    #[bpaf(short('A'), hide)]
+    pub(crate) _attr_flag: bool,
+    #[bpaf(external(InstallableArgument::positional), optional, catch)]
+    pub(crate) installable_arg: Option<InstallableArgument<Parsed, RunInstallable>>,
+}
+parseable!(Run, run);
+impl WithPassthru<Run> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        let installable_arg = self
+            .inner
+            .installable_arg
+            .unwrap_or_default()
+            .resolve_flake_attribute(&flox)
+            .await?;
+
+        flox.package(installable_arg, config.flox.stability, self.nix_args)
+            .run::<NixCommandLine>()
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Bpaf, Clone, Debug)]
+pub struct Eval {}
+parseable!(Eval, eval);
+impl WithPassthru<Eval> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        let nix = flox.nix::<NixCommandLine>(self.nix_args);
+        let command = EvalComm {
+            flake: FlakeArgs {
+                override_inputs: if config.flox.stability == Default::default() {
+                    vec![]
+                } else {
+                    vec![config.flox.stability.as_override()]
+                },
+                ..FlakeArgs::default()
+            },
+            ..Default::default()
+        };
+
+        command.run(&nix, &NixArgs::default()).await?;
+        Ok(())
+    }
+}
+
+#[derive(Bpaf, Clone, Debug)]
+pub struct Flake {
+    #[bpaf(positional("NIX FLAKE COMMAND"))]
+    pub subcommand: String,
+}
+parseable!(Flake, flake);
+impl WithPassthru<Flake> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        /// A custom nix command that passes its arguments to `nix flake`
+        #[derive(Debug, Clone)]
+        pub struct FlakeCommand {
+            subcommand: String,
+            default_flake_args: FlakeArgs,
+            args: Vec<String>,
+        }
+        impl ToArgs for FlakeCommand {
+            fn to_args(&self) -> Vec<String> {
+                let mut args = vec![self.subcommand.clone()];
+                args.append(&mut self.default_flake_args.to_args());
+                args.append(&mut self.args.clone());
+                args
+            }
+        }
+        impl NixCliCommand for FlakeCommand {
+            type Own = Self;
+
+            const FLAKE_ARGS: Group<Self, FlakeArgs> = Some(|_| Default::default());
+            const OWN_ARGS: Group<Self, Self::Own> = Some(|s| s.to_owned());
+            const SUBCOMMAND: &'static [&'static str] = &["flake"];
+        }
+
+        // currently Flox::package requires _a package_.
+        // since flake commands can't provide this flox.
+        // we need to create a custom nix instance.
+        // TODO: decide whether `flox flake` should be a "development command"
+        //       It is currently implemented as such because it is influenced by `--stability`.
+        //       Yet, it could be implemented as a different group altogether (more cleanly?).
+        let nix: NixCommandLine = flox.nix(Default::default());
+
+        // Flake commands should take `--stability`
+        // Can't be a default on the `nix` instance, because that will apply it as a flag
+        // on `nix flake` rather than `nix flake <subcommand>`.
+        // Even though documented as "Common flake-related options",
+        // flake args such as `--override-inputs` can not be applied to `nix flake`.
+        // Inform [FlakeCommand] about the issued subcommand
+        // and inject the flake args through its `ToArgs` implementation.
+        FlakeCommand {
+            subcommand: self.inner.subcommand.to_owned(),
+            default_flake_args: FlakeArgs {
+                override_inputs: if config.flox.stability == Default::default() {
+                    vec![]
+                } else {
+                    vec![config.flox.stability.as_override()]
+                },
+                ..Default::default()
+            },
+            args: self.nix_args,
+        }
+        .run(&nix, &Default::default())
+        .await?;
         Ok(())
     }
 }
@@ -736,7 +662,7 @@ async fn ensure_project_repo(
 /// Create
 async fn ensure_project<'flox>(
     git_repo: Root<'flox, Closed<GitCommandProvider>>,
-    command: &WithPassthru<interface::Init>,
+    command: &WithPassthru<InitPackage>,
 ) -> Result<Project<'flox, GitCommandProvider, ReadOnly<GitCommandProvider>>> {
     match git_repo.guard().await?.open() {
         Ok(x) => Ok(x),
@@ -769,8 +695,8 @@ pub struct PackageArgs {
 
 #[derive(Debug, Clone)]
 pub struct WithPassthru<T> {
-    inner: T,
-    nix_args: Vec<String>,
+    pub inner: T,
+    pub nix_args: Vec<String>,
 }
 
 impl<T> WithPassthru<T> {

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -445,7 +445,6 @@ impl WithPassthru<Bundle> {
 
 /// Containerize an environment
 #[derive(Bpaf, Clone, Debug)]
-#[bpaf(command)]
 pub struct Containerize {
     /// Environment to containerize
     #[bpaf(long("environment"), short('e'), argument("ENV"))]

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -215,9 +215,17 @@ pub struct Develop {
 
     /// Shell or package to develop on
     #[bpaf(external(InstallableArgument::positional), optional, catch)]
-    pub(crate) installable_arg: Option<InstallableArgument<Parsed, DevelopInstallable>>,
+    pub(crate) _installable_arg: Option<InstallableArgument<Parsed, DevelopInstallable>>,
 }
 parseable!(Develop, develop);
+impl WithPassthru<Develop> {
+    pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("develop");
+        config.override_stability(self.stability);
+
+        flox_forward(&flox).await
+    }
+}
 
 /// print shell code that can be sourced by bash to reproduce the development environment
 #[derive(Bpaf, Clone, Debug)]

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -24,9 +24,9 @@ use itertools::Itertools;
 use log::{debug, info};
 
 use crate::config::Config;
-use crate::flox_forward;
 use crate::utils::dialog::{Dialog, Text};
 use crate::utils::resolve_environment_ref;
+use crate::{flox_forward, subcommand_metric};
 
 async fn env_ref_to_flake_attribute<Git: GitProvider + 'static>(
     flox: &Flox,
@@ -124,6 +124,7 @@ pub(crate) fn template_arg() -> impl Parser<Option<InstallableArgument<Parsed, T
 parseable!(InitPackage, init_package);
 impl WithPassthru<InitPackage> {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("init-package");
         let cwd = std::env::current_dir()?;
         let basename = cwd
             .file_name()
@@ -189,6 +190,7 @@ pub struct Build {
 parseable!(Build, build);
 impl WithPassthru<Build> {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("build");
         let installable_arg = self
             .inner
             .installable_arg
@@ -218,6 +220,7 @@ pub struct PrintDevEnv {
 parseable!(PrintDevEnv, print_dev_env);
 impl WithPassthru<PrintDevEnv> {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("print-dev-env");
         config.override_stability(self.stability);
 
         flox_forward(&flox).await
@@ -268,6 +271,7 @@ pub struct Publish {
 parseable!(Publish, publish);
 impl Publish {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("publish");
         let installable = self
             .installable_arg
             .unwrap_or_default()
@@ -380,6 +384,7 @@ pub struct Shell {
 parseable!(Shell, shell);
 impl WithPassthru<Shell> {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("shell");
         let installable_arg = self
             .inner
             .installable_arg
@@ -418,6 +423,7 @@ pub(crate) fn bundler_arg() -> impl Parser<Option<InstallableArgument<Parsed, Bu
 }
 impl WithPassthru<Bundle> {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("bundle");
         let installable_arg = ResolveInstallable::<GitCommandProvider>::installable(
             &self.inner.installable_arg,
             &flox,
@@ -452,6 +458,7 @@ pub struct Containerize {
 parseable!(Containerize, containerize);
 impl WithPassthru<Containerize> {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("containerize");
         let mut installable = env_ref_to_flake_attribute::<GitCommandProvider>(
             &flox,
             "containerize",
@@ -533,6 +540,7 @@ pub struct Run {
 parseable!(Run, run);
 impl WithPassthru<Run> {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("run");
         let installable_arg = self
             .inner
             .installable_arg
@@ -554,6 +562,7 @@ pub struct Eval {}
 parseable!(Eval, eval);
 impl WithPassthru<Eval> {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("eval");
         let nix = flox.nix::<NixCommandLine>(self.nix_args);
         let stability = config.override_stability(self.stability);
         let override_input = stability.as_ref().map(Stability::as_override);
@@ -578,6 +587,7 @@ pub struct Flake {
 parseable!(Flake, flake);
 impl WithPassthru<Flake> {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("flake");
         /// A custom nix command that passes its arguments to `nix flake`
         #[derive(Debug, Clone)]
         pub struct FlakeCommand {

--- a/crates/flox/src/config/mod.rs
+++ b/crates/flox/src/config/mod.rs
@@ -326,6 +326,20 @@ impl Config {
 
         Ok(())
     }
+
+    /// If [Some] [Stability] provided, override config and set `FLOX_STABILITY` env var
+    ///
+    /// - The overriding stability is supplied by CLI args
+    /// - The env var will ensure that the selected is applied by default
+    ///   within a subshell started by flox
+    pub fn override_stability(&mut self, stability: Option<Stability>) -> Option<Stability> {
+        if let Some(stability) = stability {
+            debug!("Overriding stability to {}", stability);
+            env::set_var("FLOX_STABILITY", stability.to_string());
+            let _ = self.flox.stability.insert(stability);
+        }
+        self.flox.stability.clone()
+    }
 }
 
 fn mk_environment(envs: &mut Vec<(String, String)>, prefix: &str) -> Environment {

--- a/crates/flox/src/config/mod.rs
+++ b/crates/flox/src/config/mod.rs
@@ -47,8 +47,8 @@ pub struct FloxConfig {
     pub cache_dir: PathBuf,
     pub data_dir: PathBuf,
     pub config_dir: PathBuf,
-    #[serde(default)]
-    pub stability: Stability,
+
+    pub stability: Option<Stability>,
 
     /// The url we push _to_
     pub cache_url: Option<Url>,

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -478,7 +478,7 @@ setup_file() {
 @test "flox environments takes no arguments" {
   run $FLOX_CLI environments -e $TEST_ENVIRONMENT
   assert_failure
-  assert_output --partial "-e is not expected in this context"
+  assert_output --partial '`-e` is not expected in this context'
 }
 
 @test "flox environments should at least contain $TEST_ENVIRONMENT" {

--- a/tests/usage.bats
+++ b/tests/usage.bats
@@ -44,27 +44,27 @@ EOF
 @test "f2: command grouping changes 1: Add 'Local Development Commands' and list in order" {
     run "$FLOX_CLI" --help
     assert_output --partial - << EOF
-    Local Development Commands
-      init               Create an environment in the current directory
-      activate           Activate environment
-      search             Search packages in subscribed channels
-      install            Install a package into an environment
-      uninstall          Uninstall installed packages from an environment
-      edit               Edit declarative environment configuration
-      run                Run app from current project
-      list               List (status?) packages installed in an environment
-      nix                Access to the nix CLI
-      delete             Delete an environment
+Local Development Commands
+    init           Create an environment in the current directory
+    activate       Activate environment
+    search         Search packages in subscribed channels
+    install        Install a package into an environment
+    uninstall      Uninstall installed packages from an environment
+    edit           Edit declarative environment configuration
+    run            Run app from current project
+    list           List (status?) packages installed in an environment
+    nix            Access to the nix CLI
+    delete         Delete an environment
 EOF
 }
 
 @test "f3: command grouping changes 2: introduce "Sharing Commands" and include 1/ push 2/ pull 3/ containerize" {
     run "$FLOX_CLI" --help
     assert_output --partial - << EOF
-    Sharing Commands
-      push               Send environment to flox hub
-      pull               Pull environment from flox hub
-      containerize       Containerize an environment
+Sharing Commands
+    push           Send environment to flox hub
+    pull           Pull environment from flox hub
+    containerize   Containerize an environment
 EOF
 }
 

--- a/tests/usage.bats
+++ b/tests/usage.bats
@@ -71,9 +71,9 @@ EOF
 @test "f5: command grouping changes 3: move lesser used or not polished commands to 'Additional Commands' section with help tip." {
     run "$FLOX_CLI" --help
     assert_output --partial - << EOF
-    Additional Commands. Use 'flox COMMAND --help' for more info
-      build, upgrade, import, export, config, wipe, subscribe, unsubscribe,
-      channels, history, print-dev-env, shell
+Additional Commands. Use "flox COMMAND --help" for more info
+    build, upgrade, import, export, config, wipe-history, subscribe, unsubscribe,
+    channels, history, print-dev-env, shell
 EOF
 }
 

--- a/tests/usage.bats
+++ b/tests/usage.bats
@@ -79,7 +79,7 @@ EOF
 
 @test "f6: remove stability from flox --help command: Only show stability for commands that support it" {
     run "$FLOX_CLI" --help
-    reject_output --partial "--stability"
+    refute_output --partial "--stability"
 }
 
 @test "f7: remove debug: don't show debug in flox and only show in flox --help {


### PR DESCRIPTION
We are regrouping our commands and flox output.
Currently, all commands are defined in match branches of Existing command groups.

This PR moves all command definitions into separate structs and moves their implementation from the `match` branches to an associated `handle` method.

This reshuffling is particularly noisy with git, thus the large diff. Please take into account that this PR **does not change the implementation of any command** beyond adapting variable names.

Done:

- [x] f1: flox without commands
- [x] f2: group "local development commands" 
- [x] f3: group "sharing commands" 
- [x] package commands
- [x] wiring up all hidden commands
- [x] f5: special documentation for `Additional Commands`
- [x] align docs with test
- [x] f6: make stabilities work with "development" commands, `flox {nix,containerize,publish}` 