### PR TITLE
feat: format flox show output

### DIFF
--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -748,9 +748,9 @@ impl GitProvider for GitCommandProvider {
         };
 
         Ok(OriginInfo {
-            name: remote_name.to_string(),
+            name: remote_name,
             url,
-            reference: remote_branch.to_string(),
+            reference: remote_branch,
             revision: remote_revision,
         })
     }

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -296,6 +296,10 @@ pub struct Show {
     /// for a package name e.g. something copy-pasted from the output of `flox search`.
     #[bpaf(positional("search-term"))]
     pub search_term: String,
+
+    /// Whether to show all available package versions
+    #[bpaf(long)]
+    pub all: bool,
 }
 
 impl Show {
@@ -312,7 +316,7 @@ impl Show {
         // FIXME: We may have warnings on `stderr` even with a successful call to `pkgdb`.
         //        We aren't checking that at all at the moment because better overall error handling
         //        is coming in a later PR.
-        render_show(search_results.results.as_slice(), true)?;
+        render_show(search_results.results.as_slice(), self.all)?;
         if exit_status.success() {
             Ok(())
         } else {

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -292,14 +292,14 @@ fn dedup_and_disambiguate_display_items(mut display_items: Vec<DisplayItem>) -> 
 /// Show detailed package information
 #[derive(Bpaf, Clone)]
 pub struct Show {
+    /// Whether to show all available package versions
+    #[bpaf(long)]
+    pub all: bool,
+
     /// The package to show detailed information about. Must be an exact match
     /// for a package name e.g. something copy-pasted from the output of `flox search`.
     #[bpaf(positional("search-term"))]
     pub search_term: String,
-
-    /// Whether to show all available package versions
-    #[bpaf(long)]
-    pub all: bool,
 }
 
 impl Show {

--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -425,12 +425,9 @@ fn render_show(search_results: &[SearchResult], all: bool) -> Result<()> {
                     return None;
                 }
                 let name = sr.pkg_subpath.join(".");
-                // TODO: what if one of the search results doesn't have a version?
-                if let Some(version) = sr.version.clone() {
-                    Some([name, version].join("@"))
-                } else {
-                    Some(name)
-                }
+                // We don't print packages that don't have a version since
+                // the resolver will always rank versioned packages higher.
+                sr.version.clone().map(|version| [name, version].join("@"))
             })
             .collect::<Vec<_>>();
         multiple_versions.join(", ")

--- a/tests/channels-show.bats
+++ b/tests/channels-show.bats
@@ -78,3 +78,43 @@ setup_file() {
   run "$FLOX_CLI" show "$first_result";
   assert_success;
 }
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' - hello" {
+  run "$FLOX_CLI" show hello;
+  assert_success;
+  assert_equal "${lines[0]}" "hello - A program that produces a familiar, friendly greeting";
+  assert_equal "${lines[1]}" "    hello - hello@2.12.1";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' - hello --all" {
+  run "$FLOX_CLI" show hello --all;
+  assert_success;
+  assert_equal "${lines[0]}" "hello - A program that produces a familiar, friendly greeting";
+  assert_equal "${lines[1]}" "    hello - hello@2.12.1, hello@2.12, hello@2.10";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' - python27Full" {
+  run "$FLOX_CLI" show python27Full;
+  assert_success;
+  assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language";
+  assert_equal "${lines[1]}" "    python27Full - python27Full@2.7.18";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' - python27Full --all" {
+  run "$FLOX_CLI" show python27Full --all;
+  assert_success;
+  assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language";
+  assert_equal "${lines[1]}" "    python27Full - python27Full@2.7.18, python27Full@2.7.18.5";
+}


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This properly formats the output of the feature-flagged `flox show` command:

```
$ flox show hello
hello - A program that produces a familiar, friendly greeting
    hello - hello@2.12.1

$ flox show hello --all
hello - A program that produces a familiar, friendly greeting
    hello - hello@2.12.1, hello@2.12, hello@2.10
```

## Current Behavior

<!-- Describe the current behavior before applying this pull request. -->
The current output is a crude list of `name - description` lines.

## Checks

<!-- Please confirm the following: -->

- [x] All tests pass.
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] I have accepted the flox [Contributor License Agreement](../blob/main/.github/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](../blob/main/.github/CONTRIBUTORS.csv) file by way of this pull request or one done previously.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
