### PR TITLE
fix: remove --unspecified from help

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -452,6 +452,7 @@ pub enum EnvironmentSelect {
         environment_ref::EnvironmentRef,
     ),
     #[default]
+    #[bpaf(hide)]
     Unspecified,
 }
 


### PR DESCRIPTION
--unspecified was accidentally added to help messages:
```
Usage: flox install [-s=SYSTEM] [-d=<path> | -r=<owner/name> | --unspecified] PACKAGES...
```

This restores the expected help message:
```
Usage: flox install [-s=SYSTEM] [-d=<path> | -r=<owner/name>] PACKAGES...
```