### PR TITLE
Switch to new version of install-flox-action 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
         - "ubuntu-22.04-8core"
-        - "macos-13"
+        - "macos-latest"
 
     steps:
     - name: "Checkout"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
         #- "ubuntu-22.04-8core"
-        - "macos-latest"
+        - "macos-13"
 
     steps:
     - name: "Checkout"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - "ubuntu-22.04-8core"
+        #- "ubuntu-22.04-8core"
         - "macos-latest"
 
     steps:
@@ -39,72 +39,69 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: Debug
-      uses: mxschmitt/action-tmate@v3
-
     - name: "Cargo Test"
       run: nix develop -L '.#flox' --extra-experimental-features "nix-command flakes" --command cargo test
 
-        #  nix-build:
-        #    name: "Build and Run Bats Tests"
-        #    runs-on: ${{ matrix.os }}
-        #
-        #    strategy:
-        #      fail-fast: false
-        #      matrix:
-        #        os:
-        #        - "ubuntu-22.04-8core"
-        #        - "macos-latest"
-        #
-        #    steps:
-        #    - name: "Checkout"
-        #      uses: actions/checkout@v3
-        #      with:
-        #        fetch-depth: 0
-        #
-        #    - name: "Install flox"
-        #      uses: flox/install-flox-action@next-next
-        #      with:
-        #        github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
-        #        substituter: s3://flox-store
-        #        substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
-        #        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        #        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        #
-        #    - name: "Build flox-gh"
-        #      run: |
-        #        flox nix -- build '.#flox-gh' -L --no-update-lock-file      \
-        #                                      --print-out-paths --no-link;
-        #
-        #    - name: "Build nix-editor"
-        #      run: |
-        #        flox nix -- build '.#nix-editor' -L --no-update-lock-file      \
-        #                                         --print-out-paths --no-link;
-        #
-        #    - name: "Build builtfilter-rs"
-        #      run: |
-        #        flox nix -- build '.#builtfilter-rs' -L --no-update-lock-file      \
-        #                                             --print-out-paths --no-link;
-        #
-        #    - name: "Build flox-bash"
-        #      run: |
-        #        flox nix -- build '.#flox-bash-dev' -L --no-update-lock-file      \
-        #                                            --print-out-paths --no-link;
-        #
-        #    - name: "Build flox"
-        #      run: |
-        #        flox nix -- build '.#flox-dev' -L --no-update-lock-file  \
-        #                                       --print-out-paths;
-        #        echo "FLOX_CLI=$( readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV";
-        #        rm ./result;
-        #
-        #    - name: "Build flox-tests"
-        #      run: |
-        #        flox nix -- build '.#flox-tests' -L --no-update-lock-file      \
-        #                                         --print-out-paths --no-link;
-        #
-        #    # We ultimately test against the `FLOX_CLI' env var's path set earlier.
-        #    - name: "Bats Tests"
-        #      run: |
-        #        git clean -xfd;
-        #        nix run --extra-experimental-features "nix-command flakes" --no-update-lock-file '.#flox-tests';
+#  nix-build:
+#    name: "Build and Run Bats Tests"
+#    runs-on: ${{ matrix.os }}
+#
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os:
+#        - "ubuntu-22.04-8core"
+#        - "macos-latest"
+#
+#    steps:
+#    - name: "Checkout"
+#      uses: actions/checkout@v3
+#      with:
+#        fetch-depth: 0
+#
+#    - name: "Install flox"
+#      uses: flox/install-flox-action@next-next
+#      with:
+#        github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
+#        substituter: s3://flox-store
+#        substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
+#        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#
+#    - name: "Build flox-gh"
+#      run: |
+#        flox nix -- build '.#flox-gh' -L --no-update-lock-file      \
+#                                      --print-out-paths --no-link;
+#
+#    - name: "Build nix-editor"
+#      run: |
+#        flox nix -- build '.#nix-editor' -L --no-update-lock-file      \
+#                                         --print-out-paths --no-link;
+#
+#    - name: "Build builtfilter-rs"
+#      run: |
+#        flox nix -- build '.#builtfilter-rs' -L --no-update-lock-file      \
+#                                             --print-out-paths --no-link;
+#
+#    - name: "Build flox-bash"
+#      run: |
+#        flox nix -- build '.#flox-bash-dev' -L --no-update-lock-file      \
+#                                            --print-out-paths --no-link;
+#
+#    - name: "Build flox"
+#      run: |
+#        flox nix -- build '.#flox-dev' -L --no-update-lock-file  \
+#                                       --print-out-paths;
+#        echo "FLOX_CLI=$( readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV";
+#        rm ./result;
+#
+#    - name: "Build flox-tests"
+#      run: |
+#        flox nix -- build '.#flox-tests' -L --no-update-lock-file      \
+#                                         --print-out-paths --no-link;
+#
+#    # We ultimately test against the `FLOX_CLI' env var's path set earlier.
+#    - name: "Bats Tests"
+#      run: |
+#        git clean -xfd;
+#        nix run --extra-experimental-features "nix-command flakes" --no-update-lock-file '.#flox-tests';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,17 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+    - name: "Cache cargo"
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
     - name: "Cargo Test"
       run: |
         nix develop -L \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,42 +86,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: "Build flox-gh"
