### PR TITLE
fix(publish): clear files on newly created orphan catalog branches

### DIFF
--- a/crates/flox-rust-sdk/src/models/publish.rs
+++ b/crates/flox-rust-sdk/src/models/publish.rs
@@ -467,6 +467,7 @@ impl UpstreamRepo {
             self.git
                 .checkout(&Self::catalog_branch_name(system), true)
                 .await?;
+            self.git.rm(&[Path::new(".")], true, true, false).await?;
         }
         Ok(UpstreamCatalog { git: &self.git })
     }

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -222,7 +222,7 @@ impl Init {
         let current_dir = std::env::current_dir().unwrap();
         let home_dir = dirs::home_dir().unwrap();
 
-        let name = if let Some(name) = self.name.clone() {
+        let name = if let Some(name) = self.name {
             name
         } else if current_dir == home_dir {
             "default".parse()?
@@ -234,8 +234,7 @@ impl Init {
                 .parse()?
         };
 
-        let env =
-            PathEnvironment::<Original>::init(&current_dir, name, flox.temp_dir.clone())?;
+        let env = PathEnvironment::<Original>::init(&current_dir, name, flox.temp_dir.clone())?;
 
         println!(
             indoc::indoc! {"


### PR DESCRIPTION
When publish creates a new catalog branches it invokes `git checkout --orphan` which keeps the original working tree in the index.
This PR adds a call to `git rm .` to clear the index.


closes #220