### PR TITLE
fix: flush logger

### DIFF
--- a/crates/flox/src/main.rs
+++ b/crates/flox/src/main.rs
@@ -119,7 +119,7 @@ async fn main() -> ExitCode {
             ExitCode::from(1)
         },
     };
-    log::logger().flush();
+    utils::init::flush_logger();
     exit_code
 }
 

--- a/crates/flox/src/main.rs
+++ b/crates/flox/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> ExitCode {
     let args = args.unwrap();
 
     // Run flox. Print errors and exit with status 1 on failure
-    match run(args).await {
+    let exit_code = match run(args).await {
         Ok(()) => ExitCode::from(0),
         Err(e) => {
             // Do not print any error if caused by wrapped flox (sh)
@@ -118,7 +118,9 @@ async fn main() -> ExitCode {
 
             ExitCode::from(1)
         },
-    }
+    };
+    log::logger().flush();
+    exit_code
 }
 
 #[derive(Debug)]

--- a/crates/flox/src/utils/init/logger.rs
+++ b/crates/flox/src/utils/init/logger.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use log::{debug, error};
 use once_cell::sync::OnceCell;
 use tracing_subscriber::prelude::*;
@@ -112,4 +114,16 @@ pub fn init_logger(verbosity: Option<Verbosity>, debug: Option<bool>) {
     }) {
         error!("Updating logger filter failed: {}", err);
     }
+}
+
+pub fn flush_logger() {
+    if LOGGER_HANDLE.get().is_none() {
+        return;
+    }
+
+    let (_, fmt_handle) = LOGGER_HANDLE.get().unwrap();
+
+    let _ = fmt_handle.modify(|l| {
+        let _ = l.writer_mut().flush();
+    });
 }

--- a/crates/flox/src/utils/init/logger.rs
+++ b/crates/flox/src/utils/init/logger.rs
@@ -117,13 +117,9 @@ pub fn init_logger(verbosity: Option<Verbosity>, debug: Option<bool>) {
 }
 
 pub fn flush_logger() {
-    if LOGGER_HANDLE.get().is_none() {
-        return;
+    if let Some((_, fmt_handle)) = LOGGER_HANDLE.get() {
+        let _ = fmt_handle.modify(|l| {
+            let _ = l.writer_mut().flush();
+        });
     }
-
-    let (_, fmt_handle) = LOGGER_HANDLE.get().unwrap();
-
-    let _ = fmt_handle.modify(|l| {
-        let _ = l.writer_mut().flush();
-    });
 }

--- a/tests/publish.bats
+++ b/tests/publish.bats
@@ -83,10 +83,6 @@ setup() {
 # Publish requires a signing key.
 # Without a key, flox will fail with a meaningful error.
 @test "flox publish fails without signing-key" {
-    if [[ "$NIX_SYSTEM" = *-darwin ]] then
-        skip "broken on macOS";
-    fi
-    
     unset FLOX_SIGNING_KEY
 
     run $FLOX_CLI -v publish "$CHANNEL#hello"
@@ -97,17 +93,10 @@ setup() {
 # Publish requires a cache url.
 # Without a cache url, flox will fail with a meaningful error.
 @test "flox publish fails without cache url" {
-    case "$NIX_SYSTEM" in
-        *-darwin)
-            skip "Flaky on macOS";
-            ;;
-        *-linux)
-            unset FLOX_CACHE_URL;
-            run $FLOX_CLI -v publish "$CHANNEL#hello";
-            assert_failure;
-            assert_output --partial "Cache url is required!";
-            ;;
-    esac
+    unset FLOX_CACHE_URL;
+    run $FLOX_CLI -v publish "$CHANNEL#hello";
+    assert_failure;
+    assert_output --partial "Cache url is required!";
 }
 
 # Publish requires a cached binary.


### PR DESCRIPTION
Not flushing the logger appears to be causing flaky tests on macOS - likely the error messages expected by some tests are not being printed to stderr before flox exits.

Re-enable tests that were disabled due to this failure.