### PR TITLE
chore: check for `--version` before handling flox arguments

### DIFF
--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -250,7 +250,7 @@ impl Init {
     }
 }
 
-/// List (status?) packages installed in an environment
+/// List packages installed in an environment
 #[derive(Bpaf, Clone)]
 pub struct List {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -254,7 +254,7 @@ enum LocalDevelopmentCommands {
     /// Run app from current project
     #[bpaf(command)]
     Run(#[bpaf(external(WithPassthru::parse))] WithPassthru<Run>),
-    /// List (status?) packages installed in an environment
+    /// List packages installed in an environment
     #[bpaf(command)]
     List(#[bpaf(external(environment::list))] environment::List),
     /// Access to the nix CLI

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -77,7 +77,6 @@ impl Default for Verbosity {
 }
 
 #[derive(Bpaf)]
-#[bpaf(options, version(FLOX_VERSION))]
 pub struct FloxArgs {
     /// Verbose mode.
     ///
@@ -88,6 +87,12 @@ pub struct FloxArgs {
     /// Debug mode.
     #[bpaf(long, req_flag(()), many, map(vec_not_empty))]
     pub debug: bool,
+
+    /// With `--version` the application will print the version of the program
+    /// and quit early.
+    #[allow(dead_code)] // fake arg, `--version` is checked for separately (see [Version])
+    #[bpaf(external(version))]
+    version: Version,
 
     #[bpaf(external(commands), optional)]
     command: Option<Commands>,
@@ -547,6 +552,27 @@ impl Prefix {
             .run_inner(Args::current_args())
             .unwrap_or_default()
             .prefix
+    }
+}
+
+/// Fake argument used to parse `--version` separately
+///
+/// bpaf allows `flox --invalid option --version`
+/// (https://github.com/pacak/bpaf/issues/288) but common utilities,
+/// such as git always require correct arguments even in the presence of
+/// short circuiting flags such as `--version`
+#[derive(Bpaf, Default)]
+pub struct Version(#[bpaf(long("version"))] bool);
+
+impl Version {
+    /// Parses to [Self] and extract the `--version` flag
+    pub fn check() -> bool {
+        bpaf::construct!(version(), flox_args())
+            .to_options()
+            .run_inner(bpaf::Args::current_args())
+            .map(|(v, _)| v)
+            .unwrap_or_default()
+            .0
     }
 }
 

--- a/crates/flox/src/main.rs
+++ b/crates/flox/src/main.rs
@@ -6,7 +6,7 @@ use std::process::{ExitCode, ExitStatus};
 
 use anyhow::{anyhow, Context, Result};
 use bpaf::{Args, Parser};
-use commands::{BashPassthru, FloxArgs, Prefix};
+use commands::{BashPassthru, FloxArgs, Prefix, Version};
 use flox_rust_sdk::environment::default_nix_subprocess_env;
 use log::{debug, error, warn};
 use tokio::process::Command;
@@ -54,6 +54,12 @@ async fn main() -> ExitCode {
         return ExitCode::from(0);
     }
 
+    // Quit early if `--version` is present
+    if Version::check() {
+        println!(env!("FLOX_VERSION"));
+        return ExitCode::from(0);
+    }
+
     // Parse verbosity flags to affect help message/parse errors
     let (verbosity, debug) = {
         let verbosity_parser = commands::verbosity();
@@ -74,7 +80,9 @@ async fn main() -> ExitCode {
     // to work with the shell completion frontends
     //
     // Pass through Stdout failure; This represents `--help`
-    let args = commands::flox_args().run_inner(Args::current_args());
+    let args = commands::flox_args()
+        .to_options()
+        .run_inner(Args::current_args());
 
     if let Some(parse_err) = args.as_ref().err() {
         match parse_err {

--- a/tests/usage.bats
+++ b/tests/usage.bats
@@ -52,7 +52,7 @@ Local Development Commands
     uninstall      Uninstall installed packages from an environment
     edit           Edit declarative environment configuration
     run            Run app from current project
-    list           List (status?) packages installed in an environment
+    list           List packages installed in an environment
     nix            Access to the nix CLI
     delete         Delete an environment
 EOF


### PR DESCRIPTION
Version is implemented as a separate check that ensures all remaining args (if any) are valid argument to flox.
