### PR TITLE
feat: read registry from manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.84"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -355,7 +355,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
@@ -642,9 +642,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
+checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
  "windows-sys",
@@ -707,7 +707,8 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "toml_edit",
+ "toml 0.8.8",
+ "toml_edit 0.19.15",
  "tracing",
  "tracing-log 0.1.4",
  "tracing-subscriber",
@@ -751,7 +752,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
- "toml_edit",
+ "toml_edit 0.19.15",
  "tracing",
  "url",
  "uuid",
@@ -968,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -978,7 +979,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2002,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.23"
+version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb93593068e9babdad10e4fce47dc9b3ac25315a72a59766ffd9e9a71996a04"
+checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -2592,6 +2593,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.21.0",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2618,19 @@ name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.1.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -119,7 +119,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -202,29 +202,29 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc3b1bd654a8d16eea03586c3eee8ffd25c7f242b9eae9730cc442834fe56d9"
+checksum = "565688a36ddfcfc189cc927c94a6b69cc96c9f8a69030151ae8f0ed2b54a2ad3"
 dependencies = [
  "bpaf_derive",
 ]
 
 [[package]]
 name = "bpaf_derive"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cbaba260bbcbb69b0d54e9f0d83038a4568f3a5d1c95591fed5e8fee964539"
+checksum = "7b9b7235706863579f117a6d782a949da90ed0d49bbf633075cad4061d743ff9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
  "serde",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
 dependencies = [
  "libc",
 ]
