### PR TITLE
feat: add 'flox show' command

### DIFF
--- a/crates/flox-rust-sdk/src/models/search.rs
+++ b/crates/flox-rust-sdk/src/models/search.rs
@@ -34,6 +34,14 @@ pub enum SearchError {
     PkgDbCall(std::io::Error),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ShowError {
+    #[error("failed to perform search: {0}")]
+    Search(#[from] SearchError),
+    #[error("invalid search term: {0}")]
+    InvalidSearchTerm(String),
+}
+
 /// The input parameters for the `pkgdb search` command
 ///
 /// C++ docs: https://flox.github.io/pkgdb/structflox_1_1pkgdb_1_1PkgQueryArgs.html

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -298,6 +298,7 @@ pub struct Show {
 
 impl Show {
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("show");
         let search_params = construct_show_params(&self.search_term, &flox)?;
 
         let (search_results, exit_status) = do_search(&search_params)?;

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -31,7 +31,6 @@ use crate::utils::dialog::{Dialog, Select, Text};
 use crate::utils::init::{DEFAULT_CHANNELS, HIDDEN_CHANNELS};
 
 const SEARCH_INPUT_SEPARATOR: &'_ str = ":";
-const SEARCH_INPUT_SEPARATOR: &'_ str = ":";
 
 #[derive(Bpaf, Clone)]
 pub struct ChannelArgs {}

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -7,13 +7,7 @@ use bpaf::Bpaf;
 use derive_more::Display;
 use flox_rust_sdk::flox::{Flox, DEFAULT_OWNER};
 use flox_rust_sdk::models::search::{
-    do_search,
-    Query,
-    Registry,
-    RegistryDefaults,
-    RegistryInput,
-    SearchParams,
-    SearchResults,
+    do_search, Query, Registry, RegistryDefaults, RegistryInput, SearchParams, SearchResults,
 };
 use flox_rust_sdk::nix::command::FlakeMetadata;
 use flox_rust_sdk::nix::command_line::NixCommandLine;
@@ -272,6 +266,21 @@ fn dedup_and_disambiguate_display_items(mut display_items: Vec<DisplayItem>) -> 
     }
 
     deduped_display_items
+}
+
+/// Show detailed package information
+#[derive(Bpaf, Clone)]
+pub struct Show {
+    /// The package to show detailed information about. Must be an exact match
+    /// for a package name e.g. something copy-pasted from the output of `flox search`.
+    #[bpaf(positional("search-term"))]
+    pub search_term: Option<String>,
+}
+
+impl Show {
+    pub async fn handle(self, _flox: Flox) -> Result<()> {
+        todo!()
+    }
 }
 
 #[derive(Bpaf, Clone)]

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -7,7 +7,15 @@ use bpaf::Bpaf;
 use derive_more::Display;
 use flox_rust_sdk::flox::{Flox, DEFAULT_OWNER};
 use flox_rust_sdk::models::search::{
-    do_search, Query, Registry, RegistryDefaults, RegistryInput, SearchParams, SearchResults,
+    do_search,
+    Query,
+    Registry,
+    RegistryDefaults,
+    RegistryInput,
+    SearchParams,
+    SearchResult,
+    SearchResults,
+    ShowError,
 };
 use flox_rust_sdk::nix::command::FlakeMetadata;
 use flox_rust_sdk::nix::command_line::NixCommandLine;
@@ -101,6 +109,26 @@ impl Search {
 }
 
 fn construct_search_params(search_term: &str, flox: &Flox) -> Result<SearchParams> {
+    // Create `registry` parameter for `pkgdb`
+    let (inputs, priority) = collect_inputs(flox);
+    let registry = Registry {
+        inputs,
+        priority,
+        defaults: RegistryDefaults::default(),
+    };
+
+    // We've already checked that the search term is Some(_)
+    let query = Query::from_str(search_term)?;
+
+    Ok(SearchParams {
+        registry,
+        query,
+        systems: Some(vec![flox.system.clone()]),
+        ..SearchParams::default()
+    })
+}
+
+fn collect_inputs(flox: &Flox) -> (HashMap<String, RegistryInput>, Vec<String>) {
     let channels = flox
         .channels
         .iter()
@@ -128,21 +156,7 @@ fn construct_search_params(search_term: &str, flox: &Flox) -> Result<SearchParam
         };
         inputs.insert(entry.from.id.to_string(), input);
     }
-    let registry = Registry {
-        inputs,
-        priority,
-        defaults: RegistryDefaults::default(),
-    };
-
-    // We've already checked that the search term is Some(_)
-    let query = Query::from_str(search_term)?;
-
-    Ok(SearchParams {
-        registry,
-        query,
-        systems: Some(vec![flox.system.clone()]),
-        ..SearchParams::default()
-    })
+    (inputs, priority)
 }
 
 /// An intermediate representation of a search result used for rendering
