### PR TITLE
fix: searches handle terms containing dots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,6 +327,7 @@ The list of tags to use for integration tests is as follows:
 - `project_env`
 - `managed_env`
 - `remote_env`
+- `python`, `node`, `go`, `ruby`, etc (anything language specific)
 
 Some of these tags will overlap. For example, the `build_env` tag should be used
 any time an environment is built, so there is overlap with `install`,

--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,10 @@ cargo_test_invocation := "PKGDB_BIN=${PKGDB_BIN} cargo test --workspace"
 
 # ---------------------------------------------------------------------------- #
 
+# Build the compilation database
+build-cdb:
+    @make -C pkgdb -j -s cdb
+
 # Build only pkgdb
 @build-pkgdb:
     make -C pkgdb -j;
@@ -114,6 +118,12 @@ test-all: test-pkgdb impure-tests integ-tests functional-tests
     pushd cli;                                     \
      cargo metadata --format-version 1              \
        |jq -r '.packages[]|[.name,.license]|@csv';
+
+# ---------------------------------------------------------------------------- #
+
+# Run a `flox` command
+@flox +args="": build
+    cli/target/debug/flox {{args}}
 
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/package-search.bats
+++ b/cli/tests/package-search.bats
@@ -274,6 +274,29 @@ setup_file() {
 
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=python
+
+@test "'flox search' - python310Packages.flask" {
+  run "$FLOX_BIN" search python310Packages.flask;
+  assert_success;
+  # Ensure that the package and part of the description show up
+  assert_output --partial 'python310Packages.flask';
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=ruby
+
+@test "'flox search' - rubyPackages.rails" {
+  run "$FLOX_BIN" search rubyPackages.rails;
+  assert_success;
+  assert_output --partial 'rubyPackages.rails';
+}
+
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/cli/tests/package-show.bats
+++ b/cli/tests/package-show.bats
@@ -103,6 +103,8 @@ teardown() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=python
+
 @test "'flox show' - python27Full" {
   run "$FLOX_BIN" show python27Full;
   assert_success;
@@ -113,11 +115,35 @@ teardown() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=python
+
 @test "'flox show' - python27Full --all" {
   run "$FLOX_BIN" show python27Full --all;
   assert_success;
   assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language";
   assert_equal "${lines[1]}" "    python27Full - python27Full@2.7.18.6";
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=python
+
+@test "'flox show' - python310Packages.flask" {
+  run "$FLOX_BIN" show python310Packages.flask;
+  assert_success;
+  # Ensure that the package and part of the description show up
+  assert_output --partial 'python310Packages.flask - The';
+}
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=ruby
+
+@test "'flox show' - rubyPackages.rails" {
+  run "$FLOX_BIN" show rubyPackages.rails;
+  assert_success;
+  assert_output --partial 'rubyPackages.rails - ';
 }
 
 

--- a/pkgdb/src/search/params.cc
+++ b/pkgdb/src/search/params.cc
@@ -134,13 +134,26 @@ pkgdb::PkgQueryArgs &
 SearchQuery::fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const
 {
   /* XXX: DOES NOT CLEAR FIRST! We are called after global preferences. */
-  pqa.name             = this->name;
-  pqa.pname            = this->pname;
-  pqa.version          = this->version;
-  pqa.semver           = this->semver;
-  pqa.partialMatch     = this->partialMatch;
-  pqa.partialNameMatch = this->partialNameMatch;
-  pqa.limit            = this->limit;
+  pqa.name    = this->name;
+  pqa.pname   = this->pname;
+  pqa.version = this->version;
+  pqa.semver  = this->semver;
+  // These will both write to `path`, so only one of them can be present,
+  // which is the same invariant that we already put in place on the `flox`
+  // side.
+  if ( this->partialMatch.has_value() )
+    {
+      AttrPath path = splitAttrPath( *this->partialMatch );
+      if ( path.size() > 1 ) { pqa.relPath = path; }
+      else { pqa.partialMatch = this->partialMatch; }
+    }
+  if ( this->partialNameMatch.has_value() )
+    {
+      AttrPath path = splitAttrPath( *this->partialNameMatch );
+      if ( path.size() > 1 ) { pqa.relPath = path; }
+      else { pqa.partialNameMatch = this->partialNameMatch; }
+    }
+  pqa.limit = this->limit;
   return pqa;
 }
 

--- a/pkgdb/src/search/params.cc
+++ b/pkgdb/src/search/params.cc
@@ -138,12 +138,14 @@ SearchQuery::fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const
   pqa.pname   = this->pname;
   pqa.version = this->version;
   pqa.semver  = this->semver;
-  // These will both write to `path`, so only one of them can be present,
-  // which is the same invariant that we already put in place on the `flox`
-  // side.
+  /* These will both write to `path`, so only one of them can be present,
+  which is the same invariant that we already put in place on the `flox` side.*/
   if ( this->partialMatch.has_value() )
     {
       AttrPath path = splitAttrPath( *this->partialMatch );
+      /* There's no situation in which the search term will have more than one
+      path component and _also_ need to set `partial(Name)Match`. Any search
+      term with more than one path component is assumed to be a relative path.*/
       if ( path.size() > 1 ) { pqa.relPath = path; }
       else { pqa.partialMatch = this->partialMatch; }
     }

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -345,7 +345,7 @@ joinWithDelim( const std::vector<std::string> & strings,
 void
 printLog( const nix::Verbosity & lvl, const std::string & msg )
 {
-  if ( lvl <= nix::verbosity ) { nix::logger->log( lvl, msg ); }
+  nix::logger->log( lvl, msg );
 }
 
 void


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Properly handles search terms containing `.` (e.g. nested packages) by populating `PkgQueryArgs.relPath` when the search term is a relative path. Previously these search terms were populating the `PkgQueryArgs.partial{Name}Match` fields, and returning no results for packages in the `python3*Packages` and `rubyPackages` package sets.

Addresses #653, #596

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users should be able to search for nested packages again.

<!-- Many thanks! -->
