### PR TITLE
feat: flox upgrade

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -18,7 +18,13 @@ use crate::models::manifest::{
     PackageToInstall,
     TomlEditError,
 };
-use crate::models::pkgdb::{CallPkgDbError, UpdateResult, PKGDB_BIN};
+use crate::models::pkgdb::{
+    CallPkgDbError,
+    UpdateResult,
+    UpgradeResult,
+    UpgradeResultJSON,
+    PKGDB_BIN,
+};
 
 pub struct ReadOnly {}
 struct ReadWrite {}
@@ -265,6 +271,49 @@ impl CoreEnvironment<ReadOnly> {
         )?;
 
         Ok(result.message)
+    }
+
+    /// Atomically upgrade packages in this environment
+    pub fn upgrade(
+        &mut self,
+        flox: &Flox,
+        groups_or_iids: Vec<String>,
+    ) -> Result<UpgradeResult, CoreEnvironmentError> {
+        // TODO double check canonicalization
+        let manifest_path = self.manifest_path();
+        let lockfile_path = self.lockfile_path();
+        let maybe_lockfile = if lockfile_path.exists() {
+            debug!("found existing lockfile: {}", lockfile_path.display());
+            Some(lockfile_path)
+        } else {
+            debug!("no existing lockfile found");
+            None
+        };
+        let mut pkgdb_cmd = Command::new(Path::new(&*PKGDB_BIN));
+        pkgdb_cmd
+            .args(["manifest", "upgrade"])
+            .arg("--ga-registry")
+            .arg("--global-manifest")
+            .arg(global_manifest_path(flox))
+            .arg("--manifest")
+            .arg(manifest_path);
+        if let Some(lf_path) = maybe_lockfile {
+            let canonical_lockfile_path = lf_path
+                .canonicalize()
+                .map_err(|e| CoreEnvironmentError::BadLockfilePath(e, lf_path.to_path_buf()))?;
+            pkgdb_cmd.arg("--lockfile").arg(canonical_lockfile_path);
+        }
+        pkgdb_cmd.args(groups_or_iids);
+
+        debug!("upgrading environment with command: {pkgdb_cmd:?}");
+        let json: UpgradeResultJSON = serde_json::from_value(
+            call_pkgdb(pkgdb_cmd).map_err(CoreEnvironmentError::UpgradeFailed)?,
+        )
+        .map_err(CoreEnvironmentError::ParseUpgradeOutput)?;
+
+        self.transact_with_lockfile_contents(json.lockfile.to_string(), flox)?;
+
+        Ok(json.result)
     }
 
     /// Makes a temporary copy of the environment so modifications to the manifest
