### PR TITLE
perf: sequence CI builds and improve cache push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
@@ -34,6 +38,14 @@ jobs:
         substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: Restore Nix Caches
+      id: nix-cache-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cache/nix
+        key: ${{ runner.os }}-nix-cache
 
     # This is used to detect any new store paths we create while running builds
     # so that they can be pushed to caches.
@@ -118,6 +130,15 @@ jobs:
       run: |
         git clean -xfd;
         nix run --no-update-lock-file '.#flox-tests';
+
+    - name: Save Nix Caches
+      id: nix-cache-save
+      uses: actions/cache/save@v3
+      if: ${{ always() }}
+      with:
+        path: |
+          ~/.cache/nix
+        key: ${{ steps.nix-cache-restore.outputs.cache-primary-key }}
 
 
   # TODO: remove this job after merging to `main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
           wc -l "$NEW_STORE_PATHS_FILE"|cut -d' ' -f1;
         ) new $NIX_STORE_DIR paths" >&2;
         # Allow pushing to fail.
-        cat "$NEW_STORE_PATHS_FILE"                           \
-          |nix copy --stdin --to "$FLOX_SUBSTITUTER" -vv||:;
+        cat "$NEW_STORE_PATHS_FILE"                            \
+          |xargs -r nix copy --to "$FLOX_SUBSTITUTER" -vv||:;
 
     # These cannot be run offline so we need to build in our tree.
     - name: Rust Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-latest
+        - ubuntu-22.04-8core
         - macos-latest
         package:
         - flox-bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,8 @@ jobs:
         echo "Have $(
           wc -l "$NEW_STORE_PATHS_FILE";
         ) new $NIX_STORE_DIR paths" >&2;
-        xargs -r -a "$NEW_STORE_PATHS_FILE" -n100          \
-              flox nix -- copy --to "$FLOX_SUBSTITUTER" -vv;
+        cat "$NEW_STORE_PATHS_FILE"|xargs -r -n100  \
+          |nix copy --stdin --to "$FLOX_SUBSTITUTER" -vv;
 
     # These cannot be run offline so we need to build in our tree.
     - name: Rust Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Build flox
       run: |
-        flox nix build -L --no-update-lock-file --print-out-paths;
+        flox nix build '.#flox' -L --no-update-lock-file --print-out-paths;
         echo "FLOX_CLI=$( readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV";
         rm ./result;
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,23 +139,6 @@ jobs:
         path: |
           ~/.cache/nix
         key: ${{ steps.nix-cache-restore.outputs.cache-primary-key }}
-
-
-  # TODO: remove this job after merging to `main'
-  # It is required because `Build * on *' is the name used in a GitHub branch
-  # protection rule.
-  deprecated:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os:
-        - ubuntu-22.04-8core
-        - macos-latest
-        package:
-        - flox-bash
-        - nix-editor
-    name: Build ${{ matrix.package }} on ${{ matrix.os }}
-    steps:
       - run: |
           printf '%s' 'TODO: Remove "Build ${{ matrix.package }} on'     \
                       ' ${{ matrix.os }}" branch protection rule.' >&2;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,12 @@ on:
 jobs:
 
   build:
-    name: ${{ matrix.package.job_description }} ${{ matrix.package.name }} on ${{ matrix.os }}
+    name: Build and test flox on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        package:
-        - {name: flox, job_description: "Build and test"}
-        - {name: flox-bash, job_description: "Build" }
-        - {name: nix-editor, job_description: "Build" }
-        os: 
+        os:
         - ubuntu-latest
         - macos-latest
 
