### PR TITLE
fix: create environment symlinks in `.flox/envs`

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment.rs
@@ -182,7 +182,7 @@ impl<S: TransactionState> PathEnvironment<S> {
     /// can in fact be built.
     fn out_link(&self, system: impl AsRef<str> + Send) -> PathBuf {
         self.path
-            .join("builds")
+            .join("envs")
             .join(format!("{0}.{1}", system.as_ref(), self.name()))
     }
 }


### PR DESCRIPTION

## Proposed Changes

Rename the target for environment activation symlinks to avoid possible confusion with package build symlinks in future.

## Current Behavior

Currently environment symlinks are created in the `.flox/builds` directory and this may be a source of confusion when symlinks to package builds are also present.

## Checks

<!-- Please confirm the following: -->

- [ ] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A