### PR TITLE
chore: add Justfile for development

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,16 +1,30 @@
-flox_bats_tests_invocation := "flox run '.#flox-tests' -- -- --flox target/debug/flox"
+bats_invocation := "flox run '.#flox-tests' -- -- --flox target/debug/flox"
+cargo_test_invocation := "cargo test --workspace"
 
 _default:
     @just --list --unsorted
 
 # Run the 'bats' test suite
-shell-test +test_files="":
+bats-tests +test_files="":
     @cargo build
-    @{{flox_bats_tests_invocation}} {{test_files}}
+    @{{bats_invocation}} {{test_files}}
 
 # Run the Rust unit tests
-unit-test +regex="":
-    @cargo test --workspace {{regex}}
+unit-tests regex="":
+    @{{cargo_test_invocation}} {{regex}}
 
-# Run the entire test suite
-test: unit-test shell-test
+# Run the test suite, including impure tests
+impure-tests regex="":
+    @{{cargo_test_invocation}} {{regex}} --features "extra-tests"
+
+# Run the entire test suite, not including impure tests
+test: unit-tests bats-tests
+
+# Run the entire test suite, including impure tests
+test-all: impure-tests bats-tests
+
+# Enters the Rust development environment
+work:
+    @# Note that this command is only really useful if you have
+    @# `just` installed outside of the `flox` environment already
+    @flox develop rust-env

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,16 @@
+flox_bats_tests_invocation := "flox run '.#flox-tests' -- -- --flox target/debug/flox"
+
+_default:
+    @just --list --unsorted
+
+# Run the 'bats' test suite
+shell-test +test_files="":
+    @cargo build
+    @{{flox_bats_tests_invocation}} {{test_files}}
+
+# Run the Rust unit tests
+unit-test +regex="":
+    @cargo test --workspace {{regex}}
+
+# Run the entire test suite
+test: unit-test shell-test

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,9 @@ _default:
 # Run the 'bats' test suite
 bats-tests +test_files="":
     @cargo build
+    @flox build flox-bash
+    @export FLOX_SH_PATH="$PWD/result"
+    @export FLOX_SH="$PWD/result/libexec/flox/flox"
     @{{bats_invocation}} {{test_files}}
 
 # Run the Rust unit tests

--- a/shells/rust-env/default.nix
+++ b/shells/rust-env/default.nix
@@ -16,6 +16,7 @@
   hivemind,
   cargo-watch,
   commitizen,
+  just,
 }:
 mkShell ({
     inputsFrom = [
@@ -33,6 +34,7 @@ mkShell ({
       rust-analyzer
       rust.packages.stable.rustPlatform.rustLibSrc
       rustc
+      just
     ];
     shellHook = ''
       ${self.checks.pre-commit-check.shellHook}


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This PR adds `just` to the `rust-env` environment and a Justfile for local development. The Justfile has commands for running the test suite and makes it easier to run subsets of the `bats` test suite specifically.

Example:
```
$ just shell-test ./tests/activate.bats
```

## Current Behavior

<!-- Describe the current behavior before applying this pull request. -->
Currently if you want to run a specific test file you would have to write out:
```
$ cargo build
$ flox run '.#flox-tests' -- -- --flox target/debug/build ./tests/activate.bats
```

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
