### PR TITLE
fix: tweak logic for creating new orphaned branch

### DIFF
--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -751,8 +751,7 @@ function beginTransaction() {
 		floxmetaGitVerbose -C "$workDir" checkout --quiet --track origin/"$branchName"
 	elif [[ $createBranch -eq 1 ]]; then
 		floxmetaGitVerbose -C "$workDir" checkout --quiet --orphan "$branchName"
-		floxmetaGitVerbose -C "$workDir" ls-files                                   \
-			| $_xargs --no-run-if-empty "$_git" -C "$workDir" rm --quiet -f
+		floxmetaGitVerbose -C "$workDir" rm --quiet -f -r .
 		# A commit is needed in order to make the branch visible.
 		floxmetaGitVerbose -C "$workDir" commit --quiet --allow-empty \
 			-m "$USER created environment $environmentName ($environmentSystem)"

--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -751,7 +751,7 @@ function beginTransaction() {
 		floxmetaGitVerbose -C "$workDir" checkout --quiet --track origin/"$branchName"
 	elif [[ $createBranch -eq 1 ]]; then
 		floxmetaGitVerbose -C "$workDir" checkout --quiet --orphan "$branchName"
-		floxmetaGitVerbose -C "$workDir" rm --quiet -f -r .
+		floxmetaGitVerbose -C "$workDir" rm --quiet --ignore-unmatch --force -r .
 		# A commit is needed in order to make the branch visible.
 		floxmetaGitVerbose -C "$workDir" commit --quiet --allow-empty \
 			-m "$USER created environment $environmentName ($environmentSystem)"


### PR DESCRIPTION
Taking inspiration from the example of creating an orphaned branch recently added to the rust codebase.

## Proposed Changes

Clean up orphan branch creation logic by running `git rm -r .` rather than `git ls-files | xargs --no-run-if-empty git rm`. It's a minor change but the latter was recently the source of a bug so figured it was worth fixing.

## Current Behavior

This is just code cleanup and does not change behavior.

## Checks

<!-- Please confirm the following: -->

- [ ] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A