### PR TITLE
feat: use last activated environment

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -158,13 +158,10 @@ impl Environment for ManagedEnvironment {
         Ok(self.out_link(flox))
     }
 
-    fn parent_path(&self) -> Result<String, EnvironmentError2> {
+    fn parent_path(&self) -> Result<PathBuf, EnvironmentError2> {
         let mut path = self.path.clone();
         if path.pop() {
-            let path = path
-                .to_str()
-                .ok_or(EnvironmentError2::PathNotString(path.clone()))?;
-            Ok(path.to_string())
+            Ok(path)
         } else {
             Err(EnvironmentError2::InvalidPath(path))
         }

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -49,6 +49,7 @@ pub const GCROOTS_DIR_NAME: &str = "run";
 pub const ENV_DIR_NAME: &str = "env";
 pub const FLOX_ENV_VAR: &str = "FLOX_ENV";
 pub const FLOX_ACTIVE_ENVIRONMENTS_VAR: &str = "FLOX_ACTIVE_ENVIRONMENTS";
+pub const FLOX_PROMPT_ENVIRONMENTS_VAR: &str = "FLOX_PROMPT_ENVIRONMENTS";
 
 pub enum InstalledPackage {
     Catalog(FloxTriple, CatalogEntry),

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -105,10 +105,11 @@ pub trait Environment {
 
     /// Directory containing .flox
     ///
-    /// This should not be used for anything internal, but it is stored in
-    /// FLOX_ACTIVE_ENVIRONMENTS and printed to users so that users don't have
-    /// to see the trailing .flox
-    fn parent_path(&self) -> Result<String, EnvironmentError2>;
+    /// For anything internal, path should be used instead. `parent_path` is
+    /// stored in FLOX_ACTIVE_ENVIRONMENTS and printed to users so that users
+    /// don't have to see the trailing .flox
+    /// TODO: figure out what to store for remote environments
+    fn parent_path(&self) -> Result<PathBuf, EnvironmentError2>;
 
     /// Returns the environment name
     fn name(&self) -> EnvironmentName;
@@ -399,8 +400,6 @@ pub enum EnvironmentError2 {
     },
     #[error("invalid internal state; couldn't remove last element from path: {0}")]
     InvalidPath(PathBuf),
-    #[error("couldn't convert path to string: {0}")]
-    PathNotString(PathBuf),
 }
 
 /// Copy a whole directory recursively ignoring the original permissions
@@ -496,22 +495,6 @@ pub fn find_dot_flox(initial_dir: &Path) -> Result<Option<PathBuf>, EnvironmentE
         }
     }
     Ok(None)
-}
-
-pub fn last_activated_environment() -> Option<PathBuf> {
-    match env::var(FLOX_ACTIVE_ENVIRONMENTS_VAR) {
-        Err(_) => None,
-        Ok(active_environments) if active_environments.is_empty() => None,
-        Ok(active_environments) => {
-            Some(PathBuf::from(
-                active_environments
-                    .split_once(':')
-                    .map(|(last, _)| last)
-                    // If there's no colon, only one environment is active.
-                    .unwrap_or(&active_environments),
-            ))
-        },
-    }
 }
 
 /// Returns the path to the manifest for the given environment and optionally the path to the lockfile

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -504,7 +504,7 @@ pub fn last_activated_environment() -> Option<PathBuf> {
         Ok(active_environments) => {
             Some(PathBuf::from(
                 active_environments
-                    .split_once(":")
+                    .split_once(':')
                     .map(|(last, _)| last)
                     // If there's no colon, only one environment is active.
                     .unwrap_or(&active_environments),

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -33,8 +33,8 @@ use super::{
     DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
     ENV_BUILDER_BIN,
+    GCROOTS_DIR_NAME,
     LOCKFILE_FILENAME,
-    PATH_ENV_GCROOTS_DIR_NAME,
 };
 use crate::flox::Flox;
 use crate::models::environment::{
@@ -186,7 +186,7 @@ impl<S: TransactionState> PathEnvironment<S> {
     /// this path doesn't guarantee that the current environment can be built,
     /// just that it built at some point in the past.
     fn out_link(&self, system: &System) -> Result<PathBuf, EnvironmentError2> {
-        let run_dir = self.path.join(PATH_ENV_GCROOTS_DIR_NAME);
+        let run_dir = self.path.join(GCROOTS_DIR_NAME);
         if !run_dir.exists() {
             std::fs::create_dir_all(&run_dir).map_err(EnvironmentError2::CreateGcRootDir)?;
         }
@@ -368,6 +368,18 @@ where
     async fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
         self.build(flox).await?;
         Ok(self.out_link(&flox.system)?)
+    }
+
+    fn parent_path(&self) -> Result<String, EnvironmentError2> {
+        let mut path = self.path.clone();
+        if path.pop() {
+            let path = path
+                .to_str()
+                .ok_or(EnvironmentError2::PathNotString(path.clone()))?;
+            Ok(path.to_string())
+        } else {
+            Err(EnvironmentError2::InvalidPath(path))
+        }
     }
 }
 

--- a/crates/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -370,13 +370,10 @@ where
         Ok(self.out_link(&flox.system)?)
     }
 
-    fn parent_path(&self) -> Result<String, EnvironmentError2> {
+    fn parent_path(&self) -> Result<PathBuf, EnvironmentError2> {
         let mut path = self.path.clone();
         if path.pop() {
-            let path = path
-                .to_str()
-                .ok_or(EnvironmentError2::PathNotString(path.clone()))?;
-            Ok(path.to_string())
+            Ok(path)
         } else {
             Err(EnvironmentError2::InvalidPath(path))
         }

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -65,7 +65,7 @@ impl Environment for RemoteEnvironment {
     }
 
     #[allow(unused)]
-    fn parent_path(&self) -> Result<String, EnvironmentError2> {
+    fn parent_path(&self) -> Result<PathBuf, EnvironmentError2> {
         todo!()
     }
 

--- a/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/crates/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -64,6 +64,11 @@ impl Environment for RemoteEnvironment {
         todo!()
     }
 
+    #[allow(unused)]
+    fn parent_path(&self) -> Result<String, EnvironmentError2> {
+        todo!()
+    }
+
     /// Returns the environment name
     #[allow(unused)]
     fn name(&self) -> EnvironmentName {

--- a/crates/flox/src/commands/auth.rs
+++ b/crates/flox/src/commands/auth.rs
@@ -64,7 +64,10 @@ pub async fn authorize(client: BasicClient) -> Result<Credential> {
         .unwrap()
         .add_scope(Scope::new("openid".to_string()))
         .add_scope(Scope::new("profile".to_string()))
-        .add_extra_param("audience".to_string(), "https://hub.flox.dev/api".to_string())
+        .add_extra_param(
+            "audience".to_string(),
+            "https://hub.flox.dev/api".to_string(),
+        )
         .request_async(oauth2::reqwest::async_http_client)
         .await
         .context("Could not request device code")?;

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -23,7 +23,7 @@ use flox_rust_sdk::models::environment::{
     DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
     FLOX_ACTIVE_ENVIRONMENTS_VAR,
-    FLOX_ENV_VAR,
+    FLOX_ENV_VAR, FLOX_PROMPT_ENVIRONMENTS_VAR,
 };
 use flox_rust_sdk::models::floxmetav2::FloxmetaV2Error;
 use flox_rust_sdk::models::manifest::list_packages;
@@ -229,7 +229,7 @@ impl Activate {
         // We don't have access to the current PS1 (it's not exported), so we
         // can't modify it. Instead set FLOX_PROMPT_ENVIRONMENTS and let the
         // activation script set PS1 based on that.
-        let flox_prompt_environments = env::var("FLOX_PROMPT_ENVIRONMENTS")
+        let flox_prompt_environments = env::var(FLOX_PROMPT_ENVIRONMENTS_VAR)
             .map_or(prompt_name.clone(), |prompt_environments| {
                 format!("{prompt_name} {prompt_environments}")
             });
@@ -252,7 +252,7 @@ impl Activate {
         };
         let mut command = Command::new(&shell);
         command
-            .env("FLOX_PROMPT_ENVIRONMENTS", flox_prompt_environments)
+            .env(FLOX_PROMPT_ENVIRONMENTS_VAR, flox_prompt_environments)
             .env(FLOX_ENV_VAR, &activation_path)
             .env(FLOX_ACTIVE_ENVIRONMENTS_VAR, flox_active_environments)
             .env(

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -236,7 +236,7 @@ impl Activate {
 
         // Add to FLOX_ACTIVE_ENVIRONMENTS so we can detect what environments are active.
         let parent_path = environment.parent_path()?;
-        if parent_path.contains(":") {
+        if parent_path.contains(':') {
             bail!("Cannot activate environment that contains ':' in its path: {parent_path}");
         }
         let flox_active_environments = env::var(FLOX_ACTIVE_ENVIRONMENTS_VAR)

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -67,7 +67,7 @@ impl Edit {
 
         let mut environment = self
             .environment
-            .to_concrete_environment(&flox)?
+            .to_concrete_environment(&flox, true)?
             .into_dyn_environment();
 
         match self.provided_manifest_contents()? {
@@ -170,7 +170,7 @@ pub struct Delete {
 impl Delete {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("delete");
-        match self.environment.to_concrete_environment(&flox)? {
+        match self.environment.to_concrete_environment(&flox, true)? {
             ConcreteEnvironment::Path(environment) => environment.delete()?,
             ConcreteEnvironment::Managed(environment) => environment.delete()?,
             ConcreteEnvironment::Remote(environment) => environment.delete()?,
@@ -196,7 +196,7 @@ impl Activate {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("activate");
 
-        let concrete_environment = self.environment.to_concrete_environment(&flox)?;
+        let concrete_environment = self.environment.to_concrete_environment(&flox, false)?;
 
         // TODO could move this to a pretty print method on the Environment trait?
         let prompt_name = match concrete_environment {
@@ -384,7 +384,7 @@ impl List {
 
         let env = self
             .environment
-            .to_concrete_environment(&flox)?
+            .to_concrete_environment(&flox, true)?
             .into_dyn_environment();
 
         let manifest_contents = env.manifest_content()?;
@@ -440,7 +440,7 @@ impl Install {
             self.packages.as_slice().join(", "),
             self.environment
         );
-        let concrete_environment = self.environment.to_concrete_environment(&flox)?;
+        let concrete_environment = self.environment.to_concrete_environment(&flox, true)?;
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
         let installation = environment.install(self.packages.clone(), &flox).await?;
@@ -479,7 +479,7 @@ impl Uninstall {
             self.packages.as_slice().join(", "),
             self.environment
         );
-        let concrete_environment = self.environment.to_concrete_environment(&flox)?;
+        let concrete_environment = self.environment.to_concrete_environment(&flox, true)?;
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
         let _ = environment.uninstall(self.packages.clone(), &flox).await?;
@@ -510,7 +510,7 @@ impl WipeHistory {
 
         let env = self
             .environment
-            .to_concrete_environment(&flox)?
+            .to_concrete_environment(&flox, true)?
             .into_dyn_environment();
 
         if env.delete_symlinks()? {

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -481,9 +481,9 @@ impl EnvironmentSelect {
         Self::open_pointer(flox, path, pointer)
     }
 
-    fn open_pointer(
+    fn open_env_pointer(
         flox: &Flox,
-        path: &PathBuf,
+        path: &Path,
         pointer: EnvironmentPointer,
     ) -> Result<ConcreteEnvironment> {
         let dot_flox_path = path.join(DOT_FLOX);

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -4,7 +4,7 @@ mod general;
 mod search;
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use anyhow::{Context, Result};
@@ -463,7 +463,7 @@ impl EnvironmentSelect {
                     },
                     (Some(activated), Err(_)) => Self::open_path(flox, &activated),
                     (None, Ok(current_dir_pointer)) => {
-                        Self::open_pointer(flox, &current_dir, current_dir_pointer)
+                        Self::open_env_pointer(flox, &current_dir, current_dir_pointer)
                     },
                     (None, Err(e)) => {
                         Err(e).context(format!("No environment found in {current_dir:?}"))?
@@ -478,7 +478,7 @@ impl EnvironmentSelect {
         let pointer = EnvironmentPointer::open(path)
             .with_context(|| format!("No environment found in {path:?}"))?;
 
-        Self::open_pointer(flox, path, pointer)
+        Self::open_env_pointer(flox, path, pointer)
     }
 
     fn open_env_pointer(

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -458,8 +458,12 @@ impl EnvironmentSelect {
                 let current_dir = env::current_dir().context("could not get current directory")?;
                 let maybe_current_pointer = EnvironmentPointer::open(&current_dir);
                 match (maybe_activated, maybe_current_pointer) {
-                    (Some(_activated), Ok(_current_dir_pointer)) => {
-                        todo!("needs design");
+                    (Some(activated), Ok(current_dir_pointer)) => {
+                        if activated == current_dir {
+                            Self::open_env_pointer(flox, &current_dir, current_dir_pointer)
+                        } else {
+                            todo!("needs design");
+                        }
                     },
                     (Some(activated), Err(_)) => Self::open_path(flox, &activated),
                     (None, Ok(current_dir_pointer)) => {

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -474,6 +474,7 @@ impl EnvironmentSelect {
         }
     }
 
+    /// Open an environment defined in `{path}/.flox`
     fn open_path(flox: &Flox, path: &PathBuf) -> Result<ConcreteEnvironment> {
         let pointer = EnvironmentPointer::open(path)
             .with_context(|| format!("No environment found in {path:?}"))?;
@@ -481,6 +482,9 @@ impl EnvironmentSelect {
         Self::open_env_pointer(flox, path, pointer)
     }
 
+    /// Open an environment defined in `{path}/.flox` with an already parsed pointer
+    ///
+    /// This is used directly when the env pointer was read previously during detection.
     fn open_env_pointer(
         flox: &Flox,
         path: &Path,

--- a/tests/environment-delete.bats
+++ b/tests/environment-delete.bats
@@ -65,5 +65,5 @@ dot_flox_exists() {
   assert_failure;
   run "$FLOX_CLI" delete;
   assert_failure;
-  assert_output --partial 'No environment found in "./"';
+  assert_output --partial "No environment found in \"$(pwd -P)\"";
 }

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -127,6 +127,17 @@ teardown() {
   assert_output --partial "couldn't uninstall 'hello', wasn't previously installed";
 }
 
+@test "'flox install' uses last activated environment" {
+  mkdir 1
+  "$FLOX_CLI" init --dir 1
+  
+  mkdir 2
+  "$FLOX_CLI" init --dir 2
+  
+  SHELL=bash run expect -d "$TESTS_DIR/install/last-activated.exp"
+  assert_success
+}
+
 @test "i5: download package when install command runs" {
   skip "Don't know how to test, check out-link created?"
 }

--- a/tests/install/last-activated.exp
+++ b/tests/install/last-activated.exp
@@ -1,0 +1,54 @@
+# Test 'flox install' uses last activated environment
+
+set flox $env(FLOX_CLI)
+
+# activate environment 1
+set timeout 5
+set cmd "$flox activate --dir 1"
+spawn $flox activate --dir 1
+expect {
+    "Building environment..." {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+expect {
+    -re "\[1\].*\$" {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+
+# activate environment 2
+set timeout 5
+set cmd "$flox activate --dir 2"
+send "$cmd\n"
+expect {
+    "Building environment..." {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+expect {
+    -re "\[2 1\].*\$" {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+
+# install hello and check it's installed to environment 2
+set cmd "$flox install hello"
+send "$cmd\n"
+expect {
+  -re "✅ 'hello' installed to environment 2 at .*2" {}
+  timeout {
+    puts stderr "Reached timeout running '$cmd'"
+    exit 1
+  }
+}
+
+exit 0


### PR DESCRIPTION
- Keep track of activated environments in FLOX_ACTIVE_ENVIRONMENTS.
- For environment commands, use the last activated environment when not in a directory that contains a .flox.
- Use the parent path of the .flox directory for confirmation messages printed to users.

This is part of https://github.com/flox/flox/issues/359, but it doesn't use last activated environment for search or show, and it doesn't implement handling for when there's an activated environment and a .flox in current directory.