-      run: |
-        nix build -L \
-            --extra-experimental-features "nix-command flakes" \
-            --no-update-lock-file \
-            --print-out-paths \
-            --no-link \
-            '.#flox-gh'
-
-    - name: "Build nix-editor"
-      run: |
-        nix build -L \
-            --extra-experimental-features "nix-command flakes" \
-            --no-update-lock-file \
-            --print-out-paths \
-            --no-link \
-            '.#nix-editor'
-
-    - name: "Build builtfilter-rs"
-      run: |
-        nix build -L \
-            --extra-experimental-features "nix-command flakes" \
-            --no-update-lock-file \
-            --print-out-paths \
-            --no-link \
-            '.#builtfilter-rs'
-
-    - name: "Build flox-bash"
-      run: |
-        nix build  -L \
-            --extra-experimental-features "nix-command flakes" \
-            --no-update-lock-file \
-            --print-out-paths \
-            --no-link \
-            '.#flox-bash'
-
     - name: "Build flox"
       run: |
         nix build '.#flox' -L \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,10 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     - name: "Cargo Test"
-      run: nix develop -L '.#flox' \
+      run: nix develop -L \
         --extra-experimental-features "nix-command flakes" \
         --no-update-lock-file \
+        '.#flox' \
         --command cargo test --locked --workspace;
 
 #  nix-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+    - name: Debug
+      uses: mxschmitt/action-tmate@v3
+
     - name: "Cargo Test"
       run: nix develop -L '.#flox' --extra-experimental-features "nix-command flakes" --command cargo test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,11 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: "Development environment"
-      run: nix develop -L '.#flox' --extra-experimental-features "nix-command flakes" --command true
-
     - name: "Cargo Test"
       run: nix develop -L '.#flox' --extra-experimental-features "nix-command flakes" --command cargo test
 
   nix-build:
-    name: "Build and run Integrational Tests"
+    name: "Build and Run Bats Tests"
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -71,40 +68,40 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: Build flox-gh
+    - name: "Build flox-gh"
       run: |
         flox nix -- build '.#flox-gh' -L --no-update-lock-file      \
                                       --print-out-paths --no-link;
 
-    - name: Build nix-editor
+    - name: "Build nix-editor"
       run: |
         flox nix -- build '.#nix-editor' -L --no-update-lock-file      \
                                          --print-out-paths --no-link;
 
-    - name: Build builtfilter-rs
+    - name: "Build builtfilter-rs"
       run: |
         flox nix -- build '.#builtfilter-rs' -L --no-update-lock-file      \
                                              --print-out-paths --no-link;
 
-    - name: Build flox-bash
+    - name: "Build flox-bash"
       run: |
         flox nix -- build '.#flox-bash-dev' -L --no-update-lock-file      \
                                             --print-out-paths --no-link;
 
-    - name: Build flox
+    - name: "Build flox"
       run: |
         flox nix -- build '.#flox-dev' -L --no-update-lock-file  \
                                        --print-out-paths;
         echo "FLOX_CLI=$( readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV";
         rm ./result;
 
-    - name: Build flox-tests
+    - name: "Build flox-tests"
       run: |
         flox nix -- build '.#flox-tests' -L --no-update-lock-file      \
                                          --print-out-paths --no-link;
 
     # We ultimately test against the `FLOX_CLI' env var's path set earlier.
-    - name: Bats Tests
+    - name: "Bats Tests"
       run: |
         git clean -xfd;
         nix run --extra-experimental-features "nix-command flakes" --no-update-lock-file '.#flox-tests';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Install flox"
