### PR TITLE
chore: set `workspace.resolver = "2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = ["crates/*"]
-
 default-members = ["crates/flox"]
+
+resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1"


### PR DESCRIPTION
Fixes a compile time warning issued by cargo, because we crates and workspaces use different versions of the dependency resolver.
This PR explicitly sets the resolver for the cargo workspace to the new version `2`.