### PR TITLE
feat: refresh global registry every 24 hours

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,31 +15,30 @@ nix_options := "--extra-experimental-features nix-command \
 PKGDB_BIN := "${PWD}/pkgdb/bin/pkgdb"
 FLOX_BIN := "${PWD}/cli/target/debug/flox"
 cargo_test_invocation := "PKGDB_BIN=${PKGDB_BIN} cargo test --workspace"
-vscode_cpp_config := "./.vscode/c_cpp_properties.json"
 
 
 # ---------------------------------------------------------------------------- #
 
-_default:
-    @just --list --unsorted
+@_default:
+    just --list --unsorted
 
 
 # ---------------------------------------------------------------------------- #
 
 # Print the paths of all of the binaries
-bins:
-    @echo "{{PKGDB_BIN}}"
-    @echo "{{FLOX_BIN}}"
+@bins:
+    echo "{{PKGDB_BIN}}"
+    echo "{{FLOX_BIN}}"
 
 # ---------------------------------------------------------------------------- #
 
 # Build only pkgdb
-build-pkgdb:
-    @make -C pkgdb -j;
+@build-pkgdb:
+    make -C pkgdb -j;
 
 # Build only flox
-build-cli: build-pkgdb
-    @pushd cli; cargo build -q; popd
+@build-cli: build-pkgdb
+    pushd cli; cargo build -q; popd
 
 # Build the binaries
 build: build-cli
@@ -48,33 +47,33 @@ build: build-cli
 # ---------------------------------------------------------------------------- #
 
 # Run the pkgdb tests
-test-pkgdb: build-pkgdb
-    @make -C pkgdb -j tests;
-    @make -C pkgdb check;
+@test-pkgdb: build-pkgdb
+    make -C pkgdb -j tests;
+    make -C pkgdb check;
 
 # Run the end-to-end test suite
-functional-tests +bats_args="": build
-    @flox-tests --pkgdb "{{PKGDB_BIN}}" --flox "{{FLOX_BIN}}" {{bats_args}}
+@functional-tests +bats_args="": build
+    flox-tests --pkgdb "{{PKGDB_BIN}}" --flox "{{FLOX_BIN}}" {{bats_args}}
 
 # Run the CLI integration test suite
-integ-tests +bats_args="": build
-    @flox-cli-tests --pkgdb "{{PKGDB_BIN}}" \
+@integ-tests +bats_args="": build
+    flox-cli-tests --pkgdb "{{PKGDB_BIN}}" \
      --flox "{{FLOX_BIN}}" -- {{bats_args}}
 
 # Run a specific CLI integration test file by name (not path)
-integ-file +bats_args="": build
-    @flox-cli-tests --pkgdb "{{PKGDB_BIN}}" \
+@integ-file +bats_args="": build
+    flox-cli-tests --pkgdb "{{PKGDB_BIN}}" \
      --flox "{{FLOX_BIN}}" -- {{bats_args}}
 
 # Run the CLI unit tests
-unit-tests regex="": build
-    @pushd cli;                            \
+@unit-tests regex="": build
+    pushd cli;                            \
      {{cargo_test_invocation}} {{regex}};  \
      popd;
 
 # Run the CLI unit tests, including impure tests
-impure-tests regex="": build
-    @pushd cli;                                                     \
+@impure-tests regex="": build
+    pushd cli;                                                     \
      {{cargo_test_invocation}} {{regex}} --features "extra-tests";  \
      popd;
 
@@ -88,22 +87,22 @@ test-all: test-pkgdb impure-tests integ-tests functional-tests
 # ---------------------------------------------------------------------------- #
 
 # Enters the Rust development environment
-work:
-    @# Note that this command is only really useful if you have
-    @# `just` installed outside of the `flox` environment already
-    @nix {{nix_options}} develop
+@work:
+    # Note that this command is only really useful if you have
+    # `just` installed outside of the `flox` environment already
+    nix {{nix_options}} develop
 
 
 # ---------------------------------------------------------------------------- #
 
 # Bump all flake dependencies and commit with a descriptive message
-bump-all:
-    @nix {{nix_options}} flake update --commit-lock-file  \
+@bump-all:
+    nix {{nix_options}} flake update --commit-lock-file  \
          --commit-lockfile-summary "chore: flake bump";
 
 # Bump a specific flake input and commit with a descriptive message
-bump input:
-    @nix {{nix_options}} flake lock --update-input {{input}}  \
+@bump input:
+    nix {{nix_options}} flake lock --update-input {{input}}  \
          --commit-lock-file --commit-lockfile-summary         \
          "chore: bump '{{input}}' flake input";
 
@@ -111,25 +110,10 @@ bump input:
 # ---------------------------------------------------------------------------- #
 
 # Output licenses of all dependency crates
-license:
-    @pushd cli;                                     \
+@license:
+    pushd cli;                                     \
      cargo metadata --format-version 1              \
        |jq -r '.packages[]|[.name,.license]|@csv';
-
-# ---------------------------------------------------------------------------- #
-
-# Configure VS Code's C++ environment
-config-vscode:
-    @pushd pkgdb; make -j -s cdb; popd
-    @if [ ! -f {{vscode_cpp_config}} ]; \
-        then echo "{}" > {{vscode_cpp_config}}; \
-        fi
-    @echo $(jq '.configurations.cppStandard = "c++20"' {{vscode_cpp_config}}) \
-        > {{vscode_cpp_config}};
-    @echo $(jq \
-        '.configurations.compileCommands = \
-        "${workspaceFolder}/pkgdb/compile_commands.json"' \
-        {{vscode_cpp_config}}) > {{vscode_cpp_config}}
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/src/nix-state.cc
+++ b/pkgdb/src/nix-state.cc
@@ -49,9 +49,8 @@ initNix()
   nix::experimentalFeatureSettings.experimentalFeatures.assign(
     std::set( { nix::Xp::Flakes } ) );
 
-  nix::Settings nixSettings;
   // Only refresh the global registry once per 24 hours
-  nixSettings.tarballTtl = 60 * 60 * 24;
+  nix::settings.tarballTtl = 60 * 60 * 24;
 
   /* Use custom logger */
   bool printBuildLogs = nix::logger->isVerbose();

--- a/pkgdb/src/nix-state.cc
+++ b/pkgdb/src/nix-state.cc
@@ -49,7 +49,7 @@ initNix()
   nix::experimentalFeatureSettings.experimentalFeatures.assign(
     std::set( { nix::Xp::Flakes } ) );
 
-  // Only refresh the global registry once per 24 hours
+  /* Only refresh the global registry once per 24 hours. */
   nix::settings.tarballTtl = 60 * 60 * 24;
 
   /* Use custom logger */

--- a/pkgdb/src/nix-state.cc
+++ b/pkgdb/src/nix-state.cc
@@ -49,6 +49,10 @@ initNix()
   nix::experimentalFeatureSettings.experimentalFeatures.assign(
     std::set( { nix::Xp::Flakes } ) );
 
+  nix::Settings nixSettings;
+  // Only refresh the global registry once per 24 hours
+  nixSettings.tarballTtl = 60 * 60 * 24;
+
   /* Use custom logger */
   bool printBuildLogs = nix::logger->isVerbose();
   if ( nix::logger != nullptr ) { delete nix::logger; }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Changes the TTL on downloaded tarballs, namely `nixpkgs`, to be fresh for 24 hours rather than 1 hour. This prevents the global registry from being invalidated every hour and should result in fewer package database rebuilds.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users should have to rebuild the search index much less often.

<!-- Many thanks! -->