-      uses: flox/install-flox-action@next-next
+      uses: flox/install-flox-action@next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store
@@ -78,7 +78,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Install flox"
-      uses: flox/install-flox-action@next-next
+      uses: flox/install-flox-action@next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,4 +80,4 @@ jobs:
     - name: Bats Tests
       run: |
         git clean -xfd;
-        nix run --no-update-lock-file '.#flox-tests';
+        nix run --extra-experimental-features "nix-command flakes" --no-update-lock-file '.#flox-tests';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Install flox"
-      uses: flox/install-flox-action@next-next
+      uses: flox/install-flox-action@next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store
@@ -60,7 +60,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Install flox"
-      uses: flox/install-flox-action@next-next
+      uses: flox/install-flox-action@next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Install flox"
-      uses: flox/install-flox-action@next
+      uses: flox/install-flox-action@next-next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store
@@ -63,7 +63,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Install flox"
-      uses: flox/install-flox-action@next
+      uses: flox/install-flox-action@next-next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-    - name: Debug
-      uses: mxschmitt/action-tmate@v3
-
     - name: "Cargo Test"
       run: nix develop -L '.#flox' --extra-experimental-features "nix-command flakes" --command cargo test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - "ci-parallelize"
+      - "main"
   pull_request:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,69 +39,72 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+    - name: Debug
+      uses: mxschmitt/action-tmate@v3
+
     - name: "Cargo Test"
       run: nix develop -L '.#flox' --extra-experimental-features "nix-command flakes" --command cargo test
 
-  nix-build:
-    name: "Build and Run Bats Tests"
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-        - "ubuntu-22.04-8core"
-        - "macos-latest"
-
-    steps:
-    - name: "Checkout"
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: "Install flox"
-      uses: flox/install-flox-action@next-next
-      with:
-        github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
-        substituter: s3://flox-store
-        substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-    - name: "Build flox-gh"
-      run: |
-        flox nix -- build '.#flox-gh' -L --no-update-lock-file      \
-                                      --print-out-paths --no-link;
-
-    - name: "Build nix-editor"
-      run: |
-        flox nix -- build '.#nix-editor' -L --no-update-lock-file      \
-                                         --print-out-paths --no-link;
-
-    - name: "Build builtfilter-rs"
-      run: |
-        flox nix -- build '.#builtfilter-rs' -L --no-update-lock-file      \
-                                             --print-out-paths --no-link;
-
-    - name: "Build flox-bash"
-      run: |
-        flox nix -- build '.#flox-bash-dev' -L --no-update-lock-file      \
-                                            --print-out-paths --no-link;
-
-    - name: "Build flox"
-      run: |
-        flox nix -- build '.#flox-dev' -L --no-update-lock-file  \
-                                       --print-out-paths;
-        echo "FLOX_CLI=$( readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV";
-        rm ./result;
-
-    - name: "Build flox-tests"
-      run: |
-        flox nix -- build '.#flox-tests' -L --no-update-lock-file      \
-                                         --print-out-paths --no-link;
-
-    # We ultimately test against the `FLOX_CLI' env var's path set earlier.
-    - name: "Bats Tests"
-      run: |
-        git clean -xfd;
-        nix run --extra-experimental-features "nix-command flakes" --no-update-lock-file '.#flox-tests';
+        #  nix-build:
+        #    name: "Build and Run Bats Tests"
+        #    runs-on: ${{ matrix.os }}
+        #
+        #    strategy:
+        #      fail-fast: false
+        #      matrix:
+        #        os:
+        #        - "ubuntu-22.04-8core"
+        #        - "macos-latest"
+        #
+        #    steps:
+        #    - name: "Checkout"
+        #      uses: actions/checkout@v3
+        #      with:
+        #        fetch-depth: 0
+        #
+        #    - name: "Install flox"
+        #      uses: flox/install-flox-action@next-next
+        #      with:
+        #        github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
+        #        substituter: s3://flox-store
+        #        substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
+        #        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        #        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        #
+        #    - name: "Build flox-gh"
+        #      run: |
+        #        flox nix -- build '.#flox-gh' -L --no-update-lock-file      \
+        #                                      --print-out-paths --no-link;
+        #
+        #    - name: "Build nix-editor"
+        #      run: |
+        #        flox nix -- build '.#nix-editor' -L --no-update-lock-file      \
+        #                                         --print-out-paths --no-link;
+        #
+        #    - name: "Build builtfilter-rs"
+        #      run: |
+        #        flox nix -- build '.#builtfilter-rs' -L --no-update-lock-file      \
+        #                                             --print-out-paths --no-link;
+        #
+        #    - name: "Build flox-bash"
+        #      run: |
+        #        flox nix -- build '.#flox-bash-dev' -L --no-update-lock-file      \
+        #                                            --print-out-paths --no-link;
+        #
+        #    - name: "Build flox"
+        #      run: |
+        #        flox nix -- build '.#flox-dev' -L --no-update-lock-file  \
+        #                                       --print-out-paths;
+        #        echo "FLOX_CLI=$( readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV";
+        #        rm ./result;
+        #
+        #    - name: "Build flox-tests"
+        #      run: |
+        #        flox nix -- build '.#flox-tests' -L --no-update-lock-file      \
+        #                                         --print-out-paths --no-link;
+        #
+        #    # We ultimately test against the `FLOX_CLI' env var's path set earlier.
+        #    - name: "Bats Tests"
+        #      run: |
+        #        git clean -xfd;
+        #        nix run --extra-experimental-features "nix-command flakes" --no-update-lock-file '.#flox-tests';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,24 +13,53 @@ concurrency:
 
 jobs:
 
