### PR TITLE
feat: manage `floxhub_token` in config

### DIFF
--- a/crates/flox/src/commands/auth.rs
+++ b/crates/flox/src/commands/auth.rs
@@ -257,10 +257,14 @@ pub enum Auth2 {
     /// Login to floxhub (requires an existing github account)
     #[bpaf(command)]
     Login,
+
+    /// Logout from floxhub
+    #[bpaf(command)]
+    Logout,
 }
 
 impl Auth2 {
-    pub async fn handle(self, _config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("auth2");
         // TODO there is no obvious way to deal with
         // identifying configuration that is not hard-coded into source
@@ -292,6 +296,19 @@ impl Auth2 {
                     },
                     Err(err) => Err(err.into()),
                 }
+            },
+            Auth2::Logout => {
+                if config.flox.floxhub_token.is_none() {
+                    info!("You are not logged in");
+                    return Ok(());
+                }
+
+                update_config::<String>(&flox.config_dir, &flox.temp_dir, "floxhub_token", None)
+                    .context("Could not remove token from user config")?;
+
+                info!("Logout successful");
+
+                Ok(())
             },
         }
     }

--- a/crates/flox/src/config/mod.rs
+++ b/crates/flox/src/config/mod.rs
@@ -57,6 +57,9 @@ pub struct FloxConfig {
     /// Path to signing key
     pub signing_key: Option<PathBuf>,
 
+    /// Token to authenticate on floxhub
+    pub floxhub_token: Option<String>,
+
     #[serde(flatten)]
     pub instance: InstanceConfig,
 }


### PR DESCRIPTION
Once a token is received through `authenticate`, write the token to the user config file under the key `floxhub_token`.

Reciprocally, remove the key `floxhub_token` to logout from floxhub.

* a token can be set via `flox auth login` (which writes to the user config file), by manually editing any flox config file (how to get the token to put there 🤷🏼) or by setting the `FLOX_FLOXHUB_TOKEN` env variable.
* if a token is present, `login` will replace it (see #357 for a smarter(?) solution)
* if a token is present, `logout` will assume its in the user's config file - this will fail with a message if the token is set via the environment or a higher order config file.
* if no token is present, logout will exit early
