### PR TITLE
chore: remove defunct `async` on `Environment` methods

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -2,11 +2,8 @@ use std::os::unix::prelude::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use async_trait::async_trait;
-use flox_types::catalog::{EnvCatalog, System};
 use flox_types::version::Version;
 use log::debug;
-use runix::command_line::NixCommandLine;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -131,7 +128,6 @@ pub struct GenerationLock {
     version: Version<1>,
 }
 
-#[async_trait]
 impl Environment for ManagedEnvironment {
     fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
         let generations = self
@@ -254,15 +250,6 @@ impl Environment for ManagedEnvironment {
             .current_gen_manifest()
             .map_err(ManagedEnvironmentError::ReadManifest)?;
         Ok(manifest)
-    }
-
-    #[allow(unused)]
-    async fn catalog(
-        &self,
-        nix: &NixCommandLine,
-        system: System,
-    ) -> Result<EnvCatalog, EnvironmentError2> {
-        todo!()
     }
 
     fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -133,9 +133,8 @@ pub struct GenerationLock {
 
 #[async_trait]
 impl Environment for ManagedEnvironment {
-    #[allow(unused)]
-    async fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
-        let mut generations = self
+    fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
+        let generations = self
             .generations()
             .writable(flox.temp_dir.clone())
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
@@ -150,8 +149,7 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Install packages to the environment atomically
-    #[allow(unused)]
-    async fn install(
+    fn install(
         &mut self,
         packages: &[PackageToInstall],
         flox: &Flox,
@@ -177,8 +175,7 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Uninstall packages from the environment atomically
-    #[allow(unused)]
-    async fn uninstall(
+    fn uninstall(
         &mut self,
         packages: Vec<String>,
         flox: &Flox,
@@ -204,11 +201,7 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Atomically edit this environment, ensuring that it still builds
-    async fn edit(
-        &mut self,
-        flox: &Flox,
-        contents: String,
-    ) -> Result<EditResult, EnvironmentError2> {
+    fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError2> {
         let mut generations = self
             .generations()
             .writable(flox.temp_dir.clone())
@@ -272,8 +265,8 @@ impl Environment for ManagedEnvironment {
         todo!()
     }
 
-    async fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
-        self.build(flox).await?;
+    fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
+        self.build(flox)?;
         Ok(self.out_link.to_path_buf())
     }
 
@@ -301,7 +294,6 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Returns the environment name
-    #[allow(unused)]
     fn name(&self) -> EnvironmentName {
         self.pointer.name.clone()
     }

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -107,28 +107,24 @@ pub struct InstallationAttempt {
 #[async_trait]
 pub trait Environment {
     /// Build the environment and create a result link as gc-root
-    async fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2>;
+    fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2>;
 
     /// Install packages to the environment atomically
-    async fn install(
+    fn install(
         &mut self,
         packages: &[PackageToInstall],
         flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError2>;
 
     /// Uninstall packages from the environment atomically
-    async fn uninstall(
+    fn uninstall(
         &mut self,
         packages: Vec<String>,
         flox: &Flox,
     ) -> Result<String, EnvironmentError2>;
 
     /// Atomically edit this environment, ensuring that it still builds
-    async fn edit(
-        &mut self,
-        flox: &Flox,
-        contents: String,
-    ) -> Result<EditResult, EnvironmentError2>;
+    fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError2>;
 
     /// Atomically update this environment's inputs
     fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2>;
@@ -150,7 +146,7 @@ pub trait Environment {
     /// This should be a link to a store path so that it can be swapped
     /// dynamically, i.e. so that install/edit can modify the environment
     /// without requiring reactivation.
-    async fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2>;
+    fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2>;
 
     /// Directory containing .flox
     ///

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -2,11 +2,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::{env, fs, io};
 
-use async_trait::async_trait;
-use flox_types::catalog::{CatalogEntry, EnvCatalog, System};
+use flox_types::catalog::CatalogEntry;
 use flox_types::version::Version;
 use log::debug;
-use runix::command_line::{NixCommandLine, NixCommandLineRunJsonError};
+use runix::command_line::NixCommandLineRunJsonError;
 use runix::installable::FlakeAttribute;
 use runix::store_path::StorePath;
 use serde::{Deserialize, Serialize};
@@ -104,7 +103,6 @@ pub struct InstallationAttempt {
     pub already_installed: HashMap<String, bool>,
 }
 
-#[async_trait]
 pub trait Environment {
     /// Build the environment and create a result link as gc-root
     fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2>;
@@ -128,12 +126,6 @@ pub trait Environment {
 
     /// Atomically update this environment's inputs
     fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2>;
-
-    async fn catalog(
-        &self,
-        nix: &NixCommandLine,
-        system: System,
-    ) -> Result<EnvCatalog, EnvironmentError2>;
 
     /// Extract the current content of the manifest
     ///

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -145,7 +145,7 @@ impl Environment for PathEnvironment {
     /// - Create a result link as gc-root.
     /// - Create a lockfile if one doesn't already exist, updating it with
     ///   any new packages.
-    async fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
+    fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         env_view.build(flox)?;
         env_view.link(flox, self.out_link(&flox.system)?)?;
@@ -161,7 +161,7 @@ impl Environment for PathEnvironment {
     /// manifest.
     ///
     /// Todo: remove async
-    async fn install(
+    fn install(
         &mut self,
         packages: &[PackageToInstall],
         flox: &Flox,
@@ -178,7 +178,7 @@ impl Environment for PathEnvironment {
     /// Returns true if the environment was modified and false otherwise.
     /// TODO: this should return a list of packages that were actually
     /// uninstalled rather than a bool.
-    async fn uninstall(
+    fn uninstall(
         &mut self,
         packages: Vec<String>,
         flox: &Flox,
@@ -191,11 +191,7 @@ impl Environment for PathEnvironment {
     }
 
     /// Atomically edit this environment, ensuring that it still builds
-    async fn edit(
-        &mut self,
-        flox: &Flox,
-        contents: String,
-    ) -> Result<EditResult, EnvironmentError2> {
+    fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.edit(flox, contents)?;
         env_view.link(flox, self.out_link(&flox.system)?)?;
@@ -266,9 +262,9 @@ impl Environment for PathEnvironment {
         Ok(())
     }
 
-    async fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
-        self.build(flox).await?;
-        Ok(self.out_link(&flox.system)?)
+    fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
+        self.build(flox)?;
+        self.out_link(&flox.system)
     }
 
     /// Path to the environment's parent directory

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -17,16 +17,8 @@ use std::ffi::OsStr;
 use std::fs::{self};
 use std::path::{Path, PathBuf};
 
-use async_trait::async_trait;
-use flox_types::catalog::{EnvCatalog, System};
+use flox_types::catalog::System;
 use log::debug;
-use runix::arguments::eval::EvaluationArgs;
-use runix::arguments::EvalArgs;
-use runix::command::Eval;
-use runix::command_line::NixCommandLine;
-use runix::flake_ref::path::PathRef;
-use runix::installable::FlakeAttribute;
-use runix::RunJson;
 
 use super::core_environment::CoreEnvironment;
 use super::{
@@ -44,7 +36,7 @@ use super::{
     LOCKFILE_FILENAME,
 };
 use crate::flox::Flox;
-use crate::models::environment::{CATALOG_JSON, ENV_DIR_NAME, MANIFEST_FILENAME};
+use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::manifest::PackageToInstall;
 
@@ -138,7 +130,6 @@ impl PathEnvironment {
     }
 }
 
-#[async_trait]
 impl Environment for PathEnvironment {
     /// Build the environment with side effects:
     ///
@@ -208,39 +199,6 @@ impl Environment for PathEnvironment {
         Ok(result)
     }
 
-    /// Get a catalog of installed packages from this environment
-    ///
-    /// Evaluated using nix from the environment definition.
-    async fn catalog(
-        &self,
-        nix: &NixCommandLine,
-        system: System,
-    ) -> Result<EnvCatalog, EnvironmentError2> {
-        let mut flake_attribute = self.flake_attribute(system);
-        flake_attribute.attr_path.push_attr("catalog").unwrap(); // valid attribute name, should not fail
-
-        let eval = Eval {
-            eval: EvaluationArgs {
-                impure: true.into(),
-                ..Default::default()
-            },
-            eval_args: EvalArgs {
-                installable: Some(flake_attribute.into()),
-                apply: None,
-            },
-            ..Eval::default()
-        };
-
-        let catalog_value: serde_json::Value = eval
-            .run_json(nix, &Default::default())
-            .await
-            .map_err(EnvironmentError2::EvalCatalog)?;
-
-        std::fs::write(self.catalog_path(), catalog_value.to_string())
-            .map_err(EnvironmentError2::WriteCatalog)?;
-        serde_json::from_value(catalog_value).map_err(EnvironmentError2::ParseCatalog)
-    }
-
     /// Read the environment definition file as a string
     fn manifest_content(&self, flox: &Flox) -> Result<String, EnvironmentError2> {
         fs::read_to_string(self.manifest_path(flox)?).map_err(EnvironmentError2::ReadManifest)
@@ -285,33 +243,6 @@ impl Environment for PathEnvironment {
     /// Path to the lockfile. The path may not exist.
     fn lockfile_path(&self, _flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
         Ok(self.path.join(ENV_DIR_NAME).join(LOCKFILE_FILENAME))
-    }
-}
-
-impl PathEnvironment {
-    /// Turn the environment into a flake attribute,
-    /// a precise url to interact with the environment via nix
-    fn flake_attribute(&self, system: impl AsRef<str>) -> FlakeAttribute {
-        let flakeref = PathRef {
-            path: self.path.to_path_buf(),
-            attributes: Default::default(),
-        }
-        .into();
-
-        let attr_path = ["", "floxEnvs", system.as_ref(), "default"]
-            .try_into()
-            .unwrap(); // validated attributes
-
-        FlakeAttribute {
-            flakeref,
-            attr_path,
-            outputs: Default::default(),
-        }
-    }
-
-    /// Path to the environment's catalog
-    fn catalog_path(&self) -> PathBuf {
-        self.path.join("pkgs").join("default").join(CATALOG_JSON)
     }
 }
 
@@ -420,22 +351,5 @@ mod tests {
             "manifest exists"
         );
         assert!(actual.path.is_absolute());
-    }
-
-    #[test]
-    fn flake_attribute() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let environment_temp_dir = tempfile::tempdir().unwrap();
-        let pointer = PathPointer::new("test".parse().unwrap());
-
-        let env = PathEnvironment::init(pointer, environment_temp_dir, temp_dir).unwrap();
-
-        assert_eq!(
-            env.flake_attribute("aarch64-darwin").to_string(),
-            format!(
-                "path:{}#.floxEnvs.aarch64-darwin.default",
-                env.path.to_string_lossy()
-            )
-        )
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -95,17 +95,17 @@ impl RemoteEnvironment {
 #[async_trait]
 impl Environment for RemoteEnvironment {
     /// Build the environment and create a result link as gc-root
-    async fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
-        self.inner.build(flox).await
+    fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
+        self.inner.build(flox)
     }
 
     /// Install packages to the environment atomically
-    async fn install(
+    fn install(
         &mut self,
         packages: &[PackageToInstall],
         flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError2> {
-        let result = self.inner.install(packages, flox).await?;
+        let result = self.inner.install(packages, flox)?;
         self.inner
             .push(false)
             .map_err(RemoteEnvironmentError::UpdateUpstream)?;
@@ -114,12 +114,12 @@ impl Environment for RemoteEnvironment {
     }
 
     /// Uninstall packages from the environment atomically
-    async fn uninstall(
+    fn uninstall(
         &mut self,
         packages: Vec<String>,
         flox: &Flox,
     ) -> Result<String, EnvironmentError2> {
-        let result = self.inner.uninstall(packages, flox).await?;
+        let result = self.inner.uninstall(packages, flox)?;
         self.inner
             .push(false)
             .map_err(RemoteEnvironmentError::UpdateUpstream)?;
@@ -127,12 +127,8 @@ impl Environment for RemoteEnvironment {
     }
 
     /// Atomically edit this environment, ensuring that it still builds
-    async fn edit(
-        &mut self,
-        flox: &Flox,
-        contents: String,
-    ) -> Result<EditResult, EnvironmentError2> {
-        let result = self.inner.edit(flox, contents).await?;
+    fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError2> {
+        let result = self.inner.edit(flox, contents)?;
         self.inner
             .push(false)
             .map_err(RemoteEnvironmentError::UpdateUpstream)?;
@@ -162,8 +158,8 @@ impl Environment for RemoteEnvironment {
         self.inner.manifest_content(flox)
     }
 
-    async fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
-        self.inner.activation_path(flox).await
+    fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
+        self.inner.activation_path(flox)
     }
 
     fn parent_path(&self) -> Result<PathBuf, EnvironmentError2> {

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -1,10 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use async_trait::async_trait;
-use flox_types::catalog::{EnvCatalog, System};
 use flox_types::version::Version;
 use log::debug;
-use runix::command_line::NixCommandLine;
 use thiserror::Error;
 
 use super::managed_environment::{remote_branch_name, ManagedEnvironment, ManagedEnvironmentError};
@@ -92,7 +89,6 @@ impl RemoteEnvironment {
     }
 }
 
-#[async_trait]
 impl Environment for RemoteEnvironment {
     /// Build the environment and create a result link as gc-root
     fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
@@ -142,15 +138,6 @@ impl Environment for RemoteEnvironment {
             .push(false)
             .map_err(RemoteEnvironmentError::UpdateUpstream)?;
         Ok(result)
-    }
-
-    #[allow(unused)]
-    async fn catalog(
-        &self,
-        nix: &NixCommandLine,
-        system: System,
-    ) -> Result<EnvCatalog, EnvironmentError2> {
-        todo!()
     }
 
     /// Extract the current content of the manifest

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -81,7 +81,7 @@ impl Edit {
         let result = match self.provided_manifest_contents()? {
             // If provided with the contents of a manifest file, either via a path to a file or via
             // contents piped to stdin, use those contents to try building the environment.
-            Some(new_manifest) => environment.edit(&flox, new_manifest).await?,
+            Some(new_manifest) => environment.edit(&flox, new_manifest)?,
             // If not provided with new manifest contents, let the user edit the file directly
             // via $EDITOR or $VISUAL (as long as `flox edit` was invoked interactively).
             None => self.interactive_edit(flox, environment.as_mut()).await?,
@@ -137,7 +137,7 @@ impl Edit {
         // decides to stop.
         loop {
             let new_manifest = Edit::edited_manifest_contents(&tmp_manifest, &editor)?;
-            match environment.edit(&flox, new_manifest).await {
+            match environment.edit(&flox, new_manifest) {
                 Err(e) => {
                     error!("Environment invalid; building resulted in an error: {e}");
                     if !Dialog::can_prompt() {
@@ -312,7 +312,7 @@ impl Activate {
             .context("could't write progress message")?;
         stderr.flush().context("could't flush stderr")?;
 
-        let activation_path = environment.activation_path(&flox).await?;
+        let activation_path = environment.activation_path(&flox)?;
 
         stderr
             .queue(cursor::RestorePosition)
@@ -595,7 +595,7 @@ impl Install {
         if packages.is_empty() {
             bail!("Must specify at least one package");
         }
-        let installation = environment.install(&packages, &flox).await?;
+        let installation = environment.install(&packages, &flox)?;
         if installation.new_manifest.is_some() {
             // Print which new packages were installed
             for pkg in packages.iter() {
@@ -644,7 +644,7 @@ impl Uninstall {
             .detect_concrete_environment(&flox, "uninstall from")?;
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
-        let _ = environment.uninstall(self.packages.clone(), &flox).await?;
+        let _ = environment.uninstall(self.packages.clone(), &flox)?;
 
         // Note, you need two spaces between this emoji and the package name
         // otherwise they appear right next to each other.


### PR DESCRIPTION
The `Environment` trait started off as async when it was calling `async` runix functions.
We have since transitioned to a more classical sync approach.
Since we're not using any async components in any implementation, this removes `async` coloring .