### PR TITLE
fix: drop pkgdb warm up

### DIFF
--- a/tests/activate/envVar.exp
+++ b/tests/activate/envVar.exp
@@ -4,6 +4,7 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_CLI)
 
+set timeout 5
 set cmd "$flox activate --dir $dir"
 spawn $flox activate --dir $dir
 expect {
@@ -13,7 +14,6 @@ expect {
       exit 1
     }
 }
-set timeout 20
 expect {
     -re "project.*\$" {}
     timeout {

--- a/tests/activate/hello.exp
+++ b/tests/activate/hello.exp
@@ -6,6 +6,7 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_CLI)
 
+set timeout 5
 set cmd "$flox activate --dir $dir"
 spawn $flox activate --dir $dir
 expect {
@@ -15,7 +16,6 @@ expect {
       exit 1
     }
 }
-set timeout 300
 expect {
     -re "project.*\$" {}
     timeout {

--- a/tests/activate/hook.exp
+++ b/tests/activate/hook.exp
@@ -4,6 +4,7 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_CLI)
 
+set timeout 5
 set cmd "$flox activate --dir $dir"
 spawn $flox activate --dir $dir
 expect {
@@ -13,7 +14,6 @@ expect {
       exit 1
     }
 }
-set timeout 10
 expect {
     "Welcome to your flox environment!" {}
     timeout {

--- a/tests/activate/rc.exp
+++ b/tests/activate/rc.exp
@@ -5,6 +5,7 @@ set dir [lindex $argv 0]
 set expected_output [lindex $argv 1]
 set flox $env(FLOX_CLI)
 
+set timeout 5
 set cmd "$flox activate --dir $dir"
 spawn $flox activate --dir $dir
 expect {
@@ -14,7 +15,6 @@ expect {
       exit 1
     }
 }
-set timeout 300
 expect {
     -re "project.*\$" {}
     timeout {

--- a/tests/environment-activate.bats
+++ b/tests/environment-activate.bats
@@ -74,17 +74,6 @@ env_is_activated() {
   echo "$is_activated";
 }
 
-# ---------------------------------------------------------------------------- #
-
-# `pkgdb lock` with no packages installed fetches a nixpkgs. With a package
-# installed, it also has to evaluate the package set.
-@test "warm up pkgdb" {
-  run $FLOX_CLI install -d "$PROJECT_DIR" hello;
-  assert_success;
-  assert_output --partial "✅ 'hello' installed to environment";
-  NIX_CONFIG="extra-experimental-features = flakes" "$PKGDB_BIN" manifest lock --ga-registry "$PROJECT_DIR/.flox/env/manifest.toml"
-  # "$BUILD_ENV_BIN" "$NIX_BIN" "$NIX_SYSTEM" "$PROJECT_DIR/.flox/env/manifest.lock" "$PROJECT_DIR/.flox/run/$PROJECT_NAME.$NIX_SYSTEM" "$ENV_FROM_LOCKFILE_PATH";
-}
 
 # ---------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Now that install performs a build, flox activate will be fast without warming up pkgdb. Also adjust timeouts since flox activate is faster.