### PR TITLE
fix: --version flag usage

### DIFF
--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -87,11 +87,10 @@ pub struct FloxArgs {
     #[bpaf(long, req_flag(()), many, map(vec_not_empty))]
     pub debug: bool,
 
-    /// With `--version` the application will print the version of the program
-    /// and quit early.
+    /// Print the version of the program
     #[allow(dead_code)] // fake arg, `--version` is checked for separately (see [Version])
-    #[bpaf(external(version))]
-    version: Version,
+    #[bpaf(long)]
+    version: bool,
 
     #[bpaf(external(commands), optional)]
     command: Option<Commands>,

--- a/crates/flox/src/main.rs
+++ b/crates/flox/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> ExitCode {
 
     // Quit early if `--version` is present
     if Version::check() {
-        println!(env!("FLOX_VERSION"));
+        println!("Version: {}", env!("FLOX_VERSION"));
         return ExitCode::from(0);
     }
 


### PR DESCRIPTION
Some internal docs for `--verbose` were leaking into the usage output of flox.
This PR removes an indirection used for the "fake" `--version` flag.

As a reminder; `--version` is handled separately from the main argument handling,
so that it any flox command that contains `--version` will print the version
and abort early in proper POSIX fashion.
That change also dropped the "Version: " prefix in the output of `--version` which 713f45a reverts