### PR TITLE
fix: flox push was incorrectly writing env.json to the temp path 

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -587,7 +587,7 @@ impl ManagedEnvironment {
         temp_floxmeta.git.push("origin").unwrap();
 
         fs::write(
-            temp_floxmeta_path.join("env.json"),
+            path_environment.path.join("env.json"),
             serde_json::to_string(&pointer).unwrap(),
         )
         .unwrap();


### PR DESCRIPTION
## Proposed Changes

`flox push` was broken and it appeared that `flox push` should replace .flox/env.json with a file that says `{"owner": <owner>, "name": <name>, "version": <number>}`

This PR fixes this issue

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
