### PR TITLE
fix: use "flox-gh" identifier in secure keyring

### DIFF
--- a/pkgs/flox-gh/flox-gh.patch.v2.32.1
+++ b/pkgs/flox-gh/flox-gh.patch.v2.32.1
@@ -113,6 +113,19 @@ index ddac948c..78be21ef 100644
  
  	callbackURI := "http://127.0.0.1/callback"
  	if ghinstance.IsEnterprise(oauthHost) {
+diff --git a/internal/config/config.go b/internal/config/config.go
+index bf14a1aa..a9c4d2e7 100644
+--- a/internal/config/config.go
++++ b/internal/config/config.go
+@@ -252,7 +252,7 @@ func (c *AuthConfig) Logout(hostname string) error {
+ }
+ 
+ func keyringServiceName(hostname string) string {
+-	return "gh:" + hostname
++	return "flox-gh:" + hostname
+ }
+ 
+ type AliasConfig struct {
 diff --git a/pkg/cmd/api/api.go b/pkg/cmd/api/api.go
 index 3ac83ad6..b7120dd1 100644
 --- a/pkg/cmd/api/api.go
@@ -127,18 +140,10 @@ index 3ac83ad6..b7120dd1 100644
  
  				GH_ENTERPRISE_TOKEN, GITHUB_ENTERPRISE_TOKEN (in order of precedence): an
 diff --git a/pkg/cmd/auth/login/login.go b/pkg/cmd/auth/login/login.go
-index 84894bf1..023bf57e 100644
+index 84894bf1..66515649 100644
 --- a/pkg/cmd/auth/login/login.go
 +++ b/pkg/cmd/auth/login/login.go
-@@ -35,7 +35,6 @@ type LoginOptions struct {
- 	Token           string
- 	Web             bool
- 	GitProtocol     string
--	InsecureStorage bool
- }
- 
- func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Command {
-@@ -61,13 +60,13 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
+@@ -61,13 +61,13 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
  			authentication token will be stored internally.
  
  			Alternatively, use %[1]s--with-token%[1]s to pass in a token on standard input.
@@ -154,16 +159,7 @@ index 84894bf1..023bf57e 100644
  		`, "`"),
  		Example: heredoc.Doc(`
  			# start interactive setup
-@@ -130,8 +129,6 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
- 	cmd.Flags().BoolVar(&secureStorage, "secure-storage", false, "Save authentication credentials in secure credential store")
- 	_ = cmd.Flags().MarkHidden("secure-storage")
- 
--	cmd.Flags().BoolVar(&opts.InsecureStorage, "insecure-storage", false, "Save authentication credentials in plain text instead of credential store")
--
- 	return cmd
- }
- 
-@@ -144,11 +141,7 @@ func loginRun(opts *LoginOptions) error {
+@@ -144,11 +144,7 @@ func loginRun(opts *LoginOptions) error {
  
  	hostname := opts.Hostname
  	if opts.Interactive && hostname == "" {
@@ -176,21 +172,8 @@ index 84894bf1..023bf57e 100644
  	}
  
  	// The go-gh Config object currently does not support case-insensitive lookups for host names,
-@@ -172,7 +165,7 @@ func loginRun(opts *LoginOptions) error {
- 			return fmt.Errorf("error validating token: %w", err)
- 		}
- 		// Adding a user key ensures that a nonempty host section gets written to the config file.
--		return authCfg.Login(hostname, "x-access-token", opts.Token, opts.GitProtocol, !opts.InsecureStorage)
-+		return authCfg.Login(hostname, "x-access-token", opts.Token, opts.GitProtocol, false)
- 	}
- 
- 	existingToken, _ := authCfg.Token(hostname)
-@@ -201,26 +194,6 @@ func loginRun(opts *LoginOptions) error {
- 		Prompter:      opts.Prompter,
- 		GitClient:     opts.GitClient,
- 		Browser:       opts.Browser,
--		SecureStorage: !opts.InsecureStorage,
-+		SecureStorage: false,
+@@ -204,23 +200,3 @@ func loginRun(opts *LoginOptions) error {
+ 		SecureStorage: !opts.InsecureStorage,
  	})
  }
 -
@@ -214,58 +197,10 @@ index 84894bf1..023bf57e 100644
 -	return hostname, err
 -}
 diff --git a/pkg/cmd/auth/login/login_test.go b/pkg/cmd/auth/login/login_test.go
-index 72d796a3..81cd9b38 100644
+index 72d796a3..0c759b68 100644
 --- a/pkg/cmd/auth/login/login_test.go
 +++ b/pkg/cmd/auth/login/login_test.go
-@@ -194,7 +194,6 @@ func Test_NewCmdLogin(t *testing.T) {
- 			cli:      "--insecure-storage",
- 			wants: LoginOptions{
- 				Interactive:     true,
--				InsecureStorage: true,
- 			},
- 		},
- 		{
-@@ -202,7 +201,6 @@ func Test_NewCmdLogin(t *testing.T) {
- 			cli:  "--insecure-storage",
- 			wants: LoginOptions{
- 				Hostname:        "github.com",
--				InsecureStorage: true,
- 			},
- 		},
- 	}
-@@ -270,7 +268,6 @@ func Test_loginRun_nontty(t *testing.T) {
- 			opts: &LoginOptions{
- 				Hostname:        "github.com",
- 				Token:           "abc123",
--				InsecureStorage: true,
- 			},
- 			httpStubs: func(reg *httpmock.Registry) {
- 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
-@@ -283,7 +280,6 @@ func Test_loginRun_nontty(t *testing.T) {
- 				Hostname:        "github.com",
- 				Token:           "abc123",
- 				GitProtocol:     "https",
--				InsecureStorage: true,
- 			},
- 			httpStubs: func(reg *httpmock.Registry) {
- 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
-@@ -295,7 +291,6 @@ func Test_loginRun_nontty(t *testing.T) {
- 			opts: &LoginOptions{
- 				Hostname:        "albert.wesker",
- 				Token:           "abc123",
--				InsecureStorage: true,
- 			},
- 			httpStubs: func(reg *httpmock.Registry) {
- 				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.ScopesResponder("repo,read:org"))
-@@ -329,7 +324,6 @@ func Test_loginRun_nontty(t *testing.T) {
- 			opts: &LoginOptions{
- 				Hostname:        "github.com",
- 				Token:           "abc456",
--				InsecureStorage: true,
- 			},
- 			httpStubs: func(reg *httpmock.Registry) {
- 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,admin:org"))
-@@ -344,14 +338,14 @@ func Test_loginRun_nontty(t *testing.T) {
+@@ -344,14 +344,14 @@ func Test_loginRun_nontty(t *testing.T) {
  			},
  			cfgStubs: func(c *config.ConfigMock) {
  				authCfg := c.Authentication()
@@ -282,221 +217,6 @@ index 72d796a3..81cd9b38 100644
  				To have GitHub CLI store credentials instead, first clear the value from the environment.
  			`),
  		},
-@@ -482,7 +476,6 @@ func Test_loginRun_Survey(t *testing.T) {
- 			opts: &LoginOptions{
- 				Hostname:        "rebecca.chambers",
- 				Interactive:     true,
--				InsecureStorage: true,
- 			},
- 			wantHosts: heredoc.Doc(`
- 				rebecca.chambers:
-@@ -523,7 +516,6 @@ func Test_loginRun_Survey(t *testing.T) {
- 			`),
- 			opts: &LoginOptions{
- 				Interactive:     true,
--				InsecureStorage: true,
- 			},
- 			prompterStubs: func(pm *prompter.PrompterMock) {
- 				pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
-@@ -563,7 +555,6 @@ func Test_loginRun_Survey(t *testing.T) {
- 			`),
- 			opts: &LoginOptions{
- 				Interactive:     true,
--				InsecureStorage: true,
- 			},
- 			prompterStubs: func(pm *prompter.PrompterMock) {
- 				pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
-@@ -594,7 +585,6 @@ func Test_loginRun_Survey(t *testing.T) {
- 			`),
- 			opts: &LoginOptions{
- 				Interactive:     true,
--				InsecureStorage: true,
- 			},
- 			prompterStubs: func(pm *prompter.PrompterMock) {
- 				pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
-diff --git a/pkg/cmd/auth/logout/logout_test.go b/pkg/cmd/auth/logout/logout_test.go
-index 75c215aa..7c62a243 100644
---- a/pkg/cmd/auth/logout/logout_test.go
-+++ b/pkg/cmd/auth/logout/logout_test.go
-@@ -138,7 +138,7 @@ func Test_logoutRun_tty(t *testing.T) {
- 		},
- 		{
- 			name:          "secure storage",
--			secureStorage: true,
-+			secureStorage: false,
- 			opts: &LogoutOptions{
- 				Hostname: "github.com",
- 			},
-@@ -247,7 +247,7 @@ func Test_logoutRun_nontty(t *testing.T) {
- 		},
- 		{
- 			name:          "secure storage",
--			secureStorage: true,
-+			secureStorage: false,
- 			opts: &LogoutOptions{
- 				Hostname: "harry.mason",
- 			},
-diff --git a/pkg/cmd/auth/refresh/refresh.go b/pkg/cmd/auth/refresh/refresh.go
-index 4debd0a4..5e944aeb 100644
---- a/pkg/cmd/auth/refresh/refresh.go
-+++ b/pkg/cmd/auth/refresh/refresh.go
-@@ -32,7 +32,6 @@ type RefreshOptions struct {
- 	AuthFlow     func(*config.AuthConfig, *iostreams.IOStreams, string, []string, bool, bool) error
- 
- 	Interactive     bool
--	InsecureStorage bool
- }
- 
- func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.Command {
-@@ -109,8 +108,6 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
- 	cmd.Flags().BoolVar(&secureStorage, "secure-storage", false, "Save authentication credentials in secure credential store")
- 	_ = cmd.Flags().MarkHidden("secure-storage")
- 
--	cmd.Flags().BoolVarP(&opts.InsecureStorage, "insecure-storage", "", false, "Save authentication credentials in plain text instead of credential store")
--
- 	return cmd
- }
- 
-@@ -189,7 +186,7 @@ func refreshRun(opts *RefreshOptions) error {
- 
- 	additionalScopes.RemoveValues(opts.RemoveScopes)
- 
--	if err := opts.AuthFlow(authCfg, opts.IO, hostname, additionalScopes.ToSlice(), opts.Interactive, !opts.InsecureStorage); err != nil {
-+	if err := opts.AuthFlow(authCfg, opts.IO, hostname, additionalScopes.ToSlice(), opts.Interactive, false); err != nil {
- 		return err
- 	}
- 
-diff --git a/pkg/cmd/auth/refresh/refresh_test.go b/pkg/cmd/auth/refresh/refresh_test.go
-index c87c2bcb..0f56d83e 100644
---- a/pkg/cmd/auth/refresh/refresh_test.go
-+++ b/pkg/cmd/auth/refresh/refresh_test.go
-@@ -93,9 +93,7 @@ func Test_NewCmdRefresh(t *testing.T) {
- 			name: "insecure storage",
- 			tty:  true,
- 			cli:  "--insecure-storage",
--			wants: RefreshOptions{
--				InsecureStorage: true,
--			},
-+			wants: RefreshOptions{},
- 		},
- 		{
- 			name: "reset scopes",
-@@ -216,7 +214,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "obed.morton",
- 				scopes:        []string{},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -230,7 +228,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -250,7 +248,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -264,7 +262,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{"repo:invite", "public_key:read"},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -279,7 +277,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{"delete_repo", "codespace", "repo:invite", "public_key:read"},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -293,7 +291,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "obed.morton",
- 				scopes:        []string{},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -303,7 +301,6 @@ func Test_refreshRun(t *testing.T) {
- 			},
- 			opts: &RefreshOptions{
- 				Hostname:        "obed.morton",
--				InsecureStorage: true,
- 			},
- 			wantAuthArgs: authArgs{
- 				hostname: "obed.morton",
-@@ -323,7 +320,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -339,7 +336,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{"public_key:read", "workflow"},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -355,7 +352,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{"codespace", "public_key:read"},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -370,7 +367,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -386,7 +383,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{"delete_repo", "public_key:read"},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 		{
-@@ -401,7 +398,7 @@ func Test_refreshRun(t *testing.T) {
- 			wantAuthArgs: authArgs{
- 				hostname:      "github.com",
- 				scopes:        []string{"delete_repo"},
--				secureStorage: true,
-+				secureStorage: false,
- 			},
- 		},
- 	}
 diff --git a/pkg/cmd/auth/shared/git_credential.go b/pkg/cmd/auth/shared/git_credential.go
 index 8624cf00..026d5bcf 100644
 --- a/pkg/cmd/auth/shared/git_credential.go


### PR DESCRIPTION
## Proposed Changes

This patch sets a unique identifier for `flox-gh` tokens in the keyring so that subsequent logins/logouts of `gh` and `flox-gh` won't stomp on each other.

It also reinstates the secure storage feature previously removed during testing.

Further background and discussion of this issue is available in [discourse](https://discourse.flox.dev/t/release-announcement-v0-3-0-august-31-2023/791/5).

## Current Behavior

Authentication tokens generated by the `flox-gh` tokens are [insecurely] stored in `~/.config/flox/gh/hosts.yml`. With this patch these tokens can be stored securely, for example as implemented in Apple's keyring implementation.

When the keyring service is available, this is the expected output when logging into both of the `gh` and `flox-gh` applications:
```
flox [flox/prerelease default] rtb@Robins-MacBook-Pro flox % result/bin/flox auth status                
github.com
  ✓ Logged in to github.com as robinbrantley (keyring)
  ✓ Token: gho_************************************
  ✓ Token scopes: none
flox [flox/prerelease default] rtb@Robins-MacBook-Pro flox % result/bin/flox gh auth status             
github.com
  ✓ Logged in to github.com as robinbrantley (keyring)
  ✓ Git operations for github.com configured to use https protocol.
  ✓ Token: gho_************************************
  ✓ Token scopes: gist, read:org, repo
flox [flox/prerelease default] rtb@Robins-MacBook-Pro flox %
```

The corresponding secure storage can be further confirmed by invoking the Apple "Keychain Access" application and then searching for keys containing the string "gh:" as shown in the following screenshot.

![image](https://github.com/flox/flox/assets/36448130/5236bb1d-8b9e-4e1c-808f-6b65fbfea2e4)

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Restored secure token storage for logging into the flox CLI.