### PR TITLE
feat: recursively include propagatedBuildinputs paths

### DIFF
--- a/env-builder/src/buildenv.cc
+++ b/env-builder/src/buildenv.cc
@@ -218,6 +218,20 @@ buildEnvironment( const Path & out, Packages && pkgs )
       {
         if ( e.errNo != ENOENT && e.errNo != ENOTDIR ) { throw; }
       }
+
+    try
+      {
+        for ( const auto & p : tokenizeString<std::vector<std::string>>(
+                readFile( pkgDir + "/nix-support/propagated-build-inputs" ),
+                " \n" ) )
+          {
+            if ( ! done.count( p ) ) { postponed.insert( p ); }
+          }
+      }
+    catch ( SysError & e )
+      {
+        if ( e.errNo != ENOENT && e.errNo != ENOTDIR ) { throw; }
+      }
   };
 
   /* Symlink to the packages that have been installed explicitly by the user.
@@ -271,6 +285,7 @@ buildEnvironment( const Path & out, Packages && pkgs )
       postponed.swap( pkgDirs );
       for ( const auto & pkgDir : pkgDirs )
         {
+          printf( "postponed: %s\n", pkgDir.c_str() );
           addPkg( pkgDir, Priority { priorityCounter++ } );
         }
     }

--- a/env-builder/src/buildenv.cc
+++ b/env-builder/src/buildenv.cc
@@ -285,7 +285,6 @@ buildEnvironment( const Path & out, Packages && pkgs )
       postponed.swap( pkgDirs );
       for ( const auto & pkgDir : pkgDirs )
         {
-          printf( "postponed: %s\n", pkgDir.c_str() );
           addPkg( pkgDir, Priority { priorityCounter++ } );
         }
     }

--- a/env-builder/tests/build-env.bats
+++ b/env-builder/tests/build-env.bats
@@ -116,3 +116,22 @@ load setup_suite.bash
 
     assert_success
 }
+
+# --------------------------------------------------------------------------- #
+
+# bats test_tags=propagated
+@test "Environment includes propagated packages" {
+
+    cat $LOCKFILES/propagated/manifest.toml >&3
+
+    run "$ENV_BUILDER" build-env \
+        --lockfile "$(cat $LOCKFILES/propagated/manifest.lock)" \
+        --out-link "$BATS_TEST_TMPDIR/env"
+    assert_success
+
+    # environment contains anki
+    # -> which propagates beautifulsoup4
+    assert [ -f "$BATS_TEST_TMPDIR/env/lib/python3.10/site-packages/bs4/__init__.py" ]
+    # -> which propagates chardet
+    assert [ -f "$BATS_TEST_TMPDIR/env/lib/python3.10/site-packages/chardet/__init__.py" ]
+}


### PR DESCRIPTION
Read `nix-support/propagated-build-inputs` and add paths to environment.
This will also recursively do the same with already postponed paths.

closes flox/product#565