### PR TITLE
feat: no interaction in Environment trait

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -258,7 +258,7 @@ where
 
     #[allow(unused)]
     /// Atomically edit this environment, ensuring that it still builds
-    async fn edit(&self, contents: &impl AsRef<str>) -> Result<(), EnvironmentError2> {
+    async fn edit(&mut self, contents: &impl AsRef<str>) -> Result<(), EnvironmentError2> {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -67,11 +67,8 @@ pub trait Environment {
         system: impl AsRef<str> + Send,
     ) -> Result<(), EnvironmentError2>;
 
-    /// Activate this environment
-    async fn activate(&self, nix: &NixCommandLine) -> Result<(), EnvironmentError2>;
-
     /// Atomically edit this environment, ensuring that it still builds
-    async fn edit(&self) -> Result<(), EnvironmentError2>;
+    async fn edit(&self, contents: &impl AsRef<str>) -> Result<(), EnvironmentError2>;
 
     async fn catalog(
         &self,
@@ -259,15 +256,9 @@ where
         Ok(())
     }
 
-    /// Activate this environment
-    /// TODO: remove this `allow` once the method is filled out
-    #[allow(unused_variables)]
-    async fn activate(&self, nix: &NixCommandLine) -> Result<(), EnvironmentError2> {
-        todo!()
-    }
-
+    #[allow(unused)]
     /// Atomically edit this environment, ensuring that it still builds
-    async fn edit(&self) -> Result<(), EnvironmentError2> {
+    async fn edit(&self, contents: &impl AsRef<str>) -> Result<(), EnvironmentError2> {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -68,7 +68,7 @@ pub trait Environment {
     ) -> Result<(), EnvironmentError2>;
 
     /// Atomically edit this environment, ensuring that it still builds
-    async fn edit(&self, contents: &impl AsRef<str>) -> Result<(), EnvironmentError2>;
+    async fn edit(&mut self, contents: &impl AsRef<str>) -> Result<(), EnvironmentError2>;
 
     async fn catalog(
         &self,


### PR DESCRIPTION
Update trait to clarify that interactive operations should be managed by the flox crate

@zmitchell I leave it to you to actually use the updated interface when you work on `edit`