@@ -501,7 +501,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -512,7 +512,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -589,9 +589,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "either"
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -642,9 +642,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -709,7 +709,7 @@ dependencies = [
  "tokio",
  "toml_edit",
  "tracing",
- "tracing-log",
+ "tracing-log 0.1.4",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -726,7 +726,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "dotenv",
- "env_logger 0.10.0",
+ "env_logger 0.10.1",
  "flox-types",
  "fs_extra",
  "futures",
@@ -879,7 +879,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -924,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1035,9 +1035,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -1255,9 +1255,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1281,9 +1281,20 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1293,9 +1304,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -1525,9 +1536,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if 1.0.0",
@@ -1546,7 +1557,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1557,9 +1568,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
 dependencies = [
  "cc",
  "libc",
@@ -1613,7 +1624,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets",
 ]
@@ -1661,7 +1672,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1765,24 +1776,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -1792,12 +1785,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
@@ -1944,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "runix"
 version = "0.2.0"
-source = "git+https://github.com/flox/runix#2d0a69340662460f253267ef5398b38a7bce4b4f"
+source = "git+https://github.com/flox/runix#b7ee2d5adae241077331de0637fa783addc470c8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2009,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "ffb93593068e9babdad10e4fce47dc9b3ac25315a72a59766ffd9e9a71996a04"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -2087,29 +2080,29 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -2171,7 +2164,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2180,7 +2173,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -2260,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "smol_str"
@@ -2347,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2398,22 +2391,22 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
  "windows-sys",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
@@ -2453,7 +2446,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2512,9 +2505,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2531,13 +2524,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2613,7 +2606,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2645,7 +2638,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2681,10 +2674,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.17"
+name = "tracing-log"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2695,7 +2699,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -2828,9 +2832,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2838,24 +2842,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2865,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2875,28 +2879,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3010,9 +3014,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.17"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]

--- a/assets/global_manifest_template.toml
+++ b/assets/global_manifest_template.toml
@@ -15,4 +15,4 @@ broken = false
 [options.semver]
 # Whether unstable/pre-release versions of software should be
 # preferred over the latest stable release in search/install results.
-prefer-pre-release = false
+prefer-pre-releases = false

--- a/assets/global_manifest_template.toml
+++ b/assets/global_manifest_template.toml
@@ -1,0 +1,18 @@
+[options.allow]
+# Whether non-FOSS packages should appear in search/install results.
+unfree = true
+
+# Whether "broken" packages should appear in search/install results.
+# These are packages with known build/runtime issues.
+broken = false
+
+# Limit search/install results to only packages which
+# certain SPDX Identifiers by listing them below.
+# Leaving `licenses' undefined allows any license to be used.
+# See all valid license ids here: https://spdx.org/licenses/
+## licenses = ["LGPL2-or-later"]
+
+[options.semver]
+# Whether unstable/pre-release versions of software should be
+# preferred over the latest stable release in search/install results.
+prefer-pre-release = false

--- a/assets/templateFloxEnv/manifest.toml
+++ b/assets/templateFloxEnv/manifest.toml
@@ -1,17 +1,13 @@
-# Install packages
-[install]
-# hello = {}
+# List packages you wish to install in your environment under
+# the `[install]` table
+## [install] 
+## hello = {}
+## nodejs = { version = "^16.4.2" } 
 
-[registry.inputs.nixpkgs]
-from = { type = "github", owner = "NixOS", repo = "nixpkgs" }
-subtrees = ["legacyPackages"]
-
-# Environment variables
-[vars]
-MY_VAR = "MY_VALUE"
-
-# Add a hook that's run when entering the environment
-# [hook]
-# script = """
-#     hello >&2
-# """
+# Set your activation hook ( run when entering the environment )
+# You can write this inline with the `script` field, or provide a
+# relative path to a file using the `file` field.
+[hook]
+script = """
+  echo "Welcome to your flox environment!";
+"""

--- a/assets/templateFloxEnv/manifest.toml
+++ b/assets/templateFloxEnv/manifest.toml
@@ -1,8 +1,8 @@
 # List packages you wish to install in your environment under
 # the `[install]` table
-## [install] 
-## hello = {}
-## nodejs = { version = "^16.4.2" } 
+# [install] 
+# hello = {}
+# nodejs = { version = "^16.4.2" } 
 
 # Set your activation hook ( run when entering the environment )
 # You can write this inline with the `script` field, or provide a
@@ -11,6 +11,3 @@
 script = """
   echo "Welcome to your flox environment!";
 """
-
-[registry.inputs.nixpkgs]
-from = { type = "github", owner = "NixOS", repo = "nixpkgs", ref = "release-23.05" }

--- a/assets/templateFloxEnv/manifest.toml
+++ b/assets/templateFloxEnv/manifest.toml
@@ -11,3 +11,6 @@
 script = """
   echo "Welcome to your flox environment!";
 """
+
+[registry.inputs.nixpkgs]
+from = { type = "github", owner = "NixOS", repo = "nixpkgs", ref = "release-23.05" }

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -39,6 +39,7 @@ pub const DEFAULT_MAX_AGE_DAYS: u32 = 90;
 // Path to the executable that builds environments
 const BUILD_ENV_BIN: &'_ str = env!("BUILD_ENV_BIN");
 const ENV_FROM_LOCKFILE_PATH: &str = env!("ENV_FROM_LOCKFILE_PATH");
+const GLOBAL_MANIFEST_TEMPLATE: &str = env!("GLOBAL_MANIFEST_TEMPLATE");
 
 pub enum InstalledPackage {
     Catalog(FloxTriple, CatalogEntry),
@@ -298,6 +299,10 @@ pub enum EnvironmentError2 {
     WriteLockfile(std::io::Error),
     #[error("locking manifest failed: {0}")]
     LockManifest(PkgDbError),
+    #[error("couldn't create the global manifest: {0}")]
+    InitGlobalManifest(std::io::Error),
+    #[error("couldn't read global manifest template: {0}")]
+    ReadGlobalManifestTemplate(std::io::Error),
 }
 
 /// A struct representing error messages coming from pkgdb
@@ -403,6 +408,18 @@ pub fn lock_manifest(
             serde_json::from_slice(&output.stdout).map_err(EnvironmentError2::ParseLockfileJSON)?;
         Ok(lockfile_json)
     }
+}
+
+/// Initialize the global manifest if it doesn't exist already
+pub fn init_global_manifest(global_manifest_path: &Path) -> Result<(), EnvironmentError2> {
+    if !global_manifest_path.exists() {
+        let global_manifest_template_contents =
+            std::fs::read_to_string(&Path::new(GLOBAL_MANIFEST_TEMPLATE))
+                .map_err(EnvironmentError2::ReadGlobalManifestTemplate)?;
+        std::fs::write(global_manifest_path, global_manifest_template_contents)
+            .map_err(EnvironmentError2::InitGlobalManifest)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -40,6 +40,7 @@ pub const DEFAULT_MAX_AGE_DAYS: u32 = 90;
 const BUILD_ENV_BIN: &'_ str = env!("BUILD_ENV_BIN");
 const ENV_FROM_LOCKFILE_PATH: &str = env!("ENV_FROM_LOCKFILE_PATH");
 const GLOBAL_MANIFEST_TEMPLATE: &str = env!("GLOBAL_MANIFEST_TEMPLATE");
+const GLOBAL_MANIFEST_FILENAME: &str = "global-manifest.toml";
 
 pub enum InstalledPackage {
     Catalog(FloxTriple, CatalogEntry),
@@ -414,12 +415,19 @@ pub fn lock_manifest(
 pub fn init_global_manifest(global_manifest_path: &Path) -> Result<(), EnvironmentError2> {
     if !global_manifest_path.exists() {
         let global_manifest_template_contents =
-            std::fs::read_to_string(&Path::new(GLOBAL_MANIFEST_TEMPLATE))
+            std::fs::read_to_string(Path::new(GLOBAL_MANIFEST_TEMPLATE))
                 .map_err(EnvironmentError2::ReadGlobalManifestTemplate)?;
         std::fs::write(global_manifest_path, global_manifest_template_contents)
             .map_err(EnvironmentError2::InitGlobalManifest)?;
     }
     Ok(())
+}
+
+/// Returns the path to the global manifest
+pub fn global_manifest_path(flox: &Flox) -> PathBuf {
+    let path = flox.config_dir.join(GLOBAL_MANIFEST_FILENAME);
+    debug!("global manifest path is {}", path.display());
+    path
 }
 
 #[cfg(test)]

--- a/crates/flox-rust-sdk/src/models/search.rs
+++ b/crates/flox-rust-sdk/src/models/search.rs
@@ -334,8 +334,6 @@ pub struct SearchResult {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
-
     use super::*;
 
     const EXAMPLE_SEARCH_TERM: &'_ str = "hello@2.12.1";

--- a/crates/flox/Cargo.toml
+++ b/crates/flox/Cargo.toml
@@ -49,6 +49,7 @@ indexmap.workspace = true
 url.workspace = true
 openssl.workspace = true
 chrono.workspace = true
+toml = "0.8.8"
 
 [dev-dependencies]
 temp-env = "0.3.2"

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -15,7 +15,6 @@ use flox_rust_sdk::models::environment::managed_environment::{
 };
 use flox_rust_sdk::models::environment::path_environment::{self, Original, PathEnvironment};
 use flox_rust_sdk::models::environment::{
-    global_manifest_path,
     Environment,
     EnvironmentError2,
     EnvironmentPointer,
@@ -301,16 +300,10 @@ impl Init {
                 .parse()?
         };
 
-        let global_manifest_path = global_manifest_path(&flox);
-        debug!(
-            "global manifest path exists: {}",
-            global_manifest_path.exists()
-        );
         let env = PathEnvironment::<Original>::init(
             PathPointer::new(env_name),
             &dir,
             flox.temp_dir.clone(),
-            global_manifest_path,
         )?;
 
         println!(

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -16,6 +16,7 @@ use flox_rust_sdk::models::environment::managed_environment::{
 use flox_rust_sdk::models::environment::path_environment::{self, Original, PathEnvironment};
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
 use flox_rust_sdk::models::environment::{
+    global_manifest_path,
     Environment,
     EnvironmentError2,
     EnvironmentPointer,
@@ -372,8 +373,17 @@ impl Init {
                 .parse()?
         };
 
-        let env =
-            PathEnvironment::<Original>::init(PathPointer::new(name), &dir, flox.temp_dir.clone())?;
+        let global_manifest_path = global_manifest_path(&flox);
+        debug!(
+            "global manifest path exists: {}",
+            global_manifest_path.exists()
+        );
+        let env = PathEnvironment::<Original>::init(
+            PathPointer::new(name),
+            &dir,
+            flox.temp_dir.clone(),
+            global_manifest_path,
+        )?;
 
         println!(
             indoc::indoc! {"

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -14,7 +14,6 @@ use flox_rust_sdk::models::environment::managed_environment::{
     ManagedEnvironmentError,
 };
 use flox_rust_sdk::models::environment::path_environment::{self, Original, PathEnvironment};
-use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
 use flox_rust_sdk::models::environment::{
     global_manifest_path,
     Environment,
@@ -25,7 +24,6 @@ use flox_rust_sdk::models::environment::{
     DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
 };
-use flox_rust_sdk::models::environment_ref;
 use flox_rust_sdk::models::floxmetav2::FloxmetaV2Error;
 use flox_rust_sdk::models::manifest::list_packages;
 use flox_rust_sdk::nix::command::StoreGc;
@@ -35,6 +33,8 @@ use indoc::indoc;
 use log::{debug, error, info};
 use tempfile::NamedTempFile;
 
+use super::{environment_select, EnvironmentSelect};
+use crate::commands::ConcreteEnvironment;
 use crate::subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
 
@@ -42,78 +42,6 @@ use crate::utils::dialog::{Confirm, Dialog};
 pub struct EnvironmentArgs {
     #[bpaf(short, long, argument("SYSTEM"))]
     pub system: Option<String>,
-}
-
-#[derive(Debug, Bpaf, Clone)]
-pub enum EnvironmentSelect {
-    Dir(
-        /// Path containing a .flox/ directory
-        #[bpaf(long("dir"), short('d'), argument("path"))]
-        PathBuf,
-    ),
-    Remote(
-        /// A remote environment on floxhub
-        #[bpaf(long("remote"), short('r'), argument("owner/name"))]
-        environment_ref::EnvironmentRef,
-    ),
-}
-
-impl Default for EnvironmentSelect {
-    fn default() -> Self {
-        EnvironmentSelect::Dir(PathBuf::from("./"))
-    }
-}
-
-impl EnvironmentSelect {
-    fn to_concrete_environment(&self, flox: &Flox) -> Result<ConcreteEnvironment> {
-        let env = match self {
-            EnvironmentSelect::Dir(path) => {
-                let pointer = EnvironmentPointer::open(path)
-                    .with_context(|| format!("No environment found in {path:?}"))?;
-
-                match pointer {
-                    EnvironmentPointer::Path(path_pointer) => {
-                        debug!("detected concrete environment type: path");
-                        let dot_flox_path = path.join(DOT_FLOX);
-                        ConcreteEnvironment::Path(PathEnvironment::open(
-                            path_pointer,
-                            dot_flox_path,
-                            &flox.temp_dir,
-                        )?)
-                    },
-                    EnvironmentPointer::Managed(managed_pointer) => {
-                        debug!("detected concrete environment type: managed");
-                        let env = ManagedEnvironment::open(flox, managed_pointer, path)?;
-                        ConcreteEnvironment::Managed(env)
-                    },
-                }
-            },
-            EnvironmentSelect::Remote(_) => todo!(),
-        };
-
-        Ok(env)
-    }
-}
-
-enum ConcreteEnvironment {
-    /// Container for [PathEnvironment]
-    Path(PathEnvironment<Original>),
-    /// Container for [ManagedEnvironment]
-    #[allow(unused)] // pending implementation of ManagedEnvironment
-    Managed(ManagedEnvironment),
-    /// Container for [RemoteEnvironment]
-    #[allow(unused)] // pending implementation of RemoteEnvironment
-    Remote(RemoteEnvironment),
-}
-
-impl ConcreteEnvironment {
-    fn into_dyn_environment(self) -> Box<dyn Environment> {
-        match self {
-            ConcreteEnvironment::Path(path_env) => Box::new(path_env),
-            ConcreteEnvironment::Managed(managed_env) => Box::new(managed_env),
-            ConcreteEnvironment::Remote(remote_env) => Box::new(remote_env),
-        }
-    }
 }
 
 /// Edit declarative environment configuration
@@ -351,7 +279,7 @@ pub struct Init {
     ///
     /// "$(basename $PWD)" or "default" if in $HOME
     #[bpaf(long, short, argument("name"))]
-    name: Option<EnvironmentName>,
+    env_name: Option<EnvironmentName>,
 }
 
 impl Init {
@@ -362,7 +290,7 @@ impl Init {
 
         let home_dir = dirs::home_dir().unwrap();
 
-        let name = if let Some(name) = self.name {
+        let env_name = if let Some(name) = self.env_name {
             name
         } else if dir == home_dir {
             "default".parse()?
@@ -379,7 +307,7 @@ impl Init {
             global_manifest_path.exists()
         );
         let env = PathEnvironment::<Original>::init(
-            PathPointer::new(name),
+            PathPointer::new(env_name),
             &dir,
             flox.temp_dir.clone(),
             global_manifest_path,

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -278,7 +278,7 @@ pub struct Init {
     /// Name of the environment
     ///
     /// "$(basename $PWD)" or "default" if in $HOME
-    #[bpaf(long, short, argument("name"))]
+    #[bpaf(long("name"), short('n'), argument("name"))]
     env_name: Option<EnvironmentName>,
 }
 

--- a/crates/flox/src/commands/search.rs
+++ b/crates/flox/src/commands/search.rs
@@ -293,10 +293,6 @@ pub struct Show {
 impl Show {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("show");
-        let env = match EnvironmentSelect::default().to_concrete_environment(&flox)? {
-            ConcreteEnvironment::Path(path_env) => path_env,
-            _ => bail!("search is only available for path environments"),
-        };
         let (manifest, lockfile) =
             match EnvironmentSelect::default().to_concrete_environment(&flox)? {
                 ConcreteEnvironment::Path(path_env) => {

--- a/crates/flox/src/main.rs
+++ b/crates/flox/src/main.rs
@@ -5,6 +5,7 @@ use std::process::ExitCode;
 use anyhow::{anyhow, Context, Result};
 use bpaf::{Args, Parser};
 use commands::{FloxArgs, Prefix, Version};
+use flox_rust_sdk::models::environment::init_global_manifest;
 use log::{error, warn};
 use utils::init::init_logger;
 
@@ -17,7 +18,9 @@ async fn run(args: FloxArgs) -> Result<()> {
     init_logger(Some(args.verbosity.clone()), Some(args.debug));
     set_user()?;
     set_parent_process_id();
-    args.handle(config::Config::parse()?).await?;
+    let config = config::Config::parse()?;
+    init_global_manifest(&config.flox.config_dir.join("global-manifest.toml"))?;
+    args.handle(config).await?;
     Ok(())
 }
 

--- a/crates/flox/src/utils/mod.rs
+++ b/crates/flox/src/utils/mod.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::io::Stderr;
 use std::sync::Mutex;
 
+use anyhow::Context;
 use once_cell::sync::Lazy;
 
 pub mod colors;
@@ -21,5 +22,45 @@ fn nix_str_safe(s: &str) -> Cow<str> {
         s.into()
     } else {
         format!("{s:?}").into()
+    }
+}
+
+pub fn toml_to_json(toml_contents: &str) -> Result<serde_json::Value, anyhow::Error> {
+    // This type annotation is needed otherwise it will try to convert it to ()
+    let toml: toml::Value = toml::from_str(toml_contents).context("manifest was not valid TOML")?;
+    let json = serde_json::to_value(toml).context("couldn't convert manifest to JSON")?;
+    Ok(json)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const TOML_CONTENTS: &str = r#"
+    [my_table]
+    foo = { bar = "baz" }
+
+    [some_table]
+    key = "value"
+    "#;
+
+    const JSON_CONTENTS: &str = r#"
+    {
+        "my_table": {
+            "foo": {
+                "bar": "baz"
+            }
+        },
+        "some_table": {
+            "key": "value"
+        }
+    }
+    "#;
+
+    #[test]
+    fn converts_toml_to_json() {
+        let json = toml_to_json(TOML_CONTENTS).unwrap();
+        let expected_json: serde_json::Value = serde_json::from_str(JSON_CONTENTS).unwrap();
+        assert_eq!(json, expected_json);
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1700078850,
-        "narHash": "sha256-IfPTsSAfeueLzhZNdC3mVRS0BI51VzI3XsWDn1XwBTU=",
+        "lastModified": 1700139082,
+        "narHash": "sha256-nnZrzn4rsag+wqON8INal0TjLnd6bWMc6PaMhA/kC+w=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "e0d585adbe69216f50ab1d0611d9a9c127ebbd5e",
+        "rev": "cc4ad767c10db4b98eafcf0a26103efe9a791fd4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1700006802,
-        "narHash": "sha256-nvN91C4HM/YStSZZQyHI9h/DkOm4Nefy7I7hbuW74Gk=",
+        "lastModified": 1700078850,
+        "narHash": "sha256-IfPTsSAfeueLzhZNdC3mVRS0BI51VzI3XsWDn1XwBTU=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "91b0901717c15919777d30e48bc0f0f2861e0193",
+        "rev": "e0d585adbe69216f50ab1d0611d9a9c127ebbd5e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1699904977,
-        "narHash": "sha256-Aw9HRvSxMlleAa7eODTht3VWLlETMo8xzEOCg2167Og=",
+        "lastModified": 1700006802,
+        "narHash": "sha256-nvN91C4HM/YStSZZQyHI9h/DkOm4Nefy7I7hbuW74Gk=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "9bbf075a043d153f06baa0c84aa7fd52999987b0",
+        "rev": "91b0901717c15919777d30e48bc0f0f2861e0193",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1700139082,
-        "narHash": "sha256-nnZrzn4rsag+wqON8INal0TjLnd6bWMc6PaMhA/kC+w=",
+        "lastModified": 1700170965,
+        "narHash": "sha256-beA3q4e60Xlg7jD3SVyN6Qg2pjMid9cVEo6qTplfy3U=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "cc4ad767c10db4b98eafcf0a26103efe9a791fd4",
+        "rev": "8160d50f328e9cc07c89c146bdb56552ce41a6aa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1699460437,
-        "narHash": "sha256-0LNsjGOkulD3VD3P/TerV4ocrZhU/E5RDalSbOBcbM8=",
+        "lastModified": 1699897647,
+        "narHash": "sha256-zHg6d6myLsxueZzbaHbE9ZhpB4p1gSgjRViaQpw5gC4=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "27f19d0d51a78527497f3210dcc417c04605d636",
+        "rev": "8f31b622e9f25b1f7d63c250caaae3d8e6c8a894",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698942558,
-        "narHash": "sha256-/UmnB+mEd6Eg3mJBrAgqRcyZX//RSjHphcCO7Ig9Bpk=",
+        "lastModified": 1699882182,
+        "narHash": "sha256-6RVUYyMPdKFrNFHTDfzH6p90+8mG5dXIavlF95pl7A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "621f51253edffa1d6f08d5fce4f08614c852d17e",
+        "rev": "5e68ba52abc572bd570b80503cdca5b137b5a594",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1699897647,
-        "narHash": "sha256-zHg6d6myLsxueZzbaHbE9ZhpB4p1gSgjRViaQpw5gC4=",
+        "lastModified": 1699904977,
+        "narHash": "sha256-Aw9HRvSxMlleAa7eODTht3VWLlETMo8xzEOCg2167Og=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "8f31b622e9f25b1f7d63c250caaae3d8e6c8a894",
+        "rev": "9bbf075a043d153f06baa0c84aa7fd52999987b0",
         "type": "github"
       },
       "original": {

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -83,6 +83,11 @@
       FLOX_ENV_TEMPLATE = builtins.path {
         path = ../../assets/templateFloxEnv;
       };
+
+      # The global manifest we generate if one does not exist
+      GLOBAL_MANIFEST_TEMPLATE = builtins.path {
+        path = ../../assets/global_manifest_template.toml;
+      };
     }
     // lib.optionalAttrs hostPlatform.isDarwin {
       NIX_COREFOUNDATION_RPATH = "${darwin.CF}/Library/Frameworks";

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -33,9 +33,6 @@ project_setup() {
   mkdir -p "$PROJECT_DIR";
   pushd "$PROJECT_DIR" >/dev/null||return;
   $FLOX_CLI init -d "$PROJECT_DIR";
-  sed -i \
-    's/from = { type = "github", owner = "NixOS", repo = "nixpkgs" }/from = { type = "github", owner = "NixOS", repo = "nixpkgs", rev = "e8039594435c68eb4f780f3e9bf3972a7399c4b1" }/' \
-    "$PROJECT_DIR/.flox/env/manifest.toml";
 }
 
 project_teardown() {
@@ -82,16 +79,17 @@ env_is_activated() {
 # `pkgdb lock` with no packages installed fetches a nixpkgs. With a package
 # installed, it also has to evaluate the package set.
 @test "warm up pkgdb" {
+  skip "FIXME: needs --ga-registry flag for 'pkgdb manifest lock'";
   run $FLOX_CLI install -d "$PROJECT_DIR" hello;
   assert_success;
   assert_output --partial "✅ 'hello' installed to environment";
   NIX_CONFIG="extra-experimental-features = flakes" "$PKGDB_BIN" manifest lock "$PROJECT_DIR/.flox/env/manifest.toml"
-  # TODO might want to also warm up env-from-lockfile once url is added to the lockfile
-  # "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
+  "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
 }
 
 # ---------------------------------------------------------------------------- #
 @test "activate modifies prompt and puts package in path" {
+  skip "FIXME: needs --ga-registry flag for 'pkgdb manifest lock'";
   run $FLOX_CLI install -d "$PROJECT_DIR" hello;
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"

--- a/tests/package-search.bats
+++ b/tests/package-search.bats
@@ -19,6 +19,9 @@ project_setup() {
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" >/dev/null || return
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
 }
 
 project_teardown() {
@@ -49,8 +52,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' can be called at all" {
-  run "$FLOX_CLI" init;
-  assert_success;
   run "$FLOX_CLI" search hello;
   assert_success;
 }
@@ -59,8 +60,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' error with no search term" {
-  run "$FLOX_CLI" init;
-  assert_success;
   run "$FLOX_CLI" search;
   assert_failure;
 }
@@ -69,8 +68,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' helpful error with unquoted redirect: hello@>1 -> hello@" {
-  run "$FLOX_CLI" init;
-  assert_success;
   run "$FLOX_CLI" search hello@;
   assert_failure;
   assert_output --partial "try quoting";
@@ -80,9 +77,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' expected number of results: 'hello'" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run --separate-stderr "$FLOX_CLI" search hello;
   n_lines="${#lines[@]}";
   case "$NIX_SYSTEM" in
@@ -101,9 +95,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: hello@2.12.1" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello@2.12.1;
   n_lines="${#lines[@]}";
   assert_equal "$n_lines" 2; # search line + show hint
@@ -114,9 +105,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' returns JSON" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello --json;
   version="$(echo "$output" | jq '.[0].version')";
   assert_equal "$version" '"2.12.1"';
@@ -126,9 +114,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: 'hello@>=1'" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search 'hello@>=1' --json;
   versions="$(echo "$output" | jq -c 'map(.version)')";
   case $THIS_SYSTEM in
@@ -145,9 +130,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: hello@2.x" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello@2.x --json;
   versions="$(echo "$output" | jq -c 'map(.version)')";
   assert_equal "$versions" '["2.12.1"]';
@@ -157,9 +139,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: hello@=2.10" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello@=2.12;
   n_lines="${#lines[@]}";
   assert_equal "$n_lines" "2"; # search line + show hint
@@ -170,9 +149,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: hello@v2" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello@v2 --json;
   versions="$(echo "$output" | jq -c 'map(.version)')";
   assert_equal "$versions" '["2.12.1"]';
@@ -182,9 +158,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: 'hello@>1 <3'" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search 'hello@>1 <3' --json;
   versions="$(echo "$output" | jq -c 'map(.version)')";
   assert_equal "$versions" '["2.12.1"]';
@@ -194,9 +167,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' exact semver match listed first" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello@2.12.1 --json;
   first_line="$(echo "$output" | head -n 1 | grep 2.12.1)";
   assert [ -n first_line ];
@@ -209,9 +179,6 @@ setup_file() {
 
   skip "DEPRECATED"
 
-  run "$FLOX_CLI" subscribe nixpkgs2 github:NixOS/nixpkgs/release-23.05;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello;
   assert_output --partial "nixpkgs2${SEP}";
   assert_output --partial "nixpkgs-flox${SEP}"
@@ -223,9 +190,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' displays unambiguous packages without separator" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello;
   packages="$(echo "$output" | cut -d ' ' -f 1)";
   case $THIS_SYSTEM in
@@ -242,9 +206,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' hints at 'flox show'" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run --separate-stderr "$FLOX_CLI" search hello;
   assert_success
   assert_equal "$stderr" "$SHOW_HINT"
@@ -254,9 +215,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' error message when no results" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search surely_doesnt_exist;
   assert_equal "${#lines[@]}" 1;
   # There's a leading `ERROR: ` that's left off when run non-interactively
@@ -266,9 +224,6 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' with 'FLOX_FEATURES_SEARCH_STRATEGY=match-name' shows fewer packages" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
 
   MATCH="$(FLOX_FEATURES_SEARCH_STRATEGY=match "$FLOX_CLI" search node | wc -l)";
   MATCH_NAME="$(FLOX_FEATURES_SEARCH_STRATEGY=match-name "$FLOX_CLI" search node | wc -l)";

--- a/tests/package-search.bats
+++ b/tests/package-search.bats
@@ -49,6 +49,8 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' can be called at all" {
+  run "$FLOX_CLI" init;
+  assert_success;
   run "$FLOX_CLI" search hello;
   assert_success;
 }
@@ -57,6 +59,8 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' error with no search term" {
+  run "$FLOX_CLI" init;
+  assert_success;
   run "$FLOX_CLI" search;
   assert_failure;
 }
@@ -65,6 +69,8 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' helpful error with unquoted redirect: hello@>1 -> hello@" {
+  run "$FLOX_CLI" init;
+  assert_success;
   run "$FLOX_CLI" search hello@;
   assert_failure;
   assert_output --partial "try quoting";
@@ -74,16 +80,19 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' expected number of results: 'hello'" {
-  run "$FLOX_CLI" search hello;
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
+  run --separate-stderr "$FLOX_CLI" search hello;
   n_lines="${#lines[@]}";
   case "$NIX_SYSTEM" in
     *-darwin)
       assert_equal "$n_lines" 11; # search line + show hint
-      assert_equal "${lines[-1]}" "$SHOW_HINT"
+      assert_equal "$stderr" "$SHOW_HINT"
       ;;
     *-linux)
       assert_equal "$n_lines" 11; # 4 search lines + show hint
-      assert_equal "${lines[-1]}" "$SHOW_HINT"
+      assert_equal "$stderr" "$SHOW_HINT"
       ;;
   esac
 }
@@ -92,6 +101,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: hello@2.12.1" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search hello@2.12.1;
   n_lines="${#lines[@]}";
   assert_equal "$n_lines" 2; # search line + show hint
@@ -102,6 +114,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' returns JSON" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search hello --json;
   version="$(echo "$output" | jq '.[0].version')";
   assert_equal "$version" '"2.12.1"';
@@ -111,6 +126,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: 'hello@>=1'" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search 'hello@>=1' --json;
   versions="$(echo "$output" | jq -c 'map(.version)')";
   case $THIS_SYSTEM in
@@ -127,6 +145,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: hello@2.x" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search hello@2.x --json;
   versions="$(echo "$output" | jq -c 'map(.version)')";
   assert_equal "$versions" '["2.12.1"]';
@@ -136,6 +157,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: hello@=2.10" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search hello@=2.12;
   n_lines="${#lines[@]}";
   assert_equal "$n_lines" "2"; # search line + show hint
@@ -146,6 +170,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: hello@v2" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search hello@v2 --json;
   versions="$(echo "$output" | jq -c 'map(.version)')";
   assert_equal "$versions" '["2.12.1"]';
@@ -155,6 +182,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' semver search: 'hello@>1 <3'" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search 'hello@>1 <3' --json;
   versions="$(echo "$output" | jq -c 'map(.version)')";
   assert_equal "$versions" '["2.12.1"]';
@@ -164,6 +194,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' exact semver match listed first" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search hello@2.12.1 --json;
   first_line="$(echo "$output" | head -n 1 | grep 2.12.1)";
   assert [ -n first_line ];
@@ -190,6 +223,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' displays unambiguous packages without separator" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search hello;
   packages="$(echo "$output" | cut -d ' ' -f 1)";
   case $THIS_SYSTEM in
@@ -206,15 +242,21 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' hints at 'flox show'" {
-  run "$FLOX_CLI" search hello;
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
+  run --separate-stderr "$FLOX_CLI" search hello;
   assert_success
-  assert_equal "${lines[-1]}" "$SHOW_HINT"
+  assert_equal "$stderr" "$SHOW_HINT"
 }
 
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' error message when no results" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search surely_doesnt_exist;
   assert_equal "${#lines[@]}" 1;
   # There's a leading `ERROR: ` that's left off when run non-interactively
@@ -224,6 +266,9 @@ setup_file() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox search' with 'FLOX_FEATURES_SEARCH_STRATEGY=match-name' shows fewer packages" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
 
   MATCH="$(FLOX_FEATURES_SEARCH_STRATEGY=match "$FLOX_CLI" search node | wc -l)";
   MATCH_NAME="$(FLOX_FEATURES_SEARCH_STRATEGY=match-name "$FLOX_CLI" search node | wc -l)";

--- a/tests/package-show.bats
+++ b/tests/package-show.bats
@@ -19,6 +19,9 @@ project_setup() {
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" >/dev/null || return
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
 }
 
 project_teardown() {
@@ -41,9 +44,6 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' can be called at all" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" show hello;
   assert_success;
 }
@@ -53,9 +53,6 @@ teardown() {
 
 @test "'flox show' accepts specific input" {
   skip DEPRECATED;
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" show nixpkgs-flox:hello;
   assert_success;
   # TODO: better testing once the formatting is implemented
@@ -64,9 +61,6 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' accepts search output without separator" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search hello;
   assert_success;
   first_result="${lines[0]%% *}";
@@ -79,9 +73,6 @@ teardown() {
 
 @test "'flox show' accepts search output with separator" {
   skip DEPRECATED;
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" search nixpkgs-flox:hello;
   assert_success;
   first_result="${lines[0]%% *}";
@@ -93,9 +84,6 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' - hello" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" show hello;
   assert_success;
   assert_equal "${lines[0]}" "hello - A program that produces a familiar, friendly greeting";
@@ -106,9 +94,6 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' - hello --all" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" show hello --all;
   assert_success;
   assert_equal "${lines[0]}" "hello - A program that produces a familiar, friendly greeting";
@@ -119,9 +104,6 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' - python27Full" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" show python27Full;
   assert_success;
   assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language";
@@ -132,9 +114,6 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' - python27Full --all" {
-  run "$FLOX_CLI" init;
-  assert_success;
-  unset output;
   run "$FLOX_CLI" show python27Full --all;
   assert_success;
   assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language";

--- a/tests/package-show.bats
+++ b/tests/package-show.bats
@@ -41,6 +41,9 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' can be called at all" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" show hello;
   assert_success;
 }
@@ -50,6 +53,9 @@ teardown() {
 
 @test "'flox show' accepts specific input" {
   skip DEPRECATED;
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" show nixpkgs-flox:hello;
   assert_success;
   # TODO: better testing once the formatting is implemented
@@ -58,6 +64,9 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' accepts search output without separator" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search hello;
   assert_success;
   first_result="${lines[0]%% *}";
@@ -70,6 +79,9 @@ teardown() {
 
 @test "'flox show' accepts search output with separator" {
   skip DEPRECATED;
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" search nixpkgs-flox:hello;
   assert_success;
   first_result="${lines[0]%% *}";
@@ -81,6 +93,9 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' - hello" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" show hello;
   assert_success;
   assert_equal "${lines[0]}" "hello - A program that produces a familiar, friendly greeting";
@@ -91,6 +106,9 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' - hello --all" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" show hello --all;
   assert_success;
   assert_equal "${lines[0]}" "hello - A program that produces a familiar, friendly greeting";
@@ -101,6 +119,9 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' - python27Full" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" show python27Full;
   assert_success;
   assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language";
@@ -111,6 +132,9 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox show' - python27Full --all" {
+  run "$FLOX_CLI" init;
+  assert_success;
+  unset output;
   run "$FLOX_CLI" show python27Full --all;
   assert_success;
   assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language";


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Search inputs are no longer collected from channels or hardcoded in searches, but instead they're read from the manifest by `pkgdb` (which itself hardcodes a registry at the moment).

This greatly simplifies the search interface from the Rust side.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
