### PR TITLE
fix: init and flox CLI syntax fixes 

### DIFF
--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -426,7 +426,6 @@ impl Init {
 
             Search and install packages with `flox search <packagename>` and `flox install <packagename>`
             Enter the environment with `flox activate`
-
             "},
             name = env.name(),
             system = flox.system

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -424,8 +424,9 @@ impl Init {
             indoc::indoc! {"
             ✨ created environment {name} ({system})
 
-            Enter the environment with `flox activate`
             Search and install packages with `flox search <packagename>` and `flox install <packagename>`
+            Enter the environment with `flox activate`
+
             "},
             name = env.name(),
             system = flox.system

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -424,8 +424,8 @@ impl Init {
             indoc::indoc! {"
             ✨ created environment {name} ({system})
 
-            Enter the environment with \"flox activate\"
-            Search and install packages with \"flox search {{packagename}}\" and \"flox install {{packagename}}\"
+            Enter the environment with `flox activate`
+            Search and install packages with `flox search <packagename>` and `flox install <packagename>`
             "},
             name = env.name(),
             system = flox.system

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -428,7 +428,6 @@ impl Init {
               $ flox search <package>    <- Search for a package
               $ flox install <package>   <- Install a package into environment
               $ flox activate            <- Enter the environment
-            
             "},
             name = env.name(),
             system = flox.system

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -426,7 +426,7 @@ impl Init {
 
             Next:
               $ flox search <package>    <- Search for a package
-              $ flox install <package>   <- Install a package into environment
+              $ flox install <package>   <- Install a package into an environment
               $ flox activate            <- Enter the environment
             "},
             name = env.name(),

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -424,8 +424,11 @@ impl Init {
             indoc::indoc! {"
             ✨ created environment {name} ({system})
 
-            Search and install packages with `flox search <packagename>` and `flox install <packagename>`
-            Enter the environment with `flox activate`
+            Next:
+              $ flox search <package>    <- Search for a package
+              $ flox install <package>   <- Install a package into environment
+              $ flox activate            <- Enter the environment
+            
             "},
             name = env.name(),
             system = flox.system

--- a/crates/flox/src/commands/environment.rs
+++ b/crates/flox/src/commands/environment.rs
@@ -422,7 +422,7 @@ impl Init {
 
         println!(
             indoc::indoc! {"
-            ✨ created environment {name} ({system})
+            ✨ Created environment {name} ({system})
 
             Next:
               $ flox search <package>    <- Search for a package

--- a/crates/flox/src/commands/mod.rs
+++ b/crates/flox/src/commands/mod.rs
@@ -54,9 +54,9 @@ static FLOX_WELCOME_MESSAGE: Lazy<String> = Lazy::new(|| {
 
     Usage: flox OPTIONS (init|activate|search|install|...) [--help]
 
-    Use "flox --help" for full list of commands and more information
+    Use `flox --help` for full list of commands and more information
 
-    First time? Create an environment with "flox init"
+    First time? Create an environment with `flox init`
 "#}
 });
 

--- a/crates/flox/src/commands/search.rs
+++ b/crates/flox/src/commands/search.rs
@@ -197,7 +197,7 @@ fn render_search_results_user_facing(
         writeln!(&mut writer, "{package:<column_width$}  {desc}")?;
     }
     writer.flush().context("couldn't flush search results")?;
-    eprintln!("\nUse `flox show {{package}}` to see available versions");
+    eprintln!("\nUse `flox show <package>` to see available versions");
     Ok(())
 }
 

--- a/tests/environment-init.bats
+++ b/tests/environment-init.bats
@@ -102,7 +102,7 @@ teardown() {
 
 Next:
   $ flox search <package>    <- Search for a package
-  $ flox install <package>   <- Install a package into environment
+  $ flox install <package>   <- Install a package into an environment
   $ flox activate            <- Enter the environment
 EOF
 

--- a/tests/environment-init.bats
+++ b/tests/environment-init.bats
@@ -100,8 +100,8 @@ teardown() {
   assert_output - <<EOF
 ✨ created environment test ($NIX_SYSTEM)
 
-Enter the environment with "flox activate"
-Search and install packages with "flox search {packagename}" and "flox install {packagename}"
+Enter the environment with `flox activate`
+Search and install packages with `flox search <packagename>` and `flox install <packagename>`
 EOF
 
 }

--- a/tests/environment-init.bats
+++ b/tests/environment-init.bats
@@ -100,8 +100,8 @@ teardown() {
   assert_output - <<EOF
 ✨ created environment test ($NIX_SYSTEM)
 
-Enter the environment with `flox activate`
 Search and install packages with `flox search <packagename>` and `flox install <packagename>`
+Enter the environment with `flox activate`
 EOF
 
 }

--- a/tests/environment-init.bats
+++ b/tests/environment-init.bats
@@ -101,7 +101,7 @@ teardown() {
 ✨ created environment test ($NIX_SYSTEM)
 
 Search and install packages with \`flox search <packagename>\` and \`flox install <packagename>\`
-Enter the environment with `flox activate`
+Enter the environment with \`flox activate\`
 EOF
 
 }

--- a/tests/environment-init.bats
+++ b/tests/environment-init.bats
@@ -100,7 +100,7 @@ teardown() {
   assert_output - <<EOF
 ✨ created environment test ($NIX_SYSTEM)
 
-Search and install packages with `flox search <packagename>` and `flox install <packagename>`
+Search and install packages with \`flox search <packagename>\` and \`flox install <packagename>\`
 Enter the environment with `flox activate`
 EOF
 

--- a/tests/environment-init.bats
+++ b/tests/environment-init.bats
@@ -98,10 +98,12 @@ teardown() {
   assert_success
 
   assert_output - <<EOF
-✨ created environment test ($NIX_SYSTEM)
+✨ Created environment test ($NIX_SYSTEM)
 
-Search and install packages with \`flox search <packagename>\` and \`flox install <packagename>\`
-Enter the environment with \`flox activate\`
+Next:
+  $ flox search <package>    <- Search for a package
+  $ flox install <package>   <- Install a package into environment
+  $ flox activate            <- Enter the environment
 EOF
 
 }

--- a/tests/package-search.bats
+++ b/tests/package-search.bats
@@ -46,7 +46,7 @@ teardown() {
 setup_file() {
   common_file_setup;
 
-  export SHOW_HINT="Use \`flox show {package}\` to see available versions"
+  export SHOW_HINT="Use \`flox show <package>\` to see available versions"
   # Separator character for ambiguous package sources
   export SEP=":";
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
* corrects `flox` and `flox init` CLI output which had messages that were referencing CLI commands with double quotes and variable replacement that didn't match [standards](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html)
* flips the order of the `flox activate` hint to more naturally follow progression


## Release Notes

N/A


<!-- Many thanks! -->
