### PR TITLE
feat: implement building notification of activate as a spinner

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -104,7 +104,7 @@ pub struct InstallationAttempt {
     pub already_installed: HashMap<String, bool>,
 }
 
-pub trait Environment {
+pub trait Environment: Send {
     /// Build the environment and create a result link as gc-root
     fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2>;
 

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -137,7 +137,15 @@ impl Edit {
         // decides to stop.
         loop {
             let new_manifest = Edit::edited_manifest_contents(&tmp_manifest, &editor)?;
-            match environment.edit(&flox, new_manifest) {
+
+            let result = Dialog {
+                message: "Building environment to validate edit...",
+                help_message: None,
+                typed: Spinner::new(|| environment.edit(&flox, new_manifest.clone())),
+            }
+            .spin();
+
+            match result {
                 Err(e) => {
                     error!("Environment invalid; building resulted in an error: {e}");
                     if !Dialog::can_prompt() {

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -5,7 +5,6 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
-use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use bpaf::Bpaf;

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -652,7 +652,13 @@ impl Uninstall {
             .detect_concrete_environment(&flox, "uninstall from")?;
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
-        let _ = environment.uninstall(self.packages.clone(), &flox)?;
+
+        let _ = Dialog {
+            message: &format!("Uninstalling packages from environment {description}..."),
+            help_message: None,
+            typed: Spinner::new(|| environment.uninstall(self.packages.clone(), &flox)),
+        }
+        .spin()?;
 
         // Note, you need two spaces between this emoji and the package name
         // otherwise they appear right next to each other.

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -596,7 +596,14 @@ impl Install {
         if packages.is_empty() {
             bail!("Must specify at least one package");
         }
-        let installation = environment.install(&packages, &flox)?;
+
+        let installation = Dialog {
+            message: &format!("Installing packages to environment {description}..."),
+            help_message: None,
+            typed: Spinner::new(|| environment.install(&packages, &flox)),
+        }
+        .spin()?;
+
         if installation.new_manifest.is_some() {
             // Print which new packages were installed
             for pkg in packages.iter() {

--- a/cli/tests/activate/envVar.exp
+++ b/cli/tests/activate/envVar.exp
@@ -10,7 +10,7 @@ expect_after {
   eof { exit 2 }
   "*\n" { exp_continue }
 }
-expect "Building environment..."
+expect "Building environment"
 
 # check for alias
 send "echo \$foo\n"

--- a/cli/tests/activate/hello.exp
+++ b/cli/tests/activate/hello.exp
@@ -14,7 +14,7 @@ expect_after {
   eof { exit 2 }
   "*\n" { exp_continue }
 }
-expect "Building environment..."
+expect "Building environment"
 
 # check for hello
 send "{ command -v hello||which hello||type -P hello || echo not found ; } 2>&1\n"

--- a/cli/tests/activate/hook.exp
+++ b/cli/tests/activate/hook.exp
@@ -10,7 +10,7 @@ expect_after {
   eof { exit 2 }
   "*\n" { exp_continue }
 }
-expect "Building environment..."
+expect "Building environment"
 
 send "exit\n"
 expect eof

--- a/cli/tests/activate/remote-hello.exp
+++ b/cli/tests/activate/remote-hello.exp
@@ -14,7 +14,7 @@ expect_after {
   eof { exit 2 }
   "*\n" { exp_continue }
 }
-expect "Building environment..."
+expect "Building environment"
 
 # check for hello
 send "{ command -v hello||which hello||type -P hello || echo not found ; } 2>&1\n"

--- a/cli/tests/edit/re-activate.exp
+++ b/cli/tests/edit/re-activate.exp
@@ -13,7 +13,7 @@ expect_after {
   "*\n" { exp_continue }
 }
 
-expect -ex "Building environment..."
+expect -ex "Building environment"
 
 # edit environment and check for message prompting to re-activate
 send "$flox edit -f $manifest\n"

--- a/cli/tests/install/last-activated.exp
+++ b/cli/tests/install/last-activated.exp
@@ -11,12 +11,12 @@ expect_after {
   "*\n" { exp_continue }
 }
 
-expect -ex "Building environment..." {}
+expect -ex "Building environment" {}
 
 # activate environment 2
 set cmd "$flox activate --dir 2"
 send "$cmd\n"
-expect -ex "Building environment..." {}
+expect -ex "Building environment" {}
 
 # install hello and check it's installed to environment 2
 set cmd "$flox install hello"

--- a/cli/tests/install/prompt-which-environment-git.exp
+++ b/cli/tests/install/prompt-which-environment-git.exp
@@ -10,7 +10,7 @@ expect_after {
   eof { exit 2 }
   "*\n" { exp_continue }
 }
-expect -ex "Building environment..." {}
+expect -ex "Building environment" {}
 
 # cd to directory 2/subdirectory
 send "cd 2/subdirectory\n"

--- a/cli/tests/install/prompt-which-environment.exp
+++ b/cli/tests/install/prompt-which-environment.exp
@@ -11,7 +11,7 @@ expect_after {
   "*\n" { exp_continue }
 }
 
-expect -ex "Building environment..." {}
+expect -ex "Building environment" {}
 
 # cd to directory 2
 send "cd 2\n"

--- a/tests/python.exp
+++ b/tests/python.exp
@@ -1,6 +1,6 @@
 # Activate a project environment and check
 # - pip and python3 are installed
-# - 
+# -
 # Assume throughout that the project is named project-\d+
 
 set flox $env(FLOX_BIN)
@@ -12,7 +12,7 @@ expect_after {
   "*\n" { exp_continue }
 }
 
-expect -ex "Building environment..." {}
+expect -ex "Building environment" {}
 
 set timeout 300
 send "{ command -v python3||which python3||type -P python3; } 2>&1\n"


### PR DESCRIPTION
Adds spinners to 
- `activate` (replacing current messaging)
- `install`
- `uninstall`
- `edit`

- `pull` is implemented as part of #655