### PR TITLE
feat: add feature-flagged 'flox delete'

### DIFF
--- a/crates/flox/doc/flox-delete.md
+++ b/crates/flox/doc/flox-delete.md
@@ -1,5 +1,5 @@
 ---
-title: FLOX-DESTROY
+title: FLOX-DELETE
 section: 1
 header: "flox User Manuals"
 ...
@@ -7,11 +7,11 @@ header: "flox User Manuals"
 
 # NAME
 
-flox-destroy - destroy an environment
+flox-delete - delete an environment
 
 # SYNOPSIS
 
-flox [ `<general-options>` ] destroy [ `<options>` ] [ \--origin ] [ \--force ]
+flox [ `<general-options>` ] delete [ `<options>` ] [ \--origin ] [ \--force ]
 
 # DESCRIPTION
 
@@ -31,7 +31,7 @@ confirmation dialog. (Required for non-interactive use.)
 ./include/environment-options.md
 ```
 
-## Destroy Options
+## Delete Options
 
 [ \--origin ]
 :   Also delete environment data previously pushed upstream.

--- a/crates/flox/doc/flox.md
+++ b/crates/flox/doc/flox.md
@@ -142,7 +142,7 @@ runtime environments, developer environments, and administration.
 **push** / **pull** [ \--force ]
 :   (`git`) Push or pull metadata to the environment's `floxmeta` repository.
 
-**destroy** [ \--origin ] [ \--force ]
+**delete** [ \--origin ] [ \--force ]
 :   Remove all local data pertaining to an environment.
 
 ## Development
@@ -297,7 +297,7 @@ flox install unstable.nixpkgs-flox.hello@2.10
 [`flox-config`(1)](./flox-config.md),
 [`flox-containerize`(1)](./flox-containerize.md),
 [`flox-create`(1)](./flox-create.md),
-[`flox-destroy`(1)](./flox-destroy.md),
+[`flox-delete`(1)](./flox-delete.md),
 [`flox-develop`(1)](./flox-develop.md),
 [`flox-edit`(1)](./flox-edit.md),
 [`flox-environments`(1)](./flox-environments.md),

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -31,31 +31,6 @@ pub struct EnvironmentArgs {
 
 pub type EnvironmentRef = String;
 
-// impl EnvironmentCommands {
-//     pub async fn handle(&self, flox: Flox) -> Result<()> {
-
-//         match self {
-//             EnvironmentCommands::List { .. } => subcommand_metric!("list"),
-//             EnvironmentCommands::Envs => subcommand_metric!("envs"),
-//             EnvironmentCommands::Activate { .. } => subcommand_metric!("activate"),
-//             EnvironmentCommands::Init { .. } => subcommand_metric!("init"),
-//             EnvironmentCommands::Destroy { .. } => subcommand_metric!("destroy"),
-//             EnvironmentCommands::Edit { .. } => subcommand_metric!("edit"),
-//             EnvironmentCommands::Export { .. } => subcommand_metric!("export"),
-//             EnvironmentCommands::Generations { .. } => subcommand_metric!("generations"),
-//             EnvironmentCommands::Git { .. } => subcommand_metric!("git"),
-//             EnvironmentCommands::History { .. } => subcommand_metric!("history"),
-//             EnvironmentCommands::Import { .. } => subcommand_metric!("import"),
-//             EnvironmentCommands::Install { .. } => subcommand_metric!("install"),
-//             EnvironmentCommands::Push { .. } => subcommand_metric!("push"),
-//             EnvironmentCommands::Pull { .. } => subcommand_metric!("pull"),
-//             EnvironmentCommands::Uninstall { .. } => subcommand_metric!("remove"),
-//             EnvironmentCommands::Rollback { .. } => subcommand_metric!("rollback"),
-//             EnvironmentCommands::SwitchGeneration { .. } => subcommand_metric!("switch"),
-//             EnvironmentCommands::Upgrade { .. } => subcommand_metric!("upgrade"),
-//             EnvironmentCommands::WipeHistory { .. } => subcommand_metric!("wipe-history"),
-//         }
-
 /// Edit declarative environment configuration
 #[derive(Bpaf, Clone)]
 pub struct Edit {
@@ -70,12 +45,13 @@ pub struct Edit {
     #[bpaf(long, short, argument("FILE"))]
     file: Option<PathBuf>,
 }
+
 impl Edit {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("edit");
 
         let mut environment =
-            resolve_environment(&flox, self.environment.as_deref(), "install").await?;
+            resolve_environment(&flox, self.environment.as_deref(), "edit").await?;
         let mut temporary_environment = environment.make_temporary().await?;
 
         let nix = flox.nix(Default::default());
@@ -162,8 +138,7 @@ impl Delete {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("delete");
 
-        let environment =
-            resolve_environment(&flox, self.environment.as_deref(), "install").await?;
+        let environment = resolve_environment(&flox, self.environment.as_deref(), "delete").await?;
 
         environment
             .delete()
@@ -198,7 +173,7 @@ impl Activate {
         subcommand_metric!("activate");
 
         let environment = self.environment.first().map(|e| e.as_ref());
-        let environment = resolve_environment(&flox, environment, "install").await?;
+        let environment = resolve_environment(&flox, environment, "activate").await?;
 
         let command = Shell {
             eval: EvaluationArgs {
@@ -296,7 +271,7 @@ impl List {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("list");
 
-        let env = resolve_environment(&flox, self.environment.as_deref(), "install").await?;
+        let env = resolve_environment(&flox, self.environment.as_deref(), "list").await?;
 
         let catalog = env
             .catalog(&flox.nix(Default::default()), &flox.system)
@@ -357,6 +332,7 @@ pub struct Install {
     #[bpaf(positional("PACKAGES"), some("At least one package"))]
     packages: Vec<String>,
 }
+
 impl Install {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("install");
@@ -410,6 +386,7 @@ pub struct Uninstall {
     #[bpaf(positional("PACKAGES"), some("At least one package"))]
     packages: Vec<String>,
 }
+
 impl Uninstall {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("uninstall");
@@ -424,7 +401,7 @@ impl Uninstall {
             .collect();
 
         let mut environment =
-            resolve_environment(&flox, self.environment.as_deref(), "install").await?;
+            resolve_environment(&flox, self.environment.as_deref(), "uninstall").await?;
 
         environment
             .uninstall(
@@ -522,6 +499,7 @@ pub struct Generations {
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 }
+
 impl Generations {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("generations");
@@ -544,6 +522,7 @@ pub struct Git {
     #[bpaf(any("Git Arguments", Some))]
     git_arguments: Vec<String>,
 }
+
 impl Git {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("git");
@@ -567,6 +546,7 @@ pub struct History {
     #[bpaf(long, short, argument("ENV"))]
     environment: Option<EnvironmentRef>,
 }
+
 impl History {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("history");
@@ -672,6 +652,7 @@ pub struct Pull {
     #[bpaf(long, short)]
     force: bool,
 }
+
 impl Pull {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("pull");

--- a/flox-bash/flox.sh
+++ b/flox-bash/flox.sh
@@ -128,6 +128,9 @@ fi
 if [ "$subcommand" = "rm" ] || [ "$subcommand" = "uninstall" ]; then
        subcommand=remove
 fi
+if [ "$subcommand" = "delete" ]; then
+  subcommand="destroy"
+fi
 
 # Store the original subcommand invocation arguments.
 declare -a invocation_args=("$@")

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,8 +70,8 @@ and cleaning up after test runs.
     - This prevents tests which modify `gitconfig` from modifying a user's real
       configuration files, and prevents contamination between tests.
   + During `teardown_suite` we delete all `flox` environments with the prefix
-    `_testing_*` using `flox destroy NAME --force --origin`.
-    + This is performed by the helper function `destroyAllTestEnvs`.
+    `_testing_*` using `flox delete NAME --force --origin`.
+    + This is performed by the helper function `deleteAllTestEnvs`.
 - `setup_file` and `teardown_file`
   + Run once at the beginning and end of each `NAME.bats` file.
   + Test files may provide their own definitions of these routines, but we

--- a/tests/environment-delete.bats
+++ b/tests/environment-delete.bats
@@ -1,0 +1,82 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test 'flox delete'
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+# bats file_tags=delete
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  project_setup
+}
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+setup_file() {
+  export FLOX_FEATURES_ENV=rust
+}
+
+dot_flox_exists() {
+  # Since the return value is based on the exit code of `test`:
+  # 0 = true
+  # 1 = false
+  [[ -d .flox ]];
+}
+
+env_exists() {
+  # Since the return value is based on the exit code of `test`:
+  # 0 = true
+  # 1 = false
+  [[ -d ".flox/$1" ]];
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "deletes existing environment" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  # run env_exists "$(basename $PWD)";
+  run dot_flox_exists;
+  assert_success;
+  run "$FLOX_CLI" delete;
+  assert_success;
+  # run env_exists "$(basename $PWD)";
+  run dot_flox_exists;
+  assert_failure;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "error message when called without .flox directory" {
+  run dot_flox_exists;
+  assert_failure;
+  run "$FLOX_CLI" delete;
+  assert_failure;
+  assert_output --partial "No matching environments found";
+}

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -225,7 +225,7 @@ setup_file() {
   assert_success
   assert_output --partial "# test comment"
 
-  run $FLOX_CLI destroy --force -e "$EDIT_ENVIRONMENT"
+  run $FLOX_CLI delete --force -e "$EDIT_ENVIRONMENT"
   assert_success
 }
 
@@ -297,7 +297,7 @@ setup_file() {
   refute_output --partial "stable.nixpkgs-flox.hello"
 
   # teardown
-  run $FLOX_CLI destroy -e "$TEST_CASE_ENVIRONMENT" -f
+  run $FLOX_CLI delete -e "$TEST_CASE_ENVIRONMENT" -f
   assert_success
 }
 
@@ -322,7 +322,7 @@ setup_file() {
   refute_output --partial "nixpkgs#legacyPackages.$NIX_SYSTEM.hello"
 
   # teardown
-  run $FLOX_CLI destroy -e "$TEST_CASE_ENVIRONMENT" -f
+  run $FLOX_CLI delete -e "$TEST_CASE_ENVIRONMENT" -f
   assert_success
 }
 
@@ -392,7 +392,7 @@ setup_file() {
   # teardown
   run $FLOX_CLI unsubscribe nixpkgs-flox-upgrade-test
   assert_success
-  run $FLOX_CLI destroy -e _upgrade_testing_ -f
+  run $FLOX_CLI delete -e _upgrade_testing_ -f
   assert_success
 }
 
@@ -488,8 +488,8 @@ setup_file() {
   assert_output --partial "Alias     $TEST_ENVIRONMENT"
 }
 
-@test "flox destroy local only" {
-  run $FLOX_CLI destroy -e $TEST_ENVIRONMENT -f
+@test "flox delete local only" {
+  run $FLOX_CLI delete -e $TEST_ENVIRONMENT -f
   assert_success
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
@@ -541,7 +541,7 @@ setup_file() {
 }
 
 @test "tear down install test state" {
-  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI destroy -e $TEST_ENVIRONMENT --origin -f"
+  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI delete -e $TEST_ENVIRONMENT --origin -f"
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/tests/multi-env.bats
+++ b/tests/multi-env.bats
@@ -13,16 +13,16 @@ load test_support.bash;
 
 # ---------------------------------------------------------------------------- #
 
-destroy_envs() {
-  destroyEnvForce "${TEST_ENVIRONMENT}-1";
-  destroyEnvForce "${TEST_ENVIRONMENT}-2";
+delete_envs() {
+  deleteEnvForce "${TEST_ENVIRONMENT}-1";
+  deleteEnvForce "${TEST_ENVIRONMENT}-2";
 }
 
 setup_file() {
   common_file_setup;
   hello_pkg_setup;
-  destroyEnvForce "${TEST_ENVIRONMENT}-1";
-  destroyEnvForce "${TEST_ENVIRONMENT}-2";
+  deleteEnvForce "${TEST_ENVIRONMENT}-1";
+  deleteEnvForce "${TEST_ENVIRONMENT}-2";
   $FLOX_CLI create  -e "${TEST_ENVIRONMENT}-1";
   $FLOX_CLI install -e "${TEST_ENVIRONMENT}-1" "$HELLO_PACKAGE";
   $FLOX_CLI create  -e "${TEST_ENVIRONMENT}-2";
@@ -31,8 +31,8 @@ setup_file() {
 
 teardown_file() {
   if [[ -z "${FLOX_TEST_KEEP_TMP:-}" ]]; then
-    destroyEnvForce "${TEST_ENVIRONMENT}-1";
-    destroyEnvForce "${TEST_ENVIRONMENT}-2";
+    deleteEnvForce "${TEST_ENVIRONMENT}-1";
+    deleteEnvForce "${TEST_ENVIRONMENT}-2";
   fi
 }
 

--- a/tests/package.bats
+++ b/tests/package.bats
@@ -23,7 +23,7 @@ setup_file() {
 }
 
 @test "tear down install test state" {
-  run $FLOX_CLI destroy -e "$TEST_ENVIRONMENT" --origin -f||:
+  run $FLOX_CLI delete -e "$TEST_ENVIRONMENT" --origin -f||:
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -235,7 +235,7 @@ misc_vars_setup() {
   export VERSION_REGEX='[0-9]+\.[0-9.]+';
 
   # Used to generate environment names.
-  # All envs with this prefix are destroyed on startup and exit of this suite.
+  # All envs with this prefix are deleted on startup and exit of this suite.
   export FLOX_TEST_ENVNAME_PREFIX='_testing_';
 
   # Suppress warnings by `flox create' about environments named with
