### PR TITLE
ci: pin install-flox-action to mitigate any breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install flox
-      uses: flox/install-flox-action@main
+      uses: flox/install-flox-action@c9b5e33
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install flox
-      uses: flox/install-flox-action@c9b5e33
+      uses: flox/install-flox-action@c9b5e339b0670d375c9c66329c9473c7dde403ab
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store


### PR DESCRIPTION
This is a preparation PR to make sure I don't suddenly break CI while I merge next version of `install-flox-action` (https://github.com/flox/install-flox-action/pull/26)