### PR TITLE
fix: make git provider sync

### DIFF
--- a/crates/flox-rust-sdk/src/flox.rs
+++ b/crates/flox-rust-sdk/src/flox.rs
@@ -154,8 +154,8 @@ impl Flox {
     //       N.B.: Decide whether we want to keep the `Flox.<model>` API
     //       to create instances of subsystem models
     // region: revisit reg. channels
-    pub async fn floxmeta(&self, owner: &str) -> Result<Floxmeta<ReadOnly>, GetFloxmetaError> {
-        Floxmeta::get_floxmeta(self, owner).await
+    pub fn floxmeta(&self, owner: &str) -> Result<Floxmeta<ReadOnly>, GetFloxmetaError> {
+        Floxmeta::get_floxmeta(self, owner)
     }
 
     // endregion: revisit reg. channels

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -497,24 +497,24 @@ mod test {
     /// It results in output state of:
     /// - lock at commit 2
     /// - floxmeta at commit 2
-    #[tokio::test]
-    async fn test_ensure_locked_case_1() {
+    #[test]
+    fn test_ensure_locked_case_1() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
 
         // create a mock floxmeta
         let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // add a second commit to the remote
-        commit_file(&remote, "file 2").await;
+        commit_file(&remote, "file 2");
         let hash_2 = remote.branch_hash(&branch).unwrap();
 
         // create a .flox directory
@@ -542,18 +542,18 @@ mod test {
     /// It results in output state of:
     /// - lock at commit 1
     /// - floxmeta at commit 1
-    #[tokio::test]
-    async fn test_ensure_locked_case_2() {
+    #[test]
+    fn test_ensure_locked_case_2() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
@@ -589,28 +589,28 @@ mod test {
     /// It results in output state of:
     /// - lock at commit 2
     /// - floxmeta at commit 3
-    #[tokio::test]
-    async fn test_ensure_locked_case_3() {
+    #[test]
+    fn test_ensure_locked_case_3() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
 
         // create a mock floxmeta
         let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // add a second commit to the remote
-        commit_file(&remote, "file 2").await;
+        commit_file(&remote, "file 2");
         let hash_2 = remote.branch_hash(&branch).unwrap();
 
         // add a third commit to the remote
-        commit_file(&remote, "file 3").await;
+        commit_file(&remote, "file 3");
         let hash_3 = remote.branch_hash(&branch).unwrap();
 
         // create a .flox directory
@@ -643,25 +643,25 @@ mod test {
     ///
     /// It results in output state of:
     /// - error
-    #[tokio::test]
-    async fn test_ensure_locked_case_4() {
+    #[test]
+    fn test_ensure_locked_case_4() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
 
         // create a mock floxmeta
         let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // add a second branch to the remote
-        remote.checkout("branch_2", true).await.unwrap();
-        commit_file(&remote, "file 2").await;
+        remote.checkout("branch_2", true).unwrap();
+        commit_file(&remote, "file 2");
         let hash_2 = remote.branch_hash("branch_2").unwrap();
 
         // create a .flox directory
@@ -688,24 +688,24 @@ mod test {
     ///
     /// It results in output state of:
     /// - error
-    #[tokio::test]
-    async fn test_ensure_locked_case_5() {
+    #[test]
+    fn test_ensure_locked_case_5() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
 
         // create a mock floxmeta
         let floxmeta = create_floxmeta(&flox, &remote_path, &branch);
 
         // add a second commit to the remote
-        commit_file(&remote, "file 2").await;
+        commit_file(&remote, "file 2");
         let hash_2 = remote.branch_hash(&branch).unwrap();
 
         // create a .flox directory
@@ -734,18 +734,18 @@ mod test {
     ///
     /// It results in output state of:
     /// - no change
-    #[tokio::test]
-    async fn test_ensure_locked_case_6() {
+    #[test]
+    fn test_ensure_locked_case_6() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
@@ -779,18 +779,18 @@ mod test {
     ///
     /// It results in output state of:
     /// - error
-    #[tokio::test]
-    async fn test_ensure_locked_case_7() {
+    #[test]
+    fn test_ensure_locked_case_7() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
@@ -817,18 +817,18 @@ mod test {
     /// - branch at commit 1
     /// - rev at commit 1
     /// - local_rev at commit 1
-    #[tokio::test]
-    async fn test_ensure_branch_noop() {
+    #[test]
+    fn test_ensure_branch_noop() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta
@@ -848,23 +848,23 @@ mod test {
     /// - rev at commit 1
     /// - local_rev at commit 2
     /// ensure_branch resets the branch to commit 2
-    #[tokio::test]
-    async fn test_ensure_branch_resets_branch() {
+    #[test]
+    fn test_ensure_branch_resets_branch() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // add a second branch to the remote
-        remote.checkout("branch_2", true).await.unwrap();
-        commit_file(&remote, "file 2").await;
+        remote.checkout("branch_2", true).unwrap();
+        commit_file(&remote, "file 2");
         let hash_2 = remote.branch_hash("branch_2").unwrap();
 
         // Create a mock floxmeta (note clone is used instead of clone_branch,
@@ -876,7 +876,6 @@ mod test {
             user_floxmeta_dir,
             true,
         )
-        .await
         .unwrap();
 
         let floxmeta = FloxmetaV2::open(&flox, &TEST_POINTER).unwrap();
@@ -895,18 +894,18 @@ mod test {
     /// - rev at commit 1
     /// - local_rev at commit 1
     /// ensure_branch creates branch_2 at commit 1
-    #[tokio::test]
-    async fn test_ensure_branch_creates_branch() {
+    #[test]
+    fn test_ensure_branch_creates_branch() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         // create a mock remote
         let remote_path = flox.temp_dir.join("remote");
         fs::create_dir(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).await.unwrap();
+        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
 
         let branch = remote_branch_name(&flox.system, &TEST_POINTER);
-        remote.checkout(&branch, true).await.unwrap();
-        commit_file(&remote, "file 1").await;
+        remote.checkout(&branch, true).unwrap();
+        commit_file(&remote, "file 1");
         let hash_1 = remote.branch_hash(&branch).unwrap();
 
         // create a mock floxmeta

--- a/crates/flox-rust-sdk/src/models/floxmeta/user_meta.rs
+++ b/crates/flox-rust-sdk/src/models/floxmeta/user_meta.rs
@@ -32,11 +32,10 @@ impl<'flox, A: GitAccess> Floxmeta<'flox, A> {
     /// load and parse `floxUserMeta.json` file from floxmeta repo
     ///
     /// note: fetches updates from upstream (todo: is this a ui decision?)
-    pub async fn user_meta(&self) -> Result<UserMeta, GetUserMetaError> {
+    pub fn user_meta(&self) -> Result<UserMeta, GetUserMetaError> {
         let user_meta_str = self
             .git()
             .show(&format!("{FLOX_MAIN_BRANCH}:{FLOX_USER_META_FILE}"))
-            .await
             .map_err(GetUserMetaError::Show)?;
         let user_meta = serde_json::from_str(&user_meta_str.to_string_lossy())?;
         Ok(user_meta)
@@ -48,7 +47,7 @@ impl<'flox> Floxmeta<'flox, GitSandBox> {
     ///
     /// This is in a sandbox, where checkouts and adding files is allowed.
     /// It is assumed the correct branch is checked out before this function is called.
-    pub async fn set_user_meta(&self, user_meta: &UserMeta) -> Result<(), SetUserMetaError> {
+    pub fn set_user_meta(&self, user_meta: &UserMeta) -> Result<(), SetUserMetaError> {
         let mut file = File::create(self.git().workdir().unwrap().join(FLOX_USER_META_FILE))
             .map_err(SetUserMetaError::OpenUserMetaFile)?;
 
@@ -56,7 +55,6 @@ impl<'flox> Floxmeta<'flox, GitSandBox> {
 
         self.git()
             .add(&[Path::new(FLOX_USER_META_FILE)])
-            .await
             .map_err(SetUserMetaError::Add)?;
 
         Ok(())

--- a/crates/flox-rust-sdk/src/models/root/git.rs
+++ b/crates/flox-rust-sdk/src/models/root/git.rs
@@ -20,13 +20,12 @@ impl<'flox, Git: GitProvider> RootGuard<'flox, Closed<Git>, Closed<PathBuf>> {
 
     /// Retrieve the initialized repo or try to create one
     // todo add `bare` option
-    pub async fn init_git(self) -> Result<Root<'flox, Closed<Git>>, ProjectInitGitError<Git>> {
+    pub fn init_git(self) -> Result<Root<'flox, Closed<Git>>, ProjectInitGitError<Git>> {
         match self {
             Guard::Initialized(i) => Ok(i),
             Guard::Uninitialized(u) => {
-                let repo = Git::init(&u.state.inner, false)
-                    .await
-                    .map_err(ProjectInitGitError::InitRepoError)?;
+                let repo =
+                    Git::init(&u.state.inner, false).map_err(ProjectInitGitError::InitRepoError)?;
 
                 Ok(Root {
                     flox: u.flox,

--- a/crates/flox-rust-sdk/src/models/root/reference.rs
+++ b/crates/flox-rust-sdk/src/models/root/reference.rs
@@ -18,13 +18,13 @@ use crate::utils::guard::Guard;
 /// At this stage the root has not yet been verified.
 /// This state should be handled as a mere reference to a potential root of any kind
 impl<'flox> Root<'flox, Closed<PathBuf>> {
-    pub async fn guard(
+    pub fn guard(
         self,
     ) -> Result<
         RootGuard<'flox, Closed<GitCommandProvider>, Closed<PathBuf>>,
         ProjectDiscoverGitError,
     > {
-        match GitCommandProvider::discover(&self.state.inner).await {
+        match GitCommandProvider::discover(&self.state.inner) {
             Ok(repo) => Ok(Guard::Initialized(Root {
                 flox: self.flox,
                 state: Closed::new(repo),

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -3,7 +3,6 @@ use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use async_trait::async_trait;
 use log::{debug, error, warn};
 use thiserror::Error;
 
@@ -30,7 +29,6 @@ pub struct BranchInfo {
 
 // simple git provider for the tasks we need to provide in
 // flox
-#[async_trait(?Send)]
 pub trait GitProvider: Send + Sized + std::fmt::Debug {
     type InitError: std::error::Error;
     type CloneError: std::error::Error;
@@ -56,38 +54,37 @@ pub trait GitProvider: Send + Sized + std::fmt::Debug {
     type SetOriginError: std::error::Error;
     type GetOriginError: std::error::Error;
 
-    async fn discover<P: AsRef<Path>>(path: P) -> Result<Self, Self::DiscoverError>;
-    async fn init<P: AsRef<Path>>(path: P, bare: bool) -> Result<Self, Self::InitError>;
-    async fn clone<O: AsRef<OsStr>, P: AsRef<Path>>(
+    fn discover<P: AsRef<Path>>(path: P) -> Result<Self, Self::DiscoverError>;
+    fn init<P: AsRef<Path>>(path: P, bare: bool) -> Result<Self, Self::InitError>;
+    fn clone<O: AsRef<OsStr>, P: AsRef<Path>>(
         origin: O,
         path: P,
         bare: bool,
     ) -> Result<Self, Self::CloneError>;
 
-    async fn checkout(&self, name: &str, orphan: bool) -> Result<(), Self::CheckoutError>;
-    async fn list_branches(&self) -> Result<Vec<BranchInfo>, Self::ListBranchesError>;
-    async fn rename_branch(&self, new_name: &str) -> Result<(), Self::RenameError>;
+    fn checkout(&self, name: &str, orphan: bool) -> Result<(), Self::CheckoutError>;
+    fn list_branches(&self) -> Result<Vec<BranchInfo>, Self::ListBranchesError>;
+    fn rename_branch(&self, new_name: &str) -> Result<(), Self::RenameError>;
 
-    async fn add_remote(&self, origin_name: &str, url: &str) -> Result<(), Self::AddRemoteError>;
-    async fn mv(&self, from: &Path, to: &Path) -> Result<(), Self::MvError>;
-    async fn rm(
+    fn add_remote(&self, origin_name: &str, url: &str) -> Result<(), Self::AddRemoteError>;
+    fn mv(&self, from: &Path, to: &Path) -> Result<(), Self::MvError>;
+    fn rm(
         &self,
         paths: &[&Path],
         recursive: bool,
         force: bool,
         cached: bool,
     ) -> Result<(), Self::RmError>;
-    async fn add(&self, paths: &[&Path]) -> Result<(), Self::AddError>;
-    async fn commit(&self, message: &str) -> Result<(), Self::CommitError>;
+    fn add(&self, paths: &[&Path]) -> Result<(), Self::AddError>;
+    fn commit(&self, message: &str) -> Result<(), Self::CommitError>;
 
-    async fn show(&self, object: &str) -> Result<OsString, Self::ShowError>;
+    fn show(&self, object: &str) -> Result<OsString, Self::ShowError>;
 
-    async fn fetch(&self) -> Result<(), Self::FetchError>;
-    async fn push(&self, remote: &str) -> Result<(), Self::PushError>;
-    async fn set_origin(&self, branch: &str, origin_name: &str)
-        -> Result<(), Self::SetOriginError>;
+    fn fetch(&self) -> Result<(), Self::FetchError>;
+    fn push(&self, remote: &str) -> Result<(), Self::PushError>;
+    fn set_origin(&self, branch: &str, origin_name: &str) -> Result<(), Self::SetOriginError>;
 
-    async fn get_origin(&self) -> Result<OriginInfo, Self::GetOriginError>;
+    fn get_origin(&self) -> Result<OriginInfo, Self::GetOriginError>;
 
     fn workdir(&self) -> Option<&Path>;
     fn path(&self) -> &Path;
@@ -400,7 +397,6 @@ impl GitDiscoverError for GitCommandDiscoverError {
 
 /// A simple Git Provider that uses the git
 /// command. This would require that git is installed.
-#[async_trait(?Send)]
 impl GitProvider for GitCommandProvider {
     type AddError = GitCommandError;
     type AddRemoteError = GitCommandError;
@@ -419,7 +415,7 @@ impl GitProvider for GitCommandProvider {
     type SetOriginError = GitCommandError;
     type ShowError = GitCommandError;
 
-    async fn discover<P: AsRef<Path>>(path: P) -> Result<Self, Self::DiscoverError> {
+    fn discover<P: AsRef<Path>>(path: P) -> Result<Self, Self::DiscoverError> {
         let out_str = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&Some(&path))
                 .arg("rev-parse")
@@ -459,10 +455,7 @@ impl GitProvider for GitCommandProvider {
         })
     }
 
-    async fn init<P: AsRef<Path>>(
-        path: P,
-        bare: bool,
-    ) -> Result<GitCommandProvider, Self::InitError> {
+    fn init<P: AsRef<Path>>(path: P, bare: bool) -> Result<GitCommandProvider, Self::InitError> {
         let mut command = GitCommandProvider::new_command(&Some(&path));
         command.arg("init");
         if bare {
@@ -477,7 +470,7 @@ impl GitProvider for GitCommandProvider {
         })
     }
 
-    async fn clone<O: AsRef<OsStr>, P: AsRef<Path>>(
+    fn clone<O: AsRef<OsStr>, P: AsRef<Path>>(
         origin: O,
         path: P,
         bare: bool,
@@ -498,7 +491,7 @@ impl GitProvider for GitCommandProvider {
         })
     }
 
-    async fn checkout(&self, name: &str, orphan: bool) -> Result<(), Self::CheckoutError> {
+    fn checkout(&self, name: &str, orphan: bool) -> Result<(), Self::CheckoutError> {
         let mut command = GitCommandProvider::new_command(&self.workdir());
         command.arg("checkout");
         if orphan {
@@ -511,7 +504,7 @@ impl GitProvider for GitCommandProvider {
         Ok(())
     }
 
-    async fn add_remote(&self, origin_name: &str, url: &str) -> Result<(), Self::AddRemoteError> {
+    fn add_remote(&self, origin_name: &str, url: &str) -> Result<(), Self::AddRemoteError> {
         let _out = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&self.workdir)
                 .arg("remote")
@@ -523,7 +516,7 @@ impl GitProvider for GitCommandProvider {
         Ok(())
     }
 
-    async fn rename_branch(&self, new_name: &str) -> Result<(), Self::RenameError> {
+    fn rename_branch(&self, new_name: &str) -> Result<(), Self::RenameError> {
         let _out = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&self.workdir)
                 .arg("branch")
@@ -533,11 +526,7 @@ impl GitProvider for GitCommandProvider {
         Ok(())
     }
 
-    async fn set_origin(
-        &self,
-        branch: &str,
-        origin_name: &str,
-    ) -> Result<(), Self::SetOriginError> {
+    fn set_origin(&self, branch: &str, origin_name: &str) -> Result<(), Self::SetOriginError> {
         let _out = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&self.workdir)
                 .arg("branch")
@@ -563,7 +552,7 @@ impl GitProvider for GitCommandProvider {
     ///   (remote_name, branch_name) = split_once "/" upstream_ref
     ///   upstream_url = git remote get-url ${remote_name}
     ///   upstream_rev = git ls-remote ${remote_name} ${branch_name}
-    async fn get_origin(&self) -> Result<OriginInfo, Self::GetOriginError> {
+    fn get_origin(&self) -> Result<OriginInfo, Self::GetOriginError> {
         let (remote_name, remote_branch) = {
             let reference = GitCommandProvider::run_command(
                 GitCommandProvider::new_command(&self.workdir)
@@ -613,7 +602,7 @@ impl GitProvider for GitCommandProvider {
         })
     }
 
-    async fn mv(&self, from: &Path, to: &Path) -> Result<(), Self::MvError> {
+    fn mv(&self, from: &Path, to: &Path) -> Result<(), Self::MvError> {
         let _out = GitCommandProvider::run_command(
             GitCommandProvider::new_command(&self.workdir)
                 .arg("mv")
@@ -624,7 +613,7 @@ impl GitProvider for GitCommandProvider {
         Ok(())
     }
 
-    async fn rm(
+    fn rm(
         &self,
         paths: &[&Path],
         recursive: bool,
@@ -654,7 +643,7 @@ impl GitProvider for GitCommandProvider {
         Ok(())
     }
 
-    async fn add(&self, paths: &[&Path]) -> Result<(), Self::MvError> {
+    fn add(&self, paths: &[&Path]) -> Result<(), Self::MvError> {
         let mut command = GitCommandProvider::new_command(&self.workdir);
         command.arg("add");
         for path in paths {
@@ -666,7 +655,7 @@ impl GitProvider for GitCommandProvider {
         Ok(())
     }
 
-    async fn commit(&self, message: &str) -> Result<(), Self::CommitError> {
+    fn commit(&self, message: &str) -> Result<(), Self::CommitError> {
         let mut command = GitCommandProvider::new_command(&self.workdir());
         command.arg("commit");
         command.args(["-m", message]);
@@ -675,15 +664,15 @@ impl GitProvider for GitCommandProvider {
         Ok(())
     }
 
-    async fn show(&self, object: &str) -> Result<OsString, Self::ShowError> {
+    fn show(&self, object: &str) -> Result<OsString, Self::ShowError> {
         let mut command = GitCommandProvider::new_command(&Some(&self.path));
         command.arg("show");
         command.arg(object);
 
-        Ok(GitCommandProvider::run_command(&mut command)?)
+        GitCommandProvider::run_command(&mut command)
     }
 
-    async fn list_branches(&self) -> Result<Vec<BranchInfo>, Self::ListBranchesError> {
+    fn list_branches(&self) -> Result<Vec<BranchInfo>, Self::ListBranchesError> {
         let mut command = GitCommandProvider::new_command(&Some(&self.path));
         command.arg("branch");
         command.args(["--all", "--verbose"]);
@@ -731,7 +720,7 @@ impl GitProvider for GitCommandProvider {
         Ok(info)
     }
 
-    async fn fetch(&self) -> Result<(), Self::FetchError> {
+    fn fetch(&self) -> Result<(), Self::FetchError> {
         GitCommandProvider::run_command(
             GitCommandProvider::new_command(&self.workdir.as_deref().or(Some(&self.path)))
                 .arg("fetch")
@@ -740,7 +729,7 @@ impl GitProvider for GitCommandProvider {
         Ok(())
     }
 
-    async fn push(&self, remote: &str) -> Result<(), Self::PushError> {
+    fn push(&self, remote: &str) -> Result<(), Self::PushError> {
         let mut command = GitCommandProvider::new_command(&self.workdir());
         command.arg("push");
         command.arg("-u");
@@ -775,25 +764,23 @@ pub mod tests {
         }
     }
 
-    async fn init_temp_repo(bare: bool) -> (GitCommandProvider, tempfile::TempDir) {
+    fn init_temp_repo(bare: bool) -> (GitCommandProvider, tempfile::TempDir) {
         let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
 
-        let git_command_provider = GitCommandProvider::init(tempdir_handle.path(), bare)
-            .await
-            .unwrap();
+        let git_command_provider = GitCommandProvider::init(tempdir_handle.path(), bare).unwrap();
         (git_command_provider, tempdir_handle)
     }
 
-    pub async fn commit_file(repo: &GitCommandProvider, filename: &str) {
+    pub fn commit_file(repo: &GitCommandProvider, filename: &str) {
         let file = repo.path.join(filename);
         fs::write(&file, filename).unwrap();
-        repo.add(&[&file]).await.unwrap();
-        repo.commit(filename).await.unwrap();
+        repo.add(&[&file]).unwrap();
+        repo.commit(filename).unwrap();
     }
 
-    #[tokio::test]
-    async fn test_open() {
-        let (_, tempdir_handle) = init_temp_repo(false).await;
+    #[test]
+    fn test_open() {
+        let (_, tempdir_handle) = init_temp_repo(false);
         let path = tempdir_handle.path().to_path_buf();
         assert_eq!(
             GitCommandProvider::open(&path).unwrap(),
@@ -805,9 +792,9 @@ pub mod tests {
     }
 
     // test opening a bare repo succeeds
-    #[tokio::test]
-    async fn test_open_bare() {
-        let (_, tempdir_handle) = init_temp_repo(true).await;
+    #[test]
+    fn test_open_bare() {
+        let (_, tempdir_handle) = init_temp_repo(true);
         let path = tempdir_handle.path().to_path_buf();
         assert_eq!(
             GitCommandProvider::open(&path).unwrap(),
@@ -819,9 +806,9 @@ pub mod tests {
     }
 
     // test opening a subdirectory of a repo fails
-    #[tokio::test]
-    async fn test_open_subdirectory() {
-        let (_, tempdir_handle) = init_temp_repo(false).await;
+    #[test]
+    fn test_open_subdirectory() {
+        let (_, tempdir_handle) = init_temp_repo(false);
         let path = tempdir_handle.path().to_path_buf();
 
         let subdirectory = path.join("subdirectory");
@@ -834,9 +821,9 @@ pub mod tests {
     }
 
     // test opening a subdirectory of a bare repo fails
-    #[tokio::test]
-    async fn test_open_subdirectory_bare() {
-        let (_, tempdir_handle) = init_temp_repo(true).await;
+    #[test]
+    fn test_open_subdirectory_bare() {
+        let (_, tempdir_handle) = init_temp_repo(true);
 
         assert!(matches!(
             GitCommandProvider::open(tempdir_handle.path().join("branches")),
@@ -844,8 +831,8 @@ pub mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn test_open_nonexistent() {
+    #[test]
+    fn test_open_nonexistent() {
         assert!(matches!(
             GitCommandProvider::open(PathBuf::from("/does-not-exist")),
             Err(GitCommandOpenError::Command(GitCommandError::BadExit(
@@ -856,13 +843,13 @@ pub mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn test_branch_contains_commit() {
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+    #[test]
+    fn test_branch_contains_commit() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
         let hash_1 = repo.branch_hash("branch_1").unwrap();
-        commit_file(&repo, "dummy_2").await;
+        commit_file(&repo, "dummy_2");
         let hash_2 = repo.branch_hash("branch_1").unwrap();
 
         assert_ne!(repo.branch_hash("branch_1").unwrap(), hash_1);
@@ -870,50 +857,50 @@ pub mod tests {
         assert!(repo.branch_contains_commit(&hash_2, "branch_1").unwrap());
     }
 
-    #[tokio::test]
-    async fn test_commit_not_on_branch() {
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+    #[test]
+    fn test_commit_not_on_branch() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
         let hash_1 = repo.branch_hash("branch_1").unwrap();
 
-        repo.checkout("branch_2", true).await.unwrap();
-        commit_file(&repo, "dummy_2").await;
+        repo.checkout("branch_2", true).unwrap();
+        commit_file(&repo, "dummy_2");
 
         assert!(!repo.branch_contains_commit(&hash_1, "branch_2").unwrap());
     }
 
-    #[tokio::test]
-    async fn test_commit_not_on_any_branch() {
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+    #[test]
+    fn test_commit_not_on_any_branch() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
 
         assert!(!repo.branch_contains_commit("XXX", "branch_1").unwrap());
     }
 
-    #[tokio::test]
-    async fn test_branch_hash() {
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
+    #[test]
+    fn test_branch_hash() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
 
-        commit_file(&repo, "dummy").await;
+        commit_file(&repo, "dummy");
 
         assert!(repo.branch_hash("branch_1").unwrap().len() == 40);
     }
 
-    #[tokio::test]
-    async fn test_branch_does_not_exist() {
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
+    #[test]
+    fn test_branch_does_not_exist() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
 
         assert!(!repo.has_branch("branch_1").unwrap());
     }
 
-    #[tokio::test]
-    async fn test_create_branch() {
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+    #[test]
+    fn test_create_branch() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
         let hash = repo.branch_hash("branch_1").unwrap();
 
         repo.create_branch("test", &hash).unwrap();
@@ -921,16 +908,16 @@ pub mod tests {
     }
 
     // test that clone_branch only clones the specified branch
-    #[tokio::test]
-    async fn test_clone_branch() {
+    #[test]
+    fn test_clone_branch() {
         // create two branches in repo: branch_1 and branch_2
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
         let hash_branch_1 = repo.branch_hash("branch_1").unwrap();
 
-        repo.checkout("branch_2", true).await.unwrap();
-        commit_file(&repo, "dummy_2").await;
+        repo.checkout("branch_2", true).unwrap();
+        commit_file(&repo, "dummy_2");
         let hash_branch_2 = repo.branch_hash("branch_2").unwrap();
 
         // clone only branch_1 branch to repo_2
@@ -954,20 +941,20 @@ pub mod tests {
         assert!(!repo_2.contains_commit(&hash_branch_2).unwrap());
     }
 
-    #[tokio::test]
-    async fn test_fetch_branch() {
+    #[test]
+    fn test_fetch_branch() {
         // create three branches in repo: branch_1, branch_2, and branch_3
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
         let hash_branch_1 = repo.branch_hash("branch_1").unwrap();
 
-        repo.checkout("branch_2", true).await.unwrap();
-        commit_file(&repo, "dummy_2").await;
+        repo.checkout("branch_2", true).unwrap();
+        commit_file(&repo, "dummy_2");
         let hash_branch_2 = repo.branch_hash("branch_2").unwrap();
 
-        repo.checkout("branch_3", true).await.unwrap();
-        commit_file(&repo, "dummy_3").await;
+        repo.checkout("branch_3", true).unwrap();
+        commit_file(&repo, "dummy_3");
         let hash_branch_3 = repo.branch_hash("branch_3").unwrap();
 
         // clone only branch_1 branch to repo_2
@@ -993,19 +980,19 @@ pub mod tests {
         assert!(!repo_2.contains_commit(&hash_branch_3).unwrap());
     }
 
-    #[tokio::test]
-    async fn test_fetch_ref() {
+    #[test]
+    fn test_fetch_ref() {
         // create three branches in repo: branch_1, branch_2, and branch_3
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
 
-        repo.checkout("branch_2", true).await.unwrap();
-        commit_file(&repo, "dummy_2").await;
+        repo.checkout("branch_2", true).unwrap();
+        commit_file(&repo, "dummy_2");
         let hash_branch_2 = repo.branch_hash("branch_2").unwrap();
 
-        repo.checkout("branch_3", true).await.unwrap();
-        commit_file(&repo, "dummy_3").await;
+        repo.checkout("branch_3", true).unwrap();
+        commit_file(&repo, "dummy_3");
         let hash_branch_3 = repo.branch_hash("branch_3").unwrap();
 
         // clone only branch_1 to repo_2
@@ -1025,11 +1012,11 @@ pub mod tests {
         assert!(!repo_2.contains_commit(&hash_branch_3).unwrap());
     }
 
-    #[tokio::test]
-    async fn test_fetch_bad_ref() {
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+    #[test]
+    fn test_fetch_bad_ref() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
 
         let tempdir_handle_2 = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
         let repo_2 =
@@ -1042,15 +1029,15 @@ pub mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn test_reset_branch_existing() {
+    #[test]
+    fn test_reset_branch_existing() {
         // create two branches in repo: branch_1 and branch_2
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
 
-        repo.checkout("branch_2", true).await.unwrap();
-        commit_file(&repo, "dummy_2").await;
+        repo.checkout("branch_2", true).unwrap();
+        commit_file(&repo, "dummy_2");
         let hash_branch_2 = repo.branch_hash("branch_2").unwrap();
 
         // reset branch_1 to branch_2
@@ -1059,15 +1046,15 @@ pub mod tests {
         assert_eq!(repo.branch_hash("branch_1").unwrap(), hash_branch_2)
     }
 
-    #[tokio::test]
-    async fn test_reset_branch_new() {
+    #[test]
+    fn test_reset_branch_new() {
         // create two branches in repo: branch_1 and branch_2
-        let (repo, _tempdir_handle) = init_temp_repo(false).await;
-        repo.checkout("branch_1", true).await.unwrap();
-        commit_file(&repo, "dummy").await;
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
 
-        repo.checkout("branch_2", true).await.unwrap();
-        commit_file(&repo, "dummy_2").await;
+        repo.checkout("branch_2", true).unwrap();
+        commit_file(&repo, "dummy_2");
         let hash_branch_2 = repo.branch_hash("branch_2").unwrap();
 
         // reset branch_1 to branch_2

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -29,7 +29,7 @@ pub struct BranchInfo {
 
 // simple git provider for the tasks we need to provide in
 // flox
-pub trait GitProvider: Send + Sized + std::fmt::Debug {
+pub trait GitProvider: Sized + std::fmt::Debug {
     type InitError: std::error::Error;
     type CloneError: std::error::Error;
     type CommitError: std::error::Error;

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -9,13 +9,7 @@ use flox_rust_sdk::flox::{EnvironmentName, Flox};
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
 use flox_rust_sdk::models::environment::path_environment::{Original, PathEnvironment};
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
-use flox_rust_sdk::models::environment::{
-    Environment,
-    EnvironmentPointer,
-    PathPointer,
-    DOT_FLOX,
-    MANIFEST_FILENAME,
-};
+use flox_rust_sdk::models::environment::{Environment, EnvironmentPointer, PathPointer, DOT_FLOX};
 use flox_rust_sdk::models::environment_ref;
 use flox_rust_sdk::models::manifest::list_packages;
 use flox_rust_sdk::nix::arguments::eval::EvaluationArgs;

--- a/crates/flox/src/commands/general.rs
+++ b/crates/flox/src/commands/general.rs
@@ -87,7 +87,7 @@ impl ConfigArgs {
         subcommand_metric!("config");
 
         /// wrapper around [Config::write_to]
-        async fn update_config<V: Serialize>(
+        fn update_config<V: Serialize>(
             config_dir: &Path,
             temp_dir: &Path,
             key: impl AsRef<str>,
@@ -116,16 +116,16 @@ impl ConfigArgs {
                 }
             },
             ConfigArgs::Set(ConfigSet { key, value, .. }) => {
-                update_config(&flox.config_dir, &flox.temp_dir, key, Some(value)).await?
+                update_config(&flox.config_dir, &flox.temp_dir, key, Some(value))?
             },
             ConfigArgs::SetNumber(ConfigSetNumber { key, value, .. }) => {
-                update_config(&flox.config_dir, &flox.temp_dir, key, Some(value)).await?
+                update_config(&flox.config_dir, &flox.temp_dir, key, Some(value))?
             },
             ConfigArgs::SetBool(ConfigSetBool { key, value, .. }) => {
-                update_config(&flox.config_dir, &flox.temp_dir, key, Some(value)).await?
+                update_config(&flox.config_dir, &flox.temp_dir, key, Some(value))?
             },
             ConfigArgs::Delete(ConfigDelete { key, .. }) => {
-                update_config::<()>(&flox.config_dir, &flox.temp_dir, key, None).await?
+                update_config::<()>(&flox.config_dir, &flox.temp_dir, key, None)?
             },
         }
         Ok(())

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -160,7 +160,7 @@ impl FloxArgs {
 
         // TODO: revisit this when we discussed floxmeta's role to contribute to config/channels
         // region: revisit reg. channels
-        let floxmeta = match boostrap_flox.floxmeta(DEFAULT_OWNER).await {
+        let floxmeta = match boostrap_flox.floxmeta(DEFAULT_OWNER) {
             Ok(floxmeta) => floxmeta,
             Err(GetFloxmetaError::NotFound(_)) => {
                 Floxmeta::create_floxmeta(&boostrap_flox, DEFAULT_OWNER)
@@ -173,7 +173,6 @@ impl FloxArgs {
         //  Floxmeta::create_floxmeta creates an intial user_meta
         let user_meta = floxmeta
             .user_meta()
-            .await
             .context("Could not get user metadata")?;
 
         let user_channels = user_meta.channels.unwrap_or_default();


### PR DESCRIPTION
Probably not too important to be thorough here - not sure if https://github.com/flox/flox/issues/304 should have even gotten pulled in, but it's quick to close.

Remove async from git provider.

This may have removed some async throughout the codebase as I used some linter assistance, and I fixed a few unrelated clippy warnings.

## Release Notes

No user facing changes