@@ -331,12 +331,12 @@ gitconfig_setup() {
 
 # ---------------------------------------------------------------------------- #
 
-# destroyEnvForce ENV_NAME
+# deleteEnvForce ENV_NAME
 # ------------------------
 # Force the destruction of an env including any remote metdata.
-destroyEnvForce() {
+deleteEnvForce() {
   flox_location_setup;
-  { $FLOX_CLI destroy -e "${1?}" --origin -f||:; } >/dev/null 2>&1;
+  { $FLOX_CLI delete -e "${1?}" --origin -f||:; } >/dev/null 2>&1;
   return 0;
 }
 

--- a/tests/test_support.bash
+++ b/tests/test_support.bash
@@ -68,7 +68,7 @@ setup_test_envname() {
 
 # Build `hello' and root it temporarily so it can be used as an
 # install target in various tests.
-# This symlink is destroyed by `common_teardown'.
+# This symlink is deleteed by `common_teardown'.
 hello_pkg_setup() {
   if [[ -n "${__FT_RAN_HELLO_PKG_SETUP:-}" ]]; then return 0; fi
   export HELLO_LINK="$BATS_SUITE_TMPDIR/gc-roots/hello";
@@ -95,7 +95,7 @@ common_file_setup() {
   # Generate a `TEST_ENVIRONMENT' name.
   setup_file_envname;
   # Remove any vestiges of previous test runs.
-  destroyEnvForce "$TEST_ENVIRONMENT";
+  deleteEnvForce "$TEST_ENVIRONMENT";
   # Setup a homedir associated with this file.
   if [[ "${1:-suite}" != test ]]; then home_setup "${1:-suite}"; fi
 }
@@ -113,7 +113,7 @@ setup() { common_test_setup; }
 common_file_teardown() {
   # Delete file tmpdir and env unless the user requests to preserve them.
   if [[ -z "${FLOX_TEST_KEEP_TMP:-}" ]]; then
-    destroyEnvForce "$TEST_ENVIRONMENT";
+    deleteEnvForce "$TEST_ENVIRONMENT";
     rm -rf "$BATS_FILE_TMPDIR";
   fi
   unset FLOX_TEST_HOME;
@@ -124,7 +124,7 @@ teardown_file() { common_file_teardown; }
 
 common_test_teardown() {
   # Delete test tmpdir unless the user requests to preserve them.
-  # XXX: We do not attempt to destroy envs here.
+  # XXX: We do not attempt to delete envs here.
   if [[ -z "${FLOX_TEST_KEEP_TMP:-}" ]]; then rm -rf "$BATS_TEST_TMPDIR"; fi
 }
 

--- a/tests/usage.out
+++ b/tests/usage.out
@@ -42,7 +42,7 @@ environment commands:
          - list environment generations with contents
     flox rollback - roll back to the previous generation of an environment
     flox switch-generation - switch to a specific generation of an environment
-    flox destroy [--force] [--origin]
+    flox delete [--force] [--origin]
          - remove all data pertaining to an environment
     flox push [--force] [-m|--main]
          - send environment metadata to remote registry


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This PR adds a `flox delete` command behind the `FLOX_FEATURES_ENV="rust"` feature flag. The semantics are as follows:
- When `flox delete` is called it will attempt to delete `$PWD/.flox`.
- If `.flox` exists, it will be deleted.
- If `.flox` doesn't exist, an (extremely minimal) error message is printed

## Current Behavior

<!-- Describe the current behavior before applying this pull request. -->
This command does not exist currently.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
The `destroy` command is renamed to `delete`, but otherwise functions identically (accepts the same flags, etc)

<!-- Many thanks! -->
