### PR TITLE
feat: add flox `list {--config,--name-only}` options

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -475,6 +475,18 @@ impl Init {
 pub struct List {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
+    #[bpaf(external(list_mode), fallback(ListMode::NameOnly))]
+    list_mode: ListMode,
+}
+
+#[derive(Bpaf, Clone)]
+pub enum ListMode {
+    /// Show the raw contents of the manifest
+    #[bpaf(long, short)]
+    Config,
+    /// Show only the names of the packages installed in the environment
+    #[bpaf(long, short)]
+    NameOnly,
 }
 
 impl List {
@@ -487,9 +499,15 @@ impl List {
             .into_dyn_environment();
 
         let manifest_contents = env.manifest_content(&flox)?;
-        if let Some(pkgs) = list_packages(&manifest_contents)? {
-            pkgs.iter().for_each(|pkg| println!("{}", pkg));
+        match self.list_mode {
+            ListMode::Config => println!("{}", manifest_contents),
+            ListMode::NameOnly => {
+                if let Some(pkgs) = list_packages(&manifest_contents)? {
+                    pkgs.iter().for_each(|pkg| println!("{}", pkg));
+                }
+            },
         }
+
         Ok(())
     }
 }

--- a/cli/tests/environment-list.bats
+++ b/cli/tests/environment-list.bats
@@ -59,3 +59,23 @@ teardown() {
 hello
 EOF
 }
+
+# bats test_tags=list,list:config
+@test "'flox list --config' shows manifest content" {
+  "$FLOX_BIN" init
+  MANIFEST_CONTENT="$(
+    cat <<- EOF
+    [install]
+
+    [hook]
+    script = "something suspicious"
+EOF
+
+  )"
+
+  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+
+  run "$FLOX_BIN" list --config
+  assert_success
+  assert_output "$MANIFEST_CONTENT"
+}


### PR DESCRIPTION
* add `--config` flag: show the raw manifest
* add `--name-only` (default): show package names

both flags are mutually exclusive