### PR TITLE
bug: shell trips over `patch` output when running `flox activate` on Darwin hosts

### DIFF
--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1381,8 +1381,10 @@ function darwinPromptPatchFile() {
 	warn "seem to have been reverted, possibly by way of a recent OS update."
 	if $invoke_gum confirm --default="true" "Reapply flox patches to '$brokenFile'?"; then
 		# Intentionally relying on Mac versions of sudo and patch.
+		# Patch spits interactive output to STDOUT that should be
+		# going to STDERR, so be sure to redirect that accordingly.
 		( set -x && \
-			/usr/bin/sudo /usr/bin/patch -V none -p0 -d / --verbose < $patchFile ) || \
+			/usr/bin/sudo /usr/bin/patch -V none -p0 -d / --verbose < $patchFile 1>&2 ) || \
 			warn "problems applying '$patchFile' - please reinstall flox"
 	else
 		warn "OK, note you may encounter problems with zsh session history."


### PR DESCRIPTION
## Proposed Changes

Update invocations of `/usr/bin/patch` on Darwin hosts to send all prompts to STDERR to prevent shells from tripping over that output during `flox activate`.

## Current Behavior

When running `flox activate` on Darwin hosts flox checks to see if patches need to be (re-)applied to `/etc/zshrc{,_Apple_Terminal}`. If the output is being sourced by a shell it can then trip over the prompts sent to STDERR by `/usr/bin/patch`.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Fixed bug patching `/etc/zshrc{,_Apple_Terminal}` files when running `flox activate` from a shell "rc" file.