### PR TITLE
ci: protect against multiline expect accepting prompts

### DIFF
--- a/tests/end2end/python.exp
+++ b/tests/end2end/python.exp
@@ -4,7 +4,7 @@
 # Assume throughout that the project is named project-\d+
 
 set flox $env(FLOX_CLI)
-set prompt "flox .* \$.*"          ;# default prompt
+set prompt "flox \[^\n\r\]* \$"          ;# default prompt
 
 spawn $flox activate
 expect {
@@ -16,7 +16,7 @@ expect {
 }
 set timeout 300
 expect {
-    -re "project.*\$" {}
+    -re "project\[^\n\r\]*\$" {}
     timeout {
       puts stderr "Reached timeout running '$cmd'"
       exit 1
@@ -28,7 +28,7 @@ expect -re $prompt
 set timeout 1
 send "{ command -v python3||which python3||type -P python3; } 2>&1\n"
 expect {
-    -re "\.flox/run/.*\.project-\\d+/bin/python3" {}
+    -re "\.flox/run/\[^\n\r\]*\.project-\\d+/bin/python3" {}
     timeout {
       puts stderr "Reached timeout locating 'python3'"
       exit 1
@@ -45,7 +45,7 @@ expect {
 }
 send "{ command -v pip||which pip||type -P pip; } 2>&1\n"
 expect {
-    -re "\.flox/run/.*\.project-\\d+/bin/pip" {}
+    -re "\.flox/run/\[^\n\r\]*\.project-\\d+/bin/pip" {}
     timeout {
       puts stderr "Reached timeout locating 'pip'"
       exit 1
@@ -98,7 +98,7 @@ expect {
 set timeout 30
 send "python3 -m venv env\n"
 expect {
-    -re "flox .*\\\[project-\\d+\\\]" {}
+    -re "flox \[^\n\r\]*\\\[project-\\d+\\\]" {}
     timeout {
       puts stderr "Reached timeout checking prompt"
       exit 1
@@ -115,7 +115,7 @@ expect {
     }
 }
 expect {
-    -re "flox .*\\\[project-\\d+\\\]" {}
+    -re "flox \[^\n\r\]*\\\[project-\\d+\\\]" {}
     timeout {
       puts stderr "Reached timeout checking prompt"
       exit 1

--- a/tests/end2end/python.exp
+++ b/tests/end2end/python.exp
@@ -25,7 +25,7 @@ expect {
 
 # check for python3
 expect -re $prompt
-set timeout 1
+set timeout 10
 send "{ command -v python3||which python3||type -P python3; } 2>&1\n"
 expect {
     -re "\.flox/run/\[^\n\r\]*\.project-\\d+/bin/python3" {}
@@ -122,7 +122,7 @@ expect {
     }
 }
 # test requests library in python 
-set timeout 1
+set timeout 10
 send "./env/bin/python -c 'import requests; print(requests.__path__)'\n"
 expect {
     -re "\\\['.*/project-\\d+/env/lib/python\\d+.\\d+/site-packages/requests'\\\]" {}


### PR DESCRIPTION
## Proposed Changes

Expect is accepting lines with prompts in them. Make the regex less greedy.

## Release Notes

N/A