### PR TITLE
fix: revert to use of nix 2.15

### DIFF
--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -28,7 +28,7 @@
   makeWrapper,
   man,
   nix-editor,
-  nixStable,
+  nixVersions,
   openssh,
   pandoc,
   parser-util,
@@ -47,7 +47,7 @@
   # Choose a smaller version of git.
   git = pkgs.gitMinimal;
 
-  nixPatched = nixStable.overrideAttrs (oldAttrs: {
+  nixPatched = nixVersions.nix_2_15.overrideAttrs (oldAttrs: {
     patches =
       (oldAttrs.patches or [])
       ++ [


### PR DESCRIPTION
## Proposed Changes

Nix 2.17 has problems rendering environments locked with an old version of flox-floxpkgs which uses builtins.fetchClosure() without specifying "inputAddressed = true". Reverting to nix 2.15 for a release cycle while we work to figure out the best way to address the problem going forward.

## Current Behavior

Attempts to render a flox environment with nix 2.17 results in the following error:

<pre><span style="color:#5F5FAF"><b>flox </b></span><span style="color:#FFAF87"><b>[flox/prerelease default]</b></span> brantley@Michaels-MBP flox % result/bin/flox pull -e flox/prerelease                   
Everything up-to-date                                                                                                 
<span style="color:#FF55FF"><b>warning:</b></span> input &apos;flox-floxpkgs/etc-profiles&apos; has an override for a non-existent input &apos;flox-floxpkgs&apos;                  
<span style="color:#FF5555"><b>error:</b></span>                                                                                                                
       … while calling the &apos;<span style="color:#FF55FF"><b>head</b></span>&apos; builtin                                                                             
                                                                                                                      
         <span style="color:#5555FF"><b>at </b></span><span style="color:#FF55FF"><b>/nix/store/ma9ipxi95nzimpfaflr9hyjfq46jnrcg-source/lib/attrsets.nix:820:11</b></span>:                               
                                                                                                                      
          819|         || pred here (elemAt values 1) (head values) then                                              
          820|           head values                                                                                  
             |           <span style="color:#FF5555"><b>^</b></span>                                                                                            
          821|         else                                                                                           
                                                                                                                      
       … while calling the &apos;<span style="color:#FF55FF"><b>derivationStrict</b></span>&apos; builtin                                                                 
                                                                                                                      
         <span style="color:#5555FF"><b>at </b></span><span style="color:#FF55FF"><b>/builtin/derivation.nix:9:12</b></span>:<span style="background-color:#FFFFFF"><span style="color:#000000"> (source not available)</span></span>                                                      
                                                                                                                      
       <span style="color:#FF55FF"><b>(stack trace truncated; use &apos;--show-trace&apos; to show the full trace)</b></span>                                             
                                                                                                                      
       <span style="color:#FF5555"><b>error:</b></span> The &apos;fromPath&apos; value &apos;<span style="color:#FF55FF"><b>/nix/store/bk9r7p5rd57z9srwxxb2f8g31bl1mdj3-flox-0.3.2-r617</b></span>&apos; is input-addressed, but &apos;inputAddressed&apos; is set to &apos;false&apos; (default).
                                                                                                                      
       If you do intend to fetch an input-addressed store path, add                                                   
                                                                                                                      
           inputAddressed = true;                                                                                     
                                                                                                                      
       to the &apos;fetchClosure&apos; arguments.                                                                               
                                                                                                                      
       Note that to ensure authenticity input-addressed store paths, users must configure a trusted binary cache public key on their systems. This is not needed for content-addressed paths.
                                                                                                                      
       <span style="color:#5555FF"><b>at </b></span><span style="color:#FF55FF"><b>«none»:0</b></span>:<span style="background-color:#FFFFFF"><span style="color:#000000"> (source not available)</span></span>                                                                            
</pre>

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Reverted to use of nix 2.15.2 while we work to addressed new requirements introduced in version 2.17.1 relating to inputAddressed closures.