### PR TITLE
feat: add `SearchStrategy` feature flag

### DIFF
--- a/crates/flox/src/commands/search.rs
+++ b/crates/flox/src/commands/search.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{BufWriter, Write};
-use std::str::FromStr;
 
 use anyhow::{bail, Context, Result};
 use bpaf::Bpaf;
@@ -20,6 +19,7 @@ use flox_rust_sdk::models::search::{
 use log::debug;
 use serde_json::json;
 
+use crate::config::features::{Features, SearchStrategy};
 use crate::subcommand_metric;
 
 const SEARCH_INPUT_SEPARATOR: &'_ str = ":";
@@ -106,7 +106,10 @@ fn construct_search_params(search_term: &str, flox: &Flox) -> Result<SearchParam
     };
 
     // We've already checked that the search term is Some(_)
-    let query = Query::from_str(search_term)?;
+    let query = Query::from_str(
+        search_term,
+        Features::parse()?.search_strategy == SearchStrategy::MatchName,
+    )?;
     let params = SearchParams {
         registry,
         query,

--- a/crates/flox/src/config/features.rs
+++ b/crates/flox/src/config/features.rs
@@ -3,49 +3,21 @@ use serde::{Deserialize, Serialize};
 
 use super::Config;
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
-pub enum Feature {
-    #[serde(rename = "all")]
-    All,
-    #[serde(rename = "env")]
-    Env,
-    #[serde(rename = "nix")]
-    Nix,
-    #[serde(rename = "develop")]
-    Develop,
-    #[serde(rename = "publish")]
-    Publish,
-    #[serde(rename = "channels")]
-    Channels,
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub struct Features {
+    pub search_strategy: SearchStrategy,
 }
 
-impl Feature {
-    // Leaving this code as it may be useful for feature flagging, but it's
-    // currently dead as it's a remnant of bash passthrough
-    #[allow(unused)]
-    pub fn implementation(&self) -> Result<Impl> {
-        let map = Config::parse()?.features;
-
-        Ok(match self {
-            Feature::All => *map.get(self).unwrap_or(&Impl::Rust),
-            Feature::Env => *map
-                .get(self)
-                .or_else(|| map.get(&Self::All))
-                .unwrap_or(&Impl::Rust),
-            Feature::Nix => *map
-                .get(self)
-                .or_else(|| map.get(&Self::All))
-                .unwrap_or(&Impl::Rust),
-            Feature::Develop | Feature::Publish | Feature::Channels => *map
-                .get(self)
-                .or_else(|| map.get(&Self::All))
-                .unwrap_or(&Impl::Rust),
-        })
+impl Features {
+    pub fn parse() -> Result<Self> {
+        Ok(Config::parse()?.features)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Copy, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Impl {
-    Rust,
+#[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SearchStrategy {
+    #[default]
+    Match,
+    MatchName,
 }

--- a/crates/flox/src/config/mod.rs
+++ b/crates/flox/src/config/mod.rs
@@ -15,6 +15,8 @@ use toml_edit::{Document, Item, Key, Table, TableLike};
 use url::Url;
 use xdg::BaseDirectories;
 
+use self::features::Features;
+
 /// Name of flox managed directories (config, data, cache)
 const FLOX_DIR_NAME: &'_ str = "flox";
 const FLOX_SH_PATH: &'_ str = env!("FLOX_SH_PATH");
@@ -35,7 +37,7 @@ pub struct Config {
     pub github: GithubConfig,
 
     #[serde(default)]
-    pub features: HashMap<features::Feature, features::Impl>,
+    pub features: Features,
 }
 
 // TODO: move to flox_sdk?

--- a/tests/package-search.bats
+++ b/tests/package-search.bats
@@ -220,3 +220,14 @@ setup_file() {
   # There's a leading `ERROR: ` that's left off when run non-interactively
   assert_output "No packages matched this search term: surely_doesnt_exist";
 }
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox search' with 'FLOX_FEATURES_SEARCH_STRATEGY=match-name' shows fewer packages" {
+
+  MATCH="$(FLOX_FEATURES_SEARCH_STRATEGY=match "$FLOX_CLI" search node | wc -l)";
+  MATCH_NAME="$(FLOX_FEATURES_SEARCH_STRATEGY=match-name "$FLOX_CLI" search node | wc -l)";
+
+  assert [ "$MATCH_NAME" -lt "$MATCH" ];
+
+}


### PR DESCRIPTION
Allows to specify whether how to match packages in Search

set `FLOX_FEATURES_SEARCH_STRATEGY=match` to include matches in the package description (default)
set `FLOX_FEATURES_SEARCH_STRATEGY=match-name` to exclude matches in the package description

closes #384
