### PR TITLE
feat: activate builds environments

### DIFF
--- a/assets/mkEnv/build-env.sh
+++ b/assets/mkEnv/build-env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -eu
+
+NIX="$1";
+SYSTEM="$2";
+LOCKFILE_PATH="$3";
+OUTLINK_PREFIX="$4";
+ENV_FROM_LOCKFILE_PATH="$5";
+"$NIX" build --file "$ENV_FROM_LOCKFILE_PATH" --out-link "$OUTLINK_PREFIX" --print-out-paths --arg lockfilePath "$LOCKFILE_PATH" --argstr system "$SYSTEM"

--- a/assets/mkEnv/build-env.sh
+++ b/assets/mkEnv/build-env.sh
@@ -7,4 +7,11 @@ SYSTEM="$2";
 LOCKFILE_PATH="$3";
 OUTLINK_PREFIX="$4";
 ENV_FROM_LOCKFILE_PATH="$5";
-"$NIX" build --file "$ENV_FROM_LOCKFILE_PATH" --out-link "$OUTLINK_PREFIX" --print-out-paths --arg lockfilePath "$LOCKFILE_PATH" --argstr system "$SYSTEM"
+"$NIX" build \
+    --file "$ENV_FROM_LOCKFILE_PATH" \
+    --out-link "$OUTLINK_PREFIX" \
+    --print-out-paths \
+    --extra-experimental-features "nix-command flakes" \
+    --no-update-lock-file \
+    --arg lockfilePath "$LOCKFILE_PATH" \
+    --argstr system "$SYSTEM";

--- a/assets/mkEnv/env-from-lockfile.nix
+++ b/assets/mkEnv/env-from-lockfile.nix
@@ -1,0 +1,41 @@
+# ============================================================================ #
+#
+# Create an environment from a `lockfile.json` file.
+#
+# ---------------------------------------------------------------------------- #
+{
+  lockfilePath ?
+    throw
+    "flox: You must provide the path to a lockfile.",
+  system ? builtins.currentSystem or "unknown",
+  ...
+}: let
+  lockfileContents = builtins.fromJSON (builtins.readFile lockfilePath);
+
+  # Convert manifest elements to derivations.
+  # Return `[]' for non-active elements.
+  tryGetDrv = system: package: let
+    attrs = builtins.getFlake package.${system}.url;
+    drv = builtins.foldl' (pathComponent: flakeAttrs: builtins.getAttr flakeAttrs pathComponent) attrs package.${system}.path;
+    toInstall = drv.meta.outputsToInstall or drv.outputs;
+    numOutputs = builtins.length toInstall;
+    priority = drv.meta.priority or 5;
+  in
+    # assert drv?outPath;
+    if package.${system} == null
+    then []
+    else ["true" priority numOutputs] ++ map (output: builtins.getAttr output drv) toInstall;
+in
+  derivation {
+    inherit system;
+    name = "flox-env";
+    builder = "builtin:buildenv";
+    manifest = "/dummy";
+    derivations = builtins.concatMap (tryGetDrv system) (builtins.attrValues lockfileContents.packages);
+  }
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #
+

--- a/assets/templateFloxEnv/dummy_lockfile.json
+++ b/assets/templateFloxEnv/dummy_lockfile.json
@@ -200,7 +200,8 @@
                 },
                 "subtrees": [
                     "legacyPackages"
-                ]
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
             }
         },
         "priority": []