@@ -38,15 +34,108 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: Test
-      run: nix develop '.#rust-env' -c cargo test --locked --workspace
-      
-    - name: Build
-      run: flox build '${{ matrix.package.name }}' -L --print-out-paths
+    # This is used to detect any new store paths we create while running builds
+    # so that they can be pushed to caches.
+    - name: Record Nix Store Paths
+      run: |
+        NIX_STORE_DIR="$(
+          flox nix eval --impure --raw --expr builtins.storeDir;
+        )";
+        echo "NIX_STORE_DIR='$NIX_STORE_DIR'" >> "$GITHUB_ENV";
+        STORE_PATHS_FILE="$( mktemp; )";
+        echo "STORE_PATHS_FILE='$STORE_PATHS_FILE'" >> "$GITHUB_ENV";
+        find "$NIX_STORE_DIR" -maxdepth 1 -mindepth 1 -type d -o -type l  \
+          |sort > "$STORE_PATHS_FILE";
+        echo "Have $( wc -l "$STORE_PATHS_FILE"; ) $NIX_STORE_DIR paths" >&2;
 
-    - name: Cache the store
-      run: flox nix copy --all --to "$FLOX_SUBSTITUTER" -vv
+    - name: Build flox-gh
+      run: |
+        flox nix build '.#flox-gh' -L --no-update-lock-file      \
+                                   --print-out-paths --no-link;
 
-    - name: Test
-      if: ${{ matrix.package.name == 'flox' }}
-      run: nix run '.#flox-tests'
+    - name: Build nix-editor
+      run: |
+        flox nix build '.#nix-editor' -L --no-update-lock-file      \
+                                      --print-out-paths --no-link;
+
+    - name: Build builtfilter-rs
+      run: |
+        flox nix build '.#builtfilter-rs' -L --no-update-lock-file      \
+                                          --print-out-paths --no-link;
+
+    - name: Build flox-bash
+      run: |
+        flox nix build '.#flox-bash' -L --no-update-lock-file      \
+                                     --print-out-paths --no-link;
+
+    # These cannot be run offline so we need to build in our tree.
+    # This just builds the `rust-env' deps so that they can get cached.
+    - name: Build Rust Env
+      run: |
+        nix develop '.#rust-env' --no-update-lock-file -c  true;
+
+    - name: Build flox
+      run: |
+        flox nix build -L --no-update-lock-file --print-out-paths;
+        echo "FLOX_CLI=$( readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV";
+        rm ./result;
+
+    - name: Build flox-tests
+      run: |
+        flox nix build '.#flox-tests' -L --no-update-lock-file      \
+                                      --print-out-paths --no-link;
+
+    - name: Push New Store Paths
+      if: ${{ always() }}
+      run: |
+        # Since we run onconditionally we need to bail early in case the
+        # `STORE_PATHS_FILE' was never created.
+        if [[ -z "${STORE_PATHS_FILE:-}" ]]; then
+          echo "No old store paths were cached. Skipping push." >&2;
+          exit 1;
+        fi
+        STORE_PATHS_FILE2="$( mktemp; )";
+        find "$NIX_STORE_DIR" -maxdepth 1 -mindepth 1 -type d -o -type l  \
+          |sort > "$STORE_PATHS_FILE2";
+        NEW_STORE_PATHS_FILE="$( mktemp; )";
+        comm -13 "$STORE_PATHS_FILE" "$STORE_PATHS_FILE2"  \
+             > "$NEW_STORE_PATHS_FILE";
+        echo "Have $(
+          wc -l "$NEW_STORE_PATHS_FILE";
+        ) new $NIX_STORE_DIR paths" >&2;
+        xargs -r -a "$NEW_STORE_PATHS_FILE" -n100          \
+              flox nix copy --to "$FLOX_SUBSTITUTER" -vv;
+
+    # These cannot be run offline so we need to build in our tree.
+    - name: Rust Tests
+      run: |
+        git clean -xfd;
+        nix develop '.#rust-env' --no-update-lock-file   \
+                    -c cargo test --locked --workspace;
+
+    # We ultimately test against the `FLOX_CLI' env var's path set earlier.
+    - name: Bats Tests
+      run: |
+        git clean -xfd;
+        nix run --no-update-lock-file '.#flox-tests';
+
+
+  # TODO: remove this job after merging to `main'
+  # It is required because `Build * on *' is the name used in a GitHub branch
+  # protection rule.
+  deprecated:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+        package:
+        - flox-bash
+        - nix-editor
+    name: Build ${{ matrix.package }} on ${{ matrix.os }}
+    steps:
+      - run: |
+          printf '%s' 'TODO: Remove "Build ${{ matrix.package }} on'     \
+                      ' ${{ matrix.os }}" branch protection rule.' >&2;
+          echo '' >&2;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         echo "STORE_PATHS_FILE=$STORE_PATHS_FILE" >> "$GITHUB_ENV";
         find "$NIX_STORE_DIR" -maxdepth 1 -mindepth 1 -type d -o -type l  \
           |sort > "$STORE_PATHS_FILE";
