### PR TITLE
refactor: switch to auth0 for authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "itertools",
  "log",
  "nix",
+ "oauth2",
  "once_cell",
  "openssl",
  "pathdiff",
@@ -930,8 +931,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1096,6 +1099,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1521,6 +1538,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom",
+ "http",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1891,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1863,18 +1901,36 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2015,6 +2071,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64 0.21.5",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2136,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -2107,6 +2204,16 @@ checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2286,6 +2393,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -2545,6 +2658,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,6 +3060,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,6 @@ url = "2.4"
 uuid = { version = "1.2", features = ["serde", "v4"] }
 walkdir = "2"
 xdg = "2.4"
-
+oauth2 = "4.4"
 
 [patch.crates-io]

--- a/crates/flox/Cargo.toml
+++ b/crates/flox/Cargo.toml
@@ -49,6 +49,7 @@ indexmap.workspace = true
 url.workspace = true
 openssl.workspace = true
 chrono.workspace = true
+oauth2.workspace = true
 toml = "0.8.8"
 
 [dev-dependencies]

--- a/crates/flox/src/commands/auth.rs
+++ b/crates/flox/src/commands/auth.rs
@@ -12,6 +12,7 @@ use oauth2::{
     AuthUrl,
     ClientId,
     DeviceAuthorizationUrl,
+    Scope,
     StandardDeviceAuthorizationResponse,
     TokenResponse,
     TokenUrl,
@@ -59,11 +60,13 @@ fn create_oauth_client() -> Result<BasicClient> {
 
 pub async fn authorize(client: BasicClient) -> Result<Credential> {
     let details: StandardDeviceAuthorizationResponse = client
-                .exchange_device_code()
-                .unwrap()
-                // .add_scope(Scope::new("read".to_string()))
-                .request_async(oauth2::reqwest::async_http_client)
-                .await.context("Could not request device code")?;
+        .exchange_device_code()
+        .unwrap()
+        .add_scope(Scope::new("openid".to_string()))
+        .add_scope(Scope::new("profile".to_string()))
+        .request_async(oauth2::reqwest::async_http_client)
+        .await
+        .context("Could not request device code")?;
 
     debug!("Device code details: {details:#?}");
 

--- a/crates/flox/src/commands/auth.rs
+++ b/crates/flox/src/commands/auth.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use bpaf::Bpaf;
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
-use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::flox::{Auth0Client, Flox};
 use log::{debug, info};
 use oauth2::basic::BasicClient;
 use oauth2::{
@@ -109,6 +109,10 @@ pub enum Auth2 {
     /// Logout from floxhub
     #[bpaf(command)]
     Logout,
+
+    /// Get current username
+    #[bpaf(command, hide)]
+    User,
 }
 
 impl Auth2 {
@@ -149,6 +153,16 @@ impl Auth2 {
 
                 info!("Logout successful");
 
+                Ok(())
+            },
+            Auth2::User => {
+                let token = config.flox.floxhub_token.context("You are not logged in")?;
+
+                let user = Auth0Client::new(env!("OAUTH_BASE_URL").to_string(), token)
+                    .get_username()
+                    .await
+                    .context("Could not get user details")?;
+                println!("{user}");
                 Ok(())
             },
         }

--- a/crates/flox/src/commands/auth.rs
+++ b/crates/flox/src/commands/auth.rs
@@ -1,6 +1,5 @@
 //this module liberally borrows from github-device-flox crate
-use std::collections::HashMap;
-use std::{fmt, thread, time};
+use std::time;
 
 use anyhow::{Context, Result};
 use bpaf::Bpaf;
@@ -8,209 +7,86 @@ use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
 use flox_rust_sdk::flox::Flox;
 use log::{debug, info};
+use oauth2::basic::BasicClient;
+use oauth2::{
+    AuthUrl,
+    ClientId,
+    DeviceAuthorizationUrl,
+    StandardDeviceAuthorizationResponse,
+    TokenResponse,
+    TokenUrl,
+};
 use serde::Serialize;
 
 use crate::commands::general::update_config;
 use crate::config::Config;
 use crate::subcommand_metric;
 
+const TOKEN_INPUT_TIMEOUT: time::Duration = time::Duration::new(30, 0);
+
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct Credential {
     pub token: String,
     pub expiry: String,
-    pub refresh_token: String,
 }
 
-impl Credential {
-    fn empty() -> Credential {
-        Credential {
-            token: String::new(),
-            expiry: String::new(),
-            refresh_token: String::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum DeviceFlowError {
-    HttpError(String),
-    GitHubError(String),
-}
-
-impl fmt::Display for DeviceFlowError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            DeviceFlowError::HttpError(string) => write!(f, "DeviceFlowError: {}", string),
-            DeviceFlowError::GitHubError(string) => write!(f, "DeviceFlowError: {}", string),
-        }
-    }
-}
-
-impl std::error::Error for DeviceFlowError {}
-
-impl From<reqwest::Error> for DeviceFlowError {
-    fn from(e: reqwest::Error) -> Self {
-        DeviceFlowError::HttpError(format!("{:?}", e))
-    }
-}
-
-pub async fn authorize(
-    client_id: String,
-    host: Option<String>,
-) -> Result<Credential, DeviceFlowError> {
-    let mut flow = DeviceFlow::start(client_id.as_str(), host).await?;
-
-    // eprintln!("res is {:?}", res);
-    info!(
-        "Please visit {} in your browser",
-        flow.verification_uri.clone().unwrap()
+/// construct an oauth client using compile time constants or environment variables
+///
+/// Environment variables can be used to override the compile time constants during testing.
+/// For use in production, the compile time constants should be used.
+/// For multitenency, we will integrate with the config subsystem later.
+fn create_oauth_client() -> Result<BasicClient> {
+    let auth_url = AuthUrl::new(
+        std::env::var("FLOX_OAUTH_AUTH_URL").unwrap_or(env!("OAUTH_AUTH_URL").to_string()),
+    )
+    .context("Invalid auth url")?;
+    let token_url = TokenUrl::new(
+        std::env::var("FLOX_OAUTH_TOKEN_URL").unwrap_or(env!("OAUTH_TOKEN_URL").to_string()),
+    )
+    .context("Invalid token url")?;
+    let device_auth_url = DeviceAuthorizationUrl::new(
+        std::env::var("FLOX_OAUTH_DEVICE_AUTH_URL")
+            .unwrap_or(env!("OAUTH_DEVICE_AUTH_URL").to_string()),
+    )
+    .context("Invalid device auth url")?;
+    let client_id = ClientId::new(
+        std::env::var("FLOX_OAUTH_CLIENT_ID").unwrap_or(env!("OAUTH_CLIENT_ID").to_string()),
     );
-    info!("And enter code: {}", flow.user_code.clone().unwrap());
-
-    thread::sleep(FIVE_SECONDS);
-
-    flow.poll(20).await
+    let client = BasicClient::new(client_id, None, auth_url, Some(token_url))
+        .set_device_authorization_url(device_auth_url);
+    Ok(client)
 }
 
-#[derive(Debug, Clone)]
-pub enum DeviceFlowState {
-    Pending,
-    Processing(time::Duration),
-    Success(Credential),
-    Failure(DeviceFlowError),
-}
+pub async fn authorize(client: BasicClient) -> Result<Credential> {
+    let details: StandardDeviceAuthorizationResponse = client
+                .exchange_device_code()
+                .unwrap()
+                // .add_scope(Scope::new("read".to_string()))
+                .request_async(oauth2::reqwest::async_http_client)
+                .await.context("Could not request device code")?;
 
-#[derive(Clone)]
-pub struct DeviceFlow {
-    pub host: String,
-    pub client_id: String,
-    pub user_code: Option<String>,
-    pub device_code: Option<String>,
-    pub verification_uri: Option<String>,
-    pub state: DeviceFlowState,
-}
+    debug!("Device code details: {details:#?}");
 
-const FIVE_SECONDS: time::Duration = time::Duration::new(5, 0);
+    eprintln!(
+        "Please visit {} in your browser",
+        details.verification_uri().as_str()
+    );
+    eprintln!("And enter code: {}", details.user_code().secret());
 
-impl DeviceFlow {
-    pub fn new(client_id: String, host: String) -> Self {
-        Self {
-            client_id,
-            host,
-            user_code: None,
-            device_code: None,
-            verification_uri: None,
-            state: DeviceFlowState::Pending,
-        }
-    }
+    let token_result = client
+        .exchange_device_access_token(&details)
+        .request_async(
+            oauth2::reqwest::async_http_client,
+            tokio::time::sleep,
+            Some(TOKEN_INPUT_TIMEOUT),
+        )
+        .await
+        .context("Could not authorize via oauth")?;
 
-    pub async fn start(
-        client_id: &str,
-        maybe_host: Option<String>,
-    ) -> Result<DeviceFlow, DeviceFlowError> {
-        let mut flow = DeviceFlow::new(
-            client_id.to_string(),
-            maybe_host.unwrap_or_else(|| "github.com".to_string()),
-        );
-
-        flow.setup().await;
-
-        match flow.state {
-            DeviceFlowState::Processing(_) => Ok(flow.to_owned()),
-            DeviceFlowState::Failure(err) => Err(err),
-            _ => Err(credential_error(
-                "Something truly unexpected happened".into(),
-            )),
-        }
-    }
-
-    pub async fn setup(&mut self) {
-        let body = format!("client_id={}", &self.client_id);
-        let entry_url = format!("https://{}/login/device/code", &self.host);
-
-        if let Some(res) = send_request(self, entry_url, body).await {
-            if res.contains_key("error") && res.contains_key("error_description") {
-                self.state = DeviceFlowState::Failure(credential_error(
-                    res["error_description"].as_str().unwrap().into(),
-                ))
-            } else if res.contains_key("error") {
-                self.state = DeviceFlowState::Failure(credential_error(format!(
-                    "Error response: {:?}",
-                    res["error"].as_str().unwrap()
-                )))
-            } else {
-                self.user_code = Some(String::from(res["user_code"].as_str().unwrap()));
-                self.device_code = Some(String::from(res["device_code"].as_str().unwrap()));
-                self.verification_uri =
-                    Some(String::from(res["verification_uri"].as_str().unwrap()));
-                self.state = DeviceFlowState::Processing(FIVE_SECONDS);
-            }
-        };
-    }
-
-    pub async fn poll(&mut self, iterations: u32) -> Result<Credential, DeviceFlowError> {
-        for count in 0..iterations {
-            self.update().await;
-
-            if let DeviceFlowState::Processing(interval) = self.state {
-                if count == iterations {
-                    return Err(credential_error("Max poll iterations reached".into()));
-                }
-
-                thread::sleep(interval);
-            } else {
-                break;
-            }
-        }
-
-        match &self.state {
-            DeviceFlowState::Success(cred) => Ok(cred.to_owned()),
-            DeviceFlowState::Failure(err) => Err(err.to_owned()),
-            _ => Err(credential_error(
-                "Unable to fetch credential, sorry :/".into(),
-            )),
-        }
-    }
-
-    pub async fn update(&mut self) {
-        let poll_url = format!("https://{}/login/oauth/access_token", self.host);
-        let poll_payload = format!(
-            "client_id={}&device_code={}&grant_type=urn:ietf:params:oauth:grant-type:device_code",
-            self.client_id,
-            &self.device_code.clone().unwrap()
-        );
-
-        if let Some(res) = send_request(self, poll_url, poll_payload).await {
-            if res.contains_key("error") {
-                match res["error"].as_str().unwrap() {
-                    "authorization_pending" => {},
-                    "slow_down" => {
-                        if let DeviceFlowState::Processing(current_interval) = self.state {
-                            self.state =
-                                DeviceFlowState::Processing(current_interval + FIVE_SECONDS);
-                        };
-                    },
-                    other_reason => {
-                        self.state = DeviceFlowState::Failure(credential_error(format!(
-                            "Error checking for token: {}",
-                            other_reason
-                        )));
-                    },
-                }
-            } else {
-                let mut this_credential = Credential::empty();
-                this_credential.token = res["access_token"].as_str().unwrap().to_string();
-
-                if let Some(expires_in) = res.get("expires_in") {
-                    this_credential.expiry = calculate_expiry(expires_in.as_i64().unwrap());
-                    this_credential.refresh_token =
-                        res["refresh_token"].as_str().unwrap().to_string();
-                }
-
-                self.state = DeviceFlowState::Success(this_credential);
-            }
-        }
-    }
+    Ok(Credential {
+        token: token_result.access_token().secret().to_string(),
+        expiry: calculate_expiry(token_result.expires_in().unwrap().as_secs() as i64),
+    })
 }
 
 fn calculate_expiry(expires_in: i64) -> String {
@@ -218,37 +94,6 @@ fn calculate_expiry(expires_in: i64) -> String {
     let mut expiry: DateTime<Utc> = Utc::now();
     expiry += expires_in;
     expiry.to_rfc3339()
-}
-
-pub fn credential_error(msg: String) -> DeviceFlowError {
-    DeviceFlowError::GitHubError(msg)
-}
-
-pub async fn send_request(
-    device_flow: &mut DeviceFlow,
-    url: String,
-    body: String,
-) -> Option<HashMap<String, serde_json::Value>> {
-    let client = reqwest::Client::new();
-    let response_struct = client
-        .post(&url)
-        .header("Accept", "application/json")
-        .body(body)
-        .send();
-
-    match response_struct.await {
-        Ok(resp) => match resp.json::<HashMap<String, serde_json::Value>>().await {
-            Ok(hm) => Some(hm),
-            Err(err) => {
-                device_flow.state = DeviceFlowState::Failure(err.into());
-                None
-            },
-        },
-        Err(err) => {
-            device_flow.state = DeviceFlowState::Failure(err.into());
-            None
-        },
-    }
 }
 
 /// floxHub authentication commands
@@ -266,14 +111,16 @@ pub enum Auth2 {
 impl Auth2 {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("auth2");
-        let client_id = env!("OAUTH_CLIENT_ID").to_string();
+
+        let client = create_oauth_client()?;
+
         match self {
             Auth2::Login => {
-                let cred = authorize(client_id, None)
+                let cred = authorize(client)
                     .await
                     .context("Could not authorize via oauth")?;
 
-                debug!("Credentials received: {:?}", cred);
+                debug!("Credentials received: {cred:#?}");
                 debug!("Writing token to config");
 
                 update_config(

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 use anyhow::{anyhow, bail, Context, Result};
 use bpaf::Bpaf;
 use crossterm::{cursor, QueueableCommand};
-use flox_rust_sdk::flox::{EnvironmentName, EnvironmentOwner, EnvironmentRef, Flox, GitHubClient};
+use flox_rust_sdk::flox::{Auth0Client, EnvironmentName, EnvironmentOwner, EnvironmentRef, Flox};
 use flox_rust_sdk::models::environment::managed_environment::{
     ManagedEnvironment,
     ManagedEnvironmentError,
@@ -570,8 +570,10 @@ impl Push {
                 let owner = if let Some(owner) = self.owner {
                     owner
                 } else {
-                    let client = GitHubClient::new(
-                        "https://api.github.com".to_string(),
+                    let base_url = std::env::var("FLOX_OAUTH_BASE_URL")
+                        .unwrap_or(env!("OAUTH_BASE_URL").to_string());
+                    let client = Auth0Client::new(
+                        base_url,
                         flox.floxhub_token.clone().context("Need to be logged in")?,
                     );
                     let user_name = client

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -197,6 +197,8 @@ impl FloxArgs {
             if !self.debug || !matches!(self.verbosity, Verbosity::Verbose(1..)) {
                 let _ = fs::remove_dir_all(&temp_dir_path);
             }
+
+            std::process::exit(130);
         });
 
         // command handled above

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -65,6 +65,9 @@
 
       # oauth client id
       OAUTH_CLIENT_ID = "Iv1.3b00a7bb5f910259";
+      OAUTH_AUTH_URL = "https://0.0.0.0";
+      OAUTH_TOKEN_URL = "https://0.0.0.0";
+      OAUTH_DEVICE_AUTH_URL = "https://0.0.0.0";
 
       # the libssh crate wants to use its own libssh prebuilts
       # or build libssh from source.

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -34,6 +34,8 @@
   envs = let
     # we need to pull all of the scripts in the mkEnv directory into /nix/store
     mkEnv = ../../assets/mkEnv;
+
+    auth0BaseUrl = "https://dev-j4tiszdm1f0b70xf.us.auth0.com";
   in
     {
       # 3rd party CLIs
@@ -64,10 +66,11 @@
       METRICS_EVENTS_API_KEY = "phc_z4dOADAPvpU9VNzCjDD3pIJuSuGTyagKdFWfjak838Y";
 
       # oauth client id
-      OAUTH_CLIENT_ID = "Iv1.3b00a7bb5f910259";
-      OAUTH_AUTH_URL = "https://0.0.0.0";
-      OAUTH_TOKEN_URL = "https://0.0.0.0";
-      OAUTH_DEVICE_AUTH_URL = "https://0.0.0.0";
+      OAUTH_CLIENT_ID = "s4BF6zGVcYh3gZUHwp6C4cGf3ey5Bwio";
+      OAUTH_BASE_URL = "${auth0BaseUrl}";
+      OAUTH_AUTH_URL = "${auth0BaseUrl}/authorize";
+      OAUTH_TOKEN_URL = "${auth0BaseUrl}/oauth/token";
+      OAUTH_DEVICE_AUTH_URL = "${auth0BaseUrl}/oauth/device/code";
 
       # the libssh crate wants to use its own libssh prebuilts
       # or build libssh from source.


### PR DESCRIPTION
## Proposed Changes

* refactor manual oauth authentication with [`oauth2` crate](https://crates.io/crates/oauth2)
* read username from auth0
* make auth endpoints configurable in build expression for flox (preferred) or at runtime through environment variables
  - FLOX_OAUTH_BASE_URL
    FLOX_OAUTH_CLIENT_ID
    FLOX_OAUTH_AUTH_URL
    FLOX_OAUTH_TOKEN_URL
    FLOX_OAUTH_DEVICE_AUTH_URL