### PR TITLE
chore: bump 'pkgdb' flake input and fix breakage

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -292,6 +292,8 @@ pub enum EnvironmentError2 {
     ParsePkgDbError(String),
     #[error("couldn't parse lockfile as JSON: {0}")]
     ParseLockfileJSON(serde_json::Error),
+    #[error("couldn't parse nixpkgs rev as a string")]
+    RevNotString,
     #[error("couldn't write new lockfile contents: {0}")]
     WriteLockfile(std::io::Error),
     #[error("locking manifest failed: {0}")]
@@ -371,11 +373,13 @@ pub fn lock_manifest(
     manifest_path: &Path,
     existing_lockfile_path: Option<&Path>,
 ) -> Result<serde_json::Value, EnvironmentError2> {
-    let canoncial_manifest_path = manifest_path
+    let canonical_manifest_path = manifest_path
         .canonicalize()
         .map_err(EnvironmentError2::OpenManifest)?;
     let mut pkgdb_cmd = Command::new(pkgdb);
-    pkgdb_cmd.arg("lock").arg(canoncial_manifest_path);
+    pkgdb_cmd
+        .args(["manifest", "lock"])
+        .arg(canonical_manifest_path);
     if let Some(lf_path) = existing_lockfile_path {
         let canonical_lockfile_path = lf_path
             .canonicalize()

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -205,15 +205,11 @@ where
             maybe_lockfile,
         )?;
         // TODO: pkgdb needs to add a `url` field, until that's done we do it manually
-        let nixpkgs_url = Value::String(
-            "github:NixOS/nixpkgs/e8039594435c68eb4f780f3e9bf3972a7399c4b1".to_string(),
-        );
+        let rev = lockfile_json["registry"]["inputs"]["nixpkgs"]["from"]["rev"]
+            .as_str()
+            .ok_or(EnvironmentError2::RevNotString)?;
+        let nixpkgs_url = Value::String(format!("github:NixOS/nixpkgs/{rev}"));
         lockfile_json["registry"]["inputs"]["nixpkgs"]["url"] = nixpkgs_url.clone();
-        if let Value::Object(ref mut packages) = lockfile_json["packages"] {
-            for (_p_name, p_value) in packages.iter_mut() {
-                p_value[system]["url"] = nixpkgs_url.clone();
-            }
-        }
         debug!("generated lockfile, writing to {}", lockfile_path.display());
         std::fs::write(&lockfile_path, lockfile_json.to_string())
             .map_err(EnvironmentError2::WriteLockfile)?;

--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1699034731,
-        "narHash": "sha256-jLfjd5rnAJWbwMWXQg0BiPsmvXDcEsrcEQE9cHeK2tA=",
+        "lastModified": 1699460437,
+        "narHash": "sha256-0LNsjGOkulD3VD3P/TerV4ocrZhU/E5RDalSbOBcbM8=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "aec2f6ece0e5ed6c8f7e9e7e5b798a051d3e3db0",
+        "rev": "27f19d0d51a78527497f3210dcc417c04605d636",
         "type": "github"
       },
       "original": {

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -33,6 +33,9 @@ project_setup() {
   mkdir -p "$PROJECT_DIR";
   pushd "$PROJECT_DIR" >/dev/null||return;
   $FLOX_CLI init -d "$PROJECT_DIR";
+  sed -i \
+    's/from = { type = "github", owner = "NixOS", repo = "nixpkgs" }/from = { type = "github", owner = "NixOS", repo = "nixpkgs", rev = "e8039594435c68eb4f780f3e9bf3972a7399c4b1" }/' \
+    "$PROJECT_DIR/.flox/env/manifest.toml";
 }
 
 project_teardown() {
@@ -82,7 +85,7 @@ env_is_activated() {
   run $FLOX_CLI install -d "$PROJECT_DIR" hello;
   assert_success;
   assert_output --partial "✅ 'hello' installed to environment";
-  NIX_CONFIG="extra-experimental-features = flakes" "$PKGDB_BIN" lock "$PROJECT_DIR/.flox/env/manifest.toml"
+  NIX_CONFIG="extra-experimental-features = flakes" "$PKGDB_BIN" manifest lock "$PROJECT_DIR/.flox/env/manifest.toml"
   # TODO might want to also warm up env-from-lockfile once url is added to the lockfile
   # "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
 }


### PR DESCRIPTION
- `pkgdb lock` was moved to `pkgdb manifest lock`
- url is now added at {package}.input.url, so don't add it in Rust, and use that field in env-from-lockfile.nix
- Use registry.inputs.nixpkgs.from.rev instead of inserting a hardcoded rev for nixpkgs in Rust
- Hardcode a rev for nixpkgs in tests
- Key nesting was changed from {package}.{system} to {system}.{package}
- package.path was moved to package.attr-path

Flake lock file updates:

• Updated input 'pkgdb':
    'github:flox/pkgdb/aec2f6ece0e5ed6c8f7e9e7e5b798a051d3e3db0' (2023-11-03)
  → 'github:flox/pkgdb/27f19d0d51a78527497f3210dcc417c04605d636' (2023-11-08)


## Release Notes

No user facing changes


<!-- Many thanks! -->
