### PR TITLE
style: flat error messages

### DIFF
--- a/crates/flox/src/main.rs
+++ b/crates/flox/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fmt::{Debug, Display};
 use std::process::ExitCode;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use bpaf::{Args, Parser};
 use commands::{FloxArgs, Prefix, Version};
 use flox_rust_sdk::models::environment::init_global_manifest;
@@ -95,7 +95,12 @@ async fn main() -> ExitCode {
                 return e.downcast_ref::<FloxShellErrorCode>().unwrap().0;
             }
 
-            error!("{:?}", anyhow!(e));
+            let err_str = e
+                .chain()
+                .skip(1)
+                .fold(e.to_string(), |acc, cause| format!("{}: {}", acc, cause));
+
+            error!("{err_str}");
 
             ExitCode::from(1)
         },


### PR DESCRIPTION
flattens error chain:

flox uses standard tooling for error types, namely `thiserror` and `anyhow`

By default if given `#[source]`s in the error definitions this combination prints either _the  outermost_ error description when using `fmt::Display` or an error chain when using `fmt::Debug`.

flox always prints the debug representation 

The default error chain looks like this:

```
ERROR: locking manifest failed

     Caused by:
         0: resolution failure
         1: failed to resolve with old lockfile input
```

After a small uprising, with this PR the error would get flattened into

```
ERROR: locking manifest failed: resolution failure: failed to resolve with old lockfile input
```

As applications grow more complex, (e.g. see cargo) we can introduce filters stopping printing more low level errors if required. This is using the simplest possible error printing as a demonstration. We neither need to merge this as is or at all. 

