### PR TITLE
feat: remove semver and use cpp-semver

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,26 +145,6 @@
     "floco": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1694873346,
-        "narHash": "sha256-Uvh03bg0a6ZnNWiX1Gb8g+m343wSJ/wb8ryUASt0loc=",
-        "owner": "aakropotkin",
-        "repo": "floco",
-        "rev": "d16bd444ab9d29a6640f52ee4e43a66528e07515",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aakropotkin",
-        "repo": "floco",
-        "type": "github"
-      }
-    },
-    "floco_2": {
-      "inputs": {
-        "nixpkgs": [
           "flox-latest",
           "pkgdb",
           "nixpkgs"
@@ -385,7 +365,7 @@
     "pkgdb": {
       "inputs": {
         "argparse": "argparse",
-        "floco": "floco_2",
+        "floco": "floco",
         "nixpkgs": "nixpkgs",
         "sqlite3pp": "sqlite3pp"
       },
@@ -430,7 +410,6 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "floco": "floco",
         "flox-latest": "flox-latest",
         "nixpkgs": "nixpkgs_2",
         "parser-util": "parser-util_2",

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,6 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
 
-  inputs.floco.url = "github:aakropotkin/floco";
-  inputs.floco.inputs.nixpkgs.follows = "nixpkgs";
-
   inputs.sqlite3pp.url = "github:aakropotkin/sqlite3pp";
   inputs.sqlite3pp.inputs.nixpkgs.follows = "nixpkgs";
 
@@ -39,7 +36,6 @@
   outputs = {
     self,
     nixpkgs,
-    floco,
     sqlite3pp,
     parser-util,
     pre-commit-hooks,
@@ -84,7 +80,7 @@
       nix = final.callPackage ./pkgs/nix {};
     };
 
-    # Cherry pick `semver' recipe from `floco'.
+    # Use cpp-semver
     overlays.semver = final: prev: {
       cpp-semver = final.callPackage ./pkgs/cpp-semver {};
     };

--- a/flake.nix
+++ b/flake.nix
@@ -86,18 +86,7 @@
 
     # Cherry pick `semver' recipe from `floco'.
     overlays.semver = final: prev: {
-      semver = let
-        base = final.callPackage "${floco}/fpkgs/semver" {
-          nixpkgs = throw (
-            "`nixpkgs' should not be references when `pkgsFor' "
-            + "is provided"
-          );
-          inherit (final) lib;
-          pkgsFor = final;
-          nodePackage = final.nodejs;
-        };
-      in
-        base.overrideAttrs (prevAttrs: {preferLocalBuild = false;});
+      cpp-semver = final.callPackage ./pkgs/cpp-semver {};
     };
 
     # Aggregates all external dependency overlays before adding any of the

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -287,6 +287,11 @@ yaml_PREFIX := $(yaml_PREFIX)
 yaml_CFLAGS  = -isystem $(yaml_PREFIX)/include
 yaml_LDFLAGS = -L$(yaml_PREFIX)/lib -lyaml-cpp
 
+semver_PREFIX ?=                                                        \
+	$(shell $(NIX) build --no-link --print-out-paths '.#cpp-semver')
+semver_PREFIX := $(semver_PREFIX)
+semver_CFLAGS  = -isystem $(semver_PREFIX)/include
+
 nix_INCDIR ?= $(shell $(PKG_CONFIG) --variable=includedir nix-cmd)
 nix_INCDIR := $(nix_INCDIR)
 ifndef nix_CFLAGS
@@ -316,21 +321,11 @@ CXXFLAGS += $(nix_CFLAGS)
 CXXFLAGS += $(nljson_CFLAGS)
 CXXFLAGS += $(toml_CFLAGS)
 CXXFLAGS += $(yaml_CFLAGS)
+CXXFLAGS += $(semver_CFLAGS)
 
 LDFLAGS += $(nix_LDFLAGS)
 LDFLAGS += $(sqlite3_LDFLAGS)
 LDFLAGS += $(yaml_LDFLAGS)
-
-
-# ---------------------------------------------------------------------------- #
-
-# Locate `semver'
-# ---------------
-
-SEMVER_PATH ?=                                                        \
-  $(shell $(NIX) build --no-link --print-out-paths                    \
-	                     'github:aakropotkin/floco#semver')/bin/semver
-CXXFLAGS += '-DSEMVER_PATH="$(SEMVER_PATH)"'
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgs/cpp-semver/default.nix
+++ b/pkgs/cpp-semver/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "cpp-semver";
+  version = "unstabble-2021-12-10";
+
+  src = fetchFromGitHub {
+    owner = "easz";
+    repo = "cpp-semver";
+    rev = "7b9141d99044e4d363eb3b0a81cfb1546a33f9dd";
+    sha256 = "sha256-v0Ou3z9loiwmeYTOqSGrQNbM05OlaWOgH+F9q+/FhkI=";
+  };
+
+  # Header-only library.
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir "$out"
+    cp -r include "$out"
+  '';
+
+  meta = with lib; {
+    description = "semver in c++";
+    homepage = "https://github.com/easz/cpp-semver";
+    maintainers = with maintainers; [ tomberek ];
+    license = licenses.mit;
+  };
+}
+

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -13,11 +13,11 @@
   nlohmann_json,
   pkg-config,
   remake,
-  semver,
   sqlite,
   sqlite3pp,
   toml11,
   yaml-cpp,
+  cpp-semver,
   # For testing
   bash,
   yj,
@@ -42,8 +42,8 @@
     boost_CFLAGS = "-isystem " + boost.dev.outPath + "/include";
     toml_CFLAGS = "-isystem " + toml11.outPath + "/include";
     yaml_PREFIX = yaml-cpp.outPath;
+    semver_PREFIX = cpp-semver.outPath;
     libExt = stdenv.hostPlatform.extensions.sharedLibrary;
-    SEMVER_PATH = semver.outPath + "/bin/semver";
     # Used by `buildenv' to provide activation hook extensions.
     PROFILE_D_SCRIPT_DIR = builtins.path {
       name = "etc-profile.d";
@@ -95,7 +95,7 @@ in
           notIgnored && notResult;
       };
 
-      propagatedBuildInputs = [semver];
+      propagatedBuildInputs = [cpp-semver];
 
       nativeBuildInputs = [pkg-config coreutils gnugrep];
 
@@ -108,6 +108,7 @@ in
         yaml-cpp
         boost
         nix
+        cpp-semver
       ];
 
       configurePhase = ''
@@ -131,7 +132,7 @@ in
         inherit
           envs
           nix
-          semver
+          cpp-semver
           ;
 
         ciPackages = [


### PR DESCRIPTION
## Proposed Changes

removes semver (nodejs) and uses cpp-semver. Should result in a much smaller runtime closure.

runtime closure is now
```
...
/nix/store/zy5r5ssh2zk6n1k34gv09fd9865lcniq-git-minimal-2.40.1                             	  44.5M	 110.8M
/nix/store/2245z9m8qshclj8cx7yxj1l2zbchj2z1-flox-0.3.7                                     	  17.5M	 167.7M
/nix/store/rhhxa04dr3q2k80ipzq9nf9jnj8mnbc8-flox-0.3.6-146-g99c8a0d                        	  18.5K	 167.7M
```

Installers are now half the download size. A third of the on-disk-size.

Also adds pkgsFor back into the passthru for flox and includes the flox-cli.man into the output. (can be split into another PR if necessary)

## Release Notes
N/A