@@ -274,13 +288,97 @@ pub struct Show {
     /// The package to show detailed information about. Must be an exact match
     /// for a package name e.g. something copy-pasted from the output of `flox search`.
     #[bpaf(positional("search-term"))]
-    pub search_term: Option<String>,
+    pub search_term: String,
 }
 
 impl Show {
-    pub async fn handle(self, _flox: Flox) -> Result<()> {
-        todo!()
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        let search_params = construct_show_params(&self.search_term, &flox)?;
+
+        let (search_results, exit_status) = do_search(&search_params)?;
+
+        if search_results.results.is_empty() {
+            bail!("no packages matched this search term: {}", self.search_term);
+        }
+        // Render what we have no matter what, then indicate whether we encountered an error.
+        // FIXME: We may have warnings on `stderr` even with a successful call to `pkgdb`.
+        //        We aren't checking that at all at the moment because better overall error handling
+        //        is coming in a later PR.
+        render_show(search_results.results.as_slice())?;
+        if exit_status.success() {
+            Ok(())
+        } else {
+            bail!(
+                "pkgdb exited with status code: {}",
+                exit_status.code().unwrap_or(-1),
+            );
+        }
     }
+}
+
+fn construct_show_params(search_term: &str, flox: &Flox) -> Result<SearchParams> {
+    let parts = search_term
+        .split(SEPARATOR)
+        .map(String::from)
+        .collect::<Vec<_>>();
+    let (input_name, package_name) = match parts.len() {
+        1 => Ok((None, Some(parts[0].clone()))),
+        2 => Ok((Some(parts[0].clone()), Some(parts[1].clone()))),
+        _ => Err(ShowError::InvalidSearchTerm(search_term.into())),
+    }?;
+
+    // If we're given a specific input to search, only search that one,
+    // otherwise build the whole list of inputs to search
+    let (inputs, priority) = if let Some(input_name) = input_name {
+        let Some(reg_input) = flox
+            .channels
+            .iter()
+            .find(|entry| entry.from.id == input_name)
+            .map(|entry| RegistryInput {
+                from: entry.to.clone(),
+                subtrees: None,
+                stabilities: None,
+            })
+        else {
+            bail!("registry did not contain an input named '{}'", input_name)
+        };
+        let mut inputs = HashMap::new();
+        inputs.insert(input_name.clone(), reg_input);
+        (inputs, vec![input_name])
+    } else {
+        collect_inputs(flox)
+    };
+
+    // Only search the registry input that the search result comes from
+    let registry = Registry {
+        inputs,
+        priority,
+        ..Registry::default()
+    };
+    let query = Query {
+        r#match: package_name,
+        ..Query::default()
+    };
+
+    Ok(SearchParams {
+        registry,
+        query,
+        ..SearchParams::default()
+    })
+}
+
+fn render_show(search_results: &[SearchResult]) -> Result<()> {
+    // FIXME: Proper rendering is coming later
+    for package in search_results.iter() {
+        let pkg_name = package.pkg_subpath.join(".");
+        let description = package
+            .description
+            .as_ref()
+            .map(|d| d.replace('\n', " "))
+            .unwrap_or("<no description provided>".into());
+        println!("{} - {}", pkg_name, description);
+    }
+    Ok(())
 }
 
 #[derive(Bpaf, Clone)]

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -237,6 +237,9 @@ enum LocalDevelopmentCommands {
     /// Search packages in subscribed channels
     #[bpaf(command)]
     Search(#[bpaf(external(channel::search))] channel::Search),
+    /// Show detailed information about a single package
+    #[bpaf(command, long("show"))]
+    Show(#[bpaf(external(channel::show))] channel::Show),
     /// Install a package into an environment
     #[bpaf(command)]
     Install(#[bpaf(external(environment::install))] environment::Install),
@@ -295,6 +298,10 @@ impl LocalDevelopmentCommands {
                 subcommand_metric!("search");
                 flox_forward(&flox).await?
             },
+            LocalDevelopmentCommands::Show(_) if Feature::Channels.is_forwarded()? => {
+                subcommand_metric!("show");
+                flox_forward(&flox).await?
+            },
 
             LocalDevelopmentCommands::Init(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::Activate(args) => args.handle(flox).await?,
@@ -304,6 +311,7 @@ impl LocalDevelopmentCommands {
             LocalDevelopmentCommands::List(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::Nix(args) => args.handle(config, flox).await?,
             LocalDevelopmentCommands::Search(args) => args.handle(flox).await?,
+            LocalDevelopmentCommands::Show(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::Run(args) => args.handle(config, flox).await?,
             LocalDevelopmentCommands::Delete(args) => args.handle(flox).await?,
         }

--- a/tests/channels-show.bats
+++ b/tests/channels-show.bats
@@ -1,0 +1,80 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test of rust impl of 'flox show'
+#
+# bats file_tags=search,show
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup;
+  project_setup;
+}
+teardown() {
+  project_teardown;
+  common_test_teardown;
+}
+
+setup_file() {
+  export FLOX_FEATURES_CHANNELS=rust;
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' can be called at all" {
+  run "$FLOX_CLI" show hello;
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' accepts specific input" {
+  run "$FLOX_CLI" show nixpkgs-flox:hello;
+  assert_success;
+  # TODO: better testing once the formatting is implemented
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' accepts search output without separator" {
+  run "$FLOX_CLI" search hello;
+  assert_success;
+  first_result="${lines[0]%% *}";
+  run "$FLOX_CLI" show "$first_result";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' accepts search output with separator" {
+  run "$FLOX_CLI" search nixpkgs-flox:hello;
+  assert_success;
+  first_result="${lines[0]%% *}";
+  run "$FLOX_CLI" show "$first_result";
+  assert_success;
+}

--- a/tests/environment-list.bats
+++ b/tests/environment-list.bats
@@ -43,9 +43,8 @@ setup_file() {
 }
 
 @test "'flox list' lists packages of environment in the current dir; fails if no env found" {
-  run "$FLOX_CLI" list
-  assert_failure
-  assert_line "No matching environments found"
+  run "$FLOX_CLI" list;
+  assert_failure;
 }
 
 @test "'flox list' lists packages of environment in the current dir; No package" {

--- a/tests/usage.bats
+++ b/tests/usage.bats
@@ -48,6 +48,7 @@ Local Development Commands
     init           Create an environment in the current directory
     activate       Activate environment
     search         Search packages in subscribed channels
+    show           Show detailed information about a single package
     install        Install a package into an environment
     uninstall      Uninstall installed packages from an environment
     edit           Edit declarative environment configuration


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This adds a bare bones feature-flagged `flox show` command. The output is currently just a list of the search results from the provided package name, but the command is aware of disambiguated packages. Properly formatted output is coming in later PRs.

Closes flox/product#356.

## Current Behavior

<!-- Describe the current behavior before applying this pull request. -->

N/A


## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
