### PR TITLE
fix: use pkgdb directly as a flake

### DIFF
--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -33,7 +33,6 @@
   pandoc,
   parser-util,
   ps,
-  flox-pkgdb,
   pkgs,
   shellcheck,
   shfmt,
@@ -43,6 +42,7 @@
   semver,
   builtfilter-rs,
 }: let
+  pkgdb = inputs.pkgdb.packages.flox-pkgdb;
   # The getent package can be found in pkgs.unixtools.
   inherit (pkgs.unixtools) getent;
 
@@ -127,7 +127,7 @@ in
       semver
       builtfilter-rs
       parser-util
-      flox-pkgdb
+      pkgdb
     ];
     makeFlags =
       [

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -1,1 +1,0 @@
-{inputs, ...}: inputs.pkgdb.packages.flox-pkgdb

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -18,7 +18,6 @@
   flox-bash,
   parser-util,
   pandoc,
-  flox-pkgdb,
   cacert,
   glibcLocales,
   installShellFiles,
@@ -31,6 +30,7 @@
 }: let
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = inputs.crane.mkLib nixpkgs;
+  pkgdb = inputs.pkgdb.packages.flox-pkgdb;
 
   # build time environment variables
   envs =
@@ -41,7 +41,7 @@
       NIX_BIN = "${flox-bash}/libexec/flox/nix";
       GIT_BIN = "${gitMinimal}/bin/git";
       PARSER_UTIL_BIN = parser-util.outPath + "/bin/parser-util";
-      PKGDB_BIN = flox-pkgdb.outPath + "/bin/pkgdb";
+      PKGDB_BIN = pkgdb.outPath + "/bin/pkgdb";
       FLOX_GH_BIN = flox-gh.outPath + "/bin/flox-gh";
       GH_BIN = gh.outPath + "/bin/gh";
 


### PR DESCRIPTION
pkgdb is simply re-exposed in pkgd/flox-pkdb/default.nix which is unnecessary indirection.
