### PR TITLE
fix: Update `license` target in justfile to work

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -96,7 +96,7 @@ bump input:
 
 # Output licenses of all dependency crates
 license:
-    @cargo metadata --format-version 1 | jq -r '.packages[] | [.name, .license] | @csv'
+    @pushd cli; cargo metadata --format-version 1 | jq -r '.packages[] | [.name, .license] | @csv'
 
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
The license target broke after the cli portions of the repo were moved under
/cli. This simply updates the justfile to popd into cli directory.


## Release Notes
N/A