### PR TITLE
feat: `flox pull|push` for managed envs

### DIFF
--- a/crates/flox-rust-sdk/src/flox.rs
+++ b/crates/flox-rust-sdk/src/flox.rs
@@ -66,6 +66,7 @@ pub struct Flox {
     pub uuid: uuid::Uuid,
 
     pub floxhub_token: Option<String>,
+    pub floxhub_host: String,
 }
 
 pub trait FloxNixApi: NixBackend {

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -543,8 +543,8 @@ impl ManagedEnvironment {
             .push_ref(
                 ".",
                 format!(
-                    "FETCH_HEAD:refs/heads/{project_branch}",
-                    project_branch = branch_name(&self.system, &self.pointer, &self.path)?
+                    "FETCH_HEAD:refs/heads/{sync_branch}",
+                    sync_branch = remote_branch_name(&self.system, &self.pointer)
                 ),
             )
             .unwrap();

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -457,7 +457,7 @@ fn gcroots_dir(flox: &Flox, pointer: &ManagedPointer) -> PathBuf {
 
 impl ManagedEnvironment {
     #[allow(unused)]
-    fn pull(&mut self) -> Result<(), EnvironmentError2> {
+    pub fn pull(&mut self) -> Result<(), EnvironmentError2> {
         self.floxmeta
             .git
             .fetch_branch("origin", &remote_branch_name(&self.system, &self.pointer))

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -491,8 +491,8 @@ impl ManagedEnvironment {
             .floxmeta
             .git
             .branch_contains_commit(
-                "FETCH_HEAD",
                 &remote_branch_name(&self.system, &self.pointer),
+                "FETCH_HEAD",
             )
             .map_err(ManagedEnvironmentError::Git)?;
         if !consistent_history {

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -245,14 +245,30 @@ impl ManagedEnvironment {
             },
             Err(e) => Err(ManagedEnvironmentError::OpenFloxmeta(e))?,
         };
+        Self::open_with(floxmeta, flox, pointer, dot_flox_path)
+    }
 
+    /// Open a managed environment backed by a provided floxmeta clone.
+    /// Ensure a branch for the environment exists in floxmeta and that there is
+    /// a _unique_ branch to track its state.
+    ///
+    /// This method is primarily useful for testing.
+    /// In most cases, you want to use [`ManagedEnvironment::open`] instead which provides the flox defaults.
+    fn open_with(
+        floxmeta: FloxmetaV2,
+        flox: &Flox,
+        pointer: ManagedPointer,
+        dot_flox_path: impl AsRef<Path>,
+    ) -> Result<Self, EnvironmentError2> {
         let lock = Self::ensure_locked(flox, &pointer, &dot_flox_path, &floxmeta)?;
+
         Self::ensure_branch(
             &branch_name(&flox.system, &pointer, &dot_flox_path)?,
             &lock,
             &floxmeta,
         )?;
-        ManagedEnvironment::ensure_reverse_link(flox, &dot_flox_path)?;
+
+        Self::ensure_reverse_link(flox, &dot_flox_path)?;
 
         Ok(ManagedEnvironment {
             path: dot_flox_path.as_ref().to_path_buf(),

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -463,18 +463,6 @@ impl ManagedEnvironment {
             .fetch_branch("origin", &remote_branch_name(&self.system, &self.pointer))
             .unwrap();
 
-        // try fast forward merge upstream env branch into local env branch
-        self.floxmeta
-            .git
-            .push2(
-                ".",
-                format!(
-                    "origin/{sync_branch}:refs/heads/{sync_branch}",
-                    sync_branch = remote_branch_name(&self.system, &self.pointer)
-                ),
-            )
-            .unwrap();
-
         // try fast forward merge local env branch into project branch
         self.floxmeta
             .git

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -434,7 +434,7 @@ fn lock_env(
     };
     let lock_contents =
         serde_json::to_string_pretty(&lock).map_err(ManagedEnvironmentError::SerializeLock)?;
-    debug!("writing rev '{}' to lockfile", lock.rev);
+    debug!("writing rev '{}' to lockfile to {:?}", lock.rev, lock_path);
     fs::write(lock_path, lock_contents).map_err(ManagedEnvironmentError::WriteLock)?;
     Ok(lock)
 }
@@ -485,8 +485,8 @@ impl ManagedEnvironment {
             )
             .unwrap();
 
-        // Check whether we can fast-forward merge the remote branch into the local branch
-        // In not the environment has diverged.
+        // Check whether we can fast-forward merge the remote branch into the local branch,
+        // if not the environment has diverged.
         let consistent_history = self
             .floxmeta
             .git
@@ -502,7 +502,7 @@ impl ManagedEnvironment {
         // try fast forward merge local env branch into project branch
         self.floxmeta
             .git
-            .push2(
+            .push_ref(
                 ".",
                 format!(
                     "FETCH_HEAD:refs/heads/{project_branch}",

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 use super::{Environment, EnvironmentError2, InstallationAttempt, ManagedPointer};
 use crate::flox::Flox;
-use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRef};
+use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner};
 use crate::models::floxmetav2::{FloxmetaV2, FloxmetaV2Error};
 use crate::providers::git::{GitCommandBranchHashError, GitCommandError};
 
@@ -125,12 +125,6 @@ impl Environment for ManagedEnvironment {
         nix: &NixCommandLine,
         system: System,
     ) -> Result<EnvCatalog, EnvironmentError2> {
-        todo!()
-    }
-
-    /// Return the [EnvironmentRef] for the environment for identification
-    #[allow(unused)]
-    fn environment_ref(&self) -> EnvironmentRef {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -19,7 +19,6 @@ use self::managed_environment::ManagedEnvironmentError;
 use super::environment_ref::{
     EnvironmentName,
     EnvironmentOwner,
-    EnvironmentRef,
     EnvironmentRefError,
 };
 use super::flox_package::FloxTriple;
@@ -99,9 +98,6 @@ pub trait Environment {
 
     /// Extract the current content of the manifest
     fn manifest_content(&self) -> Result<String, EnvironmentError2>;
-
-    /// Return the [EnvironmentRef] for the environment for identification
-    fn environment_ref(&self) -> EnvironmentRef;
 
     /// Return a path containing the built environment and its activation script.
     ///

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -16,14 +16,10 @@ use thiserror::Error;
 use walkdir::WalkDir;
 
 use self::managed_environment::ManagedEnvironmentError;
-use super::environment_ref::{
-    EnvironmentName,
-    EnvironmentOwner,
-    EnvironmentRefError,
-};
+use super::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRefError};
 use super::flox_package::FloxTriple;
 use super::manifest::TomlEditError;
-use crate::flox::Flox;
+use crate::flox::{EnvironmentRef, Flox};
 use crate::utils::copy_file_without_permissions;
 use crate::utils::errors::IoError;
 
@@ -160,11 +156,22 @@ impl PathPointer {
 /// points to an environment owner and the name of the environment.
 ///
 /// This is serialized to an `env.json` inside the `.flox` directory.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Clone, Deserialize, PartialEq)]
 pub struct ManagedPointer {
     pub owner: EnvironmentOwner,
     pub name: EnvironmentName,
     version: Version<1>,
+}
+
+impl ManagedPointer {
+    /// Create a new [ManagedPointer] with the given owner and name.
+    pub fn new(owner: EnvironmentOwner, name: EnvironmentName) -> Self {
+        Self {
+            name,
+            owner,
+            version: Version::<1>,
+        }
+    }
 }
 
 impl EnvironmentPointer {
@@ -189,6 +196,12 @@ impl EnvironmentPointer {
         };
 
         serde_json::from_slice(&pointer_contents).map_err(EnvironmentError2::ParseEnvJson)
+    }
+}
+
+impl From<EnvironmentRef> for ManagedPointer {
+    fn from(value: EnvironmentRef) -> Self {
+        Self::new(value.owner().clone(), value.name().clone())
     }
 }
 

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -43,7 +43,7 @@ use crate::models::environment::{
     CATALOG_JSON,
     ENV_FROM_LOCKFILE_PATH,
 };
-use crate::models::environment_ref::{EnvironmentName, EnvironmentRef};
+use crate::models::environment_ref::EnvironmentName;
 use crate::models::manifest::{insert_packages, remove_packages};
 use crate::models::search::PKGDB_BIN;
 
@@ -306,11 +306,6 @@ where
         self.transact_with_manifest_contents(contents, nix, system)
             .await?;
         Ok(())
-    }
-
-    /// Return the [EnvironmentRef] for the environment for identification
-    fn environment_ref(&self) -> EnvironmentRef {
-        EnvironmentRef::new_from_parts(None, self.pointer.name.clone())
     }
 
     /// Get a catalog of installed packages from this environment

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -6,7 +6,7 @@ use runix::command_line::NixCommandLine;
 
 use super::{Environment, EnvironmentError2, InstallationAttempt};
 use crate::flox::Flox;
-use crate::models::environment_ref::{EnvironmentName, EnvironmentRef};
+use crate::models::environment_ref::EnvironmentName;
 
 #[derive(Debug)]
 pub struct RemoteEnvironment;
@@ -67,12 +67,6 @@ impl Environment for RemoteEnvironment {
 
     /// Extract the current content of the manifest
     fn manifest_content(&self) -> Result<String, EnvironmentError2> {
-        todo!()
-    }
-
-    /// Return the [EnvironmentRef] for the environment for identification
-    #[allow(unused)]
-    fn environment_ref(&self) -> EnvironmentRef {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -25,6 +25,8 @@ pub struct FloxmetaV2 {
 pub enum FloxmetaV2Error {
     #[error("No login token provided")]
     LoggedOut,
+    #[error("floxmeta for {0} not found")]
+    NotFound(String),
     #[error("Currently only hub.flox.dev is supported as a remote")]
     UnsupportedRemote,
     #[error("Could not open user environment directory {0}")]
@@ -33,24 +35,49 @@ pub enum FloxmetaV2Error {
     CheckForBranch(GitCommandBranchHashError),
     #[error("Failed to fetch environment: {0}")]
     FetchBranch(GitCommandError),
+    #[error("Failed to clone environment: {0}")]
+    CloneBranch(GitCommandError),
 }
 
 impl FloxmetaV2 {
-    fn open_path(
-        options: GitCommandOptions,
+    /// Clone the floxmeta repository for the given user to the given path
+    ///
+    /// Most of the time, you want to use [`FloxmetaV2::clone`] instead.
+    /// This is useful for testing and isolated remote operations.
+    pub fn clone_to(
+        flox: &Flox,
+        pointer: &ManagedPointer,
         path: impl AsRef<Path>,
     ) -> Result<Self, FloxmetaV2Error> {
-        let git = GitCommandProvider::open_with(options, path).map_err(FloxmetaV2Error::Open)?;
+        let token = flox
+            .floxhub_token
+            .as_ref()
+            .ok_or(FloxmetaV2Error::LoggedOut)?;
+
+        let git_options = floxmeta_git_options("https://git.hub.flox.dev", token);
+        let branch: String = remote_branch_name(&flox.system, pointer);
+
+        let git = GitCommandProvider::clone_branch_with(
+            git_options,
+            "https://git.hub.flox.dev",
+            path,
+            branch,
+            true,
+        )
+        .map_err(FloxmetaV2Error::CloneBranch)?;
+
         Ok(FloxmetaV2 { git })
     }
 
-    fn clone_in(
-        _path: impl AsRef<Path>,
-        _pointer: &ManagedPointer,
-    ) -> Result<Self, FloxmetaV2Error> {
-        todo!()
+    /// Clone the floxmeta repository for the given user to the default path
+    ///
+    /// Like [`FloxmetaV2::clone_to`], but uses the system path for floxmeta repositories in XDG_DATA_HOME
+    pub fn clone(flox: &Flox, pointer: &ManagedPointer) -> Result<Self, FloxmetaV2Error> {
+        Self::clone_to(flox, pointer, floxmeta_dir(flox, &pointer.owner))
     }
 
+    /// Open the floxmeta repository for the given user
+    /// and ensure a branch exists for the given environment.
     pub fn open(flox: &Flox, pointer: &ManagedPointer) -> Result<Self, FloxmetaV2Error> {
         let token = flox
             .floxhub_token
@@ -61,23 +88,22 @@ impl FloxmetaV2 {
 
         let user_floxmeta_dir = floxmeta_dir(flox, &pointer.owner);
 
-        if user_floxmeta_dir.exists() {
-            let floxmeta = FloxmetaV2::open_path(git_options, user_floxmeta_dir)?;
-            let branch = remote_branch_name(&flox.system, pointer);
-            if !floxmeta
-                .git
-                .has_branch(&branch)
-                .map_err(FloxmetaV2Error::CheckForBranch)?
-            {
-                floxmeta
-                    .git
-                    .fetch_branch("origin", &branch)
-                    .map_err(FloxmetaV2Error::FetchBranch)?;
-            }
-            Ok(floxmeta)
-        } else {
-            FloxmetaV2::clone_in(user_floxmeta_dir, pointer)
+        if !user_floxmeta_dir.exists() {
+            Err(FloxmetaV2Error::NotFound(pointer.owner.to_string()))?
         }
+
+        let git = GitCommandProvider::open_with(git_options, user_floxmeta_dir)
+            .map_err(FloxmetaV2Error::Open)?;
+        let branch: String = remote_branch_name(&flox.system, pointer);
+        if !git
+            .has_branch(&branch)
+            .map_err(FloxmetaV2Error::CheckForBranch)?
+        {
+            git.fetch_branch("origin", &branch)
+                .map_err(FloxmetaV2Error::FetchBranch)?;
+        }
+
+        Ok(FloxmetaV2 { git })
     }
 }
 

--- a/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -143,8 +143,8 @@ fn floxmeta_git_options(floxhub_host: &str, floxhub_token: &str) -> GitCommandOp
     // The credential helper should help avoinding a leak of the token in the process list.
     options.add_env_var("FLOX_FLOXHUB_TOKEN", floxhub_token);
     options.add_config_flag(
-        &format!("credentials.{floxhub_host}.helper"),
-        "!f(){ echo ${FLOX_FLOXHUB_TOKEN}; }; f",
+        &format!("credential.{floxhub_host}.helper"),
+        r#"!f(){ echo "username=oauth"; echo "password=$FLOX_FLOXHUB_TOKEN;"; }; f"#,
     );
 
     options

--- a/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -56,7 +56,7 @@ impl FloxmetaV2 {
             .ok_or(FloxmetaV2Error::LoggedOut)?;
 
         let git_options = floxmeta_git_options(&flox.floxhub_host, token);
-        let branch: String = remote_branch_name(&flox.system, pointer);
+        let branch = remote_branch_name(&flox.system, pointer);
 
         let git = GitCommandProvider::clone_branch_with(
             git_options,

--- a/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -45,9 +45,9 @@ impl FloxmetaV2 {
     /// Most of the time, you want to use [`FloxmetaV2::clone`] instead.
     /// This is useful for testing and isolated remote operations.
     pub fn clone_to(
+        path: impl AsRef<Path>,
         flox: &Flox,
         pointer: &ManagedPointer,
-        path: impl AsRef<Path>,
     ) -> Result<Self, FloxmetaV2Error> {
         let host = flox.floxhub_host.as_str();
         let token = flox
@@ -74,7 +74,7 @@ impl FloxmetaV2 {
     ///
     /// Like [`FloxmetaV2::clone_to`], but uses the system path for floxmeta repositories in XDG_DATA_HOME
     pub fn clone(flox: &Flox, pointer: &ManagedPointer) -> Result<Self, FloxmetaV2Error> {
-        Self::clone_to(flox, pointer, floxmeta_dir(flox, &pointer.owner))
+        Self::clone_to(floxmeta_dir(flox, &pointer.owner), flox, pointer)
     }
 
     /// Open a floxmeta repository at a given path
@@ -87,9 +87,9 @@ impl FloxmetaV2 {
     ///
     /// In most cases, you want to use [`FloxmetaV2::open`] instead which provides the flox defaults.
     pub fn open_at(
+        user_floxmeta_dir: impl AsRef<Path>,
         flox: &Flox,
         pointer: &ManagedPointer,
-        user_floxmeta_dir: impl AsRef<Path>,
     ) -> Result<Self, FloxmetaV2Error> {
         let token = flox
             .floxhub_token
@@ -121,7 +121,7 @@ impl FloxmetaV2 {
     /// Like [`FloxmetaV2::open_at`], but uses the system path for floxmeta repositories in XDG_DATA_HOME.
     pub fn open(flox: &Flox, pointer: &ManagedPointer) -> Result<Self, FloxmetaV2Error> {
         let user_floxmeta_dir = floxmeta_dir(flox, &pointer.owner);
-        Self::open_at(flox, pointer, user_floxmeta_dir)
+        Self::open_at(user_floxmeta_dir, flox, pointer)
     }
 }
 
@@ -194,9 +194,9 @@ mod tests {
         flox.floxhub_token = Some("no token needed here".to_string());
         flox.floxhub_host = format!("file://{}", source_path.to_string_lossy());
 
-        FloxmetaV2::clone_to(&flox, &pointer, tempdir.path().join("dest"))
+        FloxmetaV2::clone_to(tempdir.path().join("dest"), &flox, &pointer)
             .expect("Cloning a floxmeta repo should succeed");
-        FloxmetaV2::open_at(&flox, &pointer, tempdir.path().join("dest"))
+        FloxmetaV2::open_at(tempdir.path().join("dest"), &flox, &pointer)
             .expect("Opening a floxmeta repo should succeed");
     }
 

--- a/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn clone_repo() {
-        env_logger::init();
+        let _ = env_logger::try_init();
 
         let (mut flox, tempdir) = flox_instance();
 
@@ -204,7 +204,7 @@ mod tests {
     /// We check if we can clone them and pull them into an existing clone.
     #[test]
     fn clone_from_floxhub() {
-        env_logger::init();
+        let _ = env_logger::try_init();
 
         let (mut flox, _) = flox_instance();
 

--- a/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -15,7 +15,6 @@ use crate::providers::git::{
 };
 
 pub const FLOXMETA_DIR_NAME: &str = "meta";
-pub const DEFAULT_FLOXHUB_URL: &str = "https://git.hub.flox.dev";
 
 #[derive(Debug)]
 pub struct FloxmetaV2 {
@@ -50,17 +49,18 @@ impl FloxmetaV2 {
         pointer: &ManagedPointer,
         path: impl AsRef<Path>,
     ) -> Result<Self, FloxmetaV2Error> {
+        let host = flox.floxhub_host.as_str();
         let token = flox
             .floxhub_token
             .as_ref()
             .ok_or(FloxmetaV2Error::LoggedOut)?;
 
-        let git_options = floxmeta_git_options(DEFAULT_FLOXHUB_URL, token);
+        let git_options = floxmeta_git_options(&flox.floxhub_host, token);
         let branch: String = remote_branch_name(&flox.system, pointer);
 
         let git = GitCommandProvider::clone_branch_with(
             git_options,
-            DEFAULT_FLOXHUB_URL,
+            format!("{host}/{}/floxmeta", pointer.owner),
             path,
             branch,
             true,
@@ -85,7 +85,7 @@ impl FloxmetaV2 {
             .as_ref()
             .ok_or(FloxmetaV2Error::LoggedOut)?;
 
-        let git_options = floxmeta_git_options(DEFAULT_FLOXHUB_URL, token);
+        let git_options = floxmeta_git_options(&flox.floxhub_host, token);
 
         let user_floxmeta_dir = floxmeta_dir(flox, &pointer.owner);
 

--- a/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/crates/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -15,6 +15,7 @@ use crate::providers::git::{
 };
 
 pub const FLOXMETA_DIR_NAME: &str = "meta";
+pub const DEFAULT_FLOXHUB_URL: &str = "https://git.hub.flox.dev";
 
 #[derive(Debug)]
 pub struct FloxmetaV2 {
@@ -54,12 +55,12 @@ impl FloxmetaV2 {
             .as_ref()
             .ok_or(FloxmetaV2Error::LoggedOut)?;
 
-        let git_options = floxmeta_git_options("https://git.hub.flox.dev", token);
+        let git_options = floxmeta_git_options(DEFAULT_FLOXHUB_URL, token);
         let branch: String = remote_branch_name(&flox.system, pointer);
 
         let git = GitCommandProvider::clone_branch_with(
             git_options,
-            "https://git.hub.flox.dev",
+            DEFAULT_FLOXHUB_URL,
             path,
             branch,
             true,
@@ -84,7 +85,7 @@ impl FloxmetaV2 {
             .as_ref()
             .ok_or(FloxmetaV2Error::LoggedOut)?;
 
-        let git_options = floxmeta_git_options("https://git.hub.flox.dev", token);
+        let git_options = floxmeta_git_options(DEFAULT_FLOXHUB_URL, token);
 
         let user_floxmeta_dir = floxmeta_dir(flox, &pointer.owner);
 

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -434,7 +434,8 @@ impl GitCommandProvider {
         Ok(())
     }
 
-    pub fn push2(
+    /// Like [GitCommandProvider::push] but allows to specify the refspec explicitly
+    pub fn push_ref(
         &self,
         repository: impl AsRef<str>,
         push_spec: impl AsRef<str>,

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -384,7 +384,6 @@ impl GitCommandProvider {
         bare: bool,
     ) -> Result<GitCommandProvider, GitCommandError> {
         let mut command = options.new_command();
-        command.args(["-C", path.as_ref().to_str().unwrap()]);
 
         command
             .arg("clone")
@@ -393,7 +392,8 @@ impl GitCommandProvider {
             .arg("--branch")
             .arg(branch)
             .arg(origin)
-            .arg("./");
+            .arg(path.as_ref());
+
         if bare {
             command.arg("--bare");
         }

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -434,6 +434,20 @@ impl GitCommandProvider {
         Ok(())
     }
 
+    pub fn push2(
+        &self,
+        repository: impl AsRef<str>,
+        push_spec: impl AsRef<str>,
+    ) -> Result<(), GitCommandError> {
+        GitCommandProvider::run_command(
+            self.new_command()
+                .arg("push")
+                .arg(repository.as_ref())
+                .arg(push_spec.as_ref()),
+        )?;
+        Ok(())
+    }
+
     /// Update the options used by this provider.
     ///
     /// It is preferable to set the options when creating the provider

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -71,11 +71,8 @@ impl EnvironmentSelect {
                     },
                     EnvironmentPointer::Managed(managed_pointer) => {
                         debug!("detected concrete environment type: managed");
-                        ConcreteEnvironment::Managed(ManagedEnvironment::open(
-                            flox,
-                            managed_pointer,
-                            path,
-                        )?)
+                        let env = ManagedEnvironment::open(flox, managed_pointer, path)?;
+                        ConcreteEnvironment::Managed(env)
                     },
                 }
             },

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -651,7 +651,7 @@ impl Pull {
             PullSelect::Existing { dir } => {
                 let dir = dir.unwrap_or_else(|| std::env::current_dir().unwrap());
                 let pointer = {
-                    let p = EnvironmentPointer::open(dir.join(DOT_FLOX))
+                    let p = EnvironmentPointer::open(&dir)
                         .with_context(|| format!("No environment found in {dir:?}"))?;
                     match p {
                         EnvironmentPointer::Managed(managed_pointer) => managed_pointer,

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 use anyhow::{bail, Context, Result};
 use bpaf::Bpaf;
 use crossterm::{cursor, QueueableCommand};
-use flox_rust_sdk::flox::{EnvironmentName, Flox};
+use flox_rust_sdk::flox::{EnvironmentName, EnvironmentRef, Flox};
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
 use flox_rust_sdk::models::environment::path_environment::{Original, PathEnvironment};
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
@@ -29,8 +29,6 @@ pub struct EnvironmentArgs {
     #[bpaf(short, long, argument("SYSTEM"))]
     pub system: Option<String>,
 }
-
-pub type EnvironmentRef = String;
 
 #[derive(Debug, Bpaf, Clone)]
 pub enum EnvironmentSelect {
@@ -360,7 +358,7 @@ impl Init {
             Enter the environment with \"flox activate\"
             Search and install packages with \"flox search {{packagename}}\" and \"flox install {{packagename}}\"
             "},
-            name = env.environment_ref(),
+            name = env.name(),
             system = flox.system
         );
         Ok(())

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{stdin, Write};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -12,7 +12,14 @@ use flox_rust_sdk::flox::{EnvironmentName, EnvironmentRef, Flox};
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
 use flox_rust_sdk::models::environment::path_environment::{Original, PathEnvironment};
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
-use flox_rust_sdk::models::environment::{Environment, EnvironmentPointer, PathPointer, DOT_FLOX};
+use flox_rust_sdk::models::environment::{
+    Environment,
+    EnvironmentPointer,
+    ManagedPointer,
+    PathPointer,
+    DOT_FLOX,
+    ENVIRONMENT_POINTER_FILENAME,
+};
 use flox_rust_sdk::models::environment_ref;
 use flox_rust_sdk::models::manifest::list_packages;
 use flox_rust_sdk::nix::command::StoreGc;
@@ -630,10 +637,50 @@ pub struct Pull {
 }
 
 impl Pull {
-    pub async fn handle(self, _flox: Flox) -> Result<()> {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("pull");
+        match self.pull_select {
+            PullSelect::New { dir, remote } => {
+                let dir = dir.unwrap_or_else(|| std::env::current_dir().unwrap());
+                Self::pull_new_environment(&flox, dir.join(DOT_FLOX), remote)?;
+            },
+            PullSelect::Existing(_) => todo!(),
+        }
 
-        todo!("this command is planned for a future release")
+        Ok(())
+    }
+
+    /// Pull a new environment from floxhub into the given directory
+    ///
+    /// This will create a new environment in the given directory.
+    /// Uses [ManagedEnvironment::open] which will try to clone the environment.
+    ///
+    /// If the directory already exists, this will fail early.
+    /// If opening the environment fails, the .flox/ directory will be cleaned up.
+    fn pull_new_environment(
+        flox: &Flox,
+        dot_flox_path: PathBuf,
+        env_ref: EnvironmentRef,
+    ) -> Result<()> {
+        if dot_flox_path.exists() {
+            bail!("Cannot pull a new environment into an existing one")
+        }
+        let pointer = ManagedPointer::from(env_ref);
+
+        let pointer_content =
+            serde_json::to_string_pretty(&pointer).context("Could not serialize pointer")?;
+        let pointer_path = dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME);
+
+        fs::create_dir_all(&dot_flox_path).context("Could not create .flox/ directory")?;
+        fs::write(pointer_path, pointer_content).context("Could not write pointer")?;
+
+        let result = ManagedEnvironment::open(flox, pointer, &dot_flox_path)
+            .context("Could not initialize environment");
+        if let Err(err) = result {
+            fs::remove_dir_all(dot_flox_path).context("Could not clean up .flox/ directory")?;
+            Err(err)?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -600,16 +600,28 @@ pub enum PushFloxmainOrEnv {
     },
 }
 
+#[derive(Debug, Clone, Bpaf)]
+enum PullSelect {
+    New {
+        /// Directory to create the environment in (default: current directory)
+        dir: Option<PathBuf>,
+        /// ID of the environment to pull
+        remote: EnvironmentRef,
+    },
+    Existing(#[bpaf(external(environment_select))] EnvironmentSelect),
+}
+
+impl Default for PullSelect {
+    fn default() -> Self {
+        PullSelect::Existing(Default::default())
+    }
+}
+
 /// Pull environment from flox hub
 #[derive(Bpaf, Clone)]
 pub struct Pull {
-    #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour
-    #[bpaf(external(environment_args), group_help("Environment Options"))]
-    environment_args: EnvironmentArgs,
-
-    #[allow(dead_code)] // not yet handled in impl
-    #[bpaf(external(pull_floxmain_or_env), optional)]
-    target: Option<PullFloxmainOrEnv>,
+    #[bpaf(external(pull_select), fallback(Default::default()))]
+    pull_select: PullSelect,
 
     /// forceably overwrite the local copy of the environment
     #[allow(dead_code)] // not yet handled in impl
@@ -623,21 +635,6 @@ impl Pull {
 
         todo!("this command is planned for a future release")
     }
-}
-
-#[derive(Bpaf, Clone)]
-pub enum PullFloxmainOrEnv {
-    /// pull the `floxmain` branch to sync configuration
-    #[bpaf(long, short)]
-    Main,
-    Env {
-        #[bpaf(long("environment"), short('e'), argument("ENV"))]
-        env: Option<EnvironmentRef>,
-        /// do not actually render or create links to environments in the store.
-        /// (Flox internal use only.)
-        #[bpaf(long("no-render"))]
-        no_render: bool,
-    },
 }
 
 /// rollback to the previous generation of an environment

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -622,6 +622,7 @@ enum PullSelect {
         remote: EnvironmentRef,
     },
     Existing {
+        /// Directory containing a managed environment to pull
         dir: Option<PathBuf>,
     },
 }
@@ -652,10 +653,16 @@ impl Pull {
         match self.pull_select {
             PullSelect::New { dir, remote } => {
                 let dir = dir.unwrap_or_else(|| std::env::current_dir().unwrap());
+
+                debug!("Resolved user intent: pull {remote:?} into {dir:?}");
+
                 Self::pull_new_environment(&flox, dir.join(DOT_FLOX), remote)?;
             },
             PullSelect::Existing { dir } => {
                 let dir = dir.unwrap_or_else(|| std::env::current_dir().unwrap());
+
+                debug!("Resolved user intent: pull changes for environment found in {dir:?}");
+
                 let pointer = {
                     let p = EnvironmentPointer::open(&dir)
                         .with_context(|| format!("No environment found in {dir:?}"))?;

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -157,6 +157,7 @@ impl FloxArgs {
             system: env!("NIX_TARGET_SYSTEM").to_string(),
             uuid: init_uuid(&config.flox.data_dir).await?,
             floxhub_token: config.flox.floxhub_token.clone(),
+            floxhub_host: "https://git.hub.flox.dev".to_string(),
         };
 
         let channels = init_channels(BTreeMap::new())?;

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -11,7 +11,7 @@ use bpaf::{Args, Bpaf, Parser};
 use flox_rust_sdk::flox::{Flox, FLOX_VERSION};
 use flox_rust_sdk::nix::command_line::NixCommandLine;
 use indoc::{formatdoc, indoc};
-use log::{debug, info};
+use log::{debug, info, warn};
 use once_cell::sync::Lazy;
 use tempfile::TempDir;
 use toml_edit::Key;
@@ -146,6 +146,14 @@ impl FloxArgs {
             .expect("User must have a home directory")
             .join(".netrc");
 
+        let floxhub_host = std::env::var("__FLOX_FLOXHUB_URL")
+            .map(|env_set_host|{
+                warn!("Using {env_set_host} as floxhub host");
+                warn!("`$__FLOX_FLOXHUB_URL` is used for testing purposes only, alternative floxhub hosts are not yet supported!");
+                env_set_host
+            })
+            .unwrap_or_else(|_| "https://git.hub.flox.dev".to_string());
+
         let boostrap_flox = Flox {
             cache_dir: config.flox.cache_dir.clone(),
             data_dir: config.flox.data_dir.clone(),
@@ -157,7 +165,7 @@ impl FloxArgs {
             system: env!("NIX_TARGET_SYSTEM").to_string(),
             uuid: init_uuid(&config.flox.data_dir).await?,
             floxhub_token: config.flox.floxhub_token.clone(),
-            floxhub_host: "https://git.hub.flox.dev".to_string(),
+            floxhub_host,
         };
 
         let channels = init_channels(BTreeMap::new())?;

--- a/crates/flox/src/utils/completion.rs
+++ b/crates/flox/src/utils/completion.rs
@@ -76,6 +76,7 @@ impl FloxCompletionExt for Flox {
             access_tokens,
             uuid: uuid::Uuid::nil(),
             floxhub_token: config.flox.floxhub_token,
+            floxhub_host: "https://git.hub.flox.dev".to_string(),
         })
     }
 

--- a/tests/environment-pull.bats
+++ b/tests/environment-pull.bats
@@ -1,0 +1,195 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test rust impl of `flox pull`
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+# bats file_tags=pull
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  home_setup test;
+  common_test_setup
+  project_setup
+
+  export FLOX_FLOXHUB_TOKEN=flox_testOAuthToken
+  export __FLOX_FLOXHUB_URL="file://$BATS_TEST_TMPDIR/floxhub"
+
+  make_dummy_env "owner" "name"
+}
+teardown() {
+  unset __FLOX_FLOXHUB_URL
+  project_teardown
+  common_test_teardown
+}
+
+function make_dummy_env() {
+  OWNER="$1"; shift;
+  ENV_NAME="$1"; shift;
+
+  FLOXHUB_FLOXMETA_DIR="$BATS_TEST_TMPDIR/floxhub/$OWNER/floxmeta"
+
+  mkdir -p "$FLOXHUB_FLOXMETA_DIR"
+  pushd "$FLOXHUB_FLOXMETA_DIR"
+
+  # todo: fake a real upstream env
+  git init --initial-branch="$NIX_SYSTEM.$ENV_NAME"
+
+  git config user.name "test"
+  git config user.email "test@email.address"
+
+  touch "env.json"
+  git add .
+  git commit -m "initial commit"
+
+  popd >/dev/null || return
+}
+
+# simulate a dummy env update pushed to floxhub
+function update_dummy_env() {
+  OWNER="$1"; shift;
+  ENV_NAME="$1"; shift;
+
+  FLOXHUB_FLOXMETA_DIR="$BATS_TEST_TMPDIR/floxhub/$OWNER/floxmeta"
+
+  pushd "$FLOXHUB_FLOXMETA_DIR" >/dev/null || return
+
+  touch new_file
+  git add .
+  git commit -m "update"
+
+  popd >/dev/null || return
+}
+
+# ---------------------------------------------------------------------------- #
+
+
+# bats test_tags=pull:l1
+@test "l1: pull login: running flox pull before user has login metadata prompts the user to login" {
+
+  unset FLOX_FLOXHUB_TOKEN; # logout, effectively
+
+  run "$FLOX_CLI" pull --remote owner/name # dummy remote as we are not actually pulling anything
+  assert_failure
+  assert_output --partial 'Please login to floxhub with `flox auth login`'
+}
+
+# bats test_tags=pull:l2,pull:l2:a,pull:l4
+@test "l2.a/l4: flox pull accepts a flox hub namespace/environment, creates .flox if it does not exist" {
+  run "$FLOX_CLI" pull --remote owner/name # dummy remote as we are not actually pulling anything
+  assert_success
+  assert [ -e ".flox/env.json" ];
+  assert [ -e ".flox/env.lock" ];
+  assert [ $(cat .flox/env.json | jq -r '.name') == "name" ];
+  assert [ $(cat .flox/env.json | jq -r '.owner') == "owner" ];
+}
+
+# bats test_tags=pull:l2,pull:l2:b
+@test "l2.b: flox pull with --remote fails if an env is already present" {
+
+  "$FLOX_CLI" pull --remote owner/name # dummy remote as we are not actually pulling anything
+
+  run "$FLOX_CLI" pull --remote owner/name # dummy remote as we are not actually pulling anything
+  assert_failure
+
+  # todo: error message
+  # assert_output --partial <error message>
+}
+
+# bats test_tags=pull:l2,pull:l2:c
+@test "l2.c: flox pull with --remote and --dir pulls into the specified directory" {
+
+  run "$FLOX_CLI" pull --remote owner/name --dir ./inner
+  assert_success
+  assert [ -e "inner/.flox/env.json" ];
+  assert [ -e "inner/.flox/env.lock" ];
+  assert [ $(cat inner/.flox/env.json | jq -r '.name') == "name" ];
+  assert [ $(cat inner/.flox/env.json | jq -r '.owner') == "owner" ];
+}
+
+
+# bats test_tags=pull:l3,pull:l3:a
+@test "l3.a: pulling without namespace/environment" {
+
+  "$FLOX_CLI" pull --remote owner/name # dummy remote as we are not actually pulling anything
+  LOCKED_BEFORE=$(cat .flox/env.lock | jq -r '.rev')
+
+  update_dummy_env "owner" "name"
+
+  run "$FLOX_CLI" pull
+  assert_success
+
+  LOCKED_AFTER=$(cat .flox/env.lock | jq -r '.rev')
+
+  assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
+}
+
+# bats test_tags=pull:l3,pull:l3:a
+@test "l3.b: pulling without namespace/environment respects --dir" {
+
+  "$FLOX_CLI" pull --remote owner/name --dir ./inner # dummy remote as we are not actually pulling anything
+  LOCKED_BEFORE=$(cat ./inner/.flox/env.lock | jq -r '.rev')
+
+  update_dummy_env "owner" "name"
+
+  run "$FLOX_CLI" pull --dir ./inner
+  assert_success
+
+  LOCKED_AFTER=$(cat ./inner/.flox/env.lock | jq -r '.rev')
+
+  assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
+}
+
+#
+# Notice: l5 is tested in l2.a and l2.c
+#
+
+# bats test_tags=pull:l6,pull:l6:a
+@test "l6.a: pulling the same remote environment in multiple directories creates unique copies of the environment" {
+
+  mkdir first second
+
+  "$FLOX_CLI" pull --remote owner/name --dir first  # dummy remote as we are not actually pulling anything
+  LOCKED_FIRST_BEFORE=$(cat .flox/env.lock | jq -r '.rev')
+
+  update_dummy_env "owner" "name"
+
+  "$FLOX_CLI" pull --remote owner/name --dir first  # dummy remote as we are not actually pulling anything
+  LOCKED_SECOND=$(cat .flox/env.lock | jq -r '.rev')
+
+  LOCKED_FIRST_AFTER=$(cat ./first/.flox/env.lock | jq -r '.rev')
+
+  assert [ "$LOCKED_FIRST_BEFORE" == "$LOCKED_FIRST_AFTER" ]
+  assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_SECOND" ]
+
+  # after pulling first env, its at the rame rev as the second that was pulled after the update
+  "$FLOX_CLI" pull --remote owner/name --dir second  # dummy remote as we are not actually pulling anything
+  assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_FIRST_AFTER" ]
+  assert [ "$LOCKED_FIRST_BEFORE" == "$LOCKED_SECOND" ]
+}
+
+# bats test_tags=pull:l6,pull:l6:b
+@test "l6.b: installing in one directory doesn't show in the other until it is pushed and pulled again" {
+  skip "pulling is not yet implemtened"
+}

--- a/tests/environment-pull.bats
+++ b/tests/environment-pull.bats
@@ -183,7 +183,7 @@ function update_dummy_env() {
   assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_SECOND" ]
 
   # after pulling first env, its at the rame rev as the second that was pulled after the update
-  "$FLOX_CLI" pull --remote owner/name --dir second  # dummy remote as we are not actually pulling anything
+  "$FLOX_CLI" pull --dir second  # dummy remote as we are not actually pulling anything
   assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_FIRST_AFTER" ]
   assert [ "$LOCKED_FIRST_BEFORE" == "$LOCKED_SECOND" ]
 }

--- a/tests/environment-pull.bats
+++ b/tests/environment-pull.bats
@@ -145,7 +145,7 @@ function update_dummy_env() {
   assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
 }
 
-# bats test_tags=pull:l3,pull:l3:a
+# bats test_tags=pull:l3,pull:l3:b
 @test "l3.b: pulling without namespace/environment respects --dir" {
 
   "$FLOX_CLI" pull --remote owner/name --dir ./inner # dummy remote as we are not actually pulling anything

--- a/tests/environment-pull.bats
+++ b/tests/environment-pull.bats
@@ -171,14 +171,13 @@ function update_dummy_env() {
   mkdir first second
 
   "$FLOX_CLI" pull --remote owner/name --dir first  # dummy remote as we are not actually pulling anything
-  LOCKED_FIRST_BEFORE=$(cat .flox/env.lock | jq -r '.rev')
+  LOCKED_FIRST_BEFORE=$(cat ./first/.flox/env.lock | jq -r '.rev')
 
   update_dummy_env "owner" "name"
-
-  "$FLOX_CLI" pull --remote owner/name --dir first  # dummy remote as we are not actually pulling anything
-  LOCKED_SECOND=$(cat .flox/env.lock | jq -r '.rev')
-
   LOCKED_FIRST_AFTER=$(cat ./first/.flox/env.lock | jq -r '.rev')
+
+  "$FLOX_CLI" pull --remote owner/name --dir second  # dummy remote as we are not actually pulling anything
+  LOCKED_SECOND=$(cat ./second/.flox/env.lock | jq -r '.rev')
 
   assert [ "$LOCKED_FIRST_BEFORE" == "$LOCKED_FIRST_AFTER" ]
   assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_SECOND" ]

--- a/tests/environment-pull.bats
+++ b/tests/environment-pull.bats
@@ -183,9 +183,12 @@ function update_dummy_env() {
   assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_SECOND" ]
 
   # after pulling first env, its at the rame rev as the second that was pulled after the update
-  "$FLOX_CLI" pull --dir second  # dummy remote as we are not actually pulling anything
-  assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_FIRST_AFTER" ]
-  assert [ "$LOCKED_FIRST_BEFORE" == "$LOCKED_SECOND" ]
+  "$FLOX_CLI" pull --dir first  # dummy remote as we are not actually pulling anything
+
+  LOCKED_FIRST_AFTER_PULL=$(cat ./first/.flox/env.lock | jq -r '.rev')
+
+  assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_FIRST_AFTER_PULL" ]
+  assert [ "$LOCKED_FIRST_AFTER_PULL" == "$LOCKED_SECOND" ]
 }
 
 # bats test_tags=pull:l6,pull:l6:b

--- a/tests/environment-pull.bats
+++ b/tests/environment-pull.bats
@@ -192,3 +192,11 @@ function update_dummy_env() {
 @test "l6.b: installing in one directory doesn't show in the other until it is pushed and pulled again" {
   skip "pulling is not yet implemtened"
 }
+
+# bats test_tags=pull:floxhub
+# try pulling from floxhub authenticated with a test token
+@test "l?: pull environment from floxhub" {
+  unset __FLOX_FLOXHUB_URL;
+  run "$FLOX_CLI" pull --remote floxtest/default
+  assert_success
+}

--- a/tests/environment-push.bats
+++ b/tests/environment-push.bats
@@ -1,0 +1,123 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test rust impl of `flox pull`
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+# bats file_tags=push
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  home_setup test;
+  common_test_setup
+  project_setup
+
+  export FLOX_FLOXHUB_TOKEN=flox_testOAuthToken
+  export __FLOX_FLOXHUB_URL="file://$BATS_TEST_TMPDIR/floxhub"
+}
+teardown() {
+  unset __FLOX_FLOXHUB_URL
+  project_teardown
+  common_test_teardown
+}
+
+
+function make_dummy_floxmeta() {
+  OWNER="$1"; shift;
+
+  FLOXHUB_FLOXMETA_DIR="$BATS_TEST_TMPDIR/floxhub/$OWNER/floxmeta"
+
+  mkdir -p "$FLOXHUB_FLOXMETA_DIR"
+  pushd "$FLOXHUB_FLOXMETA_DIR"
+
+  # todo: fake a real upstream env
+  git init --initial-branch="dummy"
+
+  git config user.name "test"
+  git config user.email "test@email.address"
+
+  touch "dummy"
+  git add .
+  git commit -m "initial commit"
+
+  popd >/dev/null || return
+}
+
+# simulate a dummy env update pushed to floxhub
+function update_dummy_env() {
+  OWNER="$1"; shift;
+  ENV_NAME="$1"; shift;
+
+  FLOXHUB_FLOXMETA_DIR="$BATS_TEST_TMPDIR/floxhub/$OWNER/floxmeta"
+
+  pushd "$FLOXHUB_FLOXMETA_DIR" >/dev/null || return
+
+  touch new_file
+  git add .
+  git commit -m "update"
+
+  popd >/dev/null || return
+}
+
+# ---------------------------------------------------------------------------- #
+
+
+# bats test_tags=push:h1
+@test "l1: push login: running flox push before user has login metadata prompts the user to login" {
+
+  unset FLOX_FLOXHUB_TOKEN; # logout, effectively
+
+  run "$FLOX_CLI" init
+
+  run "$FLOX_CLI" push --owner owner # dummy owner
+  assert_failure
+  assert_output --partial 'Please login to floxhub with `flox auth login`'
+}
+
+
+# bats test_tags=push:h2
+@test "l2: push login: running flox push before user has login metadata prompts the user to login" {
+  make_dummy_floxmeta "owner"
+
+
+  mkdir -p "machine_a"
+  mkdir -p "machine_b"
+
+  pushd "machine_a" >/dev/null || return
+  "$FLOX_CLI" init --name "test"
+  "$FLOX_CLI" install hello
+  "$FLOX_CLI" push --owner owner
+  popd >/dev/null || return
+
+
+  pushd "machine_b" >/dev/null || return
+  run "$FLOX_CLI" pull --remote owner/test
+  assert_success
+
+  run "$FLOX_CLI" list
+  assert_success
+  assert_line "hello"
+
+  popd >/dev/null || return
+}


### PR DESCRIPTION
Implements `flox pull [--dir]` and `flox pull --remote [--dir]`.

Environment branches are updated using `fast-forward`s and fail if this is not possible.