-  build:
-    name: Build and test flox on ${{ matrix.os }}
+  cargo-test:
+    name: "Run Cargo Tests"
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-22.04-8core
-        - macos-latest
+        - "ubuntu-22.04-8core"
+        - "macos-latest"
 
     steps:
-    - name: Checkout
+    - name: "Checkout"
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - name: Install flox
+    - name: "Install flox"
+      uses: flox/install-flox-action@next
+      with:
+        github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
+        substituter: s3://flox-store
+        substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: "Cargo Test"
+      run: nix develop '.#flox' --command cargo test;
+
+  nix-build:
+    name: "Build and run Integrational Tests"
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - "ubuntu-22.04-8core"
+        - "macos-latest"
+
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: "Install flox"
       uses: flox/install-flox-action@next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
@@ -58,11 +87,6 @@ jobs:
       run: |
         flox nix -- build '.#flox-bash-dev' -L --no-update-lock-file      \
                                             --print-out-paths --no-link;
-
-    # These cannot be run offline so we need to build in our tree.
-    # This just builds the `flox' deps so that they can get cached.
-    - name: Build Rust Env
-      run: flox nix -- develop '.#flox' --no-update-lock-file -c true;
 
     - name: Build flox
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     - name: "Cargo Test"
-      run: nix develop -L \
-        --extra-experimental-features "nix-command flakes" \
-        --no-update-lock-file \
-        '.#flox' \
-        --command cargo test --locked --workspace;
+      run: |
+        nix develop -L \
+          --extra-experimental-features "nix-command flakes" \
+          --no-update-lock-file \
+          '.#flox' \
+          --command cargo test --locked --workspace;
 
 #  nix-build:
 #    name: "Build and Run Bats Tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,15 +108,15 @@ jobs:
             --no-update-lock-file \
             --print-out-paths \
             --no-link \
-            '.#flox-bash-dev'
+            '.#flox-bash'
 
     - name: "Build flox"
       run: |
-        nix build '.#flox-dev' -L 
+        nix build '.#flox' -L 
             --extra-experimental-features "nix-command flakes" \
             --no-update-lock-file \
             --print-out-paths \
-            '.#flox-dev'
+            '.#flox'
         echo "FLOX_CLI=$(readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV"
         rm ./result
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        #- "ubuntu-22.04-8core"
+        - "ubuntu-22.04-8core"
         - "macos-13"
 
     steps:
@@ -45,94 +45,94 @@ jobs:
           --extra-experimental-features "nix-command flakes" \
           --no-update-lock-file \
           '.#flox' \
-          --command cargo test --locked --workspace;
+            --command cargo test --locked --workspace;
 
