### PR TITLE
feat: format errors from pgkdb

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{fs, io};
@@ -20,6 +19,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRefError};
 use super::flox_package::FloxTriple;
 use super::manifest::TomlEditError;
+use super::pkgdb_errors::PkgDbError;
 use crate::flox::{EnvironmentRef, Flox};
 use crate::utils::copy_file_without_permissions;
 use crate::utils::errors::IoError;
@@ -305,111 +305,6 @@ pub enum EnvironmentError2 {
     #[error("couldn't read global manifest template: {0}")]
     ReadGlobalManifestTemplate(std::io::Error),
 }
-
-/// A struct representing error messages coming from pkgdb
-#[derive(Debug)]
-pub struct PkgDbError {
-    /// The exit code of pkgdb, can be used to programmatically determine
-    /// the category of error.
-    pub exit_code: u64,
-    /// The generic message for this category of error.
-    pub category_message: String,
-    /// The more contextual message for the specific error that occurred.
-    pub context_message: Option<ContextMsgError>,
-}
-
-impl<'de> Deserialize<'de> for PkgDbError {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let map = serde_json::Map::<String, Value>::deserialize(deserializer)?;
-        let exit_code = map
-            .get("exit_code")
-            .ok_or_else(|| serde::de::Error::missing_field("exit_code"))?
-            .as_u64()
-            .ok_or_else(|| serde::de::Error::custom("exit code is not an unsigned integer"))?;
-        let category_message = map
-            .get("category_message")
-            .ok_or_else(|| serde::de::Error::missing_field("category_message"))?
-            .as_str()
-            .ok_or_else(|| serde::de::Error::custom("category message was not a string"))
-            .map(|m| m.to_owned())?;
-        let context_message_contents = map
-            .get("context_message")
-            .map(|m| {
-                m.as_str()
-                    .ok_or_else(|| serde::de::Error::custom("context message was not a string"))
-                    .map(|m| m.to_owned())
-            })
-            .transpose()?;
-        let caught_message_contents = map
-            .get("caught_message")
-            .map(|m| {
-                m.as_str()
-                    .ok_or_else(|| serde::de::Error::custom("caught message was not a string"))
-                    .map(|m| m.to_owned())
-            })
-            .transpose()?;
-        let context_message = context_message_contents.map(|m| ContextMsgError {
-            message: m,
-            caught: caught_message_contents.map(|m| CaughtMsgError { message: m }),
-        });
-        Ok(PkgDbError {
-            exit_code,
-            category_message,
-            context_message,
-        })
-    }
-}
-
-impl Display for PkgDbError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.category_message)?;
-        Ok(())
-    }
-}
-
-impl std::error::Error for PkgDbError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.context_message
-            .as_ref()
-            .map(|s| s as &dyn std::error::Error)
-    }
-}
-
-/// A struct representing the context message from a pkgdb error
-#[derive(Debug, Deserialize)]
-pub struct ContextMsgError {
-    pub message: String,
-    pub caught: Option<CaughtMsgError>,
-}
-
-impl Display for ContextMsgError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for ContextMsgError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.caught.as_ref().map(|s| s as &dyn std::error::Error)
-    }
-}
-
-/// A struct representing the caught message from a pkgdb error
-#[derive(Debug, Deserialize)]
-pub struct CaughtMsgError {
-    pub message: String,
-}
-
-impl Display for CaughtMsgError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for CaughtMsgError {}
 
 /// Copy a whole directory recursively ignoring the original permissions
 ///

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -14,7 +14,6 @@ use runix::store_path::StorePath;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
-use uuid::timestamp::context;
 use walkdir::WalkDir;
 
 use self::managed_environment::ManagedEnvironmentError;
