### PR TITLE
fix: typo, $invoke_git not $_invoke_git

### DIFF
--- a/flox-bash/lib/commands/publish.sh
+++ b/flox-bash/lib/commands/publish.sh
@@ -593,8 +593,8 @@ function floxPublish() {
 				while true; do
 					[ "$pushAttempt" -lt 3 ] ||
 						error "could not push to $channelRepository after $pushAttempt attempts" </dev/null
-					$_invoke_git -C "$gitClone" pull --rebase
-					if $_invoke_git -C "$gitClone" push; then
+					$invoke_git -C "$gitClone" pull --rebase
+					if $invoke_git -C "$gitClone" push; then
 						# Job done.
 						break
 					else

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1330,7 +1330,7 @@ function selectAttrPath() {
 function checkGitRepoExists() {
 	trace "$@"
 	local origin="${1/\?*/}"
-	$_invoke_git ls-remote "$origin" >/dev/null 2>&1
+	$invoke_git ls-remote "$origin" >/dev/null 2>&1
 }
 
 function ensureGHRepoExists() {


### PR DESCRIPTION
## Proposed Changes

Fix typo in code: `$invoke_git` not `$_invoke_git`.

## Current Behavior

`flox publish` currently fails with this error:
```
/nix/store/vf55aazry7qqddbj4j6cs5i2z0jqrqb1-flox-bash-0.3.3-r626/lib/commands/publish.sh: line 596: -C: command not found
```

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

Fixed bug affecting `flox publish`.