### PR TITLE
Change endpoint and API key used to push metrics

### DIFF
--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -228,7 +228,10 @@ pub struct Delete {
 impl Delete {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("delete");
-        match self.environment.detect_concrete_environment(&flox, "delete")? {
+        match self
+            .environment
+            .detect_concrete_environment(&flox, "delete")?
+        {
             ConcreteEnvironment::Path(environment) => environment.delete()?,
             ConcreteEnvironment::Managed(environment) => environment.delete()?,
             ConcreteEnvironment::Remote(environment) => environment.delete()?,
@@ -524,7 +527,9 @@ impl Install {
             self.packages.as_slice().join(", "),
             self.environment
         );
-        let concrete_environment = self.environment.detect_concrete_environment(&flox, "install to")?;
+        let concrete_environment = self
+            .environment
+            .detect_concrete_environment(&flox, "install to")?;
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
         let installation = environment.install(self.packages.clone(), &flox).await?;
@@ -563,7 +568,9 @@ impl Uninstall {
             self.packages.as_slice().join(", "),
             self.environment
         );
-        let concrete_environment = self.environment.detect_concrete_environment(&flox, "uninstall from")?;
+        let concrete_environment = self
+            .environment
+            .detect_concrete_environment(&flox, "uninstall from")?;
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
         let _ = environment.uninstall(self.packages.clone(), &flox).await?;

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -450,15 +450,12 @@ pub enum EnvironmentSelect {
 impl EnvironmentSelect {
     /// Open a concrete environment, not detecting the currently active
     /// environment.
-    /// 
+    ///
     /// Use this method for commands like `activate` that shouldn't change
     /// behavior based on whether an environment is already active. For example,
     /// `flox activate` should never re-activate the last activated environment;
     /// it should default to an environment in the current directory.
-    pub fn to_concrete_environment(
-        &self,
-        flox: &Flox,
-    ) -> Result<ConcreteEnvironment> {
+    pub fn to_concrete_environment(&self, flox: &Flox) -> Result<ConcreteEnvironment> {
         match self {
             EnvironmentSelect::Dir(path) => open_path(flox, path),
             // TODO: needs design - do we want to search up?
@@ -476,7 +473,7 @@ impl EnvironmentSelect {
     }
 
     /// Open a concrete environment, detecting the currently active environment.
-    /// 
+    ///
     /// Use this method for commands like `install` that should use the
     /// currently activated environment. For example, `flox install` should
     /// install to the last activated environment if there isn't an environment

--- a/crates/flox/src/utils/metrics.rs
+++ b/crates/flox/src/utils/metrics.rs
@@ -200,12 +200,13 @@ async fn push_metrics(metrics: Vec<MetricEntry>, uuid: Uuid) -> Result<()> {
         })
         .collect::<Result<Vec<serde_json::Value>>>()?;
 
-    reqwest::Client::new()
-        .post(METRICS_EVENTS_URL)
-        .json(&json!({
-            "api_key": METRICS_EVENTS_API_KEY,
-            "batch": events,
-        }))
+    let client = reqwest::Client::new();
+    let res = client
+        .put(METRICS_EVENTS_URL)
+        .header("content-type", "application/json")
+        .header("x-api-key", METRICS_EVENTS_API_KEY)
+        .header("user-agent", format!("flox-cli/{}", FLOX_VERSION))
+        .json(&events)
         .send()
         .await?;
 

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -56,8 +56,8 @@
       FLOX_RESOLVER_SRC = builtins.path {path = ../../resolver;};
 
       # Metrics subsystem configuration
-      METRICS_EVENTS_URL = "https://events.flox.dev/capture";
-      METRICS_EVENTS_API_KEY = "phc_z4dOADAPvpU9VNzCjDD3pIJuSuGTyagKdFWfjak838Y";
+      METRICS_EVENTS_URL = "https://z7qixlmjr3.execute-api.eu-north-1.amazonaws.com/prod/capture";
+      METRICS_EVENTS_API_KEY = "5pAQnBqz5Q7dpqVD9BEXQ4Kdc3D2fGTd3ZgP0XXK";
 
       # oauth client id
       OAUTH_CLIENT_ID = "s4BF6zGVcYh3gZUHwp6C4cGf3ey5Bwio";


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Change the API endpoint, and API key, used to push metrics that the flox CLI generates.
Used to be managed posthog, is now self-hosted on AWS.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->

closes: flox/product#479