### PR TITLE
fix: buildenv error handling

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -642,7 +642,7 @@ pub enum CoreEnvironmentError {
     #[error("error building environment")]
     BuildEnv(#[source] CallPkgDbError),
 
-    #[error("unexpected output from pkgdb buildenv")]
+    #[error("unexpected output from environment builder command")]
     ParseBuildEnvOutput(#[source] serde_json::Error),
     // endregion
 }

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -19,6 +19,7 @@ use crate::models::manifest::{
     TomlEditError,
 };
 use crate::models::pkgdb::{
+    BuildEnvResult,
     CallPkgDbError,
     UpdateResult,
     UpgradeResult,
@@ -522,18 +523,11 @@ impl LockedManifest {
 
         debug!("building environment with command: {pkgdb_cmd:?}");
 
-        let pkgdb_output = pkgdb_cmd
-            .output()
-            .map_err(CoreEnvironmentError::BuildEnvCall)?;
+        let result: BuildEnvResult =
+            serde_json::from_value(call_pkgdb(pkgdb_cmd).map_err(CoreEnvironmentError::BuildEnv)?)
+                .map_err(CoreEnvironmentError::ParseBuildEnvOutput)?;
 
-        if !pkgdb_output.status.success() {
-            let stderr = String::from_utf8_lossy(&pkgdb_output.stderr).into_owned();
-            return Err(CoreEnvironmentError::BuildEnv(stderr));
-        }
-
-        let stdout = String::from_utf8_lossy(&pkgdb_output.stdout).into_owned();
-
-        Ok(PathBuf::from(stdout.trim()))
+        Ok(PathBuf::from(result.store_path))
     }
 }
 impl ToString for LockedManifest {
@@ -645,11 +639,11 @@ pub enum CoreEnvironmentError {
     #[error("failed to upgrade environment")]
     UpgradeFailed(#[source] CallPkgDbError),
     // endregion
-    #[error("call to `pkgdb buildenv` failed")]
-    BuildEnvCall(#[source] std::io::Error),
-
     #[error("error building environment: {0}")]
-    BuildEnv(String),
+    BuildEnv(#[source] CallPkgDbError),
+
+    #[error("unexpected output from pkgdb buildenv")]
+    ParseBuildEnvOutput(#[source] serde_json::Error),
     // endregion
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -639,7 +639,7 @@ pub enum CoreEnvironmentError {
     #[error("failed to upgrade environment")]
     UpgradeFailed(#[source] CallPkgDbError),
     // endregion
-    #[error("error building environment: {0}")]
+    #[error("error building environment")]
     BuildEnv(#[source] CallPkgDbError),
 
     #[error("unexpected output from pkgdb buildenv")]

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -40,7 +40,7 @@ pub struct UpgradeResult(pub Vec<String>);
 pub enum CallPkgDbError {
     #[error(transparent)]
     PkgDbError(#[from] PkgDbError),
-    #[error("couldn't parse pkgdb error in expected JSON format: {0}")]
+    #[error("couldn't parse pkgdb error in expected JSON format")]
     ParsePkgDbError(#[source] serde_json::Error),
     #[error("couldn't parse pkgdb output as JSON")]
     ParseJSON(#[source] serde_json::Error),

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -79,6 +79,8 @@ pub struct PkgDbError {
 }
 
 impl<'de> Deserialize<'de> for PkgDbError {
+    // Custom deserializer was likely added to control error messages. If we
+    // stop propagating them to the user, we could drop the custom deserializer.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -117,9 +119,10 @@ impl<'de> Deserialize<'de> for PkgDbError {
             caught: caught_message_contents.map(|m| CaughtMsgError { message: m }),
         });
 
-        if let Some(k) = map.keys().next() {
-            Err(serde::de::Error::unknown_field(k, &[]))?
-        }
+        debug_assert!(
+            map.keys().next().is_none(),
+            "unknown field in pkgdb error JSON"
+        );
 
         Ok(PkgDbError {
             exit_code,

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -27,6 +27,12 @@ pub struct UpgradeResultJSON {
     pub lockfile: Value,
 }
 
+/// The JSON output of a `pkgdb buildenv` call
+#[derive(Deserialize)]
+pub struct BuildEnvResult {
+    pub store_path: String,
+}
+
 #[derive(Deserialize)]
 pub struct UpgradeResult(pub Vec<String>);
 
@@ -34,8 +40,8 @@ pub struct UpgradeResult(pub Vec<String>);
 pub enum CallPkgDbError {
     #[error(transparent)]
     PkgDbError(#[from] PkgDbError),
-    #[error("couldn't parse pkgdb error as JSON: {0}")]
-    ParsePkgDbError(String),
+    #[error("couldn't parse pkgdb error in expected JSON format: {0}")]
+    ParsePkgDbError(#[source] serde_json::Error),
     #[error("couldn't parse pkgdb output as JSON")]
     ParseJSON(#[source] serde_json::Error),
     #[error("call to pkgdb failed")]
@@ -49,12 +55,9 @@ pub fn call_pkgdb(mut pkgdb_cmd: Command) -> Result<Value, CallPkgDbError> {
     let output = pkgdb_cmd.output().map_err(CallPkgDbError::PkgDbCall)?;
     // If command fails, try to parse stdout as a PkgDbError
     if !output.status.success() {
-        if let Ok::<PkgDbError, _>(pkgdb_err) = serde_json::from_slice(&output.stdout) {
-            Err(pkgdb_err)?
-        } else {
-            Err(CallPkgDbError::ParsePkgDbError(
-                String::from_utf8_lossy(&output.stdout).to_string(),
-            ))
+        match serde_json::from_slice::<PkgDbError>(&output.stdout) {
+            Ok(pkgdb_err) => Err(pkgdb_err)?,
+            Err(e) => Err(CallPkgDbError::ParsePkgDbError(e))?,
         }
     // If command succeeds, try to parse stdout as JSON value
     } else {
@@ -70,7 +73,7 @@ pub struct PkgDbError {
     /// the category of error.
     pub exit_code: u64,
     /// The generic message for this category of error.
-    pub category_message: Option<String>,
+    pub category_message: String,
     /// The more contextual message for the specific error that occurred.
     pub context_message: Option<ContextMsgError>,
 }
@@ -80,22 +83,21 @@ impl<'de> Deserialize<'de> for PkgDbError {
     where
         D: serde::Deserializer<'de>,
     {
-        let map = serde_json::Map::<String, Value>::deserialize(deserializer)?;
+        let mut map = serde_json::Map::<String, Value>::deserialize(deserializer)?;
         let exit_code = map
-            .get("exit_code")
+            .remove("exit_code")
             .ok_or_else(|| serde::de::Error::missing_field("exit_code"))?
             .as_u64()
             .ok_or_else(|| serde::de::Error::custom("exit code is not an unsigned integer"))?;
-        let category_message = map
-            .get("category_message")
-            .map(|m| {
-                m.as_str()
-                    .ok_or_else(|| serde::de::Error::custom("category message was not a string"))
-                    .map(|m| m.to_owned())
-            })
-            .transpose()?;
+        let category_message = match map.remove("category_message") {
+            Some(m) => m
+                .as_str()
+                .ok_or_else(|| serde::de::Error::custom("category message was not a string"))
+                .map(|m| m.to_owned()),
+            None => Err(serde::de::Error::missing_field("category_message")),
+        }?;
         let context_message_contents = map
-            .get("context_message")
+            .remove("context_message")
             .map(|m| {
                 m.as_str()
                     .ok_or_else(|| serde::de::Error::custom("context message was not a string"))
@@ -103,7 +105,7 @@ impl<'de> Deserialize<'de> for PkgDbError {
             })
             .transpose()?;
         let caught_message_contents = map
-            .get("caught_message")
+            .remove("caught_message")
             .map(|m| {
                 m.as_str()
                     .ok_or_else(|| serde::de::Error::custom("caught message was not a string"))
@@ -114,6 +116,11 @@ impl<'de> Deserialize<'de> for PkgDbError {
             message: m,
             caught: caught_message_contents.map(|m| CaughtMsgError { message: m }),
         });
+
+        if let Some(k) = map.keys().next() {
+            Err(serde::de::Error::unknown_field(k, &[]))?
+        }
+
         Ok(PkgDbError {
             exit_code,
             category_message,
@@ -124,11 +131,7 @@ impl<'de> Deserialize<'de> for PkgDbError {
 
 impl Display for PkgDbError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(category_message) = &self.category_message {
-            write!(f, "{}", category_message)?;
-        } else {
-            write!(f, "error calling pkgdb")?;
-        }
+        write!(f, "{}", self.category_message)?;
         Ok(())
     }
 }

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -63,9 +63,6 @@ BuildEnvCommand::run()
   auto system    = this->system.value_or( nix::settings.thisSystem.get() );
   auto storePath = createFloxEnv( *state, lockfile, system );
 
-  /* Print the resulting store path */
-  std::cout << store->printStorePath( storePath ) << std::endl;
-
   auto localStore = store.dynamic_pointer_cast<nix::LocalFSStore>();
 
   // TODO: Make a read error
@@ -85,6 +82,11 @@ BuildEnvCommand::run()
                             "outLinkPath: " + outLinkPath );
         }
     }
+
+  /* Print the resulting store path */
+  nlohmann::json result
+    = { { "store_path", store->printStorePath( storePath ) } };
+  std::cout << result.dump() << std::endl;
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Fixes a bunch of minor mistakes around `pkgdb` error handling.

- The Rust invocation of `pkgdb buildenv` doesn't correctly handle errors, because it expects them on stderr instead of stdout.
- `pkgdb buildenv` doesn't print JSON as expected for a pkgdb subcommand.
- `category_message` is `Optional` in `PkgDbError` but it is required in C++.
- `PkgDbError` doesn't deny unknown fields.
- Nix errors and errors without a wrapper in `pkgdb` are printed with the wrong JSON schema.