### PR TITLE
feat: remove `--long` flag from `flox search`

### DIFF
--- a/crates/flox/src/commands/channel.rs
+++ b/crates/flox/src/commands/channel.rs
@@ -55,10 +55,6 @@ pub struct Search {
     #[bpaf(long)]
     pub json: bool,
 
-    /// print extended search results
-    #[bpaf(short, long, long("verbose"), short('v'))]
-    pub long: bool,
-
     /// force update of catalogs from remote sources before searching
     #[bpaf(long)]
     pub refresh: bool,


### PR DESCRIPTION
`flox show` was implemented as a replacement to show detailed information about a package and fully available with #327.