### PR TITLE
Flox floxmeta repos set origin

### DIFF
--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -120,6 +120,7 @@ function floxmetaGit() {
 	# 2. Specify `user.{name,email}` as required for commits.
 	GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null \
 	$_git \
+		-c "http.version=HTTP/1.1" \
 		-c "user.name=Flox User" \
 		-c "user.email=floxuser@example.invalid" \
 		"$@"
@@ -132,6 +133,7 @@ function floxmetaGitVerbose() {
 	trace "$@"
 	GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null \
 	$invoke_git \
+		-c "http.version=HTTP/1.1" \
 		-c "user.name=Flox User" \
 		-c "user.email=floxuser@example.invalid" \
 		"$@"

--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -120,7 +120,6 @@ function floxmetaGit() {
 	# 2. Specify `user.{name,email}` as required for commits.
 	GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null \
 	$_git \
-		-c "http.version=HTTP/1.1" \
 		-c "user.name=Flox User" \
 		-c "user.email=floxuser@example.invalid" \
 		"$@"
@@ -133,7 +132,6 @@ function floxmetaGitVerbose() {
 	trace "$@"
 	GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null \
 	$invoke_git \
-		-c "http.version=HTTP/1.1" \
 		-c "user.name=Flox User" \
 		-c "user.email=floxuser@example.invalid" \
 		"$@"

--- a/pkgs/flox-gitforge/default.nix
+++ b/pkgs/flox-gitforge/default.nix
@@ -1,1 +1,0 @@
-{flox}: flox


### PR DESCRIPTION
## Proposed Changes

Automatically rewrite git origin for environments owned by `flox` and `flox-examples`.

## Current Behavior

Users are currently prompted to migrate the floxmeta repositories for the flox and flox-examples organizations, which they cannot do.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A