### PR TITLE
chore: bump 'pkgdb', call lock with --ga-registry

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -364,7 +364,7 @@ pub fn lock_manifest(
         .map_err(EnvironmentError2::OpenManifest)?;
     let mut pkgdb_cmd = Command::new(pkgdb);
     pkgdb_cmd
-        .args(["manifest", "lock"])
+        .args(["manifest", "lock", "--ga-registry"])
         .arg(canonical_manifest_path);
     if let Some(lf_path) = existing_lockfile_path {
         let canonical_lockfile_path = lf_path

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1700170965,
-        "narHash": "sha256-beA3q4e60Xlg7jD3SVyN6Qg2pjMid9cVEo6qTplfy3U=",
+        "lastModified": 1700359466,
+        "narHash": "sha256-+S0AuQCcM8r5UzvnASfBO0lYSwCS2qC7Ze5rr+jxQ2w=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "8160d50f328e9cc07c89c146bdb56552ce41a6aa",
+        "rev": "a56042073ebdaac724fdef28c0cb2ea7bac71f1e",
         "type": "github"
       },
       "original": {

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -79,17 +79,15 @@ env_is_activated() {
 # `pkgdb lock` with no packages installed fetches a nixpkgs. With a package
 # installed, it also has to evaluate the package set.
 @test "warm up pkgdb" {
-  skip "FIXME: needs --ga-registry flag for 'pkgdb manifest lock'";
   run $FLOX_CLI install -d "$PROJECT_DIR" hello;
   assert_success;
   assert_output --partial "✅ 'hello' installed to environment";
-  NIX_CONFIG="extra-experimental-features = flakes" "$PKGDB_BIN" manifest lock "$PROJECT_DIR/.flox/env/manifest.toml"
-  "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
+  NIX_CONFIG="extra-experimental-features = flakes" "$PKGDB_BIN" manifest lock --ga-registry "$PROJECT_DIR/.flox/env/manifest.toml"
+  # "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
 }
 
 # ---------------------------------------------------------------------------- #
 @test "activate modifies prompt and puts package in path" {
-  skip "FIXME: needs --ga-registry flag for 'pkgdb manifest lock'";
   run $FLOX_CLI install -d "$PROJECT_DIR" hello;
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"


### PR DESCRIPTION
This fixes an activate regression; pkgdb now expects --ga-registry, but
we hadn't started passing it to `pkgdb manifest lock`

Flake lock file updates:

• Updated input 'pkgdb':
    'github:flox/pkgdb/8160d50f328e9cc07c89c146bdb56552ce41a6aa' (2023-11-16)
  → 'github:flox/pkgdb/a56042073ebdaac724fdef28c0cb2ea7bac71f1e' (2023-11-19)