### PR TITLE
refactor: ungenerify floxmeta

### DIFF
--- a/crates/flox-rust-sdk/src/flox.rs
+++ b/crates/flox-rust-sdk/src/flox.rs
@@ -162,10 +162,7 @@ impl Flox {
         Root::closed(self, x)
     }
 
-    pub async fn floxmeta<Git: GitProvider>(
-        &self,
-        owner: &str,
-    ) -> Result<Floxmeta<Git, ReadOnly<Git>>, GetFloxmetaError<Git>> {
+    pub async fn floxmeta(&self, owner: &str) -> Result<Floxmeta<ReadOnly>, GetFloxmetaError> {
         Floxmeta::get_floxmeta(self, owner).await
     }
 

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -7,7 +7,6 @@ use flox_rust_sdk::nix::command_line::NixCommandLine;
 use flox_rust_sdk::nix::flake_ref::git_service::{GitServiceAttributes, GitServiceRef};
 use flox_rust_sdk::nix::flake_ref::FlakeRef;
 use flox_rust_sdk::nix::RunJson;
-use flox_rust_sdk::providers::git::GitCommandProvider;
 use itertools::Itertools;
 use regex::Regex;
 use serde_json::json;
@@ -199,7 +198,7 @@ impl Subscribe {
 
         // read user channels
         let floxmeta = flox
-            .floxmeta::<GitCommandProvider>(DEFAULT_OWNER)
+            .floxmeta(DEFAULT_OWNER)
             .await
             .context("Could not get default floxmeta")?;
 
@@ -250,7 +249,7 @@ impl Unsubscribe {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("unsubscribe");
         let floxmeta = flox
-            .floxmeta::<GitCommandProvider>(DEFAULT_OWNER)
+            .floxmeta(DEFAULT_OWNER)
             .await
             .context("Could not get default floxmeta")?;
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -10,7 +10,6 @@ use bpaf::{Args, Bpaf, Parser};
 use flox_rust_sdk::flox::{Flox, DEFAULT_OWNER, FLOX_VERSION};
 use flox_rust_sdk::models::floxmeta::{Floxmeta, GetFloxmetaError};
 use flox_rust_sdk::nix::command_line::NixCommandLine;
-use flox_rust_sdk::providers::git::GitCommandProvider;
 use indoc::{formatdoc, indoc};
 use log::{debug, info};
 use once_cell::sync::Lazy;
@@ -165,10 +164,7 @@ impl FloxArgs {
             uuid: init_uuid(&config.flox.data_dir).await?,
         };
 
-        let floxmeta = match boostrap_flox
-            .floxmeta::<GitCommandProvider>(DEFAULT_OWNER)
-            .await
-        {
+        let floxmeta = match boostrap_flox.floxmeta(DEFAULT_OWNER).await {
             Ok(floxmeta) => floxmeta,
             Err(GetFloxmetaError::NotFound(_)) => {
                 Floxmeta::create_floxmeta(&boostrap_flox, DEFAULT_OWNER)

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -719,12 +719,7 @@ async fn ensure_project_repo(
     flox: &Flox,
     cwd: PathBuf,
 ) -> Result<root::Root<Closed<GitCommandProvider>>, anyhow::Error> {
-    match flox
-        .resource(cwd)
-        .guard::<GitCommandProvider>()
-        .await?
-        .open()
-    {
+    match flox.resource(cwd).guard().await?.open() {
         Ok(p) => {
             info!(
                 "Found git repo{}",
@@ -747,7 +742,7 @@ async fn ensure_project_repo(
 async fn ensure_project<'flox>(
     git_repo: Root<'flox, Closed<GitCommandProvider>>,
     command: &WithPassthru<InitPackage>,
-) -> Result<Project<'flox, GitCommandProvider, ReadOnly<GitCommandProvider>>> {
+) -> Result<Project<'flox, ReadOnly>> {
     match git_repo.guard().await?.open() {
         Ok(x) => Ok(x),
         Err(g) => Ok(g


### PR DESCRIPTION
Remove `GitProvider` generic from `floxmeta` implementation.

We have been referring to the Git command interface in a generic way for the lifetime of the floxmeta abstractions.
Since we never got to implwmwnt more than one implementation, and plan to have smaller usecase focused git wrappers, we need to reduce the complexity generics add to the codebase first.
This PR should also make further refactorings of floxmeta easier as fewer generics need to be considered.