### PR TITLE
Revert "fix: flush logger (#306)"

### DIFF
--- a/crates/flox/src/main.rs
+++ b/crates/flox/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> ExitCode {
     let args = args.unwrap();
 
     // Run flox. Print errors and exit with status 1 on failure
-    let exit_code = match run(args).await {
+    match run(args).await {
         Ok(()) => ExitCode::from(0),
         Err(e) => {
             // Do not print any error if caused by wrapped flox (sh)
@@ -118,9 +118,7 @@ async fn main() -> ExitCode {
 
             ExitCode::from(1)
         },
-    };
-    utils::init::flush_logger();
-    exit_code
+    }
 }
 
 #[derive(Debug)]

--- a/crates/flox/src/utils/init/logger.rs
+++ b/crates/flox/src/utils/init/logger.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use log::{debug, error};
 use once_cell::sync::OnceCell;
 use tracing_subscriber::prelude::*;
@@ -113,13 +111,5 @@ pub fn init_logger(verbosity: Option<Verbosity>, debug: Option<bool>) {
             .event_format(logger::LogFormatter { debug });
     }) {
         error!("Updating logger filter failed: {}", err);
-    }
-}
-
-pub fn flush_logger() {
-    if let Some((_, fmt_handle)) = LOGGER_HANDLE.get() {
-        let _ = fmt_handle.modify(|l| {
-            let _ = l.writer_mut().flush();
-        });
     }
 }


### PR DESCRIPTION
This reverts commit 2d525e7a7b454b6b9a015d3505d2b28d5b23dd58.

As this commit did not fix flaky tests as first thought, revert it.