### PR TITLE
fix: render environments and generation links with rollback

### DIFF
--- a/flox-bash/lib/commands/environment.sh
+++ b/flox-bash/lib/commands/environment.sh
@@ -1335,6 +1335,10 @@ function floxRollback() {
 		1 \
 		"$me $subcommand ${invocation[*]}")
 
+	# Now that metadata has been updated, make sure environment and
+	# generation links are all in place.
+	syncEnvironment "$environment"
+
 	# Display user friendly message
 	eval $(decodeEnvironment "$environment")
 	local rollbackOrSwitch="Rolled back"


### PR DESCRIPTION

## Proposed Changes

This patch fixes a bug that prevented rolling back to generations that weren't already present in the local store by calling syncEnvironment() to render each environment and the associated generation symlinks following each rollback.

## Current Behavior

Reproducer:

<pre><span style="color:#5F5FAF"><b>flox </b></span><span style="color:#FFAF87"><b>[flox/prerelease default]</b></span> <span style="color:#55FF55"><b>[brantley@clubsoda:~/src/flox]$</b></span> flox pull -e flox/default                                                                                                                                                       
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To /home/brantley/.cache/flox/meta/flox
 * [new branch]        x86_64-linux.default -&gt; x86_64-linux.default

<span style="color:#5F5FAF"><b>flox </b></span><span style="color:#FFAF87"><b>[flox/prerelease default]</b></span> <span style="color:#55FF55"><b>[brantley@clubsoda:~/src/flox]$</b></span> ls -l /home/brantley/.local/share/flox/environments/flox/                                                                                                                       
total 2
lrwxrwxrwx 1 brantley users 28 Sep  1 18:13 <span style="color:#55FFFF"><b>x86_64-linux.default</b></span> -&gt; <span style="color:#5555FF"><b>x86_64-linux.default-33-link</b></span>
lrwxrwxrwx 1 brantley users 53 Sep  1 11:27 <span style="color:#55FFFF"><b>x86_64-linux.default-33-link</b></span> -&gt; <span style="color:#5555FF"><b>/nix/store/ax5c1i7qzqw7r4gswki25xzrh35vjy97-floxShell</b></span>

<span style="color:#5F5FAF"><b>flox </b></span><span style="color:#FFAF87"><b>[flox/prerelease default]</b></span> <span style="color:#55FF55"><b>[brantley@clubsoda:~/src/flox]$</b></span> flox rollback -e flox/default                                                                                                                                                   
<b>Rolled back environment &apos;flox/default&apos; from generation 33 to 32.</b>

<span style="color:#5F5FAF"><b>flox </b></span><span style="color:#FFAF87"><b>[flox/prerelease default]</b></span> <span style="color:#55FF55"><b>[brantley@clubsoda:~/src/flox]$</b></span> ls -l /home/brantley/.local/share/flox/environments/flox/
total 4
lrwxrwxrwx 1 brantley users 28 Sep  1 18:13 <span style="background-color:#000000"><span style="color:#FF5555"><b>x86_64-linux.default</b></span></span> -&gt; <span style="background-color:#000000"><span style="color:#FF5555"><b>x86_64-linux.default-32-link</b></span></span>
lrwxrwxrwx 1 brantley users 41 Sep  1 18:13 <span style="color:#55FFFF"><b>x86_64-linux.default-33-link</b></span> -&gt; <span style="color:#5555FF"><b>x86_64-linux.x86_64-linux.default-33-link</b></span>
lrwxrwxrwx 1 brantley users 28 Sep  1 18:13 <span style="color:#55FFFF"><b>x86_64-linux.x86_64-linux.default</b></span> -&gt; <span style="color:#5555FF"><b>x86_64-linux.default-33-link</b></span>
lrwxrwxrwx 1 brantley users 53 Sep  1 11:27 <span style="color:#55FFFF"><b>x86_64-linux.x86_64-linux.default-33-link</b></span> -&gt; <span style="color:#5555FF"><b>/nix/store/ax5c1i7qzqw7r4gswki25xzrh35vjy97-floxShell</b></span>

<span style="color:#5F5FAF"><b>flox </b></span><span style="color:#FFAF87"><b>[flox/prerelease default]</b></span> <span style="color:#55FF55"><b>[brantley@clubsoda:~/src/flox]$</b></span> ls -l /home/brantley/.local/share/flox/environments/flox/x86_64-linux.default/.
ls: cannot access &apos;/home/brantley/.local/share/flox/environments/flox/x86_64-linux.default/.&apos;: No such file or directory

<span style="color:#5F5FAF"><b>flox </b></span><span style="color:#FFAF87"><b>[flox/prerelease default]</b></span> <span style="color:#55FF55"><b>[brantley@clubsoda:~/src/flox]$</b></span> 
</pre>


## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Fixed bug affecting ability to roll back to old generations not present on disk.