### PR TITLE
feat: support `flox delete` for managed environments

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -306,7 +306,8 @@ impl Environment for ManagedEnvironment {
 
             links_dir.join(encoded)
         };
-        if reverse_link.exists() {
+        // if symlink exists, delete it
+        if fs::symlink_metadata(&reverse_link).is_ok() {
             std::fs::remove_file(&reverse_link).map_err(|e| {
                 ManagedEnvironmentError::DeleteEnvironmentReverseLink(reverse_link, e)
             })?;

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -321,6 +321,10 @@ pub enum EnvironmentError2 {
 
     #[error(transparent)]
     Canonicalize(#[from] CanonicalizeError),
+
+    #[error("environment directory cannot be {0:?}")]
+    InvalidEnvironmentDirectory(PathBuf),
+
     // endregion
 
     // todo: candidate for impl specific error

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -185,7 +185,7 @@ pub trait Environment {
     fn name(&self) -> EnvironmentName;
 
     /// Delete the Environment
-    fn delete(self) -> Result<(), EnvironmentError2>
+    fn delete(self, flox: &Flox) -> Result<(), EnvironmentError2>
     where
         Self: Sized;
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -31,6 +31,7 @@ use runix::RunJson;
 use super::core_environment::CoreEnvironment;
 use super::{
     copy_dir_recursive,
+    CanonicalPath,
     EditResult,
     Environment,
     EnvironmentError2,
@@ -57,7 +58,7 @@ use crate::models::environment_ref::EnvironmentName;
 #[derive(Debug)]
 pub struct PathEnvironment {
     /// Absolute path to the environment, typically `<...>/.flox`
-    pub path: PathBuf,
+    pub path: CanonicalPath,
 
     /// The temporary directory that this environment will use during transactions
     pub temp_dir: PathBuf,
@@ -70,17 +71,25 @@ pub struct PathEnvironment {
 
 impl PartialEq for PathEnvironment {
     fn eq(&self, other: &Self) -> bool {
-        self.path == other.path
+        *self.path == *other.path
     }
 }
 
 impl PathEnvironment {
     pub fn new(
-        dot_flox: impl AsRef<Path>,
+        dot_flox_path: impl AsRef<Path>,
         pointer: PathPointer,
         temp_dir: impl AsRef<Path>,
     ) -> Result<Self, EnvironmentError2> {
-        let env_path = dot_flox.as_ref().join(ENV_DIR_NAME);
+        let dot_flox_path = CanonicalPath::new(dot_flox_path)?;
+
+        if &*dot_flox_path == Path::new("/") {
+            return Err(EnvironmentError2::InvalidPath(
+                dot_flox_path.into_path_buf(),
+            ));
+        }
+
+        let env_path = dot_flox_path.join(ENV_DIR_NAME);
         if !env_path.exists() {
             Err(EnvironmentError2::EnvNotFound)?;
         }
@@ -91,10 +100,7 @@ impl PathEnvironment {
 
         Ok(Self {
             // path must be absolute as it is used to set FLOX_ENV
-            path: dot_flox
-                .as_ref()
-                .canonicalize()
-                .map_err(EnvironmentError2::EnvCanonicalize)?,
+            path: dot_flox_path,
             pointer,
             temp_dir: temp_dir.as_ref().to_path_buf(),
         })
@@ -263,8 +269,9 @@ impl Environment for PathEnvironment {
         Ok(self.out_link(&flox.system)?)
     }
 
+    /// Path to the environment's parent directory
     fn parent_path(&self) -> Result<PathBuf, EnvironmentError2> {
-        let mut path = self.path.clone();
+        let mut path = self.path.to_path_buf();
         if path.pop() {
             Ok(path)
         } else {
@@ -288,7 +295,7 @@ impl PathEnvironment {
     /// a precise url to interact with the environment via nix
     fn flake_attribute(&self, system: impl AsRef<str>) -> FlakeAttribute {
         let flakeref = PathRef {
-            path: self.path.clone(),
+            path: self.path.to_path_buf(),
             attributes: Default::default(),
         }
         .into();

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -254,7 +254,7 @@ impl Environment for PathEnvironment {
     }
 
     /// Delete the Environment
-    fn delete(self) -> Result<(), EnvironmentError2> {
+    fn delete(self, _flox: &Flox) -> Result<(), EnvironmentError2> {
         let dot_flox = &self.path;
         if Some(OsStr::new(".flox")) == dot_flox.file_name() {
             std::fs::remove_dir_all(dot_flox).map_err(EnvironmentError2::DeleteEnvironment)?;

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -97,7 +97,7 @@ impl Environment for RemoteEnvironment {
 
     /// Delete the Environment
     #[allow(unused)]
-    fn delete(self) -> Result<(), EnvironmentError2> {
+    fn delete(self, flox: &Flox) -> Result<(), EnvironmentError2> {
         todo!()
     }
 }

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -481,6 +481,22 @@ impl GitCommandProvider {
         Ok(())
     }
 
+    /// Deletes the specified branch
+    pub fn delete_branch(&self, branch: &str, force: bool) -> Result<(), GitCommandError> {
+        let mut command = {
+            let mut command = self.new_command();
+            command.arg("branch");
+            command.arg("--delete");
+            if force {
+                command.arg("--force");
+            }
+            command.arg(branch);
+            command
+        };
+        GitCommandProvider::run_command(&mut command)?;
+        Ok(())
+    }
+
     /// Update the options used by this provider.
     ///
     /// It is preferable to set the options when creating the provider

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -239,6 +239,18 @@ impl Delete {
 
         let description = environment_description(&environment)?;
 
+        let comfirm = Dialog {
+            message: &format!("You are about to delete your environment {description}"),
+            help_message: Some("Use `-f` to force deletion"),
+            typed: Confirm {
+                default: Some(false),
+            },
+        };
+
+        if !self.force && Dialog::can_prompt() && !comfirm.prompt().await? {
+            bail!("Ok everything stays as it is, nothing deleted");
+        }
+
         let result = match environment {
             ConcreteEnvironment::Path(environment) => environment.delete(),
             ConcreteEnvironment::Managed(environment) => environment.delete(),

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -248,7 +248,7 @@ impl Delete {
         };
 
         if !self.force && Dialog::can_prompt() && !comfirm.prompt().await? {
-            bail!("Ok everything stays as it is, nothing deleted");
+            bail!("Environment deletion cancelled");
         }
 
         let result = match environment {

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -252,9 +252,9 @@ impl Delete {
         }
 
         let result = match environment {
-            ConcreteEnvironment::Path(environment) => environment.delete(),
-            ConcreteEnvironment::Managed(environment) => environment.delete(),
-            ConcreteEnvironment::Remote(environment) => environment.delete(),
+            ConcreteEnvironment::Path(environment) => environment.delete(&flox),
+            ConcreteEnvironment::Managed(environment) => environment.delete(&flox),
+            ConcreteEnvironment::Remote(environment) => environment.delete(&flox),
         };
 
         match result {

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -259,6 +259,9 @@ EOF
 
   run dot_flox_exists
   assert_failure
+
+  run ls -lA "$FLOX_DATA_HOME/links"
+  assert_output "total 0"
 }
 
 # test that non-pushed environments can be deleted


### PR DESCRIPTION
* feat: support flox delete for managed environments 
  * deletes path specific branch
  * deletes respective .flox directory
* improve `delete` command output
* migrate `PathEnvironment` to `CanonicalPath`