### PR TITLE
feat: build envs on install/activate

### DIFF
--- a/assets/mkEnv/env-from-lockfile.nix
+++ b/assets/mkEnv/env-from-lockfile.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   lockfileContents = builtins.fromJSON (builtins.readFile lockfilePath);
-  nixpkgsFlake = builtins.getFlake "github:NixOS/nixpkgs/release-23.05";
+  nixpkgsFlake = with lockfileContents.registry.inputs.nixpkgs.from; builtins.getFlake "${type}:${owner}/${repo}/${rev}";
   pkgs = nixpkgsFlake.legacyPackages.${system};
   lib = nixpkgsFlake.lib;
 

--- a/assets/mkEnv/env-from-lockfile.nix
+++ b/assets/mkEnv/env-from-lockfile.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   lockfileContents = builtins.fromJSON (builtins.readFile lockfilePath);
-  nixpkgsFlake = builtins.getFlake lockfileContents.registry.inputs.nixpkgs.url;
+  nixpkgsFlake = builtins.getFlake "github:NixOS/nixpkgs/release-23.05";
   pkgs = nixpkgsFlake.legacyPackages.${system};
   lib = nixpkgsFlake.lib;
 

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -81,11 +81,7 @@ pub struct GenerationLock {
 #[async_trait]
 impl Environment for ManagedEnvironment {
     #[allow(unused)]
-    async fn build(
-        &mut self,
-        nix: &NixCommandLine,
-        system: &System,
-    ) -> Result<(), EnvironmentError2> {
+    async fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
         todo!()
     }
 
@@ -94,8 +90,7 @@ impl Environment for ManagedEnvironment {
     async fn install(
         &mut self,
         packages: Vec<String>,
-        nix: &NixCommandLine,
-        system: System,
+        flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError2> {
         todo!()
     }
@@ -113,12 +108,7 @@ impl Environment for ManagedEnvironment {
 
     /// Atomically edit this environment, ensuring that it still builds
     #[allow(unused)]
-    async fn edit(
-        &mut self,
-        nix: &NixCommandLine,
-        system: System,
-        contents: String,
-    ) -> Result<(), EnvironmentError2> {
+    async fn edit(&mut self, flox: &Flox, contents: String) -> Result<(), EnvironmentError2> {
         todo!()
     }
 
@@ -158,12 +148,8 @@ impl Environment for ManagedEnvironment {
         todo!()
     }
 
-    async fn activation_path(
-        &mut self,
-        flox: &Flox,
-        nix: &NixCommandLine,
-    ) -> Result<PathBuf, EnvironmentError2> {
-        self.build(nix, &flox.system).await?;
+    async fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
+        self.build(flox).await?;
         Ok(self.out_link(flox))
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -100,8 +100,7 @@ impl Environment for ManagedEnvironment {
     async fn uninstall(
         &mut self,
         packages: Vec<String>,
-        nix: &NixCommandLine,
-        system: System,
+        flox: &Flox,
     ) -> Result<String, EnvironmentError2> {
         todo!()
     }

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -367,14 +367,6 @@ pub fn lock_manifest(
     let output = pkgdb_cmd.output().map_err(EnvironmentError2::PkgDbCall)?;
     // If command fails, try to parse stdout as a PkgDbError
     if !output.status.success() {
-        eprintln!(
-            "pkgdb stdout content: {}",
-            String::from_utf8_lossy(&output.stdout)
-        );
-        eprintln!(
-            "pkgdb stderr content: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
         if let Ok::<PkgDbError, _>(pkgdb_err) = serde_json::from_slice(&output.stdout) {
             Err(EnvironmentError2::LockManifest(pkgdb_err))
         } else {

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -73,8 +73,7 @@ pub trait Environment {
     async fn uninstall(
         &mut self,
         packages: Vec<String>,
-        nix: &NixCommandLine,
-        system: System,
+        flox: &Flox,
     ) -> Result<String, EnvironmentError2>;
 
     /// Atomically edit this environment, ensuring that it still builds
@@ -368,6 +367,14 @@ pub fn lock_manifest(
     let output = pkgdb_cmd.output().map_err(EnvironmentError2::PkgDbCall)?;
     // If command fails, try to parse stdout as a PkgDbError
     if !output.status.success() {
+        eprintln!(
+            "pkgdb stdout content: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        eprintln!(
+            "pkgdb stderr content: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
         if let Ok::<PkgDbError, _>(pkgdb_err) = serde_json::from_slice(&output.stdout) {
             Err(EnvironmentError2::LockManifest(pkgdb_err))
         } else {

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -15,11 +15,7 @@ pub struct RemoteEnvironment;
 impl Environment for RemoteEnvironment {
     /// Build the environment and create a result link as gc-root
     #[allow(unused)]
-    async fn build(
-        &mut self,
-        nix: &NixCommandLine,
-        system: &System,
-    ) -> Result<(), EnvironmentError2> {
+    async fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
         todo!()
     }
 
@@ -28,8 +24,7 @@ impl Environment for RemoteEnvironment {
     async fn install(
         &mut self,
         packages: Vec<String>,
-        nix: &NixCommandLine,
-        system: System,
+        flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError2> {
         todo!()
     }
@@ -47,12 +42,7 @@ impl Environment for RemoteEnvironment {
 
     /// Atomically edit this environment, ensuring that it still builds
     #[allow(unused)]
-    async fn edit(
-        &mut self,
-        nix: &NixCommandLine,
-        system: System,
-        contents: String,
-    ) -> Result<(), EnvironmentError2> {
+    async fn edit(&mut self, flox: &Flox, contents: String) -> Result<(), EnvironmentError2> {
         todo!()
     }
 
@@ -71,11 +61,7 @@ impl Environment for RemoteEnvironment {
     }
 
     #[allow(unused)]
-    async fn activation_path(
-        &mut self,
-        flox: &Flox,
-        nix: &NixCommandLine,
-    ) -> Result<PathBuf, EnvironmentError2> {
+    async fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -34,8 +34,7 @@ impl Environment for RemoteEnvironment {
     async fn uninstall(
         &mut self,
         packages: Vec<String>,
-        nix: &NixCommandLine,
-        system: System,
+        flox: &Flox,
     ) -> Result<String, EnvironmentError2> {
         todo!()
     }

--- a/crates/flox-rust-sdk/src/models/manifest.rs
+++ b/crates/flox-rust-sdk/src/models/manifest.rs
@@ -29,15 +29,6 @@ pub struct PackageInsertion {
 }
 
 /// Insert package names into the `[install]` table of a manifest.
-///
-/// Packages are always inserted as "tables", meaning a package `foo` will appear
-/// as `[install.foo]`. The form you may be more familiar with:
-/// ```toml
-/// [install]
-/// foo = {}
-/// ```
-/// is called an "inline table" and the `toml_edit` library has middling support
-/// for entries in this form.
 pub fn insert_packages(
     manifest_contents: &str,
     pkgs: impl Iterator<Item = String>,
@@ -116,10 +107,8 @@ pub fn remove_packages(
     Ok(toml)
 }
 
-// FIXME: will be used in uninstall
 /// Check whether a TOML document contains a line declaring that the provided package
 /// should be installed.
-#[allow(unused)]
 pub fn contains_package(toml: &Document, pkg_name: &str) -> Result<bool, TomlEditError> {
     if let Some(installs) = toml.get("install") {
         if let Item::Table(installs_table) = installs {

--- a/crates/flox-rust-sdk/src/models/manifest.rs
+++ b/crates/flox-rust-sdk/src/models/manifest.rs
@@ -76,7 +76,6 @@ pub fn remove_packages(
     manifest_contents: &str,
     pkgs: &[String],
 ) -> Result<Document, TomlEditError> {
-    println!("MANIFEST CONTENTS BEFORE: {}", manifest_contents);
     debug!("attempting to remove packages from the manifest");
     let mut toml = manifest_contents
         .parse::<Document>()
@@ -105,7 +104,6 @@ pub fn remove_packages(
         }
     }
 
-    println!("MANIFEST CONTENTS AFTER: {}", toml);
     Ok(toml)
 }
 

--- a/crates/flox-rust-sdk/src/models/project/mod.rs
+++ b/crates/flox-rust-sdk/src/models/project/mod.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use walkdir::WalkDir;
 
 use self::environment::Environment;
-use super::environment::path_environment::MANIFEST_FILENAME;
+use super::environment::MANIFEST_FILENAME;
 use super::root::transaction::{GitAccess, GitSandBox, ReadOnly};
 use super::root::{Closed, Root};
 use crate::flox::{Flox, FloxNixApi};

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -186,7 +186,7 @@ impl GitCommandProvider {
     }
 
     fn run_command(command: &mut Command) -> Result<OsString, GitCommandError> {
-        debug!(target: "posix", "{:?}", command);
+        debug!("{:?}", command);
         let out = command.output()?;
 
         if !out.status.success() {

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -422,10 +422,7 @@ impl Uninstall {
         let concrete_environment = self.environment.to_concrete_environment(&flox)?;
         let description = environment_description(&concrete_environment);
         let mut environment = concrete_environment.into_dyn_environment();
-        let nix = flox.nix::<NixCommandLine>(vec![]);
-        let _ = environment
-            .uninstall(self.packages.clone(), &nix, flox.system.clone())
-            .await?;
+        let _ = environment.uninstall(self.packages.clone(), &flox).await?;
 
         // Note, you need two spaces between this emoji and the package name
         // otherwise they appear right next to each other.

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -66,15 +66,12 @@ impl Edit {
             .environment
             .to_concrete_environment(&flox)?
             .into_dyn_environment();
-        let nix = flox.nix(Default::default());
 
         match self.provided_manifest_contents()? {
             // If provided with the contents of a manifest file, either via a path to a file or via
             // contents piped to stdin, use those contents to try building the environment.
             Some(new_manifest) => {
-                environment
-                    .edit(&nix, flox.system.clone(), new_manifest)
-                    .await?;
+                environment.edit(&flox, new_manifest).await?;
                 Ok(())
             },
             // If not provided with new manifest contents, let the user edit the file directly
@@ -101,10 +98,7 @@ impl Edit {
                 // decides to stop.
                 loop {
                     let new_manifest = Edit::edited_manifest_contents(&tmp_manifest, &editor)?;
-                    if let Err(e) = environment
-                        .edit(&nix, flox.system.clone(), new_manifest)
-                        .await
-                    {
+                    if let Err(e) = environment.edit(&flox, new_manifest).await {
                         error!("Environment invalid; building resulted in an error: {e}");
                         if !Dialog::can_prompt() {
                             bail!("Can't prompt to continue editing in non-interactive context");
@@ -213,7 +207,6 @@ impl Activate {
         };
 
         let mut environment = concrete_environment.into_dyn_environment();
-        let nix = flox.nix(Default::default());
 
         let mut stderr = std::io::stdout();
         stderr
@@ -224,7 +217,7 @@ impl Activate {
             .context("could't write progress message")?;
         stderr.flush().context("could't flush stderr")?;
 
-        let activation_path = environment.activation_path(&flox, &nix).await?;
+        let activation_path = environment.activation_path(&flox).await?;
 
         stderr
             .queue(cursor::RestorePosition)
@@ -390,10 +383,7 @@ impl Install {
         let concrete_environment = self.environment.to_concrete_environment(&flox)?;
         let description = environment_description(&concrete_environment);
         let mut environment = concrete_environment.into_dyn_environment();
-        let nix = flox.nix::<NixCommandLine>(vec![]);
-        let installation = environment
-            .install(self.packages.clone(), &nix, flox.system.clone())
-            .await?;
+        let installation = environment.install(self.packages.clone(), &flox).await?;
         if installation.new_manifest.is_some() {
             // Print which new packages were installed
             for pkg in self.packages.iter() {

--- a/crates/flox/src/utils/mod.rs
+++ b/crates/flox/src/utils/mod.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::io::Stderr;
 use std::sync::Mutex;
 
-use anyhow::Context;
 use once_cell::sync::Lazy;
 
 pub mod colors;
@@ -23,30 +22,4 @@ fn nix_str_safe(s: &str) -> Cow<str> {
     } else {
         format!("{s:?}").into()
     }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    const TOML_CONTENTS: &str = r#"
-    [my_table]
-    foo = { bar = "baz" }
-
-    [some_table]
-    key = "value"
-    "#;
-
-    const JSON_CONTENTS: &str = r#"
-    {
-        "my_table": {
-            "foo": {
-                "bar": "baz"
-            }
-        },
-        "some_table": {
-            "key": "value"
-        }
-    }
-    "#;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "sqlite3pp": "sqlite3pp"
       },
       "locked": {
-        "lastModified": 1700516596,
-        "narHash": "sha256-huItsgFL/iXLVTaBdjlUIaWJKevRuAAy4U1Rm1Vl5gw=",
+        "lastModified": 1700529847,
+        "narHash": "sha256-afwFF9U0o6LPCjmYnYi1zpcmt8FnIImNLXdaS3o7FwY=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "ab37dea494d21774aa58446a04cb0cccbeede2a6",
+        "rev": "d3d78820fc99c4f9b8743cc76c2d97587312e8ce",
         "type": "github"
       },
       "original": {

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -54,9 +54,9 @@ teardown() {
 
 @test "'flox install' edits manifest" {
   "$FLOX_CLI" init;
-  run "$FLOX_CLI" install foo;
+  run "$FLOX_CLI" install hello;
   assert_success;
-  run grep "foo = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
+  run grep "hello = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
   assert_success;
 }
 
@@ -74,10 +74,10 @@ teardown() {
 
 @test "'flox uninstall' edits manifest" {
   "$FLOX_CLI" init;
-  run "$FLOX_CLI" install foo;
+  run "$FLOX_CLI" install hello;
   assert_success;
-  run "$FLOX_CLI" uninstall foo;
-  run grep "foo = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
+  run "$FLOX_CLI" uninstall hello;
+  run grep "^hello = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
   assert_failure;
 }
 

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -13,7 +13,8 @@ load test_support.bash
 # Helpers for project based tests.
 
 project_setup() {
-  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  export PROJECT_NAME="test";
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" >/dev/null || return
@@ -79,6 +80,51 @@ teardown() {
   run "$FLOX_CLI" uninstall hello;
   run grep "^hello = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
   assert_failure;
+}
+
+@test "'flox install' reports error when package not found" {
+  "$FLOX_CLI" init;
+  run "$FLOX_CLI" install not-a-package;
+  assert_failure;
+  assert_output --partial "failed to resolve \`not-a-package'";
+}
+
+@test "'flox uninstall' reports error when package not found" {
+  "$FLOX_CLI" init;
+  run "$FLOX_CLI" uninstall not-a-package;
+  assert_failure;
+  assert_output --partial "couldn't uninstall 'not-a-package', wasn't previously installed";
+}
+
+@test "'flox install' creates link to installed binary" {
+  "$FLOX_CLI" init;
+  run "$FLOX_CLI" install hello;
+  assert_success;
+  assert_output --partial "✅ 'hello' installed to environment";
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/bin/hello" ];
+  assert_success;
+}
+
+@test "'flox uninstall' removes link to installed binary" {
+  "$FLOX_CLI" init;
+  run "$FLOX_CLI" install hello;
+  assert_success;
+  assert_output --partial "✅ 'hello' installed to environment";
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/bin/hello" ];
+  assert_success;
+  run "$FLOX_CLI" uninstall hello;
+  assert_success;
+  run [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/bin/hello" ];
+  assert_success;
+}
+
+@test "'flox uninstall' has helpful error message with no packages installed" {
+  # If the [install] table is missing entirely we don't want to report a TOML
+  # parse error, we want to report that there's nothing to uninstall.
+  "$FLOX_CLI" init;
+  run "$FLOX_CLI" uninstall hello;
+  assert_failure;
+  assert_output --partial "couldn't uninstall 'hello', wasn't previously installed";
 }
 
 @test "i5: download package when install command runs" {


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Attempt to transactionally build the environment when installing, uninstalling, or activating. This has the added benefit of ensuring that you can't install a package that doesn't exist.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Installing/uninstalling a package now actually builds the environment rather than simply putting the package name in the manifest.

<!-- Many thanks! -->
