### PR TITLE
feat: print environment modified by {un,}install

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -24,7 +24,8 @@ const GENERATION_LOCK_FILENAME: &str = "env.lock";
 #[derive(Debug)]
 pub struct ManagedEnvironment {
     /// Path to the directory containing `env.json`
-    path: PathBuf,
+    // TODO might be better to keep this private
+    pub path: PathBuf,
     pointer: ManagedPointer,
     system: String,
     floxmeta: FloxmetaV2,

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -416,7 +416,12 @@ impl List {
 fn environment_description(environment: &ConcreteEnvironment) -> String {
     match environment {
         ConcreteEnvironment::Managed(environment) => {
-            format!("{}/{}", environment.owner(), environment.name())
+            format!(
+                "{}/{} at {}",
+                environment.owner(),
+                environment.name(),
+                environment.path.to_string_lossy()
+            )
         },
         ConcreteEnvironment::Path(environment) => format!(
             "{} at {}",


### PR DESCRIPTION
Instead of printing e.g.:
✅ 'python' installed to environment
Print:
✅ 'python' installed to environment name at /some/path

## Release Notes

Improve confirmation messages for install/uninstall (idk if this is big enough to mention)