### PR TITLE
fix: store absolute paths in environments

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -23,7 +23,7 @@ const GENERATION_LOCK_FILENAME: &str = "env.lock";
 
 #[derive(Debug)]
 pub struct ManagedEnvironment {
-    /// Path to the directory containing `env.json`
+    /// Absolute path to the directory containing `env.json`
     // TODO might be better to keep this private
     pub path: PathBuf,
     pointer: ManagedPointer,
@@ -181,6 +181,24 @@ impl Environment for ManagedEnvironment {
 }
 
 impl ManagedEnvironment {
+    pub fn new(
+        path: impl AsRef<Path>,
+        pointer: ManagedPointer,
+        system: String,
+        floxmeta: FloxmetaV2,
+    ) -> Result<Self, EnvironmentError2> {
+        Ok(Self {
+            // path must be absolute as it is used to set FLOX_ENV
+            path: path
+                .as_ref()
+                .canonicalize()
+                .map_err(EnvironmentError2::EnvCanonicalize)?,
+            pointer,
+            system,
+            floxmeta,
+        })
+    }
+
     /// Returns a unique identifier for the location of the project.
     fn encode(path: impl AsRef<Path>) -> Result<String, ManagedEnvironmentError> {
         let path =
@@ -300,12 +318,7 @@ impl ManagedEnvironment {
 
         Self::ensure_reverse_link(flox, &dot_flox_path)?;
 
-        Ok(ManagedEnvironment {
-            path: dot_flox_path.as_ref().to_path_buf(),
-            system: flox.system.clone(),
-            floxmeta,
-            pointer,
-        })
+        ManagedEnvironment::new(dot_flox_path, pointer, flox.system.clone(), floxmeta)
     }
 
     /// Ensure:

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -120,12 +120,12 @@ impl<S: TransactionState> PathEnvironment<S> {
         copy_dir_recursive(&self.path, &transaction_dir, true)
             .map_err(EnvironmentError2::MakeTemporaryEnv)?;
 
-        Ok(PathEnvironment {
-            path: transaction_dir.into_path(),
-            temp_dir: self.temp_dir.clone(),
-            pointer: self.pointer.clone(),
-            state: Temporary,
-        })
+        PathEnvironment::new(
+            transaction_dir.into_path(),
+            self.pointer.clone(),
+            self.temp_dir.clone(),
+            Temporary,
+        )
     }
 
     /// Replace the contents of this environment's `.flox` with that of another environment's `.flox`
@@ -524,17 +524,18 @@ mod tests {
             "{before:?}"
         );
 
-        let expected = PathEnvironment {
-            path: environment_temp_dir.path().to_path_buf().join(".flox"),
-            pointer: PathPointer::new("test".parse().unwrap()),
-            temp_dir: temp_dir.path().to_path_buf(),
-            state: Original,
-        };
-
         let actual = PathEnvironment::<Original>::init(
             pointer,
-            environment_temp_dir.into_path(),
+            environment_temp_dir.path(),
             temp_dir.path(),
+        )
+        .unwrap();
+
+        let expected = PathEnvironment::new(
+            environment_temp_dir.into_path().join(".flox"),
+            PathPointer::new("test".parse().unwrap()),
+            temp_dir.path().to_path_buf(),
+            Original,
         )
         .unwrap();
 

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -594,7 +594,10 @@ mod tests {
 
         let mut temp_env = env.make_temporary().unwrap();
 
-        assert_eq!(temp_env.path.parent().unwrap(), sandbox_path);
+        assert_eq!(
+            temp_env.path.parent().unwrap(),
+            sandbox_path.canonicalize().unwrap()
+        );
 
         let new_env_str = r#"
         { }

--- a/tests/activate/activate.exp
+++ b/tests/activate/activate.exp
@@ -37,6 +37,24 @@ expect {
     }
 }
 
+# check for hello after changing directory
+send "cd ..\n"
+expect {
+    -re "project.*\$" {}
+    timeout {
+      puts stderr "Reached timeout running 'cd ..'"
+      exit 1
+    }
+}
+send "{ command -v hello||which hello||type -P hello; } 2>&1\n"
+expect {
+    -re "project-\\d+/\.flox/run/.*\.project-\\d+/bin/hello" {}
+    timeout {
+      puts stderr "Reached timeout locating 'hello'"
+      exit 1
+    }
+}
+
 expect {
     # TODO check prompt colors
     -re "flox .*\\\[project-\\d+\\\]" {}


### PR DESCRIPTION
The `path` field on environments is used to set FLOX_ENV and then PATH, so it must be absolute, otherwise changing directory will invalidate PATH.

## Release Notes

Fixes bug where changing directory invalidates PATH after running `flox activate`