### PR TITLE
feat(activate): support bash 3.2 and nixpkgs#bash

### DIFF
--- a/assets/mkEnv/set-prompt.sh
+++ b/assets/mkEnv/set-prompt.sh
@@ -12,7 +12,18 @@ colorPrompt1="\[${_esc}38;5;${FLOX_PROMPT_COLOR_1}m\]"
 colorPrompt2="\[${_esc}38;5;${FLOX_PROMPT_COLOR_2}m\]"
 _floxPrompt1="${colorPrompt1}flox"
 _floxPrompt2="${colorPrompt2}[$FLOX_PROMPT_ENVIRONMENTS]"
-_flox=$(echo -e -n "${colorBold}${FLOX_PROMPT-$_floxPrompt1} ${_floxPrompt2}${colorReset} ")
+# nixpkgs#bash doesn't have readline, so the prompt gets garbled if we use escapes.
+# Detect if we have readline by checking for progcomp; support for progcomp is
+# disabled when readline is not present, see:
+# https://git.savannah.gnu.org/cgit/bash.git/tree/bashline.c#n23
+# Note that we set colors even if support for progcomp is compiled in, but it is
+# turned off.
+if [[ $(shopt) =~ progcomp ]]; then
+    _flox=$(echo -e -n "${colorBold}${FLOX_PROMPT-$_floxPrompt1} ${_floxPrompt2}${colorReset} ")
+else
+    _flox=$(echo -e -n "${FLOX_PROMPT-flox} [$FLOX_PROMPT_ENVIRONMENTS] ")
+fi
+
 unset _esc colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
 
 if [ -n "$_flox" ] && [ -n "${PS1:-}" ]

--- a/assets/mkEnv/source-profiles.sh
+++ b/assets/mkEnv/source-profiles.sh
@@ -39,8 +39,10 @@ if [ -d "$FLOX_ENV/etc/profile.d" ]; then
   declare -a _prof_scripts;
   _prof_scripts=( $(
     case "$( detect_shell; )" in
-      zsh) set -o nullglob; ;;
-      *)   shopt -s nullglob; ;;
+      # Add opening parenthesis to case statements since otherwise bash 3 gets
+      # confused by the closing parenthesis
+      (zsh) set -o nullglob; ;;
+      (*)   shopt -s nullglob; ;;
     esac
     echo "$FLOX_ENV/etc/profile.d"/*.sh;
   ) );


### PR DESCRIPTION
- bash 3.2 gets confused by a closing parenthesis in a subshell, so add the optional opening parenthesis
- nixpkgs#bash does not have readline, so don't attempt to set a colorized prompt as it gets garbled