### PR TITLE
chore: use larger x86_64-linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         - {name: flox-bash, job_description: "Build" }
         - {name: nix-editor, job_description: "Build" }
         os: 
-        - ubuntu-latest
+        - ubuntu-22.04-8core
         - macos-latest
 
     steps:


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This PR has no effect on `flox` itself, it's just adding a larger runner for CI.

## Current Behavior

<!-- Describe the current behavior before applying this pull request. -->


## Checks

<!-- Please confirm the following: -->

- [ ] All tests pass.
- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
