### PR TITLE
feat: green path `flox push`

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -528,7 +528,8 @@ impl ManagedEnvironment {
 
         fs::create_dir_all(&temp_floxmeta_path).unwrap();
 
-        let temp_floxmeta = FloxmetaV2::new_in(&temp_floxmeta_path, flox, &pointer).unwrap();
+        let temp_floxmeta = FloxmetaV2::new_in(&temp_floxmeta_path, flox, &pointer)
+            .map_err(ManagedEnvironmentError::OpenFloxmeta)?;
 
         let generation_dir = temp_floxmeta_path.join("0");
         fs::create_dir_all(&generation_dir).unwrap();

--- a/tests/environment-push.bats
+++ b/tests/environment-push.bats
@@ -1,0 +1,76 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test rust impl of `flox pull`
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+# bats file_tags=push
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  home_setup test;
+  common_test_setup
+  project_setup
+
+  export FLOX_FLOXHUB_TOKEN=flox_testOAuthToken
+  export __FLOX_FLOXHUB_URL="file://$BATS_TEST_TMPDIR/floxhub"
+}
+teardown() {
+  unset __FLOX_FLOXHUB_URL
+  project_teardown
+  common_test_teardown
+}
+
+
+
+# simulate a dummy env update pushed to floxhub
+function update_dummy_env() {
+  OWNER="$1"; shift;
+  ENV_NAME="$1"; shift;
+
+  FLOXHUB_FLOXMETA_DIR="$BATS_TEST_TMPDIR/floxhub/$OWNER/floxmeta"
+
+  pushd "$FLOXHUB_FLOXMETA_DIR" >/dev/null || return
+
+  touch new_file
+  git add .
+  git commit -m "update"
+
+  popd >/dev/null || return
+}
+
+# ---------------------------------------------------------------------------- #
+
+
+# bats test_tags=push:h1
+@test "l1: push login: running flox push before user has login metadata prompts the user to login" {
+
+  unset FLOX_FLOXHUB_TOKEN; # logout, effectively
+
+  run "$FLOX_CLI" init
+
+  run "$FLOX_CLI" push --owner owner # dummy owner
+  assert_failure
+  assert_output --partial 'Please login to floxhub with `flox auth login`'
+}


### PR DESCRIPTION
Implements `flox push [--dir]` and `flox push [--dir] --owner` in a highly green pathed way.
Maily this is due to missing implementations of `Environment for ManagedEnvironment`. E.g. we have not yet implemented generational `install` et.al.
Thus, we everything this implementation is useful for at the moment is pushing an existing path environment to floxhub, converting it to a managed env in the process.
Pushing of new generation _should_ work but due to the fact that we are not creating new generations yet, I'm unable to test this case.