### PR TITLE
test: disable flaky test

### DIFF
--- a/tests/end2end/python.bats
+++ b/tests/end2end/python.bats
@@ -49,6 +49,7 @@ teardown() { project_teardown; common_test_teardown; }
 # ---------------------------------------------------------------------------- #
 #
 @test "install requests with pip" {
+  skip "FIXME: flaky"
   run $FLOX_CLI install pip python3;
 
   assert_success;


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This skips the flaky test that is failing in CI. It can be enabled at a later date when it's confirmed to be working.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
