### PR TITLE
feat: next iteration of `flox install`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "log",
  "nixpkgs-fmt",
  "once_cell",
+ "pretty_assertions",
  "regex",
  "rnix 0.11.0",
  "rowan 0.15.11",

--- a/crates/flox-rust-sdk/Cargo.toml
+++ b/crates/flox-rust-sdk/Cargo.toml
@@ -40,6 +40,7 @@ sha2.workspace = true
 anyhow = "1.0.65"
 dotenv = "0.15.0"
 env_logger = "0.10"
+pretty_assertions.workspace = true
 
 [features]
 extra-tests = ["impure-unit-tests"]

--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -205,8 +205,11 @@ where
 {
     /// Build the environment with side effects:
     ///
-    /// - create a result link as gc-root
-    /// - copy catalog.json from the result into the environment
+    /// - Create a result link as gc-root.
+    /// - Copy catalog.json from the result into the environment. Whenever the
+    /// environment is built, the lock is potentially updated. The lockfile is
+    /// an input to the build and allows skipping relocking, so we copy it back
+    /// into the environment to avoid relocking.
     async fn build(
         &mut self,
         nix: &NixCommandLine,

--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -47,7 +47,7 @@ pub enum InstalledPackage {
 pub trait Environment {
     /// Build the environment and create a result link as gc-root
     async fn build(
-        &self,
+        &mut self,
         nix: &NixCommandLine,
         system: impl AsRef<str> + Send,
     ) -> Result<(), EnvironmentError2>;
@@ -210,7 +210,7 @@ where
     /// - create a result link as gc-root
     /// - copy catalog.json from the result into the environment
     async fn build(
-        &self,
+        &mut self,
         nix: &NixCommandLine,
         system: impl AsRef<str> + Send,
     ) -> Result<(), EnvironmentError2> {

--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -626,7 +626,6 @@ fn copy_dir_recursive(
                 // If target is a relative symlink, this will potentially orphan
                 // it. But we're assuming it's absolute since we only copy links
                 // to the Nix store.
-                println!("new_path={}", new_path.to_string_lossy());
                 std::os::unix::fs::symlink(target, &new_path)?;
                 // TODO handle permissions
             },

--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -176,7 +176,7 @@ impl<S: TransactionState> PathEnvironment<S> {
     ///
     /// Mind that an existing out link does not necessarily imply that the environment
     /// can in fact be built.
-    pub fn out_link(&self, system: impl AsRef<str> + Send) -> PathBuf {
+    fn out_link(&self, system: impl AsRef<str> + Send) -> PathBuf {
         self.path
             .join("builds")
             .join(format!("{0}.{1}", system.as_ref(), self.name()))

--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -158,9 +158,7 @@ impl<S: TransactionState> PathEnvironment<S> {
     ) -> Result<(), EnvironmentError2> {
         let transaction_backup = self
             .path
-            .parent()
-            .expect("path shouldn't be /")
-            .join(format!("{}.tmp", self.name().0));
+            .with_file_name(format!("{}.tmp", self.name().as_ref()));
         if transaction_backup.exists() {
             return Err(EnvironmentError2::PriorTransaction(transaction_backup));
         }

--- a/crates/flox-rust-sdk/src/models/environment_ref.rs
+++ b/crates/flox-rust-sdk/src/models/environment_ref.rs
@@ -29,7 +29,7 @@ impl FromStr for EnvironmentOwner {
 }
 
 #[derive(Debug, Clone, PartialEq, AsRef, Display)]
-pub struct EnvironmentName(pub String);
+pub struct EnvironmentName(String);
 
 impl FromStr for EnvironmentName {
     type Err = EnvironmentRefError;

--- a/crates/flox-rust-sdk/src/models/environment_ref.rs
+++ b/crates/flox-rust-sdk/src/models/environment_ref.rs
@@ -29,7 +29,7 @@ impl FromStr for EnvironmentOwner {
 }
 
 #[derive(Debug, Clone, PartialEq, AsRef, Display)]
-pub struct EnvironmentName(String);
+pub struct EnvironmentName(pub String);
 
 impl FromStr for EnvironmentName {
     type Err = EnvironmentRefError;

--- a/crates/flox-rust-sdk/src/models/flox_package.rs
+++ b/crates/flox-rust-sdk/src/models/flox_package.rs
@@ -211,9 +211,44 @@ pub enum ParseError {
     NoPackage,
 }
 
+impl Display for FloxTriple {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.stability != Stability::Stable {
+            write!(f, "{}.", self.stability)?;
+        }
+        if self.channel != "nixpkgs-flox" {
+            write!(f, "{}.", self.channel)?;
+        }
+        write!(f, "{}", self.name)?;
+        if let Some(version) = &self.version {
+            write!(f, "@{}", version)?;
+        }
+        Ok(())
+    }
+}
+
 impl Display for FloxPackage {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FloxPackage::Triple(triple) => write!(f, "{}", triple),
+            _ => todo!(),
+        }
+    }
+}
+
+pub fn packages_to_string(packages: &Vec<FloxPackage>) -> String {
+    match packages.len() {
+        0 => "".to_string(),
+        1 => format!("'{}'", packages[0]),
+        2 => format!("'{}' and '{}'", packages[0], packages[1]),
+        _ => {
+            let mut result = String::new();
+            for package in &packages[0..packages.len() - 1] {
+                result.push_str(&format!("'{}', ", package));
+            }
+            result.push_str(format!("and '{}'", packages[packages.len() - 1]).as_str());
+            result
+        },
     }
 }
 
@@ -327,5 +362,30 @@ mod tests {
             FloxPackage::parse(".#packages.aarch64-darwin.flox", &CHANNELS, DEFAULT_CHANNEL)
                 .expect("should parse");
         assert_eq!(parsed, expected);
+    }
+
+    /// Helper function to create a triple from a string
+    fn create_triple(name: &str) -> FloxPackage {
+        FloxPackage::Triple(FloxTriple {
+            stability: Stability::Stable,
+            channel: "nixpkgs-flox".parse().unwrap(),
+            name: name.parse().unwrap(),
+            version: None,
+        })
+    }
+
+    #[test]
+    fn test_packages_to_string() {
+        let mut packages = vec![];
+        assert_eq!(packages_to_string(&packages), "");
+        packages.push(create_triple("hello"));
+        assert_eq!(packages_to_string(&packages), "'hello'");
+        packages.push(create_triple("curl"));
+        assert_eq!(packages_to_string(&packages), "'hello' and 'curl'");
+        packages.push(create_triple("ripgrep"));
+        assert_eq!(
+            packages_to_string(&packages),
+            "'hello', 'curl', and 'ripgrep'"
+        );
     }
 }

--- a/crates/flox-rust-sdk/src/models/flox_package.rs
+++ b/crates/flox-rust-sdk/src/models/flox_package.rs
@@ -236,22 +236,6 @@ impl Display for FloxPackage {
     }
 }
 
-pub fn packages_to_string(packages: &Vec<FloxPackage>) -> String {
-    match packages.len() {
-        0 => "".to_string(),
-        1 => format!("'{}'", packages[0]),
-        2 => format!("'{}' and '{}'", packages[0], packages[1]),
-        _ => {
-            let mut result = String::new();
-            for package in &packages[0..packages.len() - 1] {
-                result.push_str(&format!("'{}', ", package));
-            }
-            result.push_str(format!("and '{}'", packages[packages.len() - 1]).as_str());
-            result
-        },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use flox_types::constants::DEFAULT_CHANNEL;
@@ -362,30 +346,5 @@ mod tests {
             FloxPackage::parse(".#packages.aarch64-darwin.flox", &CHANNELS, DEFAULT_CHANNEL)
                 .expect("should parse");
         assert_eq!(parsed, expected);
-    }
-
-    /// Helper function to create a triple from a string
-    fn create_triple(name: &str) -> FloxPackage {
-        FloxPackage::Triple(FloxTriple {
-            stability: Stability::Stable,
-            channel: "nixpkgs-flox".parse().unwrap(),
-            name: name.parse().unwrap(),
-            version: None,
-        })
-    }
-
-    #[test]
-    fn test_packages_to_string() {
-        let mut packages = vec![];
-        assert_eq!(packages_to_string(&packages), "");
-        packages.push(create_triple("hello"));
-        assert_eq!(packages_to_string(&packages), "'hello'");
-        packages.push(create_triple("curl"));
-        assert_eq!(packages_to_string(&packages), "'hello' and 'curl'");
-        packages.push(create_triple("ripgrep"));
-        assert_eq!(
-            packages_to_string(&packages),
-            "'hello', 'curl', and 'ripgrep'"
-        );
     }
 }

--- a/crates/flox-rust-sdk/src/models/project/mod.rs
+++ b/crates/flox-rust-sdk/src/models/project/mod.rs
@@ -290,7 +290,6 @@ impl<'flox, Git: GitProvider> Project<'flox, Git, ReadOnly<Git>> {
                     .map_err(TransactionEnterError::CopyDir)?;
             } else {
                 copy_file_without_permissions(entry.path(), &new_path)
-                    .await
                     .map_err(TransactionEnterError::CopyFile)?;
             }
         }

--- a/crates/flox-types/Cargo.toml
+++ b/crates/flox-types/Cargo.toml
@@ -6,13 +6,15 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 derive_more.workspace = true
-pretty_assertions.workspace = true
 runix.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 thiserror.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true
 
 [features]
 extra-tests = []

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -387,16 +387,13 @@ impl Install {
             .context("could not install packages")?
         {
             println!(
-                "✅ Installed {} into '{}' environment.",
-                packages_str,
+                "✅ Installed {packages_str} into '{}' environment.",
                 environment.environment_ref()
             );
         } else {
             let verb = if plural { "are" } else { "is" };
             println!(
-                "No changes; {} {} already installed into '{}' environment.",
-                packages_str,
-                verb,
+                "No changes; {packages_str} {verb} already installed into '{}' environment.",
                 environment.environment_ref()
             );
         }

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -13,12 +13,13 @@ use flox_rust_sdk::nix::arguments::eval::EvaluationArgs;
 use flox_rust_sdk::nix::command::{Shell, StoreGc};
 use flox_rust_sdk::nix::command_line::NixCommandLine;
 use flox_rust_sdk::nix::Run;
-use flox_rust_sdk::prelude::flox_package::{packages_to_string, FloxPackage};
+use flox_rust_sdk::prelude::flox_package::FloxPackage;
 use flox_types::constants::{DEFAULT_CHANNEL, LATEST_VERSION};
 use itertools::Itertools;
 use log::{error, info};
 
 use crate::utils::dialog::{Confirm, Dialog};
+use crate::utils::display::packages_to_string;
 use crate::utils::resolve_environment_ref;
 use crate::{flox_forward, subcommand_metric};
 

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -13,7 +13,7 @@ use flox_rust_sdk::nix::arguments::eval::EvaluationArgs;
 use flox_rust_sdk::nix::command::{Shell, StoreGc};
 use flox_rust_sdk::nix::command_line::NixCommandLine;
 use flox_rust_sdk::nix::Run;
-use flox_rust_sdk::prelude::flox_package::FloxPackage;
+use flox_rust_sdk::prelude::flox_package::{packages_to_string, FloxPackage};
 use flox_types::constants::{DEFAULT_CHANNEL, LATEST_VERSION};
 use itertools::Itertools;
 use log::{error, info};
@@ -373,14 +373,32 @@ impl Install {
         //     anyhow::bail!("{installed} is already installed");
         // }
 
-        environment
+        let packages_str = packages_to_string(&packages);
+        let plural = packages.len() > 1;
+
+        if environment
             .install(
                 packages.drain(..),
                 &flox.nix(Default::default()),
                 &flox.system,
             )
             .await
-            .context("could not install packages")?;
+            .context("could not install packages")?
+        {
+            println!(
+                "✅ Installed {} into '{}' environment.",
+                packages_str,
+                environment.environment_ref()
+            );
+        } else {
+            let verb = if plural { "are" } else { "is" };
+            println!(
+                "No changes; {} {} already installed into '{}' environment.",
+                packages_str,
+                verb,
+                environment.environment_ref()
+            );
+        }
         Ok(())
     }
 }

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -51,7 +51,7 @@ impl Edit {
 
         let mut environment =
             resolve_environment(&flox, self.environment.as_deref(), "edit").await?;
-        let mut temporary_environment = environment.make_temporary().await?;
+        let mut temporary_environment = environment.make_temporary()?;
 
         let nix = flox.nix(Default::default());
 
@@ -234,7 +234,7 @@ impl Init {
         };
 
         let env =
-            PathEnvironment::<Original>::init(&current_dir, name, flox.temp_dir.clone()).await?;
+            PathEnvironment::<Original>::init(&current_dir, name, flox.temp_dir.clone())?;
 
         println!(
             indoc::indoc! {"

--- a/crates/flox/src/utils/display.rs
+++ b/crates/flox/src/utils/display.rs
@@ -1,0 +1,51 @@
+use flox_rust_sdk::prelude::flox_package::FloxPackage;
+use itertools::Itertools;
+
+pub fn packages_to_string(packages: &[FloxPackage]) -> String {
+    match packages.len() {
+        0 => "".to_string(),
+        1 => format!("'{}'", packages[0]),
+        2 => format!("'{}' and '{}'", packages[0], packages[1]),
+        _ => {
+            let almost_all = packages.len() - 1;
+            format!(
+                "'{}', and '{}'",
+                packages.iter().take(almost_all).join("', '"),
+                packages[almost_all],
+            )
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flox_rust_sdk::prelude::flox_package::FloxTriple;
+    use flox_types::stability::Stability;
+
+    use super::*;
+
+    /// Helper function to create a triple from a string
+    pub fn create_triple(name: &str) -> FloxPackage {
+        FloxPackage::Triple(FloxTriple {
+            stability: Stability::Stable,
+            channel: "nixpkgs-flox".parse().unwrap(),
+            name: name.parse().unwrap(),
+            version: None,
+        })
+    }
+
+    #[test]
+    fn test_packages_to_string() {
+        let mut packages = vec![];
+        assert_eq!(packages_to_string(&packages), "");
+        packages.push(create_triple("hello"));
+        assert_eq!(packages_to_string(&packages), "'hello'");
+        packages.push(create_triple("curl"));
+        assert_eq!(packages_to_string(&packages), "'hello' and 'curl'");
+        packages.push(create_triple("ripgrep"));
+        assert_eq!(
+            packages_to_string(&packages),
+            "'hello', 'curl', and 'ripgrep'"
+        );
+    }
+}

--- a/crates/flox/src/utils/mod.rs
+++ b/crates/flox/src/utils/mod.rs
@@ -17,6 +17,7 @@ use once_cell::sync::Lazy;
 pub mod colors;
 mod completion;
 pub mod dialog;
+pub mod display;
 pub mod init;
 pub mod installables;
 pub mod logger;

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -1,0 +1,99 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test rust impl of `flox install`
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  project_setup
+}
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+setup_file() {
+  export FLOX_FEATURES_ENV=rust
+}
+
+# without specifying a name should install to an environment found in the user's current directory.
+@test "i2.a: install outside of shell (option1)" {
+
+  "$FLOX_CLI" init
+
+  run "$FLOX_CLI" install hello
+  assert_success
+
+  run "$FLOX_CLI" list
+  assert_success
+  assert_output --regexp - <<EOF
+.*
+Packages in test:
+stable.hello
+EOF
+}
+
+@test "i3: flox install allows -e for explicit environment name;  If .flox does not exist, a .flox is created." {
+  run ls .flox
+  assert_failure
+
+  run "$FLOX_CLI" install -e env hello
+  assert_success
+
+  run ls .flox
+  assert_success
+}
+
+@test "i3: flox install allows -e for explicit environment name;  If the environment is not staged in FLOX_META, it is pulled" {
+  skip "remote environments handled in another phase"
+}
+
+@test "i3: flox install allows -e for explicit environment name; If the environment exists in FLOX_META or locally, .flox is a link" {
+  skip "remote environments handled in another phase"
+}
+
+@test "i4: If -e specifies an environment different than the one in .flox, an error is thrown" {
+  "$FLOX_CLI" init -e env
+  run "$FLOX_CLI" install -e not-env hello
+  assert_failure
+  assert_output "Env Not found"
+}
+
+@test "i4: confirmation message" {
+  "$FLOX_CLI" init
+  run "$FLOX_CLI" install hello
+  assert_success
+  assert_output "✅ Installed 'hello' package(s) into 'test' environment."
+}
+
+@test "i5: download package when install command runs" {
+  skip "Don't know how to test, check out-link created?"
+}
+
+@test "i6: install on a pushed environment stages locally" {
+  skip "remote environments handled in another phase"
+}

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -42,25 +42,14 @@ setup_file() {
 
 # without specifying a name should install to an environment found in the user's current directory.
 @test "i2.a: install outside of shell (option1)" {
-
-  "$FLOX_CLI" init
-
-  run "$FLOX_CLI" install hello
-  assert_success
-
-  run "$FLOX_CLI" list
-  assert_success
-  assert_output --regexp - <<EOF
-.*
-Packages in test:
-stable.hello
-EOF
+  skip "Environment defaults handled in another phase"
 }
 
 @test "i3: flox install allows -e for explicit environment name;  If .flox does not exist, a .flox is created." {
   run ls .flox
   assert_failure
 
+  skip "Environment defaults handled in another phase"
   run "$FLOX_CLI" install -e env hello
   assert_success
 
@@ -76,18 +65,15 @@ EOF
   skip "remote environments handled in another phase"
 }
 
-@test "i4: If -e specifies an environment different than the one in .flox, an error is thrown" {
-  "$FLOX_CLI" init -e env
-  run "$FLOX_CLI" install -e not-env hello
-  assert_failure
-  assert_output "Env Not found"
-}
-
-@test "i4: confirmation message" {
+@test "i?: confirmation message" {
   "$FLOX_CLI" init
   run "$FLOX_CLI" install hello
   assert_success
-  assert_output "✅ Installed 'hello' package(s) into 'test' environment."
+  assert_output --partial "✅ Installed 'hello' into 'test' environment."
+  
+  skip "our current editing of Nix expressions doesn't detect already installed packages."
+  run "$FLOX_CLI" install hello
+  assert_output --partial "...already installed..."
 }
 
 @test "i5: download package when install command runs" {

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -46,10 +46,10 @@ setup_file() {
 }
 
 @test "i3: flox install allows -e for explicit environment name;  If .flox does not exist, a .flox is created." {
+  skip "Environment defaults handled in another phase"
   run ls .flox
   assert_failure
 
-  skip "Environment defaults handled in another phase"
   run "$FLOX_CLI" install -e env hello
   assert_success
 

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -70,9 +70,13 @@ setup_file() {
   run "$FLOX_CLI" install hello
   assert_success
   assert_output --partial "✅ Installed 'hello' into 'test' environment."
-  
+}
+
+@test "i?: warning message if package is already installed
   skip "our current editing of Nix expressions doesn't detect already installed packages."
-  run "$FLOX_CLI" install hello
+  run "$FLOX_CLI" install hello # install once
+  run "$FLOX_CLI" install hello # try install again
+  assert_success
   assert_output --partial "...already installed..."
 }
 

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -72,7 +72,7 @@ setup_file() {
   assert_output --partial "✅ Installed 'hello' into 'test' environment."
 }
 
-@test "i?: warning message if package is already installed
+@test "i?: warning message if package is already installed {
   skip "our current editing of Nix expressions doesn't detect already installed packages."
   run "$FLOX_CLI" install hello # install once
   run "$FLOX_CLI" install hello # try install again


### PR DESCRIPTION
- create symlink to built environment in .flox/builds/{system}.{name}
  - this required some changes to copying directories, as
  fs_extra::dir::copy does not support symlinks
- copy catalog.json into the built environment
- print a message to users saying whether a package was installed
- add a test for flox_nix_content_with_new_packages