### PR TITLE
feat: expose original closure

### DIFF
--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -201,5 +201,7 @@ in
       passthru.rustPlatform = rustPlatform;
       passthru.flox-bash = flox-bash;
       passthru.cargoDeps = cargoDepsArtifacts;
+      passthru.nixPatched = flox-bash.passthru.nixPatched;
+      passthru.pkgsFor = pkgsFor;
     }
     // envs)


### PR DESCRIPTION
This does mean some overrides will not work, but makes it far easier and reproducible to grab the original closure available to callPackage.

## Proposed Changes

- stores some values in passthru needed during installation
- prepares for flox-bash removal https://github.com/flox/flox/issues/336

## Release Notes
N/A