@@ -329,7 +328,7 @@ impl<'de> Deserialize<'de> for PkgDbError {
             .get("exit_code")
             .ok_or_else(|| serde::de::Error::missing_field("exit_code"))?
             .as_u64()
-            .ok_or_else(|| serde::de::Error::custom("exit_code is not an unsigned integer"))?;
+            .ok_or_else(|| serde::de::Error::custom("exit code is not an unsigned integer"))?;
         let category_message = map
             .get("category_message")
             .ok_or_else(|| serde::de::Error::missing_field("category_message"))?

--- a/crates/flox-rust-sdk/src/models/mod.rs
+++ b/crates/flox-rust-sdk/src/models/mod.rs
@@ -10,5 +10,6 @@ pub use runix::{flake_ref, registry};
 pub mod floxmeta;
 pub mod floxmetav2;
 pub mod manifest;
+pub mod pkgdb_errors;
 pub mod project;
 pub mod search;

--- a/crates/flox-rust-sdk/src/models/pkgdb_errors.rs
+++ b/crates/flox-rust-sdk/src/models/pkgdb_errors.rs
@@ -1,0 +1,109 @@
+use std::fmt::Display;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+/// A struct representing error messages coming from pkgdb
+#[derive(Debug)]
+pub struct PkgDbError {
+    /// The exit code of pkgdb, can be used to programmatically determine
+    /// the category of error.
+    pub exit_code: u64,
+    /// The generic message for this category of error.
+    pub category_message: String,
+    /// The more contextual message for the specific error that occurred.
+    pub context_message: Option<ContextMsgError>,
+}
+
+impl<'de> Deserialize<'de> for PkgDbError {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let map = serde_json::Map::<String, Value>::deserialize(deserializer)?;
+        let exit_code = map
+            .get("exit_code")
+            .ok_or_else(|| serde::de::Error::missing_field("exit_code"))?
+            .as_u64()
+            .ok_or_else(|| serde::de::Error::custom("exit code is not an unsigned integer"))?;
+        let category_message = map
+            .get("category_message")
+            .ok_or_else(|| serde::de::Error::missing_field("category_message"))?
+            .as_str()
+            .ok_or_else(|| serde::de::Error::custom("category message was not a string"))
+            .map(|m| m.to_owned())?;
+        let context_message_contents = map
+            .get("context_message")
+            .map(|m| {
+                m.as_str()
+                    .ok_or_else(|| serde::de::Error::custom("context message was not a string"))
+                    .map(|m| m.to_owned())
+            })
+            .transpose()?;
+        let caught_message_contents = map
+            .get("caught_message")
+            .map(|m| {
+                m.as_str()
+                    .ok_or_else(|| serde::de::Error::custom("caught message was not a string"))
+                    .map(|m| m.to_owned())
+            })
+            .transpose()?;
+        let context_message = context_message_contents.map(|m| ContextMsgError {
+            message: m,
+            caught: caught_message_contents.map(|m| CaughtMsgError { message: m }),
+        });
+        Ok(PkgDbError {
+            exit_code,
+            category_message,
+            context_message,
+        })
+    }
+}
+
+impl Display for PkgDbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.category_message)?;
+        Ok(())
+    }
+}
+
+impl std::error::Error for PkgDbError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.context_message
+            .as_ref()
+            .map(|s| s as &dyn std::error::Error)
+    }
+}
+
+/// A struct representing the context message from a pkgdb error
+#[derive(Debug, Deserialize)]
+pub struct ContextMsgError {
+    pub message: String,
+    pub caught: Option<CaughtMsgError>,
+}
+
+impl Display for ContextMsgError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ContextMsgError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.caught.as_ref().map(|s| s as &dyn std::error::Error)
+    }
+}
+
+/// A struct representing the caught message from a pkgdb error
+#[derive(Debug, Deserialize)]
+pub struct CaughtMsgError {
+    pub message: String,
+}
+
+impl Display for CaughtMsgError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for CaughtMsgError {}

--- a/crates/flox-rust-sdk/src/models/search.rs
+++ b/crates/flox-rust-sdk/src/models/search.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::environment::PkgDbError;
+use super::pkgdb_errors::PkgDbError;
 
 // This is the `PKGDB` path that we actually use.
 // This is set once and prefers the `PKGDB` env variable, but will use


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This adds a custom std::error::Error implementation for `PkgDbError` such that the JSON we receive from `pkgdb` is printed as if it we any other encountered on the Rust side.

Example:
```
$ flox search hello
ERROR: search encountered an error

    Caused by:
        0: invalid manifest file
        1: unrecognized manifest field `options.doesnt_exist'.
```

Previously the JSON errors received from `pkgdb` would simply be printed in their raw form.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users will now see friendly error messages when there's an error with their manifest or when an error is encountered during a search.

<!-- Many thanks! -->
