### PR TITLE
feat: git open method

### DIFF
--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -286,20 +286,19 @@ impl GitCommandProvider {
 
     /// Open a repo, erroring if `path` is not a repo or is a subdirectory of a repo
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitCommandOpenError> {
-        let out = GitCommandProvider::run_command(
+        let out_str = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&Some(&path))
                 .arg("rev-parse")
                 .arg("--is-bare-repository"),
-        )?;
-
-        let out_str = out
-            .to_str()
-            .ok_or(GitCommandDiscoverError::GitDirEncoding)?;
+        )?
+        .to_str()
+        .ok_or(GitCommandDiscoverError::GitDirEncoding)?
+        .to_string();
 
         let bare = out_str
             .trim()
             .parse::<bool>()
-            .map_err(|_| GitCommandDiscoverError::UnexpectedOutput(out_str.to_string()))?;
+            .map_err(|_| GitCommandDiscoverError::UnexpectedOutput(out_str))?;
 
         let toplevel_or_git_dir = if bare {
             GitCommandProvider::run_command(
@@ -403,20 +402,19 @@ impl GitProvider for GitCommandProvider {
     type ShowError = GitCommandError;
 
     async fn discover<P: AsRef<Path>>(path: P) -> Result<Self, Self::DiscoverError> {
-        let out = GitCommandProvider::run_command(
+        let out_str = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&Some(&path))
                 .arg("rev-parse")
                 .arg("--is-bare-repository"),
-        )?;
-
-        let out_str = out
-            .to_str()
-            .ok_or(GitCommandDiscoverError::GitDirEncoding)?;
+        )?
+        .to_str()
+        .ok_or(GitCommandDiscoverError::GitDirEncoding)?
+        .to_string();
 
         let bare = out_str
             .trim()
             .parse::<bool>()
-            .map_err(|_| GitCommandDiscoverError::UnexpectedOutput(out_str.to_string()))?;
+            .map_err(|_| GitCommandDiscoverError::UnexpectedOutput(out_str))?;
 
         if bare {
             return Ok(GitCommandProvider {

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -771,7 +771,7 @@ pub mod tests {
         let (_, tempdir_handle) = init_temp_repo(false).await;
         let path = tempdir_handle.path().to_path_buf();
         assert_eq!(
-            GitCommandProvider::open(path.clone()).unwrap(),
+            GitCommandProvider::open(&path).unwrap(),
             GitCommandProvider {
                 workdir: Some(path.clone()),
                 path
@@ -785,7 +785,7 @@ pub mod tests {
         let (_, tempdir_handle) = init_temp_repo(true).await;
         let path = tempdir_handle.path().to_path_buf();
         assert_eq!(
-            GitCommandProvider::open(path.clone()).unwrap(),
+            GitCommandProvider::open(&path).unwrap(),
             GitCommandProvider {
                 workdir: None,
                 path
@@ -800,7 +800,7 @@ pub mod tests {
         let path = tempdir_handle.path().to_path_buf();
 
         let subdirectory = path.join("subdirectory");
-        std::fs::create_dir(subdirectory.clone()).unwrap();
+        std::fs::create_dir(&subdirectory).unwrap();
 
         assert!(matches!(
             GitCommandProvider::open(subdirectory),

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -284,7 +284,7 @@ impl GitCommandProvider {
         Ok(OsString::from_vec(out.stdout))
     }
 
-    /// open repo, erroring if path is not a repo or is a subdirectory of a repo
+    /// Open a repo, erroring if `path` is not a repo or is a subdirectory of a repo
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitCommandOpenError> {
         let path = path.as_ref().to_path_buf();
 

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -286,8 +286,6 @@ impl GitCommandProvider {
 
     /// Open a repo, erroring if `path` is not a repo or is a subdirectory of a repo
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitCommandOpenError> {
-        let path = path.as_ref().to_path_buf();
-
         let out = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&Some(&path))
                 .arg("rev-parse")
@@ -325,6 +323,8 @@ impl GitCommandProvider {
         )
         .canonicalize()
         .map_err(GitCommandOpenError::Canonicalize)?;
+
+        let path = path.as_ref().to_path_buf();
 
         if canonicalized
             != path

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -285,6 +285,8 @@ impl GitCommandProvider {
     }
 
     /// Open a repo, erroring if `path` is not a repo or is a subdirectory of a repo
+    //
+    // TODO should share more code with discover?
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitCommandOpenError> {
         let out_str = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&Some(&path))


### PR DESCRIPTION
Open a repo, but don't search upwards, instead erroring if a subdirectory of a repo is specified.

We currently only have a discover method which searches upwards.