### PR TITLE
feat: detect environments in git repos

### DIFF
--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -22,6 +22,7 @@ use super::flox_package::FloxTriple;
 use super::manifest::{Manifest, TomlEditError};
 use super::pkgdb_errors::PkgDbError;
 use crate::flox::{EnvironmentRef, Flox};
+use crate::providers::git::{GitCommandOpenError, GitCommandProvider};
 use crate::utils::copy_file_without_permissions;
 use crate::utils::errors::IoError;
 
@@ -140,7 +141,7 @@ pub trait Environment {
 /// A pointer to an environment, either managed or path.
 /// This is used to determine the type of an environment at a given path.
 /// See [EnvironmentPointer::open].
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum EnvironmentPointer {
     /// Identifies an environment whose source of truth lies outside of the project itself
@@ -234,6 +235,7 @@ impl From<EnvironmentRef> for ManagedPointer {
 /// However, this type does not perform any validation of the referenced environment.
 /// Opening the environment with [ManagedEnvironment::open] or
 /// [PathEnvironment::open], could still fail.
+#[derive(Debug, PartialEq)]
 pub struct UninitializedEnvironment {
     pub path: PathBuf,
     pub pointer: EnvironmentPointer,
@@ -475,6 +477,8 @@ pub enum EnvironmentError2 {
         #[source]
         source: Box<EnvironmentError2>,
     },
+    #[error("error checking if in a git repo")]
+    DetectGitDirectory(#[source] GitCommandOpenError),
 }
 
 /// Copy a whole directory recursively ignoring the original permissions
@@ -553,7 +557,7 @@ pub fn find_dot_flox(
             path: initial_dir.to_path_buf(),
             source: e,
         })?;
-    let mut tentative_dot_flox = path.join(DOT_FLOX);
+    let tentative_dot_flox = path.join(DOT_FLOX);
     debug!(
         "looking for .flox: starting_path={}",
         tentative_dot_flox.display()
@@ -569,14 +573,33 @@ pub fn find_dot_flox(
         debug!(".flox found: path={}", tentative_dot_flox.display());
         return Ok(Some(pointer));
     }
-    // Search upwards for a .flox
-    while let Some(grandparent) = tentative_dot_flox.parent().and_then(|p| p.parent()) {
-        let grandparent_clone = grandparent.to_path_buf();
-        tentative_dot_flox = grandparent.join(DOT_FLOX);
+
+    // Check if we're in a git repo.
+    let toplevel =
+        match GitCommandProvider::toplevel(&path).map_err(EnvironmentError2::DetectGitDirectory)? {
+            None => return Ok(None),
+            Some(toplevel) => toplevel,
+        };
+
+    // We already checked the immediate child.
+    let parent = match path.parent() {
+        None => return Ok(None),
+        Some(parent) => parent,
+    };
+
+    for ancestor in parent.ancestors() {
+        // If we're above the git repo, return None.
+        // ancestor and toplevel have both been canonicalized.
+        if !ancestor.starts_with(&toplevel) {
+            return Ok(None);
+        }
+        let tentative_dot_flox = ancestor.join(DOT_FLOX);
+        debug!("looking for .flox: path={}", tentative_dot_flox.display());
+
         if tentative_dot_flox.exists() {
-            let pointer = UninitializedEnvironment::open(grandparent_clone).map_err(|err| {
+            let pointer = UninitializedEnvironment::open(ancestor).map_err(|err| {
                 EnvironmentError2::InvalidDotFlox {
-                    path: tentative_dot_flox.clone(),
+                    path: ancestor.to_path_buf(),
                     source: Box::new(err),
                 }
             })?;
@@ -591,7 +614,10 @@ pub fn find_dot_flox(
 mod test {
     use std::str::FromStr;
 
+    use pretty_assertions::assert_eq;
+
     use super::*;
+    use crate::providers::git::GitProvider;
 
     const MANAGED_ENV_JSON: &'_ str = r#"{
         "name": "name",
@@ -603,6 +629,14 @@ mod test {
         "name": "name",
         "version": 1
     }"#;
+
+    const MANAGED_ENV_POINTER: Lazy<EnvironmentPointer> = Lazy::new(|| {
+        EnvironmentPointer::Managed(ManagedPointer {
+            name: EnvironmentName::from_str("name").unwrap(),
+            owner: EnvironmentOwner::from_str("owner").unwrap(),
+            version: Version::<1> {},
+        })
+    });
 
     #[test]
     fn serializes_managed_environment_pointer() {
@@ -622,14 +656,7 @@ mod test {
     #[test]
     fn deserializes_managed_environment_pointer() {
         let managed_pointer: EnvironmentPointer = serde_json::from_str(MANAGED_ENV_JSON).unwrap();
-        assert_eq!(
-            managed_pointer,
-            EnvironmentPointer::Managed(ManagedPointer {
-                name: EnvironmentName::from_str("name").unwrap(),
-                owner: EnvironmentOwner::from_str("owner").unwrap(),
-                version: Version::<1> {},
-            })
-        );
+        assert_eq!(managed_pointer, *MANAGED_ENV_POINTER);
     }
 
     #[test]
@@ -658,54 +685,181 @@ mod test {
         );
     }
 
-    // #[test]
-    // fn discovers_immediate_child_dot_flox() {
-    //     let temp_dir = tempfile::tempdir().unwrap();
-    //     let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
-    //     std::fs::create_dir_all(&actual_dot_flox).unwrap();
-    //     let found_dot_flox = find_dot_flox(temp_dir.path())
-    //         .unwrap()
-    //         .expect("expected to find dot flox");
-    //     assert_eq!(found_dot_flox, actual_dot_flox.canonicalize().unwrap());
-    // }
+    #[test]
+    fn errors_immediate_child_invalid() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
+        std::fs::create_dir_all(&actual_dot_flox).unwrap();
+        assert!(matches!(
+            find_dot_flox(temp_dir.path()),
+            Err(EnvironmentError2::InvalidDotFlox { .. })
+        ))
+    }
 
-    // #[test]
-    // fn discovers_existing_upwards_dot_flox() {
-    //     let temp_dir = tempfile::tempdir().unwrap();
-    //     let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
-    //     let start_path = actual_dot_flox.join("foo").join("bar");
-    //     std::fs::create_dir_all(&start_path).unwrap();
-    //     let found_dot_flox = find_dot_flox(&start_path)
-    //         .unwrap()
-    //         .expect("expected to find dot flox");
-    //     assert_eq!(found_dot_flox, actual_dot_flox.canonicalize().unwrap());
-    // }
+    #[test]
+    fn discovers_immediate_child_dot_flox() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
+        std::fs::create_dir_all(&actual_dot_flox).unwrap();
 
-    // #[test]
-    // fn discovers_adjacent_dot_flox() {
-    //     let temp_dir = tempfile::tempdir().unwrap();
-    //     let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
-    //     std::fs::create_dir_all(&actual_dot_flox).unwrap();
-    //     let found_dot_flox = find_dot_flox(&actual_dot_flox)
-    //         .unwrap()
-    //         .expect("expected to find dot flox");
-    //     assert_eq!(found_dot_flox, actual_dot_flox.canonicalize().unwrap());
-    // }
+        fs::write(
+            actual_dot_flox.join(ENVIRONMENT_POINTER_FILENAME),
+            serde_json::to_string_pretty(&*MANAGED_ENV_POINTER).unwrap(),
+        )
+        .unwrap();
 
-    // #[test]
-    // fn no_error_on_discovering_nonexistent_dot_flox() {
-    //     let temp_dir = tempfile::tempdir().unwrap();
-    //     let start_path = temp_dir.path().join("foo").join("bar");
-    //     std::fs::create_dir_all(&start_path).unwrap();
-    //     let found_dot_flox = find_dot_flox(&start_path).unwrap();
-    //     assert_eq!(found_dot_flox, None);
-    // }
+        let found_environment = find_dot_flox(temp_dir.path())
+            .unwrap()
+            .expect("expected to find dot flox");
+        assert_eq!(found_environment, UninitializedEnvironment {
+            path: temp_dir.path().canonicalize().unwrap(),
+            pointer: (*MANAGED_ENV_POINTER).clone()
+        });
+    }
+
+    /// An environment is found upwards, but only if it is within a git repo.
+    #[test]
+    fn discovers_existing_upwards_dot_flox() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
+        let start_path = actual_dot_flox.join("foo").join("bar");
+        std::fs::create_dir_all(&start_path).unwrap();
+        fs::write(
+            actual_dot_flox.join(ENVIRONMENT_POINTER_FILENAME),
+            serde_json::to_string_pretty(&*MANAGED_ENV_POINTER).unwrap(),
+        )
+        .unwrap();
+
+        let found_environment = find_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environment, None);
+
+        GitCommandProvider::init(temp_dir.path(), false).unwrap();
+
+        let found_environment = find_dot_flox(temp_dir.path())
+            .unwrap()
+            .expect("expected to find dot flox");
+        assert_eq!(found_environment, UninitializedEnvironment {
+            path: temp_dir.path().canonicalize().unwrap(),
+            pointer: (*MANAGED_ENV_POINTER).clone()
+        });
+    }
+
+    /// An environment is found upwards and adjacent, but only if it is within
+    /// a git repo.
+    ///
+    /// .
+    /// ├── .flox
+    /// │   └── env.json
+    /// └── foo
+    ///     └── bar
+    #[test]
+    fn discovers_upwards_adjacent_dot_flox() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
+        std::fs::create_dir_all(&actual_dot_flox).unwrap();
+        let start_path = temp_dir.path().join("foo").join("bar");
+        std::fs::create_dir_all(&start_path).unwrap();
+        fs::write(
+            actual_dot_flox.join(ENVIRONMENT_POINTER_FILENAME),
+            serde_json::to_string_pretty(&*MANAGED_ENV_POINTER).unwrap(),
+        )
+        .unwrap();
+
+        let found_environment = find_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environment, None);
+
+        GitCommandProvider::init(temp_dir.path(), false).unwrap();
+
+        let found_environment = find_dot_flox(&start_path)
+            .unwrap()
+            .expect("expected to find dot flox");
+        assert_eq!(found_environment, UninitializedEnvironment {
+            path: temp_dir.path().canonicalize().unwrap(),
+            pointer: (*MANAGED_ENV_POINTER).clone()
+        });
+    }
+
+    /// An environment is found upwards and adjacent when it is a subdirectory
+    /// of a git repo.
+    ///
+    /// .
+    /// ├── .git
+    /// └── foo
+    ///     ├── .flox
+    ///     │   └── env.json
+    ///     └── bar
+    #[test]
+    fn discovers_upwards_git_subdirectory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path();
+        let foo = path.join("foo");
+        let actual_dot_flox = foo.join(DOT_FLOX);
+        std::fs::create_dir_all(&actual_dot_flox).unwrap();
+        let start_path = foo.join("bar");
+        std::fs::create_dir_all(&start_path).unwrap();
+        fs::write(
+            actual_dot_flox.join(ENVIRONMENT_POINTER_FILENAME),
+            serde_json::to_string_pretty(&*MANAGED_ENV_POINTER).unwrap(),
+        )
+        .unwrap();
+
+        let found_environment = find_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environment, None);
+
+        GitCommandProvider::init(path, false).unwrap();
+
+        let found_environment = find_dot_flox(&start_path)
+            .unwrap()
+            .expect("expected to find dot flox");
+        assert_eq!(found_environment, UninitializedEnvironment {
+            path: foo.canonicalize().unwrap(),
+            pointer: (*MANAGED_ENV_POINTER).clone()
+        });
+    }
+
+    /// An environment above a git repo is not found.
+    ///
+    /// .
+    /// ├── .flox
+    /// │   └── env.json
+    /// └── foo
+    ///     ├── .git
+    ///     └── bar
+    #[test]
+    fn does_not_discover_above_git_repo() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path();
+        let foo = path.join("foo");
+        let actual_dot_flox = path.join(DOT_FLOX);
+        std::fs::create_dir_all(&actual_dot_flox).unwrap();
+        let start_path = foo.join("bar");
+        std::fs::create_dir_all(&start_path).unwrap();
+        fs::write(
+            actual_dot_flox.join(ENVIRONMENT_POINTER_FILENAME),
+            serde_json::to_string_pretty(&*MANAGED_ENV_POINTER).unwrap(),
+        )
+        .unwrap();
+
+        GitCommandProvider::init(foo, false).unwrap();
+
+        let found_environment = find_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environment, None);
+    }
+
+    #[test]
+    fn no_error_on_discovering_nonexistent_dot_flox() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let start_path = temp_dir.path().join("foo").join("bar");
+        std::fs::create_dir_all(&start_path).unwrap();
+        let found_environment = find_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environment, None);
+    }
 
     #[test]
     fn error_when_discovering_dot_flox_in_nonexistent_directory() {
         let temp_dir = tempfile::tempdir().unwrap();
         let start_path = temp_dir.path().join("foo").join("bar");
-        let found_dot_flox = find_dot_flox(&start_path);
-        assert!(found_dot_flox.is_err());
+        let found_environment = find_dot_flox(&start_path);
+        assert!(found_environment.is_err());
     }
 }

