### PR TITLE
chore: improve error handling in `managed_environment` module

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -841,7 +841,7 @@ impl ManagedEnvironment {
         let project_branch = branch_name(&self.system, &self.pointer, &self.path);
         let sync_branch = remote_branch_name(&self.system, &self.pointer);
 
-        // Fetch the remote branch into FETCH_HEAD
+        // Fetch the remote branch into sync branch
         self.floxmeta
             .git
             .fetch_ref("origin", &format!("+{sync_branch}:{sync_branch}",))

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -886,11 +886,8 @@ impl Pull {
         Ok(())
     }
 
-    fn convert_error(err: EnvironmentError2) -> anyhow::Error {
-        if let EnvironmentError2::ManagedEnvironment(ManagedEnvironmentError::OpenFloxmeta(
-            FloxmetaV2Error::LoggedOut,
-        )) = err
-        {
+    fn convert_error(err: ManagedEnvironmentError) -> anyhow::Error {
+        if let ManagedEnvironmentError::OpenFloxmeta(FloxmetaV2Error::LoggedOut) = err {
             anyhow!(indoc! {"
                 Could not pull environment: not logged in to floxhub.
 


### PR DESCRIPTION
* replace `unwrap`s for better error types
* further mixing error types in `managed_environments` module
* refactor `flox push` to check divergence through "sync branch" rather than `FETCH_HEAD` 

