### PR TITLE
feat(activate): run command interactively if provided

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -278,6 +278,10 @@ impl Delete {
 pub struct Activate {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
+
+    /// Command to run interactively in the context of the environment
+    #[bpaf(positional("cmd"), strict, many)]
+    run_args: Vec<String>,
 }
 
 impl Activate {
@@ -395,6 +399,12 @@ impl Activate {
         } else {
             bail!("Unsupported SHELL '{shell}'");
         };
+
+        if !self.run_args.is_empty() {
+            command.arg("-i");
+            command.arg("-c");
+            command.arg(self.run_args.join(" "));
+        }
 
         debug!("running activation command: {:?}", command);
         let error = command.exec();


### PR DESCRIPTION
A very preliminary implementation of `flox activate --`
Instead of opening an interactive shell with `exec shell`,
its passing down the run arguments to the shell as `shell -i -c <run args>`.
Being interactive it does all the initializations of the flox environment which are tied to the rc files.
