### PR TITLE
test: validate that activate works on managed environments

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -238,7 +238,7 @@ impl Generations<ReadWrite> {
     /// If `set_current` is true, the generation will also be set as the current generation.
     fn register_generation(
         &mut self,
-        environment: CoreEnvironment,
+        environment: &mut CoreEnvironment,
         generation: usize,
         description: String,
         set_current: bool,
@@ -298,7 +298,7 @@ impl Generations<ReadWrite> {
     /// and sets it as the current generation.
     pub fn add_generation(
         &mut self,
-        environment: CoreEnvironment,
+        environment: &mut CoreEnvironment,
         description: String,
     ) -> Result<(), GenerationsError> {
         // keys should all be numbers (but)

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -648,6 +648,15 @@ impl ManagedEnvironment {
 /// if the local revision is not available on the machine,
 /// i.e. any machine other than the one that committed the lockfile.
 /// See [`ManagedEnvironment::ensure_locked`] for more details.
+///
+/// todo: allow updating only the local revision
+/// avoid race conditions where the remote revision is unintentionally updated.
+/// If I pull an environment at rev A,
+/// -> somebody pushes rev B,
+/// -> I do an operation with -r that fetches the environment,
+/// -> and then I make a change that takes me from rev A to rev C,
+/// my lock will set rev to B.
+/// That's undesirable, and rev should always be in local_rev's history.
 fn write_pointer_lockfile(
     lock_path: PathBuf,
     floxmeta: &FloxmetaV2,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -14,6 +14,7 @@ use super::core_environment::CoreEnvironment;
 use super::generations::{Generations, GenerationsError};
 use super::path_environment::PathEnvironment;
 use super::{
+    CoreEnvironmentError,
     CanonicalPath,
     EditResult,
     Environment,
@@ -93,6 +94,12 @@ pub enum ManagedEnvironmentError {
     #[error("could not create files for current generation")]
     CreateGenerationFiles(#[source] GenerationsError),
 
+    #[error("could not commit generation")]
+    CommitGeneration(#[source] GenerationsError),
+
+    #[error("could not link environment")]
+    Link(#[source] CoreEnvironmentError),
+
     #[error("could not read manifest")]
     ReadManifest(#[source] GenerationsError),
 }
@@ -116,7 +123,8 @@ impl Environment for ManagedEnvironment {
             .get_current_generation()
             .map_err(ManagedEnvironmentError::CreateGenerationFiles)?;
 
-        let result = temporary.build(flox)?;
+        temporary.build(flox)?;
+        temporary.link(flox, self.out_link(flox))?;
 
         Ok(())
     }
@@ -139,9 +147,11 @@ impl Environment for ManagedEnvironment {
         let metadata = format!("installed packages: {:?}", &packages);
         let result = temporary.install(packages, flox)?;
 
-        generations.add_generation(temporary, metadata).unwrap();
-
+        generations
+            .add_generation(&mut temporary, metadata)
+            .map_err(ManagedEnvironmentError::CommitGeneration)?;
         self.lock_pointer()?;
+        temporary.link(flox, &self.out_link(flox))?;
 
         Ok(result)
     }
@@ -164,8 +174,11 @@ impl Environment for ManagedEnvironment {
         let metadata = format!("uninstalled packages: {:?}", &packages);
         let result = temporary.uninstall(packages, flox)?;
 
-        generations.add_generation(temporary, metadata).unwrap();
+        generations
+            .add_generation(&mut temporary, metadata)
+            .map_err(ManagedEnvironmentError::CommitGeneration)?;
         self.lock_pointer()?;
+        temporary.link(flox, &self.out_link(flox))?;
 
         Ok(result)
     }
@@ -188,10 +201,10 @@ impl Environment for ManagedEnvironment {
 
         if matches!(result, EditResult::Success | EditResult::ReActivateRequired) {
             generations
-                .add_generation(temporary, "manually edited".to_string())
-                .unwrap();
-
+                .add_generation(&mut temporary, "manually edited".to_string())
+                .map_err(ManagedEnvironmentError::CommitGeneration)?;
             self.lock_pointer()?;
+            temporary.link(flox, &self.out_link(flox))?;
         }
 
         Ok(result)
@@ -206,8 +219,11 @@ impl Environment for ManagedEnvironment {
 
         let metadata = format!("updated environment: {message}");
 
-        generations.add_generation(temporary, metadata).unwrap();
+        generations
+            .add_generation(&mut temporary, metadata)
+            .map_err(ManagedEnvironmentError::CommitGeneration)?;
         self.lock_pointer()?;
+        temporary.link(flox, &self.out_link(flox))?;
 
         Ok(message)
     }
@@ -580,7 +596,6 @@ impl ManagedEnvironment {
     /// Where to link a built environment to.
     ///
     /// The parent directory may not exist!
-
     fn out_link(&self, flox: &Flox) -> PathBuf {
         gcroots_dir(flox, &self.pointer.owner).join(branch_name(
             &self.system,
@@ -764,7 +779,7 @@ impl ManagedEnvironment {
 
         generations
             .add_generation(
-                path_environment.into_core_environment(),
+                &mut path_environment.into_core_environment(),
                 "Add first generation".to_string(),
             )
             .unwrap();

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -907,11 +907,8 @@ impl Pull {
         Ok(())
     }
 
-    fn convert_error(err: EnvironmentError2) -> anyhow::Error {
-        if let EnvironmentError2::ManagedEnvironment(ManagedEnvironmentError::OpenFloxmeta(
-            FloxmetaV2Error::LoggedOut,
-        )) = err
-        {
+    fn convert_error(err: ManagedEnvironmentError) -> anyhow::Error {
+        if let ManagedEnvironmentError::OpenFloxmeta(FloxmetaV2Error::LoggedOut) = err {
             anyhow!(indoc! {"
                 Could not pull environment: not logged in to floxhub.
 

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> ExitCode {
 
     // Quit early if `--version` is present
     if Version::check() {
-        println!("Version: {}", FLOX_VERSION.to_string());
+        println!("Version: {}", &*FLOX_VERSION);
         return ExitCode::from(0);
     }
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -235,7 +235,7 @@ EOF
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
   SHELL=bash USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR";
-  assert_output --regexp "bin/hello"
+  assert_output --regexp "$FLOX_CACHE_HOME/run/owner/.+\..+\..+/bin/hello"
   refute_output "not found"
 }
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -13,9 +13,9 @@ load test_support.bash
 # Helpers for project based tests.
 
 project_setup() {
-  export PROJECT_NAME="test";
+  export PROJECT_NAME="test"
   export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
-  export OWNER="owner";
+  export OWNER="owner"
 
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
@@ -37,8 +37,8 @@ project_teardown() {
 setup() {
   common_test_setup
   project_setup
-  home_setup test;
-  floxhub_setup "$OWNER";
+  home_setup test
+  floxhub_setup "$OWNER"
 }
 
 teardown() {
@@ -71,7 +71,7 @@ dot_flox_exists() {
 
   run --separate-stderr "$FLOX_BIN" list
   assert_success
-  assert_output  ""
+  assert_output ""
 
   run "$FLOX_BIN" install hello
   assert_success
@@ -81,7 +81,6 @@ dot_flox_exists() {
   assert_success
   assert_output "hello"
 }
-
 
 # bats test_tags=uninstall,managed
 @test "m2: uninstall a package from a managed environment" {
@@ -102,7 +101,7 @@ dot_flox_exists() {
 
   TMP_MANIFEST_PATH="$BATS_TEST_TMPDIR/manifest.toml"
 
-  cat << "EOF" >> "$TMP_MANIFEST_PATH"
+  cat <<"EOF" >>"$TMP_MANIFEST_PATH"
 [install]
 hello = {}
 EOF
@@ -117,10 +116,8 @@ EOF
 # bats test_tags=managed,pull,managed:pull
 @test "m4: pushed environment can be pulled" {
 
-
-
-  mkdir a a_data;
-  mkdir b b_data;
+  mkdir a a_data
+  mkdir b b_data
 
   # on machine a, create and push the environment
   export FLOX_DATA_DIR="$(pwd)/a_data"
@@ -129,7 +126,6 @@ EOF
   "$FLOX_BIN" install hello
   "$FLOX_BIN" push --owner "$OWNER"
   popd >/dev/null || return
-
 
   # on another b machine, pull the environment
   export FLOX_DATA_DIR="$(pwd)/b_data"
@@ -142,12 +138,10 @@ EOF
   popd >/dev/null || return
 }
 
-
-
 # bats test_tags=managed,update,managed:update
 @test "m5: updated environment can be pulled" {
-  mkdir a a_data;
-  mkdir b b_data;
+  mkdir a a_data
+  mkdir b b_data
 
   # on machine a, create and push the (empty) environment
   export FLOX_DATA_DIR="$(pwd)/a_data"
@@ -155,7 +149,6 @@ EOF
   "$FLOX_BIN" init
   "$FLOX_BIN" push --owner "$OWNER"
   popd >/dev/null || return
-
 
   # on another b machine,
   #  - pull the environment
@@ -182,11 +175,10 @@ EOF
   popd >/dev/null || return
 }
 
-
 # bats test_tags=managed,diverged,managed:diverged
 @test "m7: remote can not be pulled into diverged environment" {
-  mkdir a a_data;
-  mkdir b b_data;
+  mkdir a a_data
+  mkdir b b_data
 
   # on machine a, create and push the (empty) environment
   export FLOX_DATA_DIR="$(pwd)/a_data"
@@ -194,7 +186,6 @@ EOF
   "$FLOX_BIN" init
   "$FLOX_BIN" push --owner "$OWNER"
   popd >/dev/null || return
-
 
   # on another b machine,
   #  - pull the environment
@@ -228,8 +219,8 @@ EOF
 @test "m8: search works in managed environment" {
   make_empty_remote_env
 
-  run "$FLOX_BIN" search hello;
-  assert_success;
+  run "$FLOX_BIN" search hello
+  assert_success
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -13,7 +13,7 @@ load test_support.bash
 # Helpers for project based tests.
 
 project_setup() {
-  export PROJECT_NAME="test"
+  export PROJECT_NAME="test";
   export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
   export OWNER="owner"
 
@@ -116,8 +116,8 @@ EOF
 # bats test_tags=managed,pull,managed:pull
 @test "m4: pushed environment can be pulled" {
 
-  mkdir a a_data
-  mkdir b b_data
+  mkdir a a_data;
+  mkdir b b_data;
 
   # on machine a, create and push the environment
   export FLOX_DATA_DIR="$(pwd)/a_data"
@@ -140,8 +140,8 @@ EOF
 
 # bats test_tags=managed,update,managed:update
 @test "m5: updated environment can be pulled" {
-  mkdir a a_data
-  mkdir b b_data
+  mkdir a a_data;
+  mkdir b b_data;
 
   # on machine a, create and push the (empty) environment
   export FLOX_DATA_DIR="$(pwd)/a_data"
@@ -177,8 +177,8 @@ EOF
 
 # bats test_tags=managed,diverged,managed:diverged
 @test "m7: remote can not be pulled into diverged environment" {
-  mkdir a a_data
-  mkdir b b_data
+  mkdir a a_data;
+  mkdir b b_data;
 
   # on machine a, create and push the (empty) environment
   export FLOX_DATA_DIR="$(pwd)/a_data"
@@ -219,8 +219,8 @@ EOF
 @test "m8: search works in managed environment" {
   make_empty_remote_env
 
-  run "$FLOX_BIN" search hello
-  assert_success
+  run "$FLOX_BIN" search hello;
+  assert_success;
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -15,24 +15,11 @@ load test_support.bash
 project_setup() {
   export PROJECT_NAME="test";
   export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
+  export OWNER="owner";
 
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" >/dev/null || return
-
-}
-
-floxhub_setup() {
-  export FLOX_FLOXHUB_TOKEN=flox_testOAuthToken
-  export FLOX_FLOXHUB_PATH="$BATS_TEST_TMPDIR/floxhub"
-  export OWNER="owner"
-  export FLOXHUB_FLOXMETA_DIR="$FLOX_FLOXHUB_PATH/$OWNER/floxmeta"
-
-  mkdir -p "$FLOX_FLOXHUB_PATH"
-  mkdir -p "$FLOXHUB_FLOXMETA_DIR"
-  git -C "$FLOXHUB_FLOXMETA_DIR" init --bare
-
-  export __FLOX_FLOXHUB_URL="file://$FLOX_FLOXHUB_PATH"
 
 }
 
@@ -50,8 +37,8 @@ project_teardown() {
 setup() {
   common_test_setup
   project_setup
-  floxhub_setup
   home_setup test;
+  floxhub_setup "$OWNER";
 }
 
 teardown() {

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -225,6 +225,22 @@ EOF
 
 # ---------------------------------------------------------------------------- #
 
+# Make sure we haven't activate
+# bats test_tags=managed,activate,managed:activate
+@test "m9: activate works in managed environment" {
+  make_empty_remote_env
+  "$FLOX_BIN" install hello
+
+  # TODO: flox will set HOME if it doesn't match the home of the user with
+  # current euid. I'm not sure if we should change that, but for now just set
+  # USER to REAL_USER.
+  SHELL=bash USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR";
+  assert_output --regexp "bin/hello"
+  refute_output "not found"
+}
+
+# ---------------------------------------------------------------------------- #
+
 # bats test_tags=managed,delete,managed:delete
 @test "m10: deletes existing environment" {
   make_empty_remote_env

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -82,6 +82,28 @@ hello_pkg_setup() {
   export __FT_RAN_HELLO_PKG_SETUP=:;
 }
 
+# ---------------------------------------------------------------------------- #
+
+# floxhub_setup <owner>
+#
+# * sets up a local "floxhub" repo for the given owner.
+#   can be called multiple times with different owners.
+# * sets `FLOX_FLOXHUB_TOKEN` to a dummy value so flox _thinks_ its logged in.
+#
+# This is used by tests that need to push/pull to/from floxhub.
+# In the future we may want to use a local floxhub server instead.
+floxhub_setup() {
+  OWNER="$1"; shift;
+  export FLOX_FLOXHUB_TOKEN=flox_testOAuthToken
+  export FLOX_FLOXHUB_PATH="$BATS_TEST_TMPDIR/floxhub"
+  export FLOXHUB_FLOXMETA_DIR="$FLOX_FLOXHUB_PATH/$OWNER/floxmeta"
+
+  mkdir -p "$FLOX_FLOXHUB_PATH"
+  mkdir -p "$FLOXHUB_FLOXMETA_DIR"
+  git -C "$FLOXHUB_FLOXMETA_DIR" init --bare
+
+  export __FLOX_FLOXHUB_URL="file://$FLOX_FLOXHUB_PATH"
+}
 
 # ---------------------------------------------------------------------------- #
 


### PR DESCRIPTION
* fix: link built environments to `out_path`
* test: move `floxhub_setup` to `test_support.bash`
* test: add an integration tests that tests activate works with managed environments
` * added a single test that checks for setting the PATH
  * the built environment is equivalent to the one produced by `PathEnvironments`
  * Possibly more generic (and complete) testing of environment operations
    may be implemented with flox/product#462
