### PR TITLE
refactor: cleanup `EnvironmentError2`

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1,21 +1,18 @@
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use log::debug;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
 
-use super::{
-    copy_dir_recursive,
-    EditResult,
-    EnvironmentError2,
-    InstallationAttempt,
-    LockedManifest,
-    LOCKFILE_FILENAME,
-    MANIFEST_FILENAME,
-};
+use super::{copy_dir_recursive, InstallationAttempt, LOCKFILE_FILENAME, MANIFEST_FILENAME};
 use crate::flox::Flox;
 use crate::models::environment::{global_manifest_path, ENV_BUILDER_BIN};
-use crate::models::manifest::{insert_packages, remove_packages};
+use crate::models::manifest::{insert_packages, remove_packages, Manifest, TomlEditError};
+use crate::models::pkgdb_errors::PkgDbError;
 use crate::models::search::PKGDB_BIN;
 
 pub struct ReadOnly {}
@@ -55,8 +52,8 @@ impl<State> CoreEnvironment<State> {
     }
 
     /// Read the manifest file
-    fn manifest_content(&self) -> Result<String, EnvironmentError2> {
-        fs::read_to_string(self.manifest_path()).map_err(EnvironmentError2::ReadManifest)
+    fn manifest_content(&self) -> Result<String, CoreEnvironmentError> {
+        fs::read_to_string(self.manifest_path()).map_err(CoreEnvironmentError::ReadManifest)
     }
 
     /// Lock the environment.
@@ -68,7 +65,7 @@ impl<State> CoreEnvironment<State> {
     /// and because it doesn't modify the manifest.
     ///
     /// todo: should we always write the lockfile to disk?
-    pub fn lock(&mut self, flox: &Flox) -> Result<LockedManifest, EnvironmentError2> {
+    pub fn lock(&mut self, flox: &Flox) -> Result<LockedManifest, CoreEnvironmentError> {
         let manifest_path = self.manifest_path();
         let lockfile_path = self.lockfile_path();
         let maybe_lockfile = if lockfile_path.exists() {
@@ -89,7 +86,7 @@ impl<State> CoreEnvironment<State> {
         // todo: do we always want to do this?
         debug!("generated lockfile, writing to {}", lockfile_path.display());
         std::fs::write(&lockfile_path, lockfile.to_string())
-            .map_err(EnvironmentError2::WriteLockfile)?;
+            .map_err(CoreEnvironmentError::WriteLockfile)?;
 
         Ok(lockfile)
     }
@@ -104,7 +101,7 @@ impl<State> CoreEnvironment<State> {
     /// Linking should be done explicitly by the caller using [Self::link].
     ///
     /// todo: should we always write the lockfile to disk?
-    pub fn build(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
+    pub fn build(&mut self, flox: &Flox) -> Result<PathBuf, CoreEnvironmentError> {
         let lockfile = self.lock(flox)?;
 
         debug!(
@@ -131,7 +128,7 @@ impl<State> CoreEnvironment<State> {
         &mut self,
         flox: &Flox,
         out_link_path: impl AsRef<Path>,
-    ) -> Result<(), EnvironmentError2> {
+    ) -> Result<(), CoreEnvironmentError> {
         let lockfile = self.lock(flox)?;
         debug!(
             "linking environment: system={}, lockfilePath={}, outLinkPath={}",
@@ -172,15 +169,14 @@ impl CoreEnvironment<ReadOnly> {
         &mut self,
         packages: Vec<String>,
         flox: &Flox,
-    ) -> Result<InstallationAttempt, EnvironmentError2> {
+    ) -> Result<InstallationAttempt, CoreEnvironmentError> {
         let current_manifest_contents = self.manifest_content()?;
-        let installation =
-            insert_packages(&current_manifest_contents, &packages).map(|insertion| {
-                InstallationAttempt {
-                    new_manifest: insertion.new_toml.map(|toml| toml.to_string()),
-                    already_installed: insertion.already_installed,
-                }
-            })?;
+        let installation = insert_packages(&current_manifest_contents, &packages)
+            .map(|insertion| InstallationAttempt {
+                new_manifest: insertion.new_toml.map(|toml| toml.to_string()),
+                already_installed: insertion.already_installed,
+            })
+            .map_err(CoreEnvironmentError::ModifyToml)?;
         if let Some(ref new_manifest) = installation.new_manifest {
             self.transact_with_manifest_contents(new_manifest, flox)?;
         }
@@ -196,15 +192,20 @@ impl CoreEnvironment<ReadOnly> {
         &mut self,
         packages: Vec<String>,
         flox: &Flox,
-    ) -> Result<String, EnvironmentError2> {
+    ) -> Result<String, CoreEnvironmentError> {
         let current_manifest_contents = self.manifest_content()?;
-        let toml = remove_packages(&current_manifest_contents, &packages)?;
+        let toml = remove_packages(&current_manifest_contents, &packages)
+            .map_err(CoreEnvironmentError::ModifyToml)?;
         self.transact_with_manifest_contents(toml.to_string(), flox)?;
         Ok(toml.to_string())
     }
 
     /// Atomically edit this environment, ensuring that it still builds
-    pub fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError2> {
+    pub fn edit(
+        &mut self,
+        flox: &Flox,
+        contents: String,
+    ) -> Result<EditResult, CoreEnvironmentError> {
         let old_contents = self.manifest_content()?;
         // TODO we should probably skip this if the manifest hasn't changed
         self.transact_with_manifest_contents(&contents, flox)?;
@@ -217,9 +218,9 @@ impl CoreEnvironment<ReadOnly> {
     fn writable(
         &mut self,
         tempdir: impl AsRef<Path>,
-    ) -> Result<CoreEnvironment<ReadWrite>, EnvironmentError2> {
+    ) -> Result<CoreEnvironment<ReadWrite>, CoreEnvironmentError> {
         copy_dir_recursive(&self.env_dir, &tempdir.as_ref(), true)
-            .map_err(EnvironmentError2::MakeTemporaryEnv)?;
+            .map_err(CoreEnvironmentError::MakeTemporaryEnv)?;
 
         Ok(CoreEnvironment {
             env_dir: tempdir.as_ref().to_path_buf(),
@@ -234,7 +235,7 @@ impl CoreEnvironment<ReadOnly> {
     fn replace_with(
         &mut self,
         replacement: CoreEnvironment<ReadWrite>,
-    ) -> Result<(), EnvironmentError2> {
+    ) -> Result<(), CoreEnvironmentError> {
         let transaction_backup = self.env_dir.with_extension("tmp");
 
         if transaction_backup.exists() {
@@ -242,7 +243,7 @@ impl CoreEnvironment<ReadOnly> {
                 "transaction backup exists: {}",
                 transaction_backup.display()
             );
-            return Err(EnvironmentError2::PriorTransaction(transaction_backup));
+            return Err(CoreEnvironmentError::PriorTransaction(transaction_backup));
         }
         debug!(
             "backing up env: from={}, to={}",
@@ -250,7 +251,7 @@ impl CoreEnvironment<ReadOnly> {
             transaction_backup.display()
         );
         fs::rename(&self.env_dir, &transaction_backup)
-            .map_err(EnvironmentError2::BackupTransaction)?;
+            .map_err(CoreEnvironmentError::BackupTransaction)?;
         // try to restore the backup if the move fails
         debug!(
             "replacing original env: from={}, to={}",
@@ -264,13 +265,13 @@ impl CoreEnvironment<ReadOnly> {
                 transaction_backup.display(),
                 self.env_dir.display(),
             );
-            fs::remove_dir_all(&self.env_dir).map_err(EnvironmentError2::AbortTransaction)?;
+            fs::remove_dir_all(&self.env_dir).map_err(CoreEnvironmentError::AbortTransaction)?;
             fs::rename(transaction_backup, &self.env_dir)
-                .map_err(EnvironmentError2::AbortTransaction)?;
-            return Err(EnvironmentError2::Move(err));
+                .map_err(CoreEnvironmentError::AbortTransaction)?;
+            return Err(CoreEnvironmentError::Move(err));
         }
         debug!("removing backup: path={}", transaction_backup.display());
-        fs::remove_dir_all(transaction_backup).map_err(EnvironmentError2::RemoveBackup)?;
+        fs::remove_dir_all(transaction_backup).map_err(CoreEnvironmentError::RemoveBackup)?;
         Ok(())
     }
 
@@ -279,9 +280,9 @@ impl CoreEnvironment<ReadOnly> {
         &mut self,
         manifest_contents: impl AsRef<str>,
         flox: &Flox,
-    ) -> Result<(), EnvironmentError2> {
+    ) -> Result<(), CoreEnvironmentError> {
         let tempdir = tempfile::tempdir_in(&flox.temp_dir)
-            .map_err(EnvironmentError2::MakeSandbox)?
+            .map_err(CoreEnvironmentError::MakeSandbox)?
             .into_path();
 
         debug!(
@@ -308,18 +309,206 @@ impl CoreEnvironment<ReadOnly> {
 /// This is not public to enforce that environments are only edited atomically.
 impl CoreEnvironment<ReadWrite> {
     /// Updates the environment manifest with the provided contents
-    fn update_manifest(&mut self, contents: &impl AsRef<str>) -> Result<(), EnvironmentError2> {
+    fn update_manifest(&mut self, contents: &impl AsRef<str>) -> Result<(), CoreEnvironmentError> {
         debug!("writing new manifest to {}", self.manifest_path().display());
         let mut manifest_file = std::fs::OpenOptions::new()
             .write(true)
             .truncate(true)
             .open(self.manifest_path())
-            .map_err(EnvironmentError2::OpenManifest)?;
+            .map_err(CoreEnvironmentError::OpenManifest)?;
         manifest_file
             .write_all(contents.as_ref().as_bytes())
-            .map_err(EnvironmentError2::UpdateManifest)?;
+            .map_err(CoreEnvironmentError::UpdateManifest)?;
         Ok(())
     }
+}
+
+#[derive(Debug, Serialize, Clone, Deserialize, PartialEq)]
+pub struct LockedManifest(Value);
+impl LockedManifest {
+    /// Use pkgdb to lock a manifest
+    pub fn lock_manifest(
+        pkgdb: &Path,
+        manifest_path: &Path,
+        existing_lockfile_path: Option<&Path>,
+        global_manifest_path: &Path,
+    ) -> Result<Self, CoreEnvironmentError> {
+        let canonical_manifest_path = manifest_path
+            .canonicalize()
+            .map_err(|e| CoreEnvironmentError::BadManifestPath(e, manifest_path.to_path_buf()))?;
+
+        let mut pkgdb_cmd = Command::new(pkgdb);
+        pkgdb_cmd
+            .args(["manifest", "lock"])
+            .arg("--ga-registry")
+            .arg("--global-manifest")
+            .arg(global_manifest_path);
+        if let Some(lf_path) = existing_lockfile_path {
+            let canonical_lockfile_path = lf_path
+                .canonicalize()
+                .map_err(|e| CoreEnvironmentError::BadLockfilePath(e, lf_path.to_path_buf()))?;
+            pkgdb_cmd.arg("--lockfile").arg(canonical_lockfile_path);
+        }
+        pkgdb_cmd.arg(canonical_manifest_path);
+
+        debug!("locking manifest with command: {pkgdb_cmd:?}");
+        let output = pkgdb_cmd
+            .output()
+            .map_err(CoreEnvironmentError::PkgDbCall)?;
+        // If command fails, try to parse stdout as a PkgDbError
+        if !output.status.success() {
+            if let Ok::<PkgDbError, _>(pkgdb_err) = serde_json::from_slice(&output.stdout) {
+                Err(CoreEnvironmentError::LockManifest(pkgdb_err))
+            } else {
+                Err(CoreEnvironmentError::ParsePkgDbError(
+                    String::from_utf8_lossy(&output.stdout).to_string(),
+                ))
+            }
+        // If command succeeds, try to parse stdout as JSON value
+        } else {
+            let lockfile_json = serde_json::from_slice(&output.stdout)
+                .map_err(CoreEnvironmentError::ParseLockfileJSON)?;
+            Ok(lockfile_json)
+        }
+    }
+
+    /// Build a locked manifest
+    ///
+    /// if a gcroot_out_link_path is provided,
+    /// the environment will be linked to that path and a gcroot will be created
+    pub fn build(
+        &self,
+        builder: &Path,
+        gcroot_out_link_path: Option<&Path>,
+    ) -> Result<PathBuf, CoreEnvironmentError> {
+        let mut env_builder_cmd = Command::new(builder);
+        env_builder_cmd.arg("build-env");
+        env_builder_cmd.args(["--lockfile", &self.0.to_string()]);
+
+        if let Some(gcroot_out_link_path) = gcroot_out_link_path {
+            env_builder_cmd.args(["--out-link", &gcroot_out_link_path.to_string_lossy()]);
+        }
+
+        debug!("building environment with command: {env_builder_cmd:?}");
+
+        let env_builder_output = env_builder_cmd
+            .output()
+            .map_err(CoreEnvironmentError::BuildEnvCall)?;
+
+        if !env_builder_output.status.success() {
+            let stderr = String::from_utf8_lossy(&env_builder_output.stderr).into_owned();
+            return Err(CoreEnvironmentError::BuildEnv(stderr));
+        }
+
+        let stdout = String::from_utf8_lossy(&env_builder_output.stdout).into_owned();
+
+        Ok(PathBuf::from(stdout.trim()))
+    }
+}
+impl ToString for LockedManifest {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(Debug)]
+pub enum EditResult {
+    /// The manifest was not modified.
+    Unchanged,
+    /// The manifest was modified, and the user needs to re-activate it.
+    ReActivateRequired,
+    /// The manifest was modified, but the user does not need to re-activate it.
+    Success,
+}
+
+impl EditResult {
+    pub fn new(old_manifest: &str, new_manifest: &str) -> Result<Self, CoreEnvironmentError> {
+        if old_manifest == new_manifest {
+            Ok(Self::Unchanged)
+        } else {
+            // todo: use a single toml crate (toml_edit already implements serde traits)
+            let old_manifest: Manifest =
+                toml::from_str(old_manifest).map_err(CoreEnvironmentError::DeserializeManifest)?;
+            let new_manifest: Manifest =
+                toml::from_str(new_manifest).map_err(CoreEnvironmentError::DeserializeManifest)?;
+            // TODO: some modifications to `install` currently require re-activation
+            if old_manifest.hook != new_manifest.hook || old_manifest.vars != new_manifest.vars {
+                Ok(Self::ReActivateRequired)
+            } else {
+                Ok(Self::Success)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CoreEnvironmentError {
+    // region: immutable manifest errors
+    #[error("could not modify manifest")]
+    ModifyToml(#[source] TomlEditError),
+    #[error("could not deserialize manifest")]
+    DeserializeManifest(#[source] toml::de::Error),
+    // endregion
+
+    // region: transaction errors
+    #[error("could not make temporary directory for transaction")]
+    MakeSandbox(#[source] std::io::Error),
+
+    #[error("couldn't write new lockfile contents")]
+    WriteLockfile(#[source] std::io::Error),
+
+    #[error("could not make temporary copy of environment")]
+    MakeTemporaryEnv(#[source] std::io::Error),
+    /// Thrown when a .flox/env.tmp directory already exists
+    #[error("prior transaction in progress -- delete {0} to discard")]
+    PriorTransaction(PathBuf),
+    #[error("could not create backup for transaction")]
+    BackupTransaction(#[source] std::io::Error),
+    #[error("Failed to abort transaction; backup could not be moved back into place")]
+    AbortTransaction(#[source] std::io::Error),
+    #[error("Failed to move modified environment into place")]
+    Move(#[source] std::io::Error),
+    #[error("Failed to remove transaction backup")]
+    RemoveBackup(#[source] std::io::Error),
+
+    // endregion
+
+    // region: mutable manifest errors
+    #[error("could not open manifest")]
+    OpenManifest(#[source] std::io::Error),
+    #[error("could not write manifest")]
+    UpdateManifest(#[source] std::io::Error),
+    // endregion
+
+    // region: pkgdb/locking errors
+    #[error("provided manifest path does not exist ({1:?})")]
+    BadManifestPath(#[source] std::io::Error, PathBuf),
+
+    #[error("provided lockfile path does not exist ({1:?})")]
+    BadLockfilePath(#[source] std::io::Error, PathBuf),
+
+    #[error("call to pkgdb failed")]
+    PkgDbCall(#[source] std::io::Error),
+
+    #[error("could not lock manifest")]
+    LockManifest(#[source] PkgDbError),
+
+    #[error("unknown error locking manifest {0}")]
+    ParsePkgDbError(String),
+
+    #[error("couldn't parse lockfile as JSON")]
+    ParseLockfileJSON(#[source] serde_json::Error),
+
+    #[error("could not open manifest file")]
+    ReadManifest(#[source] std::io::Error),
+
+    // might be merged with pkgdb soon
+    #[error("call to env-builder failed")]
+    BuildEnvCall(#[source] std::io::Error),
+
+    #[error("error building environment: {0}")]
+    BuildEnv(String),
+    // endregion
 }
 
 #[cfg(test)]
@@ -374,7 +563,7 @@ mod tests {
             .replace_with(temp_env)
             .expect_err("Should fail if backup exists");
 
-        assert!(matches!(err, EnvironmentError2::PriorTransaction(_)));
+        assert!(matches!(err, CoreEnvironmentError::PriorTransaction(_)));
     }
 
     /// creating backup should fail if env is readonly
@@ -402,7 +591,7 @@ mod tests {
         ));
 
         assert!(
-            matches!(err, EnvironmentError2::BackupTransaction(err) if err.kind() == std::io::ErrorKind::PermissionDenied)
+            matches!(err, CoreEnvironmentError::BackupTransaction(err) if err.kind() == std::io::ErrorKind::PermissionDenied)
         );
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -86,7 +86,7 @@ impl PathEnvironment {
         }
 
         if !env_path.join(MANIFEST_FILENAME).exists() {
-            Err(EnvironmentError2::DirectoryNotAnEnv)?
+            Err(EnvironmentError2::ManifestNotFound)?
         }
 
         Ok(Self {
@@ -330,7 +330,9 @@ impl PathEnvironment {
         match EnvironmentPointer::open(dot_flox_parent_path.as_ref()) {
             Err(EnvironmentError2::EnvNotFound) => {},
             Err(e) => Err(e)?,
-            Ok(_) => Err(EnvironmentError2::EnvironmentExists)?,
+            Ok(_) => Err(EnvironmentError2::EnvironmentExists(
+                dot_flox_parent_path.as_ref().to_path_buf(),
+            ))?,
         }
         let dot_flox_path = dot_flox_parent_path.as_ref().join(DOT_FLOX);
         let env_dir = dot_flox_path.join(ENV_DIR_NAME);


### PR DESCRIPTION
* Move all `EnvironmentError2` errors produced by _core_ environment operations (env transactions, locking, building, etc) into `core_environment::CoreEnvironmentError`
* Remove other unused error variants of `EnvironmentError2`
* Group remaining variants and add `todo:`s for future refactoring