### PR TITLE
Initial search/replace of floxdev.com->flox.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://floxdev.com" target="_blank">
+  <a href="https://flox.dev" target="_blank">
     <picture>
       <source media="(prefers-color-scheme: dark)"  srcset="img/flox_orange_small.png" />
       <source media="(prefers-color-scheme: light)" srcset="img/flox_blue_small.png" />
@@ -24,11 +24,11 @@
 
 <h3 align="center">
    &emsp;
-   <a href="https://discourse.floxdev.com"><b>Discourse</b></a>
+   <a href="https://discourse.flox.dev"><b>Discourse</b></a>
    &emsp; | &emsp; 
-   <a href="https://floxdev.com/docs"><b>Documentation</b></a>
+   <a href="https://flox.dev/docs"><b>Documentation</b></a>
    &emsp; | &emsp; 
-   <a href="https://floxdev.com/blog"><b>Blog</b></a>
+   <a href="https://flox.dev/blog"><b>Blog</b></a>
    &emsp; | &emsp;  
    <a href="https://twitter.com/floxdevelopment"><b>Twitter</b></a>
    &emsp;
@@ -55,13 +55,13 @@ Install packages from [the biggest open source repository
 (nixpkgs)][post-nixpkgs] that contains **more that 80.000 packages**.
 
 With `flox` you can:<br/>
