### PR TITLE
fix(git): test catching `push` authentication errors

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -30,7 +30,13 @@ use thiserror::Error;
 use super::core_environment::CoreEnvironment;
 use super::{copy_dir_recursive, PathPointer, ENV_DIR_NAME};
 use crate::models::environment::MANIFEST_FILENAME;
-use crate::providers::git::{GitCommandError, GitCommandOptions, GitCommandProvider, GitProvider};
+use crate::providers::git::{
+    GitCommandError,
+    GitCommandOptions,
+    GitCommandProvider,
+    GitProvider,
+    GitRemoteCommandError,
+};
 
 const GENERATIONS_METADATA_FILE: &str = "metadata.json";
 
@@ -353,7 +359,7 @@ pub enum GenerationsError {
     #[error("could not create generations branch")]
     CreateBranch(#[source] GitCommandError),
     #[error("could not make bare clone of generations branch")]
-    MakeBareClone(#[source] GitCommandError),
+    MakeBareClone(#[source] GitRemoteCommandError),
 
     // endregion
 
@@ -378,13 +384,13 @@ pub enum GenerationsError {
 
     // region: repo/transaction
     #[error("could not clone generations branch")]
-    CloneToFS(#[source] GitCommandError),
+    CloneToFS(#[source] GitRemoteCommandError),
     #[error("could not stage changes")]
     StageChanges(#[source] GitCommandError),
     #[error("could not commit changes")]
     CommitChanges(#[source] GitCommandError),
     #[error("could not complete transaction")]
-    CompleteTransaction(#[source] GitCommandError),
+    CompleteTransaction(#[source] GitRemoteCommandError),
     // endregion
 
     // region: manifest errors

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -52,7 +52,7 @@ pub enum ManagedEnvironmentError {
     #[error("failed to open floxmeta git repo: {0}")]
     OpenFloxmeta(FloxmetaV2Error),
     #[error("failed to fetch environment: {0}")]
-    Fetch(GitCommandError),
+    Fetch(GitRemoteCommandError),
     #[error("failed to check for git revision: {0}")]
     CheckGitRevision(GitCommandError),
     #[error("failed to check for branch existence")]
@@ -99,7 +99,7 @@ pub enum ManagedEnvironmentError {
     DeleteEnvironmentReverseLink(PathBuf, #[source] std::io::Error),
 
     #[error("could not sync environment from upstream")]
-    FetchUpdates(#[source] GitCommandError),
+    FetchUpdates(#[source] GitRemoteCommandError),
     #[error("could not apply updates from upstream")]
     ApplyUpdates(#[source] GitRemoteCommandError),
 
@@ -572,10 +572,10 @@ impl ManagedEnvironment {
                         .git
                         .fetch_ref("dynamicorigin", &format!("+{0}:{0}", remote_branch))
                         .map_err(|err| match err {
-                            GitCommandError::BadExit(_, _, _) => {
-                                ManagedEnvironmentError::Fetch(err)
+                            GitRemoteCommandError::Command(e @ GitCommandError::Command(_)) => {
+                                ManagedEnvironmentError::Git(e)
                             },
-                            _ => ManagedEnvironmentError::Git(err),
+                            _ => ManagedEnvironmentError::Fetch(err),
                         })?;
                 }
                 // If it still doesn't exist after fetching,

--- a/cli/flox-rust-sdk/src/models/floxmeta/mod.rs
+++ b/cli/flox-rust-sdk/src/models/floxmeta/mod.rs
@@ -17,7 +17,12 @@ use super::root::transaction::{GitAccess, GitSandBox, ReadOnly};
 use super::root::{Closed, Root};
 use crate::flox::Flox;
 use crate::models::floxmeta::user_meta::UserMeta;
-use crate::providers::git::{GitCommandError, GitCommandProvider as Git, GitProvider};
+use crate::providers::git::{
+    GitCommandError,
+    GitCommandProvider as Git,
+    GitProvider,
+    GitRemoteCommandError,
+};
 
 pub const FLOXMETA_DIR_NAME: &str = "meta";
 
@@ -385,16 +390,16 @@ pub enum TransactionEnterError {
     #[error("Failed to create tempdir for transaction")]
     CreateTempdir(std::io::Error),
     #[error("Failed to clone env into tempdir")]
-    GitClone(GitCommandError),
+    GitClone(GitRemoteCommandError),
 }
 #[derive(Error, Debug)]
 pub enum TransactionCommitError {
     #[error("Failed committing changes: {0}")]
     GitCommit(GitCommandError),
     #[error("Failed synchronizing changes: {0}")]
-    GitPush(GitCommandError),
+    GitPush(GitRemoteCommandError),
 }
 
 #[derive(Error, Debug)]
 #[error("Failed updating floxmeta: {0}")]
-pub struct FetchError(GitCommandError);
+pub struct FetchError(GitRemoteCommandError);

--- a/cli/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/cli/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -10,11 +10,11 @@ use super::environment_ref::EnvironmentOwner;
 use crate::flox::{Flox, Floxhub};
 use crate::providers::git::{
     GitCommandBranchHashError,
-    GitCommandError,
     GitCommandOpenError,
     GitCommandOptions,
     GitCommandProvider,
     GitProvider,
+    GitRemoteCommandError,
 };
 
 pub const FLOXMETA_DIR_NAME: &str = "meta";
@@ -37,9 +37,9 @@ pub enum FloxmetaV2Error {
     #[error("Failed to check for branch: {0}")]
     CheckForBranch(GitCommandBranchHashError),
     #[error("Failed to fetch environment: {0}")]
-    FetchBranch(GitCommandError),
+    FetchBranch(GitRemoteCommandError),
     #[error("Failed to clone environment: {0}")]
-    CloneBranch(GitCommandError),
+    CloneBranch(GitRemoteCommandError),
 
     #[error("invalid floxhub base url")]
     InvalidFloxhubBaseUrl(#[from] url::ParseError),

--- a/cli/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/cli/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -229,7 +229,7 @@ pub fn floxmeta_git_options(
     // Set authentication with the floxhub token using an inline credential helper.
     // The credential helper should help avoinding a leak of the token in the process list.
     //
-    // If no token is provided, we still set the credential helper
+    // If no token is provided, we still set the credential helper and pass an empty string as password
     // to enforce authentication failures and avoid fallback to pinentry
     options.add_env_var("FLOX_FLOXHUB_TOKEN", token);
     options.add_config_flag(

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -408,7 +408,7 @@ impl GitCommandProvider {
         path: impl AsRef<Path>,
         branch: impl AsRef<OsStr>,
         bare: bool,
-    ) -> Result<GitCommandProvider, GitCommandError> {
+    ) -> Result<GitCommandProvider, GitRemoteCommandError> {
         let mut command = options.new_command();
 
         command
@@ -438,12 +438,16 @@ impl GitCommandProvider {
         path: impl AsRef<Path>,
         branch: &str,
         bare: bool,
-    ) -> Result<GitCommandProvider, GitCommandError> {
+    ) -> Result<GitCommandProvider, GitRemoteCommandError> {
         Self::clone_branch_with(GitCommandOptions::default(), origin, path, branch, bare)
     }
 
     /// Fetch branch and update the corresponding local ref
-    pub fn fetch_branch(&self, repository: &str, branch: &str) -> Result<(), GitCommandError> {
+    pub fn fetch_branch(
+        &self,
+        repository: &str,
+        branch: &str,
+    ) -> Result<(), GitRemoteCommandError> {
         GitCommandProvider::run_command(
             self.new_command()
                 .arg("fetch")
@@ -453,7 +457,7 @@ impl GitCommandProvider {
         Ok(())
     }
 
-    pub fn fetch_ref(&self, repository: &str, r#ref: &str) -> Result<(), GitCommandError> {
+    pub fn fetch_ref(&self, repository: &str, r#ref: &str) -> Result<(), GitRemoteCommandError> {
         GitCommandProvider::run_command(
             self.new_command().arg("fetch").arg(repository).arg(r#ref),
         )?;
@@ -591,11 +595,31 @@ impl GitDiscoverError for GitCommandDiscoverError {
 #[derive(Error, Debug)]
 pub enum GitRemoteCommandError {
     #[error(transparent)]
-    Command(#[from] GitCommandError),
+    Command(GitCommandError),
     #[error("access denied")]
     AccessDenied,
     #[error("branches diverged")]
     Diverged,
+}
+
+impl From<GitCommandError> for GitRemoteCommandError {
+    fn from(err: GitCommandError) -> Self {
+        match err {
+            GitCommandError::BadExit(_, _, ref stderr)
+                if stderr.contains("DENIED") || stderr.contains("Authentication failed") =>
+            {
+                debug!("Access denied: {err}");
+                GitRemoteCommandError::AccessDenied
+            },
+            GitCommandError::BadExit(_, ref stdout, _)
+                if stdout.contains("[rejected] (fetch first)") =>
+            {
+                debug!("Branches diverged: {err}");
+                GitRemoteCommandError::Diverged
+            },
+            e => GitRemoteCommandError::Command(e),
+        }
+    }
 }
 
 /// A simple Git Provider that uses the git
@@ -604,15 +628,15 @@ impl GitProvider for GitCommandProvider {
     type AddError = GitCommandError;
     type AddRemoteError = GitCommandError;
     type CheckoutError = GitCommandError;
-    type CloneError = GitCommandError;
+    type CloneError = GitRemoteCommandError;
     type CommitError = GitCommandError;
     type DiscoverError = GitCommandDiscoverError;
-    type FetchError = GitCommandError;
+    type FetchError = GitRemoteCommandError;
     type GetOriginError = GitCommandGetOriginError;
     type InitError = GitCommandError;
     type ListBranchesError = GitCommandError;
     type MvError = GitCommandError;
-    type PushError = GitCommandError;
+    type PushError = GitRemoteCommandError;
     type RenameError = GitCommandError;
     type RmError = GitCommandError;
     type SetOriginError = GitCommandError;
@@ -1274,7 +1298,11 @@ pub mod tests {
 
         assert!(matches!(
             repo_2.fetch_ref("origin", "does-not-exist"),
-            Err(GitCommandError::BadExit(128, _, _))
+            Err(GitRemoteCommandError::Command(GitCommandError::BadExit(
+                128,
+                _,
+                _
+            )))
         ));
     }
 
@@ -1309,5 +1337,60 @@ pub mod tests {
         // reset branch_1 to branch_2
         repo.reset_branch("branch_3", &hash_branch_2).unwrap();
         assert_eq!(repo.branch_hash("branch_3").unwrap(), hash_branch_2)
+    }
+
+    /// Test that we pushing to a read only repo fails with [GitRemoteCommandError::AccessDenied]
+    #[test]
+    fn test_push_access_denied() {
+        let (mut repo, _tempdir_handle) = init_temp_repo(false);
+        repo.add_remote("origin", "https://github.com/torvalds/linux")
+            .unwrap();
+        repo.get_options_mut().add_config_flag(
+            "credential.helper",
+            r#"!f(){ echo "username="; echo "password="; }; f"#,
+        );
+
+        repo.checkout("branch_1", true).unwrap();
+        commit_file(&repo, "dummy");
+        let err = repo.push("origin", false).unwrap_err();
+        assert!(matches!(dbg!(err), GitRemoteCommandError::AccessDenied));
+    }
+
+    /// Test that we pushing to a read only repo fails with [GitRemoteCommandError::AccessDenied]
+    #[test]
+    fn test_fetch_access_denied() {
+        let (mut repo, _tempdir_handle) = init_temp_repo(false);
+        repo.add_remote("origin", "https://github.com/flox/flox-private")
+            .unwrap();
+        repo.get_options_mut().add_config_flag(
+            "credential.helper",
+            r#"!f(){ echo "username="; echo "password="; }; f"#,
+        );
+
+        let err = repo.fetch().unwrap_err();
+
+        assert!(matches!(dbg!(err), GitRemoteCommandError::AccessDenied));
+    }
+
+    /// Test that we pushing to a read only repo fails with [GitRemoteCommandError::AccessDenied]
+    #[test]
+    fn test_clone_access_denied() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let mut options = GitCommandOptions::default();
+        options.add_config_flag(
+            "credential.helper",
+            r#"!f(){ echo "username="; echo "password="; }; f"#,
+        );
+
+        let err: GitRemoteCommandError = GitCommandProvider::clone_branch_with(
+            options,
+            "https://github.com/flox/flox-private",
+            tempdir,
+            "master",
+            false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(dbg!(err), GitRemoteCommandError::AccessDenied));
     }
 }


### PR DESCRIPTION
* Add another error detection for failed authentication with git remotes (i.e. floxhub)
* Improve error reporting

closes #686
(cherry picked from commit 784b61704d028231d0d75a6eaa1e11850d85148c)

