### PR TITLE
fix: github username api request

### DIFF
--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -639,11 +639,12 @@ impl Push {
                     owner
                 } else {
                     let client = GitHubClient::new(
-                        "github.com".to_string(),
+                        "https://api.github.com".to_string(),
                         flox.floxhub_token.clone().context("Need to be logged in")?,
                     );
                     let user_name = client
                         .get_username()
+                        .await
                         .context("Could not get username from github")?;
                     user_name
                         .parse::<EnvironmentOwner>()


### PR DESCRIPTION
* make get username async again as blocking as we are still in a tokio runtime
* use bearer authentication on gh api since we don't have a jwt
* set `user-agent: flox cli` as github will resopond with `403 FORBIDDEN` without it
* use `https://api.github.com` as base url

closes #423 
