### PR TITLE
feat: install packages via path instead of name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 compile_commands.json
 result
 result-*
+bin/
+*.o

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@
 compile_commands.json
 result
 result-*
-bin/
-*.o

--- a/Justfile
+++ b/Justfile
@@ -58,12 +58,13 @@ functional-tests +bats_args="": build
 
 # Run the CLI integration test suite
 integ-tests +bats_args="": build
-    @flox-cli-tests --pkgdb "{{PKGDB_BIN}}" --flox "{{FLOX_BIN}}" {{bats_args}}
+    @flox-cli-tests --pkgdb "{{PKGDB_BIN}}" \
+     --flox "{{FLOX_BIN}}" -- {{bats_args}}
 
 # Run a specific CLI integration test file by name (not path)
-integ-file file +bats_args="": build
-    @flox-cli-tests --tests "{{file}}" --pkgdb "{{PKGDB_BIN}}" \
-     --flox "{{FLOX_BIN}}" {{bats_args}}
+integ-file +bats_args="": build
+    @flox-cli-tests --pkgdb "{{PKGDB_BIN}}" \
+     --flox "{{FLOX_BIN}}" -- {{bats_args}}
 
 # Run the CLI unit tests
 unit-tests regex="": build

--- a/Justfile
+++ b/Justfile
@@ -26,6 +26,14 @@ _default:
 
 # ---------------------------------------------------------------------------- #
 
+# Print the paths of all of the binaries
+bins:
+    @echo "{{PKGDB_BIN}}"
+    @echo "{{ENV_BUILDER_BIN}}"
+    @echo "{{FLOX_BIN}}"
+
+# ---------------------------------------------------------------------------- #
+
 build-pkgdb:
     @make -C pkgdb -j;
 
@@ -44,18 +52,18 @@ test-pkgdb: build-pkgdb
 
 # Run the end-to-end test suite
 functional-tests +bats_args="": build
-    @flox-tests --pkgdb "${PKGDB_BIN}" --flox "${FLOX_BIN}" \
-        --env-builder "${ENV_BUILDER_BIN}" {{bats_args}}
+    @flox-tests --pkgdb "{{PKGDB_BIN}}" --flox "{{FLOX_BIN}}" \
+        --env-builder "{{ENV_BUILDER_BIN}}" {{bats_args}}
 
 # Run the CLI integration test suite
 integ-tests +bats_args="": build
-    @flox-cli-tests --pkgdb "${PKGDB_BIN}" --flox "${FLOX_BIN}" \
-        --env-builder "${ENV_BUILDER_BIN}" {{bats_args}}
+    @flox-cli-tests --pkgdb "{{PKGDB_BIN}}" --flox "{{FLOX_BIN}}" \
+        --env-builder "{{ENV_BUILDER_BIN}}" {{bats_args}}
 
 # Run a specific 'flox' integration test file by name (not path)
 integ-file file: build
-    @flox-cli-tests --tests "{{file}}" --pkgdb "${PKGDB_BIN}" \
-        --flox "${FLOX_BIN}" --env-builder "${ENV_BUILDER_BIN}"
+    @flox-cli-tests --tests "{{file}}" --pkgdb "{{PKGDB_BIN}}" \
+        --flox "{{FLOX_BIN}}" --env-builder "{{ENV_BUILDER_BIN}}"
 
 # Run the Rust unit tests
 unit-tests regex="": build
@@ -118,7 +126,8 @@ config-vscode:
     @echo $(jq '.configurations.cppStandard = "c++20"' {{vscode_cpp_config}}) \
         > {{vscode_cpp_config}};
     @echo $(jq \
-        '.configurations.compileCommands = "${workspaceFolder}/pkgdb/compile_commands.json"' \
+        '.configurations.compileCommands = \
+        "${workspaceFolder}/pkgdb/compile_commands.json"' \
         {{vscode_cpp_config}}) > {{vscode_cpp_config}}
 
 

--- a/assets/templateFloxEnv/manifest.toml
+++ b/assets/templateFloxEnv/manifest.toml
@@ -1,6 +1,6 @@
 # List packages you wish to install in your environment under
 # the `[install]` table
-# [install]
+[install]
 # hello.path = "hello"
 # nodejs = { version = "^18.4.2", path = "nodejs_18" }
 

--- a/assets/templateFloxEnv/manifest.toml
+++ b/assets/templateFloxEnv/manifest.toml
@@ -1,8 +1,8 @@
 # List packages you wish to install in your environment under
 # the `[install]` table
 # [install]
-# hello = {}
-# nodejs = { version = "^16.4.2" }
+# hello.path = "hello"
+# nodejs = { version = "^18.4.2", path = "nodejs_18" }
 
 # Set your activation hook ( run when entering the environment )
 # You can write this inline with the `script` field, or provide a

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 anyhow = "1"
 async-trait = "0.1.52"
 blake3 = "1.5.0"
-bpaf = { version = "0.9.7", features = ["derive", "autocomplete"] }
+bpaf = { version = "0.9.8", features = ["derive", "autocomplete"] }
 chrono = "0.4.24"
 config = "0.13.1"
 crossterm = "0.26"
@@ -33,7 +33,7 @@ openssl = "0.10.57"
 pathdiff = "0.2"
 pretty_assertions = "1.3"
 regex = "1"
-reqwest = { version = "0.11", features = ["json","blocking"] }
+reqwest = { version = "0.11", features = ["json", "blocking"] }
 rnix = "0.11"
 rowan = "0.15"
 runix = { git = "https://github.com/flox/runix" }

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -11,7 +11,13 @@ use thiserror::Error;
 use super::{copy_dir_recursive, InstallationAttempt, LOCKFILE_FILENAME, MANIFEST_FILENAME};
 use crate::flox::Flox;
 use crate::models::environment::{call_pkgdb, global_manifest_path};
-use crate::models::manifest::{insert_packages, remove_packages, Manifest, TomlEditError};
+use crate::models::manifest::{
+    insert_packages,
+    remove_packages,
+    Manifest,
+    PackageToInstall,
+    TomlEditError,
+};
 use crate::models::pkgdb::{CallPkgDbError, UpdateResult, PKGDB_BIN};
 
 pub struct ReadOnly {}