--- a/crates/flox-rust-sdk/src/models/environment/mod.rs
+++ b/crates/flox-rust-sdk/src/models/environment/mod.rs
@@ -582,15 +582,11 @@ pub fn find_dot_flox(
         };
 
     // We already checked the immediate child.
-    let parent = match path.parent() {
-        None => return Ok(None),
-        Some(parent) => parent,
-    };
-
-    for ancestor in parent.ancestors() {
+    for ancestor in parent.ancestors().skip(1) {
         // If we're above the git repo, return None.
         // ancestor and toplevel have both been canonicalized.
         if !ancestor.starts_with(&toplevel) {
+            debug!("git boundary reached: path={}", ancestor.display());
             return Ok(None);
         }
         let tentative_dot_flox = ancestor.join(DOT_FLOX);

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -226,11 +226,10 @@ impl GitCommandProvider {
     }
 
     /// Check if repo is bare. This will error if not in a git repo.
-    fn is_bare(
-        options: &GitCommandOptions,
+    fn is_bare_repo(
         path: impl AsRef<Path>,
     ) -> Result<bool, GitCommandOpenError> {
-        let mut command = options.new_command();
+        let mut command = GitCommandOptions::default().new_command();
         command
             .args(["-C", path.as_ref().to_str().unwrap()])
             .arg("rev-parse")

--- a/crates/flox-rust-sdk/src/providers/git.rs
+++ b/crates/flox-rust-sdk/src/providers/git.rs
@@ -226,9 +226,7 @@ impl GitCommandProvider {
     }
 
     /// Check if repo is bare. This will error if not in a git repo.
-    fn is_bare_repo(
-        path: impl AsRef<Path>,
-    ) -> Result<bool, GitCommandOpenError> {
+    fn is_bare_repo(path: impl AsRef<Path>) -> Result<bool, GitCommandDiscoverError> {
         let mut command = GitCommandOptions::default().new_command();
         command
             .args(["-C", path.as_ref().to_str().unwrap()])
@@ -247,54 +245,12 @@ impl GitCommandProvider {
         Ok(bare)
     }
 
-    /// Return canonicalized path to toplevel of a containing git repo, or None
-    /// if in a bare repo or not in a git repo.
-    pub fn toplevel(path: impl AsRef<Path>) -> Result<Option<PathBuf>, GitCommandOpenError> {
-        let options = GitCommandOptions::new();
-
-        // Check if path is even a git repo.
-        let mut command = options.new_command();
-        command
-            .args(["-C", path.as_ref().to_str().unwrap()])
-            .arg("rev-parse");
-
-        let out_str = GitCommandProvider::run_command(&mut command);
-        match out_str {
-            // Not a git repo
-            Err(GitCommandError::BadExit(128, _, _)) => return Ok(None),
-            // Error checking whether path is a git repo
-            Err(e) => Err(e)?,
-            Ok(_) => (),
-        }
-
-        if Self::is_bare(&options, &path)? {
-            Ok(None)
-        } else {
-            let mut command = options.new_command();
-            command
-                .args(["-C", path.as_ref().to_str().unwrap()])
-                .arg("rev-parse")
-                .arg("--show-toplevel");
-            let toplevel = GitCommandProvider::run_command(&mut command)?;
-            let toplevel = toplevel
-                .to_str()
-                .ok_or(GitCommandDiscoverError::GitDirEncoding)?
-                .trim();
-
-            Ok(Some(
-                PathBuf::from(toplevel)
-                    .canonicalize()
-                    .map_err(GitCommandOpenError::Canonicalize)?,
-            ))
-        }
-    }
-
     /// Open a repo, erroring if `path` is not a repo or is a subdirectory of a repo
     pub fn open_with<P: AsRef<Path>>(
         options: GitCommandOptions,
         path: P,
     ) -> Result<Self, GitCommandOpenError> {
-        let bare = Self::is_bare(&options, &path)?;
+        let bare = Self::is_bare_repo(&path)?;
 
         // resolved and canonicalized path to the git repo
         let resolved_path = {
@@ -621,23 +577,11 @@ impl GitProvider for GitCommandProvider {
     type ShowError = GitCommandError;
 
     /// Discover a git repository at `path` and return a provider with default options
+    ///
+    /// Use DiscoverError::not_found() to check if the path is not a git repo.
     fn discover<P: AsRef<Path>>(path: P) -> Result<Self, Self::DiscoverError> {
         let options = GitCommandOptions::default();
-        let out_str = GitCommandProvider::run_command(
-            options
-                .new_command()
-                .current_dir(&path)
-                .arg("rev-parse")
-                .arg("--is-bare-repository"),
-        )?
-        .to_str()
-        .ok_or(GitCommandDiscoverError::GitDirEncoding)?
-        .to_string();
-
-        let bare = out_str
-            .trim()
-            .parse::<bool>()
-            .map_err(|_| GitCommandDiscoverError::UnexpectedOutput(out_str))?;
+        let bare = Self::is_bare_repo(&path)?;
 
         if bare {
             return Ok(GitCommandProvider {
@@ -958,6 +902,8 @@ pub mod tests {
 
     use std::fs;
 
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     /// A provider with path set to /does-not-exist for use in tests
@@ -984,39 +930,57 @@ pub mod tests {
     }
 
     #[test]
-    fn toplevel() {
+    fn discover() {
         let (_, tempdir_handle) = init_temp_repo(false);
-        let path = tempdir_handle.path().to_path_buf();
+        let path = tempdir_handle.path().canonicalize().unwrap();
         assert_eq!(
-            GitCommandProvider::toplevel(&path).unwrap(),
-            Some(path.canonicalize().unwrap())
+            GitCommandProvider::discover(&path).unwrap(),
+            GitCommandProvider {
+                options: GitCommandOptions::default(),
+                workdir: Some(path.clone()),
+                path
+            }
         );
     }
 
     #[test]
-    fn toplevel_subdirectory() {
+    fn discover_subdirectory() {
         let (_, tempdir_handle) = init_temp_repo(false);
-        let path = tempdir_handle.path().to_path_buf();
+        let path = tempdir_handle.path().canonicalize().unwrap();
         let subdirectory = path.join("subdirectory");
         std::fs::create_dir(&subdirectory).unwrap();
         assert_eq!(
-            GitCommandProvider::toplevel(&subdirectory).unwrap(),
-            Some(path.canonicalize().unwrap())
+            GitCommandProvider::discover(&subdirectory).unwrap(),
+            GitCommandProvider {
+                options: GitCommandOptions::default(),
+                workdir: Some(path.clone()),
+                path
+            }
         );
     }
 
     #[test]
-    fn toplevel_bare() {
+    fn discover_bare() {
         let (_, tempdir_handle) = init_temp_repo(true);
         let path = tempdir_handle.path().to_path_buf();
-        assert_eq!(GitCommandProvider::toplevel(&path).unwrap(), None);
+        assert_eq!(
+            GitCommandProvider::discover(&path).unwrap(),
+            GitCommandProvider {
+                options: GitCommandOptions::default(),
+                workdir: None,
+                path
+            }
+        );
     }
 
     #[test]
-    fn toplevel_not_git_repo() {
+    fn discover_not_git_repo() {
         let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
         let path = tempdir_handle.path().to_path_buf();
-        assert_eq!(GitCommandProvider::toplevel(&path).unwrap(), None);
+        assert!(GitCommandProvider::discover(path)
+            .err()
+            .unwrap()
+            .not_found());
     }
 
     #[test]
@@ -1076,13 +1040,13 @@ pub mod tests {
 
     #[test]
     fn test_open_nonexistent() {
+        let a = GitCommandProvider::open(PathBuf::from("/does-not-exist"));
+        println!("{:?}", a);
         assert!(matches!(
             GitCommandProvider::open(PathBuf::from("/does-not-exist")),
-            Err(GitCommandOpenError::Command(GitCommandError::BadExit(
-                128,
-                _,
-                _
-            ))),
+            Err(GitCommandOpenError::Discover(
+                GitCommandDiscoverError::Command(GitCommandError::BadExit(128, _, _))
+            )),
         ));
     }
 

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -523,7 +523,7 @@ pub fn detect_environment(message: &str) -> Result<Option<UninitializedEnvironme
         // If there's both an activated environment and an environment in the
         // current directory or git repo, prompt for which to use.
         (Some(activated_path), Some(found)) => {
-            let activated = UninitializedEnvironment::open(&activated_path)?;
+            let activated = UninitializedEnvironment::open(activated_path)?;
             let type_of_directory = if found.path == current_dir {
                 "current directory's flox environment"
             } else {

--- a/tests/environment-install.bats
+++ b/tests/environment-install.bats
@@ -149,6 +149,19 @@ teardown() {
   assert_success
 }
 
+@test "'flox install' prompts when an environment is activated and there is an environment in the containing git repo" {
+  mkdir 1
+  "$FLOX_CLI" init --dir 1
+
+  mkdir 2
+  "$FLOX_CLI" init --dir 2
+  git -C 2 init
+  mkdir 2/subdirectory
+
+  SHELL=bash run expect -d "$TESTS_DIR/install/prompt-which-environment-git.exp"
+  assert_success
+}
+
 @test "i5: download package when install command runs" {
   skip "Don't know how to test, check out-link created?"
 }

--- a/tests/install/prompt-which-environment-git.exp
+++ b/tests/install/prompt-which-environment-git.exp
@@ -1,0 +1,71 @@
+# Test 'flox install' prompts when an environment is activated and there is an environment in the containing git repo
+
+set flox $env(FLOX_CLI)
+
+# activate environment 1
+set timeout 5
+set cmd "$flox activate --dir 1"
+spawn $flox activate --dir 1
+expect {
+    "Building environment..." {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+expect {
+    -re "\[1\].*\$" {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+
+# cd to directory 2/subdirectory
+set cmd "cd 2/subdirectory"
+send "$cmd\n"
+expect {
+    -re "\[1\].*\$" {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+
+# install hello and expect an interactive prompt
+set cmd "$flox install hello"
+send "$cmd\n"
+expect {
+    "Do you want to install to the flox environment detected in git repo or the current active flox environment?" {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+expect {
+    -re {flox environment detected in git repo \[2 at .*2\]} {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+expect {
+    -re {current active flox environment \[1 at .*1\]} {}
+    timeout {
+      puts stderr "Reached timeout running '$cmd'"
+      exit 1
+    }
+}
+
+# choose the first option and expect the corresponding installation
+send "\r"
+# install hello and check it's installed to environment 2
+expect {
+  -re "✅ 'hello' installed to environment 2 at .*2" {}
+  timeout {
+    puts stderr "Reached timeout running '$cmd'"
+    exit 1
+  }
+}
+
+exit 0

--- a/tests/package-search.bats
+++ b/tests/package-search.bats
@@ -368,7 +368,7 @@ setup_file() {
 @test "'flox search' prompts when an environment is activated and there is an environment in the current directory" {
   # Set up two environments locked to different revisions of nixpkgs, and
   # confirm that flox show displays different versions of nodejs for each.
-  
+
   mkdir 1
   pushd 1
   "$FLOX_CLI" init
@@ -379,14 +379,14 @@ setup_file() {
   assert_success;
   assert_output '    nodejs - nodejs@18.16.0';
   popd
-  
+
 
   mkdir 2
   pushd 2
   "$FLOX_CLI" init
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
     "$FLOX_CLI" install nodejs
-  
+
   run --separate-stderr sh -c "$FLOX_CLI show nodejs|tail -n1";
   assert_success;
   assert_output '    nodejs - nodejs@18.17.1';


### PR DESCRIPTION
Instead of searching up for flox environments all the way to `/`, only search up if in a git repo, and only search up to the top of the git repo.

Additionally, change prompt wording when an environment is detected in a git repo but it is not in the current directory:
```
? Do you want to search for packages using the flox environment detected in git repo or the current active flox environment?
> flox environment detected in git repo [name at path]
  current active flox environment [name at path]
[↑↓ to move, enter to select, type to filter]
```