### PR TITLE
fix: improve pkgdb error handling

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -382,6 +382,7 @@ pub fn lock_manifest(
         pkgdb_cmd.arg(canonical_lockfile_path);
     }
     let output = pkgdb_cmd.output().map_err(EnvironmentError2::PkgDbCall)?;
+    // If command fails, try to parse stdout as a PkgDbError
     if !output.status.success() {
         if let Ok::<PkgDbError, _>(pkgdb_err) = serde_json::from_slice(&output.stdout) {
             Err(EnvironmentError2::LockManifest(pkgdb_err))
@@ -390,6 +391,7 @@ pub fn lock_manifest(
                 String::from_utf8_lossy(&output.stdout).to_string(),
             ))
         }
+    // If command succeeds, try to parse stdout as JSON value
     } else {
         let lockfile_json: Value =
             serde_json::from_slice(&output.stdout).map_err(EnvironmentError2::ParseLockfileJSON)?;

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -287,12 +287,14 @@ pub enum EnvironmentError2 {
     BadLockfilePath(std::io::Error),
     #[error("call to pkgdb failed: {0}")]
     PkgDbCall(std::io::Error),
+    #[error("couldn't parse pkgdb error as JSON: {0}")]
+    ParsePkgDbError(String),
     #[error("couldn't parse lockfile as JSON: {0}")]
     ParseLockfileJSON(serde_json::Error),
     #[error("couldn't write new lockfile contents: {0}")]
     WriteLockfile(std::io::Error),
-    #[error("registry resolution failed: {0}")]
-    FailedResolution(PkgDbError),
+    #[error("locking manifest failed: {0}")]
+    LockManifest(PkgDbError),
 }
 
 /// A struct representing error messages coming from pkgdb
@@ -304,18 +306,21 @@ pub struct PkgDbError {
     /// The generic message for this category of error.
     pub category_message: String,
     /// The more contextual message for the specific error that occurred.
-    pub context_message: String,
+    pub context_message: Option<String>,
     /// The underlying error message if an exception was caught.
-    pub caught_message: String,
+    pub caught_message: Option<String>,
 }
 
 impl Display for PkgDbError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}: {}: {}",
-            self.category_message, self.context_message, self.caught_message
-        )
+        write!(f, "{}", self.category_message)?;
+        if let Some(context_message) = &self.context_message {
+            write!(f, ": {}", context_message)?;
+        }
+        if let Some(caught_message) = &self.caught_message {
+            write!(f, ": {}", caught_message)?;
+        }
+        Ok(())
     }
 }
 
@@ -377,9 +382,19 @@ pub fn lock_manifest(
         pkgdb_cmd.arg(canonical_lockfile_path);
     }
     let output = pkgdb_cmd.output().map_err(EnvironmentError2::PkgDbCall)?;
-    let lockfile_json: Value =
-        serde_json::from_slice(&output.stdout).map_err(EnvironmentError2::ParseLockfileJSON)?;
-    Ok(lockfile_json)
+    if !output.status.success() {
+        if let Ok::<PkgDbError, _>(pkgdb_err) = serde_json::from_slice(&output.stdout) {
+            Err(EnvironmentError2::LockManifest(pkgdb_err))
+        } else {
+            Err(EnvironmentError2::ParsePkgDbError(
+                String::from_utf8_lossy(&output.stdout).to_string(),
+            ))
+        }
+    } else {
+        let lockfile_json: Value =
+            serde_json::from_slice(&output.stdout).map_err(EnvironmentError2::ParseLockfileJSON)?;
+        Ok(lockfile_json)
+    }
 }
 
 #[cfg(test)]

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -314,10 +314,10 @@ pub struct PkgDbError {
 impl Display for PkgDbError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.category_message)?;
-        if let Some(context_message) = &self.context_message {
+        if let Some(ref context_message) = self.context_message {
             write!(f, ": {}", context_message)?;
         }
-        if let Some(caught_message) = &self.caught_message {
+        if let Some(ref caught_message) = self.caught_message {
             write!(f, ": {}", caught_message)?;
         }
         Ok(())

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -205,9 +205,6 @@ where
             &manifest_path,
             maybe_lockfile,
         )?;
-        if let Ok::<PkgDbError, _>(pkgdb_err) = serde_json::from_value(lockfile_json.clone()) {
-            return Err(EnvironmentError2::FailedResolution(pkgdb_err));
-        }
         // TODO: pkgdb needs to add a `url` field, until that's done we do it manually
         let nixpkgs_url = Value::String(
             "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1".to_string(),

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -38,7 +38,6 @@ use crate::environment::NIX_BIN;
 use crate::flox::Flox;
 use crate::models::environment::{
     lock_manifest,
-    PkgDbError,
     BUILD_ENV_BIN,
     CATALOG_JSON,
     ENV_FROM_LOCKFILE_PATH,


### PR DESCRIPTION
- Check pkgdb exit code. Currently pkgdb exit status is ignored, and we only detect errors if deserialization of an error succeeds. Although pkgdb makes a best effort to output valid error JSON, this is not always guaranteed, so exit code should be checked.
- Make context_message and caught_message optional, as they are optional in pkgdb
- Rename FailedResolution to LockManifest since users are more likely to understand what locking a manifest means as opposed to resolving a registry

## Release Notes

No user facing changes