### PR TITLE
fix: remove user.{name,email} git config from test setup

### DIFF
--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -258,6 +258,11 @@ impl GitCommandProvider {
             c.arg(workdir.as_ref());
         }
 
+        c.arg("-c");
+        c.arg("user.name=Flox User");
+        c.arg("-c");
+        c.arg("user.email=floxuser@example.invalid");
+
         c
     }
 

--- a/tests/publish.bats
+++ b/tests/publish.bats
@@ -50,7 +50,10 @@ setup() {
     git -C "$CHANNEL" add flake.nix pkgs/hello/default.nix
     $FLOX_CLI flake update "$CHANNEL"
     git -C "$CHANNEL" add flake.lock
-    git -C "$CHANNEL" commit -m "root commit"
+    git -C "$CHANNEL" \
+        -c user.email="floxuser@example.invalid" \
+        -c user.name="Flox User" \
+        commit -m "root commit"
 
     # set remote to the local repository to minimize external state
     git -C "$CHANNEL" remote add origin "$CHANNEL"

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -316,8 +316,6 @@ gitconfig_setup() {
   mkdir -p "$BATS_SUITE_TMPDIR/git";
   export GIT_CONFIG_SYSTEM="$BATS_SUITE_TMPDIR/git/gitconfig.system";
   # Handle config shared across whole test suite.
-  git config --system user.name  'Flox User';
-  git config --system user.email 'floxuser@example.invalid';
   git config --system gpg.format ssh;
   # Create a temporary `ssh' key for use by `git'.
   ssh_key_setup;


### PR DESCRIPTION
## Proposed Changes

Tests need to succeed when the user has not configured their own git `user.{name,email}` settings, so we shouldn't be setting these in our tests either. We should instead set default values for the git operations in which we explicitly require them.

## Current Behavior

Tests don't detect when flox functionality silently relies upon the user's git `user.{name,email}` having been set.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A