### PR TITLE
ci: extend timeout for python in case under load

### DIFF
--- a/tests/end2end/python.exp
+++ b/tests/end2end/python.exp
@@ -95,7 +95,7 @@ expect {
       exit 1
     }
 }
-set timeout 10
+set timeout 30
 send "python3 -m venv env\n"
 expect {
     -re "flox .*\\\[project-\\d+\\\]" {}
@@ -106,7 +106,6 @@ expect {
 }
 
 # create python virtualenv
-set timeout 30
 send "./env/bin/pip install requests\n"
 expect {
     -re "Collecting requests" {}


### PR DESCRIPTION
## Proposed Changes
Juggle the python timeout tests. Possible that when the builder is under load this takes a bit of time. Better would be to run this via the same scheduler as builds so there is a limited concurrency.

## Release Notes
N/A