### PR TITLE
feat(publish): impl binary cache check retry

### DIFF
--- a/crates/flox/doc/flox-publish.md
+++ b/crates/flox/doc/flox-publish.md
@@ -59,16 +59,21 @@ upstream repository.
     a different transport. For example, to upload packages
     to a (writable, authenticated) `s3://` URL,
     but download these packages from an (read-only,
-    unauthenticated) `https://cache.floxdev.com endpoint``.
+    unauthenticated) `https://cache.floxdev.com endpoint`.
 
     If not provided the `--public-cache-url` argument will default to
     the `public_cache_url` config value,
     or same value as provided for the `--cache-url` argument.
 
+`[ --retry <number> ]`
+:   Number of retries if the binary was not found in the cache at the first time
+
+    If not provided, defaults to `3` retries
+
 `[ --signing-key <file> | -k <file> ]`
 :   Used for identifying the path to the private key
     to be used to sign packages before upload.
-    If not provided the, will default to the `sign_key` config value.
+    If not provided, defaults to the `signing_key` config value.
 
 
 `--prefer-https`

--- a/crates/flox/doc/flox-publish.md
+++ b/crates/flox/doc/flox-publish.md
@@ -65,8 +65,8 @@ upstream repository.
     the `public_cache_url` config value,
     or same value as provided for the `--cache-url` argument.
 
