### PR TITLE
fix: non-root follows

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,21 +7,21 @@
   # Do not override `nixpkgs` input
   inputs.pkgdb.url = "github:flox/pkgdb";
 
-  inputs.nixpkgs.follows = "/pkgdb/nixpkgs";
+  inputs.nixpkgs.follows = "pkgdb/nixpkgs";
 
-  inputs.floco.follows = "/pkgdb/floco";
-  inputs.floco.inputs.nixpkgs.follows = "/nixpkgs";
+  inputs.floco.follows = "pkgdb/floco";
+  inputs.floco.inputs.nixpkgs.follows = "nixpkgs";
 
   inputs.parser-util.url = "github:flox/parser-util/v0";
-  inputs.parser-util.inputs.nixpkgs.follows = "/nixpkgs";
+  inputs.parser-util.inputs.nixpkgs.follows = "nixpkgs";
 
   inputs.shellHooks.url = "github:cachix/pre-commit-hooks.nix";
-  inputs.shellHooks.inputs.nixpkgs.follows = "/nixpkgs";
+  inputs.shellHooks.inputs.nixpkgs.follows = "nixpkgs";
 
   inputs.crane.url = "github:ipetkov/crane";
-  inputs.crane.inputs.nixpkgs.follows = "/nixpkgs";
-  inputs.crane.inputs.flake-compat.follows = "/shellHooks/flake-compat";
-  inputs.crane.inputs.flake-utils.follows = "/shellHooks/flake-utils";
+  inputs.crane.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.crane.inputs.flake-compat.follows = "shellHooks/flake-compat";
+  inputs.crane.inputs.flake-utils.follows = "shellHooks/flake-utils";
 
   # -------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Proposed Changes

Rooted follows (with the "/") prefix, seems to disable the ability to override a full input tree, ie: the rest of the tree remains as the original, this is very likely not the intended behavior.

```
$ nix eval git+ssh://git@github.com/flox/flox?ref=latest#flox --json
"/nix/store/a149wgp7j6nnipga3km57r7pjc83wpn0-flox-0.3.6-r692"

$ nix eval git+ssh://git@github.com/flox/flox-passthru#flox --json
"/nix/store/a149wgp7j6nnipga3km57r7pjc83wpn0-flox-0.3.6-r692"
```

so far so good, hashes match

```
$ nix eval git+ssh://git@github.com/flox/flox?rev=3863f43de63a622ec01e3d9eab9bcd078d58880f#flox --json
"/nix/store/vpx3jks05c5s1nvhd6whxymca2qck9y6-flox-0.3.7-r732"

$ nix eval git+ssh://git@github.com/flox/flox-passthru#flox --override-input f 'git+ssh://git@github.com/flox/flox?rev=3863f43de63a622ec01e3d9eab9bcd078d58880f' --json
• Updated input 'f':
    'git+ssh://git@github.com/flox/flox?ref=latest&rev=2f44b10256364e57291b0bbaa2be4d26573f7a90' (2023-10-26)
  → 'git+ssh://git@github.com/flox/flox?rev=3863f43de63a622ec01e3d9eab9bcd078d58880f' (2023-11-07)
"/nix/store/zsqnjdbrjl1nx9vmav4vv1904vz1m4iv-flox-0.3.7-r732"
```
WAT?!
That is odd, now using a variant that doesn't have "/" follows prefixes

```
$ nix eval git+ssh://git@github.com/flox/flox?ref=tomberek.test-diff#flox --json
"/nix/store/2r9xnl21v8hbchc6swgl6g7h3awhjdb2-flox-0.3.7-r734"

$ nix eval git+ssh://git@github.com/flox/flox-passthru?ref=tomberek.test-diff#flox --json
"/nix/store/2r9xnl21v8hbchc6swgl6g7h3awhjdb2-flox-0.3.7-r734"

$ nix eval git+ssh://git@github.com/flox/flox-passthru?ref=tomberek.test-diff#flox --override-input f 'git+ssh://git@github.com/flox/flox?rev=3863f43de63a622ec01e3d9eab9bcd078d58880f' --json
• Updated input 'f':
    'git+ssh://git@github.com/flox/flox?ref=tomberek.test-diff&rev=a56ad1c40f7483d931f3d2394f4dcbe98cdced97' (2023-11-08)
  → 'git+ssh://git@github.com/flox/flox?rev=3863f43de63a622ec01e3d9eab9bcd078d58880f' (2023-11-07)
"/nix/store/vpx3jks05c5s1nvhd6whxymca2qck9y6-flox-0.3.7-r732"
```
this now matches the expected output path
## Release Notes

N/A
