### PR TITLE
Use recipes instead of packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -988,6 +988,21 @@
         "type": "github"
       }
     },
+    "nixpkgs_19": {
+      "locked": {
+        "lastModified": 1690729170,
+        "narHash": "sha256-uWHLUuBVUUJDx2zQNxAnhrLI/w93Pd5MXi1TovL0Nhk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "195110917ecbeebf27946990cf0a260b99178ded",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1674236650,
@@ -1330,7 +1345,8 @@
         "flox-floxpkgs": "flox-floxpkgs",
         "parser-util": "parser-util_3",
         "pkgdb": "pkgdb_3",
-        "shellHooks": "shellHooks_3"
+        "shellHooks": "shellHooks_3",
+        "sqlite3pp": "sqlite3pp_4"
       }
     },
     "rust-overlay": {
@@ -1534,6 +1550,24 @@
           "pkgdb",
           "nixpkgs"
         ]
+      },
+      "locked": {
+        "lastModified": 1691154329,
+        "narHash": "sha256-nMtwh/G1/Zt70rl540jn+nFVJuju0NdXJwk2Y3pNB+k=",
+        "owner": "aakropotkin",
+        "repo": "sqlite3pp",
+        "rev": "775e48a6c7a63a51585cd628f6c9816ba634a246",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aakropotkin",
+        "repo": "sqlite3pp",
+        "type": "github"
+      }
+    },
+    "sqlite3pp_4": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_19"
       },
       "locked": {
         "lastModified": 1691154329,

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
   };
   inputs.parser-util.url = "github:flox/parser-util/v0";
   inputs.pkgdb.url = "github:flox/pkgdb";
+  inputs.sqlite3pp.url = "github:aakropotkin/sqlite3pp";
 
   outputs = inputs:
     inputs.flox-floxpkgs.project inputs (_: {});

--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -44,7 +44,6 @@
   pkgdb,
   flox-nix,
 }: let
-  # pkgdb = inputs.pkgdb.packages.flox-pkgdb;
   # The getent package can be found in pkgs.unixtools.
   inherit (pkgs.unixtools) getent;
 

--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -29,7 +29,6 @@
   makeWrapper,
   man,
   nix-editor,
-  nixVersions,
   openssh,
   pandoc,
   parser-util,
@@ -42,23 +41,14 @@
   which,
   semver,
   builtfilter-rs,
+  pkgdb,
+  flox-nix,
 }: let
-  pkgdb = inputs.pkgdb.packages.flox-pkgdb;
+  # pkgdb = inputs.pkgdb.packages.flox-pkgdb;
   # The getent package can be found in pkgs.unixtools.
   inherit (pkgs.unixtools) getent;
 
-  nixPatched = nixVersions.nix_2_15.overrideAttrs (oldAttrs: {
-    patches =
-      (oldAttrs.patches or [])
-      ++ [
-        ./nix-patches/CmdProfileBuild.patch
-        ./nix-patches/CmdSearchAttributes.patch
-        ./nix-patches/update-profile-list-warning.patch
-        ./nix-patches/multiple-github-tokens.2.13.2.patch
-        ./nix-patches/curl_flox_version.patch
-        ./nix-patches/no-default-prefixes-hash.2.15.1.patch
-      ];
-  });
+  nixPatched = flox-nix;
 
   # TODO: floxActivateFish, etc.
   floxActivateBashDarwin = substituteAll {

--- a/pkgs/flox-nix/default.nix
+++ b/pkgs/flox-nix/default.nix
@@ -1,0 +1,13 @@
+{nixVersions, ...}:
+nixVersions.nix_2_15.overrideAttrs (oldAttrs: {
+  patches =
+    (oldAttrs.patches or [])
+    ++ [
+      ../flox-bash/nix-patches/CmdProfileBuild.patch
+      ../flox-bash/nix-patches/CmdSearchAttributes.patch
+      ../flox-bash/nix-patches/update-profile-list-warning.patch
+      ../flox-bash/nix-patches/multiple-github-tokens.2.13.2.patch
+      ../flox-bash/nix-patches/curl_flox_version.patch
+      ../flox-bash/nix-patches/no-default-prefixes-hash.2.15.1.patch
+    ];
+})

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -27,10 +27,10 @@
   gitMinimal,
   flox-gh,
   gh,
+  pkgdb,
 }: let
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = inputs.crane.mkLib nixpkgs;
-  pkgdb = inputs.pkgdb.packages.flox-pkgdb;
 
   # build time environment variables
   envs =

--- a/pkgs/parser-util/default.nix
+++ b/pkgs/parser-util/default.nix
@@ -1,1 +1,1 @@
-{inputs, ...}: inputs.parser-util.packages.parser-util
+{inputs, callPackage, ...}: callPackage (inputs.parser-util + "/pkg-fun.nix") {}

--- a/pkgs/pkgdb/default.nix
+++ b/pkgs/pkgdb/default.nix
@@ -4,6 +4,6 @@
   flox-nix,
   ...
 }:
-callPackage (inputs.parser-util + "/pkg-fun.nix") {
+callPackage (inputs.pkgdb + "/pkg-fun.nix") {
   nix = flox-nix;
 }

--- a/pkgs/sqlite3pp/default.nix
+++ b/pkgs/sqlite3pp/default.nix
@@ -1,0 +1,1 @@
+{inputs, callPackage, ...}: callPackage (inputs.sqlite3pp + "/pkg-fun.nix") {}


### PR DESCRIPTION
## Proposed Changes

Use recipes instead of packages when bringing in dependencies like parser-util, nix, pkgdb, etc. Break out our patched nix into its own package and re-use it where needed.

## Current Behavior

This helps reduce closure size 1.5GB -> 1.1GB

## Checks

- [ ] All tests pass.
- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.

## Release Notes

N/A

https://github.com/flox/product/issues/520