-&rarr; [Create composable environments](https://floxdev.com/docs/tutorials/projects)<br/>
-&rarr; [Share your environments with others](https://floxdev.com/docs/cookbook/managed-environments/#share-an-environment)<br/>
-&rarr; [Build container images](https://floxdev.com/docs/tutorials/build-container-images)<br/>
+&rarr; [Create composable environments](https://flox.dev/docs/tutorials/projects)<br/>
+&rarr; [Share your environments with others](https://flox.dev/docs/cookbook/managed-environments/#share-an-environment)<br/>
+&rarr; [Build container images](https://flox.dev/docs/tutorials/build-container-images)<br/>
 &rarr; [... and much more][docs]<br/>
 
 <div align="center">
-  <a href="https://floxdev.com/docs/#install-flox">
+  <a href="https://flox.dev/docs/#install-flox">
     <img alt="install flox" src="https://img.shields.io/badge/Install-flox-brightgreen?style=for-the-badge"/>
   </a>
 </div>
@@ -111,15 +111,15 @@ guide](./CONTRIBUTING.md) first.
 The flox CLI is licensed under the GPLv2. See [LICENSE](./LICENSE).
 
 
-[website]: https://floxdev.com
-[discourse]: https://discourse.floxdev.com
+[website]: https://flox.dev
+[discourse]: https://discourse.flox.dev
 [nix]: https://nixos.org
-[basics]:https://floxdev.com/docs/basics
-[share-envs]: https://floxdev.com/docs/share-environments
-[images]: https://floxdev.com/docs/build-container-images
-[docs]: https://floxdev.com/docs
+[basics]:https://flox.dev/docs/basics
+[share-envs]: https://flox.dev/docs/share-environments
+[images]: https://flox.dev/docs/build-container-images
+[docs]: https://flox.dev/docs
 [twitter]: https://twitter.com/floxdevelopment
 [matrix]: https://matrix.to/#/#flox:matrix.org
 [discord]: https://discord.gg/5H7hN57eQR
 [new-issue]: https://github.com/flox/flox/issues/new/choose
-[post-nixpkgs]: https://floxdev.com/blog/nixpkgs
+[post-nixpkgs]: https://flox.dev/blog/nixpkgs

--- a/doc/release-notes/rl-0.1.2.md
+++ b/doc/release-notes/rl-0.1.2.md
@@ -3,7 +3,7 @@
 This release introduces the ability to declare a project environment via a top-level `flox.nix` file.
 This file is a Nix set (a map) which lists the packages to be included in the environment.
 This way, you can `flox activate` at the project root, and instantiate an environment with all the packages you need to develop against that project.
-See the [documentation](https://floxdev.com/docs) for details.
+See the [documentation](https://flox.dev/docs) for details.
 
 - Added the ability to provide flox configuration files in TOML format, in 3 different places of the user's choosing read in the following order:
   - package defaults from `$PREFIX/etc/flox.toml` (PREFIX=${flox-bash})

--- a/doc/release-notes/rl-0.1.4.md
+++ b/doc/release-notes/rl-0.1.4.md
@@ -13,4 +13,4 @@ This release includes several performance improvements, bug fixes, and feature r
 - Updated output level of internal commands to forward more prompts and warnings to users, e.g. to provide passwords or yubikey input.
 - Squashed some bugs, improved error messages / UX output, updated manpages and fixed typos.
 
-We especially want to thank all our <a href="https://github.com/flox/flox">github.com/flox/flox</a> contributors and <a href="https://discourse.floxdev.com">discourse community</a> members for all your valuable feedback!
+We especially want to thank all our <a href="https://github.com/flox/flox">github.com/flox/flox</a> contributors and <a href="https://discourse.flox.dev">discourse community</a> members for all your valuable feedback!

--- a/doc/release-notes/rl-0.1.5.md
+++ b/doc/release-notes/rl-0.1.5.md
@@ -10,4 +10,4 @@ This release includes several bug fixes and feature refinements based on feedbac
 - Squashed some bugs, supressed superfluous warnings, and improved error messages / UX output.
 
 We especially want to thank all our <a href="https://github.com/flox/flox">github.com/flox/flox</a> contributors and 
-<a href="https://discourse.floxdev.com">discourse community</a> members for all your valuable feedback!
+<a href="https://discourse.flox.dev">discourse community</a> members for all your valuable feedback!

--- a/doc/release-notes/rl-0.2.5.md
+++ b/doc/release-notes/rl-0.2.5.md
@@ -2,5 +2,5 @@
 
 This maintenance release addresses the following bugs:
 - Show all stabilities in output of `flox search --long `and `flox search --json`.
-- Fixed flox installer bug affecting Mac installations only. Please [upgrade](https://floxdev.com/docs/install-flox/) to the
+- Fixed flox installer bug affecting Mac installations only. Please [upgrade](https://flox.dev/docs/install-flox/) to the
   latest version if you encounter the error `curl: (35) OpenSSL/3.0.9: error:16000069:STORE routines::unregistered scheme`.

--- a/flox-bash/README.md
+++ b/flox-bash/README.md
@@ -1,5 +1,5 @@
 <p>
-    <a href="https://floxdev.com" target="_blank">
+    <a href="https://flox.dev" target="_blank">
         <img src="../img/flox_blue_small.png" alt="flox logo" />
     </a>
 </p>
@@ -10,7 +10,7 @@
 
 ## flox (beta)
 
-The [flox](https://floxdev.com) CLI is a multi-platform environment manager
+The [flox](https://flox.dev) CLI is a multi-platform environment manager
 built on [Nix](https://github.com/nixOS/nix).
 
 <img style="float:right" alt="flox flywheel" align="right" width="280" src="../img/310703783_812187779826049_7314390197914243071_n.png">
@@ -27,11 +27,11 @@ With `flox` you can:
 ## Installation
 
 You can download the `flox` CLI via one of our native installers for Mac, Linux,
-or Windows WSL [here](https://floxdev.com/docs#install-flox).
+or Windows WSL [here](https://flox.dev/docs#install-flox).
 
 ## Usage
 
-See the [docs](https://floxdev.com/docs) for more detail on usage.
+See the [docs](https://flox.dev/docs) for more detail on usage.
 
 #### Search through available packages:
 
@@ -106,7 +106,7 @@ using [Nixpkgs](https://github.com/NixOS/nixpkgs).
 Using packages from a `flox` channel adds a few features to
 [Nixpkgs](https://github.com/NixOS/nixpkgs) such as: semantic versioning,
 stabilities, and guaranteed cache hits.
-See the [docs](https://floxdev.com/docs/basics) for more info.
+See the [docs](https://flox.dev/docs/basics) for more info.
 
 ## Contributing
 
@@ -119,7 +119,7 @@ The `flox` CLI is written in Rust.
 Building `flox` requires a running Nix daemon.
 
 The simplest way to build `flox` is via `flox`!
-- [Download and install](https://floxdev.com/docs/#install-flox) `flox`, then
+- [Download and install](https://flox.dev/docs/#install-flox) `flox`, then
   run `flox build flox-bash` in the project directory.
 
 If you're a Nix user, you can run the following:
@@ -143,7 +143,7 @@ The `flox` CLI is licensed under the GPLv2. See [LICENSE](./LICENSE).
 
 ## Community
 
-Find us on [Twitter](https://twitter.com/floxdevelopment) and [Discourse](https://discourse.floxdev.com).
+Find us on [Twitter](https://twitter.com/floxdevelopment) and [Discourse](https://discourse.flox.dev).
 
 For updates to the `flox` CLI, follow this repo on
 [GitHub](https://github.com/flox/flox)!

--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -252,7 +252,7 @@ function floxActivate() {
 	# unless we want to risk even further breakage by disabling path_helper in
 	# /etc/zprofile this is the best workaround we've come up with.
 	#
-	# https://discourse.floxdev.com/t/losing-part-of-my-shell-environment-when-using-flox-develop/556/2
+	# https://discourse.flox.dev/t/losing-part-of-my-shell-environment-when-using-flox-develop/556/2
 	if [[ -x /usr/libexec/path_helper ]] && [[ "$PATH" =~ ^/usr/local/bin: ]]
 	then
 		if [[ "${#cmdArgs[@]}" -eq 0 ]] && [[ "$spawnMode" -eq 0 ]]; then

--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -1531,7 +1531,7 @@ function floxPushPull() {
 	tmpDir=$(mkTempDir)
 	floxmetaGitVerbose clone --quiet --shared "$environmentMetaDir" $tmpDir
 
-	# XXX Temporary migrate floxmeta from github.com -> floxdev.com with upgrade to 0.3.0
+	# XXX Temporary migrate floxmeta from github.com -> flox.dev with upgrade to 0.3.0
 	temporaryMigrateGitHubTo030Floxdev "$tmpDir"
 	# /XXX
 

--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -427,7 +427,7 @@ function floxmetaHelperGit() {
 }
 
 # XXX TEMPORARY function to migrate floxmeta repositories from
-# github.com -> git.floxdev.com
+# github.com -> git.flox.dev
 #     **Delete after GA**
 function temporaryMigrateGitHubTo030Floxdev() {
 	trace "$@"

--- a/flox-bash/libexec/flox/darwin-path-fixer.awk
+++ b/flox-bash/libexec/flox/darwin-path-fixer.awk
@@ -10,7 +10,7 @@
 # /etc/zprofile this is the best workaround we've come up with.
 #
 # See following URL for more detail:
-# https://discourse.floxdev.com/t/losing-part-of-my-shell-environment-when-using-flox-develop/556/2
+# https://discourse.flox.dev/t/losing-part-of-my-shell-environment-when-using-flox-develop/556/2
 #
 # Usage: echo $PATH | awk -v shellDialect=bash -f path/to/darwin-path-fixer.awk
 #

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -57,7 +57,7 @@
       FLOX_ANALYZER_SRC = ../../flox-bash/lib/catalog-ingest;
 
       # Metrics subsystem configuration
-      METRICS_EVENTS_URL = "https://events.floxdev.com/capture";
+      METRICS_EVENTS_URL = "https://events.flox.dev/capture";
       METRICS_EVENTS_API_KEY = "phc_z4dOADAPvpU9VNzCjDD3pIJuSuGTyagKdFWfjak838Y";
 
       # the libssh crate wants to use its own libssh prebuilts


### PR DESCRIPTION
This PR should be merged once website/discourse/events.flox.dev domain are ready.