### PR TITLE
test: add integ tests for manifest presence

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -21,6 +21,7 @@ use super::environment_ref::{EnvironmentName, EnvironmentOwner, EnvironmentRefEr
 use super::flox_package::FloxTriple;
 use super::manifest::TomlEditError;
 use crate::flox::{EnvironmentRef, Flox};
+use crate::models::environment::path_environment::{LOCKFILE_FILENAME, MANIFEST_FILENAME};
 use crate::utils::copy_file_without_permissions;
 use crate::utils::errors::IoError;
 
@@ -304,6 +305,12 @@ pub enum EnvironmentError2 {
     InitGlobalManifest(std::io::Error),
     #[error("couldn't read global manifest template: {0}")]
     ReadGlobalManifestTemplate(std::io::Error),
+    #[error("provided path couldn't be canonicalized: {path}")]
+    CanonicalPath {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 /// A struct representing error messages coming from pkgdb
@@ -430,6 +437,52 @@ pub fn global_manifest_path(flox: &Flox) -> PathBuf {
     path
 }
 
+/// Searches upwards for a `.flox` directory, returning the path if found.
+pub fn find_dot_flox_upwards(start_path: &Path) -> Result<Option<PathBuf>, EnvironmentError2> {
+    let mut path = start_path
+        .canonicalize()
+        .map_err(|e| EnvironmentError2::CanonicalPath {
+            path: start_path.to_path_buf(),
+            source: e,
+        })?;
+    while path != Path::new("/") {
+        if let Some(parent) = path.parent() {
+            let tentative_dot_flox = parent.join(DOT_FLOX);
+            if tentative_dot_flox.exists() && tentative_dot_flox.is_dir() {
+                return Ok(Some(tentative_dot_flox));
+            } else {
+                path = parent.to_path_buf();
+            }
+            continue;
+        }
+        break;
+    }
+    Ok(None)
+}
+
+/// Returns the path to the manifest for the given environment and optionally the path to the lockfile
+/// if it exists
+pub fn manifest_and_lockfile(
+    current_dir: &Path,
+) -> Result<(Option<PathBuf>, Option<PathBuf>), EnvironmentError2> {
+    if let Some(dot_flox_path) = find_dot_flox_upwards(current_dir)? {
+        let manifest_path = dot_flox_path.join(MANIFEST_FILENAME);
+        let lockfile_path = dot_flox_path.join(LOCKFILE_FILENAME);
+        let lockfile = if lockfile_path.exists() {
+            Some(lockfile_path)
+        } else {
+            None
+        };
+        let manifest = if manifest_path.exists() {
+            Some(manifest_path)
+        } else {
+            None
+        };
+        return Ok((manifest, lockfile));
+    }
+    Ok((None, None))
+}
+
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
@@ -499,5 +552,45 @@ mod test {
                 version: Version::<1> {},
             })
         );
+    }
+
+    #[test]
+    fn discovers_existing_upwards_dot_flox() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
+        let start_path = actual_dot_flox.join("foo").join("bar");
+        std::fs::create_dir_all(&start_path).unwrap();
+        let found_dot_flox = find_dot_flox_upwards(&start_path)
+            .unwrap()
+            .expect("expected to find dot flox");
+        assert_eq!(found_dot_flox, actual_dot_flox.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn discovers_adjacent_dot_flox() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
+        std::fs::create_dir_all(&actual_dot_flox).unwrap();
+        let found_dot_flox = find_dot_flox_upwards(&actual_dot_flox)
+            .unwrap()
+            .expect("expected to find dot flox");
+        assert_eq!(found_dot_flox, actual_dot_flox.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn no_error_on_discovering_nonexistent_dot_flox() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let start_path = temp_dir.path().join("foo").join("bar");
+        std::fs::create_dir_all(&start_path).unwrap();
+        let found_dot_flox = find_dot_flox_upwards(&start_path).unwrap();
+        assert_eq!(found_dot_flox, None);
+    }
+
+    #[test]
+    fn error_when_discovering_dot_flox_in_nonexistent_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let start_path = temp_dir.path().join("foo").join("bar");
+        let found_dot_flox = find_dot_flox_upwards(&start_path);
+        assert!(found_dot_flox.is_err());
     }
 }

--- a/crates/flox-rust-sdk/src/models/search.rs
+++ b/crates/flox-rust-sdk/src/models/search.rs
@@ -53,7 +53,7 @@ pub enum ShowError {
 #[serde(rename_all = "kebab-case")]
 pub struct SearchParams {
     /// Either an absolute path to a manifest or an inline JSON manifest
-    pub manifest: PathOrJson,
+    pub manifest: Option<PathOrJson>,
     /// Either an absolute path to a manifest or an inline JSON manifest
     pub global_manifest: PathOrJson,
     /// An optional exisiting lockfile
@@ -381,7 +381,7 @@ mod test {
     #[test]
     fn serializes_search_params() {
         let params = SearchParams {
-            manifest: PathOrJson::Path("/path/to/manifest".into()),
+            manifest: Some(PathOrJson::Path("/path/to/manifest".into())),
             global_manifest: PathOrJson::Path("/path/to/manifest".into()),
             lockfile: None,
             query: Query::from_str(EXAMPLE_SEARCH_TERM, false).unwrap(),

--- a/tests/package-search.bats
+++ b/tests/package-search.bats
@@ -249,3 +249,24 @@ setup_file() {
   assert [ "$MATCH_NAME" -lt "$MATCH" ];
 
 }
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox search' works in project without manifest or lockfile" {
+  rm -f "$PROJECT_DIR/.flox/manifest.toml";
+  run --separate-stderr "$FLOX_CLI" search hello;
+  assert_success;
+  n_lines="${#lines[@]}";
+  assert_equal "$n_lines" 11; # search results from global manifest registry
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox search' works outside of projects" {
+  rm -rf "$PROJECT_DIR/.flox";
+  run --separate-stderr "$FLOX_CLI" search hello;
+  assert_success;
+  n_lines="${#lines[@]}";
+  assert_equal "$n_lines" 11; # search results from global manifest registry
+}

--- a/tests/package-search.bats
+++ b/tests/package-search.bats
@@ -257,7 +257,7 @@ setup_file() {
   run --separate-stderr "$FLOX_CLI" search hello;
   assert_success;
   n_lines="${#lines[@]}";
-  assert_equal "$n_lines" 11; # search results from global manifest registry
+  assert_equal "$n_lines" 10; # search results from global manifest registry
 }
 
 
@@ -268,5 +268,5 @@ setup_file() {
   run --separate-stderr "$FLOX_CLI" search hello;
   assert_success;
   n_lines="${#lines[@]}";
-  assert_equal "$n_lines" 11; # search results from global manifest registry
+  assert_equal "$n_lines" 10; # search results from global manifest registry
 }

--- a/tests/package-show.bats
+++ b/tests/package-show.bats
@@ -119,3 +119,21 @@ teardown() {
   assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language";
   assert_equal "${lines[1]}" "    python27Full - python27Full@2.7.18.6";
 }
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' works in project without manifest or lockfile" {
+  rm -f "$PROJECT_DIR/.flox/manifest.toml";
+  run --separate-stderr "$FLOX_CLI" show hello;
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox show' works outside of projects" {
+  rm -rf "$PROJECT_DIR/.flox";
+  run --separate-stderr "$FLOX_CLI" show hello;
+  assert_success;
+}


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This adds a couple of tests for `search`/`show` that ensure these commands fall back to the global manifest when outside of a project.

As part of making the tests pass some helper functions were added that aid in discovering a `.flox` directory.

This is the final PR required for closing flox/product#551.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
