### PR TITLE
fix: detect bash invoked as sh

### DIFF
--- a/flox-bash/lib/commands/activate.sh
+++ b/flox-bash/lib/commands/activate.sh
@@ -269,7 +269,7 @@ function floxActivate() {
 	local rcScript
 	rcScript="$(mktemp)" # cleans up after itself, do not use mkTempFile()
 	case "$rcShell" in
-	*bash|*dash)
+	sh|*/sh|*bash|*dash)
 		bashRC "${_environments_to_activate[@]}" >> "$rcScript"
 		;;
 	*zsh)
@@ -354,7 +354,7 @@ function floxActivate() {
 	if [ "$spawnMode" -eq 1 ]; then
 		# Spawn mode - launch subshell.
 		case "$rcShell" in
-		*bash|*dash)
+		sh|*/sh|*bash|*dash)
 			export FLOX_BASH_INIT_SCRIPT="$rcScript"
 			[ "$verbose" -eq 0 ] || pprint "+$colorBold" exec "$rcShell" "--rcfile" "$_etc/flox.bashrc" "$colorReset" 1>&2
 			case "$rcShell" in
@@ -362,7 +362,7 @@ function floxActivate() {
 				# `dash' lacks an equivalent for `--rcfile' so we have to do
 				# things "the good ol' fashioned way" - manually sourcing the
 				# profile script and then executing an interactive shell.
-				*dash)
+				sh|*/sh|*dash)
 					exec "$rcShell" -c                                      \
 					       "source '$_etc/flox.bashrc'; exec $rcShell -i";
 					;;
@@ -391,7 +391,7 @@ function floxActivate() {
 		local _flox_activate_verbose=/dev/null
 		[ "$verbose" -eq 0 ] || _flox_activate_verbose=/dev/stderr
 		case "$rcShell" in
-		*bash|*zsh|*dash)
+		sh|*/sh|*bash|*zsh|*dash)
 			$_cat "$rcScript" | $_tee "$_flox_activate_verbose"
 			;;
 		*)

--- a/flox-bash/lib/utils.sh
+++ b/flox-bash/lib/utils.sh
@@ -1438,10 +1438,12 @@ function identifyParentShell() {
 	# Only attempt a guess if we know our parent PID.
 	if [ -n "${FLOX_PARENT_PID:-}" ]; then
 		# First attempt to identify details of parent shell process.
-		if [ -L "/proc/$FLOX_PARENT_PID/exe" -a \
-			 -r "/proc/$FLOX_PARENT_PID/exe" ]; then
-			# Linux - use information from /proc.
-			parentShell="$($_readlink "/proc/$FLOX_PARENT_PID/exe")"
+		if [ -r "/proc/$FLOX_PARENT_PID/cmdline" ]; then
+			# Linux - use information from /proc. bash can be invoked as sh, so we use
+			# argv[0] rather than /proc/$FLOX_PARENT_PID/exe
+			# -d '' splits on null bytes
+			mapfile -d '' cmdline < "/proc/$FLOX_PARENT_PID/cmdline"
+			parentShell="${cmdline[0]}"
 		elif local psOutput="$($_ps -c -o command= -p $FLOX_PARENT_PID 2>/dev/null)"; then
 			# Darwin/other - use `ps` to guess the shell.
 			# Note that this value often comes back with a leading "-" character


### PR DESCRIPTION
So this was an interesting one. bash can be invoked as sh, which is not currently detected by identifyParentShell.
The first commit uses /proc/$pid/cmdline to determine argv[0] instead of /proc/$pid/exe. That breaks CI, because it correctly detects that bash has been invoked as sh. But then flox doesn't think it can handle sh, so it fails. https://github.com/flox/flox/actions/runs/6343743972/job/17232325528#step:7:367

The second commit changes `activate` to be okay with `sh` - I'm assuming sh should be handled the same as dash, but I'm not actually 100% sure, is that correct?