### PR TITLE
fix: revert xargs bug introduced with floxmetaGit

### DIFF
--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -752,7 +752,7 @@ function beginTransaction() {
 	elif [[ $createBranch -eq 1 ]]; then
 		floxmetaGitVerbose -C "$workDir" checkout --quiet --orphan "$branchName"
 		floxmetaGitVerbose -C "$workDir" ls-files                                   \
-			| $_xargs --no-run-if-empty floxmetaGit -C "$workDir" rm --quiet -f
+			| $_xargs --no-run-if-empty "$_git" -C "$workDir" rm --quiet -f
 		# A commit is needed in order to make the branch visible.
 		floxmetaGitVerbose -C "$workDir" commit --quiet --allow-empty \
 			-m "$USER created environment $environmentName ($environmentSystem)"


### PR DESCRIPTION
## Proposed Changes

Replacing the use of $_git with floxmetaGit() in all floxmeta-related functions worked in all cases except when invoked with xargs, which of course cannot invoke a bash function. Reverting this one instance from the previous bulk change.

Closes #243 

## Current Behavior

See #243 

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

Fixed bug creating managed environments introduced in  version 0.3.0.