### PR TITLE
fix: provide pkgdb via correct env var

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -45,9 +45,13 @@ test-env-builder: build-env-builder
     @pushd env-builder; make -j tests; popd
     @pushd env-builder; make check; popd
 
-# Run the 'bats' test suite
-bats-tests +bats_args="": build
+# Run the end-to-end test suite
+functional-tests +bats_args="": build
     @flox-tests {{bats_args}}
+
+# Run the integration test suite
+integ-tests: build
+    @flox-cli-tests --pkgdb "${PWD}/pkgdb/bin/pkgdb" --flox "${PWD}/cli/target/debug/flox" --env-builder "${PWD}/env-builder/bin/env-builder"
 
 # Run a specific 'bats' test file
 bats-file file: build
@@ -62,10 +66,10 @@ impure-tests regex="": build
     @pushd cli; {{cargo_test_invocation}} {{regex}} --features "extra-tests"; popd
 
 # Run the entire test suite, not including impure tests
-test: build unit-tests bats-tests
+test-cli: build unit-tests functional-tests integ-tests
 
 # Run the entire test suite, including impure tests
-test-all: test-pkgdb test-env-builder build impure-tests bats-tests
+test-all: test-pkgdb test-env-builder impure-tests functional-tests integ-tests
 
 
 # ---------------------------------------------------------------------------- #

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -15,7 +15,7 @@ use super::pkgdb_errors::PkgDbError;
 // This is set once and prefers the `PKGDB` env variable, but will use
 // the fallback to the binary available at build time if it is unset.
 pub static PKGDB_BIN: Lazy<String> =
-    Lazy::new(|| env::var("PKGDB").unwrap_or(env!("PKGDB_BIN").to_string()));
+    Lazy::new(|| env::var("PKGDB_BIN").unwrap_or(env!("PKGDB_BIN").to_string()));
 
 #[derive(Debug, thiserror::Error)]
 pub enum SearchError {


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
The path to the `pkgdb` binary is provided via an environment variable at either build time or runtime. The environment variable for providing the path at runtime did not have the same name as what was used to provide the path at build time (`PKGDB` vs. `PKGDB_BIN`).

Also, the Justfile was never calling the integration test suite, so that command has been added and included in the `test-all` target.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