-`[ --retry <number> ]`
-:   Number of retries if the binary was not found in the cache at the first time
+`[ --max-retries <number> ]`
+:   Number of retries if the binary is not found in the cache
 
     If not provided, defaults to `3` retries
 

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -222,7 +222,7 @@ impl Init {
         let current_dir = std::env::current_dir().unwrap();
         let home_dir = dirs::home_dir().unwrap();
 
-        let name = if let Some(name) = self.name.clone() {
+        let name = if let Some(name) = self.name {
             name
         } else if current_dir == home_dir {
             "default".parse()?
@@ -234,8 +234,7 @@ impl Init {
                 .parse()?
         };
 
-        let env =
-            PathEnvironment::<Original>::init(&current_dir, name, flox.temp_dir.clone())?;
+        let env = PathEnvironment::<Original>::init(&current_dir, name, flox.temp_dir.clone())?;
 
         println!(
             indoc::indoc! {"

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -54,6 +54,8 @@ use crate::utils::installables::{
 };
 use crate::utils::{InstallableArgument, InstallableDef, Parsed};
 
+const RETRY_SLEEP_DURATION: Duration = Duration::from_secs(5);
+
 #[derive(Clone, Debug)]
 pub enum PosOrEnv<T: InstallableDef> {
     Pos(InstallableArgument<Parsed, T>),
@@ -416,7 +418,7 @@ impl Publish {
             }
             // increase try count and wait
             *current_try += 1;
-            tokio::time::sleep(Duration::from_secs(5)).await;
+            tokio::time::sleep(RETRY_SLEEP_DURATION).await;
         };
 
         if !found_upstream {

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fmt::Debug;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use bpaf::{construct, Bpaf, Parser};
@@ -21,10 +22,10 @@ use flox_rust_sdk::providers::git::{GitCommandProvider, GitProvider};
 use flox_types::stability::Stability;
 use indoc::indoc;
 use itertools::Itertools;
-use log::{debug, info};
+use log::{debug, info, warn};
 
 use crate::config::Config;
-use crate::utils::dialog::{Dialog, Text};
+use crate::utils::dialog::{Confirm, Dialog, Text};
 use crate::utils::resolve_environment_ref;
 use crate::{flox_forward, subcommand_metric};
 
@@ -270,6 +271,10 @@ pub struct Publish {
     #[bpaf(long, short('s'), argument("url"))]
     pub public_cache_url: Option<SubstituterUrl>,
 
+    /// Number of retries if the binary was not found in the cache at the first time
+    #[bpaf(long, fallback(3), argument("number"))]
+    pub retry: i32,
+
     /// Print snapshot JSON to stdout instead of uploading it to the catalog
     #[bpaf(long, hide)]
     pub json: bool,
@@ -369,10 +374,58 @@ impl Publish {
         info!("done!");
 
         info!("Checking binary can be downloaded from {substituter_url}...");
-        publish
-            .check_substituter(substituter_url)
-            .await
-            .context("Binary cannot be downloaded")?;
+
+        let mut retry_count = None;
+        let found_upstream = loop {
+            let check_result = publish.check_substituter(substituter_url.clone()).await;
+
+            if check_result.is_ok() {
+                break true;
+            }
+
+            let err = check_result.unwrap_err();
+            warn!("Unable to find binary at {substituter_url}: {err}");
+
+            // in first round:
+            // if we can prompt, confirm that we should retry
+            // else              assume yes, retry {self.retry} times
+            if retry_count.is_none() && Dialog::can_prompt() {
+                let help_message = Some(format!(
+                    "flox query {substituter_url} {} more times; waiting 5 seconds inbetween.",
+                    self.retry
+                ));
+                let confirm = Dialog {
+                    message: "Keep looking for binary?",
+                    help_message: help_message.as_deref(),
+                    typed: Confirm {
+                        default: Some(true),
+                    },
+                };
+
+                if !confirm.prompt().await? {
+                    bail!("aborted publish!");
+                }
+            }
+
+            // get the current try count
+            let current_try = retry_count.get_or_insert(1);
+
+            // return unsuccessful if max tries exceeded
+            if *current_try > self.retry {
+                break false;
+            }
+            // increase try count and wait
+            *current_try += 1;
+            std::thread::sleep(Duration::from_secs(5));
+        };
+
+        if !found_upstream {
+            bail!(
+                "Unable to locate binary after retrying {} times",
+                self.retry
+            );
+        }
+
         info!("done!");
 
         if self.json {

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -272,8 +272,8 @@ pub struct Publish {
     pub public_cache_url: Option<SubstituterUrl>,
 
     /// Number of retries if the binary was not found in the cache at the first time
-    #[bpaf(long, fallback(3), argument("number"))]
-    pub retry: i32,
+    #[bpaf(long("max-retries"), fallback(3), argument("number"))]
+    pub max_retries: i32,
 
     /// Print snapshot JSON to stdout instead of uploading it to the catalog
     #[bpaf(long, hide)]
@@ -392,7 +392,7 @@ impl Publish {
             if retry_count.is_none() && Dialog::can_prompt() {
                 let help_message = Some(format!(
                     "flox query {substituter_url} {} more times; waiting 5 seconds inbetween.",
-                    self.retry
+                    self.max_retries
                 ));
                 let confirm = Dialog {
                     message: "Keep looking for binary?",
@@ -411,7 +411,7 @@ impl Publish {
             let current_try = retry_count.get_or_insert(1);
 
             // return unsuccessful if max tries exceeded
-            if *current_try > self.retry {
+            if *current_try > self.max_retries {
                 break false;
             }
             // increase try count and wait
@@ -422,7 +422,7 @@ impl Publish {
         if !found_upstream {
             bail!(
                 "Unable to locate binary after retrying {} times",
-                self.retry
+                self.max_retries
             );
         }
 

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -249,25 +249,25 @@ impl WithPassthru<PrintDevEnv> {
 
 #[derive(Bpaf, Clone, Debug)]
 pub struct Publish {
-    /// Signing key file to sign the binary with
+    /// Path to signing key file to sign the binary with
     ///
     /// When omitted, reads from the config.
     /// See flox-config(1) for more details.
-    #[bpaf(long, short('k'))]
+    #[bpaf(long, short('k'), argument("path"))]
     pub signing_key: Option<PathBuf>,
 
     /// Url of a binary cache to push binaries _to_
     ///
     /// When omitted, reads from the config.
     /// See flox-config(1) for more details.
-    #[bpaf(long, short('c'))]
+    #[bpaf(long, short('c'), argument("url"))]
     pub cache_url: Option<SubstituterUrl>,
 
     /// URL of a substituter to pull binaries _from_
     ///
     /// When ommitted, falls back to the config or uses the value for cache-url.
     /// See flox-config(1) for more details.
-    #[bpaf(long, short('s'))]
+    #[bpaf(long, short('s'), argument("url"))]
     pub public_cache_url: Option<SubstituterUrl>,
 
     /// Print snapshot JSON to stdout instead of uploading it to the catalog

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -393,7 +393,7 @@ impl Publish {
             // else              assume yes, retry {self.retry} times
             if retry_count.is_none() && Dialog::can_prompt() {
                 let help_message = Some(format!(
-                    "flox query {substituter_url} {} more times; waiting 5 seconds inbetween.",
+                    "query {substituter_url} {} more times, waiting 5 seconds in-between.",
                     self.max_retries
                 ));
                 let confirm = Dialog {

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -416,7 +416,7 @@ impl Publish {
             }
             // increase try count and wait
             *current_try += 1;
-            std::thread::sleep(Duration::from_secs(5));
+            tokio::time::sleep(Duration::from_secs(5)).await;
         };
 
         if !found_upstream {

--- a/tests/publish.bats
+++ b/tests/publish.bats
@@ -107,7 +107,7 @@ EOF
 }
 
 # Publish requires a cached binary.
-# If the binary is not found at the first try, publish will retry for `--retry <n>` times
+# If the binary is not found at the first try, publish will retry `--retry <n>` times
 @test "flox publish retries fetching url; --retry 2" {
     run $FLOX_CLI -v publish "$CHANNEL#hello" --public-cache-url http://url.example --retry 2
     assert_failure

--- a/tests/publish.bats
+++ b/tests/publish.bats
@@ -93,6 +93,19 @@ setup() {
     assert_output --partial "Cache url is required!"
 }
 
+# Publish requires a cached binary.
+# If the binary is not found at the first try, publish will retry for 3 times
+@test "flox publish retries fetching url 3 times" {
+    run $FLOX_CLI -v publish "$CHANNEL#hello" --public-cache-url http://url.example
+    assert_failure
+    assert_output --regexp - <<EOF
+.*
+Checking binary can be downloaded from http://url\.example/\.\.\.
+.*
+(Unable to find binary at http://url\.example/: Failed to invoke path-info:.*){4}
+EOF
+}
+
 teardown_file() {
     kill "$NIX_SERVE_PID"
 }

--- a/tests/publish.bats
+++ b/tests/publish.bats
@@ -94,7 +94,7 @@ setup() {
 }
 
 # Publish requires a cached binary.
-# If the binary is not found at the first try, publish will retry for 3 times
+# If the binary is not found at the first try, publish will retry 3 times
 @test "flox publish retries fetching url 3 times" {
     run $FLOX_CLI -v publish "$CHANNEL#hello" --public-cache-url http://url.example
     assert_failure

--- a/tests/publish.bats
+++ b/tests/publish.bats
@@ -107,9 +107,9 @@ EOF
 }
 
 # Publish requires a cached binary.
-# If the binary is not found at the first try, publish will retry `--retry <n>` times
-@test "flox publish retries fetching url; --retry 2" {
-    run $FLOX_CLI -v publish "$CHANNEL#hello" --public-cache-url http://url.example --retry 2
+# If the binary is not found at the first try, publish will retry `--max-retries <n>` times
+@test "flox publish retries fetching url; --max-retries 2" {
+    run $FLOX_CLI -v publish "$CHANNEL#hello" --public-cache-url http://url.example --max-retries 2
     assert_failure
     assert_output --regexp - <<EOF
 .*

--- a/tests/publish.bats
+++ b/tests/publish.bats
@@ -106,6 +106,19 @@ Checking binary can be downloaded from http://url\.example/\.\.\.
 EOF
 }
 
+# Publish requires a cached binary.
+# If the binary is not found at the first try, publish will retry for `--retry <n>` times
+@test "flox publish retries fetching url; --retry 2" {
+    run $FLOX_CLI -v publish "$CHANNEL#hello" --public-cache-url http://url.example --retry 2
+    assert_failure
+    assert_output --regexp - <<EOF
+.*
+Checking binary can be downloaded from http://url\.example/\.\.\.
+.*
+(Unable to find binary at http://url\.example/: Failed to invoke path-info:.*){3}
+EOF
+}
+
 teardown_file() {
     kill "$NIX_SERVE_PID"
 }


### PR DESCRIPTION
closes #221 

Also fixes a bug where, cache misses where treated as success, because nix wont error on them, rather issue

```
[
  {
    "path": "/nix/store/q90yr4zhzbvfwpkfqikn6brvsgyhn9av-builtfilter-rs-0.1.0",
    "valid": false
  }
]
```