### PR TITLE
fix: hint the correct flag and config when signing key absent

### DIFF
--- a/crates/flox/src/commands/package.rs
+++ b/crates/flox/src/commands/package.rs
@@ -326,7 +326,7 @@ impl Publish {
             .ok_or_else(|| {
                 anyhow!(indoc! {"
                             Signing key is required!
-                            Provide using `--sign-key` or the `sign_key` config key
+                            Provide using `--signing-key` or the `signing_key` config key
                         "})
             })?;
 


### PR DESCRIPTION
flox publish manually checks whether a `signing-key` is provided as a command line argument or via the config system.
If absent will provide an error that provides a hint which flag/config key to set. `signing-key` was previously called `sign-key` which did not get renamed in all instances.
