### PR TITLE
fix: unset `*_BIN` vars if unavailable

### DIFF
--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -60,6 +60,14 @@
       # rather than relying on or modifying the user's `PATH` variable
       GIT_BIN = "${gitMinimal}/bin/git";
       NIX_BIN = "${nix}/bin/nix";
+      PKGDB_BIN =
+        if flox-pkgdb == null
+        then "pkgdb"
+        else "${flox-pkgdb}/bin/pkgdb";
+      ENV_BUILDER_BIN =
+        if flox-env-builder == null
+        then "flox-env-builder"
+        else "${flox-env-builder}/bin/env-builder";
       PARSER_UTIL_BIN = "${parser-util}/bin/parser-util";
       FLOX_ETC_DIR = ../../assets/etc;
       FLOX_ZDOTDIR = ../../assets/flox.zdotdir;
@@ -121,12 +129,6 @@
     }
     // lib.optionalAttrs hostPlatform.isLinux {
       LOCALE_ARCHIVE = "${glibcLocalesUtf8}/lib/locale/locale-archive";
-    }
-    // lib.optionalAttrs (flox-pkgdb != null) {
-      PKGDB_BIN = "${flox-pkgdb}/bin/pkgdb";
-    }
-    // lib.optionalAttrs (flox-env-builder != null) {
-      ENV_BUILDER_BIN = "${flox-env-builder}/bin/env-builder";
     };
 
   # compiled manpages

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -61,14 +61,6 @@
       GIT_BIN = "${gitMinimal}/bin/git";
       NIX_BIN = "${nix}/bin/nix";
       PARSER_UTIL_BIN = "${parser-util}/bin/parser-util";
-      PKGDB_BIN =
-        if flox-pkgdb == null
-        then ""
-        else "${flox-pkgdb}/bin/pkgdb";
-      ENV_BUILDER_BIN =
-        if flox-env-builder == null
-        then ""
-        else "${flox-env-builder}/bin/env-builder";
       FLOX_ETC_DIR = ../../assets/etc;
       FLOX_ZDOTDIR = ../../assets/flox.zdotdir;
 
@@ -129,6 +121,12 @@
     }
     // lib.optionalAttrs hostPlatform.isLinux {
       LOCALE_ARCHIVE = "${glibcLocalesUtf8}/lib/locale/locale-archive";
+    }
+    // lib.optionalAttrs (flox-pkgdb != null) {
+      PKGDB_BIN = "${flox-pkgdb}/bin/pkgdb";
+    }
+    // lib.optionalAttrs (flox-env-builder != null) {
+      ENV_BUILDER_BIN = "${flox-env-builder}/bin/env-builder";
     };
 
   # compiled manpages

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -66,7 +66,7 @@
         else "${flox-pkgdb}/bin/pkgdb";
       ENV_BUILDER_BIN =
         if flox-env-builder == null
-        then "flox-env-builder"
+        then "env-builder"
         else "${flox-env-builder}/bin/env-builder";
       PARSER_UTIL_BIN = "${parser-util}/bin/parser-util";
       FLOX_ETC_DIR = ../../assets/etc;


### PR DESCRIPTION
fixes #591

I don't know if there are subtle dependencies on these variables being set to `""`.
Maybe we can set proper defaults in the (devShell) shellHook already as well (`!ci`) so we don't need to set tehm manually (to always the same path) in dev.