### PR TITLE
chore: nix -> 2.15.3 and remove superfluous patches

### DIFF
--- a/pkgs/flox-bash/default.nix
+++ b/pkgs/flox-bash/default.nix
@@ -15,18 +15,7 @@
   glibcLocalesUtf8,
   darwin,
 }: let
-  nixPatched = nixVersions.nix_2_15.overrideAttrs (oldAttrs: {
-    patches =
-      (oldAttrs.patches or [])
-      ++ [
-        ./nix-patches/CmdProfileBuild.patch
-        ./nix-patches/CmdSearchAttributes.patch
-        ./nix-patches/update-profile-list-warning.patch
-        ./nix-patches/multiple-github-tokens.2.13.2.patch
-        ./nix-patches/curl_flox_version.patch
-        ./nix-patches/no-default-prefixes-hash.2.15.1.patch
-      ];
-  });
+  nixPatched = nixVersions.nix_2_15;
 in
   stdenv.mkDerivation rec {
     pname = "flox-bash";


### PR DESCRIPTION
## Proposed Changes

Remove patches that are not used. Will continue to upstream multiple-github-tokens and nlohmann tempates.

## Release Notes

Patch supporting "flake#.rawAttrPath" syntax is removed. (is available in upstream latest, pending next release).
Patch supporting multiple access tokens per domain removed.
