### PR TITLE
feat: ManagedEnvironment::encode method, reverse links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +167,19 @@ name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
+name = "blake3"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -314,6 +339,12 @@ dependencies = [
  "toml",
  "yaml-rust",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
@@ -680,6 +711,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "blake3",
  "chrono",
  "derive_more",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1.52"
+blake3 = "1.5.0"
 bpaf = { version = "0.9.5", features = ["derive", "autocomplete"] }
 chrono = "0.4.24"
 config = "0.13.1"

--- a/crates/flox-rust-sdk/Cargo.toml
+++ b/crates/flox-rust-sdk/Cargo.toml
@@ -35,6 +35,7 @@ chrono.workspace = true
 git-url-parse.workspace = true
 rowan.workspace = true
 sha2.workspace = true
+blake3.workspace = true
 
 [dev-dependencies]
 anyhow = "1.0.65"

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1,4 +1,4 @@
-use std::hash::{Hash, Hasher};
+use std::os::unix::prelude::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
@@ -163,14 +163,12 @@ impl Environment for ManagedEnvironment {
 impl ManagedEnvironment {
     /// Returns a unique identifier for the location of the project.
     fn encode(path: impl AsRef<Path>) -> Result<String, ManagedEnvironmentError> {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
         let path =
             std::fs::canonicalize(&path).map_err(|e| ManagedEnvironmentError::Canonicalize {
                 path: path.as_ref().to_path_buf(),
                 err: e,
             })?;
-        path.as_path().hash(&mut hasher);
-        Ok(format!("{:X}", hasher.finish()))
+        Ok(format!("{}", blake3::hash(path.as_os_str().as_bytes())))
     }
 
     /// Returns the path to an environment given the branch name in the floxmeta repository.

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -22,7 +22,7 @@ const GENERATION_LOCK_FILENAME: &str = "env.lock";
 
 #[derive(Debug)]
 pub struct ManagedEnvironment {
-    /// Path to the project's .flox directory
+    /// Path to the directory containing `env.json`
     _path: PathBuf,
     _pointer: ManagedPointer,
     _system: String,
@@ -55,6 +55,14 @@ pub enum ManagedEnvironmentError {
     ReverseLink(std::io::Error),
     #[error("couldn't create links directory: {0}")]
     CreateLinksDir(std::io::Error),
+    #[error("couldn't canonicalize path '{path}': {err}")]
+    Canonicalize { path: PathBuf, err: std::io::Error },
+    #[error("attempted to open the empty path ''")]
+    EmptyPath,
+    #[error("floxmeta branch name was malformed: {0}")]
+    BadBranchName(String),
+    #[error("project wasn't found at path {path}: {err}")]
+    ProjectNotFound { path: PathBuf, err: std::io::Error },
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
@@ -154,28 +162,54 @@ impl Environment for ManagedEnvironment {
 
 impl ManagedEnvironment {
     /// Returns a unique identifier for the location of the project.
-    pub fn encode(path: impl AsRef<Path>) -> String {
+    fn encode(path: impl AsRef<Path>) -> Result<String, ManagedEnvironmentError> {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        path.as_ref().hash(&mut hasher);
-        format!("{:X}", hasher.finish())
+        let path =
+            std::fs::canonicalize(&path).map_err(|e| ManagedEnvironmentError::Canonicalize {
+                path: path.as_ref().to_path_buf(),
+                err: e,
+            })?;
+        path.as_path().hash(&mut hasher);
+        Ok(format!("{:X}", hasher.finish()))
+    }
+
+    /// Returns the path to an environment given the branch name in the floxmeta repository
+    #[allow(unused)]
+    fn decode(flox: &Flox, branch: &impl AsRef<str>) -> Result<PathBuf, ManagedEnvironmentError> {
+        let branch_name = branch.as_ref();
+        branch_name
+            .split('.')
+            .next_back()
+            .map(|hash| {
+                let links_dir = reverse_links_dir(flox);
+                let link = links_dir.join(hash);
+                std::fs::read_link(&link)
+                    .map_err(|e| ManagedEnvironmentError::ProjectNotFound { path: link, err: e })
+            })
+            .unwrap_or(Err(ManagedEnvironmentError::BadBranchName(String::from(
+                branch_name,
+            ))))
     }
 
     /// Creates a symlink pointing from the `FloxMeta` back to the project environment
     /// using this managed environment if the symlink doesn't already exist.
-    pub fn ensure_reverse_link(
+    fn ensure_reverse_link(
         flox: &Flox,
         path: impl AsRef<Path>,
     ) -> Result<(), ManagedEnvironmentError> {
         let links_dir = reverse_links_dir(flox);
+        let encoded = ManagedEnvironment::encode(&path)?;
+        let link = links_dir.join(encoded);
         if !links_dir.exists() {
             std::fs::create_dir_all(&links_dir).map_err(ManagedEnvironmentError::CreateLinksDir)?;
-        }
-        let encoded = ManagedEnvironment::encode(&path);
-        let link = links_dir.join(encoded);
-        // Do not use `Path.exists` to check whether the link exists. It will return `false` if
-        // the symlink is broken or if you can't read the file metadata due to permissions errors.
-        if !link.is_symlink() {
             std::os::unix::fs::symlink(path, link).map_err(ManagedEnvironmentError::ReverseLink)?;
+        } else {
+            // Do not use `Path.exists` to check whether the link exists. It will return `false` if
+            // the symlink is broken or if you can't read the file metadata due to permissions errors.
+            if !link.is_symlink() {
+                std::os::unix::fs::symlink(path, link)
+                    .map_err(ManagedEnvironmentError::ReverseLink)?;
+            }
         }
         Ok(())
     }
@@ -214,7 +248,7 @@ impl ManagedEnvironment {
 
         let lock = Self::ensure_locked(flox, &pointer, &dot_flox_path, &floxmeta)?;
         Self::ensure_branch(
-            &branch_name(&flox.system, &pointer, &dot_flox_path),
+            &branch_name(&flox.system, &pointer, &dot_flox_path)?,
             &lock,
             &floxmeta,
         )?;
@@ -370,26 +404,31 @@ impl ManagedEnvironment {
     }
 }
 
-fn branch_name(system: &str, pointer: &ManagedPointer, dot_flox_path: impl AsRef<Path>) -> String {
-    format!(
+fn branch_name(
+    system: &str,
+    pointer: &ManagedPointer,
+    dot_flox_path: impl AsRef<Path>,
+) -> Result<String, ManagedEnvironmentError> {
+    Ok(format!(
         "{}.{}.{}",
         system,
         pointer.name,
-        ManagedEnvironment::encode(dot_flox_path)
-    )
+        ManagedEnvironment::encode(dot_flox_path)?
+    ))
 }
 
 pub fn remote_branch_name(system: &str, pointer: &ManagedPointer) -> String {
     format!("{}.{}", system, pointer.name)
 }
 
-pub fn reverse_links_dir(flox: &Flox) -> PathBuf {
+fn reverse_links_dir(flox: &Flox) -> PathBuf {
     flox.data_dir.join("links")
 }
 
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
+    use std::time::Duration;
 
     use once_cell::sync::Lazy;
 
@@ -872,16 +911,49 @@ mod test {
 
     #[test]
     fn stable_encode_name() {
-        let path = PathBuf::from_str("foo").unwrap();
-        let encode1 = ManagedEnvironment::encode(&path);
-        let encode2 = ManagedEnvironment::encode(&path);
+        // Ensure that running the encode function gives you the same results
+        // with the same input e.g. doesn't depend on time, etc
+        let (_flox, tmp_dir) = flox_instance();
+        let path = tmp_dir.path().join("foo");
+        std::fs::File::create(&path).unwrap();
+        let encode1 = ManagedEnvironment::encode(&path).unwrap();
+        std::thread::sleep(Duration::from_millis(1_000));
+        let encode2 = ManagedEnvironment::encode(&path).unwrap();
         assert_eq!(encode1, encode2);
     }
 
     #[test]
+    fn canonicalized_paths_encode_the_same() {
+        let (_flox, tmp) = flox_instance();
+        // std::fs::canonicalize requires that the path being checked actually exists,
+        // so we're going to create a directory structure under a temporary directory.
+        let parent_dir = tmp.into_path();
+        let subdir = parent_dir.join("foo/bar/baz");
+        std::fs::create_dir_all(&subdir).unwrap();
+        let path = subdir.join("file.txt");
+        let _file = std::fs::File::create(&path).unwrap();
+        // Make sure the path is canonicalized internally before hashing
+        let canonicalized = std::fs::canonicalize(&path).unwrap();
+        let c_encoded = ManagedEnvironment::encode(canonicalized).unwrap();
+        let encoded = ManagedEnvironment::encode(&path).unwrap();
+        assert_eq!(
+            c_encoded, encoded,
+            "sane path is canonicalized before encoding"
+        );
+        // Now do the same thing with cursed paths
+        let up_down = path.parent().unwrap().join("../../bar/baz/file.txt");
+        let encoded = ManagedEnvironment::encode(up_down).unwrap();
+        assert_eq!(
+            c_encoded, encoded,
+            "cursed path is canonicalized before encoding"
+        );
+    }
+
+    #[test]
     fn creates_reverse_links_dir() {
-        let (flox, _) = flox_instance();
-        let path = PathBuf::from_str("foo").unwrap();
+        let (flox, tmp_dir) = flox_instance();
+        let path = tmp_dir.path().join("foo");
+        std::fs::File::create(&path).unwrap();
         let links_dir = reverse_links_dir(&flox);
         assert!(!links_dir.exists());
         ManagedEnvironment::ensure_reverse_link(&flox, path).unwrap();
@@ -890,13 +962,15 @@ mod test {
 
     #[test]
     fn creates_reverse_link() {
-        let (flox, _) = flox_instance();
+        let (flox, tmp_dir) = flox_instance();
         let links_dir = reverse_links_dir(&flox);
-        let path = PathBuf::from_str("foo").unwrap();
+        let path = tmp_dir.path().join("foo");
+        std::fs::File::create(&path).unwrap();
         // There are no links if the directory hasn't been created
         assert!(!links_dir.exists());
         // Create the reverse link
         ManagedEnvironment::ensure_reverse_link(&flox, &path).unwrap();
+        // Ensure that only one symlink was created.
         assert_eq!(links_dir.read_dir().unwrap().count(), 1);
         let link_name = links_dir
             .read_dir()
@@ -905,19 +979,21 @@ mod test {
             .unwrap()
             .unwrap()
             .file_name();
-        let expected_link_name = ManagedEnvironment::encode(&path);
+        let expected_link_name = ManagedEnvironment::encode(&path).unwrap();
         assert_eq!(link_name.to_str().unwrap(), &expected_link_name);
     }
 
     #[test]
     fn noop_when_symlink_exists() {
-        let (flox, _) = flox_instance();
+        let (flox, tmp_dir) = flox_instance();
         let links_dir = reverse_links_dir(&flox);
-        let path = PathBuf::from_str("foo").unwrap();
+        let path = tmp_dir.path().join("foo");
+        std::fs::File::create(&path).unwrap();
         // There are no links if the directory hasn't been created
         assert!(!links_dir.exists());
         // Create the reverse link
         ManagedEnvironment::ensure_reverse_link(&flox, &path).unwrap();
+        // Ensure that only one symlink was created.
         assert_eq!(links_dir.read_dir().unwrap().count(), 1);
         let link_name = links_dir
             .read_dir()
@@ -926,7 +1002,7 @@ mod test {
             .unwrap()
             .unwrap()
             .file_name();
-        let expected_link_name = ManagedEnvironment::encode(&path);
+        let expected_link_name = ManagedEnvironment::encode(&path).unwrap();
         assert_eq!(link_name.to_str().unwrap(), &expected_link_name);
         // Ensure that the link exists, checking that another one hasn't been created
         ManagedEnvironment::ensure_reverse_link(&flox, &path).unwrap();
@@ -939,5 +1015,30 @@ mod test {
             .unwrap()
             .file_name();
         assert_eq!(link_name.to_str().unwrap(), &expected_link_name);
+    }
+
+    #[test]
+    fn decode_branch_name_to_path() {
+        let (flox, tmp_dir) = flox_instance();
+        let links_dir = reverse_links_dir(&flox);
+        let path = tmp_dir.path().join("foo");
+        std::fs::File::create(&path).unwrap();
+        // There are no links if the directory hasn't been created
+        assert!(!links_dir.exists());
+        // Create the reverse link
+        ManagedEnvironment::ensure_reverse_link(&flox, &path).unwrap();
+        // Ensure that only one symlink was created.
+        assert_eq!(links_dir.read_dir().unwrap().count(), 1);
+        // Decode the branch name and assert that it's the same path we created before
+        let pointer = ManagedPointer {
+            owner: EnvironmentOwner::from_str("owner").unwrap(),
+            name: EnvironmentName::from_str("name").unwrap(),
+            version: Version::<1>,
+        };
+        let branch_name = branch_name(&flox.system, &pointer, &path).unwrap();
+        let decoded_path = ManagedEnvironment::decode(&flox, &branch_name).unwrap();
+        let canonicalized_decoded_path = std::fs::canonicalize(decoded_path).unwrap();
+        let canonicalized_path = std::fs::canonicalize(&path).unwrap();
+        assert_eq!(canonicalized_path, canonicalized_decoded_path);
     }
 }

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -151,8 +151,7 @@ impl Environment for ManagedEnvironment {
 }
 
 impl ManagedEnvironment {
-    /// Returns the branch name inside of the `FloxMeta` repo corresponding to this
-    /// managed environment.
+    /// Returns a unique identifier for the location of the project.
     pub fn encode(path: impl AsRef<Path>) -> String {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         path.as_ref().hash(&mut hasher);
@@ -160,8 +159,8 @@ impl ManagedEnvironment {
     }
 
     /// Creates a symlink pointing from the `FloxMeta` back to the project environment
-    /// using this managed environment.
-    pub fn create_reverse_symlink_if_not_exists(
+    /// using this managed environment if the symlink doesn't already exist.
+    pub fn ensure_reverse_link(
         flox: &Flox,
         path: impl AsRef<Path>,
     ) -> Result<(), ManagedEnvironmentError> {
@@ -212,7 +211,7 @@ impl ManagedEnvironment {
             &lock,
             &floxmeta,
         )?;
-        ManagedEnvironment::create_reverse_symlink_if_not_exists(flox, &dot_flox_path)?;
+        ManagedEnvironment::ensure_reverse_link(flox, &dot_flox_path)?;
 
         Ok(ManagedEnvironment {
             _path: dot_flox_path.as_ref().to_path_buf(),

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -397,7 +397,7 @@ mod test {
         }
     }
 
-    async fn create_floxmeta(flox: &Flox, remote_path: &Path, branch: &str) -> FloxmetaV2 {
+    fn create_floxmeta(flox: &Flox, remote_path: &Path, branch: &str) -> FloxmetaV2 {
         let user_floxmeta_dir = floxmeta_dir(flox, &TEST_POINTER.owner);
         fs::create_dir_all(&user_floxmeta_dir).unwrap();
         GitCommandProvider::clone_branch(
@@ -433,7 +433,7 @@ mod test {
         commit_file(&remote, "file 1").await;
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // add a second commit to the remote
         commit_file(&remote, "file 2").await;
@@ -479,7 +479,7 @@ mod test {
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // create a .flox directory
         let lock = GenerationLock {
@@ -525,7 +525,7 @@ mod test {
         commit_file(&remote, "file 1").await;
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // add a second commit to the remote
         commit_file(&remote, "file 2").await;
@@ -579,7 +579,7 @@ mod test {
         commit_file(&remote, "file 1").await;
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // add a second branch to the remote
         remote.checkout("branch_2", true).await.unwrap();
@@ -624,7 +624,7 @@ mod test {
         commit_file(&remote, "file 1").await;
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // add a second commit to the remote
         commit_file(&remote, "file 2").await;
@@ -671,7 +671,7 @@ mod test {
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // create a .flox directory
         let dot_flox_path = flox.temp_dir.join(DOT_FLOX);
@@ -716,7 +716,7 @@ mod test {
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // create a .flox directory
         let dot_flox_path = flox.temp_dir.join(DOT_FLOX);
@@ -754,7 +754,7 @@ mod test {
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         let lock = GenerationLock {
             rev: hash_1.clone(),
@@ -832,7 +832,7 @@ mod test {
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
-        let floxmeta = create_floxmeta(&flox, &remote_path, &branch).await;
+        let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         let lock = GenerationLock {
             rev: hash_1.clone(),

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -173,13 +173,16 @@ impl ManagedEnvironment {
         Ok(format!("{:X}", hasher.finish()))
     }
 
-    /// Returns the path to an environment given the branch name in the floxmeta repository
+    /// Returns the path to an environment given the branch name in the floxmeta repository.
+    ///
+    /// Will only error if the symlink doesn't exist, the path the symlink points to doesn't
+    /// exist, or if the branch name is malformed.
     #[allow(unused)]
     fn decode(flox: &Flox, branch: &impl AsRef<str>) -> Result<PathBuf, ManagedEnvironmentError> {
         let branch_name = branch.as_ref();
         branch_name
             .split('.')
-            .next_back()
+            .nth(2)
             .map(|hash| {
                 let links_dir = reverse_links_dir(flox);
                 let link = links_dir.join(hash);

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1,3 +1,4 @@
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
@@ -148,8 +149,13 @@ impl Environment for ManagedEnvironment {
 }
 
 impl ManagedEnvironment {
-    pub fn encode(pointer: &ManagedPointer, _path: impl AsRef<Path>) -> String {
-        format!("todo-{}", pointer.name)
+    /// Returns the branch name inside of the `FloxMeta` repo corresponding to this
+    /// managed environment.
+    pub fn encode(path: impl AsRef<Path>) -> String {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        path.as_ref().hash(&mut hasher);
+        let path_hash = hasher.finish();
+        format!("{:X}", path_hash)
     }
 
     /// Open a managed environment by reading its lockfile and ensuring there is
@@ -346,7 +352,7 @@ fn branch_name(system: &str, pointer: &ManagedPointer, dot_flox_path: impl AsRef
         "{}.{}.{}",
         system,
         pointer.name,
-        ManagedEnvironment::encode(pointer, dot_flox_path)
+        ManagedEnvironment::encode(dot_flox_path)
     )
 }
 

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -420,6 +420,7 @@ fn branch_name(
     ))
 }
 
+/// The original branch name of an environment that is used to sync an environment with the hub
 pub fn remote_branch_name(system: &str, pointer: &ManagedPointer) -> String {
     format!("{}.{}", system, pointer.name)
 }

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -196,6 +196,9 @@ impl ManagedEnvironment {
 
     /// Creates a symlink pointing from the `FloxMeta` back to the project environment
     /// using this managed environment if the symlink doesn't already exist.
+    ///
+    /// Iff an environment in `<path>` refers to a branch `<system>.<name>.<encode(path)>`
+    /// then `reverse_links_dir(_).join(encode(path))` is a link to <path>
     fn ensure_reverse_link(
         flox: &Flox,
         path: impl AsRef<Path>,

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -425,6 +425,14 @@ pub fn remote_branch_name(system: &str, pointer: &ManagedPointer) -> String {
     format!("{}.{}", system, pointer.name)
 }
 
+/// Path to the directory that contains symlinks
+/// that map unique branch ids to
+/// the directories linking to the environment.
+///
+/// see also: [ManagedEnvironment::encode],
+///           [ManagedEnvironment::decode],
+///           [ManagedEnvironment::ensure_reverse_link],
+///           [branch_name]
 fn reverse_links_dir(flox: &Flox) -> PathBuf {
     flox.data_dir.join("links")
 }

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -116,11 +116,15 @@ pub trait Environment {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum EnvironmentPointer {
+    /// Identifies an environment whose source of truth lies outside of the project itself
     Managed(ManagedPointer),
+    /// Identifies an environment whose source of truth lies inside the project
     Path(PathPointer),
 }
 
-/// implies the current directory
+/// The identifier for a project environment.
+///
+/// This is serialized to `env.json` inside the `.flox` directory
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PathPointer {
     pub name: EnvironmentName,
@@ -137,6 +141,10 @@ impl PathPointer {
     }
 }
 
+/// The identifier for an environment that's defined outside of the project itself, and
+/// points to an environment owner and the name of the environment.
+///
+/// This is serialized to an `env.json` inside the `.flox` directory.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ManagedPointer {
     pub owner: EnvironmentOwner,

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -120,6 +120,7 @@ pub enum EnvironmentPointer {
     Path(PathPointer),
 }
 
+/// implies the current directory
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PathPointer {
     pub name: EnvironmentName,


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This PR implements the `ManagedEnvironment::encode` method and creates symlinks back to the project environment.

Closes flox/product#511

## Current Behavior

<!-- Describe the current behavior before applying this pull request. -->
N/A

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
