### PR TITLE
feat: report full upgrade details

### DIFF
--- a/flox-bash/lib/diff-catalogs.jq
+++ b/flox-bash/lib/diff-catalogs.jq
@@ -127,7 +127,10 @@ packagePaths($unique_b) as $unique_b_paths |
     . as $packagePath |
     ( $unique_a | getpath($packagePath) ) as $package_a |
     ( $unique_b | getpath($packagePath) ) as $package_b |
-    if ($package_a != null) then [$packagePath, $package_b] else empty end
+    if ($package_a != null) then [$packagePath, {
+      "from-package": $package_a,
+      "to-package": $package_b
+    }] else empty end
   )
 ) | flatten(1) as $upgrades |
 


### PR DESCRIPTION
The diff-catalogs.jq script was reporting the new package to be upgraded, but not the old package being upgraded. With this patch it now reports both, introducing the new "from-package" and "to-package" keys in the process.

This is an internal change with no user-facing changes.