### PR TITLE
feat!: environment selection with `--dir` and `--remote`

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -53,6 +53,11 @@ impl Environment for ManagedEnvironment {
         todo!()
     }
 
+    /// Extract the current content of the manifest
+    fn manifest_content(&self) -> Result<String, EnvironmentError2> {
+        todo!()
+    }
+
     #[allow(unused)]
     async fn catalog(
         &self,

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use flox_types::catalog::EnvCatalog;
+use flox_types::catalog::{EnvCatalog, System};
 use runix::command_line::NixCommandLine;
 
 use super::{Environment, EnvironmentError2};
@@ -15,7 +15,7 @@ impl Environment for ManagedEnvironment {
     async fn build(
         &mut self,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
+        system: System,
     ) -> Result<(), EnvironmentError2> {
         todo!()
     }
@@ -24,9 +24,9 @@ impl Environment for ManagedEnvironment {
     #[allow(unused)]
     async fn install(
         &mut self,
-        packages: impl IntoIterator<Item = FloxPackage> + Send,
+        packages: Vec<FloxPackage>,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
+        system: System,
     ) -> Result<bool, EnvironmentError2> {
         todo!()
     }
@@ -35,9 +35,9 @@ impl Environment for ManagedEnvironment {
     #[allow(unused)]
     async fn uninstall(
         &mut self,
-        packages: impl IntoIterator<Item = FloxPackage> + Send,
+        packages: Vec<FloxPackage>,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
+        system: System,
     ) -> Result<bool, EnvironmentError2> {
         todo!()
     }
@@ -47,8 +47,8 @@ impl Environment for ManagedEnvironment {
     async fn edit(
         &mut self,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
-        contents: impl AsRef<str> + Send,
+        system: System,
+        contents: String,
     ) -> Result<(), EnvironmentError2> {
         todo!()
     }
@@ -57,7 +57,7 @@ impl Environment for ManagedEnvironment {
     async fn catalog(
         &self,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
+        system: System,
     ) -> Result<EnvCatalog, EnvironmentError2> {
         todo!()
     }

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -70,7 +70,7 @@ impl Environment for ManagedEnvironment {
 
     /// Return the [EnvironmentRef] for the environment for identification
     #[allow(unused)]
-    fn environment_ref(&self) -> &EnvironmentRef {
+    fn environment_ref(&self) -> EnvironmentRef {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use flox_types::catalog::{EnvCatalog, System};
 use runix::command_line::NixCommandLine;
+use runix::installable::FlakeAttribute;
 
 use super::{Environment, EnvironmentError2};
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRef};
@@ -70,6 +71,11 @@ impl Environment for ManagedEnvironment {
     /// Return the [EnvironmentRef] for the environment for identification
     #[allow(unused)]
     fn environment_ref(&self) -> &EnvironmentRef {
+        todo!()
+    }
+
+    #[allow(unused)]
+    fn flake_attribute(&self, _system: System) -> FlakeAttribute {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -83,6 +83,9 @@ pub trait Environment {
     /// Return the [EnvironmentRef] for the environment for identification
     fn environment_ref(&self) -> &EnvironmentRef;
 
+    /// Return a flake attribute installable for this environment
+    fn flake_attribute(&self, system: System) -> FlakeAttribute;
+
     /// Returns the environment owner
     fn owner(&self) -> Option<EnvironmentOwner>;
 

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -81,7 +81,7 @@ pub trait Environment {
     fn manifest_content(&self) -> Result<String, EnvironmentError2>;
 
     /// Return the [EnvironmentRef] for the environment for identification
-    fn environment_ref(&self) -> &EnvironmentRef;
+    fn environment_ref(&self) -> EnvironmentRef;
 
     /// Return a flake attribute installable for this environment
     // TODO consider removing this from the trait

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -84,6 +84,7 @@ pub trait Environment {
     fn environment_ref(&self) -> &EnvironmentRef;
 
     /// Return a flake attribute installable for this environment
+    // TODO consider removing this from the trait
     fn flake_attribute(&self, system: System) -> FlakeAttribute;
 
     /// Returns the environment owner
@@ -98,6 +99,7 @@ pub trait Environment {
         Self: Sized;
 
     /// Remove gc-roots
+    // TODO consider renaming or removing - we might not support this for PathEnvironment
     fn delete_symlinks(&self) -> Result<bool, EnvironmentError2> {
         Ok(false)
     }

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -93,6 +93,11 @@ pub trait Environment {
     fn delete(self) -> Result<(), EnvironmentError2>
     where
         Self: Sized;
+
+    /// Remove gc-roots
+    fn delete_symlinks(&self) -> Result<bool, EnvironmentError2> {
+        Ok(false)
+    }
 }
 
 #[derive(Debug, Error)]

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -77,6 +77,9 @@ pub trait Environment {
         system: System,
     ) -> Result<EnvCatalog, EnvironmentError2>;
 
+    /// Extract the current content of the manifest
+    fn manifest_content(&self) -> Result<String, EnvironmentError2>;
+
     /// Return the [EnvironmentRef] for the environment for identification
     fn environment_ref(&self) -> &EnvironmentRef;
 

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -45,8 +45,8 @@ pub struct PathEnvironment<S> {
     /// The temporary directory that this environment will use during transactions
     pub temp_dir: PathBuf,
 
-    /// The [EnvironmentRef] this env is created from (and validated against)
-    pub environment_ref: EnvironmentRef,
+    /// The [EnvironmentName] of this environment
+    pub name: EnvironmentName,
 
     /// The transaction state
     pub state: S,
@@ -80,7 +80,7 @@ impl<S: TransactionState> PathEnvironment<S> {
         Ok(PathEnvironment {
             path: transaction_dir.into_path(),
             temp_dir: self.temp_dir.clone(),
-            environment_ref: self.environment_ref.clone(),
+            name: self.name.clone(),
             state: Temporary,
         })
     }
@@ -251,8 +251,8 @@ where
     }
 
     /// Return the [EnvironmentRef] for the environment for identification
-    fn environment_ref(&self) -> &EnvironmentRef {
-        &self.environment_ref
+    fn environment_ref(&self) -> EnvironmentRef {
+        EnvironmentRef::new_from_parts(None, self.name.clone())
     }
 
     /// Get a catalog of installed packages from this environment
@@ -294,12 +294,12 @@ where
 
     /// Returns the environment owner
     fn owner(&self) -> Option<EnvironmentOwner> {
-        self.environment_ref.owner().cloned()
+        None
     }
 
     /// Returns the environment name
     fn name(&self) -> EnvironmentName {
-        self.environment_ref.name().clone()
+        self.name.clone()
     }
 
     /// Delete the Environment
@@ -429,7 +429,7 @@ impl PathEnvironment<Original> {
 
         Ok(PathEnvironment {
             path: env_path,
-            environment_ref: EnvironmentRef::new_from_parts(None, name),
+            name,
             temp_dir: temp_dir.as_ref().to_path_buf(),
             state: Original,
         })
@@ -507,7 +507,7 @@ mod tests {
                 .canonicalize()
                 .unwrap()
                 .join(".flox/test"),
-            environment_ref: EnvironmentRef::new(None, "test").unwrap(),
+            name: EnvironmentName::from_str("test").unwrap(),
             temp_dir: environment_temp_dir.path().to_path_buf(),
             state: Original,
         };

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -316,6 +316,10 @@ where
         }
         Ok(())
     }
+
+    fn flake_attribute(&self, system: System) -> FlakeAttribute {
+        self.flake_attribute(system)
+    }
 }
 
 impl<S: TransactionState> PathEnvironment<S> {

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -441,18 +441,18 @@ impl PathEnvironment<Original> {
         current_dir: impl AsRef<Path>,
         temp_dir: impl AsRef<Path>,
     ) -> Result<Option<Self>, EnvironmentError2> {
-        let dot_flox = current_dir
+        let maybe_dot_flox = current_dir
             .as_ref()
             .ancestors()
             .find(|ancestor| ancestor.join(".flox").exists());
 
-        let dot_flox = if let Some(dot_flox) = dot_flox {
-            dot_flox
+        let with_dot_flox = if let Some(with_dot_flox) = maybe_dot_flox {
+            with_dot_flox
         } else {
             return Ok(None);
         };
 
-        Some(Self::open(current_dir, temp_dir)).transpose()
+        Some(Self::open(with_dot_flox, temp_dir)).transpose()
     }
 
     /// Create a new env in a `.flox` directory within a specific path or open it if it exists.

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -319,14 +319,6 @@ where
 }
 
 impl<S: TransactionState> PathEnvironment<S> {
-    /// Remove gc-roots
-    ///
-    /// Currently stubbed out due to missing activation that could need linked results
-    pub fn delete_symlinks(&self) -> Result<bool, EnvironmentError2> {
-        // todo
-        Ok(false)
-    }
-
     /// Turn the environment into a flake attribute,
     /// a precise url to interact with the environment via nix
     ///

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use flox_types::catalog::{EnvCatalog, System};
 use runix::command_line::NixCommandLine;
+use runix::installable::FlakeAttribute;
 
 use super::{Environment, EnvironmentError2};
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRef};
@@ -71,6 +72,11 @@ impl Environment for RemoteEnvironment {
     /// Return the [EnvironmentRef] for the environment for identification
     #[allow(unused)]
     fn environment_ref(&self) -> &EnvironmentRef {
+        todo!()
+    }
+
+    #[allow(unused)]
+    fn flake_attribute(&self, system: System) -> FlakeAttribute {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -71,7 +71,7 @@ impl Environment for RemoteEnvironment {
 
     /// Return the [EnvironmentRef] for the environment for identification
     #[allow(unused)]
-    fn environment_ref(&self) -> &EnvironmentRef {
+    fn environment_ref(&self) -> EnvironmentRef {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use flox_types::catalog::EnvCatalog;
+use flox_types::catalog::{EnvCatalog, System};
 use runix::command_line::NixCommandLine;
 
 use super::{Environment, EnvironmentError2};
@@ -16,7 +16,7 @@ impl Environment for RemoteEnvironment {
     async fn build(
         &mut self,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
+        system: System,
     ) -> Result<(), EnvironmentError2> {
         todo!()
     }
@@ -25,9 +25,9 @@ impl Environment for RemoteEnvironment {
     #[allow(unused)]
     async fn install(
         &mut self,
-        packages: impl IntoIterator<Item = FloxPackage> + Send,
+        packages: Vec<FloxPackage>,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
+        system: System,
     ) -> Result<bool, EnvironmentError2> {
         todo!()
     }
@@ -36,9 +36,9 @@ impl Environment for RemoteEnvironment {
     #[allow(unused)]
     async fn uninstall(
         &mut self,
-        packages: impl IntoIterator<Item = FloxPackage> + Send,
+        packages: Vec<FloxPackage>,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
+        system: System,
     ) -> Result<bool, EnvironmentError2> {
         todo!()
     }
@@ -48,8 +48,8 @@ impl Environment for RemoteEnvironment {
     async fn edit(
         &mut self,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
-        contents: impl AsRef<str> + Send,
+        system: System,
+        contents: String,
     ) -> Result<(), EnvironmentError2> {
         todo!()
     }
@@ -58,7 +58,7 @@ impl Environment for RemoteEnvironment {
     async fn catalog(
         &self,
         nix: &NixCommandLine,
-        system: impl AsRef<str> + Send,
+        system: System,
     ) -> Result<EnvCatalog, EnvironmentError2> {
         todo!()
     }

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -63,6 +63,11 @@ impl Environment for RemoteEnvironment {
         todo!()
     }
 
+    /// Extract the current content of the manifest
+    fn manifest_content(&self) -> Result<String, EnvironmentError2> {
+        todo!()
+    }
+
     /// Return the [EnvironmentRef] for the environment for identification
     #[allow(unused)]
     fn environment_ref(&self) -> &EnvironmentRef {

--- a/crates/flox-rust-sdk/src/models/environment_ref.rs
+++ b/crates/flox-rust-sdk/src/models/environment_ref.rs
@@ -138,11 +138,7 @@ impl EnvironmentRef {
         &self,
         temp_dir: PathBuf,
     ) -> Result<PathEnvironment<Original>, EnvironmentError2> {
-        let env = PathEnvironment::<Original>::open(
-            std::env::current_dir().unwrap(),
-            self.clone(),
-            temp_dir,
-        )?;
+        let env = PathEnvironment::<Original>::open(std::env::current_dir().unwrap(), temp_dir)?;
         Ok(env)
     }
 

--- a/crates/flox-rust-sdk/src/models/flox_installable.rs
+++ b/crates/flox-rust-sdk/src/models/flox_installable.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 // Matches against strings which are likely to be flakerefs
 // Such as: `github:NixOS/nixpkgs`, `.`, `../somedir`, etc
 static PROBABLY_FLAKEREF_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"^(?:\.?\.?/|\.$|[a-z+]+:)"#).unwrap());
+    Lazy::new(|| Regex::new(r"^(?:\.?\.?/|\.$|[a-z+]+:)").unwrap());
 
 #[derive(PartialEq, Eq, Clone, Debug, Default)]
 pub struct FloxInstallable {

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -156,7 +156,7 @@ fn render_search_results(search_results: &SearchResults) -> Result<()> {
         .map(|r| {
             let path_components = r.attr_path.clone();
             let flake_attr = if !DEFAULT_CHANNELS.contains_key(r.input.as_str()) {
-                vec![r.input.clone(), path_components.join(".")].join("#")
+                [r.input.clone(), path_components.join(".")].join("#")
             } else {
                 path_components.join(".")
             };

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -69,8 +69,13 @@ impl EnvironmentSelect {
 }
 
 enum ConcreteEnvironment {
+    /// Container for [PathEnvironment]
     Path(PathEnvironment<Original>),
+    /// Container for [ManagedEnvironment]
+    #[allow(unused)] // pending implementation of ManagedEnvironment
     Managed(ManagedEnvironment),
+    /// Container for [RemoteEnvironment]
+    #[allow(unused)] // pending implementation of RemoteEnvironment
     Remote(RemoteEnvironment),
 }
 

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -593,6 +593,7 @@ pub struct Export {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(unused)] // Command currently forwarded
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 }
@@ -616,6 +617,7 @@ pub struct Generations {
     #[bpaf(long)]
     json: bool,
 
+    #[allow(unused)] // Command currently forwarded
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 }
@@ -627,6 +629,7 @@ impl Generations {
         flox_forward(&flox).await
     }
 }
+
 /// access to the git CLI for floxmeta repository
 #[derive(Bpaf, Clone)]
 pub struct Git {
@@ -634,6 +637,7 @@ pub struct Git {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(unused)] // Command currently forwarded
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 
@@ -661,6 +665,7 @@ pub struct History {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(unused)] // Command currently forwarded
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 }
@@ -680,6 +685,7 @@ pub struct Import {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(unused)] // Command currently forwarded
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 
@@ -826,6 +832,7 @@ pub struct SwitchGeneration {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(unused)] // Command currently forwarded
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 
@@ -849,6 +856,7 @@ pub struct Upgrade {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
+    #[allow(unused)] // Command currently forwarded
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -57,8 +57,7 @@ impl EnvironmentSelect {
     fn to_concrete_environment(&self, temp_dir: impl AsRef<Path>) -> Result<ConcreteEnvironment> {
         let env = match self {
             EnvironmentSelect::Dir(path) => ConcreteEnvironment::Path(
-                PathEnvironment::open(path, "default".parse().unwrap(), temp_dir)
-                    .context("Couldn't open path environment")?,
+                PathEnvironment::open(path, temp_dir).context("No matching environments found")?,
             ),
 
             EnvironmentSelect::Remote(_) => todo!(),

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -558,9 +558,7 @@ impl WipeHistory {
             .to_concrete_environment(tempfile::tempdir_in(&flox.temp_dir)?.into_path())?
             .into_dyn_environment();
 
-        if todo!()
-        /* env.delete_symlinks()? */
-        {
+        if env.delete_symlinks()? {
             // The flox nix instance is created with `--quiet --quiet`
             // because nix logs are passed to stderr unfiltered.
             // nix store gc logs are more useful,

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -125,14 +125,12 @@ impl Edit {
                     .or(std::env::var("VISUAL"))
                     .context("no editor found; neither EDITOR nor VISUAL are set")?;
                 // TODO: check for interactivity before allowing the editor to be opened
-                let _manifest_path = todo!(); // environment.manifest_path(); dont forget to uncomment the file copy below
-
                 // Make a copy of the manifest for the user to edit so failed edits aren't left in
                 // the original manifest. You can't put creation/cleanup inside the `edited_manifest_contents`
                 // method because the temporary manifest needs to stick around in case the user wants
                 // or needs to make successive edits without starting over each time.
                 let tmp_manifest = NamedTempFile::new_in(&flox.temp_dir)?;
-                // std::fs::copy(todo!(), &tmp_manifest)?;
+                std::fs::write(&tmp_manifest, environment.manifest_content()?)?;
                 let should_continue = Dialog {
                     message: "Continue editing?",
                     help_message: Default::default(),

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -579,8 +579,10 @@ pub struct BashPassthru {
     #[bpaf(long("bash-passthru"))]
     do_passthru: bool,
 
+    // swallows '--' arguments
+    // hence the arguments are determined differently below.
     #[bpaf(any("REST", Some), many)]
-    flox_args: Vec<String>,
+    _flox_args: Vec<String>,
 }
 
 impl BashPassthru {
@@ -593,7 +595,12 @@ impl BashPassthru {
             .unwrap_or_default();
 
         if passtrhu.do_passthru {
-            return Some(passtrhu.flox_args);
+            return Some(
+                std::env::args()
+                    .skip(1)
+                    .filter(|arg| arg != "--bash-passthru")
+                    .collect(),
+            );
         }
 
         None

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -579,8 +579,13 @@ pub struct BashPassthru {
     #[bpaf(long("bash-passthru"))]
     do_passthru: bool,
 
-    // swallows '--' arguments
-    // hence the arguments are determined differently below.
+    // bpaf parses all arguments and collects them into a Vec
+    // however by doing so it also (correctly) parses `--` as a
+    // delimiter.
+    // The delimiter is _not_ part of the collected arguments.
+    // When passing on this parsed list of args, `--` will be missing,
+    // causing invalid arguments to e.g. `flox-bash activate`.
+    // Hence the arguments are determined differently below, which adds `--` back in.
     #[bpaf(any("REST", Some), many)]
     _flox_args: Vec<String>,
 }

--- a/crates/flox/src/main.rs
+++ b/crates/flox/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> ExitCode {
 
     // redirect to flox early if `--bash-passthru` is present
     if let Some(args) = BashPassthru::check() {
+        set_parent_process_id();
         let bash_command = run_in_flox(None, &args).await;
 
         match bash_command {

--- a/crates/flox/src/utils/init/mod.rs
+++ b/crates/flox/src/utils/init/mod.rs
@@ -79,9 +79,9 @@ pub fn init_access_tokens(
 
     let mut tokens = Vec::new();
 
-    tokens.extend(nix_tokens.into_iter());
-    tokens.extend(gh_tokens.into_iter());
-    tokens.extend(config_tokens.clone().into_iter());
+    tokens.extend(nix_tokens);
+    tokens.extend(gh_tokens);
+    tokens.extend(config_tokens.clone());
     tokens.dedup();
 
     Ok(tokens)

--- a/tests/activate.bats
+++ b/tests/activate.bats
@@ -19,16 +19,16 @@ load test_support.bash;
 
 setup_file() {
   common_file_setup;
-  "$FLOX_CLI" create -e "$TEST_ENVIRONMENT";
-  "$FLOX_CLI" install -e "$TEST_ENVIRONMENT" hello cowsay;
+  "$FLOX_CLI" --bash-passthru create -e "$TEST_ENVIRONMENT";
+  "$FLOX_CLI" --bash-passthru install -e "$TEST_ENVIRONMENT" hello cowsay;
 
   # Run by various shells to test that `flox activate ... -- ...;' works.
-  _inline_cmd="$FLOX_CLI activate -e '$TEST_ENVIRONMENT'";
+  _inline_cmd="$FLOX_CLI --bash-passthru activate -e '$TEST_ENVIRONMENT'";
   _inline_cmd="$_inline_cmd -- sh -c 'hello|cowsay'";
   export _inline_cmd;
 
   # Run by various shells to test that `eval "$( flox activate ...; )";' works.
-  _eval_cmd="eval \"\$( $FLOX_CLI activate -e '$TEST_ENVIRONMENT'; )\"";
+  _eval_cmd="eval \"\$( $FLOX_CLI --bash-passthru activate -e '$TEST_ENVIRONMENT'; )\"";
   _eval_cmd="$_eval_cmd; hello|cowsay;";
   export _eval_cmd;
 }
@@ -108,10 +108,10 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox activate' accepts '-s,--system' options" {
-  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" --system "$NIX_SYSTEM"  \
+  run "$FLOX_CLI" --bash-passthru activate -e "$TEST_ENVIRONMENT" --system "$NIX_SYSTEM"  \
                            -- sh -c ':'
   assert_success
-  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" -s "$NIX_SYSTEM"  \
+  run "$FLOX_CLI" --bash-passthru activate -e "$TEST_ENVIRONMENT" -s "$NIX_SYSTEM"  \
                            -- sh -c ':'
   assert_success
 }

--- a/tests/develop.bats
+++ b/tests/develop.bats
@@ -203,7 +203,7 @@ runExpect() {
 
 @test "'flox develop' toplevel with 'flox install' env" {
   loadHarness toplevel-flox-nix;
-  run "$FLOX_CLI" install -e '.#default' hello;
+  run "$FLOX_CLI" --bash-passthru install -e '.#default' hello;
   assert_success;
   # for some reason expect hangs forever when SHELL=zsh and I don't feel like
   # debugging why

--- a/tests/develop/devShell.exp
+++ b/tests/develop/devShell.exp
@@ -1,11 +1,11 @@
 set attr [lindex $argv 0]
 set flox $env(FLOX_CLI)
 if {$attr eq ""} {
-    set cmd "$flox -v develop"
+    set cmd "$flox --bash-passthru -v develop"
     spawn $flox -v develop
 } else {
-    set cmd "$flox -v develop $attr"
-    spawn $flox -v develop $attr
+    set cmd "$flox --bash-passthru -v develop $attr"
+    spawn $flox --bash-passthru -v develop $attr
 }
 set timeout 30
 expect {

--- a/tests/develop/develop-fail.exp
+++ b/tests/develop/develop-fail.exp
@@ -1,11 +1,11 @@
 set attr [lindex $argv 0]
 set flox $env(FLOX_CLI)
 if {$attr eq ""} {
-    set cmd "$flox -v develop"
-    spawn $flox -v develop
+    set cmd "$flox --bash-passthru -v develop"
+    spawn $flox --bash-passthru -v develop
 } else {
-    set cmd "$flox -v develop $attr"
-    spawn $flox -v develop $attr
+    set cmd "$flox --bash-passthru -v develop $attr"
+    spawn $flox --bash-passthru -v develop $attr
 }
 expect {
     "ERROR: could not determine toplevel directory" {}

--- a/tests/develop/develop.exp
+++ b/tests/develop/develop.exp
@@ -1,11 +1,11 @@
 set attr [lindex $argv 0]
 set flox $env(FLOX_CLI)
 if {$attr eq ""} {
-    set cmd "$flox -v develop"
-    spawn $flox -v develop
+    set cmd "$flox --bash-passthru -v develop"
+    spawn $flox --bash-passthru -v develop
 } else {
-    set cmd "$flox -v develop $attr"
-    spawn $flox -v develop $attr
+    set cmd "$flox --bash-passthru -v develop $attr"
+    spawn $flox --bash-passthru -v develop $attr
 }
 set timeout 30
 expect {

--- a/tests/develop/toplevel-flox-nix.exp
+++ b/tests/develop/toplevel-flox-nix.exp
@@ -1,11 +1,11 @@
 set attr [lindex $argv 0]
 set flox $env(FLOX_CLI)
 if {$attr eq ""} {
-    set cmd "$flox -v develop"
-    spawn $flox -v develop
+    set cmd "$flox --bash-passthru -v develop"
+    spawn $flox --bash-passthru -v develop
 } else {
-    set cmd "$flox -v develop $attr"
-    spawn $flox -v develop $attr
+    set cmd "$flox --bash-passthru -v develop $attr"
+    spawn $flox --bash-passthru -v develop $attr
 }
 set timeout 60
 expect {

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -25,7 +25,7 @@ setup_file() {
 # If each test shared an env their edits may cause a race condition.
 setup() {
   setup_test_envname;
-  $FLOX_CLI create -e "$TEST_ENVIRONMENT";
+  $FLOX_CLI --bash-passthru create -e "$TEST_ENVIRONMENT";
 }
 
 
@@ -33,11 +33,11 @@ setup() {
 
 # test reading from a file
 @test "'flox edit -f FILE'" {
-  run $FLOX_CLI edit -e "$TEST_ENVIRONMENT" -f "$TESTS_DIR/test-flox.nix";
+  run $FLOX_CLI --bash-passthru edit -e "$TEST_ENVIRONMENT" -f "$TESTS_DIR/test-flox.nix";
   assert_success;
   assert_output --partial "Environment '$TEST_ENVIRONMENT' modified.";
 
-  run sh -c "EDITOR=cat $FLOX_CLI edit -e '$TEST_ENVIRONMENT';";
+  run sh -c "EDITOR=cat $FLOX_CLI --bash-passthru edit -e '$TEST_ENVIRONMENT';";
   assert_success;
   assert_output --partial 'environmentVariables.test = "file"';
 }
@@ -48,11 +48,11 @@ setup() {
 # test reading from stdin
 @test "'flox edit -f -'" {
   run sh -c "echo '{ environmentVariables.test = \"stdin\"; }' |
-              $FLOX_CLI edit -e '$TEST_ENVIRONMENT' --file -;";
+              $FLOX_CLI --bash-passthru edit -e '$TEST_ENVIRONMENT' --file -;";
   assert_success;
   assert_output --partial "Environment '$TEST_ENVIRONMENT' modified.";
 
-  run sh -c "EDITOR=cat $FLOX_CLI edit -e '$TEST_ENVIRONMENT';";
+  run sh -c "EDITOR=cat $FLOX_CLI --bash-passthru edit -e '$TEST_ENVIRONMENT';";
   assert_success;
   assert_output --partial 'environmentVariables.test = "stdin";';
 }

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -44,7 +44,7 @@ project_teardown() {
 }
 
 activate_local_env() {
-  run "$FLOX_CLI" activate -e "$PROJECT_NAME";
+  run "$FLOX_CLI" activate -d "$PROJECT_DIR";
 }
 
 
@@ -101,7 +101,7 @@ env_is_activated() {
 
 @test "a3: 'flox activate' accepts explicit environment name" {
   skip FIXME;
-  run "$FLOX_CLI" activate -e "$PROJECT_NAME"
+  run "$FLOX_CLI" activate -d "$PROJECT_DIR"
   assert_success;
   is_activated=$(env_is_activated "$PROJECT_NAME");
   assert_equal "$is_activated" "1";
@@ -113,7 +113,7 @@ env_is_activated() {
 @test "a4: 'flox activate' modifies shell prompt with 'bash'" {
   skip FIXME;
   prompt_before="${PS1@P}";
-  bash -c '"$FLOX_CLI" activate -e "$PROJECT_NAME"';
+  bash -c '"$FLOX_CLI" activate -d "$PROJECT_DIR"';
   assert_success;
   prompt_after="${PS1@P}";
   assert_not_equal prompt_before prompt_after;
@@ -126,7 +126,7 @@ env_is_activated() {
 @test "a4: 'flox activate' modifies shell prompt with 'zsh'" {
   skip FIXME;
   prompt_before="${(%%)PS1}";
-  zsh -c '"$FLOX_CLI" activate -e "$PROJECT_NAME"';
+  zsh -c '"$FLOX_CLI" activate -d "$PROJECT_DIR"';
   assert_success;
   prompt_after="${(%%)PS1}";
   assert_not_equal prompt_before prompt_after;

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -45,23 +45,7 @@ setup_file() {
   skip "Environment defaults handled in another phase"
 }
 
-@test "i3: flox install allows -e for explicit environment name;  If .flox does not exist, a .flox is created." {
-  skip "Environment defaults handled in another phase"
-  run ls .flox
-  assert_failure
-
-  run "$FLOX_CLI" install -e env hello
-  assert_success
-
-  run ls .flox
-  assert_success
-}
-
-@test "i3: flox install allows -e for explicit environment name;  If the environment is not staged in FLOX_META, it is pulled" {
-  skip "remote environments handled in another phase"
-}
-
-@test "i3: flox install allows -e for explicit environment name; If the environment exists in FLOX_META or locally, .flox is a link" {
+@test "flox install allows -r for installing to a specific remote environment name, creating a new generation." {
   skip "remote environments handled in another phase"
 }
 

--- a/tests/environment-list.bats
+++ b/tests/environment-list.bats
@@ -45,7 +45,7 @@ setup_file() {
 @test "'flox list' lists packages of environment in the current dir; fails if no env found" {
   run "$FLOX_CLI" list
   assert_failure
-  assert_output "No matching environments found"
+  assert_line "No matching environments found"
 }
 
 @test "'flox list' lists packages of environment in the current dir; No package" {
@@ -66,38 +66,4 @@ setup_file() {
 .*
 hello
 EOF
-}
-
-@test "'flox list' lists packages of environment in the current dir; matching names" {
-  "$FLOX_CLI" init -n not-test
-  "$FLOX_CLI" install -e not-test hello
-
-  run "$FLOX_CLI" list -e not-test
-  assert_success
-  assert_output --regexp - <<EOF
-.*
-hello
-EOF
-}
-
-
-@test "'flox list' lists packages of environment in the current dir; no name" {
-  "$FLOX_CLI" init -n not-test
-  "$FLOX_CLI" install -e not-test hello
-
-  run "$FLOX_CLI" list
-  assert_success
-  assert_output --regexp - <<EOF
-.*
-hello
-EOF
-}
-
-@test "'flox list' lists packages of environment in the current dir; no matching name" {
-  "$FLOX_CLI" init -n not-test
-  "$FLOX_CLI" install -e not-test hello
-
-  run "$FLOX_CLI" list -e test
-  assert_failure
-  assert_output "No matching environments found"
 }

--- a/tests/flox-pushpull.bats
+++ b/tests/flox-pushpull.bats
@@ -15,8 +15,8 @@ load test_support.bash;
 
 setup_file() {
   common_file_setup;
-  "$FLOX_CLI" create -e "$TEST_ENVIRONMENT";
-  "$FLOX_CLI" install -e "$TEST_ENVIRONMENT" hello cowsay;
+  "$FLOX_CLI" --bash-passthru create -e "$TEST_ENVIRONMENT";
+  "$FLOX_CLI" --bash-passthru install -e "$TEST_ENVIRONMENT" hello cowsay;
   export GITHUB_TOKEN="ghx_bogus_token"
   export GH_TOKEN="$GITHUB_TOKEN"
 }
@@ -57,7 +57,7 @@ teardown() { common_test_teardown; }
 @test "'flox list -e $TEST_ENVIRONMENT'" {
   # Confirm environment was created as part of setup and contains
   # the expected packages.
-  run "$FLOX_CLI" list -e "$TEST_ENVIRONMENT";
+  run "$FLOX_CLI" --bash-passthru list -e "$TEST_ENVIRONMENT";
   assert_success;
   assert_output --partial "stable.nixpkgs-flox.cowsay";
   assert_output --partial "stable.nixpkgs-flox.hello";
@@ -67,7 +67,7 @@ teardown() { common_test_teardown; }
 # bats test_tags=uri:github
 @test "'flox push -e $TEST_ENVIRONMENT'" {
   # Confirm we can push the environment to the gitforge.
-  run "$FLOX_CLI" push -e "$TEST_ENVIRONMENT";
+  run "$FLOX_CLI" --bash-passthru push -e "$TEST_ENVIRONMENT";
   assert_success;
   assert_output --partial "To https://git.hub.flox.dev/floxtest/floxmeta";
   assert_output --partial "origin/$NIX_SYSTEM.$TEST_ENVIRONMENT -> $NIX_SYSTEM.$TEST_ENVIRONMENT";
@@ -77,7 +77,7 @@ teardown() { common_test_teardown; }
 # bats test_tags=uri:github
 @test "'flox pull -e $TEST_ENVIRONMENT'" {
   # Confirm we can pull the environment from the gitforge.
-  run "$FLOX_CLI" pull -e "$TEST_ENVIRONMENT";
+  run "$FLOX_CLI" --bash-passthru pull -e "$TEST_ENVIRONMENT";
   assert_success;
   assert_output --partial "Everything up-to-date";
 }
@@ -86,7 +86,7 @@ teardown() { common_test_teardown; }
 # bats test_tags=uri:github
 @test "'flox destroy -e $TEST_ENVIRONMENT --origin --force'" {
   # Confirm we have privileges to destroy the environment on the origin.
-  run "$FLOX_CLI" destroy -e "$TEST_ENVIRONMENT" --origin --force;
+  run "$FLOX_CLI" --bash-passthru destroy -e "$TEST_ENVIRONMENT" --origin --force;
   assert_success;
   assert_output --partial "Deleted branch $NIX_SYSTEM.$TEST_ENVIRONMENT";
   assert_output --partial "Deleted remote-tracking branch origin/$NIX_SYSTEM.$TEST_ENVIRONMENT";

--- a/tests/gpgsign.bats
+++ b/tests/gpgsign.bats
@@ -35,13 +35,13 @@ teardown() { cd "$BATS_RUN_TMPDIR"||return; }
   run git config --global commit.gpgsign true;
   assert_success;
 
-  run $FLOX_CLI create -e "${TEST_ENVIRONMENT}1";
+  run $FLOX_CLI --bash-passthru create -e "${TEST_ENVIRONMENT}1";
   assert_success;
 
-  run $FLOX_CLI install -e "${TEST_ENVIRONMENT}1" cowsay;
+  run $FLOX_CLI --bash-passthru install -e "${TEST_ENVIRONMENT}1" cowsay;
   assert_success;
 
-  run $FLOX_CLI activate -e "${TEST_ENVIRONMENT}1" --     \
+  run $FLOX_CLI --bash-passthru activate -e "${TEST_ENVIRONMENT}1" --     \
     sh -c 'cowsay "Signature set in Global Config" >&2';
   assert_success;
 
@@ -62,13 +62,13 @@ teardown() { cd "$BATS_RUN_TMPDIR"||return; }
   run git config commit.gpgsign true;
   assert_success;
 
-  run $FLOX_CLI create -e "${TEST_ENVIRONMENT}2";
+  run $FLOX_CLI --bash-passthru create -e "${TEST_ENVIRONMENT}2";
   assert_success;
 
-  run $FLOX_CLI install -e "${TEST_ENVIRONMENT}2" cowsay;
+  run $FLOX_CLI --bash-passthru install -e "${TEST_ENVIRONMENT}2" cowsay;
   assert_success;
 
-  run $FLOX_CLI activate -e "${TEST_ENVIRONMENT}2" --   \
+  run $FLOX_CLI --bash-passthru activate -e "${TEST_ENVIRONMENT}2" --   \
     sh -c 'cowsay "Signature set in User Config" >&2';
   assert_success;
 

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -99,37 +99,37 @@ setup_file() {
 }
 
 @test "flox create -e $TEST_ENVIRONMENT" {
-  run $FLOX_CLI create -e "$TEST_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru create -e "$TEST_ENVIRONMENT"
   assert_success
   assert_output --partial "created environment $TEST_ENVIRONMENT ($NIX_SYSTEM)"
 }
 
 @test "flox create -e $TEST_ENVIRONMENT fails when run again" {
-  run $FLOX_CLI create -e "$TEST_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru create -e "$TEST_ENVIRONMENT"
   assert_failure
   assert_output --partial "ERROR: environment $TEST_ENVIRONMENT ($NIX_SYSTEM) already exists"
 }
 
 @test "flox install hello" {
-  run $FLOX_CLI install -e "$TEST_ENVIRONMENT" hello
+  run $FLOX_CLI --bash-passthru install -e "$TEST_ENVIRONMENT" hello
   assert_success
   assert_output --partial "Installed 'hello' package(s) into '$TEST_ENVIRONMENT' environment."
 }
 
 @test "flox export -> import is a no-op" {
-  run sh -c "$FLOX_CLI export -e $TEST_ENVIRONMENT | $FLOX_CLI --debug import -e $TEST_ENVIRONMENT"
+  run sh -c "$FLOX_CLI --bash-passthru export -e $TEST_ENVIRONMENT | $FLOX_CLI --bash-passthru --debug import -e $TEST_ENVIRONMENT"
   assert_success
   assert_output --partial "No environment changes detected"
 }
 
 @test "flox install nixpkgs-flox.hello" {
-  run $FLOX_CLI install -e $TEST_ENVIRONMENT nixpkgs-flox.hello
+  run $FLOX_CLI --bash-passthru install -e $TEST_ENVIRONMENT nixpkgs-flox.hello
   assert_success
   assert_output --partial "No change! Package(s) 'nixpkgs-flox.hello' already installed into '$TEST_ENVIRONMENT' environment."
 }
 
 @test "flox install stable.nixpkgs-flox.hello" {
-  run $FLOX_CLI install -e $TEST_ENVIRONMENT stable.nixpkgs-flox.hello
+  run $FLOX_CLI --bash-passthru install -e $TEST_ENVIRONMENT stable.nixpkgs-flox.hello
   assert_success
   assert_output --partial "No change! Package(s) 'stable.nixpkgs-flox.hello' already installed into '$TEST_ENVIRONMENT' environment."
 }
@@ -142,19 +142,19 @@ setup_file() {
 }
 
 @test "flox install stable.nixpkgs-flox-dup.hello" {
-  run $FLOX_CLI install -e $TEST_ENVIRONMENT stable.nixpkgs-flox-dup.hello
+  run $FLOX_CLI --bash-passthru install -e $TEST_ENVIRONMENT stable.nixpkgs-flox-dup.hello
   assert_failure
   assert_output --regexp ".*error: package nixpkgs-flox.$NIX_SYSTEM.stable.hello.latest is identical to package nixpkgs-flox-dup.$NIX_SYSTEM.stable.hello.latest"
 }
 
 @test "flox install cowsay jq dasel" {
-  run $FLOX_CLI --debug install -e $TEST_ENVIRONMENT cowsay jq dasel
+  run $FLOX_CLI  --bash-passthru --debug install -e $TEST_ENVIRONMENT cowsay jq dasel
   assert_success
   assert_output --partial "created generation 3"
 }
 
 @test "flox list after install should contain cowsay and hello" {
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru list -e $TEST_ENVIRONMENT
   assert_success
   assert_output --regexp "0  stable.nixpkgs-flox.cowsay +"$VERSION_REGEX
   assert_output --regexp "1  stable.nixpkgs-flox.dasel +"$VERSION_REGEX
@@ -163,13 +163,13 @@ setup_file() {
 }
 
 @test "flox edit remove hello" {
-  EDITOR=./tests/remove-hello run $FLOX_CLI edit -e $TEST_ENVIRONMENT
+  EDITOR=./tests/remove-hello run $FLOX_CLI --bash-passthru edit -e $TEST_ENVIRONMENT
   assert_success
   assert_output --partial "Environment '$TEST_ENVIRONMENT' modified."
 }
 
 @test "verify flox edit removed hello from manifest.json" {
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru list -e $TEST_ENVIRONMENT
   assert_success
   assert_output --regexp "0  stable.nixpkgs-flox.cowsay +"$VERSION_REGEX
   assert_output --regexp "1  stable.nixpkgs-flox.dasel +"$VERSION_REGEX
@@ -178,7 +178,7 @@ setup_file() {
 }
 
 @test "verify flox edit removed hello from flox.nix" {
-  EDITOR=cat run $FLOX_CLI edit -e $TEST_ENVIRONMENT
+  EDITOR=cat run $FLOX_CLI --bash-passthru edit -e $TEST_ENVIRONMENT
   assert_success
   assert_output --partial 'nixpkgs-flox.cowsay = {'
   assert_output --partial 'nixpkgs-flox.dasel = {'
@@ -188,13 +188,13 @@ setup_file() {
 }
 
 @test "flox edit add hello" {
-  EDITOR=./tests/add-hello run $FLOX_CLI edit -e $TEST_ENVIRONMENT
+  EDITOR=./tests/add-hello run $FLOX_CLI --bash-passthru edit -e $TEST_ENVIRONMENT
   assert_success
   assert_output --partial "Environment '$TEST_ENVIRONMENT' modified."
 }
 
 @test "verify flox edit added hello to manifest.json" {
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru list -e $TEST_ENVIRONMENT
   assert_success
   assert_output --regexp "0  stable.nixpkgs-flox.cowsay +"$VERSION_REGEX
   assert_output --regexp "1  stable.nixpkgs-flox.dasel +"$VERSION_REGEX
@@ -203,7 +203,7 @@ setup_file() {
 }
 
 @test "verify flox edit added hello to flox.nix" {
-  EDITOR=cat run $FLOX_CLI edit -e $TEST_ENVIRONMENT
+  EDITOR=cat run $FLOX_CLI --bash-passthru edit -e $TEST_ENVIRONMENT
   assert_success
   assert_output --partial 'nixpkgs-flox.cowsay = {'
   assert_output --partial 'nixpkgs-flox.dasel = {'
@@ -214,29 +214,29 @@ setup_file() {
 
 @test "flox edit preserves comments" {
   EDIT_ENVIRONMENT=_edit_testing_
-  run $FLOX_CLI create -e "$EDIT_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru create -e "$EDIT_ENVIRONMENT"
   assert_success
 
-  EDITOR=./tests/add-comment run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT"
+  EDITOR=./tests/add-comment run $FLOX_CLI --bash-passthru edit -e "$EDIT_ENVIRONMENT"
   assert_success
   assert_output --partial "Environment '$EDIT_ENVIRONMENT' modified."
 
-  EDITOR=cat run $FLOX_CLI edit -e "$EDIT_ENVIRONMENT"
+  EDITOR=cat run $FLOX_CLI --bash-passthru edit -e "$EDIT_ENVIRONMENT"
   assert_success
   assert_output --partial "# test comment"
 
-  run $FLOX_CLI delete --force -e "$EDIT_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru delete --force -e "$EDIT_ENVIRONMENT"
   assert_success
 }
 
 @test "flox remove hello" {
-  run $FLOX_CLI remove -e $TEST_ENVIRONMENT hello
+  run $FLOX_CLI --bash-passthru remove -e $TEST_ENVIRONMENT hello
   assert_success
   assert_output --partial "Removed 'hello' package(s) from '$TEST_ENVIRONMENT' environment."
 }
 
 @test "flox list after remove should not contain hello" {
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru list -e $TEST_ENVIRONMENT
   assert_success
   assert_output --regexp "0  stable.nixpkgs-flox.cowsay +"$VERSION_REGEX
   assert_output --regexp "1  stable.nixpkgs-flox.dasel +"$VERSION_REGEX
@@ -245,7 +245,7 @@ setup_file() {
 }
 
 @test "flox list of generation 3 should contain hello" {
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT 3
+  run $FLOX_CLI --bash-passthru list -e $TEST_ENVIRONMENT 3
   assert_success
   assert_output --regexp "0  stable.nixpkgs-flox.cowsay +"$VERSION_REGEX
   assert_output --regexp "1  stable.nixpkgs-flox.dasel +"$VERSION_REGEX
@@ -254,7 +254,7 @@ setup_file() {
 }
 
 @test "flox history should contain the install and removal of stable.nixpkgs-flox.hello" {
-  run $FLOX_CLI history -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru history -e $TEST_ENVIRONMENT
   assert_success
   assert_output --partial "removed stable.nixpkgs-flox.hello"
   assert_output --partial "installed stable.nixpkgs-flox.cowsay stable.nixpkgs-flox.jq stable.nixpkgs-flox.dasel"
@@ -263,7 +263,7 @@ setup_file() {
 }
 
 @test "flox remove from nonexistent environment should fail" {
-  run $FLOX_CLI remove -e does-not-exist hello
+  run $FLOX_CLI --bash-passthru remove -e does-not-exist hello
   assert_failure
   assert_output --partial "ERROR: environment does-not-exist ($NIX_SYSTEM) does not exist"
   run sh -c "$FLOX_CLI git branch -a | grep -q does-not-exist"
@@ -280,49 +280,49 @@ setup_file() {
 @test "flox remove channel package by index" {
   TEST_CASE_ENVIRONMENT="$(echo $RANDOM | md5sum | head -c 20; echo)"
 
-  run $FLOX_CLI install -e "$TEST_CASE_ENVIRONMENT" hello
+  run $FLOX_CLI --bash-passthru install -e "$TEST_CASE_ENVIRONMENT" hello
   assert_success
 
-  run $FLOX_CLI list -e "$TEST_CASE_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru list -e "$TEST_CASE_ENVIRONMENT"
   assert_success
   assert_output --regexp "0 +stable.nixpkgs-flox.hello +$VERSION_REGEX"
 
-  run $FLOX_CLI remove -e "$TEST_CASE_ENVIRONMENT" 0
+  run $FLOX_CLI --bash-passthru remove -e "$TEST_CASE_ENVIRONMENT" 0
   assert_success
   assert_output --partial                                                \
     "Removed '0' package(s) from '$TEST_CASE_ENVIRONMENT' environment."
 
-  run $FLOX_CLI list -e "$TEST_CASE_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru list -e "$TEST_CASE_ENVIRONMENT"
   assert_success
   refute_output --partial "stable.nixpkgs-flox.hello"
 
   # teardown
-  run $FLOX_CLI delete -e "$TEST_CASE_ENVIRONMENT" -f
+  run $FLOX_CLI --bash-passthru delete -e "$TEST_CASE_ENVIRONMENT" -f
   assert_success
 }
 
 @test "flox remove flake package by index" {
   TEST_CASE_ENVIRONMENT="$(echo $RANDOM | md5sum | head -c 20; echo)"
 
-  run $FLOX_CLI install -e "$TEST_CASE_ENVIRONMENT" nixpkgs#hello
+  run $FLOX_CLI --bash-passthru install -e "$TEST_CASE_ENVIRONMENT" nixpkgs#hello
   assert_success
 
-  run $FLOX_CLI list -e "$TEST_CASE_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru list -e "$TEST_CASE_ENVIRONMENT"
   assert_success
   assert_output --regexp  \
     "0 +nixpkgs#legacyPackages\.$NIX_SYSTEM\.hello +$VERSION_REGEX"
 
-  run $FLOX_CLI remove -e "$TEST_CASE_ENVIRONMENT" 0
+  run $FLOX_CLI --bash-passthru remove -e "$TEST_CASE_ENVIRONMENT" 0
   assert_success
   assert_output --partial  \
     "Removed '0' package(s) from '$TEST_CASE_ENVIRONMENT' environment."
 
-  run $FLOX_CLI list -e "$TEST_CASE_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru list -e "$TEST_CASE_ENVIRONMENT"
   assert_success
   refute_output --partial "nixpkgs#legacyPackages.$NIX_SYSTEM.hello"
 
   # teardown
-  run $FLOX_CLI delete -e "$TEST_CASE_ENVIRONMENT" -f
+  run $FLOX_CLI --bash-passthru delete -e "$TEST_CASE_ENVIRONMENT" -f
   assert_success
 }
 
@@ -368,40 +368,40 @@ setup_file() {
   run $FLOX_CLI subscribe nixpkgs-flox-upgrade-test github:flox/nixpkgs-flox/master
   assert_success
   # Note the use of --dereference to copy flake.{nix,lock} as files.
-  run sh -c "tar -cf - --dereference --mode u+w -C $TESTS_DIR/upgrade/$NIX_SYSTEM . | $FLOX_CLI import -e _upgrade_testing_"
+  run sh -c "tar -cf - --dereference --mode u+w -C $TESTS_DIR/upgrade/$NIX_SYSTEM . | $FLOX_CLI --bash-passthru import -e _upgrade_testing_"
   assert_success
-  run $FLOX_CLI activate -e _upgrade_testing_ -- sh -xc 'realpath $(which rg)'
+  run $FLOX_CLI --bash-passthru activate -e _upgrade_testing_ -- sh -xc 'realpath $(which rg)'
   assert_output --partial "$RG_PATH"
-  run $FLOX_CLI activate -e _upgrade_testing_ -- sh -xc 'realpath $(which curl)'
+  run $FLOX_CLI --bash-passthru activate -e _upgrade_testing_ -- sh -xc 'realpath $(which curl)'
   assert_output --partial "$CURL_PATH"
 
   # upgrade ripgrep but not curl
-  run $FLOX_CLI upgrade -e _upgrade_testing_ ripgrep
+  run $FLOX_CLI --bash-passthru upgrade -e _upgrade_testing_ ripgrep
   assert_success
   assert_output --partial "Environment '_upgrade_testing_' upgraded."
-  run $FLOX_CLI activate -e _upgrade_testing_ -- sh -xc 'realpath $(which rg)'
+  run $FLOX_CLI --bash-passthru activate -e _upgrade_testing_ -- sh -xc 'realpath $(which rg)'
   ! assert_output --partial "$RG_PATH"
-  run $FLOX_CLI activate -e _upgrade_testing_ -- sh -xc 'realpath $(which curl)'
+  run $FLOX_CLI --bash-passthru activate -e _upgrade_testing_ -- sh -xc 'realpath $(which curl)'
   assert_output --partial "$CURL_PATH"
 
   # upgrade everything
-  run $FLOX_CLI --debug upgrade -e _upgrade_testing_
+  run $FLOX_CLI --bash-passthru --debug upgrade -e _upgrade_testing_
   assert_success
   assert_output --partial "Environment '_upgrade_testing_' upgraded."
-  run $FLOX_CLI activate -e _upgrade_testing_ -- sh -xc 'realpath $(which rg)'
+  run $FLOX_CLI --bash-passthru activate -e _upgrade_testing_ -- sh -xc 'realpath $(which rg)'
   ! assert_output --partial "$RG_PATH"
-  run $FLOX_CLI activate -e _upgrade_testing_ -- sh -xc 'realpath $(which curl)'
+  run $FLOX_CLI --bash-passthru activate -e _upgrade_testing_ -- sh -xc 'realpath $(which curl)'
   ! assert_output --partial "$CURL_PATH"
 
   # teardown
   run $FLOX_CLI unsubscribe nixpkgs-flox-upgrade-test
   assert_success
-  run $FLOX_CLI delete -e _upgrade_testing_ -f
+  run $FLOX_CLI --bash-passthru delete -e _upgrade_testing_ -f
   assert_success
 }
 
 @test "flox upgrade of nonexistent environment should fail" {
-  run $FLOX_CLI upgrade -e does-not-exist
+  run $FLOX_CLI --bash-passthru upgrade -e does-not-exist
   assert_failure
   assert_output --partial "ERROR: environment does-not-exist ($NIX_SYSTEM) does not exist"
   run sh -c "$FLOX_CLI git branch -a | grep -q does-not-exist"
@@ -417,7 +417,7 @@ setup_file() {
 }
 
 @test "flox rollback of nonexistent environment should fail" {
-  run $FLOX_CLI rollback -e does-not-exist
+  run $FLOX_CLI --bash-passthru rollback -e does-not-exist
   assert_failure
   assert_output --partial "ERROR: environment does-not-exist ($NIX_SYSTEM) does not exist"
   run sh -c "$FLOX_CLI git branch -a | grep -q does-not-exist"
@@ -433,13 +433,13 @@ setup_file() {
 }
 
 @test "flox rollback" {
-  run $FLOX_CLI rollback -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru rollback -e $TEST_ENVIRONMENT
   assert_success
   assert_output --partial "Rolled back environment '$TEST_ENVIRONMENT' from generation 6 to 5."
 }
 
 @test "flox list after rollback should reflect generation 2" {
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru list -e $TEST_ENVIRONMENT
   assert_success
   assert_output --regexp "0  stable.nixpkgs-flox.cowsay +"$VERSION_REGEX
   assert_output --regexp "1  stable.nixpkgs-flox.dasel +"$VERSION_REGEX
@@ -448,10 +448,10 @@ setup_file() {
 }
 
 @test "flox rollback --to 4" {
-  run $FLOX_CLI rollback --to 4 -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru rollback --to 4 -e $TEST_ENVIRONMENT
   assert_success
   assert_output --regexp "Rolled back environment '$TEST_ENVIRONMENT' from generation [0-9]+ to 4."
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru list -e $TEST_ENVIRONMENT
   assert_success
   assert_output --partial "Curr Gen  4"
   assert_output --regexp "0  stable.nixpkgs-flox.cowsay +"$VERSION_REGEX
@@ -461,10 +461,10 @@ setup_file() {
 }
 
 @test "flox switch-generation 2" {
-  run $FLOX_CLI switch-generation 2 -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru switch-generation 2 -e $TEST_ENVIRONMENT
   assert_success
   assert_output --regexp "Switched environment '$TEST_ENVIRONMENT' from generation [0-9]+ to 2."
-  run $FLOX_CLI list -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru list -e $TEST_ENVIRONMENT
   assert_success
   assert_output --partial "Curr Gen  2"
   assert_output --regexp "0  stable.nixpkgs-flox.hello +"$VERSION_REGEX
@@ -474,26 +474,26 @@ setup_file() {
 }
 
 @test "flox switch-generation 9999" {
-  run $FLOX_CLI switch-generation 9999 -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru switch-generation 9999 -e $TEST_ENVIRONMENT
   assert_failure
   assert_output --partial "ERROR: could not find environment data for generation '9999'"
 }
 
 @test "flox environments takes no arguments" {
-  run $FLOX_CLI environments -e $TEST_ENVIRONMENT
+  run $FLOX_CLI --bash-passthru environments -e $TEST_ENVIRONMENT
   assert_failure
-  assert_output --partial '`-e` is not expected in this context'
+  # assert_output --partial '`-e` is not expected in this context' # this is a bpaf error, cant expect that with --bash-passthru`
 }
 
 @test "flox environments should at least contain $TEST_ENVIRONMENT" {
-  run $FLOX_CLI --debug environments
+  run $FLOX_CLI --bash-passthru --debug environments
   assert_success
   assert_output --partial "/$TEST_ENVIRONMENT"
   assert_output --partial "Alias     $TEST_ENVIRONMENT"
 }
 
 @test "flox delete local only" {
-  run $FLOX_CLI delete -e $TEST_ENVIRONMENT -f
+  run $FLOX_CLI --bash-passthru delete -e $TEST_ENVIRONMENT -f
   assert_success
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
@@ -501,37 +501,37 @@ setup_file() {
 }
 
 @test "flox install by /nix/store path" {
-  run $FLOX_CLI install -e $TEST_ENVIRONMENT "$HELLO_PACKAGE"
+  run $FLOX_CLI --bash-passthru install -e $TEST_ENVIRONMENT "$HELLO_PACKAGE"
   assert_success
   assert_output --partial "Installed '$HELLO_PACKAGE' package(s) into '$TEST_ENVIRONMENT' environment."
 }
 
 @test "flox install by nixpkgs flake" {
-  run $FLOX_CLI install -e $TEST_ENVIRONMENT "nixpkgs#cowsay"
+  run $FLOX_CLI --bash-passthru install -e $TEST_ENVIRONMENT "nixpkgs#cowsay"
   assert_success
   assert_output --partial "Installed 'nixpkgs#cowsay' package(s) into '$TEST_ENVIRONMENT' environment."
 }
 
 @test "flox export to $FLOX_TEST_HOME/floxExport.tar" {
-  run sh -c "$FLOX_CLI export -e $TEST_ENVIRONMENT > $FLOX_TEST_HOME/floxExport.tar"
+  run sh -c "$FLOX_CLI --bash-passthru export -e $TEST_ENVIRONMENT > $FLOX_TEST_HOME/floxExport.tar"
   assert_success
 }
 
 @test "flox.nix after installing by nixpkgs flake should contain package" {
-  EDITOR='cat' run $FLOX_CLI edit -e "$TEST_ENVIRONMENT"
+  EDITOR='cat' run $FLOX_CLI --bash-passthru edit -e "$TEST_ENVIRONMENT"
   assert_success
   assert_output --partial 'packages.nixpkgs.cowsay = {};'
   refute_output --partial "created generation"
 }
 
 @test "flox remove by nixpkgs flake 1" {
-  run $FLOX_CLI remove -e "$TEST_ENVIRONMENT" "nixpkgs#cowsay"
+  run $FLOX_CLI --bash-passthru remove -e "$TEST_ENVIRONMENT" "nixpkgs#cowsay"
   assert_success
   assert_output --partial "Removed 'nixpkgs#cowsay' package(s) from '$TEST_ENVIRONMENT' environment."
 }
 
 @test "flox list after remove by nixpkgs flake 2 should not contain package" {
-  run $FLOX_CLI list -e "$TEST_ENVIRONMENT"
+  run $FLOX_CLI --bash-passthru list -e "$TEST_ENVIRONMENT"
   assert_success
   assert_output --regexp "[0-9]+ +$HELLO_PACKAGE +$HELLO_PACKAGE_FIRST8"
   refute_output --partial "nixpkgs#cowsay"
@@ -539,13 +539,13 @@ setup_file() {
 }
 
 @test "flox import from $FLOX_TEST_HOME/floxExport.tar" {
-  run sh -c "$FLOX_CLI import -e $TEST_ENVIRONMENT < $FLOX_TEST_HOME/floxExport.tar"
+  run sh -c "$FLOX_CLI --bash-passthru import -e $TEST_ENVIRONMENT < $FLOX_TEST_HOME/floxExport.tar"
   assert_success
   assert_output --partial "Environment '$TEST_ENVIRONMENT' imported."
 }
 
 @test "tear down install test state" {
-  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI delete -e $TEST_ENVIRONMENT --origin -f"
+  run sh -c "XDG_CONFIG_HOME=$REAL_XDG_CONFIG_HOME GH_CONFIG_DIR=$REAL_GH_CONFIG_DIR $FLOX_CLI --bash-passthru delete -e $TEST_ENVIRONMENT --origin -f"
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/tests/multi-env.bats
+++ b/tests/multi-env.bats
@@ -23,10 +23,10 @@ setup_file() {
   hello_pkg_setup;
   deleteEnvForce "${TEST_ENVIRONMENT}-1";
   deleteEnvForce "${TEST_ENVIRONMENT}-2";
-  $FLOX_CLI create  -e "${TEST_ENVIRONMENT}-1";
-  $FLOX_CLI install -e "${TEST_ENVIRONMENT}-1" "$HELLO_PACKAGE";
-  $FLOX_CLI create  -e "${TEST_ENVIRONMENT}-2";
-  $FLOX_CLI install -e "${TEST_ENVIRONMENT}-2" "$HELLO_PACKAGE";
+  $FLOX_CLI --bash-passthru create  -e "${TEST_ENVIRONMENT}-1";
+  $FLOX_CLI --bash-passthru install -e "${TEST_ENVIRONMENT}-1" "$HELLO_PACKAGE";
+  $FLOX_CLI --bash-passthru create  -e "${TEST_ENVIRONMENT}-2";
+  $FLOX_CLI --bash-passthru install -e "${TEST_ENVIRONMENT}-2" "$HELLO_PACKAGE";
 }
 
 teardown_file() {
@@ -41,7 +41,7 @@ teardown_file() {
 
 @test "flox activate on multiple environments" {
   #shellcheck disable=SC2016
-  run "$FLOX_CLI" activate                                   \
+  run "$FLOX_CLI" --bash-passthru activate                                   \
       -e "${TEST_ENVIRONMENT}-1" -e "${TEST_ENVIRONMENT}-2"  \
       -- bash -c 'test -d "$FLOX_ENV" && echo "FLOX_ENV: $FLOX_ENV"';
   assert_success;

--- a/tests/package.bats
+++ b/tests/package.bats
@@ -10,20 +10,20 @@ setup_file() {
 }
 
 @test "flox install by /nix/store path" {
-  run "$FLOX_CLI" install -e "$TEST_ENVIRONMENT" "$HELLO_PACKAGE"
+  run "$FLOX_CLI" --bash-passthru  install -e "$TEST_ENVIRONMENT" "$HELLO_PACKAGE"
   assert_success
   assert_output --partial "Installed '$HELLO_PACKAGE' package(s) into '$TEST_ENVIRONMENT' environment."
 }
 
 @test "flox list after installing by store path should contain package" {
-  run "$FLOX_CLI" list -e "$TEST_ENVIRONMENT"
+  run "$FLOX_CLI" --bash-passthru  list -e "$TEST_ENVIRONMENT"
   assert_success
   assert_output --partial "Curr Gen  1"
   assert_output --partial "0  $HELLO_PACKAGE  $HELLO_PACKAGE_FIRST8"
 }
 
 @test "tear down install test state" {
-  run $FLOX_CLI delete -e "$TEST_ENVIRONMENT" --origin -f||:
+  run $FLOX_CLI  --bash-passthru delete -e "$TEST_ENVIRONMENT" --origin -f||:
   assert_output --partial "WARNING: you are about to delete the following"
   assert_output --partial "Deleted branch"
   assert_output --partial "removed"

--- a/tests/progs.bats
+++ b/tests/progs.bats
@@ -87,11 +87,11 @@ cmds=(
 # ---------------------------------------------------------------------------- #
 
 @test "ensure activated shell doesn't inherit '_${cmds[1]}'" {
-  run "$FLOX_CLI" create -e "$TEST_ENVIRONMENT";
+  run "$FLOX_CLI" --bash-passthru create -e "$TEST_ENVIRONMENT";
   assert_success;
-  run "$FLOX_CLI" install -e "$TEST_ENVIRONMENT" hello bash;
+  run "$FLOX_CLI" --bash-passthru install -e "$TEST_ENVIRONMENT" hello bash;
   assert_success;
-  run "$FLOX_CLI" activate -e "$TEST_ENVIRONMENT" --  \
+  run "$FLOX_CLI" --bash-passthru activate -e "$TEST_ENVIRONMENT" --  \
         bash -c "echo \"\${_${cmds[1]}:-NOPE}\";";
   assert_output --partial NOPE;
 }

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -334,7 +334,7 @@ gitconfig_setup() {
 # Force the destruction of an env including any remote metdata.
 deleteEnvForce() {
   flox_location_setup;
-  { $FLOX_CLI delete -e "${1?}" --origin -f||:; } >/dev/null 2>&1;
+  { $FLOX_CLI --bash-passthru delete -e "${1?}" --origin -f||:; } >/dev/null 2>&1;
   return 0;
 }
 


### PR DESCRIPTION
Add argument parsers for `--dir` and `--remote` and make changes to `Environment` in order to use the trait as a trait object in cases where we don't need/want to know the concrete implementation.

[BREAKING CHANGE]: removing the `-e`/`--environment` flag is backwards incompatible with the legacy flox commands. The bash implemented commands can be recovered using the `--bash-passthru` flag. All Tests that test the legacy behavior have hence been edited to contain this flag in [c299877](https://github.com/flox/flox/pull/272/commits/c299877778b3681b954aa41cc29dd1694ce97377)


* [refactor: make environment trait "object save"](https://github.com/flox/flox/commit/5fe6875f449d2e4ef26b0e20f71a0b3373429727)

In order to create trait objects of the Environment trait, e.g. `Box<dyn Environment>`
the trait needs to "object safe" [1].
One criterion that makes traits not object safe are generic trait methods

    fn my_thing<T>(T) -> ();

The Environment trait as it was before was using `impl AsRef<...>` as argument types,
which is syntax sugar for an unnamed generic parameter, hence making `Environment` not
trait safe.

Another criterion are sized `Self` parameters, i.e. any methods consuming `self` requires
a "Sized" self, in short: the concrete Type needs to be known.
`Evironment::delete` was thus extended with a `where Self: Sized` boundary.

* [feat: add environment selection argument handling](https://github.com/flox/flox/commit/cd7ef6327edae5605225d28e62219236622ab333)

Add argument parser for `--dir` and `--remote`.
Implement resolution to concrete `Environments` and dynamic trait objects


* [fix(regression): remove ident from PathEnvironment::open](https://github.com/flox/flox/pull/272/commits/38ad869ad3596828b1199617ac38dea2076f9c73)

There is at most one environment in any `.flox/` dir.
The `ident` argument was used to choose one of N environments which is now obsolete.
We removed code for reading `.flox` from the cli crate
so logic to determine the name of the env is now contained within the `open` method.

* [refactor: do not store an EnvironmentRef](https://github.com/flox/flox/pull/272/commits/69ec53f2a96ff4962b18d43d65b584890ecfce44)

No need to store an `EnvironmentRef` within path environments if they can never have an owner


[1]: https://doc.rust-lang.org/reference/items/traits.html#object-safety



