### PR TITLE
fix: non-feature flagged rust command regression

### DIFF
--- a/crates/flox-rust-sdk/src/models/floxmeta/mod.rs
+++ b/crates/flox-rust-sdk/src/models/floxmeta/mod.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
 
-mod environment;
+pub mod environment;
 pub mod user_meta;
 use environment::{Metadata, METADATA_JSON};
 

--- a/crates/flox-rust-sdk/src/models/legacy_environment.rs
+++ b/crates/flox-rust-sdk/src/models/legacy_environment.rs
@@ -1,0 +1,82 @@
+use std::borrow::Cow;
+
+use runix::installable::{FlakeAttribute, ParseInstallableError};
+use serde_json::Value;
+use thiserror::Error;
+
+use super::flox_package::FloxPackage;
+use super::floxmeta::environment::GenerationError;
+use super::root::transaction::ReadOnly;
+use super::{floxmeta, project};
+
+pub static CATALOG_JSON: &str = "catalog.json";
+// don't forget to update the man page
+pub const DEFAULT_KEEP_GENERATIONS: usize = 10;
+// don't forget to update the man page
+pub const DEFAULT_MAX_AGE_DAYS: u32 = 90;
+
+pub enum CommonEnvironment<'flox> {
+    Named(floxmeta::environment::Environment<'flox, ReadOnly>),
+    Project(project::environment::Environment<'flox, ReadOnly>),
+}
+
+impl<'flox> CommonEnvironment<'flox> {
+    /// get a flake attribute for the environment
+    /// todo flake_attribute should be constructed earlier
+    pub async fn flake_attribute(
+        &self,
+    ) -> Result<FlakeAttribute, EnvironmentError<GenerationError, ParseInstallableError>> {
+        match self {
+            CommonEnvironment::Named(n) => n
+                .flake_attribute(Default::default())
+                .await
+                .map_err(EnvironmentError::Named),
+            CommonEnvironment::Project(p) => p.flake_attribute().map_err(EnvironmentError::Project),
+        }
+    }
+
+    pub fn system(&self) -> Cow<str> {
+        match self {
+            CommonEnvironment::Named(n) => n.system(),
+            CommonEnvironment::Project(p) => p.system(),
+        }
+    }
+
+    pub fn packages(&self) -> Value {
+        todo!()
+    }
+
+    pub async fn install(&self, _packages: &[FloxPackage]) {
+        todo!()
+    }
+
+    pub async fn uninstall(&self, _packages: &[FloxPackage]) {
+        todo!()
+    }
+
+    pub async fn upgrade(&self, _packages: &[FloxPackage]) {
+        todo!()
+    }
+
+    pub fn named(self) -> Option<floxmeta::environment::Environment<'flox, ReadOnly>> {
+        match self {
+            CommonEnvironment::Named(n) => Some(n),
+            CommonEnvironment::Project(_) => None,
+        }
+    }
+
+    pub fn project(self) -> Option<project::environment::Environment<'flox, ReadOnly>> {
+        match self {
+            CommonEnvironment::Named(_) => None,
+            CommonEnvironment::Project(p) => Some(p),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum EnvironmentError<N, P> {
+    #[error(transparent)]
+    Named(N),
+    #[error(transparent)]
+    Project(P),
+}

--- a/crates/flox-rust-sdk/src/models/legacy_environment_ref.rs
+++ b/crates/flox-rust-sdk/src/models/legacy_environment_ref.rs
@@ -1,0 +1,479 @@
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
+
+use log::debug;
+use runix::command::{Eval, FlakeMetadata};
+use runix::flake_ref::git::{GitAttributes, GitRef};
+use runix::flake_ref::path::PathRef;
+use runix::flake_ref::FlakeRef;
+use runix::installable::FlakeAttribute;
+use runix::{NixBackend, RunJson};
+use thiserror::Error;
+use url::Url;
+
+use super::legacy_environment::CommonEnvironment;
+use super::flox_installable::{FloxInstallable, ParseFloxInstallableError};
+use super::floxmeta::{self, Floxmeta, GetFloxmetaError};
+use super::project::{self, OpenProjectError};
+use super::root::reference::ProjectDiscoverGitError;
+use super::root::transaction::{GitAccess, ReadOnly};
+use crate::flox::{Flox, FloxNixApi, ResolveFloxInstallableError};
+use crate::providers::git::{GitProvider, GitCommandError};
+
+static DEFAULT_NAME: &str = "default";
+pub static DEFAULT_OWNER: &str = "local";
+
+#[derive(Debug)]
+pub struct Project<'flox> {
+    pub flox: &'flox Flox,
+    pub flake_attribute: FlakeAttribute,
+    pub workdir: PathBuf, // todo https://github.com/flox/runix/issues/7
+    pub name: String,
+}
+
+#[derive(Error, Debug)]
+pub enum FindProjectError<Nix: FloxNixApi>
+where
+    Eval: RunJson<Nix>,
+{
+    #[error("Error reading current dir path: {0}")]
+    CurrentDir(io::Error),
+    #[error("Error trying to discover Git repo")]
+    DiscoverError,
+    #[error("Not in a Git repository")]
+    NotInGitRepo,
+    #[error("Error checking for project")]
+    OpenError,
+    #[error("Git repository found is not a flox project")]
+    NotProject,
+    #[error("Git repository found is bare")]
+    BareRepo,
+    #[error("Missing a name")]
+    NoName,
+    #[error("Failed to parse as flox installable: {0}")]
+    Parse(#[from] ParseFloxInstallableError),
+    #[error("Workdir is not valid unicode")]
+    WorkdirEncoding,
+    #[error("Error attempting to resolve to installables: {0}")]
+    ResolveFailure(ResolveFloxInstallableError<Nix>),
+}
+
+impl<'flox> Project<'flox> {
+    /// Returns a list of project matches for a user specified environment
+    pub async fn find<Nix: FloxNixApi, Git: GitProvider>(
+        flox: &'flox Flox,
+        environment_name: Option<&str>,
+    ) -> Result<Vec<Project<'flox>>, FindProjectError<Nix>>
+    where
+        Eval: RunJson<Nix>,
+        FlakeMetadata: RunJson<Nix>,
+    {
+        // Find the `Project` to use, erroring all the way if it is not in the perfect state.
+        // TODO: further changes and integrations to make more flexible possible?
+        let git_repo = flox
+            .resource(std::env::current_dir().map_err(FindProjectError::CurrentDir)?)
+            .guard()
+            .await
+            .map_err(|_| FindProjectError::DiscoverError)?
+            .open()
+            .map_err(|_| FindProjectError::NotInGitRepo)?;
+
+        let project = git_repo
+            .guard()
+            .await
+            .map_err(|_| FindProjectError::OpenError)?
+            .open()
+            .map_err(|_| FindProjectError::NotProject)?;
+
+        // TODO: it is easy to use `.path()` instead, but we do not know any default branch.
+        // In the future we may want to handle this?
+        let workdir = project.workdir().ok_or(FindProjectError::BareRepo)?;
+
+        let workdir_str = workdir.to_str().ok_or(FindProjectError::WorkdirEncoding)?;
+
+        let flox_installables = match environment_name {
+            Some(name) => vec![name.parse::<FloxInstallable>()?],
+            None => vec![],
+        };
+
+        let matches = flox
+            .resolve_matches::<Nix, Git>(
+                &flox_installables,
+                &[&format!("git+file://{workdir_str}")],
+                &[("floxEnvs", true)],
+                true,
+                None,
+            )
+            .await
+            .map_err(FindProjectError::ResolveFailure)?;
+
+        matches
+            .into_iter()
+            .map(|m| {
+                Ok(Project {
+                    flox,
+                    workdir: workdir.to_owned(),
+                    name: m.key.last().ok_or(FindProjectError::NoName)?.to_owned(),
+                    flake_attribute: m.flake_attribute(),
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug)]
+pub struct Named {
+    pub owner: String,
+    pub name: String,
+}
+
+#[derive(Error, Debug)]
+pub enum NamedGetCurrentGenError {
+    #[error("Error printing metadata {0}")]
+    Show(GitCommandError),
+    #[error("Metadata file is not valid unicode")]
+    MetadataEncoding,
+    #[error("Error parsing current generation from metadata: {0}")]
+    Parse(#[from] serde_json::Error),
+    #[error("`currentGen` attribute is missing")]
+    NoCurrentGen,
+    #[error("`currentGen` attribute is wrong type")]
+    BadCurrentGen,
+    #[error("Failed to open floxmeta directory for environment")]
+    GetFloxmeta(GetFloxmetaError),
+}
+
+#[derive(Error, Debug)]
+pub enum FindDefaultOwnerError {
+    #[error("Symlink is invalid")]
+    DefaultOwnerSymlinkTarget,
+    #[error("Error checking symlink")]
+    ReadLink(io::Error),
+    #[error("Symlink is not valid unicode")]
+    DefaultOwnerSymlinkEncoding,
+}
+
+#[derive(Error, Debug)]
+pub enum FindNamedError {
+    #[error("Error finding default owner: {0}")]
+    DefaultOwnerSymlinkTarget(#[from] FindDefaultOwnerError),
+    #[error("Error checking directory")]
+    CheckEnvironmentError(std::io::Error),
+    #[error("Not found")]
+    NotFound,
+    #[error("Cached Git directory is missing")]
+    OwnerPath(std::io::Error),
+    #[error("Failed to open floxmeta directory for environment")]
+    GetFloxmeta(GetFloxmetaError),
+}
+
+impl<'flox> Named {
+    /// Check if user specified environment matches a named environment
+    pub async fn find(
+        flox: &'flox Flox,
+        environment: Option<&str>,
+    ) -> Result<Option<Named>, FindNamedError> {
+        let (owner, name) = match environment {
+            None => {
+                let default_owner = Self::find_default_owner(flox).await?;
+                (default_owner, DEFAULT_NAME.to_string())
+            },
+            Some(e) => match e.rsplit_once('/') {
+                None => {
+                    let default_owner = Self::find_default_owner(flox).await?;
+
+                    (
+                        default_owner,
+                        if e.is_empty() {
+                            DEFAULT_NAME.to_string()
+                        } else {
+                            e.to_string()
+                        },
+                    )
+                },
+                Some((owner, "")) => (owner.to_string(), DEFAULT_NAME.to_string()),
+                Some((owner, name)) => (owner.to_string(), name.to_string()),
+            },
+        };
+
+        // sanity check that floxmeta is valid
+        match Floxmeta::<ReadOnly>::get_floxmeta(flox, &owner).await {
+            Ok(_) => Ok(Some(Named { owner, name })),
+            Err(GetFloxmetaError::NotFound(_)) => Ok(None),
+            Err(e) => Err(FindNamedError::GetFloxmeta(e)),
+        }
+    }
+
+    fn meta_dir(flox: &Flox) -> PathBuf {
+        flox.cache_dir.join("meta")
+    }
+
+    /// Return path to the environment data dir for an owner,
+    /// e.g. ~/.local/share/flox/environments/owner
+    pub fn associated_owner_dir(flox: &Flox, owner: &str) -> PathBuf {
+        flox.data_dir.join("environments").join(owner)
+    }
+
+    /// Try to infer the name for the default owner.
+    ///
+    /// Installations of pacakges without an explicit owner are done for a pseudo owner
+    /// called 'local'.
+    /// Once a user is authenticated, and we know their username,
+    /// the `local/*` environments are migrated
+    /// and 'local' is linked to the the _actual_ `<user>` directory.
+    ///
+    /// This method tries to read the `local` link to infer the current owner name.
+    ///
+    /// Note: Username tracking is likely to change.
+    async fn find_default_owner(flox: &Flox) -> Result<String, FindDefaultOwnerError> {
+        let link_path = Self::associated_owner_dir(flox, DEFAULT_OWNER);
+        debug!(
+            "Checking `local` symlink (`{}`) for true name of default user",
+            link_path.display()
+        );
+
+        match tokio::fs::read_link(link_path).await {
+            Ok(p) => Ok(p
+                .file_name()
+                .ok_or(FindDefaultOwnerError::DefaultOwnerSymlinkTarget)?
+                .to_str()
+                .ok_or(FindDefaultOwnerError::DefaultOwnerSymlinkEncoding)?
+                .to_owned()),
+            Err(err) => match err.kind() {
+                // `InvalidInput` occurs if the path is not a symlink
+                // return DEFAULT_OWNER if it is a directory or doesn't already exist
+                ErrorKind::NotFound | ErrorKind::InvalidInput => Ok(DEFAULT_OWNER.to_owned()),
+                _ => Err(FindDefaultOwnerError::ReadLink(err)),
+            },
+        }
+    }
+
+    /// Convert an environment reference to an installable
+    fn get_installable(&self, flox: &Flox, system: &str, gen: &str) -> FlakeAttribute {
+        let flakeref = FlakeRef::GitPath(GitRef {
+            // we can unwrap here since we construct and know the path
+            url: Url::from_file_path(Self::meta_dir(flox).join(&self.owner))
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            attributes: GitAttributes {
+                reference: format!("{system}.{name}", name = self.name).into(),
+                dir: Path::new(gen).to_path_buf().into(),
+                ..Default::default()
+            },
+        });
+
+        FlakeAttribute {
+            flakeref,
+            // The git branch varies but the name always remains `default`,
+            // which comes from the template
+            // https://github.com/flox/flox-bash-private/tree/main/lib/templateFloxEnv/pkgs/default
+            // and does not get renamed.
+            //
+            // enforce exact attr path (<flakeref>#.floxEnvs.<system>.default)
+            attr_path: ["", "floxEnvs", system, "default"].try_into().unwrap(),
+            outputs: Default::default(),
+        }
+    }
+
+    async fn get_current_gen(
+        &self,
+        flox: &'flox Flox,
+    ) -> Result<String, NamedGetCurrentGenError> {
+        let floxmeta = Floxmeta::<ReadOnly>::get_floxmeta(flox, &self.owner)
+            .await
+            .map_err(NamedGetCurrentGenError::GetFloxmeta)?;
+        let out_os_str = floxmeta
+            .access
+            .git()
+            .show(&format!(
+                "{system}.{name}:metadata.json",
+                system = flox.system,
+                name = self.name
+            ))
+            .await
+            .map_err(|e| NamedGetCurrentGenError::Show(e))?;
+
+        let out_str = out_os_str
+            .to_str()
+            .ok_or(NamedGetCurrentGenError::MetadataEncoding)?;
+
+        let out: serde_json::Value = serde_json::from_str(out_str)?;
+
+        Ok(out
+            .get("currentGen")
+            .ok_or(NamedGetCurrentGenError::NoCurrentGen)?
+            .as_str()
+            .ok_or(NamedGetCurrentGenError::BadCurrentGen)?
+            .to_owned())
+    }
+}
+
+#[derive(Debug)]
+pub enum EnvironmentRef<'flox> {
+    Named(Named),
+    Project(Project<'flox>),
+}
+
+#[derive(Error, Debug)]
+pub enum EnvironmentRefError<Nix: FloxNixApi>
+where
+    Eval: RunJson<Nix>,
+{
+    #[error("Error finding project environment: {0}")]
+    Project(FindProjectError<Nix>),
+    #[error("Error finding named environment: {0}")]
+    Named(FindNamedError),
+    #[error("Name format is invalid")]
+    Invalid,
+}
+
+#[allow(unused)]
+impl EnvironmentRef<'_> {
+    /// Returns a list of all matches for a user specified environment, including both named and
+    /// project environment matches
+    pub async fn find<'flox, Nix: FloxNixApi, Git: GitProvider>(
+        flox: &'flox Flox,
+        environment_name: Option<&str>,
+    ) -> Result<(Vec<EnvironmentRef<'flox>>), EnvironmentRefError<Nix>>
+    where
+        Eval: RunJson<Nix>,
+        FlakeMetadata: RunJson<Nix>,
+    {
+        let (not_proj, not_named) = match environment_name {
+            Some(name) => {
+                debug!("Finding environment for {}", name);
+
+                // Assume packages do not have '/' in their name
+                // This is a weak assumption that is "mostly" true
+                let not_proj = name.contains('/');
+
+                let not_named =
+                    // Skip named resolution if name starts with floxEnvs. or .floxEnvs.
+                    name.starts_with("floxEnvs.") || name.starts_with(".floxEnvs.")
+                    // Don't allow # in named environments as they look like flakerefs
+                    || name.contains('#');
+
+                // houston we have a problem
+                if not_proj && not_named {
+                    return Err(EnvironmentRefError::Invalid);
+                }
+                (not_proj, not_named)
+            },
+            None => {
+                debug!("Finding environments");
+                (false, false)
+            },
+        };
+
+        let mut environment_refs = Vec::new();
+
+        if !not_proj {
+            match Project::find::<Nix, Git>(flox, environment_name).await {
+                Err(e @ (FindProjectError::NotInGitRepo | FindProjectError::NotProject)) => {
+                    debug!("{}", e);
+                },
+                Err(err) => return Err(EnvironmentRefError::Project(err)),
+                Ok(ps) => {
+                    for p in ps {
+                        environment_refs.push(EnvironmentRef::Project(p));
+                    }
+                },
+            };
+        }
+
+        if !not_named {
+            match Named::find(flox, environment_name).await {
+                Err(err) => return Err(EnvironmentRefError::Named(err)),
+                Ok(None) => {},
+                Ok(Some(n)) => {
+                    environment_refs.push(EnvironmentRef::Named(n));
+                },
+            };
+        }
+
+        Ok(environment_refs)
+    }
+
+    pub async fn get_latest_flake_attribute<'flox, Git: GitProvider>(
+        &self,
+        flox: &'flox Flox,
+    ) -> Result<FlakeAttribute, NamedGetCurrentGenError> {
+        match self {
+            EnvironmentRef::Project(project_ref) => Ok(project_ref.flake_attribute.clone()),
+            EnvironmentRef::Named(named_ref) => {
+                let gen = named_ref.get_current_gen(flox).await?;
+                Ok(named_ref.get_installable(flox, &flox.system, &gen))
+            },
+        }
+    }
+
+    pub async fn to_env<'flox, Git: GitProvider + 'flox, Nix: FloxNixApi>(
+        &'flox self,
+        flox: &'flox Flox,
+    ) -> Result<CommonEnvironment, CastError<Nix>>
+    where
+        Eval: RunJson<Nix>,
+    {
+        let env = match self {
+            EnvironmentRef::Named(Named { owner, name }) => {
+                let floxmeta = Floxmeta::get_floxmeta(flox, owner).await?;
+                let environment = floxmeta.environment(name).await?;
+                CommonEnvironment::Named(environment)
+            },
+            EnvironmentRef::Project(Project {
+                flox,
+                flake_attribute,
+                workdir,
+                name,
+            }) => {
+                let path = match &flake_attribute.flakeref {
+                    runix::flake_ref::FlakeRef::Path(PathRef { path, .. }) => path.clone(),
+                    runix::flake_ref::FlakeRef::GitPath(GitRef { url, .. }) => {
+                        url.to_file_path().unwrap()
+                    },
+                    _ => Err(CastError::InvalidFlakeRef)?,
+                };
+
+                let git = flox
+                    .resource(path)
+                    .guard()
+                    .await?
+                    .open()
+                    .map_err(|_| CastError::NotFound(flake_attribute.to_string()))?;
+
+                let project = git
+                    .guard()
+                    .await?
+                    .open()
+                    .map_err(|_| CastError::NotFound(flake_attribute.to_string()))?;
+
+                let environment = project.environment(name).await?;
+
+                CommonEnvironment::Project(environment)
+            },
+        };
+        Ok(env)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CastError<Nix: NixBackend>
+where
+    Eval: RunJson<Nix>,
+{
+    #[error(transparent)]
+    GetFloxmeta(#[from] GetFloxmetaError),
+    #[error(transparent)]
+    GetFloxmetaEnvironment(#[from] floxmeta::environment::GetEnvironmentError),
+    #[error(transparent)]
+    DiscoveGit(#[from] ProjectDiscoverGitError),
+    #[error("Environment not found: {0}")]
+    NotFound(String),
+    #[error("Only local git repositories ('git+file://') are supported at the moment")]
+    InvalidFlakeRef,
+    #[error(transparent)]
+    OpenProject(#[from] OpenProjectError),
+    #[error(transparent)]
+    GetProjectEnvironment(#[from] project::GetEnvironmentError<Nix>),
+}

--- a/crates/flox-rust-sdk/src/models/legacy_environment_ref.rs
+++ b/crates/flox-rust-sdk/src/models/legacy_environment_ref.rs
@@ -11,14 +11,14 @@ use runix::{NixBackend, RunJson};
 use thiserror::Error;
 use url::Url;
 
-use super::legacy_environment::CommonEnvironment;
 use super::flox_installable::{FloxInstallable, ParseFloxInstallableError};
 use super::floxmeta::{self, Floxmeta, GetFloxmetaError};
+use super::legacy_environment::CommonEnvironment;
 use super::project::{self, OpenProjectError};
 use super::root::reference::ProjectDiscoverGitError;
 use super::root::transaction::{GitAccess, ReadOnly};
 use crate::flox::{Flox, FloxNixApi, ResolveFloxInstallableError};
-use crate::providers::git::{GitProvider, GitCommandError};
+use crate::providers::git::{GitCommandError, GitProvider};
 
 static DEFAULT_NAME: &str = "default";
 pub static DEFAULT_OWNER: &str = "local";
@@ -276,10 +276,7 @@ impl<'flox> Named {
         }
     }
 
-    async fn get_current_gen(
-        &self,
-        flox: &'flox Flox,
-    ) -> Result<String, NamedGetCurrentGenError> {
+    async fn get_current_gen(&self, flox: &'flox Flox) -> Result<String, NamedGetCurrentGenError> {
         let floxmeta = Floxmeta::<ReadOnly>::get_floxmeta(flox, &self.owner)
             .await
             .map_err(NamedGetCurrentGenError::GetFloxmeta)?;
@@ -292,7 +289,7 @@ impl<'flox> Named {
                 name = self.name
             ))
             .await
-            .map_err(|e| NamedGetCurrentGenError::Show(e))?;
+            .map_err(NamedGetCurrentGenError::Show)?;
 
         let out_str = out_os_str
             .to_str()

--- a/crates/flox-rust-sdk/src/models/mod.rs
+++ b/crates/flox-rust-sdk/src/models/mod.rs
@@ -2,7 +2,9 @@
 
 pub mod channels;
 pub mod environment;
+pub mod legacy_environment;
 pub mod environment_ref;
+pub mod legacy_environment_ref;
 pub mod flox_installable;
 pub mod flox_package;
 pub mod root;

--- a/crates/flox-rust-sdk/src/models/mod.rs
+++ b/crates/flox-rust-sdk/src/models/mod.rs
@@ -2,11 +2,11 @@
 
 pub mod channels;
 pub mod environment;
-pub mod legacy_environment;
 pub mod environment_ref;
-pub mod legacy_environment_ref;
 pub mod flox_installable;
 pub mod flox_package;
+pub mod legacy_environment;
+pub mod legacy_environment_ref;
 pub mod root;
 pub use runix::{flake_ref, registry};
 pub mod floxmeta;

--- a/crates/flox-rust-sdk/src/models/project/environment.rs
+++ b/crates/flox-rust-sdk/src/models/project/environment.rs
@@ -1,0 +1,328 @@
+use std::borrow::Cow;
+use std::fmt::Display;
+use std::path::PathBuf;
+
+use flox_types::catalog::{EnvCatalog, StorePath};
+use runix::arguments::eval::EvaluationArgs;
+use runix::arguments::{BuildArgs, EvalArgs};
+use runix::command::{Build, Eval};
+use runix::command_line::{NixCommandLine, NixCommandLineRunJsonError};
+use runix::installable::{FlakeAttribute, ParseInstallableError};
+use runix::{NixBackend, Run, RunJson, RunTyped};
+use thiserror::Error;
+
+use super::{Index, Project, TransactionCommitError, TransactionEnterError};
+use crate::flox::{Flox, FloxNixApi};
+use crate::models::root::transaction::{GitAccess, GitSandBox, ReadOnly};
+use crate::utils::errors::IoError;
+
+pub struct Environment<'flox, Access: GitAccess> {
+    /// aka. Nix attrpath, undr the assumption that they are not nested!
+    pub(super) name: String,
+    pub(super) system: String,
+    pub(super) project: Project<'flox, Access>,
+}
+
+#[derive(Error, Debug)]
+pub enum ProjectEnvironmentError {
+    #[error(transparent)]
+    ParseInstallable(#[from] ParseInstallableError),
+    #[error(transparent)]
+    Io(#[from] IoError),
+    #[error("Failed to eval environment catalog: {0}")]
+    EvalCatalog(NixCommandLineRunJsonError),
+    #[error("Failed parsing environment catalog: {0}")]
+    ParseCatalog(serde_json::Error),
+    #[error("Failed parsing store paths installed in environment: {0}")]
+    ParseStorePaths(serde_json::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum EnvironmentBuildError<Nix: NixBackend>
+where
+    Build: Run<Nix>,
+{
+    #[error("Could not create installable: {0}")]
+    ParseInstallable(#[from] ParseInstallableError),
+    #[error(transparent)]
+    Build(<Build as Run<Nix>>::Error),
+}
+
+/// Implementations for an environment
+impl<A: GitAccess> Environment<'_, A> {
+    pub fn name(&self) -> Cow<str> {
+        Cow::from(&self.name)
+    }
+
+    pub fn system(&self) -> Cow<str> {
+        Cow::from(&self.system)
+    }
+
+    // pub async fn metadata(&self) -> Result<Metadata, MetadataError<Git>> {
+    //    todo!("to be replaced by catalog")
+    // }
+
+    /// get a flake_attribute for this environment
+    // todo: share with named env
+    pub fn flake_attribute(&self) -> Result<FlakeAttribute, ParseInstallableError> {
+        Ok(FlakeAttribute {
+            flakeref: self.project.flakeref(),
+            attr_path: ["", "floxEnvs", &self.system, &self.name].try_into()?,
+            outputs: Default::default(),
+        })
+    }
+
+    pub async fn installed_store_paths(
+        &self,
+        flox: &Flox,
+    ) -> Result<Vec<StorePath>, ProjectEnvironmentError> {
+        let nix = flox.nix::<NixCommandLine>(Default::default());
+
+        let mut flake_attribute = self.flake_attribute()?;
+        flake_attribute.attr_path.push_attr("installedStorePaths")?;
+
+        let eval = Eval {
+            eval: EvaluationArgs {
+                impure: true.into(),
+                ..Default::default()
+            },
+            eval_args: EvalArgs {
+                installable: Some(flake_attribute.into()),
+                apply: None,
+            },
+            ..Eval::default()
+        };
+
+        let installed_store_paths_value: serde_json::Value = eval
+            .run_json(&nix, &Default::default())
+            .await
+            .map_err(ProjectEnvironmentError::EvalCatalog)?;
+
+        serde_json::from_value(installed_store_paths_value)
+            .map_err(ProjectEnvironmentError::ParseStorePaths)
+    }
+
+    pub async fn catalog(&self, flox: &Flox) -> Result<EnvCatalog, ProjectEnvironmentError> {
+        let nix = flox.nix::<NixCommandLine>(Default::default());
+
+        let mut flake_attribute = self.flake_attribute()?;
+        flake_attribute.attr_path.push_attr("catalog")?;
+
+        let eval = Eval {
+            eval: EvaluationArgs {
+                impure: true.into(),
+                ..Default::default()
+            },
+            eval_args: EvalArgs {
+                installable: Some(flake_attribute.into()),
+                apply: None,
+            },
+            ..Eval::default()
+        };
+
+        let catalog_value: serde_json::Value = eval
+            .run_json(&nix, &Default::default())
+            .await
+            .map_err(ProjectEnvironmentError::EvalCatalog)?;
+
+        serde_json::from_value(catalog_value).map_err(ProjectEnvironmentError::ParseCatalog)
+    }
+
+    pub fn systematized_name(&self) -> String {
+        format!("{0}.{1}", self.system, self.name)
+    }
+
+    /// Where to link a built environment to
+    ///
+    /// When used as a lookup signals whether the environment has *at some point* been built before
+    /// and is "activatable". Note that the environment may have been modified since it was last built.
+    ///
+    /// Mind that an existing out link does not necessarily imply that the environment
+    /// can in fact be built.
+    pub fn out_link(&self) -> PathBuf {
+        self.project
+            .environment_out_link_dir()
+            .join(self.systematized_name())
+    }
+
+    /// Try building the environment and optionally linking it to the associated out_link
+    ///
+    /// [try_build]'s only external effect is having nix build
+    /// and create a gcroot/out_link for an environment derivation.
+    pub async fn try_build<Nix>(&self) -> Result<(), EnvironmentBuildError<Nix>>
+    where
+        Nix: FloxNixApi,
+        Build: RunTyped<Nix>,
+    {
+        let nix: Nix = self.project.flox.nix([].to_vec());
+
+        let build = Build {
+            installables: [self.flake_attribute()?.into()].into(),
+            eval: runix::arguments::eval::EvaluationArgs {
+                impure: true.into(),
+                ..Default::default()
+            },
+            build: BuildArgs {
+                out_link: Some(self.out_link().into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        build
+            .run(&nix, &Default::default())
+            .await
+            .map_err(EnvironmentBuildError::Build)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct BuildError<Nix: NixBackend>(pub(crate) <Build as Run<Nix>>::Error)
+where
+    Build: Run<Nix>;
+
+/// Implementations for R/O only instances
+///
+/// Mainly transformation into modifiable sandboxed instances
+impl<'flox> Environment<'flox, ReadOnly> {
+    /// Enter into editable mode by creating a git sandbox for the floxmeta
+    pub async fn enter_transaction(
+        self,
+    ) -> Result<(Environment<'flox, GitSandBox>, Index), TransactionEnterError> {
+        let (project, index) = self.project.enter_transaction().await?;
+        Ok((
+            Environment {
+                name: self.name,
+                system: self.system,
+                project,
+            },
+            index,
+        ))
+    }
+}
+
+/// Implementations for sandboxed only Environments
+impl<'flox> Environment<'flox, GitSandBox> {
+    /// Commit changes to environment by closing the underlying transaction
+    pub async fn commit_transaction(
+        self,
+        index: Index,
+        message: &'flox str,
+    ) -> Result<Environment<'_, ReadOnly>, TransactionCommitError> {
+        let project = self.project.commit_transaction(index, message).await?;
+        Ok(Environment {
+            name: self.name,
+            system: self.system,
+            project,
+        })
+    }
+}
+
+impl<A: GitAccess> Display for Environment<'_, A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // this assumes self.project.flakeref is the current working directory
+        write!(f, "environment .#{}", self.name)
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "impure-unit-tests")]
+mod tests {
+    use std::env;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::flox::Flox;
+    use crate::prelude::ChannelRegistry;
+    use crate::providers::git::GitCommandProvider;
+
+    fn flox_instance() -> (Flox, TempDir) {
+        let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+
+        let cache_dir = tempdir_handle.path().join("caches");
+        let temp_dir = tempdir_handle.path().join("temp");
+        let config_dir = tempdir_handle.path().join("config");
+
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        let mut channels = ChannelRegistry::default();
+        channels.register_channel("flox", "github:flox/floxpkgs/master".parse().unwrap());
+
+        let flox = Flox {
+            system: "aarch64-darwin".to_string(),
+            cache_dir,
+            temp_dir,
+            config_dir,
+            channels,
+            ..Default::default()
+        };
+
+        (flox, tempdir_handle)
+    }
+
+    #[tokio::test]
+    async fn build_environment() {
+        use tokio::io::AsyncWriteExt;
+
+        let temp_home = tempfile::tempdir().unwrap();
+        env::set_var("HOME", temp_home.path());
+
+        let (flox, tempdir_handle) = flox_instance();
+
+        let project_dir = tempfile::tempdir_in(tempdir_handle.path()).unwrap();
+        let _project_git = GitCommandProvider::init(project_dir.path(), false)
+            .await
+            .expect("should create git repo");
+
+        let project = flox
+            .resource(project_dir.path().to_path_buf())
+            .guard::<GitCommandProvider>()
+            .await
+            .expect("Finding dir should succeed")
+            .open()
+            .expect("should find git repo")
+            .guard()
+            .await
+            .expect("Openeing project dir should succeed")
+            .init_project(Vec::new())
+            .await
+            .expect("Should init a new project");
+
+        let (project, mut index) = project
+            .enter_transaction()
+            .await
+            .expect("Should be able to make sandbox");
+
+        project.create_default_env(&mut index).await;
+        let mut flox_nix = tokio::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(project.flake_root().unwrap().join("flox.nix"))
+            .await
+            .unwrap();
+        flox_nix
+            .write_all("{ packages.flox.flox = {}; }\n".as_bytes())
+            .await
+            .unwrap();
+
+        let project = project
+            .commit_transaction(index, "unused")
+            .await
+            .expect("Should commit transaction");
+
+        let project = project
+            .environment("default")
+            .await
+            .expect("should find new environment");
+
+        project.try_build().await.expect("should build");
+
+        assert!(project.out_link().exists());
+        assert!(project.out_link().join("bin").join("flox").exists());
+    }
+}

--- a/crates/flox-rust-sdk/src/models/project/mod.rs
+++ b/crates/flox-rust-sdk/src/models/project/mod.rs
@@ -14,7 +14,6 @@ use thiserror::Error;
 use walkdir::WalkDir;
 
 use self::environment::Environment;
-
 use super::root::transaction::{GitAccess, GitSandBox, ReadOnly};
 use super::root::{Closed, Root};
 use crate::flox::{Flox, FloxNixApi};

--- a/crates/flox-rust-sdk/src/models/project/mod.rs
+++ b/crates/flox-rust-sdk/src/models/project/mod.rs
@@ -13,6 +13,8 @@ use tempfile::TempDir;
 use thiserror::Error;
 use walkdir::WalkDir;
 
+use self::environment::Environment;
+
 use super::root::transaction::{GitAccess, GitSandBox, ReadOnly};
 use super::root::{Closed, Root};
 use crate::flox::{Flox, FloxNixApi};
@@ -22,6 +24,8 @@ use crate::utils::guard::Guard;
 use crate::utils::{copy_file_without_permissions, find_and_replace, FindAndReplaceError};
 
 static PACKAGE_NAME_PLACEHOLDER: &str = "__PACKAGE_NAME__";
+
+pub mod environment;
 
 /// A representation of a project, i.e. a git repo with a flake.nix
 ///
@@ -137,6 +141,20 @@ impl<'flox> Guard<Project<'flox, ReadOnly>, Root<'flox, Closed<GitCommandProvide
 
 /// Implementations for an opened project (read only)
 impl<'flox, Access: GitAccess> Project<'flox, Access> {
+    pub(crate) fn environment_out_link_dir(&self) -> PathBuf {
+        unimplemented!()
+    }
+
+    pub async fn environment<Nix: FloxNixApi>(
+        &self,
+        _name: &str,
+    ) -> Result<Environment<'flox, ReadOnly>, GetEnvironmentError<Nix>>
+    where
+        Eval: RunJson<Nix>,
+    {
+        unimplemented!()
+    }
+
     /// Construct a new Project object
     ///
     /// Private in this module, as intialization through git guard is prefered

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -1,4 +1,3 @@
-use std::env::current_dir;
 use std::fs::File;
 use std::io::stdin;
 use std::path::{Path, PathBuf};
@@ -8,7 +7,6 @@ use anyhow::{bail, Context, Result};
 use bpaf::{construct, Bpaf, Parser, ShellComp};
 use flox_rust_sdk::flox::{EnvironmentName, Flox};
 use flox_rust_sdk::models::environment::{Environment, Original, PathEnvironment};
-use flox_rust_sdk::models::environment_ref;
 use flox_rust_sdk::nix::arguments::eval::EvaluationArgs;
 use flox_rust_sdk::nix::command::{Shell, StoreGc};
 use flox_rust_sdk::nix::command_line::NixCommandLine;
@@ -21,7 +19,6 @@ use tempfile::NamedTempFile;
 
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::display::packages_to_string;
-use crate::utils::resolve_environment_ref;
 use crate::{flox_forward, subcommand_metric};
 
 #[derive(Bpaf, Clone)]
@@ -491,8 +488,7 @@ impl WipeHistory {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("wipe-history");
 
-        let env=
-            resolve_environment(&flox, self.environment.as_deref(), "uninstall").await?;
+        let env = resolve_environment(&flox, self.environment.as_deref(), "uninstall").await?;
 
         if env.delete_symlinks()? {
             // The flox nix instance is created with `--quiet --quiet`
@@ -810,7 +806,7 @@ async fn resolve_environment<'flox>(
     let environment_refs =
         flox_rust_sdk::models::environment_ref::EnvironmentRef::find(flox, environment_name)?;
     let environment_ref = match environment_refs.len() {
-        0 => bail!("No environments found"),
+        0 => bail!("No matching environments found"),
         1 => &environment_refs[0],
         _ => bail!("Multiple environments found"),
     };

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -34,7 +34,7 @@ async fn env_ref_to_flake_attribute<Git: GitProvider + 'static>(
     subcommand: &str,
     environment_name: &str,
 ) -> anyhow::Result<FlakeAttribute> {
-    let env_ref = resolve_environment_ref(flox, subcommand, Some(environment_name)).await?;
+    let env_ref = resolve_environment_ref::<GitCommandProvider>(flox, subcommand, Some(environment_name)).await?;
     Ok(env_ref.get_latest_flake_attribute::<Git>(flox).await?)
 }
 

--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -34,7 +34,9 @@ async fn env_ref_to_flake_attribute<Git: GitProvider + 'static>(
     subcommand: &str,
     environment_name: &str,
 ) -> anyhow::Result<FlakeAttribute> {
-    let env_ref = resolve_environment_ref::<GitCommandProvider>(flox, subcommand, Some(environment_name)).await?;
+    let env_ref =
+        resolve_environment_ref::<GitCommandProvider>(flox, subcommand, Some(environment_name))
+            .await?;
     Ok(env_ref.get_latest_flake_attribute::<Git>(flox).await?)
 }
 

--- a/crates/flox/src/utils/mod.rs
+++ b/crates/flox/src/utils/mod.rs
@@ -19,11 +19,11 @@ use once_cell::sync::Lazy;
 pub mod colors;
 mod completion;
 pub mod dialog;
+pub mod display;
 pub mod init;
 pub mod installables;
 pub mod logger;
 pub mod metrics;
-pub mod display;
 
 use regex::Regex;
 use tokio::sync::Mutex;

--- a/crates/flox/src/utils/mod.rs
+++ b/crates/flox/src/utils/mod.rs
@@ -2,13 +2,15 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::io::Stderr;
 use std::marker::PhantomData;
+use std::path::Path;
 use std::str::FromStr;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use bpaf::Parser;
-use flox_rust_sdk::flox::{EnvironmentRef, Flox, FloxInstallable, ResolvedInstallableMatch};
+use flox_rust_sdk::flox::{Flox, FloxInstallable, ResolvedInstallableMatch};
+use flox_rust_sdk::models::legacy_environment_ref::EnvironmentRef;
 use flox_rust_sdk::prelude::FlakeAttribute;
-use flox_rust_sdk::providers::git::GitCommandProvider;
+use flox_rust_sdk::providers::git::{GitCommandProvider, GitProvider};
 use indoc::indoc;
 use itertools::Itertools;
 use log::{debug, error, warn};
@@ -17,11 +19,11 @@ use once_cell::sync::Lazy;
 pub mod colors;
 mod completion;
 pub mod dialog;
-pub mod display;
 pub mod init;
 pub mod installables;
 pub mod logger;
 pub mod metrics;
+pub mod display;
 
 use regex::Regex;
 use tokio::sync::Mutex;
@@ -411,18 +413,61 @@ pub async fn resolve_installable_from_matches(
 /// - return the match if there is only one
 /// - start an interactive dialog if multiple matches were found
 ///   and a controlling tty was detected
-pub async fn resolve_environment_ref<'flox>(
+pub async fn resolve_environment_ref<'flox, Git: GitProvider + 'static>(
     flox: &'flox Flox,
     subcommand: &str,
     environment_name: Option<&str>,
-) -> Result<EnvironmentRef> {
-    let environment_refs = EnvironmentRef::find(flox, environment_name)?;
-    match &environment_refs[..] {
-        [] => {
+) -> Result<EnvironmentRef<'flox>> {
+    let mut environment_refs = EnvironmentRef::find::<_, Git>(flox, environment_name).await?;
+    match environment_refs.len() {
+        0 => {
             bail!("No matching environments found");
         },
-        [r] => Ok(r.clone()),
-        choices => {
+        1 => Ok(environment_refs.remove(0)),
+        _ => {
+            let mut sources: HashSet<Option<&Path>> = HashSet::new();
+
+            for m in &environment_refs {
+                if let EnvironmentRef::Project(p) = m {
+                    sources.insert(Some(&p.workdir));
+                } else {
+                    sources.insert(None);
+                }
+            }
+
+            let current_dir = std::env::current_dir()?;
+
+            // Compile a list of choices for the user to choose from, and shorter choices for suggestions
+            let mut choices: Vec<(String, &String)> = environment_refs
+                .iter()
+                .map(
+                    // Format the results according to how verbose we have to be for disambiguation, only showing the flakeref or prefix when multiple are used
+                    |m| {
+                        let prefix: Cow<str> = match m {
+                            EnvironmentRef::Named(_) if sources.len() > 1 => "Named - ".into(),
+                            EnvironmentRef::Project(n) if sources.len() > 1 => {
+                                let rel = pathdiff::diff_paths(&n.workdir, &current_dir)
+                                    .ok_or_else(|| anyhow!("Project path should be absolute"))?;
+
+                                if rel == Path::new("") {
+                                    ". - ".into()
+                                } else {
+                                    format!("{} - ", rel.display()).into()
+                                }
+                            },
+                            _ => "".into(),
+                        };
+
+                        let name = match m {
+                            EnvironmentRef::Named(n) => &n.name,
+                            EnvironmentRef::Project(p) => &p.name,
+                        };
+
+                        Ok((format!("{prefix}{name}"), name))
+                    },
+                )
+                .collect::<Result<Vec<_>>>()?;
+
             if !Dialog::can_prompt() {
                 error!(
                     indoc! {"
@@ -434,10 +479,10 @@ pub async fn resolve_environment_ref<'flox>(
                     {choices_list}
                 "},
                     subcommand = subcommand,
-                    first_choice = choices.get(0).expect("Expected at least one choice"),
+                    first_choice = choices.get(0).expect("Expected at least one choice").1,
                     choices_list = choices
                         .iter()
-                        .map(|env_ref| format!("  - {env_ref}"))
+                        .map(|(long, _)| format!("  - {long}"))
                         .join("\n")
                 );
 
@@ -449,22 +494,24 @@ pub async fn resolve_environment_ref<'flox>(
                 message: &format!("Select an environment for flox {subcommand}"),
                 help_message: None,
                 typed: Select {
-                    options: choices.to_vec(),
+                    options: choices.iter().cloned().map(|(long, _)| long).collect(),
                 },
             };
 
-            let (_, selected) = dialog
+            let (sel, _) = dialog
                 .raw_prompt()
                 .await
                 .context("Failed to prompt for environment choice")?;
 
-            let escaped = shell_escape::escape(selected.to_string().into()).into_owned();
+            let escaped = shell_escape::escape(choices.remove(sel).1.into()).into_owned();
+
+            let environment_ref = environment_refs.remove(sel);
 
             warn!(
                 "HINT: avoid selecting an environment next time with:\n  $ flox {subcommand} -e {escaped}",
             );
 
-            Ok(selected)
+            Ok(environment_ref)
         },
     }
 }


### PR DESCRIPTION
This is was a quick attempt to restore behavior - I only expect we should merge this if we want to get containerize working in the near term. It might not be the most "correct" way to revert the changes, but `flox containerize -e <name>` works again.

c0bdfe19311396c901668737d7401f7312a8001a broke non-feature flagged behavior of pure Rust commands like containerize. This partially restores that behavior - in particular flox containerize of environments in floxmeta works again.

Behavior for project environments was not fully restored; in particular environment() and environment_out_link_dir() were restored simply as unimplemented!().