### PR TITLE
fix: evaluate `vars` before running the `hook` script

### DIFF
--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -200,7 +200,27 @@ EOF
   SHELL=zsh bar=baz USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
-  SHELL=bash bar=baz NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
+  SHELL=zsh bar=baz NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
+  assert_success
+  assert_output --partial "baz"
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate,activate:envVar-before-hook:zsh
+@test "zsh: activate sets env var" {
+  cat << "EOF" >> "$PROJECT_DIR/.flox/env/manifest.toml"
+[vars]
+foo = "$bar"
+[hook]
+script = """
+  echo "$foo";
+"""
+EOF
+  # TODO: flox will set HOME if it doesn't match the home of the user with
+  # current euid. I'm not sure if we should change that, but for now just set
+  # USER to REAL_USER.
+  SHELL=zsh bar=baz NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- exit
   assert_success
   assert_output --partial "baz"
 }

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -208,7 +208,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:envVar-before-hook:zsh
-@test "zsh: activate sets env var" {
+@test "zsh and bash: activate sets env var before hook" {
   cat << "EOF" >> "$PROJECT_DIR/.flox/env/manifest.toml"
 [vars]
 foo = "$bar"
@@ -221,6 +221,9 @@ EOF
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
   SHELL=zsh bar=baz NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- exit
+  assert_success
+  assert_output --partial "baz"
+  SHELL=bash bar=baz NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- exit
   assert_success
   assert_output --partial "baz"
 }


### PR DESCRIPTION
Variables set in the manifest are now also available in the activation hook script

fixes flox/flox#614