-        echo "Have $( wc -l "$STORE_PATHS_FILE"; ) $NIX_STORE_DIR paths" >&2;
+        echo "Have $(
+          wc -l "$STORE_PATHS_FILE"|cut -d' ' -f1;
+        ) $NIX_STORE_DIR paths" >&2;
 
     - name: Build flox-gh
       run: |
@@ -113,7 +115,7 @@ jobs:
         comm -13 "$STORE_PATHS_FILE" "$STORE_PATHS_FILE2"  \
              > "$NEW_STORE_PATHS_FILE";
         echo "Have $(
-          wc -l "$NEW_STORE_PATHS_FILE";
+          wc -l "$NEW_STORE_PATHS_FILE"|cut -d' ' -f1;
         ) new $NIX_STORE_DIR paths" >&2;
         # Allow pushing to fail.
         cat "$NEW_STORE_PATHS_FILE"                           \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,4 @@ jobs:
           printf '%s' 'TODO: Remove "Build ${{ matrix.package }} on'     \
                       ' ${{ matrix.os }}" branch protection rule.' >&2;
           echo '' >&2;
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
         NIX_STORE_DIR="$(
           flox nix eval --impure --raw --expr builtins.storeDir;
         )";
-        echo "NIX_STORE_DIR='$NIX_STORE_DIR'" >> "$GITHUB_ENV";
+        echo "NIX_STORE_DIR=$NIX_STORE_DIR" >> "$GITHUB_ENV";
         STORE_PATHS_FILE="$( mktemp; )";
-        echo "STORE_PATHS_FILE='$STORE_PATHS_FILE'" >> "$GITHUB_ENV";
+        echo "STORE_PATHS_FILE=$STORE_PATHS_FILE" >> "$GITHUB_ENV";
         find "$NIX_STORE_DIR" -maxdepth 1 -mindepth 1 -type d -o -type l  \
           |sort > "$STORE_PATHS_FILE";
         echo "Have $( wc -l "$STORE_PATHS_FILE"; ) $NIX_STORE_DIR paths" >&2;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,9 @@ jobs:
         echo "Have $(
           wc -l "$NEW_STORE_PATHS_FILE";
         ) new $NIX_STORE_DIR paths" >&2;
-        cat "$NEW_STORE_PATHS_FILE"                        \
-          |nix copy --stdin --to "$FLOX_SUBSTITUTER" -vv;
+        # Allow pushing to fail.
+        cat "$NEW_STORE_PATHS_FILE"                           \
+          |nix copy --stdin --to "$FLOX_SUBSTITUTER" -vv||:;
 
     # These cannot be run offline so we need to build in our tree.
     - name: Rust Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         echo "Have $(
           wc -l "$NEW_STORE_PATHS_FILE";
         ) new $NIX_STORE_DIR paths" >&2;
-        cat "$NEW_STORE_PATHS_FILE"|xargs -r -n100  \
+        cat "$NEW_STORE_PATHS_FILE"                        \
           |nix copy --stdin --to "$FLOX_SUBSTITUTER" -vv;
 
     # These cannot be run offline so we need to build in our tree.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-latest
+        - ubuntu-22.04-8core
         - macos-latest
 
     steps:
@@ -40,7 +40,7 @@ jobs:
     - name: Record Nix Store Paths
       run: |
         NIX_STORE_DIR="$(
-          flox nix eval --impure --raw --expr builtins.storeDir;
+          flox nix -- eval --impure --raw --expr builtins.storeDir;
         )";
         echo "NIX_STORE_DIR=$NIX_STORE_DIR" >> "$GITHUB_ENV";
         STORE_PATHS_FILE="$( mktemp; )";
@@ -51,40 +51,39 @@ jobs:
 
     - name: Build flox-gh
       run: |
-        flox nix build '.#flox-gh' -L --no-update-lock-file      \
-                                   --print-out-paths --no-link;
+        flox nix -- build '.#flox-gh' -L --no-update-lock-file      \
+                                      --print-out-paths --no-link;
 
     - name: Build nix-editor
       run: |
-        flox nix build '.#nix-editor' -L --no-update-lock-file      \
-                                      --print-out-paths --no-link;
+        flox nix -- build '.#nix-editor' -L --no-update-lock-file      \
+                                         --print-out-paths --no-link;
 
     - name: Build builtfilter-rs
       run: |
-        flox nix build '.#builtfilter-rs' -L --no-update-lock-file      \
-                                          --print-out-paths --no-link;
+        flox nix -- build '.#builtfilter-rs' -L --no-update-lock-file      \
+                                             --print-out-paths --no-link;
 
     - name: Build flox-bash
       run: |
-        flox nix build '.#flox-bash' -L --no-update-lock-file      \
-                                     --print-out-paths --no-link;
+        flox nix -- build '.#flox-bash' -L --no-update-lock-file      \
+                                        --print-out-paths --no-link;
 
     # These cannot be run offline so we need to build in our tree.
     # This just builds the `rust-env' deps so that they can get cached.
     - name: Build Rust Env
-      run: |
-        nix develop '.#rust-env' --no-update-lock-file -c  true;
+      run: flox nix -- develop '.#rust-env' --no-update-lock-file -c true;
 
     - name: Build flox
       run: |
-        flox nix build '.#flox' -L --no-update-lock-file --print-out-paths;
+        flox nix -- build '.#flox' -L --no-update-lock-file --print-out-paths;
         echo "FLOX_CLI=$( readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV";
         rm ./result;
 
     - name: Build flox-tests
       run: |
-        flox nix build '.#flox-tests' -L --no-update-lock-file      \
-                                      --print-out-paths --no-link;
+        flox nix -- build '.#flox-tests' -L --no-update-lock-file      \
+                                         --print-out-paths --no-link;
 
     - name: Push New Store Paths
       if: ${{ always() }}
@@ -105,7 +104,7 @@ jobs:
           wc -l "$NEW_STORE_PATHS_FILE";
         ) new $NIX_STORE_DIR paths" >&2;
         xargs -r -a "$NEW_STORE_PATHS_FILE" -n100          \
-              flox nix copy --to "$FLOX_SUBSTITUTER" -vv;
+              flox nix -- copy --to "$FLOX_SUBSTITUTER" -vv;
 
     # These cannot be run offline so we need to build in our tree.
     - name: Rust Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,3 @@ jobs:
         path: |
           ~/.cache/nix
         key: ${{ steps.nix-cache-restore.outputs.cache-primary-key }}
-      - run: |
-          printf '%s' 'TODO: Remove "Build ${{ matrix.package }} on'     \
-                      ' ${{ matrix.os }}" branch protection rule.' >&2;
-          echo '' >&2;
-


### PR DESCRIPTION
## Proposed Changes

Sequence package matrix to avoid redundant builds.
Avoid pushing the entire `nix` store - only push new paths.


## Current Behavior

Multiple runners may be used to build individual packages which require setup.
Since all targets are dependencies of `flox`, runners which only build earlier dependencies perform redundant work.

For caches we previously cached the entire `nix` store instead of just
newly added paths.


## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

N/A


<!-- Many thanks! -->
