### PR TITLE
fix: remove unused imports

### DIFF
--- a/crates/flox/src/utils/init/mod.rs
+++ b/crates/flox/src/utils/init/mod.rs
@@ -1,13 +1,10 @@
 use std::collections::{BTreeMap, HashMap};
-use std::env;
-use std::path::Path;
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
 use indoc::indoc;
-use log::{debug, info};
+use log::debug;
 use serde::Deserialize;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 mod logger;
 mod metrics;


### PR DESCRIPTION
Imports became unused after the change of git config initialization in https://github.com/flox/flox/pull/184

