### PR TITLE
refactor: adapt `PathEnvironment` to use `PathPointer`

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -110,6 +110,9 @@ pub trait Environment {
     }
 }
 
+/// A pointer to an environment, either managed or path.
+/// This is used to determine the type of an environment at a given path.
+/// See [EnvironmentPointer::open].
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum EnvironmentPointer {

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -159,7 +159,7 @@ impl EnvironmentPointer {
         let pointer_contents = match fs::read(pointer_path) {
             Ok(contents) => contents,
             Err(err) => match err.kind() {
-                io::ErrorKind::NotFound => Err(EnvironmentError2::DirectoryNotAnEnv)?,
+                io::ErrorKind::NotFound => Err(EnvironmentError2::EnvNotFound)?,
                 _ => Err(EnvironmentError2::ReadEnvironmentMetadata(err))?,
             },
         };

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -131,6 +131,15 @@ pub struct ManagedPointer {
 }
 
 impl EnvironmentPointer {
+    /// The function attempts to open an environment at the specified path
+    /// by reading the contents of a file named .flox/[ENVIRONMENT_POINTER_FILENAME].
+    /// If the file is found and its contents can be deserialized,
+    /// the function returns an [EnvironmentPointer] containing information about the environment.
+    /// If reading or parsing the file fails, an [EnvironmentError2] is returned.
+    ///
+    /// Use this method to determine the type of an environment at a given path.
+    /// The result should be used to call the appropriate `open` method
+    /// on either [PathEnvironment] or [ManagedEnvironment].
     pub fn open(path: impl AsRef<Path>) -> Result<EnvironmentPointer, EnvironmentError2> {
         let dot_flox_path = path.as_ref().join(DOT_FLOX);
         let pointer_path = dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME);

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -122,7 +122,7 @@ pub enum EnvironmentPointer {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct PathPointer {
-    name: EnvironmentName,
+    pub name: EnvironmentName,
     version: Version<1>,
 }
 

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -120,10 +120,20 @@ pub enum EnvironmentPointer {
     Path(PathPointer),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PathPointer {
     pub name: EnvironmentName,
     version: Version<1>,
+}
+
+impl PathPointer {
+    /// Create a new [PathPointer] with the given name.
+    pub fn new(name: EnvironmentName) -> Self {
+        Self {
+            name,
+            version: Version::<1>,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -230,6 +230,10 @@ pub enum EnvironmentError2 {
     CopyFile(IoError),
     #[error("Failed parsing contents of env.json file: {0}")]
     ParseEnvJson(serde_json::Error),
+    #[error("Failed serializing contents of env.json file: {0}")]
+    SerializeEnvJson(serde_json::Error),
+    #[error("Failed write env.json file: {0}")]
+    WriteEnvJson(std::io::Error),
     #[error(transparent)]
     ManagedEnvironment(#[from] ManagedEnvironmentError),
 }

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -438,7 +438,7 @@ impl PathEnvironment<Original> {
         temp_dir: impl AsRef<Path>,
     ) -> Result<Self, EnvironmentError2> {
         match EnvironmentPointer::open(path.as_ref()) {
-            Err(EnvironmentError2::DirectoryNotAnEnv) => {},
+            Err(EnvironmentError2::EnvNotFound) => {},
             Err(e) => Err(e)?,
             Ok(_) => Err(EnvironmentError2::EnvironmentExists)?,
         }

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -2,7 +2,6 @@ use std::ffi::OsStr;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use async_trait::async_trait;
 use flox_types::catalog::{EnvCatalog, System};
@@ -21,12 +20,18 @@ use super::{
     flox_nix_content_with_packages_removed,
     Environment,
     EnvironmentError2,
+    EnvironmentPointer,
     ManifestContent,
+    PathPointer,
+    DOT_FLOX,
+    ENVIRONMENT_POINTER_FILENAME,
 };
 use crate::models::environment::CATALOG_JSON;
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRef};
 use crate::prelude::flox_package::FloxPackage;
 use crate::utils::copy_file_without_permissions;
+
+const ENVIRONMENT_DIR_NAME: &'_ str = "env";
 
 /// Struct representing a local environment
 ///
@@ -45,8 +50,10 @@ pub struct PathEnvironment<S> {
     /// The temporary directory that this environment will use during transactions
     pub temp_dir: PathBuf,
 
-    /// The [EnvironmentName] of this environment
-    pub name: EnvironmentName,
+    /// The associated [PathPointer] of this environment.
+    ///
+    /// Used to identify the environment.
+    pub pointer: PathPointer,
 
     /// The transaction state
     pub state: S,
@@ -80,7 +87,7 @@ impl<S: TransactionState> PathEnvironment<S> {
         Ok(PathEnvironment {
             path: transaction_dir.into_path(),
             temp_dir: self.temp_dir.clone(),
-            name: self.name.clone(),
+            pointer: self.pointer.clone(),
             state: Temporary,
         })
     }
@@ -252,7 +259,7 @@ where
 
     /// Return the [EnvironmentRef] for the environment for identification
     fn environment_ref(&self) -> EnvironmentRef {
-        EnvironmentRef::new_from_parts(None, self.name.clone())
+        EnvironmentRef::new_from_parts(None, self.pointer.name.clone())
     }
 
     /// Get a catalog of installed packages from this environment
@@ -299,7 +306,7 @@ where
 
     /// Returns the environment name
     fn name(&self) -> EnvironmentName {
-        self.name.clone()
+        self.pointer.name.clone()
     }
 
     /// Delete the Environment
@@ -327,7 +334,7 @@ impl<S: TransactionState> PathEnvironment<S> {
     /// a precise url to interact with the environment via nix
     ///
     /// ```
-    /// # tokio_test::block_on(async {
+    /// # use flox_rust_sdk::models::environment::PathPointer;
     /// # use flox_rust_sdk::models::environment::path_environment::{Original,PathEnvironment};
     /// # use std::path::PathBuf;
     /// # let tempdir = tempfile::tempdir().unwrap();
@@ -336,18 +343,16 @@ impl<S: TransactionState> PathEnvironment<S> {
     /// # let system = "aarch64-darwin";
     ///
     /// let env = PathEnvironment::<Original>::init(
+    ///     PathPointer::new("test_env".parse().unwrap()),
     ///     &path,
-    ///     "test_env".parse().unwrap(),
     ///     environment_temp_dir.into_path(),
     /// )
     /// .unwrap();
     ///
-    /// let flake_attribute = format!("path:{path}/.flox/test_env#.floxEnvs.{system}.default")
+    /// let flake_attribute = format!("path:{path}/.flox/env#.floxEnvs.{system}.default")
     ///     .parse()
     ///     .unwrap();
     /// assert_eq!(env.flake_attribute(system), flake_attribute)
-    ///
-    /// # })
     /// ```
     pub fn flake_attribute(&self, system: impl AsRef<str>) -> FlakeAttribute {
         let flakeref = PathRef {
@@ -398,38 +403,27 @@ impl PathEnvironment<Original> {
     ///
     /// Ensure that the path exists and contains files that "look" like an environment
     pub fn open(
-        path: impl AsRef<Path>,
+        pointer: PathPointer,
+        dot_flox_path: impl AsRef<Path>,
         temp_dir: impl AsRef<Path>,
     ) -> Result<Self, EnvironmentError2> {
-        let path = path.as_ref().to_path_buf();
-        let dot_flox_path = path.join(".flox");
-        let env_dir_entry = dot_flox_path
-            .read_dir()
-            .map_err(EnvironmentError2::ReadDotFlox)?
-            .find_map(|entry| {
-                let entry = entry.ok()?;
-                let path = entry.path();
-                if path.is_dir() {
-                    Some(entry)
-                } else {
-                    None
-                }
-            })
-            .ok_or(EnvironmentError2::EnvNotFound)?;
+        let env_dir = dot_flox_path.as_ref().join(ENVIRONMENT_DIR_NAME);
+        if !env_dir.exists() {
+            Err(EnvironmentError2::EnvNotFound)?;
+        }
 
-        let env_path = env_dir_entry
-            .path()
+        let env_path = env_dir
             .canonicalize()
             .map_err(EnvironmentError2::EnvCanonicalize)?;
+
+        // TODO: replace with checks for manifest file once we transition
         if !env_path.join("flake.nix").exists() {
             Err(EnvironmentError2::DirectoryNotAnEnv)?
         }
 
-        let name = EnvironmentName::from_str(&env_dir_entry.file_name().to_string_lossy())?;
-
         Ok(PathEnvironment {
             path: env_path,
-            name,
+            pointer,
             temp_dir: temp_dir.as_ref().to_path_buf(),
             state: Original,
         })
@@ -439,22 +433,36 @@ impl PathEnvironment<Original> {
     ///
     /// The method creates or opens a `.flox` directory _contained_ within `path`!
     pub fn init(
+        pointer: PathPointer,
         path: impl AsRef<Path>,
-        name: EnvironmentName,
         temp_dir: impl AsRef<Path>,
     ) -> Result<Self, EnvironmentError2> {
-        if Self::open(&path, &temp_dir).is_ok() {
-            Err(EnvironmentError2::EnvironmentExists)?;
+        match EnvironmentPointer::open(path.as_ref()) {
+            Err(EnvironmentError2::DirectoryNotAnEnv) => {},
+            Err(e) => Err(e)?,
+            Ok(_) => Err(EnvironmentError2::EnvironmentExists)?,
         }
 
-        let env_dir = path.as_ref().join(".flox").join(name.as_ref());
+        let dot_flox_path = path.as_ref().join(DOT_FLOX);
 
+        let env_dir = dot_flox_path.join(ENVIRONMENT_DIR_NAME);
         std::fs::create_dir_all(&env_dir).map_err(EnvironmentError2::InitEnv)?;
+
+        let pointer_content =
+            serde_json::to_string_pretty(&pointer).map_err(EnvironmentError2::SerializeEnvJson)?;
 
         copy_dir_recursive(&env!("FLOX_ENV_TEMPLATE"), &env_dir, false)
             .map_err(EnvironmentError2::InitEnv)?;
 
-        Self::open(path, temp_dir)
+        if let Err(e) = fs::write(
+            dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME),
+            pointer_content,
+        ) {
+            fs::remove_dir_all(env_dir).map_err(EnvironmentError2::InitEnv)?;
+            Err(EnvironmentError2::WriteEnvJson(e))?;
+        }
+
+        Self::open(pointer, dot_flox_path, temp_dir)
     }
 }
 
@@ -469,33 +477,39 @@ mod tests {
     use crate::flox::tests::flox_instance;
     use crate::prelude::flox_package::FloxTriple;
 
-    #[tokio::test]
-    async fn create_env() {
-        let tempdir = tempfile::tempdir().unwrap();
+    #[test]
+    fn create_env() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let environment_temp_dir = tempfile::tempdir().unwrap();
-        let before = PathEnvironment::<Original>::open(tempdir.path(), environment_temp_dir.path());
+        let pointer = PathPointer::new("test".parse().unwrap());
+
+        let before = PathEnvironment::<Original>::open(
+            pointer.clone(),
+            environment_temp_dir.path(),
+            temp_dir.path(),
+        );
 
         assert!(
-            matches!(before, Err(EnvironmentError2::ReadDotFlox(_))),
+            matches!(before, Err(EnvironmentError2::EnvNotFound)),
             "{before:?}"
         );
 
         let expected = PathEnvironment {
-            path: tempdir
+            path: environment_temp_dir
                 .path()
                 .to_path_buf()
                 .canonicalize()
                 .unwrap()
-                .join(".flox/test"),
-            name: EnvironmentName::from_str("test").unwrap(),
-            temp_dir: environment_temp_dir.path().to_path_buf(),
+                .join(".flox/env"),
+            pointer: PathPointer::new("test".parse().unwrap()),
+            temp_dir: temp_dir.path().to_path_buf(),
             state: Original,
         };
 
         let actual = PathEnvironment::<Original>::init(
-            tempdir.path(),
-            EnvironmentName::from_str("test").unwrap(),
+            pointer,
             environment_temp_dir.into_path(),
+            temp_dir.path(),
         )
         .unwrap();
 
@@ -517,16 +531,14 @@ mod tests {
         assert!(actual.path.is_absolute());
     }
 
-    #[tokio::test]
-    async fn flake_attribute() {
-        let tempdir = tempfile::tempdir().unwrap();
+    #[test]
+    fn flake_attribute() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let environment_temp_dir = tempfile::tempdir().unwrap();
-        let env = PathEnvironment::<Original>::init(
-            tempdir.path(),
-            "test".parse().unwrap(),
-            environment_temp_dir.into_path(),
-        )
-        .unwrap();
+        let pointer = PathPointer::new("test".parse().unwrap());
+
+        let env =
+            PathEnvironment::<Original>::init(pointer, environment_temp_dir, temp_dir).unwrap();
 
         assert_eq!(
             env.flake_attribute("aarch64-darwin").to_string(),
@@ -571,11 +583,12 @@ mod tests {
     #[cfg(feature = "impure-unit-tests")]
     async fn edit_env() {
         let (_flox, tempdir) = flox_instance();
+        let pointer = PathPointer::new("test".parse().unwrap());
+
         let sandbox_path = tempdir.path().join("sandbox");
         std::fs::create_dir(&sandbox_path).unwrap();
 
-        let mut env =
-            PathEnvironment::init(tempdir.path(), "test".parse().unwrap(), &sandbox_path).unwrap();
+        let mut env = PathEnvironment::init(pointer, &tempdir, &sandbox_path).unwrap();
 
         let mut temp_env = env.make_temporary().unwrap();
 
@@ -601,12 +614,12 @@ mod tests {
         flox.channels
             .register_channel("nixpkgs-flox", "github:flox/nixpkgs-flox".parse().unwrap());
         let (nix, system) = (flox.nix(Default::default()), flox.system);
+        let pointer = PathPointer::new("test".parse().unwrap());
 
         let sandbox_path = tempdir.path().join("sandbox");
         std::fs::create_dir(&sandbox_path).unwrap();
 
-        let mut env =
-            PathEnvironment::init(tempdir.path(), "test".parse().unwrap(), &sandbox_path).unwrap();
+        let mut env = PathEnvironment::init(pointer, tempdir.path(), &sandbox_path).unwrap();
 
         let mut temp_env = env.make_temporary().unwrap();
 
@@ -665,11 +678,12 @@ mod tests {
             .register_channel("nixpkgs-flox", "github:flox/nixpkgs-flox".parse().unwrap());
         let (nix, system) = (flox.nix(Default::default()), flox.system);
 
+        let pointer = PathPointer::new("test".parse().unwrap());
+
         let sandbox_path = tempdir.path().join("sandbox");
         std::fs::create_dir(&sandbox_path).unwrap();
 
-        let mut env =
-            PathEnvironment::init(tempdir.path(), "test".parse().unwrap(), &sandbox_path).unwrap();
+        let mut env = PathEnvironment::init(pointer, tempdir.path(), &sandbox_path).unwrap();
 
         let mut temp_env = env.make_temporary().unwrap();
 

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -435,26 +435,6 @@ impl PathEnvironment<Original> {
         })
     }
 
-    /// Find the closest `.flox` starting with `current_dir`
-    /// and looking up ancestor directories until `/`
-    pub fn discover(
-        current_dir: impl AsRef<Path>,
-        temp_dir: impl AsRef<Path>,
-    ) -> Result<Option<Self>, EnvironmentError2> {
-        let maybe_dot_flox = current_dir
-            .as_ref()
-            .ancestors()
-            .find(|ancestor| ancestor.join(".flox").exists());
-
-        let with_dot_flox = if let Some(with_dot_flox) = maybe_dot_flox {
-            with_dot_flox
-        } else {
-            return Ok(None);
-        };
-
-        Some(Self::open(with_dot_flox, temp_dir)).transpose()
-    }
-
     /// Create a new env in a `.flox` directory within a specific path or open it if it exists.
     ///
     /// The method creates or opens a `.flox` directory _contained_ within `path`!

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -64,9 +64,13 @@ impl EnvironmentSelect {
     fn to_concrete_environment(&self, flox: &Flox) -> Result<ConcreteEnvironment> {
         let env = match self {
             EnvironmentSelect::Dir(path) => match EnvironmentPointer::open(path)? {
-                EnvironmentPointer::Path(_path_pointer) => {
+                EnvironmentPointer::Path(path_pointer) => {
                     let dot_flox_path = path.join(DOT_FLOX);
-                    ConcreteEnvironment::Path(PathEnvironment::open(dot_flox_path, &flox.temp_dir)?)
+                    ConcreteEnvironment::Path(PathEnvironment::open(
+                        path_pointer,
+                        dot_flox_path,
+                        &flox.temp_dir,
+                    )?)
                 },
                 EnvironmentPointer::Managed(managed_pointer) => ConcreteEnvironment::Managed(
                     ManagedEnvironment::open(flox, managed_pointer, path)?,
@@ -329,7 +333,11 @@ impl Init {
                 .parse()?
         };
 
-        let env = PathEnvironment::<Original>::init(&current_dir, name, flox.temp_dir.clone())?;
+        let env = PathEnvironment::<Original>::init(
+            PathPointer::new(name),
+            &current_dir,
+            flox.temp_dir.clone(),
+        )?;
 
         println!(
             indoc::indoc! {"

--- a/tests/environment-delete.bats
+++ b/tests/environment-delete.bats
@@ -58,7 +58,6 @@ env_exists() {
 # ---------------------------------------------------------------------------- #
 
 @test "deletes existing environment" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   run "$FLOX_CLI" init;
   assert_success;
   # run env_exists "$(basename $PWD)";
@@ -75,7 +74,6 @@ env_exists() {
 # ---------------------------------------------------------------------------- #
 
 @test "error message when called without .flox directory" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   run dot_flox_exists;
   assert_failure;
   run "$FLOX_CLI" delete;

--- a/tests/environment-delete.bats
+++ b/tests/environment-delete.bats
@@ -78,5 +78,5 @@ env_exists() {
   assert_failure;
   run "$FLOX_CLI" delete;
   assert_failure;
-  assert_output --partial "No matching environments found";
+  assert_output --partial 'No environment found in "./"';
 }

--- a/tests/environment-edit.bats
+++ b/tests/environment-edit.bats
@@ -97,7 +97,6 @@ check_manifest_updated() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' accepts contents via filename" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   run cat "$EXTERNAL_MANIFEST_PATH"
   run "$FLOX_CLI" edit -f "$EXTERNAL_MANIFEST_PATH";
   assert_success;
@@ -109,7 +108,6 @@ check_manifest_updated() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' accepts contents via pipe to stdin" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   run sh -c "cat ${EXTERNAL_MANIFEST_PATH} | ${FLOX_CLI} edit -f -";
   assert_success;
   # Get the contents as they appear in the actual manifest after the operation
@@ -163,7 +161,6 @@ check_manifest_updated() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' adds package with EDITOR" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   EDITOR="$TESTS_DIR/add-hello" run "$FLOX_CLI" edit;
   assert_success;
   run check_manifest_updated;

--- a/tests/environment-edit.bats
+++ b/tests/environment-edit.bats
@@ -51,7 +51,7 @@ EOF
   pushd "$PROJECT_DIR" >/dev/null || return;
 
   "$FLOX_CLI" init
-  export MANIFEST_PATH="$PROJECT_DIR/.flox/test/pkgs/default/flox.nix";
+  export MANIFEST_PATH="$PROJECT_DIR/.flox/env/pkgs/default/flox.nix";
   echo "$ORIGINAL_MANIFEST_CONTENTS" > "$MANIFEST_PATH";
   export EXTERNAL_MANIFEST_PATH="$PROJECT_DIR/input.nix";
   echo "$NEW_MANIFEST_CONTENTS" > "$EXTERNAL_MANIFEST_PATH";

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -50,7 +50,6 @@ setup_file() {
 }
 
 @test "i?: install confirmation message" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   "$FLOX_CLI" init
   run "$FLOX_CLI" install hello
   assert_success
@@ -58,7 +57,6 @@ setup_file() {
 }
 
 @test "uninstall confirmation message" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   "$FLOX_CLI" init
   run "$FLOX_CLI" install hello
   assert_success

--- a/tests/environment-list.bats
+++ b/tests/environment-list.bats
@@ -48,7 +48,6 @@ setup_file() {
 }
 
 @test "'flox list' lists packages of environment in the current dir; No package" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   "$FLOX_CLI" init
   run "$FLOX_CLI" list
   assert_success
@@ -57,7 +56,6 @@ setup_file() {
 }
 
 @test "'flox list' lists packages of environment in the current dir; One package from nixpkgs" {
-  skip "Re-enable when `PathEnvironment`s use env.json"
   "$FLOX_CLI" init
   "$FLOX_CLI" install hello
 

--- a/tests/environment-list.bats
+++ b/tests/environment-list.bats
@@ -51,8 +51,6 @@ setup_file() {
   "$FLOX_CLI" init
   run "$FLOX_CLI" list
   assert_success
-  # There's no output without any packages installed, all you get is warnings about overrides
-  assert_output "warning: input 'flox-floxpkgs/etc-profiles' has an override for a non-existent input 'flox-floxpkgs'"
 }
 
 @test "'flox list' lists packages of environment in the current dir; One package from nixpkgs" {
@@ -62,7 +60,6 @@ setup_file() {
   run "$FLOX_CLI" list
   assert_success
   assert_output --regexp - <<EOF
-.*
 hello
 EOF
 }


### PR DESCRIPTION
We implemented Environment opening through an intermediate `EnvironmentPointer` in #280 for `ManagedEnvironments`.

This PR implements the required changes to `PathEnvironment` to support `EnvironmentPointer`s.

In the course of the PR some previous APIs were removed (`PathEnvironment::discover`, various `EnvironmentRef` methods) in favor of a future pointer based implementation.

`flox envs` (which was using `PathEnvironment::discover`) refactored to use `EnvironmentPointer::open` in the meantime, before being either removed or `EnvironmentPointer::discover` is implemented.