### PR TITLE
fix: relax log level for metrics submit errors

### DIFF
--- a/crates/flox/src/utils/metrics.rs
+++ b/crates/flox/src/utils/metrics.rs
@@ -60,7 +60,7 @@ impl PosthogLayer {
             handle.block_on(async {
                 while let Ok(event) = rx.recv() {
                     if let Err(err) = add_metric(event.subcommand).await {
-                        error!("Error adding metric: {err}");
+                        debug!("Error adding metric: {err}");
                     }
                 }
             })


### PR DESCRIPTION
fixes #432 

\* With asterisk, sa the underlying error is _not_ fixed. Internal metrics issues are just not echoed directly to the user any longer.
