### PR TITLE
fix: drop internal packages from devShells

### DIFF
--- a/shells/flox-pkgdb/default.nix
+++ b/shells/flox-pkgdb/default.nix
@@ -21,14 +21,15 @@
   lldb ? throw "`lldb' is required for debugging with `clang++'",
   valgrind ? throw "`valgrind' is required for memory sanitization on Linux",
   flox-pkgdb,
-  flox-pkgdb-tests-dev,
-  # Limit packages to only those required for building and testing `pkgdb' in CI.
+  # Limit packages to only those required for building and testing `pkgdb'
+  # in CI.
   # This includes Doxygen for generating docs, but excludes linting tools like
-  # `clang-tidy' and `include-what-you-use' which are only provided in the _full_
-  # interactive shell ( `ci = false' produces the _full_ interactive shell ).
+  # `clang-tidy' and `include-what-you-use' which are only provided in the
+  # _full_ interactive shell
+  # ( `ci = false' produces the _full_ interactive shell ).
   ci ? false,
 }: let
-  # ---------------------------------------------------------------------------- #
+  # -------------------------------------------------------------------------- #
   # For use in GitHub Actions and local development.
   ciPkgs = let
     batsWith = bats.withLibraries (libs: [
@@ -64,8 +65,6 @@
         then gdb
         else lldb
       )
-      # script to run tests
-      flox-pkgdb-tests-dev
     ]
     ++ (
       if stdenv.isLinux or false


### PR DESCRIPTION
- Removes dependence on _internal_ packages from `devShell`s.
- Adds _internal_ build-tree `bin/` directories to `PATH` in `devShell`s.

TODO:
- Fix `env-builder/Makefile` `pkgdb_CFLAGS` and `pkgdb_LDFLAGS`.
- Top level Makefile with `cargo` invocation.
