### PR TITLE
feat: edit manifest with 'flox uninstall'

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -15,7 +15,6 @@ use super::{Environment, EnvironmentError2, InstallationAttempt, ManagedPointer}
 use crate::flox::Flox;
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRef};
 use crate::models::floxmetav2::{FloxmetaV2, FloxmetaV2Error};
-use crate::prelude::flox_package::FloxPackage;
 use crate::providers::git::{GitCommandBranchHashError, GitCommandError};
 
 const GENERATION_LOCK_FILENAME: &str = "env.lock";
@@ -98,10 +97,10 @@ impl Environment for ManagedEnvironment {
     #[allow(unused)]
     async fn uninstall(
         &mut self,
-        packages: Vec<FloxPackage>,
+        packages: Vec<String>,
         nix: &NixCommandLine,
         system: System,
-    ) -> Result<Option<String>, EnvironmentError2> {
+    ) -> Result<String, EnvironmentError2> {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -19,7 +19,7 @@ use super::environment_ref::{
     EnvironmentRef,
     EnvironmentRefError,
 };
-use super::flox_package::{FloxPackage, FloxTriple};
+use super::flox_package::FloxTriple;
 use super::manifest::TomlEditError;
 use crate::utils::copy_file_without_permissions;
 use crate::utils::errors::IoError;
@@ -71,10 +71,10 @@ pub trait Environment {
     /// Uninstall packages from the environment atomically
     async fn uninstall(
         &mut self,
-        packages: Vec<FloxPackage>,
+        packages: Vec<String>,
         nix: &NixCommandLine,
         system: System,
-    ) -> Result<Option<String>, EnvironmentError2>;
+    ) -> Result<String, EnvironmentError2>;
 
     /// Atomically edit this environment, ensuring that it still builds
     async fn edit(

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -27,8 +27,7 @@ use super::{
 };
 use crate::models::environment::CATALOG_JSON;
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRef};
-use crate::models::manifest::insert_packages;
-use crate::prelude::flox_package::FloxPackage;
+use crate::models::manifest::{insert_packages, remove_packages};
 use crate::utils::copy_file_without_permissions;
 
 const ENVIRONMENT_DIR_NAME: &'_ str = "env";
@@ -228,23 +227,15 @@ where
     /// uninstalled rather than a bool.
     async fn uninstall(
         &mut self,
-        _packages: Vec<FloxPackage>,
+        packages: Vec<String>,
         _nix: &NixCommandLine,
         _system: System,
-    ) -> Result<Option<String>, EnvironmentError2> {
-        // let current_manifest_contents = self.manifest_content()?;
-
-        // let new_manifest_contents =
-        //     flox_nix_content_with_packages_removed(&current_manifest_contents, packages)?;
-        // match new_manifest_contents {
-        //     ManifestContent::Unchanged => return Ok(false),
-        //     ManifestContent::Changed(contents) => {
-        //         self.transact_with_manifest_contents(contents, nix, system)
-        //             .await?;
-        //         Ok(true)
-        //     },
-        // }
-        todo!()
+    ) -> Result<String, EnvironmentError2> {
+        let current_manifest_contents = self.manifest_content()?;
+        let toml = remove_packages(&current_manifest_contents, packages.iter().cloned())?;
+        // TODO: enable transactions once build is re-implemented
+        // self.transact_with_manifest_contents(toml.to_string(), nix, system).await?;
+        Ok(toml.to_string())
     }
 
     /// Atomically edit this environment, ensuring that it still builds

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -5,7 +5,6 @@ use runix::installable::FlakeAttribute;
 
 use super::{Environment, EnvironmentError2, InstallationAttempt};
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRef};
-use crate::prelude::flox_package::FloxPackage;
 
 #[derive(Debug)]
 pub struct RemoteEnvironment;
@@ -37,10 +36,10 @@ impl Environment for RemoteEnvironment {
     #[allow(unused)]
     async fn uninstall(
         &mut self,
-        packages: Vec<FloxPackage>,
+        packages: Vec<String>,
         nix: &NixCommandLine,
         system: System,
-    ) -> Result<Option<String>, EnvironmentError2> {
+    ) -> Result<String, EnvironmentError2> {
         todo!()
     }
 

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -60,22 +60,30 @@ setup_file() {
   "$FLOX_CLI" init;
   run "$FLOX_CLI" install foo;
   assert_success;
-  contains_foo=$(cat "$PROJECT_DIR/.flox/env/manifest.toml" | grep "foo = ");
-  assert [ -n "$contains_foo" ];
+  run grep "foo = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
+  assert_success;
 }
 
 @test "uninstall confirmation message" {
-  skip TODO
   "$FLOX_CLI" init
   run "$FLOX_CLI" install hello
   assert_success
-  assert_output --partial "✅ 'hello' installed to environment."
+  assert_output --partial "✅ 'hello' installed to environment"
 
   run "$FLOX_CLI" uninstall hello
   assert_success
-  assert_output --partial "🗑️ 'hello' uninstalled from environment."
+  # Note that there's TWO spaces between the emoji and the package name
+  assert_output --partial "🗑️  'hello' uninstalled from environment"
 }
 
+@test "'flox uninstall' edits manifest" {
+  "$FLOX_CLI" init;
+  run "$FLOX_CLI" install foo;
+  assert_success;
+  run "$FLOX_CLI" uninstall foo;
+  run grep "foo = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
+  assert_failure;
+}
 
 @test "i5: download package when install command runs" {
   skip "Don't know how to test, check out-link created?"


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This PR edits `manifest.toml` with `flox uninstall`.

Given a `manifest.toml` that looks like
```toml
[install]
foo = {}
bar = {}
```
and the uninstallation command you'll see the following output
```
$ flox uninstall foo bar
🗑️ 'foo' uninstalled from environment
🗑️ 'bar' uninstalled from environment
```

If _any_ of the packages requested for uninstallation is missing from the manifest the whole operation is aborted and the manifest is unchanged. This is to pave the way for transactional operations.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
`flox uninstall` removes packages from `manifest.toml`

<!-- Many thanks! -->