--- a/assets/templateFloxEnv/dummy_lockfile.json
+++ b/assets/templateFloxEnv/dummy_lockfile.json
@@ -1,0 +1,208 @@
+{
+    "lockfileVersion": 0,
+    "manifest": {
+        "hook": {
+            "script": "hello >&2;\ncowsay \"$message $message2\" >&2;\n"
+        },
+        "install": {
+            "bad": {
+                "optional": true
+            },
+            "charasay": {
+                "version": "^2"
+            },
+            "pip": {
+                "path": "python310Packages.pip"
+            }
+        },
+        "options": {
+            "systems": [
+                "x86_64-linux",
+                "aarch64-darwin"
+            ]
+        },
+        "registry": {
+            "inputs": {
+                "nixpkgs": {
+                    "from": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    }
+                }
+            }
+        },
+        "vars": {
+            "message": "Howdy",
+            "message2": "partner"
+        }
+    },
+    "packages": {
+        "bad": {
+            "aarch64-darwin": null,
+            "x86_64-linux": null
+        },
+        "charasay": {
+            "aarch64-darwin": {
+                "info": {
+                    "license": "MIT",
+                    "pname": "charasay",
+                    "version": "2.0.0"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "aarch64-darwin",
+                    "charasay"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            },
+            "x86_64-linux": {
+                "info": {
+                    "license": "MIT",
+                    "pname": "charasay",
+                    "version": "2.0.0"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "x86_64-linux",
+                    "charasay"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            }
+        },
+        "pip": {
+            "aarch64-darwin": {
+                "info": {
+                    "license": null,
+                    "pname": "pip",
+                    "version": "23.0.1"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "aarch64-darwin",
+                    "python310Packages",
+                    "pip"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            },
+            "x86_64-linux": {
+                "info": {
+                    "license": null,
+                    "pname": "pip",
+                    "version": "23.0.1"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "x86_64-linux",
+                    "python310Packages",
+                    "pip"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            }
+        },
+        "curl": {
+            "aarch64-darwin": {
+                "info": {
+                    "license": null,
+                    "pname": "curl",
+                    "version": "23.0.1"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "aarch64-darwin",
+                    "curl"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            },
+            "x86_64-linux": {
+                "info": {
+                    "license": null,
+                    "pname": "curl",
+                    "version": "23.0.1"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "x86_64-linux",
+                    "curl"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            }
+        }
+    },
+    "registry": {
+        "defaults": {
+            "subtrees": null
+        },
+        "inputs": {
+            "nixpkgs": {
+                "from": {
+                    "lastModified": 1685979279,
+                    "narHash": "sha256-1UGacsv5coICyvAzwuq89v9NsS00Lo8sz22cDHwhnn8=",
+                    "owner": "NixOS",
+                    "repo": "nixpkgs",
+                    "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                    "type": "github"
+                },
+                "subtrees": [
+                    "legacyPackages"
+                ]
+            }
+        },
+        "priority": []
+    }
+}

--- a/assets/templateFloxEnv/dummy_lockfile.json
+++ b/assets/templateFloxEnv/dummy_lockfile.json
@@ -41,7 +41,8 @@
     "packages": {
         "bad": {
             "aarch64-darwin": null,
-            "x86_64-linux": null
+            "x86_64-linux": null,
+            "x86_64-darwin": null
         },
         "charasay": {
             "aarch64-darwin": {
@@ -84,6 +85,28 @@
                 "path": [
                     "legacyPackages",
                     "x86_64-linux",
+                    "charasay"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            },
+            "x86_64-darwin": {
+                "info": {
+                    "license": "MIT",
+                    "pname": "charasay",
+                    "version": "2.0.0"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "x86_64-darwin",
                     "charasay"
                 ],
                 "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
@@ -135,6 +158,29 @@
                     "pip"
                 ],
                 "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            },
+            "x86_64-darwin": {
+                "info": {
+                    "license": null,
+                    "pname": "pip",
+                    "version": "23.0.1"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "x86_64-darwin",
+                    "python310Packages",
+                    "pip"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
             }
         },
         "curl": {
@@ -178,6 +224,28 @@
                 "path": [
                     "legacyPackages",
                     "x86_64-linux",
+                    "curl"
+                ],
+                "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"
+            },
+            "x86_64-darwin": {
+                "info": {
+                    "license": null,
+                    "pname": "curl",
+                    "version": "23.0.1"
+                },
+                "input": {
+                    "locked": {
+                        "owner": "NixOS",
+                        "repo": "nixpkgs",
+                        "rev": "e8039594435c68eb4f780f3e9bf3972a7399c4b1",
+                        "type": "github"
+                    },
+                    "name": "nixpkgs"
+                },
+                "path": [
+                    "legacyPackages",
+                    "x86_64-darwin",
                     "curl"
                 ],
                 "url": "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1"

--- a/checks/pre-commit-check/default.nix
+++ b/checks/pre-commit-check/default.nix
@@ -3,7 +3,6 @@
   rustfmt,
   cargo,
   commitizen,
-  clippy,
   alejandra,
   system,
   ...
@@ -15,12 +14,10 @@ in
     hooks = {
       alejandra.enable = true;
       rustfmt.enable = true;
-      clippy.enable = true;
       commitizen.enable = true;
     };
-    settings.clippy.denyWarnings = true;
     tools = {
-      inherit cargo commitizen clippy rustfmt alejandra;
+      inherit cargo commitizen rustfmt alejandra;
     };
   })
   // {passthru = {inherit rustfmt;};}

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -41,6 +41,7 @@ pub const DEFAULT_MAX_AGE_DAYS: u32 = 90;
 
 // Path to the executable that builds environments
 const BUILD_ENV_BIN: &'_ str = env!("BUILD_ENV_BIN");
+const ENV_FROM_LOCKFILE_PATH: &str = env!("ENV_FROM_LOCKFILE_PATH");
 
 pub enum InstalledPackage {
     Catalog(FloxTriple, CatalogEntry),

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_KEEP_GENERATIONS: usize = 10;
 pub const DEFAULT_MAX_AGE_DAYS: u32 = 90;
 
 // Path to the executable that builds environments
-const BUILD_ENV: &'_ str = env!("BUILD_ENV");
+const BUILD_ENV_BIN: &'_ str = env!("BUILD_ENV_BIN");
 
 pub enum InstalledPackage {
     Catalog(FloxTriple, CatalogEntry),

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -266,8 +266,8 @@ pub enum EnvironmentError2 {
     Install(#[from] TomlEditError),
     #[error("couldn't locate the manifest for this environment")]
     ManifestNotFound,
-    #[error("couldn't locate gc roots directory")]
-    GcRootsDirNotFound,
+    #[error("failed to create GC roots directory: {0}")]
+    CreateGcRootDir(std::io::Error),
     #[error("error building environment: {0}")]
     BuildEnvCall(std::io::Error),
     #[error("error building environment: {0}")]

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -33,10 +33,14 @@ pub const CATALOG_JSON: &str = "catalog.json";
 pub const DOT_FLOX: &str = ".flox";
 pub const ENVIRONMENT_POINTER_FILENAME: &str = "env.json";
 pub const MANIFEST_FILENAME: &str = "manifest.toml";
+pub const PATH_ENV_GCROOTS_DIR: &str = "run";
 // don't forget to update the man page
 pub const DEFAULT_KEEP_GENERATIONS: usize = 10;
 // don't forget to update the man page
 pub const DEFAULT_MAX_AGE_DAYS: u32 = 90;
+
+// Path to the executable that builds environments
+const BUILD_ENV: &'_ str = env!("BUILD_ENV");
 
 pub enum InstalledPackage {
     Catalog(FloxTriple, CatalogEntry),
@@ -260,6 +264,14 @@ pub enum EnvironmentError2 {
     ManagedEnvironment(#[from] ManagedEnvironmentError),
     #[error(transparent)]
     Install(#[from] TomlEditError),
+    #[error("couldn't locate the manifest for this environment")]
+    ManifestNotFound,
+    #[error("couldn't locate gc roots directory")]
+    GcRootsDirNotFound,
+    #[error("error building environment: {0}")]
+    BuildEnvCall(std::io::Error),
+    #[error("error building environment: {0}")]
+    BuildEnv(String),
 }
 
 /// Copy a whole directory recursively ignoring the original permissions

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -26,7 +26,7 @@ use super::{
     MANIFEST_FILENAME,
 };
 use crate::environment::NIX_BIN;
-use crate::models::environment::{BUILD_ENV, CATALOG_JSON, PATH_ENV_GCROOTS_DIR};
+use crate::models::environment::{BUILD_ENV_BIN, CATALOG_JSON, PATH_ENV_GCROOTS_DIR};
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRef};
 use crate::models::manifest::{insert_packages, remove_packages};
 
@@ -181,7 +181,7 @@ where
             "building environment: system={system}, lockfilePath={}",
             lockfile_path.display()
         );
-        let build_output = std::process::Command::new(BUILD_ENV)
+        let build_output = std::process::Command::new(BUILD_ENV_BIN)
             .arg(NIX_BIN)
             .arg(&system)
             .arg(lockfile_path)

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -501,7 +501,7 @@ mod tests {
                 .join(ENVIRONMENT_DIR_NAME)
                 .join("flake.nix")
                 .exists(),
-            "flake exists"
+            "flake does not exist"
         );
         assert!(actual.manifest_path().exists(), "manifest exists");
         assert!(

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -118,19 +118,20 @@ impl<S: TransactionState> PathEnvironment<S> {
         Ok(())
     }
 
-    /// Where to link a built environment to. The parent directory may not exist.
+    /// Where to link a built environment to. The path may not exist if the environment has
+    /// never been built.
     ///
-    /// When used as a lookup signals whether the environment has *at some point* been built before
-    /// and is "activatable". Note that the environment may have been modified since it was last built.
+    /// The existence of this path guarantees exactly two things:
+    /// - The environment was built at some point in the past.
+    /// - The environment can be activated.
     ///
-    /// Mind that an existing out link does not necessarily imply that the environment
-    /// can in fact be built.
+    /// The existence of this path explicitly _does not_ guarantee that the current
+    /// state of the environment is "buildable". The environment may have been modified
+    /// since it was last built and therefore may no longer build. Thus, the presence of
+    /// this path doesn't guarantee that the current environment can be built,
+    /// just that it built at some point in the past.
     fn out_link(&self, system: &System) -> Result<PathBuf, EnvironmentError2> {
-        let run_dir = self
-            .path
-            .parent()
-            .ok_or(EnvironmentError2::DotFloxNotFound)?
-            .join(PATH_ENV_GCROOTS_DIR);
+        let run_dir = self.path.join(PATH_ENV_GCROOTS_DIR);
         if !run_dir.exists() {
             std::fs::create_dir_all(&run_dir).map_err(EnvironmentError2::CreateGcRootDir)?;
         }

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -27,7 +27,12 @@ use super::{
 };
 use crate::environment::NIX_BIN;
 use crate::flox::Flox;
-use crate::models::environment::{BUILD_ENV_BIN, CATALOG_JSON, PATH_ENV_GCROOTS_DIR};
+use crate::models::environment::{
+    BUILD_ENV_BIN,
+    CATALOG_JSON,
+    ENV_FROM_LOCKFILE_PATH,
+    PATH_ENV_GCROOTS_DIR,
+};
 use crate::models::environment_ref::{EnvironmentName, EnvironmentRef};
 use crate::models::manifest::{insert_packages, remove_packages};
 
@@ -189,6 +194,7 @@ where
             .arg(system)
             .arg(lockfile_path)
             .arg(self.out_link(system)?)
+            .arg(ENV_FROM_LOCKFILE_PATH)
             .output()
             .map_err(EnvironmentError2::BuildEnvCall)?;
 

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -183,6 +183,7 @@ where
             "building environment: system={system}, lockfilePath={}",
             lockfile_path.display()
         );
+
         let build_output = std::process::Command::new(BUILD_ENV_BIN)
             .arg(NIX_BIN)
             .arg(system)

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 use flox_types::catalog::{EnvCatalog, System};
 use runix::command_line::NixCommandLine;

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use async_trait::async_trait;
 use flox_types::catalog::{EnvCatalog, System};
 use runix::command_line::NixCommandLine;

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -5,7 +5,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use bpaf::{Bpaf, Parser};
 use flox_rust_sdk::flox::{EnvironmentName, Flox};
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
@@ -17,7 +17,7 @@ use flox_rust_sdk::models::manifest::list_packages;
 use flox_rust_sdk::nix::command::StoreGc;
 use flox_rust_sdk::nix::command_line::NixCommandLine;
 use flox_rust_sdk::nix::Run;
-use log::{debug, error, info, warn};
+use log::{debug, error, info};
 use tempfile::NamedTempFile;
 
 use crate::subcommand_metric;

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
-use bpaf::{Bpaf, Parser};
+use bpaf::Bpaf;
 use flox_rust_sdk::flox::{EnvironmentName, Flox};
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
 use flox_rust_sdk::models::environment::path_environment::{Original, PathEnvironment};
@@ -240,25 +240,16 @@ impl Delete {
     }
 }
 
-/// Activate environment
+/// Activate an environment
 ///
-///
-/// Modes:
-///  * in current shell: eval "$(flox activate)"
-///  * in subshell: flox activate
-///  * for command: flox activate -- <command> <args>
+/// When called with no arguments `flox activate` will look for a `.flox` directory
+/// in the current directory. Calling `flox activate` in your home directory will
+/// activate a default environment. Environments in other directories and remote
+/// environments are activated with the `-d` and `-r` flags respectively.
 #[derive(Bpaf, Clone)]
 pub struct Activate {
-    #[allow(dead_code)] // TODO: pending spec for `-e`, `--dir` behaviour
-    #[bpaf(external(environment_args), group_help("Environment Options"))]
-    environment_args: EnvironmentArgs,
-
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
-
-    #[allow(dead_code)] // TODO: not yet handled in impl
-    #[bpaf(external(activate_run_args))]
-    arguments: Option<(String, Vec<String>)>,
 }
 
 impl Activate {
@@ -716,11 +707,4 @@ impl Containerize {
 
         todo!("this command is planned for a future release");
     }
-}
-
-fn activate_run_args() -> impl Parser<Option<(String, Vec<String>)>> {
-    let command = bpaf::positional("COMMAND").strict();
-    let args = bpaf::any("ARGUMENTS", Some).many();
-
-    bpaf::construct!(command, args).optional()
 }

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -5,7 +5,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use bpaf::{Bpaf, Parser};
 use flox_rust_sdk::flox::{EnvironmentName, Flox};
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
@@ -17,7 +17,7 @@ use flox_rust_sdk::models::manifest::list_packages;
 use flox_rust_sdk::nix::command::StoreGc;
 use flox_rust_sdk::nix::command_line::NixCommandLine;
 use flox_rust_sdk::nix::Run;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use tempfile::NamedTempFile;
 
 use crate::subcommand_metric;

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -26,14 +26,13 @@
   pkgsFor,
   floxVersion,
   flox-pkgdb,
-  writeScript,
 }: let
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = inputs.crane.mkLib pkgsFor;
 
   # build time environment variables
   envs =
-    rec {
+    {
       # 3rd party CLIs
       # we want to use our own binaries by absolute path
       # rather than relying on or modifying the user's `PATH` variable
@@ -45,13 +44,7 @@
       GH_BIN = "${gh}/bin/gh";
       FLOX_SH_PATH = flox-bash.outPath;
       ENV_FROM_LOCKFILE_PATH = ../../assets/mkEnv/env-from-lockfile.nix;
-      BUILD_ENV_BIN = writeScript "build-env" ''
-        NIX="$1";
-        SYSTEM="$2";
-        LOCKFILE_PATH="$3";
-        OUTLINK_PREFIX="$4";
-        "$NIX" build --file ${ENV_FROM_LOCKFILE_PATH} --out-link "$OUTLINK_PREFIX" --print-out-paths --arg lockfilePath "$LOCKFILE_PATH" --argstr system "$SYSTEM"
-      '';
+      BUILD_ENV_BIN = ../../assets/mkEnv/build-env.sh;
 
       # Modified nix completion scripts
       # used to pass through nix completion ability for `flox nix *`

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -46,7 +46,7 @@
       GH_BIN = "${gh}/bin/gh";
       FLOX_SH_PATH = flox-bash.outPath;
       ENV_FROM_LOCKFILE_PATH = ../../assets/mkEnv/env-from-lockfile.nix;
-      BUILD_ENV = writeScript "build-env" ''
+      BUILD_ENV_BIN = writeScript "build-env" ''
         NIX="$1";
         SYSTEM="$2";
         LOCKFILE_PATH="$3";

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -26,13 +26,15 @@
   pkgsFor,
   floxVersion,
   flox-pkgdb,
+  writeScript,
+  system,
 }: let
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = inputs.crane.mkLib pkgsFor;
 
   # build time environment variables
   envs =
-    {
+    rec {
       # 3rd party CLIs
       # we want to use our own binaries by absolute path
       # rather than relying on or modifying the user's `PATH` variable
@@ -43,6 +45,14 @@
       FLOX_GH_BIN = "${flox-gh}/bin/flox-gh";
       GH_BIN = "${gh}/bin/gh";
       FLOX_SH_PATH = flox-bash.outPath;
+      ENV_FROM_LOCKFILE_PATH = ../../assets/mkEnv/env-from-lockfile.nix;
+      BUILD_ENV = writeScript "build-env" ''
+        NIX="$1";
+        SYSTEM="$2";
+        LOCKFILE_PATH="$3";
+        OUTLINK_PREFIX="$4";
+        "$NIX" build --file ${ENV_FROM_LOCKFILE_PATH} --out-link "$OUTLINK_PREFIX" --print-out-paths --arg lockfilePath "$LOCKFILE_PATH" --argstr system "$SYSTEM"
+      '';
 
       # Modified nix completion scripts
       # used to pass through nix completion ability for `flox nix *`

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -27,7 +27,6 @@
   floxVersion,
   flox-pkgdb,
   writeScript,
-  system,
 }: let
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = inputs.crane.mkLib pkgsFor;

--- a/tests/channels-search.bats
+++ b/tests/channels-search.bats
@@ -39,8 +39,6 @@ teardown() {
 }
 
 setup_file() {
-  export FLOX_FEATURES_CHANNELS=rust;
-
   export SHOW_HINT="Use \`flox show {package}\` to see available versions"
 
   # Separator character for ambiguous package sources

--- a/tests/channels-show.bats
+++ b/tests/channels-show.bats
@@ -38,10 +38,6 @@ teardown() {
   common_test_teardown;
 }
 
-setup_file() {
-  export FLOX_FEATURES_CHANNELS=rust;
-}
-
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' can be called at all" {

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -19,7 +19,6 @@ load test_support.bash;
 
 setup_file() {
   common_file_setup;
-  export FLOX_FEATURES_ENV="rust";
 }
 
 

--- a/tests/environment-build.bats
+++ b/tests/environment-build.bats
@@ -1,0 +1,70 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test that we can build environments
+#
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash;
+
+# bats file_tags=activate,init
+
+
+# ---------------------------------------------------------------------------- #
+
+setup_file() {
+  common_file_setup;
+  export FLOX_FEATURES_ENV="rust";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}";
+  export PROJECT_NAME="${PROJECT_DIR##*/}";
+  rm -rf "$PROJECT_DIR";
+  mkdir -p "$PROJECT_DIR";
+  pushd "$PROJECT_DIR" >/dev/null||return;
+  git init;
+}
+
+project_teardown() {
+  popd >/dev/null||return;
+  rm -rf "${PROJECT_DIR?}";
+  unset PROJECT_DIR;
+  unset PROJECT_NAME;
+}
+
+activate_local_env() {
+  run "$FLOX_CLI" activate -d "$PROJECT_DIR";
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup;
+  project_setup;
+}
+
+teardown() {
+  project_teardown;
+  common_test_teardown;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'build-env' builds fresh environment" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  run "$BUILD_ENV" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/dummy_lockfile.json" "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME";
+  assert_success;
+  run [ -d "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME" ];
+  assert_success;
+}

--- a/tests/environment-build.bats
+++ b/tests/environment-build.bats
@@ -16,7 +16,6 @@ load test_support.bash;
 
 setup_file() {
   common_file_setup;
-  export FLOX_FEATURES_ENV="rust";
 }
 
 

--- a/tests/environment-build.bats
+++ b/tests/environment-build.bats
@@ -62,7 +62,11 @@ teardown() {
 @test "'build-env' builds fresh environment" {
   run "$FLOX_CLI" init;
   assert_success;
-  run "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/dummy_lockfile.json" "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME";
+  run "$BUILD_ENV_BIN" "$NIX_BIN" \
+    "$NIX_SYSTEM" \
+    "$PROJECT_DIR/.flox/env/dummy_lockfile.json" \
+    "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME" \
+    "$ENV_FROM_LOCKFILE_PATH";
   assert_success;
   run [ -d "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME" ];
   assert_success;

--- a/tests/environment-build.bats
+++ b/tests/environment-build.bats
@@ -63,7 +63,7 @@ teardown() {
 @test "'build-env' builds fresh environment" {
   run "$FLOX_CLI" init;
   assert_success;
-  run "$BUILD_ENV" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/dummy_lockfile.json" "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME";
+  run "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/dummy_lockfile.json" "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME";
   assert_success;
   run [ -d "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME" ];
   assert_success;

--- a/tests/environment-delete.bats
+++ b/tests/environment-delete.bats
@@ -45,14 +45,7 @@ dot_flox_exists() {
   # Since the return value is based on the exit code of `test`:
   # 0 = true
   # 1 = false
-  [[ -d .flox ]];
-}
-
-env_exists() {
-  # Since the return value is based on the exit code of `test`:
-  # 0 = true
-  # 1 = false
-  [[ -d ".flox/$1" ]];
+  [[ -d "$PROJECT_DIR/.flox" ]];
 }
 
 # ---------------------------------------------------------------------------- #
@@ -60,12 +53,10 @@ env_exists() {
 @test "deletes existing environment" {
   run "$FLOX_CLI" init;
   assert_success;
-  # run env_exists "$(basename $PWD)";
   run dot_flox_exists;
   assert_success;
   run "$FLOX_CLI" delete;
   assert_success;
-  # run env_exists "$(basename $PWD)";
   run dot_flox_exists;
   assert_failure;
 }

--- a/tests/environment-delete.bats
+++ b/tests/environment-delete.bats
@@ -37,10 +37,6 @@ teardown() {
   common_test_teardown
 }
 
-setup_file() {
-  export FLOX_FEATURES_ENV=rust
-}
-
 dot_flox_exists() {
   # Since the return value is based on the exit code of `test`:
   # 0 = true

--- a/tests/environment-edit.bats
+++ b/tests/environment-edit.bats
@@ -77,10 +77,6 @@ teardown() {
   common_test_teardown;
 }
 
-setup_file() {
-  export FLOX_FEATURES_ENV=rust
-}
-
 # ---------------------------------------------------------------------------- #
 
 check_manifest_unchanged() {

--- a/tests/environment-init.bats
+++ b/tests/environment-init.bats
@@ -36,10 +36,6 @@ teardown() {
   common_test_teardown
 }
 
-setup_file() {
-  export FLOX_FEATURES_ENV=rust
-}
-
 @test "c2: flox init without a name should create an environment named the same as the directory the user is in" {
 
   run "$FLOX_CLI" init

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -36,10 +36,6 @@ teardown() {
   common_test_teardown
 }
 
-setup_file() {
-  export FLOX_FEATURES_ENV=rust
-}
-
 # without specifying a name should install to an environment found in the user's current directory.
 @test "i2.a: install outside of shell (option1)" {
   skip "Environment defaults handled in another phase"

--- a/tests/environment-list.bats
+++ b/tests/environment-list.bats
@@ -38,10 +38,6 @@ teardown() {
   common_test_teardown
 }
 
-setup_file() {
-  export FLOX_FEATURES_ENV=rust
-}
-
 @test "'flox list' lists packages of environment in the current dir; fails if no env found" {
   run "$FLOX_CLI" list;
   assert_failure;

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -163,6 +163,46 @@ EOF
 
 # ---------------------------------------------------------------------------- #
 
+env_lockfile_setup() {
+  if [[ -n "${__FT_RAN_ENV_LOCKFILE_LOCATION_SETUP:-}" ]]; then return 0; fi
+  repo_root_setup;
+  if [[ -z "${ENV_FROM_LOCKFILE_PATH:-}" ]]; then
+    if [[ -r "${REPO_ROOT:?}/assets/mkEnv/env-from-lockfile.nix" ]]; then
+      ENV_FROM_LOCKFILE_PATH="$REPO_ROOT/assets/mkEnv/env-from-lockfile.nix";
+    else
+      echo "ERROR: couldn't locate env-from-lockfile.nix" >&2;
+      exit 1;
+    fi
+  fi
+
+  # Force absolute paths for ENV_FROM_LOCKFILE_PATH
+  ENV_FROM_LOCKFILE_PATH="$( readlink -f "$ENV_FROM_LOCKFILE_PATH"; )";
+  export ENV_FROM_LOCKFILE_PATH;
+  export __FT_RAN_ENV_LOCKFILE_LOCATION_SETUP=:;
+}
+
+# ---------------------------------------------------------------------------- #
+
+build_env_bin_setup() {
+  if [[ -n "${__FT_RAN_BUILD_ENV_LOCATION_SETUP:-}" ]]; then return 0; fi
+  repo_root_setup;
+  if [[ -z "${BUILD_ENV_BIN:-}" ]]; then
+    if [[ -r "${REPO_ROOT:?}/assets/mkEnv/build-env.sh" ]]; then
+      BUILD_ENV_BIN="$REPO_ROOT/assets/mkEnv/build-env.sh";
+    else
+      echo "ERROR: couldn't locate build-env.sh" >&2;
+      exit 1;
+    fi
+  fi
+
+  # Force absolute paths for ENV_FROM_LOCKFILE_PATH
+  BUILD_ENV_BIN="$( readlink -f "$BUILD_ENV_BIN"; )";
+  export BUILD_ENV_BIN;
+  export __FT_RAN_BUILD_ENV_LOCATION_SETUP=:;
+}
+
+# ---------------------------------------------------------------------------- #
+
 print_var() { eval echo "  $1: \$$1"; }
 
 # Backup environment variables pointing to "real" system and users paths.
@@ -175,6 +215,8 @@ reals_setup() {
   xdg_reals_setup;
   git_reals_setup;
   flox_location_setup;
+  env_lockfile_setup;
+  build_env_bin_setup;
   {
     print_var REAL_USER;
     print_var REAL_HOME;

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -189,6 +189,8 @@ reals_setup() {
     print_var REAL_GIT_CONFIG_GLOBAL;
     print_var FLOX_CLI;
     print_var NIX_BIN;
+    print_var ENV_FROM_LOCKFILE_PATH;
+    print_var BUILD_ENV_BIN;
   } >&3;
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR builds environments when `flox activate` is called. The environment is built with a new executable called `build-env`, which currently is just a shell script that calls `nix build` on another new file: `env-from-lockfile.nix` .

The `activate` command currently builds a hard-coded lockfile. Generating a lockfile from the manifest is coming in a later PR.

This PR also disables `clippy` as a precommit hook because it's super annoying.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
`flox activate` now builds an environment.

<!-- Many thanks! -->