@@ -587,8 +636,14 @@ pub enum CoreEnvironmentError {
     #[error("unexpected output from pkgdb update")]
     ParseUpdateOutput(#[source] serde_json::Error),
 
+    #[error("unexpected output from pkgdb update")]
+    ParseUpgradeOutput(#[source] serde_json::Error),
+
     #[error("failed to update environment")]
     UpdateFailed(#[source] CallPkgDbError),
+
+    #[error("failed to upgrade environment")]
+    UpgradeFailed(#[source] CallPkgDbError),
     // endregion
     #[error("call to `pkgdb buildenv` failed")]
     BuildEnvCall(#[source] std::io::Error),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -261,8 +261,14 @@ impl Environment for ManagedEnvironment {
         flox: &Flox,
         groups_or_iids: Vec<String>,
     ) -> Result<UpgradeResult, EnvironmentError2> {
-        let mut generations = self.generations().writable(flox.temp_dir.clone()).unwrap();
-        let mut temporary = generations.get_current_generation().unwrap();
+        let mut generations = self
+            .generations()
+            .writable(flox.temp_dir.clone())
+            .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
+
+        let mut temporary = generations
+            .get_current_generation()
+            .map_err(ManagedEnvironmentError::CreateGenerationFiles)?;
 
         let result = temporary.upgrade(flox, groups_or_iids)?;
 
@@ -270,7 +276,7 @@ impl Environment for ManagedEnvironment {
 
         generations
             .add_generation(&mut temporary, metadata)
-            .unwrap();
+            .map_err(ManagedEnvironmentError::CommitGeneration)?;
 
         write_pointer_lockfile(
             self.path.join(GENERATION_LOCK_FILENAME),

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -18,6 +18,7 @@ use self::remote_environment::RemoteEnvironmentError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
 use super::flox_package::FloxTriple;
 use super::manifest::PackageToInstall;
+use super::pkgdb::UpgradeResult;
 use crate::flox::{EnvironmentRef, Flox};
 use crate::models::pkgdb::call_pkgdb;
 use crate::providers::git::{
@@ -132,6 +133,13 @@ pub trait Environment {
 
     /// Atomically update this environment's inputs
     fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2>;
+
+    /// Atomically upgrade packages in this environment
+    fn upgrade(
+        &mut self,
+        flox: &Flox,
+        groups_or_iids: Vec<String>,
+    ) -> Result<UpgradeResult, EnvironmentError2>;
 
     async fn catalog(
         &self,

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -47,6 +47,7 @@ use crate::flox::Flox;
 use crate::models::environment::{CATALOG_JSON, ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::manifest::PackageToInstall;
+use crate::models::pkgdb::UpgradeResult;
 
 /// Struct representing a local environment
 ///
@@ -207,6 +208,19 @@ impl Environment for PathEnvironment {
     fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.update(flox, inputs)?;
+        env_view.link(flox, self.out_link(&flox.system)?)?;
+
+        Ok(result)
+    }
+
+    /// Atomically upgrade packages in this environment
+    fn upgrade(
+        &mut self,
+        flox: &Flox,
+        groups_or_iids: Vec<String>,
+    ) -> Result<UpgradeResult, EnvironmentError2> {
+        let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
+        let result = env_view.upgrade(flox, groups_or_iids)?;
         env_view.link(flox, self.out_link(&flox.system)?)?;
 
         Ok(result)

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -21,6 +21,7 @@ use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmetav2::{FloxmetaV2, FloxmetaV2Error};
 use crate::models::manifest::PackageToInstall;
+use crate::models::pkgdb::UpgradeResult;
 
 #[derive(Debug, Error)]
 pub enum RemoteEnvironmentError {
@@ -142,6 +143,19 @@ impl Environment for RemoteEnvironment {
     /// Atomically update this environment's inputs
     fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2> {
         let result = self.inner.update(flox, inputs)?;
+        self.inner
+            .push(false)
+            .map_err(RemoteEnvironmentError::UpdateUpstream)?;
+        Ok(result)
+    }
+
+    /// Atomically upgrade packages in this environment
+    fn upgrade(
+        &mut self,
+        flox: &Flox,
+        groups_or_iids: Vec<String>,
+    ) -> Result<UpgradeResult, EnvironmentError2> {
+        let result = self.inner.upgrade(flox, groups_or_iids)?;
         self.inner
             .push(false)
             .map_err(RemoteEnvironmentError::UpdateUpstream)?;

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -20,6 +20,16 @@ pub struct UpdateResult {
     pub lockfile: Value,
 }
 
+/// The JSON output of a `pkgdb upgrade` call
+#[derive(Deserialize)]
+pub struct UpgradeResultJSON {
+    pub result: UpgradeResult,
+    pub lockfile: Value,
+}
+
+#[derive(Deserialize)]
+pub struct UpgradeResult(pub Vec<String>);
+
 #[derive(Debug, Error)]
 pub enum CallPkgDbError {
     #[error(transparent)]

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1202,19 +1202,6 @@ impl Update {
     }
 }
 
-/// Upgrade packages in an environment
-///
-/// When no arguments are specified, all packages in the environment are
-/// upgraded.
-///
-/// Packages to upgrade can be specified by either group name or, if a package
-/// is not in a group with any other packages, it may be specified by ID.
-///
-/// If the specified argument is both a group name and a package ID, only the
-/// group is upgraded.
-///
-/// Packages without a specified group in the manifest can be upgraded by
-/// passing 'toplevel' as the group name.
 #[derive(Bpaf, Clone)]
 pub struct Upgrade {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1094,6 +1094,18 @@ impl Update {
 }
 
 /// Upgrade packages in an environment
+///
+/// When no arguments are specified, all packages in the environment are
+/// upgraded.
+///
+/// Packages to upgrade can be specified by either group name or, if a package
+/// is not in a group with any other packages, it may be specified by ID.
+///
+/// If the specified argument is both a group name and a package ID, only the
+/// group is upgraded.
+///
+/// Packages without a specified group in the manifest can be upgraded by
+/// passing 'toplevel' as the group name.
 #[derive(Bpaf, Clone)]
 pub struct Upgrade {
     #[allow(dead_code)] // pending spec for `-e`, `--dir` behaviour

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -355,19 +355,19 @@ enum AdditionalCommands {
     #[bpaf(command, hide)]
     Update(#[bpaf(external(environment::update))] environment::Update),
     #[bpaf(command, hide, header(indoc! {"
-When no arguments are specified, all packages in the environment are upgraded.
-
-
-
-Packages to upgrade can be specified by either group name or, if a package is
-not in a group with any other packages, it may be specified by ID. If the
-specified argument is both a group name and a package ID, only the group is
-upgraded.
-
-
-
-Packages without a specified group in the manifest can be upgraded by passing
-'toplevel' as the group name.
+        When no arguments are specified, all packages in the environment are upgraded.
+        
+        
+        
+        Packages to upgrade can be specified by either group name or, if a package is
+        not in a group with any other packages, it may be specified by ID. If the
+        specified argument is both a group name and a package ID, only the group is
+        upgraded.
+        
+        
+        
+        Packages without a specified group in the manifest can be upgraded by passing
+        'toplevel' as the group name.
     "}))]
     /// Upgrade packages in an environment
     Upgrade(#[bpaf(external(environment::upgrade))] environment::Upgrade),

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -355,17 +355,13 @@ enum AdditionalCommands {
     #[bpaf(command, hide)]
     Update(#[bpaf(external(environment::update))] environment::Update),
     #[bpaf(command, hide, header(indoc! {"
-        When no arguments are specified, all packages in the environment are upgraded.
-        
-        
-        
+        When no arguments are specified, all packages in the environment are upgraded.\n\n
+
         Packages to upgrade can be specified by either group name or, if a package is
         not in a group with any other packages, it may be specified by ID. If the
         specified argument is both a group name and a package ID, only the group is
-        upgraded.
-        
-        
-        
+        upgraded.\n\n
+
         Packages without a specified group in the manifest can be upgraded by passing
         'toplevel' as the group name.
     "}))]

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -354,7 +354,22 @@ enum AdditionalCommands {
     ),
     #[bpaf(command, hide)]
     Update(#[bpaf(external(environment::update))] environment::Update),
-    #[bpaf(command, hide)]
+    #[bpaf(command, hide, header(indoc! {"
+When no arguments are specified, all packages in the environment are upgraded.
+
+
+
+Packages to upgrade can be specified by either group name or, if a package is
+not in a group with any other packages, it may be specified by ID. If the
+specified argument is both a group name and a package ID, only the group is
+upgraded.
+
+
+
+Packages without a specified group in the manifest can be upgraded by passing
+'toplevel' as the group name.
+    "}))]
+    /// Upgrade packages in an environment
     Upgrade(#[bpaf(external(environment::upgrade))] environment::Upgrade),
     #[bpaf(command, hide)]
     Config(#[bpaf(external(general::config_args))] general::ConfigArgs),

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -281,4 +281,19 @@ EOF
   refute_output "vim"
 }
 
+@test "sanity check upgrade works for managed environments" {
+  make_empty_remote_env
+
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
+    "$FLOX_BIN" install hello
+
+  # After an update, nixpkgs is the new nixpkgs, but hello is still from the
+  # old one.
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
+    "$FLOX_BIN" update
+
+  run "$FLOX_BIN" upgrade
+  assert_output --partial "upgraded 'hello'"
+}
+
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -155,3 +155,18 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
+
+@test "sanity check upgrade works for remote environments" {
+  make_empty_remote_env
+
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
+    "$FLOX_BIN" install hello --remote "$OWNER/test"
+
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
+    "$FLOX_BIN" update --remote "$OWNER/test"
+
+  run "$FLOX_BIN" upgrade --remote "$OWNER/test"
+  assert_output --partial "upgraded 'hello'"
+}
+
+# ---------------------------------------------------------------------------- #

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -1,0 +1,146 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test `flox update`
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_NAME="test";
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
+  export MANIFEST_PATH="$PROJECT_DIR/.flox/env/manifest.toml"
+  export LOCK_PATH="$PROJECT_DIR/.flox/env/manifest.lock"
+  export TMP_MANIFEST_PATH="${BATS_TEST_TMPDIR}/manifest.toml"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  rm -f "${TMP_MANIFEST_PATH?}"
+  unset PROJECT_DIR
+  unset MANIFEST_PATH
+  unset TMP_MANIFEST_PATH
+}
+
+assert_old_hello() {
+  run jq -r ".packages.\"$NIX_SYSTEM\".hello.input.attrs.narHash" "$LOCK_PATH"
+  assert_success
+  assert_output "$OLD_NAR_HASH"
+}
+
+assert_new_hello() {
+  run jq -r ".packages.\"$NIX_SYSTEM\".hello.input.attrs.narHash" "$LOCK_PATH"
+  assert_success
+  assert_output "$NEW_NAR_HASH"
+}
+
+OLD_NAR_HASH="sha256-1UGacsv5coICyvAzwuq89v9NsS00Lo8sz22cDHwhnn8="
+NEW_NAR_HASH="sha256-5uA6jKckTf+DCbVBNKsmT5pUT/7Apt5tNdpcbLnPzFI="
+GLOBAL_MANIFEST_LOCK="$FLOX_CONFIG_HOME/global-manifest.lock"
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  project_setup
+}
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+@test "upgrade hello" {
+  "$FLOX_BIN" init
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
+    "$FLOX_BIN" install hello
+
+  # nixpkgs and hello are both locked to the old nixpkgs
+  run jq -r '.registry.inputs.nixpkgs.from.narHash' "$LOCK_PATH"
+  assert_success
+  assert_output "$OLD_NAR_HASH"
+
+  assert_old_hello
+
+  # After an update, nixpkgs is the new nixpkgs, but hello is still from the
+  # old one.
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
+    "$FLOX_BIN" update
+  run jq -r '.registry.inputs.nixpkgs.from.narHash' "$LOCK_PATH"
+  assert_success
+  assert_output "$NEW_NAR_HASH"
+
+  assert_old_hello
+
+  run "$FLOX_BIN" upgrade
+  assert_output --partial "upgraded 'hello'"
+  assert_new_hello
+}
+
+@test "upgrade by group" {
+  "$FLOX_BIN" init
+  cat << "EOF" > "$TMP_MANIFEST_PATH"
+[install]
+hello = { package-group = "blue" }
+EOF
+
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
+    "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
+
+
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
+    "$FLOX_BIN" update
+  assert_old_hello
+
+  run "$FLOX_BIN" upgrade blue
+  assert_output --partial "upgraded 'hello'"
+  assert_new_hello
+}
+
+@test "upgrade toplevel group" {
+  "$FLOX_BIN" init
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
+    "$FLOX_BIN" install hello
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
+    "$FLOX_BIN" update
+  assert_old_hello
+
+  run "$FLOX_BIN" upgrade toplevel
+  assert_output --partial "upgraded 'hello'"
+  assert_new_hello
+}
+
+@test "upgrade by iid" {
+  "$FLOX_BIN" init
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
+    "$FLOX_BIN" install hello
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
+    "$FLOX_BIN" update
+  assert_old_hello
+
+  run "$FLOX_BIN" upgrade hello
+  assert_output --partial "upgraded 'hello'"
+  assert_new_hello
+}
+
+@test "upgrade errors on iid in group with other packages" {
+  "$FLOX_BIN" init
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
+    "$FLOX_BIN" install curl hello
+
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
+    "$FLOX_BIN" update
+
+  run "$FLOX_BIN" upgrade hello
+  assert_failure
+  assert_output --partial "package in a group with multiple packages"
+}

--- a/pkgdb/include/flox/resolver/command.hh
+++ b/pkgdb/include/flox/resolver/command.hh
@@ -134,6 +134,40 @@ public:
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Upgrade groups or standalone packages in an environment. */
+class UpgradeCommand : public GAEnvironmentMixin
+{
+
+private:
+
+  std::optional<std::vector<std::string>> groupsOrIIDS;
+
+  command::VerboseParser parser;
+
+
+public:
+
+  UpgradeCommand();
+
+  [[nodiscard]] command::VerboseParser &
+  getParser()
+  {
+    return this->parser;
+  }
+
+  /**
+   * @brief Execute the `upgrade` routine.
+   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+   */
+  int
+  run();
+
+
+}; /* End class `UpgradeCommand' */
+
+
+/* -------------------------------------------------------------------------- */
+
 /** @brief Show information about an environment's registries. */
 class RegistryCommand : public GAEnvironmentMixin
 {
@@ -175,6 +209,7 @@ private:
   LockCommand            cmdLock;     /**< `manifest lock`     command */
   DiffCommand            cmdDiff;     /**< `manifest diff`     command */
   UpdateCommand          cmdUpdate;   /**< `manifest update`   command */
+  UpgradeCommand         cmdUpgrade;  /**< `manifest upgrade`  command */
   RegistryCommand        cmdRegistry; /**< `manifest registry` command */
 
 

--- a/pkgdb/include/flox/resolver/descriptor.hh
+++ b/pkgdb/include/flox/resolver/descriptor.hh
@@ -30,7 +30,6 @@ namespace flox::resolver {
 /** @brief A named group which a descriptor/package can be a member of. */
 using GroupName = std::string;
 
-
 /* -------------------------------------------------------------------------- */
 
 /**

--- a/pkgdb/include/flox/resolver/manifest.hh
+++ b/pkgdb/include/flox/resolver/manifest.hh
@@ -47,6 +47,8 @@ namespace flox::resolver {
 
 /* -------------------------------------------------------------------------- */
 
+static const GroupName TOPLEVEL_GROUP_NAME = "toplevel";
+
 /** @brief Read a flox::resolver::ManifestBase from a file. */
 template<manifest_raw_type RawType>
 static inline RawType
@@ -258,12 +260,15 @@ using GlobalManifestGA = GlobalManifestBase<GlobalManifestRawGA>;
 /** @brief A map of _install IDs_ to _manifest descriptors_. */
 using InstallDescriptors = std::unordered_map<InstallID, ManifestDescriptor>;
 
+/** @brief Structure to store groups of descriptors by group name. */
+using Groups = std::unordered_map<GroupName, InstallDescriptors>;
+
 /**
  * @brief Returns all descriptors, grouping those with a _group_ field, and
- *        returning those without a group field as a map with a
- *        single element.
+ *        returning those without a group field in the group named
+ *        TOPLEVEL_GROUP_NAME.
  */
-[[nodiscard]] std::vector<InstallDescriptors>
+[[nodiscard]] Groups
 getGroupedDescriptors( const InstallDescriptors & descriptors );
 
 
@@ -388,10 +393,10 @@ public:
 
   /**
    * @brief Returns all descriptors, grouping those with a _group_ field, and
-   *        returning those without a group field as a map with a
-   *        single element.
+   *        returning those without a group field in the group named
+   *        TOPLEVEL_GROUP_NAME.
    */
-  [[nodiscard]] std::vector<InstallDescriptors>
+  [[nodiscard]] Groups
   getGroupedDescriptors() const
   {
     return flox::resolver::getGroupedDescriptors( this->descriptors );

--- a/pkgdb/include/flox/resolver/mixins.hh
+++ b/pkgdb/include/flox/resolver/mixins.hh
@@ -108,6 +108,8 @@ private:
   /** Lazily initialized environment wrapper. */
   std::optional<Environment> environment;
 
+  std::optional<Upgrades> upgrades;
+
 
 protected:
 
@@ -205,6 +207,16 @@ protected:
   setLockfileRaw( LockfileRaw lockfileRaw );
 
   /**
+   * @brief Set the @a upgrades member variable.
+   *
+   * @throws @a EnvironmentMixinException if called after @a environment is
+   * initialized, as the environment has already been calculated without
+   * upgrades.
+   */
+  virtual void
+  setUpgrades( Upgrades upgrades );
+
+  /**
    * @brief Initialize a @a flox::resolver::Lockfile from @a lockfileRaw.
    *
    * If @a lockfilePath is not set return an empty @a std::optional.
@@ -265,6 +277,13 @@ public:
    */
   [[nodiscard]] const std::optional<Lockfile> &
   getLockfile();
+
+
+  [[nodiscard]] const std::optional<Upgrades> &
+  getUpgrades()
+  {
+    return this->upgrades;
+  };
 
   /**
    * @brief Laziliy initialize and return the @a environment.

--- a/pkgdb/include/flox/resolver/mixins.hh
+++ b/pkgdb/include/flox/resolver/mixins.hh
@@ -108,6 +108,8 @@ private:
   /** Lazily initialized environment wrapper. */
   std::optional<Environment> environment;
 
+  /** Packages to attempt to upgrade. These are passed to the Environment
+   * constructor. */
   std::optional<Upgrades> upgrades;
 
 
@@ -277,13 +279,6 @@ public:
    */
   [[nodiscard]] const std::optional<Lockfile> &
   getLockfile();
-
-
-  [[nodiscard]] const std::optional<Upgrades> &
-  getUpgrades()
-  {
-    return this->upgrades;
-  };
 
   /**
    * @brief Laziliy initialize and return the @a environment.

--- a/pkgdb/src/resolver/lockfile.cc
+++ b/pkgdb/src/resolver/lockfile.cc
@@ -40,7 +40,7 @@ LockfileRaw::check() const
 void
 Lockfile::checkGroups() const
 {
-  for ( const InstallDescriptors & group :
+  for ( const auto & [_, group] :
         this->getManifest().getGroupedDescriptors() )
     {
       for ( const auto & system : this->manifest.getSystems() )

--- a/pkgdb/src/resolver/mixins.cc
+++ b/pkgdb/src/resolver/mixins.cc
@@ -197,6 +197,17 @@ EnvironmentMixin::setLockfileRaw( LockfileRaw lockfileRaw )
   this->lockfileRaw = std::move( lockfileRaw );
 }
 
+void
+EnvironmentMixin::setUpgrades( Upgrades upgrades )
+{
+  if ( this->environment.has_value() )
+    {
+      throw EnvironmentMixinException(
+        "upgrades cannot be set after environment is initialized" );
+    }
+  this->upgrades = std::move( upgrades );
+}
+
 const std::optional<Lockfile> &
 EnvironmentMixin::getLockfile()
 {
@@ -245,10 +256,11 @@ EnvironmentMixin::getEnvironment()
 {
   if ( ! this->environment.has_value() )
     {
-      this->environment
-        = std::make_optional<Environment>( this->getGlobalManifest(),
-                                           this->getManifest(),
-                                           this->getLockfile() );
+      this->environment = std::make_optional<Environment>(
+        this->getGlobalManifest(),
+        this->getManifest(),
+        this->getLockfile(),
+        this->upgrades.has_value() ? *this->upgrades : false );
     }
   return *this->environment;
 }

--- a/pkgdb/tests/environment.cc
+++ b/pkgdb/tests/environment.cc
@@ -222,9 +222,9 @@ test_groupIsLocked0()
 
   /* All groups should be locked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( environment.groupIsLocked( name, group, lockfile, _system ) );
     }
 
   return true;
@@ -265,9 +265,9 @@ test_groupIsLocked1()
 
   /* All groups should be locked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( environment.groupIsLocked( name, group, lockfile, _system ) );
     }
   return true;
 }
@@ -302,9 +302,9 @@ test_groupIsLocked2()
 
   /* All groups should be unlocked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( ! environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( ! environment.groupIsLocked( name, group, lockfile, _system ) );
     }
   return true;
 }
@@ -339,9 +339,9 @@ test_groupIsLocked3()
 
   /* All groups should be unlocked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( ! environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( ! environment.groupIsLocked( name, group, lockfile, _system ) );
     }
   return true;
 }
@@ -374,9 +374,9 @@ test_groupIsLocked4()
 
   /* All groups should be unlocked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( ! environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( ! environment.groupIsLocked( name, group, lockfile, _system ) );
     }
   return true;
 }
@@ -414,15 +414,16 @@ test_groupIsLocked5()
   /* The group with hello should stay locked, but curl should be unlocked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
   auto            groups = manifest.getGroupedDescriptors();
-  for ( const InstallDescriptors & group : groups )
+  for ( const auto & [name, group] : groups )
     {
       if ( group.contains( "hello" ) )
         {
-          EXPECT( environment.groupIsLocked( group, lockfile, _system ) );
+          EXPECT( environment.groupIsLocked( name, group, lockfile, _system ) );
         }
       else
         {
-          EXPECT( ! environment.groupIsLocked( group, lockfile, _system ) );
+          EXPECT(
+            ! environment.groupIsLocked( name, group, lockfile, _system ) );
         }
     }
   return true;
@@ -454,9 +455,9 @@ test_groupIsLocked6()
 
   /* All groups should be locked. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( environment.groupIsLocked( name, group, lockfile, _system ) );
     }
 
   return true;
@@ -487,36 +488,46 @@ test_groupIsLocked_upgrades()
 
   /* Reuse lock when upgrades = false. */
   TestEnvironment environment( std::nullopt, manifest, lockfile, false );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( environment.groupIsLocked( name, group, lockfile, _system ) );
     }
 
   /* Re-lock when upgrades = true. */
   environment = TestEnvironment( std::nullopt, manifest, lockfile, true );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( ! environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( ! environment.groupIsLocked( name, group, lockfile, _system ) );
     }
 
-  /* Reuse lock when `hello' not in upgrades list. */
+  /* Reuse lock when TOPLEVEL_GROUP_NAME not in upgrades list. */
   environment = TestEnvironment( std::nullopt,
                                  manifest,
                                  lockfile,
-                                 std::vector<InstallID> {} );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+                                 std::vector<GroupName> {} );
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( environment.groupIsLocked( name, group, lockfile, _system ) );
     }
 
-  /* Re-lock when `hello' is in upgrades list. */
+  /* Reuse lock when `hello' in upgrades list. */
   environment = TestEnvironment( std::nullopt,
                                  manifest,
                                  lockfile,
-                                 std::vector<InstallID> { "hello" } );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+                                 std::vector<GroupName> { "hello" } );
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
-      EXPECT( ! environment.groupIsLocked( group, lockfile, _system ) );
+      EXPECT( environment.groupIsLocked( name, group, lockfile, _system ) );
+    }
+
+  /* Re-lock when TOPLEVEL_GROUP_NAME is in upgrades list. */
+  environment = TestEnvironment( std::nullopt,
+                                 manifest,
+                                 lockfile,
+                                 std::vector<GroupName> { TOPLEVEL_GROUP_NAME } );
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
+    {
+      EXPECT( ! environment.groupIsLocked( name, group, lockfile, _system ) );
     }
   return true;
 }
@@ -556,7 +567,7 @@ test_getGroupInput0()
 
   /* The locked input is returned by `getGroupInput`. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
       auto input = environment.getGroupInput( group, lockfile, _system );
       EXPECT( input.has_value() );
@@ -605,7 +616,7 @@ test_getGroupInput1()
 
   /* The locked input is returned by `getGroupInput`. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
       auto input = environment.getGroupInput( group, lockfile, _system );
       EXPECT( input.has_value() );
@@ -660,7 +671,7 @@ test_getGroupInput2()
   /* The locked input of one of the packages is returned. At this point, we
    * don't care which. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
       auto input = environment.getGroupInput( group, lockfile, _system );
       EXPECT( input.has_value() );
@@ -703,7 +714,7 @@ test_getGroupInput3()
 
   /* The old locked input is *not* used. */
   TestEnvironment environment( std::nullopt, manifest, lockfile );
-  for ( const InstallDescriptors & group : manifest.getGroupedDescriptors() )
+  for ( const auto & [name, group] : manifest.getGroupedDescriptors() )
     {
       auto input = environment.getGroupInput( group, lockfile, _system );
       EXPECT( ! input.has_value() );


### PR DESCRIPTION
`flox upgrade` tries to resolve packages in a newer input. Upgrades can
be specified using iid or group name. "toplevel" is introduced as the
group name for packages without a group. `upgrade` will fail if an iid
for a package that is part of a group with other packages is specified.

Code notes:
- In pkgdb, groups are now stored as an unordered_map instead of a
  vector using group name as key, since "toplevel" can be used as the
  key for the toplevel group.
- A bug in `tryResolveGroup` was fixed where packages that should have
  been upgraded were being resolved in the old input.