### PR TITLE
feat: Pretty-print manifest.lock contents

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -84,8 +84,11 @@ impl<State> CoreEnvironment<State> {
         // Write the lockfile to disk
         // todo: do we always want to do this?
         debug!("generated lockfile, writing to {}", lockfile_path.display());
-        std::fs::write(&lockfile_path, lockfile.to_string())
-            .map_err(CoreEnvironmentError::WriteLockfile)?;
+        std::fs::write(
+            &lockfile_path,
+            serde_json::to_string_pretty(&lockfile).unwrap(),
+        )
+        .map_err(CoreEnvironmentError::WriteLockfile)?;
 
         Ok(lockfile)
     }
@@ -250,7 +253,10 @@ impl CoreEnvironment<ReadOnly> {
         )
         .map_err(CoreEnvironmentError::ParseUpdateOutput)?;
 
-        self.transact_with_lockfile_contents(result.lockfile.to_string(), flox)?;
+        self.transact_with_lockfile_contents(
+            serde_json::to_string_pretty(&result.lockfile).unwrap(),
+            flox,
+        )?;
 
         Ok(result.message)
     }

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1006,8 +1006,11 @@ impl Update {
             .map_err(CoreEnvironmentError::ParseUpdateOutput)?;
 
         debug!("writing lockfile to {}", lockfile_path.display());
-        std::fs::write(lockfile_path, result.lockfile.to_string())
-            .context("updating global inputs failed")?;
+        std::fs::write(
+            lockfile_path,
+            serde_json::to_string_pretty(&result.lockfile).unwrap(),
+        )
+        .context("updating global inputs failed")?;
         Ok(result.message)
     }
 


### PR DESCRIPTION
This makes the contents diff nicely when committed to a project repo.

Closes #629.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->

N/A

<!-- Many thanks! -->