### PR TITLE
test: support runnning raw tests on a host

### DIFF
--- a/cli/tests/activate/envVar.exp
+++ b/cli/tests/activate/envVar.exp
@@ -9,6 +9,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 expect "Building environment"
 

--- a/cli/tests/activate/hello.exp
+++ b/cli/tests/activate/hello.exp
@@ -13,6 +13,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 expect "Building environment"
 

--- a/cli/tests/activate/hook.exp
+++ b/cli/tests/activate/hook.exp
@@ -9,6 +9,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 expect "Building environment"
 

--- a/cli/tests/activate/rc.exp
+++ b/cli/tests/activate/rc.exp
@@ -10,6 +10,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 
 expect -re "flox .*\\\[project-\\d+\\\]" {}

--- a/cli/tests/activate/remote-hello.exp
+++ b/cli/tests/activate/remote-hello.exp
@@ -13,6 +13,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 expect "Building environment"
 

--- a/cli/tests/edit/re-activate.exp
+++ b/cli/tests/edit/re-activate.exp
@@ -11,6 +11,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 
 expect -ex "Building environment"

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -13,8 +13,8 @@ load test_support.bash
 # Helpers for project based tests.
 
 project_setup() {
-  export PROJECT_NAME="test"
-  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-managed-${BATS_TEST_NUMBER?}"
+  export PROJECT_NAME="${PROJECT_DIR##*/}"
   export OWNER="owner"
 
   rm -rf "$PROJECT_DIR"
@@ -75,7 +75,7 @@ dot_flox_exists() {
 
   run "$FLOX_BIN" install hello
   assert_success
-  assert_output --partial "environment $OWNER/test" # managed env output
+  assert_output --partial "environment $OWNER/project-managed-${BATS_TEST_NUMBER}" # managed env output
 
   run --separate-stderr "$FLOX_BIN" list --name
   assert_success
@@ -309,7 +309,7 @@ EOF
   assert_failure
 
   # when recreating an environment, a new branch should be used
-  run "$FLOX_BIN" pull --remote "$OWNER/test"
+  run "$FLOX_BIN" pull --remote "$OWNER/project-managed-${BATS_TEST_NUMBER}"
   assert_success
 
   "$FLOX_BIN" install emacs

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -14,7 +14,7 @@ load test_support.bash
 # Helpers for project based tests.
 
 project_setup() {
-  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-push-${BATS_TEST_NUMBER?}"
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" > /dev/null || return

--- a/cli/tests/environment-push.bats
+++ b/cli/tests/environment-push.bats
@@ -14,7 +14,7 @@ load test_support.bash
 # Helpers for project based tests.
 
 project_setup() {
-  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-push-${BATS_TEST_NUMBER?}"
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" > /dev/null || return

--- a/cli/tests/install/last-activated.exp
+++ b/cli/tests/install/last-activated.exp
@@ -9,6 +9,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 
 expect -ex "Building environment" {}

--- a/cli/tests/install/prompt-which-environment-git.exp
+++ b/cli/tests/install/prompt-which-environment-git.exp
@@ -9,6 +9,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 expect -ex "Building environment" {}
 

--- a/cli/tests/install/prompt-which-environment.exp
+++ b/cli/tests/install/prompt-which-environment.exp
@@ -9,6 +9,7 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 
 expect -ex "Building environment" {}

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -305,12 +305,12 @@ xdg_tmp_setup() {
   mkdir -p "${XDG_CONFIG_HOME:?}"
   chmod u+w "$XDG_CONFIG_HOME"
 
-  if [[ -e "${REAL_XDG_CONFIG_HOME:?}/nix" ]]; then
+  if [[ -e "${REAL_XDG_CONFIG_HOME:?}/nix" && "$REAL_XDG_CONFIG_HOME" != "$XDG_CONFIG_HOME" ]]; then
     rm -rf "$XDG_CONFIG_HOME/nix"
     cp -Tr -- "$REAL_XDG_CONFIG_HOME/nix" "$XDG_CONFIG_HOME/nix"
     chmod -R u+w "$XDG_CONFIG_HOME/nix"
   fi
-  if [[ -e "$REAL_XDG_CONFIG_HOME/flox" ]]; then
+  if [[ -e "${REAL_XDG_CONFIG_HOME}/flox" && "$REAL_XDG_CONFIG_HOME" != "$XDG_CONFIG_HOME" ]]; then
     rm -rf "$XDG_CONFIG_HOME/flox"
     cp -Tr -- "$REAL_XDG_CONFIG_HOME/flox" "$XDG_CONFIG_HOME/flox"
     chmod -R u+w "$XDG_CONFIG_HOME/flox"
@@ -391,6 +391,11 @@ flox_vars_setup() {
 # Homedirs can be created "globally" for the entire test suite ( default ), or
 # for individual files or single tests by passing an optional argument.
 home_setup() {
+  if [[ "${__FT_RAN_HOME_SETUP:-}" = "real" ]]; then
+    export FLOX_TEST_HOME="$REAL_HOME"
+    export HOME="$REAL_HOME"
+    return 0;
+  fi
   case "${1:-suite}" in
     suite) export FLOX_TEST_HOME="${BATS_SUITE_TMPDIR?}/home" ;;
     file) export FLOX_TEST_HOME="${BATS_FILE_TMPDIR?}/home" ;;
@@ -400,7 +405,6 @@ home_setup() {
       return 1
       ;;
   esac
-  #if [[ "${__FT_RAN_HOME_SETUP:-}" = "$FLOX_TEST_HOME" ]]; then return 0; fi
   # Force recreation on `home' on every invocation.
   unset __FT_RAN_HOME_SETUP
   xdg_tmp_setup
@@ -439,6 +443,7 @@ common_suite_setup() {
   {
     print_var FLOX_TEST_HOME
     print_var HOME
+    print_var PATH
     print_var XDG_CACHE_HOME
     print_var XDG_CONFIG_HOME
     print_var XDG_DATA_HOME

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -394,19 +394,19 @@ home_setup() {
   if [[ "${__FT_RAN_HOME_SETUP:-}" = "real" ]]; then
     export FLOX_TEST_HOME="$REAL_HOME"
     export HOME="$REAL_HOME"
-    return 0;
+  else
+    case "${1:-suite}" in
+      suite) export FLOX_TEST_HOME="${BATS_SUITE_TMPDIR?}/home" ;;
+      file) export FLOX_TEST_HOME="${BATS_FILE_TMPDIR?}/home" ;;
+      test) export FLOX_TEST_HOME="${BATS_TEST_TMPDIR?}/home" ;;
+      *)
+        echo "home_setup: Invalid homedir category '${1?}'" >&2
+        return 1
+        ;;
+    esac
+    # Force recreation on `home' on every invocation.
+    unset __FT_RAN_HOME_SETUP
   fi
-  case "${1:-suite}" in
-    suite) export FLOX_TEST_HOME="${BATS_SUITE_TMPDIR?}/home" ;;
-    file) export FLOX_TEST_HOME="${BATS_FILE_TMPDIR?}/home" ;;
-    test) export FLOX_TEST_HOME="${BATS_TEST_TMPDIR?}/home" ;;
-    *)
-      echo "home_setup: Invalid homedir category '${1?}'" >&2
-      return 1
-      ;;
-  esac
-  # Force recreation on `home' on every invocation.
-  unset __FT_RAN_HOME_SETUP
   xdg_tmp_setup
   flox_vars_setup
   export __FT_RAN_HOME_SETUP="$FLOX_TEST_HOME"

--- a/cli/tests/show/prompt-which-environment.exp
+++ b/cli/tests/show/prompt-which-environment.exp
@@ -9,9 +9,10 @@ expect_after {
   timeout { exit 1 }
   eof { exit 2 }
   "*\n" { exp_continue }
+  "*\r" { exp_continue }
 }
 
-expect "*\n" {}
+expect "?" {} # match any character
 send "cd 2\n"
 expect "cd 2" {}
 


### PR DESCRIPTION
## Proposed Changes

Support running existing bats/expect tests with no isolation.

can be run via something like:
```
FLOX_BIN=flox \
NIX_BIN=nix \
TESTS_DIR=$PWD/cli/tests \
SHELL=bash \ PKGDB_BIN=/nix/store/zggaya81gm8m7y8bkjjrx7fxjynmaxaz-flox-pkgdb-0.1.0/bin/pkgdb \
__FT_RAN_HOME_SETUP=real \
bats cli/tests
```

Intention is to allow running and using existing bats/expect tests in a non-isolated fashion, in VMs, containers, etc.

Requires: jq, expect, bats-with-libraries (TODO)

## Release Notes
N/A