### PR TITLE
feat: check `FLOX_BASH_PASSTHRU` in addition to `bash-passthru`

### DIFF
--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -599,13 +599,17 @@ impl BashPassthru {
             .run_inner(Args::current_args())
             .unwrap_or_default();
 
+        let args = std::env::args()
+            .skip(1)
+            .filter(|arg| arg != "--bash-passthru")
+            .collect();
+
         if passtrhu.do_passthru {
-            return Some(
-                std::env::args()
-                    .skip(1)
-                    .filter(|arg| arg != "--bash-passthru")
-                    .collect(),
-            );
+            return Some(args);
+        }
+
+        if let Ok("true") = env::var("FLOX_BASH_PASSTHRU").as_deref() {
+            return Some(args);
         }
 
         None


### PR DESCRIPTION
Allows users to drop back to legacy behavior by setting an environment variable