@@ -169,11 +175,11 @@ impl CoreEnvironment<ReadOnly> {
     /// manifest.
     pub fn install(
         &mut self,
-        packages: Vec<String>,
+        packages: &[PackageToInstall],
         flox: &Flox,
     ) -> Result<InstallationAttempt, CoreEnvironmentError> {
         let current_manifest_contents = self.manifest_content()?;
-        let installation = insert_packages(&current_manifest_contents, &packages)
+        let installation = insert_packages(&current_manifest_contents, packages)
             .map(|insertion| InstallationAttempt {
                 new_manifest: insertion.new_toml.map(|toml| toml.to_string()),
                 already_installed: insertion.already_installed,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -28,6 +28,7 @@ use super::{
 use crate::flox::Flox;
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner};
 use crate::models::floxmetav2::{floxmeta_git_options, FloxmetaV2, FloxmetaV2Error};
+use crate::models::manifest::PackageToInstall;
 use crate::providers::git::{GitCommandBranchHashError, GitCommandError, GitProvider};
 
 const GENERATION_LOCK_FILENAME: &str = "env.lock";
@@ -152,7 +153,7 @@ impl Environment for ManagedEnvironment {
     #[allow(unused)]
     async fn install(
         &mut self,
-        packages: Vec<String>,
+        packages: &[PackageToInstall],
         flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError2> {
         let mut generations = self

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -17,6 +17,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use self::remote_environment::RemoteEnvironmentError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
 use super::flox_package::FloxTriple;
+use super::manifest::PackageToInstall;
 use crate::flox::{EnvironmentRef, Flox};
 use crate::models::pkgdb::call_pkgdb;
 use crate::providers::git::{
@@ -111,7 +112,7 @@ pub trait Environment {
     /// Install packages to the environment atomically
     async fn install(
         &mut self,
-        packages: Vec<String>,
+        packages: &[PackageToInstall],
         flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError2>;
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -46,6 +46,8 @@ use super::{
 use crate::flox::Flox;
 use crate::models::environment::{CATALOG_JSON, ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
+use crate::models::manifest::PackageToInstall;
+
 /// Struct representing a local environment
 ///
 /// This environment performs transactional edits by first copying the environment
@@ -131,6 +133,7 @@ impl PathEnvironment {
     ///
     /// This method should only be used to create [CoreEnvironment]s for a [PathEnvironment].
     /// To modify the environment, use the [PathEnvironment] methods instead.
+    #[allow(dead_code)]
     pub(super) fn into_core_environment(self) -> CoreEnvironment {
         CoreEnvironment::new(self.path.join(ENV_DIR_NAME))
     }
@@ -161,7 +164,7 @@ impl Environment for PathEnvironment {
     /// Todo: remove async
     async fn install(
         &mut self,
-        packages: Vec<String>,
+        packages: &[PackageToInstall],
         flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -133,7 +133,6 @@ impl PathEnvironment {
     ///
     /// This method should only be used to create [CoreEnvironment]s for a [PathEnvironment].
     /// To modify the environment, use the [PathEnvironment] methods instead.
-    #[allow(dead_code)]
     pub(super) fn into_core_environment(self) -> CoreEnvironment {
         CoreEnvironment::new(self.path.join(ENV_DIR_NAME))
     }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmetav2::{FloxmetaV2, FloxmetaV2Error};
+use crate::models::manifest::PackageToInstall;
 
 #[derive(Debug, Error)]
 pub enum RemoteEnvironmentError {
@@ -101,7 +102,7 @@ impl Environment for RemoteEnvironment {
     /// Install packages to the environment atomically
     async fn install(
         &mut self,
-        packages: Vec<String>,
+        packages: &[PackageToInstall],
         flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError2> {
         let result = self.inner.install(packages, flox).await?;

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -1,8 +1,21 @@
 use std::collections::HashMap;
+use std::process::Command;
+use std::str::FromStr;
 
 use log::debug;
 use serde::Deserialize;
-use toml_edit::{self, Document, InlineTable, Item, Table, Value};
+use toml_edit::{self, Document, Formatted, InlineTable, Item, Table, Value};
+
+use crate::models::pkgdb::PKGDB_BIN;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError {
+    #[error("couldn't parse descriptor '{}': {}", desc, msg)]
+    MalformedStringDescriptor { msg: String, desc: String },
+    /// FIXME: This is a temporary error variant until `flox` parses descriptors on its own
+    #[error("failed while calling pkgdb")]
+    PkgDbCall(#[source] std::io::Error),
+}
 
 /// A subset of the manifest used to check what type of edits users make. We
 /// don't use this struct for making our own edits.
@@ -42,10 +55,37 @@ pub struct PackageInsertion {
     pub already_installed: HashMap<String, bool>,
 }
 
+/// A package to install.
+///
+/// Users may specify a different install ID than the package name,
+/// especially when the package is nested. This struct is the common
+/// denominator for packages with specified IDs and packages with
+/// default IDs.
+#[derive(Debug, PartialEq)]
+pub struct PackageToInstall {
+    pub id: String,
+    pub path: String,
+    pub version: Option<String>,
+    pub input: Option<String>,
+}
+
+impl FromStr for PackageToInstall {
+    type Err = ManifestError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        temporary_parse_descriptor(s)
+    }
+}
+
 /// Insert package names into the `[install]` table of a manifest.
+///
+/// Note that the packages may be provided as dot-separated attribute paths
+/// that should be interpreted as relative paths under whatever input they're
+/// coming from. For this reason we put them under the `<descriptor>.path` key
+/// rather than `<descriptor>.name`.
 pub fn insert_packages(
     manifest_contents: &str,
-    pkgs: &[String],
+    pkgs: &[PackageToInstall],
 ) -> Result<PackageInsertion, TomlEditError> {
     debug!("attempting to insert packages into manifest");
     let mut already_installed: HashMap<String, bool> = HashMap::new();
@@ -65,13 +105,22 @@ pub fn insert_packages(
     };
 
     for pkg in pkgs {
-        if !install_table.contains_key(pkg) {
-            install_table.insert(pkg, Item::Value(Value::InlineTable(InlineTable::new())));
-            already_installed.insert(pkg.clone(), false);
-            debug!("package '{pkg}' newly installed");
+        if !install_table.contains_key(&pkg.id) {
+            let mut descriptor_table = InlineTable::new();
+            descriptor_table.insert("path", Value::String(Formatted::new(pkg.path.clone())));
+            if let Some(ref version) = pkg.version {
+                descriptor_table.insert("version", Value::String(Formatted::new(version.clone())));
+            }
+            if let Some(ref input) = pkg.input {
+                descriptor_table.insert("input", Value::String(Formatted::new(input.clone())));
+            }
+            descriptor_table.set_dotted(true);
+            install_table.insert(&pkg.id, Item::Value(Value::InlineTable(descriptor_table)));
+            already_installed.insert(pkg.id.clone(), false);
+            debug!("package newly installed: id={}, path={}", pkg.id, pkg.path);
         } else {
-            already_installed.insert(pkg.clone(), true);
-            debug!("package '{pkg}' already installed");
+            already_installed.insert(pkg.id.clone(), true);
+            debug!("package already installed: id={}", pkg.id);
         }
     }
 
@@ -157,6 +206,89 @@ pub fn list_packages(manifest_contents: &str) -> Result<Option<Vec<String>>, Tom
     }
 }
 
+/// A parsed descriptor from `pkgdb parse descriptor --manifest`
+///
+/// FIXME: this is currently a hack using a tool in `pkgdb` only meant for debugging.
+#[derive(Debug, Deserialize)]
+pub struct ParsedDescriptor {
+    pub name: Option<String>,
+    pub path: Option<Vec<String>>,
+    pub input: Option<Input>,
+    pub version: Option<String>,
+    pub semver: Option<String>,
+}
+
+/// A parsed input
+///
+/// FIXME: this is currently a hack using a tool in `pkgdb` only meant for debugging.
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Input {
+    pub id: String,
+}
+
+/// Parse a shorthand descriptor into structured data
+///
+/// FIXME: this is currently a hack using a tool in `pkgdb` only meant for debugging.
+pub fn temporary_parse_descriptor(descriptor: &str) -> Result<PackageToInstall, ManifestError> {
+    let output = Command::new(&*PKGDB_BIN)
+        .arg("parse")
+        .arg("descriptor")
+        .arg("--to")
+        .arg("manifest")
+        .arg(descriptor)
+        .output()
+        .map_err(ManifestError::PkgDbCall)?;
+    let parsed: Result<ParsedDescriptor, _> = serde_json::from_slice(&output.stdout);
+    if let Ok(parsed) = parsed {
+        let (id, path) = if let Some(mut path) = parsed.path {
+            // Quote any path components that need quoting
+            path.iter_mut().for_each(|attr| {
+                if attr.contains('.') || attr.contains('"') {
+                    *attr = format!("\"{}\"", attr);
+                }
+            });
+            let id_part = path.last().cloned().map(Ok).unwrap_or_else(|| {
+                Err(ManifestError::MalformedStringDescriptor {
+                    msg: "descriptor had an empty path".to_string(),
+                    desc: descriptor.to_string(),
+                })
+            })?;
+            (id_part, path.join("."))
+        } else if let Some(name) = parsed.name {
+            (name.clone(), name)
+        } else {
+            // This should have been caught by `pkgdb parse descriptor`,
+            // it's more likely that if we hit this we got unexpected output
+            // that we didn't know how to parse. It's possible, but unlikely,
+            // and something ignored for the sake of time when we can write
+            // a parser in `flox` instead of leaning on `pkgdb` debugging tools.
+            return Err(ManifestError::MalformedStringDescriptor {
+                msg: "descriptor had no name or path".to_string(),
+                desc: descriptor.to_string(),
+            });
+        };
+        let version = if let Some(version) = parsed.version {
+            let mut v = "=".to_string();
+            v.push_str(&version);
+            Some(v)
+        } else {
+            parsed.semver
+        };
+        let input = parsed.input.map(|input| input.id);
+        Ok(PackageToInstall {
+            id,
+            path,
+            version,
+            input,
+        })
+    } else {
+        Err(ManifestError::MalformedStringDescriptor {
+            msg: String::from_utf8_lossy(&output.stdout).to_string(),
+            desc: descriptor.to_string(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -180,23 +312,23 @@ ripgrep = {}
 
     #[test]
     fn insert_adds_new_package() {
-        let test_packages = vec!["python".to_owned()];
+        let test_packages = vec![PackageToInstall::from_str("python").unwrap()];
         let pre_addition_toml = DUMMY_MANIFEST.parse::<Document>().unwrap();
-        assert!(!contains_package(&pre_addition_toml, &test_packages[0]).unwrap());
+        assert!(!contains_package(&pre_addition_toml, &test_packages[0].id).unwrap());
         let insertion =
             insert_packages(DUMMY_MANIFEST, &test_packages).expect("couldn't add package");
         assert!(
             insertion.new_toml.is_some(),
             "manifest was changed by install"
         );
-        assert!(contains_package(&insertion.new_toml.unwrap(), &test_packages[0]).unwrap());
+        assert!(contains_package(&insertion.new_toml.unwrap(), &test_packages[0].id).unwrap());
     }
 
     #[test]
     fn no_change_adding_existing_package() {
-        let test_packages = vec!["hello".to_owned()];
+        let test_packages = vec![PackageToInstall::from_str("hello").unwrap()];
         let pre_addition_toml = DUMMY_MANIFEST.parse::<Document>().unwrap();
-        assert!(contains_package(&pre_addition_toml, &test_packages[0]).unwrap());
+        assert!(contains_package(&pre_addition_toml, &test_packages[0].id).unwrap());
         let insertion = insert_packages(DUMMY_MANIFEST, &test_packages).unwrap();
         assert!(
             insertion.new_toml.is_none(),
@@ -210,9 +342,11 @@ ripgrep = {}
 
     #[test]
     fn insert_adds_install_table_when_missing() {
-        let test_packages = vec!["foo".to_owned()];
+        let test_packages = vec![PackageToInstall::from_str("foo").unwrap()];
         let insertion = insert_packages("", &test_packages).unwrap();
-        assert!(contains_package(&insertion.new_toml.clone().unwrap(), &test_packages[0]).unwrap());
+        assert!(
+            contains_package(&insertion.new_toml.clone().unwrap(), &test_packages[0].id).unwrap()
+        );
         assert!(
             insertion.new_toml.is_some(),
             "manifest was changed by install"
@@ -225,7 +359,7 @@ ripgrep = {}
 
     #[test]
     fn insert_error_when_manifest_malformed() {
-        let test_packages = vec!["foo".to_owned()];
+        let test_packages = vec![PackageToInstall::from_str("foo").unwrap()];
         let attempted_insertion = insert_packages(BAD_MANIFEST, &test_packages);
         assert!(matches!(
             attempted_insertion,
@@ -263,5 +397,61 @@ ripgrep = {}
         let test_packages = vec!["hello".to_owned(), "DOES_NOT_EXIST".to_owned()];
         let removal = remove_packages(DUMMY_MANIFEST, &test_packages);
         assert!(matches!(removal, Err(TomlEditError::PackageNotFound(_))));
+    }
+
+    #[test]
+    fn inserts_package_needing_quotes() {
+        let attrs = r#"foo."bar.baz".qux"#;
+        let test_packages = vec![PackageToInstall::from_str(attrs).unwrap()];
+        let pre_addition_toml = DUMMY_MANIFEST.parse::<Document>().unwrap();
+        assert!(!contains_package(&pre_addition_toml, &test_packages[0].id).unwrap());
+        let insertion =
+            insert_packages(DUMMY_MANIFEST, &test_packages).expect("couldn't add package");
+        assert!(
+            insertion.new_toml.is_some(),
+            "manifest was changed by install"
+        );
+        let new_toml = insertion.new_toml.unwrap();
+        assert!(contains_package(&new_toml, &test_packages[0].id).unwrap());
+        let inserted_path = new_toml
+            .get("install")
+            .and_then(|t| t.get("qux"))
+            .and_then(|d| d.get("path"))
+            .and_then(|p| p.as_str())
+            .unwrap();
+        assert_eq!(inserted_path, r#"foo."bar.baz".qux"#);
+    }
+
+    #[test]
+    fn parses_string_descriptor() {
+        // FIXME: remove or update this test when `flox` can parse descriptors on its own
+        let parsed = temporary_parse_descriptor("hello").unwrap();
+        assert_eq!(parsed, PackageToInstall {
+            id: "hello".to_string(),
+            path: "hello".to_string(),
+            version: None,
+            input: None,
+        });
+        let parsed = temporary_parse_descriptor("nixpkgs:foo.bar@=1.2.3").unwrap();
+        assert_eq!(parsed, PackageToInstall {
+            id: "bar".to_string(),
+            path: "foo.bar".to_string(),
+            version: Some("=1.2.3".to_string()),
+            input: Some("nixpkgs".to_string())
+        });
+        let parsed = temporary_parse_descriptor("nixpkgs:foo.bar@23.11").unwrap();
+        assert_eq!(parsed, PackageToInstall {
+            id: "bar".to_string(),
+            path: "foo.bar".to_string(),
+            version: Some("23.11".to_string()),
+            input: Some("nixpkgs".to_string())
+        });
+        let parsed = temporary_parse_descriptor("nixpkgs:rubyPackages.\"http_parser.rb\"").unwrap();
+        assert_eq!(parsed, PackageToInstall {
+            id: "\"http_parser.rb\"".to_string(),
+            path: "rubyPackages.\"http_parser.rb\"".to_string(),
+            version: None,
+            input: Some("nixpkgs".to_string())
+        });
     }
 }

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -24,7 +24,7 @@ pub enum FindAndReplaceError {
     WriteTemplateFile(std::io::Error),
 }
 
-/// Replace all occurrences of find with replace in a directory or file
+/// Replace all occurrences of `find` with `replace` in a directory or file
 pub async fn find_and_replace(
     path: &Path,
     find: &str,
@@ -95,4 +95,27 @@ pub fn copy_file_without_permissions(
         err: io_err,
     })?;
     Ok(())
+}
+
+/// Returns the last component of a dot-separated attribute path or the
+/// attribute provided if there is only one path component.
+pub fn attr_name(path: &str) -> String {
+    path.split('.')
+        .rev()
+        .next()
+        .map(|s| s.to_string())
+        .unwrap_or(path.to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn splits_multipart_attr_path() {
+        assert_eq!("foo".to_string(), attr_name("foo"));
+        assert_eq!("bar".to_string(), attr_name("foo.bar"));
+        assert_eq!("baz".to_string(), attr_name("foo.bar.baz"));
+        assert_eq!("".to_string(), attr_name(""));
+    }
 }

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -96,26 +96,3 @@ pub fn copy_file_without_permissions(
     })?;
     Ok(())
 }
-
-/// Returns the last component of a dot-separated attribute path or the
-/// attribute provided if there is only one path component.
-pub fn attr_name(path: &str) -> String {
-    path.split('.')
-        .rev()
-        .next()
-        .map(|s| s.to_string())
-        .unwrap_or(path.to_string())
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn splits_multipart_attr_path() {
-        assert_eq!("foo".to_string(), attr_name("foo"));
-        assert_eq!("bar".to_string(), attr_name("foo.bar"));
-        assert_eq!("baz".to_string(), attr_name("foo.bar.baz"));
-        assert_eq!("".to_string(), attr_name(""));
-    }
-}

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -4,6 +4,7 @@ use std::io::{stdin, Write};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Context, Result};
 use bpaf::Bpaf;
@@ -32,7 +33,7 @@ use flox_rust_sdk::models::environment::{
     FLOX_PROMPT_ENVIRONMENTS_VAR,
 };
 use flox_rust_sdk::models::floxmetav2::FloxmetaV2Error;
-use flox_rust_sdk::models::manifest::list_packages;
+use flox_rust_sdk::models::manifest::{list_packages, PackageToInstall};
 use flox_rust_sdk::models::pkgdb::{call_pkgdb, UpdateResult, PKGDB_BIN};
 use flox_rust_sdk::nix::command::StoreGc;
 use flox_rust_sdk::nix::command_line::NixCommandLine;
@@ -541,8 +542,27 @@ pub struct Install {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 
-    #[bpaf(positional("PACKAGES"), some("Must specify at least one package"))]
+    /// Option to specify a package ID
+    #[bpaf(external(pkg_with_id_option), many)]
+    id: Vec<PkgWithIdOption>,
+
+    #[bpaf(positional("packages"))]
     packages: Vec<String>,
+}
+
+#[derive(Debug, Bpaf, Clone)]
+#[bpaf(adjacent)]
+#[allow(clippy::manual_non_exhaustive)]
+pub struct PkgWithIdOption {
+    /// Install a package and assign an explicit ID
+    #[bpaf(long("id"), short('i'))]
+    _option: (),
+    /// ID of the package to install
+    #[bpaf(positional("id"))]
+    pub id: String,
+    /// Path to the package to install as shown by `flox search`
+    #[bpaf(positional("package"))]
+    pub path: String,
 }
 
 impl Install {
@@ -559,18 +579,37 @@ impl Install {
             .detect_concrete_environment(&flox, "install to")?;
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
-        let installation = environment.install(self.packages.clone(), &flox).await?;
+        let mut packages = self
+            .packages
+            .iter()
+            .map(|p| PackageToInstall::from_str(p))
+            .collect::<Result<Vec<_>, _>>()?;
+        packages.extend(self.id.iter().map(|p| PackageToInstall {
+            id: p.id.clone(),
+            path: p.path.clone(),
+            version: None,
+            input: None,
+        }));
+        let installation = environment.install(&packages, &flox).await?;
         if installation.new_manifest.is_some() {
             // Print which new packages were installed
-            for pkg in self.packages.iter() {
-                if let Some(false) = installation.already_installed.get(pkg) {
-                    info!("✅ '{pkg}' installed to environment {description}");
+            for pkg in packages.iter() {
+                if let Some(false) = installation.already_installed.get(&pkg.id) {
+                    info!("✅ '{}' installed to environment {description}", pkg.id);
                 } else {
-                    info!("⚠️ '{pkg}' already installed to environment {description}");
+                    info!(
+                        "⚠️  package with id '{}' already installed to environment {description}",
+                        pkg.id
+                    );
                 }
             }
         } else {
-            info!("⚠️ package(s) already installed to environment {description}");
+            for pkg in packages.iter() {
+                info!(
+                    "⚠️  package with id '{}' already installed to environment {description}",
+                    pkg.id
+                );
+            }
         }
         Ok(())
     }

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -590,6 +590,9 @@ impl Install {
             version: None,
             input: None,
         }));
+        if packages.is_empty() {
+            bail!("Must specify at least one package");
+        }
         let installation = environment.install(&packages, &flox).await?;
         if installation.new_manifest.is_some() {
             // Print which new packages were installed

--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -113,9 +113,9 @@ impl ConfigArgs {
 
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(adjacent)]
-#[allow(unused)]
 pub struct ConfigSet {
     /// set <key> to <value>
+    #[allow(unused)]
     set: (),
     /// Configuration key
     #[bpaf(positional("key"))]

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -81,7 +81,7 @@ env_is_activated() {
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello;
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  SHELL=bash USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR";
+  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR";
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -96,7 +96,7 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR";
+  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR";
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -111,7 +111,7 @@ script = """
   echo "Welcome to your flox environment!";
 """
 EOF
-  SHELL=bash run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR";
+  SHELL=bash NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR";
   assert_output --partial "Welcome to your flox environment!"
 }
 
@@ -129,7 +129,7 @@ EOF
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
   # SHELL=zsh USER="$REAL_USER" run -0 bash -c "echo exit | $FLOX_CLI activate --dir $PROJECT_DIR";
-  SHELL=zsh USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR";
+  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR";
   assert_output --partial "Welcome to your flox environment!"
 }
 
@@ -141,7 +141,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=bash USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is aliased to \`echo testing'";
 }
 
@@ -153,7 +153,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is an alias for echo testing";
 }
 
@@ -165,7 +165,7 @@ EOF
 [vars]
 foo = "$bar"
 EOF
-  SHELL=bash bar=baz run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR";
+  SHELL=bash bar=baz NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR";
   assert_output --partial "baz";
 }
 
@@ -180,7 +180,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh bar=baz USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR";
+  SHELL=zsh bar=baz USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR";
   assert_output --partial "baz";
 }
 

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -10,226 +10,215 @@
 #
 # ---------------------------------------------------------------------------- #
 
-load test_support.bash;
+load test_support.bash
 
 # bats file_tags=activate
-
 
 # ---------------------------------------------------------------------------- #
 
 setup_file() {
-  common_file_setup;
+	common_file_setup
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Helpers for project based tests.
 
 project_setup() {
-  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}";
-  export PROJECT_NAME="${PROJECT_DIR##*/}";
-  rm -rf "$PROJECT_DIR";
-  mkdir -p "$PROJECT_DIR";
-  pushd "$PROJECT_DIR" >/dev/null||return;
-  "$FLOX_BIN" init -d "$PROJECT_DIR";
+	export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+	export PROJECT_NAME="${PROJECT_DIR##*/}"
+	rm -rf "$PROJECT_DIR"
+	mkdir -p "$PROJECT_DIR"
+	pushd "$PROJECT_DIR" >/dev/null || return
+	"$FLOX_BIN" init -d "$PROJECT_DIR"
 }
 
 project_teardown() {
-  popd >/dev/null||return;
-  rm -rf "${PROJECT_DIR?}";
-  unset PROJECT_DIR;
-  unset PROJECT_NAME;
+	popd >/dev/null || return
+	rm -rf "${PROJECT_DIR?}"
+	unset PROJECT_DIR
+	unset PROJECT_NAME
 }
 
 activate_local_env() {
-  run "$FLOX_BIN" activate -d "$PROJECT_DIR";
+	run "$FLOX_BIN" activate -d "$PROJECT_DIR"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
-setup()    { common_test_setup; project_setup;       }
-teardown() { project_teardown; common_test_teardown; }
+setup() {
+	common_test_setup
+	project_setup
+}
+teardown() {
+	project_teardown
+	common_test_teardown
+}
 
 # ---------------------------------------------------------------------------- #
 
 activated_envs() {
-  # Note that this variable is unset at the start of the test suite,
-  # so it will only exist after activating an environment
-  activated_envs=($(echo "$FLOX_PROMPT_ENVIRONMENTS"));
-  echo "${activated_envs[*]}";
+	# Note that this variable is unset at the start of the test suite,
+	# so it will only exist after activating an environment
+	activated_envs=($(echo "$FLOX_PROMPT_ENVIRONMENTS"))
+	echo "${activated_envs[*]}"
 }
 
 env_is_activated() {
-  local is_activated;
-  is_activated=0;
-  for ae in $(activated_envs)
-  do
-    echo "activated_env = $ae, query = $1";
-    if [[ "$ae" =~ "$1" ]]; then
-      is_activated=1;
-    fi
-  done
-  echo "$is_activated";
+	local is_activated
+	is_activated=0
+	for ae in $(activated_envs); do
+		echo "activated_env = $ae, query = $1"
+		if [[ $ae =~ $1 ]]; then
+			is_activated=1
+		fi
+	done
+	echo "$is_activated"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "bash: activate modifies prompt and puts package in path" {
-  run "$FLOX_BIN" install -d "$PROJECT_DIR" hello;
-  assert_success
-  assert_output --partial "✅ 'hello' installed to environment"
-  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR";
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+	run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
+	assert_success
+	assert_output --partial "✅ 'hello' installed to environment"
+	SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+	assert_output --regexp "bin/hello"
+	refute_output "not found"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "zsh: activate modifies prompt and puts package in path" {
-  run "$FLOX_BIN" install -d "$PROJECT_DIR" hello;
-  assert_success
-  assert_output --partial "✅ 'hello' installed to environment"
-  # TODO: flox will set HOME if it doesn't match the home of the user with
-  # current euid. I'm not sure if we should change that, but for now just set
-  # USER to REAL_USER.
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR";
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+	run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
+	assert_success
+	assert_output --partial "✅ 'hello' installed to environment"
+	# TODO: flox will set HOME if it doesn't match the home of the user with
+	# current euid. I'm not sure if we should change that, but for now just set
+	# USER to REAL_USER.
+	SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+	assert_output --regexp "bin/hello"
+	refute_output "not found"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "bash: activate runs hook" {
-  cat << "EOF" >> "$PROJECT_DIR/.flox/env/manifest.toml"
+	cat <<"EOF" >>"$PROJECT_DIR/.flox/env/manifest.toml"
 [hook]
 script = """
   echo "Welcome to your flox environment!";
 """
 EOF
-  SHELL=bash NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR";
-  assert_output --partial "Welcome to your flox environment!"
+	SHELL=bash NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+	assert_output --partial "Welcome to your flox environment!"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "zsh: activate runs hook" {
-  cat << "EOF" >> "$PROJECT_DIR/.flox/env/manifest.toml"
+	cat <<"EOF" >>"$PROJECT_DIR/.flox/env/manifest.toml"
 [hook]
 script = """
   echo "Welcome to your flox environment!";
 """
 EOF
-  # TODO: flox will set HOME if it doesn't match the home of the user with
-  # current euid. I'm not sure if we should change that, but for now just set
-  # USER to REAL_USER.
-  # SHELL=zsh USER="$REAL_USER" run -0 bash -c "echo exit | $FLOX_CLI activate --dir $PROJECT_DIR";
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR";
-  assert_output --partial "Welcome to your flox environment!"
+	# TODO: flox will set HOME if it doesn't match the home of the user with
+	# current euid. I'm not sure if we should change that, but for now just set
+	# USER to REAL_USER.
+	# SHELL=zsh USER="$REAL_USER" run -0 bash -c "echo exit | $FLOX_CLI activate --dir $PROJECT_DIR";
+	SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+	assert_output --partial "Welcome to your flox environment!"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "bash: activate respects ~/.bashrc" {
-  echo "alias test_alias='echo testing'" > "$HOME/.bashrc";
-  # TODO: flox will set HOME if it doesn't match the home of the user with
-  # current euid. I'm not sure if we should change that, but for now just set
-  # USER to REAL_USER.
-  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
-  assert_output --partial "test_alias is aliased to \`echo testing'";
+	echo "alias test_alias='echo testing'" >"$HOME/.bashrc"
+	# TODO: flox will set HOME if it doesn't match the home of the user with
+	# current euid. I'm not sure if we should change that, but for now just set
+	# USER to REAL_USER.
+	SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+	assert_output --partial "test_alias is aliased to \`echo testing'"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "zsh: activate respects ~/.zshrc" {
-  echo "alias test_alias='echo testing'" > "$HOME/.zshrc";
-  # TODO: flox will set HOME if it doesn't match the home of the user with
-  # current euid. I'm not sure if we should change that, but for now just set
-  # USER to REAL_USER.
-  SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
-  assert_output --partial "test_alias is an alias for echo testing";
+	echo "alias test_alias='echo testing'" >"$HOME/.zshrc"
+	# TODO: flox will set HOME if it doesn't match the home of the user with
+	# current euid. I'm not sure if we should change that, but for now just set
+	# USER to REAL_USER.
+	SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+	assert_output --partial "test_alias is an alias for echo testing"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "bash: activate sets env var" {
-  cat << "EOF" >> "$PROJECT_DIR/.flox/env/manifest.toml"
+	cat <<"EOF" >>"$PROJECT_DIR/.flox/env/manifest.toml"
 [vars]
 foo = "$bar"
 EOF
-  SHELL=bash bar=baz NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR";
-  assert_output --partial "baz";
+	SHELL=bash bar=baz NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+	assert_output --partial "baz"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "zsh: activate sets env var" {
-  cat << "EOF" >> "$PROJECT_DIR/.flox/env/manifest.toml"
+	cat <<"EOF" >>"$PROJECT_DIR/.flox/env/manifest.toml"
 [vars]
 foo = "$bar"
 EOF
-  # TODO: flox will set HOME if it doesn't match the home of the user with
-  # current euid. I'm not sure if we should change that, but for now just set
-  # USER to REAL_USER.
-  SHELL=zsh bar=baz USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR";
-  assert_output --partial "baz";
+	# TODO: flox will set HOME if it doesn't match the home of the user with
+	# current euid. I'm not sure if we should change that, but for now just set
+	# USER to REAL_USER.
+	SHELL=zsh bar=baz USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+	assert_output --partial "baz"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "a1: 'flox develop' aliases to 'flox activate'" {
-  skip FIXME;
-  run "$FLOX_BIN" develop;
-  assert_success;
-  is_activated=$(env_is_activated "$PROJECT_NAME");
-  assert_equal "$is_activated" "1";
+	skip FIXME
+	run "$FLOX_BIN" develop
+	assert_success
+	is_activated=$(env_is_activated "$PROJECT_NAME")
+	assert_equal "$is_activated" "1"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "a2: activates environment in current dir by default" {
-  skip FIXME;
-  run "$FLOX_BIN" activate;
-  assert_success;
-  is_activated=$(env_is_activated "$PROJECT_NAME");
-  assert_equal "$is_activated" "1";
+	skip FIXME
+	run "$FLOX_BIN" activate
+	assert_success
+	is_activated=$(env_is_activated "$PROJECT_NAME")
+	assert_equal "$is_activated" "1"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "a3: 'flox activate' accepts explicit environment name" {
-  skip FIXME;
-  run "$FLOX_BIN" activate -d "$PROJECT_DIR"
-  assert_success;
-  is_activated=$(env_is_activated "$PROJECT_NAME");
-  assert_equal "$is_activated" "1";
+	skip FIXME
+	run "$FLOX_BIN" activate -d "$PROJECT_DIR"
+	assert_success
+	is_activated=$(env_is_activated "$PROJECT_NAME")
+	assert_equal "$is_activated" "1"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "a4: 'flox activate' modifies shell prompt with 'bash'" {
-  skip FIXME;
-  prompt_before="${PS1@P}";
-  bash -c '"$FLOX_BIN" activate -d "$PROJECT_DIR"';
-  assert_success;
-  prompt_after="${PS1@P}";
-  assert_not_equal prompt_before prompt_after;
-  assert_regex prompt_after "flox \[.*$PROJECT_NAME.*\]"
+	skip FIXME
+	prompt_before="${PS1@P}"
+	bash -c '"$FLOX_BIN" activate -d "$PROJECT_DIR"'
+	assert_success
+	prompt_after="${PS1@P}"
+	assert_not_equal prompt_before prompt_after
+	assert_regex prompt_after "flox \[.*$PROJECT_NAME.*\]"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
@@ -245,61 +234,57 @@ EOF
 #   assert_regex prompt_after "\[.*$PROJECT_NAME.*\]"
 # }
 
-
 # ---------------------------------------------------------------------------- #
 
 @test "a5: multiple activations are layered" {
-  skip FIXME;
-  # Steps
-  # - Activate env1
-  # - Activate env2
-  # - Read activated envs with `activated_envs`
-  # - Ensure that env2 (the last activated env) appears on the left
+	skip FIXME
+	# Steps
+	# - Activate env1
+	# - Activate env2
+	# - Read activated envs with `activated_envs`
+	# - Ensure that env2 (the last activated env) appears on the left
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "a6: activate an environment by path" {
-  skip FIXME;
-  # Steps
-  # - Activate an environment with the -d option
-  # - Ensure that the environment is activated with `env_is_activated`
-  is_activated=$(env_is_activated "$PROJECT_NAME");
-  assert_equal "$is_activated" "1";
+	skip FIXME
+	# Steps
+	# - Activate an environment with the -d option
+	# - Ensure that the environment is activated with `env_is_activated`
+	is_activated=$(env_is_activated "$PROJECT_NAME")
+	assert_equal "$is_activated" "1"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "a7: language specifics are set" {
-  skip FIXME;
-  # Steps
-  # - Unset the PYTHON_PATH variable
-  # - Install Python to the local environment
-  # - Activate the environment
-  # - Verify that PYTHON_PATH is set
+	skip FIXME
+	# Steps
+	# - Unset the PYTHON_PATH variable
+	# - Install Python to the local environment
+	# - Activate the environment
+	# - Verify that PYTHON_PATH is set
 }
 
 # ---------------------------------------------------------------------------- #
 
 @test "active environment is removed from active list after deactivating" {
-  skip FIXME;
-  # Steps
-  # - Active an environment
-  # - Verify that it appears in the list of active environments
-  # - Exit the environment
-  # - Ensure that it no longer appears in the list of active environments
+	skip FIXME
+	# Steps
+	# - Active an environment
+	# - Verify that it appears in the list of active environments
+	# - Exit the environment
+	# - Ensure that it no longer appears in the list of active environments
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox activate' modifies path" {
-  skip FIXME;
-  original_path="$PATH";
-  # Hangs because activate runs `nix shell` interactively right now
-  run "$FLOX_BIN" activate -- echo "$PATH"
-  assert_success;
-  assert_equal "$original_path" "$output";
+	skip FIXME
+	original_path="$PATH"
+	# Hangs because activate runs `nix shell` interactively right now
+	run "$FLOX_BIN" activate -- echo "$PATH"
+	assert_success
+	assert_equal "$original_path" "$output"
 }

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -153,7 +153,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is an alias for echo testing";
 }
 
@@ -233,15 +233,17 @@ EOF
 
 # ---------------------------------------------------------------------------- #
 
-@test "a4: 'flox activate' modifies shell prompt with 'zsh'" {
-  skip FIXME;
-  prompt_before="${(%%)PS1}";
-  zsh -c '"$FLOX_BIN" activate -d "$PROJECT_DIR"';
-  assert_success;
-  prompt_after="${(%%)PS1}";
-  assert_not_equal prompt_before prompt_after;
-  assert_regex prompt_after "\[.*$PROJECT_NAME.*\]"
-}
+# Commented out until someone decides to make this test pass,
+# otherwise shellcheck complains.
+# @test "a4: 'flox activate' modifies shell prompt with 'zsh'" {
+#   skip FIXME;
+#   prompt_before="${(%%)PS1}";
+#   zsh -c '"$FLOX_BIN" activate -d "$PROJECT_DIR"';
+#   assert_success;
+#   prompt_after="${(%%)PS1}";
+#   assert_not_equal prompt_before prompt_after;
+#   assert_regex prompt_after "\[.*$PROJECT_NAME.*\]"
+# }
 
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -104,6 +104,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' says to re-activate when hook is modified and environment is active" {
+  skip "FIXME: hangs locally"
   "$FLOX_BIN" init
   cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
   cat << "EOF" >> "$TMP_MANIFEST_PATH"

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -60,9 +60,9 @@ check_manifest_updated() {
 @test "'flox edit' confirms successful edit" {
   "$FLOX_BIN" init
   cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
-  cat << "EOF" >> "$TMP_MANIFEST_PATH"
+  cat << "EOF" > "$TMP_MANIFEST_PATH"
 [install]
-hello = {}
+hello.path = "hello"
 EOF
 
   run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -13,193 +13,180 @@ load test_support.bash
 # Helpers for project based tests.
 
 project_setup() {
-  export PROJECT_NAME="test";
-  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
-  export MANIFEST_PATH="$PROJECT_DIR/.flox/env/manifest.toml"
-  export TMP_MANIFEST_PATH="${BATS_TEST_TMPDIR}/manifest.toml"
-  rm -rf "$PROJECT_DIR"
-  mkdir -p "$PROJECT_DIR"
-  pushd "$PROJECT_DIR" >/dev/null || return
+	export PROJECT_NAME="test"
+	export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
+	export MANIFEST_PATH="$PROJECT_DIR/.flox/env/manifest.toml"
+	export TMP_MANIFEST_PATH="${BATS_TEST_TMPDIR}/manifest.toml"
+	rm -rf "$PROJECT_DIR"
+	mkdir -p "$PROJECT_DIR"
+	pushd "$PROJECT_DIR" >/dev/null || return
 }
 
 project_teardown() {
-  popd >/dev/null || return
-  rm -rf "${PROJECT_DIR?}"
-  rm -f "${TMP_MANIFEST_PATH?}"
-  unset PROJECT_DIR
-  unset MANIFEST_PATH
-  unset TMP_MANIFEST_PATH
+	popd >/dev/null || return
+	rm -rf "${PROJECT_DIR?}"
+	rm -f "${TMP_MANIFEST_PATH?}"
+	unset PROJECT_DIR
+	unset MANIFEST_PATH
+	unset TMP_MANIFEST_PATH
 }
 
 # ---------------------------------------------------------------------------- #
 
 setup() {
-  common_test_setup;
-  project_setup;
+	common_test_setup
+	project_setup
 }
 teardown() {
-  project_teardown;
-  common_test_teardown;
+	project_teardown
+	common_test_teardown
 }
 
 # ---------------------------------------------------------------------------- #
 
 check_manifest_unchanged() {
-  current_contents=$(cat "$MANIFEST_PATH")
-  [[ "$current_contents" = "$ORIGINAL_MANIFEST_CONTENTS" ]]
+	current_contents=$(cat "$MANIFEST_PATH")
+	[[ $current_contents == "$ORIGINAL_MANIFEST_CONTENTS" ]]
 }
 
 check_manifest_updated() {
-  current_contents=$(cat "$MANIFEST_PATH")
-  [[ "$current_contents" = "$NEW_MANIFEST_CONTENTS" ]]
+	current_contents=$(cat "$MANIFEST_PATH")
+	[[ $current_contents == "$NEW_MANIFEST_CONTENTS" ]]
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' confirms successful edit" {
-  "$FLOX_BIN" init
-  cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
-  cat << "EOF" > "$TMP_MANIFEST_PATH"
+	"$FLOX_BIN" init
+	cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
+	cat <<"EOF" >"$TMP_MANIFEST_PATH"
 [install]
 hello.path = "hello"
 EOF
 
-  run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
-  assert_success
-  assert_output --partial "✅ environment successfully edited"
+	run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
+	assert_success
+	assert_output --partial "✅ environment successfully edited"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' says no changes made" {
-  "$FLOX_BIN" init
-  cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
+	"$FLOX_BIN" init
+	cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
 
-  run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
-  assert_success
-  assert_output --partial "⚠️  no changes made to environment"
+	run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
+	assert_success
+	assert_output --partial "⚠️  no changes made to environment"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' does not say to re-activate when hook is modified and environment is not active" {
-  "$FLOX_BIN" init
-  cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
-  cat << "EOF" >> "$TMP_MANIFEST_PATH"
+	"$FLOX_BIN" init
+	cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
+	cat <<"EOF" >>"$TMP_MANIFEST_PATH"
 [hook]
 script = """
   echo "Welcome to your flox environment!";
 """
 EOF
 
-  run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
-  assert_success
-  assert_output --partial "✅ environment successfully edited"
+	run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
+	assert_success
+	assert_output --partial "✅ environment successfully edited"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' says to re-activate when hook is modified and environment is active" {
-  skip "FIXME: hangs locally"
-  "$FLOX_BIN" init
-  cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
-  cat << "EOF" >> "$TMP_MANIFEST_PATH"
+	"$FLOX_BIN" init
+	cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
+	cat <<"EOF" >>"$TMP_MANIFEST_PATH"
 [hook]
 script = """
   echo "Welcome to your flox environment!";
 """
 EOF
 
-  SHELL=bash run expect -d "$TESTS_DIR/edit/re-activate.exp" "$TMP_MANIFEST_PATH"
-  assert_success
+	SHELL=bash run expect -d "$TESTS_DIR/edit/re-activate.exp" "$TMP_MANIFEST_PATH"
+	assert_success
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' accepts contents via filename" {
-  skip "FIXME: broken migrating to manifest.toml";
-  run cat "$EXTERNAL_MANIFEST_PATH"
-  run "$FLOX_BIN" edit -f "$EXTERNAL_MANIFEST_PATH";
-  assert_success;
-  WRITTEN=$(cat "$MANIFEST_PATH");
-  assert_equal "$WRITTEN" "$NEW_MANIFEST_CONTENTS";
+	skip "FIXME: broken migrating to manifest.toml"
+	run cat "$EXTERNAL_MANIFEST_PATH"
+	run "$FLOX_BIN" edit -f "$EXTERNAL_MANIFEST_PATH"
+	assert_success
+	WRITTEN=$(cat "$MANIFEST_PATH")
+	assert_equal "$WRITTEN" "$NEW_MANIFEST_CONTENTS"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' accepts contents via pipe to stdin" {
-  skip "FIXME: broken migrating to manifest.toml";
-  run sh -c "cat ${EXTERNAL_MANIFEST_PATH} | ${FLOX_BIN} edit -f -";
-  assert_success;
-  # Get the contents as they appear in the actual manifest after the operation
-  WRITTEN=$(cat "$MANIFEST_PATH");
-  # Assert that it's the same as the contents we supplied
-  assert_equal "$WRITTEN" "$NEW_MANIFEST_CONTENTS";
+	skip "FIXME: broken migrating to manifest.toml"
+	run sh -c "cat ${EXTERNAL_MANIFEST_PATH} | ${FLOX_BIN} edit -f -"
+	assert_success
+	# Get the contents as they appear in the actual manifest after the operation
+	WRITTEN=$(cat "$MANIFEST_PATH")
+	# Assert that it's the same as the contents we supplied
+	assert_equal "$WRITTEN" "$NEW_MANIFEST_CONTENTS"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' fails with invalid contents supplied via filename" {
-  skip "FIXME: broken migrating to manifest.toml";
-  echo "foo = " > "$EXTERNAL_MANIFEST_PATH";
-  run "$FLOX_BIN" edit -f "$EXTERNAL_MANIFEST_PATH";
-  assert_failure;
-  run check_manifest_unchanged;
-  assert_success;
+	skip "FIXME: broken migrating to manifest.toml"
+	echo "foo = " >"$EXTERNAL_MANIFEST_PATH"
+	run "$FLOX_BIN" edit -f "$EXTERNAL_MANIFEST_PATH"
+	assert_failure
+	run check_manifest_unchanged
+	assert_success
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' fails with invalid contents supplied via stdin" {
-  skip "FIXME: broken migrating to manifest.toml";
-  run sh -c "echo 'foo = ;' | ${FLOX_BIN} edit -f -";
-  assert_failure;
-  run check_manifest_unchanged;
-  assert_success;
+	skip "FIXME: broken migrating to manifest.toml"
+	run sh -c "echo 'foo = ;' | ${FLOX_BIN} edit -f -"
+	assert_failure
+	run check_manifest_unchanged
+	assert_success
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' fails when provided filename doesn't exist" {
-  run "$FLOX_BIN" edit -f "does_not_exist.toml";
-  assert_failure;
+	run "$FLOX_BIN" edit -f "does_not_exist.toml"
+	assert_failure
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' fails when EDITOR is not set" {
-  run "$FLOX_BIN" edit;
-  assert_failure;
+	run "$FLOX_BIN" edit
+	assert_failure
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' adds package with EDITOR" {
-  skip "FIXME: broken migrating to manifest.toml";
-  EDITOR="$TESTS_DIR/add-hello" run "$FLOX_BIN" edit;
-  assert_success;
-  run check_manifest_updated;
-  assert_success;
+	skip "FIXME: broken migrating to manifest.toml"
+	EDITOR="$TESTS_DIR/add-hello" run "$FLOX_BIN" edit
+	assert_success
+	run check_manifest_updated
+	assert_success
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 @test "'flox edit' fails when EDITOR makes invalid edit" {
-  skip "FIXME: broken migrating to manifest.toml";
-  EDITOR="$TESTS_DIR/add-invalid-edit" run "$FLOX_BIN" edit;
-  assert_failure;
-  run check_manifest_unchanged;
-  assert_success;
+	skip "FIXME: broken migrating to manifest.toml"
+	EDITOR="$TESTS_DIR/add-invalid-edit" run "$FLOX_BIN" edit
+	assert_failure
+	run check_manifest_unchanged
+	assert_success
 }

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -175,7 +175,7 @@ teardown() {
   assert_success;
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml");
   # This also checks that it correctly infers the install ID
-  assert_regex "$manifest" 'hello.path = "hello"';
+  assert_regex "$manifest" 'hello\.path = "hello"';
 }
 
 @test "'flox install' infers install ID" {
@@ -185,7 +185,7 @@ teardown() {
   assert_success;
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml");
   # This also checks that it correctly infers the install ID
-  assert_regex "$manifest" 'rails.path = "rubyPackages_3_2\.rails"';
+  assert_regex "$manifest" 'rails\.path = "rubyPackages_3_2\.rails"';
 }
 
 @test "'flox install' overrides install ID with '-i'" {
@@ -194,7 +194,7 @@ teardown() {
   run "$FLOX_BIN" install -i foo hello;
   assert_success;
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml");
-  assert_regex "$manifest" 'foo.path = "hello"';
+  assert_regex "$manifest" 'foo\.path = "hello"';
 }
 
 @test "'flox install' overrides install ID with '--id'" {
@@ -203,7 +203,7 @@ teardown() {
   run "$FLOX_BIN" install --id foo hello;
   assert_success;
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml");
-  assert_regex "$manifest" 'foo.path = "hello"';
+  assert_regex "$manifest" 'foo\.path = "hello"';
 }
 
 @test "'flox install' accepts mix of inferred and supplied install IDs" {
@@ -212,7 +212,7 @@ teardown() {
   run "$FLOX_BIN" install -i foo rubyPackages_3_2.webmention ripgrep -i bar rubyPackages_3_2.rails;
   assert_success;
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml");
-  assert_regex "$manifest" 'foo.path = "rubyPackages_3_2\.webmention"';
-  assert_regex "$manifest" 'ripgrep.path = "ripgrep"';
-  assert_regex "$manifest" 'bar.path = "rubyPackages_3_2\.rails"';
+  assert_regex "$manifest" 'foo\.path = "rubyPackages_3_2\.webmention"';
+  assert_regex "$manifest" 'ripgrep\.path = "ripgrep"';
+  assert_regex "$manifest" 'bar\.path = "rubyPackages_3_2\.rails"';
 }

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -57,7 +57,7 @@ teardown() {
   "$FLOX_BIN" init;
   run "$FLOX_BIN" install hello;
   assert_success;
-  run grep "hello = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
+  run grep 'hello.path = "hello"' "$PROJECT_DIR/.flox/env/manifest.toml";
   assert_success;
 }
 
@@ -78,7 +78,7 @@ teardown() {
   run "$FLOX_BIN" install hello;
   assert_success;
   run "$FLOX_BIN" uninstall hello;
-  run grep "^hello = {}" "$PROJECT_DIR/.flox/env/manifest.toml";
+  run grep '^hello.path = "hello"' "$PROJECT_DIR/.flox/env/manifest.toml";
   assert_failure;
 }
 

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -7,10 +7,9 @@
 #
 # ---------------------------------------------------------------------------- #
 
-bats_load_library bats-support;
-bats_load_library bats-assert;
-bats_require_minimum_version '1.5.0';
-
+bats_load_library bats-support
+bats_load_library bats-assert
+bats_require_minimum_version '1.5.0'
 
 # ---------------------------------------------------------------------------- #
 
@@ -21,79 +20,76 @@ bats_require_minimum_version '1.5.0';
 #
 # NOTE: we unset these variables past this point to avoid pollution.
 xdg_reals_setup() {
-  if [[ -n "${__FT_RAN_XDG_REALS_SETUP:-}" ]]; then return 0; fi
-  # Set fallbacks and export.
-  : "${USER:=$( id -un 2>/dev/null; )}";
-  if [[ -z "${HOME:-}" ]]; then
-		: HOME="$( getent passwd "$USER" 2>/dev/null|cut -d: -f6; )";
-    if [[ -z "${HOME:-}" ]]; then
-      if [[ -d "/home/$USER" ]]; then
-        HOME="/home/$USER"
-      else
-        HOME="${BATS_RUN_TMPDIR:?}/homeless-shelter";
-      fi
-    fi
-  fi
-  : "${XDG_CONFIG_HOME:=${HOME:?}/.config}";
-  : "${XDG_CACHE_HOME:=$HOME/.cache}";
-  : "${XDG_DATA_HOME:=$HOME/.local/share}";
-  : "${XDG_STATE_HOME:=$HOME/.local/state}";
-  export REAL_USER="$USER";
-  export REAL_HOME="$HOME";
-  export REAL_XDG_CONFIG_HOME="${XDG_CONFIG_HOME:?}";
-  export REAL_XDG_CACHE_HOME="${XDG_CACHE_HOME:?}";
-  export REAL_XDG_DATA_HOME="${XDG_DATA_HOME:?}";
-  export REAL_XDG_STATE_HOME="${XDG_STATE_HOME:?}";
-  # Prevent later routines from referencing real dirs.
-  unset USER HOME XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME XDG_STATE_HOME;
-  export __FT_RAN_XDG_REALS_SETUP=:;
+	if [[ -n ${__FT_RAN_XDG_REALS_SETUP-} ]]; then return 0; fi
+	# Set fallbacks and export.
+	: "${USER:=$(id -un 2>/dev/null)}"
+	if [[ -z ${HOME-} ]]; then
+		: HOME="$(getent passwd "$USER" 2>/dev/null | cut -d: -f6)"
+		if [[ -z ${HOME-} ]]; then
+			if [[ -d "/home/$USER" ]]; then
+				HOME="/home/$USER"
+			else
+				HOME="${BATS_RUN_TMPDIR:?}/homeless-shelter"
+			fi
+		fi
+	fi
+	: "${XDG_CONFIG_HOME:=${HOME:?}/.config}"
+	: "${XDG_CACHE_HOME:=$HOME/.cache}"
+	: "${XDG_DATA_HOME:=$HOME/.local/share}"
+	: "${XDG_STATE_HOME:=$HOME/.local/state}"
+	export REAL_USER="$USER"
+	export REAL_HOME="$HOME"
+	export REAL_XDG_CONFIG_HOME="${XDG_CONFIG_HOME:?}"
+	export REAL_XDG_CACHE_HOME="${XDG_CACHE_HOME:?}"
+	export REAL_XDG_DATA_HOME="${XDG_DATA_HOME:?}"
+	export REAL_XDG_STATE_HOME="${XDG_STATE_HOME:?}"
+	# Prevent later routines from referencing real dirs.
+	unset USER HOME XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME XDG_STATE_HOME
+	export __FT_RAN_XDG_REALS_SETUP=:
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 git_reals_setup() {
-  if [[ -n "${__FT_RAN_GIT_REALS_SETUP:-}" ]]; then return 0; fi
-  xdg_reals_setup;
-  # Set fallbacks and export.
-  : "${GIT_CONFIG_SYSTEM:=/etc/gitconfig}";
-  if [[ -z "${GIT_CONFIG_GLOBAL:-}" ]]; then
-    if [[ -r "$REAL_XDG_CONFIG_HOME/git/gitconfig" ]]; then
-      GIT_CONFIG_GLOBAL="$REAL_XDG_CONFIG_HOME/git/gitconfig";
-    else
-      GIT_CONFIG_GLOBAL="${REAL_HOME:?}/.gitconfig";
-    fi
-  fi
-  export REAL_GIT_CONFIG_SYSTEM="${GIT_CONFIG_SYSTEM:?}";
-  export REAL_GIT_CONFIG_GLOBAL="${GIT_CONFIG_GLOBAL:?}";
-  # Prevent later routines from referencing real configs.
-  unset GIT_CONFIG_SYSTEM GIT_CONFIG_GLOBAL;
-  export __FT_RAN_GIT_REALS_SETUP=:;
+	if [[ -n ${__FT_RAN_GIT_REALS_SETUP-} ]]; then return 0; fi
+	xdg_reals_setup
+	# Set fallbacks and export.
+	: "${GIT_CONFIG_SYSTEM:=/etc/gitconfig}"
+	if [[ -z ${GIT_CONFIG_GLOBAL-} ]]; then
+		if [[ -r "$REAL_XDG_CONFIG_HOME/git/gitconfig" ]]; then
+			GIT_CONFIG_GLOBAL="$REAL_XDG_CONFIG_HOME/git/gitconfig"
+		else
+			GIT_CONFIG_GLOBAL="${REAL_HOME:?}/.gitconfig"
+		fi
+	fi
+	export REAL_GIT_CONFIG_SYSTEM="${GIT_CONFIG_SYSTEM:?}"
+	export REAL_GIT_CONFIG_GLOBAL="${GIT_CONFIG_GLOBAL:?}"
+	# Prevent later routines from referencing real configs.
+	unset GIT_CONFIG_SYSTEM GIT_CONFIG_GLOBAL
+	export __FT_RAN_GIT_REALS_SETUP=:
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Prime the flox-gh authentication to use the test credential.
 floxtest_gitforge_setup() {
-  if [[ -n "${__FT_RAN_FLOXTEST_GITFORGE_SETUP:-}" ]]; then return 0; fi
-  xdg_tmp_setup;
-  flox_vars_setup;
-  # Create fake flox-gh auth token data recognised as test user on flox
-  # gitforge. This obviously won't be recognised as a valid token by the
-  # GitHub API, but that's OK because we've hard-coded this identity both
-  # in flox-gh and on our gitforge proxy.
-  mkdir -p $FLOX_CONFIG_HOME/gh
-  cat >$FLOX_CONFIG_HOME/gh/hosts.yml <<EOF
+	if [[ -n ${__FT_RAN_FLOXTEST_GITFORGE_SETUP-} ]]; then return 0; fi
+	xdg_tmp_setup
+	flox_vars_setup
+	# Create fake flox-gh auth token data recognised as test user on flox
+	# gitforge. This obviously won't be recognised as a valid token by the
+	# GitHub API, but that's OK because we've hard-coded this identity both
+	# in flox-gh and on our gitforge proxy.
+	mkdir -p $FLOX_CONFIG_HOME/gh
+	cat >$FLOX_CONFIG_HOME/gh/hosts.yml <<EOF
 github.com:
     oauth_token: flox_testOAuthToken
     user: floxtest
     git_protocol: https
 EOF
-  chmod 600 $FLOX_CONFIG_HOME/gh/hosts.yml
-  export __FT_RAN_FLOXTEST_GITFORGE_SETUP=:;
+	chmod 600 $FLOX_CONFIG_HOME/gh/hosts.yml
+	export __FT_RAN_FLOXTEST_GITFORGE_SETUP=:
 }
-
 
 # ---------------------------------------------------------------------------- #
 
@@ -103,117 +99,115 @@ print_var() { eval echo "  $1: \$$1"; }
 # We sometimes refer to these in order to copy resources from the system into
 # our isolated sandboxes.
 reals_setup() {
-  nix_store_dir_setup;
-  xdg_reals_setup;
-  git_reals_setup;
-  {
-    print_var FLOX_BIN;
-    print_var NIX_BIN;
-    print_var NIX_STORE;
-    print_var REAL_GIT_CONFIG_GLOBAL;
-    print_var REAL_GIT_CONFIG_SYSTEM;
-    print_var REAL_HOME;
-    print_var REAL_USER;
-    print_var REAL_XDG_CACHE_HOME;
-    print_var REAL_XDG_CONFIG_HOME;
-    print_var REAL_XDG_DATA_HOME;
-    print_var REAL_XDG_STATE_HOME;
-    print_var TESTS_DIR;
-  } >&3;
+	nix_store_dir_setup
+	xdg_reals_setup
+	git_reals_setup
+	{
+		print_var FLOX_BIN
+		print_var NIX_BIN
+		print_var NIX_STORE
+		print_var REAL_GIT_CONFIG_GLOBAL
+		print_var REAL_GIT_CONFIG_SYSTEM
+		print_var REAL_HOME
+		print_var REAL_USER
+		print_var REAL_XDG_CACHE_HOME
+		print_var REAL_XDG_CONFIG_HOME
+		print_var REAL_XDG_DATA_HOME
+		print_var REAL_XDG_STATE_HOME
+		print_var TESTS_DIR
+	} >&3
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Lookup system pair recognized by `nix' for this system.
 nix_system_setup() {
-  : "${NIX_SYSTEM:=$(
-    $NIX_BIN --experimental-features nix-command eval --impure --expr builtins.currentSystem --raw;
-  )}";
-  export NIX_SYSTEM;
+	: "${NIX_SYSTEM:=$(
+		$NIX_BIN --experimental-features nix-command eval --impure --expr builtins.currentSystem --raw
+	)}"
+	export NIX_SYSTEM
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Lookup the path to the Nix store.
 # This is mostly important for testing "single user installs"
 nix_store_dir_setup() {
-  : "${NIX_STORE:=$(
-    $NIX_BIN --experimental-features nix-command eval --impure --expr builtins.storeDir --raw;
-  )}";
-  export NIX_STORE;
+	: "${NIX_STORE:=$(
+		$NIX_BIN --experimental-features nix-command eval --impure --expr builtins.storeDir --raw
+	)}"
+	export NIX_STORE
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Set variables related to locating test resources and misc. bats settings.
 misc_vars_setup() {
-  if [[ -n "${__FT_RAN_MISC_VARS_SETUP:-}" ]]; then return 0; fi
+	if [[ -n ${__FT_RAN_MISC_VARS_SETUP-} ]]; then return 0; fi
 
-  # Assume that versions:
-  # a) start with numbers
-  # b) contain at least one dot
-  # c) contain only numbers and dots
-  #
-  # Of course this isn't true in general, but we can adhere to this
-  # convention for this set of unit tests.
-  #
-  # N.B.:
-  # - do NOT include $VERSION_REGEX within quotes (eats backslashes)
-  # - do NOT add '$' at the end to anchor the match at EOL (doesn't work)
-  export VERSION_REGEX='[0-9]+\.[0-9.]+';
+	# Assume that versions:
+	# a) start with numbers
+	# b) contain at least one dot
+	# c) contain only numbers and dots
+	#
+	# Of course this isn't true in general, but we can adhere to this
+	# convention for this set of unit tests.
+	#
+	# N.B.:
+	# - do NOT include $VERSION_REGEX within quotes (eats backslashes)
+	# - do NOT add '$' at the end to anchor the match at EOL (doesn't work)
+	export VERSION_REGEX='[0-9]+\.[0-9.]+'
 
-  # Used to generate environment names.
-  # All envs with this prefix are deleted on startup and exit of this suite.
-  export FLOX_TEST_ENVNAME_PREFIX='_testing_';
+	# Used to generate environment names.
+	# All envs with this prefix are deleted on startup and exit of this suite.
+	export FLOX_TEST_ENVNAME_PREFIX='_testing_'
 
-  # Suppress warnings by `flox create' about environments named with
-  # '_testing_*' prefixes.
-  export _FLOX_TEST_SUITE_MODE=:;
+	# Suppress warnings by `flox create' about environments named with
+	# '_testing_*' prefixes.
+	export _FLOX_TEST_SUITE_MODE=:
 
-  export __FT_RAN_MISC_VARS_SETUP=:;
+	export __FT_RAN_MISC_VARS_SETUP=:
+
+	# If $ZDOTDIR is set, setting $HOME to a different location won't prevent
+	# rc files from getting loaded.
+	unset ZDOTDIR
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Scrub vars recognized by `flox' CLI and set a few configurables.
 flox_cli_vars_setup() {
-  unset FLOX_PROMPT_ENVIRONMENTS FLOX_ACTIVE_ENVIRONMENTS;
-  export FLOX_DISABLE_METRICS='true';
+	unset FLOX_PROMPT_ENVIRONMENTS FLOX_ACTIVE_ENVIRONMENTS
+	export FLOX_DISABLE_METRICS='true'
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Creates an ssh key and sets `SSH_AUTH_SOCK' for use by the test suite.
 # It is recommended that you use this setup routine in `setup_suite'.
 ssh_key_setup() {
-  if [[ -n "${__FT_RAN_SSH_KEY_SETUP:-}" ]]; then return 0; fi
-  : "${FLOX_TEST_SSH_KEY:=${BATS_SUITE_TMPDIR?}/ssh/id_ed25519}";
-  export FLOX_TEST_SSH_KEY;
-  if ! [[ -r "$FLOX_TEST_SSH_KEY" ]]; then
-    mkdir -p "${FLOX_TEST_SSH_KEY%/*}";
-    ssh-keygen -t ed25519 -q -N '' -f "$FLOX_TEST_SSH_KEY"  \
-               -C 'floxuser@example.invalid';
-    chmod 600 "$FLOX_TEST_SSH_KEY";
-  fi
-  export SSH_AUTH_SOCK="$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock";
-  if ! [[ -d "${SSH_AUTH_SOCK%/*}" ]]; then mkdir -p "${SSH_AUTH_SOCK%/*}"; fi
-  # If our socket isn't open ( it probably ain't ) we open one.
-  if ! [[ -e "$SSH_AUTH_SOCK" ]]; then
-    # You can't find work in this town without a good agent. Lets get one.
-    eval "$( ssh-agent -s; )";
-    ln -sf "$SSH_AUTH_SOCK" "$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock";
-    export SSH_AUTH_SOCK="$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock";
-    ssh-add "$FLOX_TEST_SSH_KEY";
-  fi
-  unset SSH_ASKPASS;
-  export __FT_RAN_SSH_KEY_SETUP=:;
+	if [[ -n ${__FT_RAN_SSH_KEY_SETUP-} ]]; then return 0; fi
+	: "${FLOX_TEST_SSH_KEY:=${BATS_SUITE_TMPDIR?}/ssh/id_ed25519}"
+	export FLOX_TEST_SSH_KEY
+	if ! [[ -r $FLOX_TEST_SSH_KEY ]]; then
+		mkdir -p "${FLOX_TEST_SSH_KEY%/*}"
+		ssh-keygen -t ed25519 -q -N '' -f "$FLOX_TEST_SSH_KEY" \
+			-C 'floxuser@example.invalid'
+		chmod 600 "$FLOX_TEST_SSH_KEY"
+	fi
+	export SSH_AUTH_SOCK="$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
+	if ! [[ -d ${SSH_AUTH_SOCK%/*} ]]; then mkdir -p "${SSH_AUTH_SOCK%/*}"; fi
+	# If our socket isn't open ( it probably ain't ) we open one.
+	if ! [[ -e $SSH_AUTH_SOCK ]]; then
+		# You can't find work in this town without a good agent. Lets get one.
+		eval "$(ssh-agent -s)"
+		ln -sf "$SSH_AUTH_SOCK" "$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
+		export SSH_AUTH_SOCK="$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
+		ssh-add "$FLOX_TEST_SSH_KEY"
+	fi
+	unset SSH_ASKPASS
+	export __FT_RAN_SSH_KEY_SETUP=:
 }
-
 
 # ---------------------------------------------------------------------------- #
 
@@ -226,37 +220,36 @@ ssh_key_setup() {
 # TODO: Secret key signing for `git' blows up this needs to be fixed.
 # Tests that require GPG signing are temporarily disabled.
 gpg_key_setup() {
-  if [[ -n "${__FT_RAN_GPG_KEY_SETUP:-}" ]]; then return 0; fi
-  misc_vars_setup;
-  mkdir -p "$BATS_RUN_TMPDIR/homeless-shelter/.gnupg";
-  gpg --full-gen-key --batch <( printf '%s\n'                                \
-    'Key-Type: 1' 'Key-Length: 4096' 'Subkey-Type: 1' 'Subkey-Length: 4096'  \
-    'Expire-Date: 0' 'Name-Real: Flox User'                                  \
-    'Name-Email: floxuser@example.invalid' '%no-protection';
-  );
-  export __FT_RAN_GPG_KEY_SETUP=:;
+	if [[ -n ${__FT_RAN_GPG_KEY_SETUP-} ]]; then return 0; fi
+	misc_vars_setup
+	mkdir -p "$BATS_RUN_TMPDIR/homeless-shelter/.gnupg"
+	gpg --full-gen-key --batch <(
+		printf '%s\n' \
+			'Key-Type: 1' 'Key-Length: 4096' 'Subkey-Type: 1' 'Subkey-Length: 4096' \
+			'Expire-Date: 0' 'Name-Real: Flox User' \
+			'Name-Email: floxuser@example.invalid' '%no-protection'
+	)
+	export __FT_RAN_GPG_KEY_SETUP=:
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Create a temporary `gitconfig' suitable for this test suite.
 gitconfig_setup() {
-  if [[ -n "${__FT_RAN_GITCONFIG_SETUP:-}" ]]; then return 0; fi
-  git_reals_setup;
-  mkdir -p "$BATS_SUITE_TMPDIR/git";
-  export GIT_CONFIG_SYSTEM="$BATS_SUITE_TMPDIR/git/gitconfig.system";
-  # Handle config shared across whole test suite.
-  git config --system gpg.format ssh;
-  # Create a temporary `ssh' key for use by `git'.
-  ssh_key_setup;
-  git config --system user.signingkey "$FLOX_TEST_SSH_KEY.pub";
-  # Test files and some individual tests may override this.
-  export GIT_CONFIG_GLOBAL="$BATS_SUITE_TMPDIR/git/gitconfig.global";
-  touch "$GIT_CONFIG_GLOBAL";
-  export __FT_RAN_GITCONFIG_SETUP=:;
+	if [[ -n ${__FT_RAN_GITCONFIG_SETUP-} ]]; then return 0; fi
+	git_reals_setup
+	mkdir -p "$BATS_SUITE_TMPDIR/git"
+	export GIT_CONFIG_SYSTEM="$BATS_SUITE_TMPDIR/git/gitconfig.system"
+	# Handle config shared across whole test suite.
+	git config --system gpg.format ssh
+	# Create a temporary `ssh' key for use by `git'.
+	ssh_key_setup
+	git config --system user.signingkey "$FLOX_TEST_SSH_KEY.pub"
+	# Test files and some individual tests may override this.
+	export GIT_CONFIG_GLOBAL="$BATS_SUITE_TMPDIR/git/gitconfig.global"
+	touch "$GIT_CONFIG_GLOBAL"
+	export __FT_RAN_GITCONFIG_SETUP=:
 }
-
 
 # ---------------------------------------------------------------------------- #
 
@@ -264,141 +257,131 @@ gitconfig_setup() {
 # ------------------------
 # Force the destruction of an env including any remote metdata.
 deleteEnvForce() {
-  # TODO delete using Rust
-  # { $FLOX_BIN --bash-passthru delete -e "${1?}" --origin -f||:; } >/dev/null 2>&1;
-  return 0;
+	# TODO delete using Rust
+	# { $FLOX_BIN --bash-passthru delete -e "${1?}" --origin -f||:; } >/dev/null 2>&1;
+	return 0
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Set `XDG_*_HOME' variables to temporary paths.
 # This helper should be run after setting `FLOX_TEST_HOME'.
 xdg_vars_setup() {
-  export XDG_CONFIG_HOME="${FLOX_TEST_HOME:?}/.config";
-  export XDG_CACHE_HOME="$FLOX_TEST_HOME/.cache";
-  export XDG_DATA_HOME="$FLOX_TEST_HOME/.local/share";
-  export XDG_STATE_HOME="$FLOX_TEST_HOME/.local/state";
+	export XDG_CONFIG_HOME="${FLOX_TEST_HOME:?}/.config"
+	export XDG_CACHE_HOME="$FLOX_TEST_HOME/.cache"
+	export XDG_DATA_HOME="$FLOX_TEST_HOME/.local/share"
+	export XDG_STATE_HOME="$FLOX_TEST_HOME/.local/state"
 }
-
 
 # Copy user's real caches into temporary cache to speed up eval and fetching.
 xdg_tmp_setup() {
-  xdg_reals_setup;
-  xdg_vars_setup;
-  if [[ "${__FT_RAN_XDG_TMP_SETUP:-}" = "${XDG_CACHE_HOME:?}" ]]; then
-    return 0;
-  fi
+	xdg_reals_setup
+	xdg_vars_setup
+	if [[ ${__FT_RAN_XDG_TMP_SETUP-} == "${XDG_CACHE_HOME:?}" ]]; then
+		return 0
+	fi
 
-  # Cache Dirs
+	# Cache Dirs
 
-  mkdir -p "$XDG_CACHE_HOME";
-  chmod u+w "$XDG_CACHE_HOME";
-  # We symlink the cache for `nix' so that the fetcher cache and eval cache are
-  # shared across the entire suite and between runs.
-  # We DO NOT want to use a similar approach for `flox' caches.
-  if ! [[ -e "$XDG_CACHE_HOME/nix" ]]; then
-    if [[ -e "${REAL_XDG_CACHE_HOME:?}/nix" ]]; then
-      chmod u+w "$REAL_XDG_CACHE_HOME/nix";
-      ln -s -- "$REAL_XDG_CACHE_HOME/nix" "$XDG_CACHE_HOME/nix";
-    else
-      mkdir -p "$XDG_CACHE_HOME/nix";
-    fi
-  fi
+	mkdir -p "$XDG_CACHE_HOME"
+	chmod u+w "$XDG_CACHE_HOME"
+	# We symlink the cache for `nix' so that the fetcher cache and eval cache are
+	# shared across the entire suite and between runs.
+	# We DO NOT want to use a similar approach for `flox' caches.
+	if ! [[ -e "$XDG_CACHE_HOME/nix" ]]; then
+		if [[ -e "${REAL_XDG_CACHE_HOME:?}/nix" ]]; then
+			chmod u+w "$REAL_XDG_CACHE_HOME/nix"
+			ln -s -- "$REAL_XDG_CACHE_HOME/nix" "$XDG_CACHE_HOME/nix"
+		else
+			mkdir -p "$XDG_CACHE_HOME/nix"
+		fi
+	fi
 
-  mkdir -p "$XDG_CACHE_HOME/nix/eval-cache-v4";
-  chmod u+w "$XDG_CACHE_HOME/nix/eval-cache-v4";
+	mkdir -p "$XDG_CACHE_HOME/nix/eval-cache-v4"
+	chmod u+w "$XDG_CACHE_HOME/nix/eval-cache-v4"
 
+	# Config Dirs
 
-  # Config Dirs
+	mkdir -p "${XDG_CONFIG_HOME:?}"
+	chmod u+w "$XDG_CONFIG_HOME"
 
-  mkdir -p "${XDG_CONFIG_HOME:?}";
-  chmod u+w "$XDG_CONFIG_HOME";
+	if [[ -e "${REAL_XDG_CONFIG_HOME:?}/nix" ]]; then
+		rm -rf "$XDG_CONFIG_HOME/nix"
+		cp -Tr -- "$REAL_XDG_CONFIG_HOME/nix" "$XDG_CONFIG_HOME/nix"
+		chmod -R u+w "$XDG_CONFIG_HOME/nix"
+	fi
+	if [[ -e "$REAL_XDG_CONFIG_HOME/flox" ]]; then
+		rm -rf "$XDG_CONFIG_HOME/flox"
+		cp -Tr -- "$REAL_XDG_CONFIG_HOME/flox" "$XDG_CONFIG_HOME/flox"
+		chmod -R u+w "$XDG_CONFIG_HOME/flox"
+	fi
 
-  if [[ -e "${REAL_XDG_CONFIG_HOME:?}/nix" ]]; then
-    rm -rf "$XDG_CONFIG_HOME/nix";
-    cp -Tr -- "$REAL_XDG_CONFIG_HOME/nix" "$XDG_CONFIG_HOME/nix";
-    chmod -R u+w "$XDG_CONFIG_HOME/nix";
-  fi
-  if [[ -e "$REAL_XDG_CONFIG_HOME/flox" ]]; then
-    rm -rf "$XDG_CONFIG_HOME/flox";
-    cp -Tr -- "$REAL_XDG_CONFIG_HOME/flox" "$XDG_CONFIG_HOME/flox";
-    chmod -R u+w "$XDG_CONFIG_HOME/flox";
-  fi
+	# Data Dirs
 
+	mkdir -p "${XDG_DATA_HOME:?}"
+	chmod u+w "$XDG_DATA_HOME"
+	mkdir -p "$XDG_DATA_HOME/flox"
+	chmod u+w "$XDG_DATA_HOME/flox"
+	mkdir -p "$XDG_DATA_HOME/flox/environments"
+	chmod u+w "$XDG_DATA_HOME/flox/environments"
 
-  # Data Dirs
+	# State Dirs
 
-  mkdir -p "${XDG_DATA_HOME:?}";
-  chmod u+w "$XDG_DATA_HOME";
-  mkdir -p "$XDG_DATA_HOME/flox";
-  chmod u+w "$XDG_DATA_HOME/flox";
-  mkdir -p "$XDG_DATA_HOME/flox/environments";
-  chmod u+w "$XDG_DATA_HOME/flox/environments";
+	mkdir -p "${XDG_STATE_HOME:?}"
+	chmod u+w "$XDG_STATE_HOME"
+	mkdir -p "$XDG_STATE_HOME/flox"
+	chmod u+w "$XDG_STATE_HOME/flox"
 
-
-  # State Dirs
-
-  mkdir -p "${XDG_STATE_HOME:?}";
-  chmod u+w "$XDG_STATE_HOME";
-  mkdir -p "$XDG_STATE_HOME/flox";
-  chmod u+w "$XDG_STATE_HOME/flox";
-
-
-  export __FT_RAN_XDG_TMP_SETUP="$XDG_CACHE_HOME";
+	export __FT_RAN_XDG_TMP_SETUP="$XDG_CACHE_HOME"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Set variables related to `pkgdb' settings.
 pkgdb_vars_setup() {
-  if [[ -n "${__FT_RAN_PKGDB_VARS_SETUP:-}" ]]; then return 0; fi
+	if [[ -n ${__FT_RAN_PKGDB_VARS_SETUP-} ]]; then return 0; fi
 
-  export _PKGDB_TEST_SUITE_MODE=:;
+	export _PKGDB_TEST_SUITE_MODE=:
 
-  # This revision is a bit old, but it was created from `release-23.05'.
-  # Notably its default `nodejs' version is `18.16.0' which is referenced in
-  # some test cases.
-  PKGDB_NIXPKGS_REV_OLD='e8039594435c68eb4f780f3e9bf3972a7399c4b1';
-  # This revision is a bit newer, and was also created from `release-23.05'.
-  # Notably its default `nodejs' version is `18.17.1' which is referenced in
-  # some test cases.
-  PKGDB_NIXPKGS_REV_NEW='9faf91e6d0b7743d41cce3b63a8e5c733dc696a3';
+	# This revision is a bit old, but it was created from `release-23.05'.
+	# Notably its default `nodejs' version is `18.16.0' which is referenced in
+	# some test cases.
+	PKGDB_NIXPKGS_REV_OLD='e8039594435c68eb4f780f3e9bf3972a7399c4b1'
+	# This revision is a bit newer, and was also created from `release-23.05'.
+	# Notably its default `nodejs' version is `18.17.1' which is referenced in
+	# some test cases.
+	PKGDB_NIXPKGS_REV_NEW='9faf91e6d0b7743d41cce3b63a8e5c733dc696a3'
 
-  PKGDB_NIXPKGS_REF_OLD="github:NixOS/nixpkgs/$PKGDB_NIXPKGS_REV_OLD";
-  PKGDB_NIXPKGS_REF_NEW="github:NixOS/nixpkgs/$PKGDB_NIXPKGS_REV_NEW";
+	PKGDB_NIXPKGS_REF_OLD="github:NixOS/nixpkgs/$PKGDB_NIXPKGS_REV_OLD"
+	PKGDB_NIXPKGS_REF_NEW="github:NixOS/nixpkgs/$PKGDB_NIXPKGS_REV_NEW"
 
-  # This causes `pkgdb' to use this revision for `nixpkgs' anywhere the
-  # `--ga-registry' flag is used.
-  # This is useful for testing `pkgdb' against a specific revision of `nixpkgs'
-  # so that we get consistent packages and improved caching.
-  _PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_OLD";
+	# This causes `pkgdb' to use this revision for `nixpkgs' anywhere the
+	# `--ga-registry' flag is used.
+	# This is useful for testing `pkgdb' against a specific revision of `nixpkgs'
+	# so that we get consistent packages and improved caching.
+	_PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_OLD"
 
+	export PKGDB_NIXPKGS_REV_OLD PKGDB_NIXPKGS_REV_NEW \
+		PKGDB_NIXPKGS_REF_OLD PKGDB_NIXPKGS_REF_NEW \
+		_PKGDB_GA_REGISTRY_REF_OR_REV
 
-  export PKGDB_NIXPKGS_REV_OLD PKGDB_NIXPKGS_REV_NEW  \
-         PKGDB_NIXPKGS_REF_OLD PKGDB_NIXPKGS_REF_NEW  \
-         _PKGDB_GA_REGISTRY_REF_OR_REV;
-
-  export __FT_RAN_PKGDB_VARS_SETUP=:;
+	export __FT_RAN_PKGDB_VARS_SETUP=:
 }
-
 
 # ---------------------------------------------------------------------------- #
 
 # This helper should be run after setting `FLOX_TEST_HOME'.
 flox_vars_setup() {
-  xdg_vars_setup;
-  export FLOX_CACHE_HOME="$XDG_CACHE_HOME/flox";
-  export FLOX_CONFIG_HOME="$XDG_CONFIG_HOME/flox";
-  export FLOX_DATA_HOME="$XDG_DATA_HOME/flox";
-  export FLOX_STATE_HOME="$XDG_STATE_HOME/flox";
-  export FLOX_META="$FLOX_CACHE_HOME/meta";
-  export FLOX_ENVIRONMENTS="$FLOX_DATA_HOME/environments";
-  export USER="flox-test";
-  export HOME="${FLOX_TEST_HOME:-$HOME}";
+	xdg_vars_setup
+	export FLOX_CACHE_HOME="$XDG_CACHE_HOME/flox"
+	export FLOX_CONFIG_HOME="$XDG_CONFIG_HOME/flox"
+	export FLOX_DATA_HOME="$XDG_DATA_HOME/flox"
+	export FLOX_STATE_HOME="$XDG_STATE_HOME/flox"
+	export FLOX_META="$FLOX_CACHE_HOME/meta"
+	export FLOX_ENVIRONMENTS="$FLOX_DATA_HOME/environments"
+	export USER="flox-test"
+	export HOME="${FLOX_TEST_HOME:-$HOME}"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
@@ -408,20 +391,22 @@ flox_vars_setup() {
 # Homedirs can be created "globally" for the entire test suite ( default ), or
 # for individual files or single tests by passing an optional argument.
 home_setup() {
-  case "${1:-suite}" in
-    suite) export FLOX_TEST_HOME="${BATS_SUITE_TMPDIR?}/home";                ;;
-    file)  export FLOX_TEST_HOME="${BATS_FILE_TMPDIR?}/home";                 ;;
-    test)  export FLOX_TEST_HOME="${BATS_TEST_TMPDIR?}/home";                 ;;
-    *)     echo "home_setup: Invalid homedir category '${1?}'" >&2; return 1; ;;
-  esac
-  #if [[ "${__FT_RAN_HOME_SETUP:-}" = "$FLOX_TEST_HOME" ]]; then return 0; fi
-  # Force recreation on `home' on every invocation.
-  unset __FT_RAN_HOME_SETUP;
-  xdg_tmp_setup;
-  flox_vars_setup;
-  export __FT_RAN_HOME_SETUP="$FLOX_TEST_HOME";
+	case "${1:-suite}" in
+	suite) export FLOX_TEST_HOME="${BATS_SUITE_TMPDIR?}/home" ;;
+	file) export FLOX_TEST_HOME="${BATS_FILE_TMPDIR?}/home" ;;
+	test) export FLOX_TEST_HOME="${BATS_TEST_TMPDIR?}/home" ;;
+	*)
+		echo "home_setup: Invalid homedir category '${1?}'" >&2
+		return 1
+		;;
+	esac
+	#if [[ "${__FT_RAN_HOME_SETUP:-}" = "$FLOX_TEST_HOME" ]]; then return 0; fi
+	# Force recreation on `home' on every invocation.
+	unset __FT_RAN_HOME_SETUP
+	xdg_tmp_setup
+	flox_vars_setup
+	export __FT_RAN_HOME_SETUP="$FLOX_TEST_HOME"
 }
-
 
 # ---------------------------------------------------------------------------- #
 
@@ -434,76 +419,74 @@ home_setup() {
 # `{setup,teardown}_suite' functions must be defined in `setup_suite.bash'
 # files, AND keep in mind that `SET_TESTS_DIR' will likely differ.
 common_suite_setup() {
-  # Backup real env vars.
-  reals_setup;
-  # Setup a phony home directory shared by the test suite.
-  # Individual files and tests may create their own private homedirs, but this
-  # default one is required before we try to invoke any `flox' CLI commands.
-  home_setup suite;
-  # Set common env vars.
-  nix_system_setup;
-  misc_vars_setup;
-  flox_cli_vars_setup;
-  pkgdb_vars_setup;
-  # Generate configs and auth.
-  ssh_key_setup;
-  floxtest_gitforge_setup;
-  # TODO: fix gpg setup and re-enable along with `gpgsign.bats' tests.
-  #gpg_key_setup;
-  gitconfig_setup;
-  {
-    print_var FLOX_TEST_HOME;
-    print_var HOME;
-    print_var XDG_CACHE_HOME;
-    print_var XDG_CONFIG_HOME;
-    print_var XDG_DATA_HOME;
-    print_var XDG_STATE_HOME;
-    print_var FLOX_CACHE_HOME;
-    print_var FLOX_CONFIG_HOME;
-    print_var FLOX_DATA_HOME;
-    print_var FLOX_STATE_HOME;
-    print_var FLOX_META;
-    print_var FLOX_ENVIRONMENTS;
-    print_var NIX_SYSTEM;
-    print_var FLOX_TEST_SSH_KEY;
-    print_var SSH_AUTH_SOCK;
-    print_var GIT_CONFIG_SYSTEM;
-    print_var GIT_CONFIG_GLOBAL;
-    print_var PKGDB_NIXPKGS_REV_NEW;
-    print_var PKGDB_NIXPKGS_REV_OLD;
-    print_var PKGDB_NIXPKGS_REF_NEW;
-    print_var PKGDB_NIXPKGS_REF_OLD;
-    print_var _PKGDB_GA_REGISTRY_REF_OR_REV;
-  } >&3;
+	# Backup real env vars.
+	reals_setup
+	# Setup a phony home directory shared by the test suite.
+	# Individual files and tests may create their own private homedirs, but this
+	# default one is required before we try to invoke any `flox' CLI commands.
+	home_setup suite
+	# Set common env vars.
+	nix_system_setup
+	misc_vars_setup
+	flox_cli_vars_setup
+	pkgdb_vars_setup
+	# Generate configs and auth.
+	ssh_key_setup
+	floxtest_gitforge_setup
+	# TODO: fix gpg setup and re-enable along with `gpgsign.bats' tests.
+	#gpg_key_setup;
+	gitconfig_setup
+	{
+		print_var FLOX_TEST_HOME
+		print_var HOME
+		print_var XDG_CACHE_HOME
+		print_var XDG_CONFIG_HOME
+		print_var XDG_DATA_HOME
+		print_var XDG_STATE_HOME
+		print_var FLOX_CACHE_HOME
+		print_var FLOX_CONFIG_HOME
+		print_var FLOX_DATA_HOME
+		print_var FLOX_STATE_HOME
+		print_var FLOX_META
+		print_var FLOX_ENVIRONMENTS
+		print_var NIX_SYSTEM
+		print_var FLOX_TEST_SSH_KEY
+		print_var SSH_AUTH_SOCK
+		print_var GIT_CONFIG_SYSTEM
+		print_var GIT_CONFIG_GLOBAL
+		print_var PKGDB_NIXPKGS_REV_NEW
+		print_var PKGDB_NIXPKGS_REV_OLD
+		print_var PKGDB_NIXPKGS_REF_NEW
+		print_var PKGDB_NIXPKGS_REF_OLD
+		print_var _PKGDB_GA_REGISTRY_REF_OR_REV
+	} >&3
 }
 
 # Recognized by `bats'.
 setup_suite() { common_suite_setup; }
-
 
 # ---------------------------------------------------------------------------- #
 
 # Shared in common by all members of this test suite.
 # Run on exit after all other `*teardown' routines.
 common_suite_teardown() {
-  # Delete suite tmpdir and envs unless the user requests to preserve them.
-  if [[ -z "${FLOX_TEST_KEEP_TMP:-}" ]]; then
-    rm -rf "$BATS_SUITE_TMPDIR";
-  fi
-  # Our agent was useful, but it's time for them to retire.
-  # We force true in case we are tearing down when an agent never launched.
-  eval "$( ssh-agent -k 2>/dev/null || echo ':'; )";
-  cd "$BAT_RUN_TMPDIR"||return;
-  # This directory is always deleted because it contains generated secrets.
-  # I can't imagine what anyone would ever do with them, but I'm not interested
-  # in learning about some esoteric new exploit in an
-  # incident response situation because I left them laying around.
-  rm -rf "$BATS_RUN_TMPDIR/homeless-shelter";
+	# Delete suite tmpdir and envs unless the user requests to preserve them.
+	if [[ -z ${FLOX_TEST_KEEP_TMP-} ]]; then
+		rm -rf "$BATS_SUITE_TMPDIR"
+	fi
+	# Our agent was useful, but it's time for them to retire.
+	# We force true in case we are tearing down when an agent never launched.
+	eval "$(ssh-agent -k 2>/dev/null || echo ':')"
+	cd "$BAT_RUN_TMPDIR" || return
+	# This directory is always deleted because it contains generated secrets.
+	# I can't imagine what anyone would ever do with them, but I'm not interested
+	# in learning about some esoteric new exploit in an
+	# incident response situation because I left them laying around.
+	rm -rf "$BATS_RUN_TMPDIR/homeless-shelter"
 }
 
 # Recognized by `bats'.
 teardown_suite() { common_suite_teardown; }
-
 
 # ---------------------------------------------------------------------------- #
 #

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,7 @@
           };
           clippy.enable = true;
           commitizen.enable = true;
-          shfmt.enable = true;
+          # shfmt.enable = false; # disabled until someone makes a formatting PR
           # shellcheck.enable = true; # disabled until we have time to fix all the warnings
         };
         settings = {
@@ -248,3 +248,4 @@
 #
 #
 # ============================================================================ #
+

--- a/pkgdb/.gitignore
+++ b/pkgdb/.gitignore
@@ -36,6 +36,7 @@
 result
 result-*
 compile_commands.json
+bin/
 
 # Logs, Debug Info, Etc
 *.gcno

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -235,8 +235,8 @@ ifeq (gcc,$(TOOLCHAIN))
 CXXFLAGS += -ggdb3 -pg -fno-omit-frame-pointer
 LDFLAGS  += -ggdb3 -pg -fno-omit-frame-pointer
 else # Clang
-CXXFLAGS += -g -pg
-LDFLAGS  += -g -pg
+CXXFLAGS += -g -glldb -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+LDFLAGS  += -g -glldb -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
 endif # ifeq (gcc,$(TOOLCHAIN))
 endif # ifneq ($(DEBUG),)
 

--- a/pkgdb/include/flox/core/util.hh
+++ b/pkgdb/include/flox/core/util.hh
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <nix/attrs.hh>
+#include <nix/error.hh>
 #include <nix/flake/flakeref.hh>
 #include <nlohmann/json.hpp>
 
@@ -427,6 +428,51 @@ vectorMapOptional( const std::vector<T> & orig )
  */
 std::string
 displayableGlobbedPath( const AttrPathGlob & attrs );
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Join a vector of strings with a delimiter between elements.
+ */
+std::string
+joinWithDelim( const std::vector<std::string> & strings,
+               const std::string &              delim );
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Print a log message with the provided log level. */
+void
+printLog( const nix::Verbosity & lvl, const std::string & msg );
+
+/**
+ * @brief Prints a log message to `stderr` when called with `-vvvv`.
+ */
+void
+traceLog( const std::string & msg );
+
+/**
+ * @brief Prints a log message to `stderr` when called with `--debug` or `-vvv`.
+ */
+void
+debugLog( const std::string & msg );
+
+/**
+ * @brief Prints a log message to `stderr` at default verbosity.
+ */
+void
+infoLog( const std::string & msg );
+
+/**
+ * @brief Prints a log message to `stderr` when verbosity is at least `-q`.
+ */
+void
+warningLog( const std::string & msg );
+
+/**
+ * @brief Prints a log message to `stderr` when verbosity is at least `-qq`.
+ */
+void
+errorLog( const std::string & msg );
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/include/flox/core/util.hh
+++ b/pkgdb/include/flox/core/util.hh
@@ -474,6 +474,7 @@ warningLog( const std::string & msg );
 void
 errorLog( const std::string & msg );
 
+
 /* -------------------------------------------------------------------------- */
 
 }  // namespace flox

--- a/pkgdb/include/flox/pkgdb/input.hh
+++ b/pkgdb/include/flox/pkgdb/input.hh
@@ -229,7 +229,10 @@ public:
 
   /** @brief Return the name if it was provided. */
   [[nodiscard]] std::optional<std::string>
-  getName() const;
+  getName() const
+  {
+    return this->name;
+  }
 }; /* End struct `PkgDbInput' */
 
 

--- a/pkgdb/include/flox/pkgdb/input.hh
+++ b/pkgdb/include/flox/pkgdb/input.hh
@@ -227,7 +227,9 @@ public:
   [[nodiscard]] nlohmann::json
   getRowJSON( row_id row );
 
-
+  /** @brief Return the name if it was provided. */
+  [[nodiscard]] std::optional<std::string>
+  getName() const;
 }; /* End struct `PkgDbInput' */
 
 

--- a/pkgdb/include/flox/resolver/descriptor.hh
+++ b/pkgdb/include/flox/resolver/descriptor.hh
@@ -270,7 +270,10 @@ public:
                                const ManifestDescriptorRaw & raw )
     : ManifestDescriptor( raw )
   {
-    if ( ! this->name.has_value() ) { this->name = installID; }
+    if ( ( ! this->name.has_value() ) && ( ! this->path.has_value() ) )
+      {
+        this->path = AttrPath { std::string( installID ) };
+      }
   }
 
   /**

--- a/pkgdb/src/pkgdb/input.cc
+++ b/pkgdb/src/pkgdb/input.cc
@@ -183,6 +183,12 @@ PkgDbInput::getRowJSON( row_id row )
   return rsl;
 }
 
+std::optional<std::string>
+PkgDbInput::getName() const
+{
+  return this->name;
+}
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/src/pkgdb/input.cc
+++ b/pkgdb/src/pkgdb/input.cc
@@ -183,12 +183,6 @@ PkgDbInput::getRowJSON( row_id row )
   return rsl;
 }
 
-std::optional<std::string>
-PkgDbInput::getName() const
-{
-  return this->name;
-}
-
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/src/resolver/manifest-raw.cc
+++ b/pkgdb/src/resolver/manifest-raw.cc
@@ -545,7 +545,6 @@ installFromJSON( const nlohmann::json & install )
   std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>> result;
   for ( const auto & [name, desc] : install.items() )
     {
-      /* An empty/null descriptor uses `name' of the attribute. */
       if ( desc.is_null() ) { result.emplace( name, std::nullopt ); }
       else  // TODO: parse CLI strings
         {

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -326,6 +326,58 @@ displayableGlobbedPath( const flox::AttrPathGlob & attrs )
 
 /* -------------------------------------------------------------------------- */
 
+
+std::string
+joinWithDelim( const std::vector<std::string> & strings,
+               const std::string &              delim )
+{
+  auto fold
+    = [&]( std::string acc, std::string elem ) { return acc + delim + elem; };
+  std::string joined = std::accumulate( std::next( strings.begin() ),
+                                        strings.end(),
+                                        strings[0],
+                                        fold );
+  return joined;
+}
+
+/* -------------------------------------------------------------------------- */
+
+void
+printLog( const nix::Verbosity & lvl, const std::string & msg )
+{
+  if ( lvl <= nix::verbosity ) { nix::logger->log( lvl, msg ); }
+}
+
+void
+traceLog( const std::string & msg )
+{
+  printLog( nix::Verbosity::lvlVomit, msg );
+}
+
+void
+debugLog( const std::string & msg )
+{
+  printLog( nix::Verbosity::lvlDebug, msg );
+}
+
+void
+infoLog( const std::string & msg )
+{
+  printLog( nix::Verbosity::lvlInfo, msg );
+}
+
+void
+warningLog( const std::string & msg )
+{
+  printLog( nix::Verbosity::lvlWarn, msg );
+}
+
+void
+errorLog( const std::string & msg )
+{
+  printLog( nix::Verbosity::lvlError, msg );
+}
+
 }  // namespace flox
 
 

--- a/pkgdb/tests/environment.cc
+++ b/pkgdb/tests/environment.cc
@@ -558,13 +558,7 @@ test_getGroupInput0()
   TestEnvironment environment( std::nullopt, manifest, lockfile );
   for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
     {
-      std::cerr << "getting group input" << std::endl;
       auto input = environment.getGroupInput( group, lockfile, _system );
-      if ( input.has_value() )
-        {
-
-          std::cerr << "got input" << *input << std::endl;
-        }
       EXPECT( input.has_value() );
       EXPECT_EQ( *input, mockHelloLocked.input );
     }

--- a/pkgdb/tests/environment.cc
+++ b/pkgdb/tests/environment.cc
@@ -242,7 +242,9 @@ test_groupIsLocked1()
 {
   /* Create manifest with hello */
   ManifestRaw manifestRaw;
-  manifestRaw.install          = { { "hello", std::nullopt } };
+  manifestRaw.install          = { { "hello",
+                                     ManifestDescriptorRaw(
+                              nlohmann::json( { { "path", "hello" } } ) ) } };
   manifestRaw.options          = Options {};
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
@@ -531,7 +533,9 @@ test_getGroupInput0()
 {
   /* Create manifest with hello */
   ManifestRaw manifestRaw;
-  manifestRaw.install          = { { "hello", std::nullopt } };
+  manifestRaw.install          = { { "hello",
+                                     ManifestDescriptorRaw(
+                              nlohmann::json( { { "path", "hello" } } ) ) } };
   manifestRaw.options          = Options {};
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
@@ -554,7 +558,13 @@ test_getGroupInput0()
   TestEnvironment environment( std::nullopt, manifest, lockfile );
   for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
     {
+      std::cerr << "getting group input" << std::endl;
       auto input = environment.getGroupInput( group, lockfile, _system );
+      if ( input.has_value() )
+        {
+
+          std::cerr << "got input" << *input << std::endl;
+        }
       EXPECT( input.has_value() );
       EXPECT_EQ( *input, mockHelloLocked.input );
     }

--- a/tests/python.bats
+++ b/tests/python.bats
@@ -49,7 +49,7 @@ teardown() { project_teardown; common_test_teardown; }
 # ---------------------------------------------------------------------------- #
 #
 @test "install requests with pip" {
-  run "$FLOX_BIN" install pip python3;
+  run "$FLOX_BIN" install -i pip python310Packages.pip python3;
 
   assert_success;
   assert_output --partial "✅ 'pip' installed to environment";


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This PR has a number of changes, only some of which are related to the title:
- Calling `flox install foo` will create an entry in the manifest `foo.path = "foo"`, which allows users to install packages like `rubyPackages.rails` via `flox install` rather than needing to manually edit the manifest.
- Infers the install ID from `flox install foo` and provides a flag for manually specifying the install ID at the CLI.
- Fixes a bug that would automatically set the descriptor `name` if one wasn't provided, which prevented installing packages that provided their own install ID that differed from the package name.
- Refactors the Justfile to make it a little bit more sane
- Adds a suite of logging functions that mirror those found in the Rust side of `flox` so that it's easy to turn on logging when desired.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users can now provide arbitrary names to the packages they install via `flox install` so that they can shorten package names to something more convenient e.g. `flox install -i rails rubyPackages.rails`.

<!-- Many thanks! -->