-#  nix-build:
-#    name: "Build and Run Bats Tests"
-#    runs-on: ${{ matrix.os }}
-#
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os:
-#        - "ubuntu-22.04-8core"
-#        - "macos-latest"
-#
-#    steps:
-#    - name: "Checkout"
-#      uses: actions/checkout@v3
-#      with:
-#        fetch-depth: 0
-#
-#    - name: "Install flox"
-#      uses: flox/install-flox-action@next-next
-#      with:
-#        github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
-#        substituter: s3://flox-store
-#        substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
-#        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#
-#    - name: "Build flox-gh"
-#      run: |
-#        nix build -L \
-#            --extra-experimental-features "nix-command flakes" \
-#            --no-update-lock-file \
-#            --print-out-paths \
-#            --no-link \
-#            '.#flox-gh'
-#
-#    - name: "Build nix-editor"
-#      run: |
-#        nix build -L \
-#            --extra-experimental-features "nix-command flakes" \
-#            --no-update-lock-file \
-#            --print-out-paths \
-#            --no-link \
-#            '.#nix-editor'
-#
-#    - name: "Build builtfilter-rs"
-#      run: |
-#        nix build -L \
-#            --extra-experimental-features "nix-command flakes" \
-#            --no-update-lock-file \
-#            --print-out-paths \
-#            --no-link \
-#            '.#builtfilter-rs'
-#
-#    - name: "Build flox-bash"
-#      run: |
-#        nix build  -L \
-#            --extra-experimental-features "nix-command flakes" \
-#            --no-update-lock-file \
-#            --print-out-paths \
-#            --no-link \
-#            '.#flox-bash-dev'
-#
-#    - name: "Build flox"
-#      run: |
-#        nix build '.#flox-dev' -L 
-#            --extra-experimental-features "nix-command flakes" \
-#            --no-update-lock-file \
-#            --print-out-paths \
-#            '.#flox-dev'
-#        echo "FLOX_CLI=$(readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV"
-#        rm ./result
-#
-#    - name: "Build flox-tests"
-#      run: |
-#        nix build -L \
-#            --extra-experimental-features "nix-command flakes" \
-#            --no-update-lock-file \
-#            --print-out-paths \
-#            --no-link \
-#            '.#flox-tests'
-#
-#    # We ultimately test against the `FLOX_CLI' env var's path set earlier.
-#    - name: "Bats Tests"
-#      run: |
-#        git clean -xfd
-#        nix run \
-#            --extra-experimental-features "nix-command flakes" \
-#            --no-update-lock-file \
-#            '.#flox-tests'
+  nix-build:
+    name: "Build and Run Bats Tests"
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - "ubuntu-22.04-8core"
+        - "macos-latest"
+
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: "Install flox"
+      uses: flox/install-flox-action@next-next
+      with:
+        github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
+        substituter: s3://flox-store
+        substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: "Build flox-gh"
+      run: |
+        nix build -L \
+            --extra-experimental-features "nix-command flakes" \
+            --no-update-lock-file \
+            --print-out-paths \
+            --no-link \
+            '.#flox-gh'
+
+    - name: "Build nix-editor"
+      run: |
+        nix build -L \
+            --extra-experimental-features "nix-command flakes" \
+            --no-update-lock-file \
+            --print-out-paths \
+            --no-link \
+            '.#nix-editor'
+
+    - name: "Build builtfilter-rs"
+      run: |
+        nix build -L \
+            --extra-experimental-features "nix-command flakes" \
+            --no-update-lock-file \
+            --print-out-paths \
+            --no-link \
+            '.#builtfilter-rs'
+
+    - name: "Build flox-bash"
+      run: |
+        nix build  -L \
+            --extra-experimental-features "nix-command flakes" \
+            --no-update-lock-file \
+            --print-out-paths \
+            --no-link \
+            '.#flox-bash-dev'
+
+    - name: "Build flox"
+      run: |
+        nix build '.#flox-dev' -L 
+            --extra-experimental-features "nix-command flakes" \
+            --no-update-lock-file \
+            --print-out-paths \
+            '.#flox-dev'
+        echo "FLOX_CLI=$(readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV"
+        rm ./result
+
+    - name: "Build flox-tests"
+      run: |
+        nix build -L \
+            --extra-experimental-features "nix-command flakes" \
+            --no-update-lock-file \
+            --print-out-paths \
+            --no-link \
+            '.#flox-tests'
+
+    # We test against the `FLOX_CLI' env var's path set earlier.
+    - name: "Bats Tests"
+      run: |
+        git clean -xfd
+        nix run \
+            --extra-experimental-features "nix-command flakes" \
+            --no-update-lock-file \
+            '.#flox-tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
     - name: "Build flox"
       run: |
-        nix build '.#flox' -L 
+        nix build '.#flox' -L \
             --extra-experimental-features "nix-command flakes" \
             --no-update-lock-file \
             --print-out-paths \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,37 +31,13 @@ jobs:
         fetch-depth: 0
 
     - name: Install flox
