### PR TITLE
fix: callPackage has an .override already

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
           inherit inputs self floxVersion;
           pkgsFor = final;
         });
-      genPkg = name: _: final.lib.makeOverridable (callPackage (./pkgs + ("/" + name))) {};
+      genPkg = name: _: callPackage (./pkgs + ("/" + name)) {};
     in
       builtins.mapAttrs genPkg (builtins.readDir ./pkgs);
 


### PR DESCRIPTION
## Proposed Changes

Use only callPackage, it [should already be overridable](https://github.com/NixOS/nixpkgs/blob/master/lib/customisation.nix#L192C34-L192C49). 

Quick testing:
```
nix build .#flox-tests .#flox-tests-end2end --json --extra-substituters s3://flox-store | jq .[].drvPath -r | xargs nix-diff --color always | grep -C1 TESTS_DIR
warning: Git tree '/home/tom/flox/flox/main' is dirty
warning: Git tree '/home/tom/flox/flox/main' is dirty
    Usage: $0 [--flox <FLOX BINARY>| -F <FLOX BINARY>] \
              [--tests <TESTS_DIR>| -T <TESTS_DIR>] \
              [--watch | -W] \
--
            -[fF]|--flox)         export FLOX_CLI="${2?}"; shift; ;;
            -[tT]|--tests)        export TESTS_DIR="${2?}"; shift; ;;
            -[wW]|--watch)        WATCH=:; ;;
--
        # Default flag values
        : "${TESTS_DIR:=$PWD/tests}";"${TESTS_DIR:=$PWD/tests/end2end}";
        export TESTS_DIR FLOX_CLI;

        if [[ "${#_TESTS[@]}" -lt 1 ]]; then
          _TESTS=( "$TESTS_DIR" );
        fi
--
          echo "  FLOX_CLI:     $FLOX_CLI";
          echo "  TESTS_DIR:    $TESTS_DIR";
          echo "  tests:        ${_TESTS[*]}";
--
        if [[ -n "${WATCH:-}" ]]; then
          find "$TESTS_DIR" "$FLOX_CLI"  \
            |entr -s "bats ${_BATS_ARGS[*]} ${_TESTS[*]}";
```

in-progress: let's see the CI tests!

## Release Notes
