### PR TITLE
fix: return 0 when not using default git_base_url

### DIFF
--- a/flox-bash/lib/metadata.sh
+++ b/flox-bash/lib/metadata.sh
@@ -214,7 +214,7 @@ function temporaryMigrateGitHubTo030Floxdev() {
 	trace "$@"
 	local workDir="$1"; shift
 	# First assert that $git_base_url has not been overridden.
-	[[ "$git_base_url" == "https://git.hub.flox.dev/" ]] || return
+	[[ "$git_base_url" == "https://git.hub.flox.dev/" ]] || return 0
 	# Identify the real environmentMetaDir from the workdir clone.
 	local realEnvironmentMetaDir
 	realEnvironmentMetaDir="$(


### PR DESCRIPTION
The temporaryMigrateGitHubTo030Floxdev() function was failing when run with a non-default git_base_url. This patch fixes the bug by ensuring it returns 0 (success) when invoked against a non-default git_base_url.