-      uses: flox/install-flox-action@main
+      uses: flox/install-flox-action@next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store
         substituter-key: ${{ secrets.FLOX_STORE_PUBLIC_NIX_SECRET_KEY }}
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-    - name: Restore Nix Caches
-      id: nix-cache-restore
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cache/nix
-        key: ${{ runner.os }}-nix-cache
-
-    # This is used to detect any new store paths we create while running builds
-    # so that they can be pushed to caches.
-    - name: Record Nix Store Paths
-      run: |
-        NIX_STORE_DIR="$(
-          flox nix -- eval --impure --raw --expr builtins.storeDir;
-        )";
-        echo "NIX_STORE_DIR=$NIX_STORE_DIR" >> "$GITHUB_ENV";
-        STORE_PATHS_FILE="$( mktemp; )";
-        echo "STORE_PATHS_FILE=$STORE_PATHS_FILE" >> "$GITHUB_ENV";
-        find "$NIX_STORE_DIR" -maxdepth 1 -mindepth 1 -type d -o -type l  \
-          |sort > "$STORE_PATHS_FILE";
-        echo "Have $(
-          wc -l "$STORE_PATHS_FILE"|cut -d' ' -f1;
-        ) $NIX_STORE_DIR paths" >&2;
 
     - name: Build flox-gh
       run: |
@@ -100,46 +76,8 @@ jobs:
         flox nix -- build '.#flox-tests' -L --no-update-lock-file      \
                                          --print-out-paths --no-link;
 
-    - name: Push New Store Paths
-      if: ${{ always() }}
-      run: |
-        # Since we run onconditionally we need to bail early in case the
-        # `STORE_PATHS_FILE' was never created.
-        if [[ -z "${STORE_PATHS_FILE:-}" ]]; then
-          echo "No old store paths were cached. Skipping push." >&2;
-          exit 1;
-        fi
-        STORE_PATHS_FILE2="$( mktemp; )";
-        find "$NIX_STORE_DIR" -maxdepth 1 -mindepth 1 -type d -o -type l  \
-          |sort > "$STORE_PATHS_FILE2";
-        NEW_STORE_PATHS_FILE="$( mktemp; )";
-        comm -13 "$STORE_PATHS_FILE" "$STORE_PATHS_FILE2"  \
-             > "$NEW_STORE_PATHS_FILE";
-        echo "Have $(
-          wc -l "$NEW_STORE_PATHS_FILE"|cut -d' ' -f1;
-        ) new $NIX_STORE_DIR paths" >&2;
-        # Allow pushing to fail.
-        cat "$NEW_STORE_PATHS_FILE"                            \
-          |xargs -r nix copy --to "$FLOX_SUBSTITUTER" -vv||:;
-
-    # These cannot be run offline so we need to build in our tree.
-    - name: Rust Tests
-      run: |
-        git clean -xfd;
-        nix develop '.#flox' --no-update-lock-file   \
-                    -c cargo test --locked --workspace;
-
     # We ultimately test against the `FLOX_CLI' env var's path set earlier.
     - name: Bats Tests
       run: |
         git clean -xfd;
         nix run --no-update-lock-file '.#flox-tests';
-
-    - name: Save Nix Caches
-      id: nix-cache-save
-      uses: actions/cache/save@v3
-      if: ${{ always() }}
-      with:
-        path: |
-          ~/.cache/nix
-        key: ${{ steps.nix-cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     - name: "Cargo Test"
-      run: nix develop '.#flox' --command cargo test;
+      run: nix develop '.#flox' --extra-experimental-features "nix-command flakes" --command cargo test;
 
   nix-build:
     name: "Build and run Integrational Tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: cargo-${{ runner.os }}-
 
     - name: "Cargo Test"
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Install flox"
-      uses: flox/install-flox-action@next
+      uses: flox/install-flox-action@next-next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store
@@ -60,7 +60,7 @@ jobs:
         fetch-depth: 0
 
     - name: "Install flox"
-      uses: flox/install-flox-action@next
+      uses: flox/install-flox-action@next-next
       with:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
         substituter: s3://flox-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,11 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+    - name: "Development environment"
+      run: nix develop -L '.#flox' --extra-experimental-features "nix-command flakes" --command true
+
     - name: "Cargo Test"
-      run: nix develop '.#flox' --extra-experimental-features "nix-command flakes" --command cargo test;
+      run: nix develop -L '.#flox' --extra-experimental-features "nix-command flakes" --command cargo test
 
   nix-build:
     name: "Build and run Integrational Tests"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 result
 result-*
 /.flox
+/.direnv/


### PR DESCRIPTION
And also:
- run again, since it was removed from CI, `cargo tests`
- we run Cargo tests in parallel to Bats tests
- sneaking in support for direnv (`.envrc` file)