### PR TITLE
feat: set match-name to be default

### DIFF
--- a/crates/flox/src/config/features.rs
+++ b/crates/flox/src/config/features.rs
@@ -17,7 +17,7 @@ impl Features {
 #[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum SearchStrategy {
-    #[default]
     Match,
+    #[default]
     MatchName,
 }

--- a/tests/package-search.bats
+++ b/tests/package-search.bats
@@ -76,16 +76,34 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
+@test "'FLOX_FEATURES_SEARCH_STRATEGY=match flox search' expected number of results: 'hello'" {
+  FLOX_FEATURES_SEARCH_STRATEGY=match run --separate-stderr "$FLOX_CLI" search hello;
+  n_lines="${#lines[@]}";
+  case "$NIX_SYSTEM" in
+    *-darwin)
+      assert_equal "$n_lines" 11;
+      assert_equal "$stderr" "$SHOW_HINT"
+      ;;
+    *-linux)
+      assert_equal "$n_lines" 11;
+      assert_equal "$stderr" "$SHOW_HINT"
+      ;;
+  esac
+}
+
+
+# ---------------------------------------------------------------------------- #
+
 @test "'flox search' expected number of results: 'hello'" {
   run --separate-stderr "$FLOX_CLI" search hello;
   n_lines="${#lines[@]}";
   case "$NIX_SYSTEM" in
     *-darwin)
-      assert_equal "$n_lines" 11; # search line + show hint
+      assert_equal "$n_lines" 10;
       assert_equal "$stderr" "$SHOW_HINT"
       ;;
     *-linux)
-      assert_equal "$n_lines" 11; # 4 search lines + show hint
+      assert_equal "$n_lines" 10;
       assert_equal "$stderr" "$SHOW_HINT"
       ;;
   esac


### PR DESCRIPTION
Set default search strategy to match-name. The match strategy can still be used by setting FLOX_FEATURES_SEARCH_STRATEGY=match