### PR TITLE
fix: warm up pkgdb to avoid timeout

### DIFF
--- a/pkgs/flox-tests/default.nix
+++ b/pkgs/flox-tests/default.nix
@@ -58,7 +58,7 @@ in
   writeShellScriptBin "flox-tests" ''
 
         export PATH="${lib.makeBinPath paths}"
-        export PKGDB_BIN="${flox.passthru.envs.PKGDB_BIN}"
+        export PKGDB_BIN="${flox.PKGDB_BIN}"
 
         usage() {
               cat << EOF

--- a/pkgs/flox-tests/default.nix
+++ b/pkgs/flox-tests/default.nix
@@ -8,6 +8,7 @@
   entr,
   expect,
   findutils,
+  flox,
   flox-bash,
   gawk,
   git,
@@ -57,6 +58,7 @@ in
   writeShellScriptBin "flox-tests" ''
 
         export PATH="${lib.makeBinPath paths}"
+        export PKGDB_BIN="${flox.passthru.envs.PKGDB_BIN}"
 
         usage() {
               cat << EOF

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -76,6 +76,18 @@ env_is_activated() {
 
 # ---------------------------------------------------------------------------- #
 
+# `pkgdb lock` with no packages installed fetches a nixpkgs. With a package
+# installed, it also has to evaluate the package set.
+@test "warm up pkgdb" {
+  run $FLOX_CLI install -d "$PROJECT_DIR" hello;
+  assert_success;
+  assert_output --partial "✅ 'hello' installed to environment";
+  "$PKGDB_BIN" lock "$PROJECT_DIR/.flox/env/manifest.toml" > "$PROJECT_DIR/.flox/env/manifest.lock";
+  # TODO might want to also warm up env-from-lockfile once url is added to the lockfile
+  # "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
+}
+
+# ---------------------------------------------------------------------------- #
 @test "activate modifies prompt and puts package in path" {
   run $FLOX_CLI install -d "$PROJECT_DIR" hello;
   assert_success

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -82,7 +82,7 @@ env_is_activated() {
   run $FLOX_CLI install -d "$PROJECT_DIR" hello;
   assert_success;
   assert_output --partial "✅ 'hello' installed to environment";
-  "$PKGDB_BIN" lock "$PROJECT_DIR/.flox/env/manifest.toml"
+  NIX_CONFIG="extra-experimental-features = flakes" "$PKGDB_BIN" lock "$PROJECT_DIR/.flox/env/manifest.toml"
   # TODO might want to also warm up env-from-lockfile once url is added to the lockfile
   # "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
 }

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -82,7 +82,7 @@ env_is_activated() {
   run $FLOX_CLI install -d "$PROJECT_DIR" hello;
   assert_success;
   assert_output --partial "✅ 'hello' installed to environment";
-  "$PKGDB_BIN" lock "$PROJECT_DIR/.flox/env/manifest.toml" > "$PROJECT_DIR/.flox/env/manifest.lock";
+  "$PKGDB_BIN" lock "$PROJECT_DIR/.flox/env/manifest.toml"
   # TODO might want to also warm up env-from-lockfile once url is added to the lockfile
   # "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
 }


### PR DESCRIPTION
pkgdb must download and evaulate nixpkgs, which is time intensive. At times this causes expect to time out.

Instead of bumping the timeout, factor out operations that we never want to timeout outside of the expect test. Since expect must have a timeout, the timeout will be easier to set accurately if we move actions that should never timeout outside of expect. This may also make caching easier in the future.

## Release Notes

No user facing changes