### PR TITLE
fix: replace transaction .flox by copying

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -313,6 +313,10 @@ fn copy_dir_recursive(
     to: &impl AsRef<Path>,
     keep_permissions: bool,
 ) -> Result<(), std::io::Error> {
+    if !to.as_ref().exists() {
+        std::fs::create_dir(to).unwrap();
+    }
+
     for entry in WalkDir::new(from).into_iter().skip(1) {
         let entry = entry.unwrap();
         let new_path = to.as_ref().join(entry.path().strip_prefix(from).unwrap());


### PR DESCRIPTION
`fs::rename` requires both source and destination paths to be on the same file system. Since the project may be on any mount point on the system, it can not be guaranteed that restoring the .flox copy under transaction by renaming will succeed.

This change will finish the transaction by _copying_ back the modified .flox rather than trying to rename it.