### PR TITLE
feat: rich error messages for environment operations

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -65,7 +65,7 @@ impl<State> CoreEnvironment<State> {
 
     /// Read the manifest file
     fn manifest_content(&self) -> Result<String, CoreEnvironmentError> {
-        fs::read_to_string(self.manifest_path()).map_err(CoreEnvironmentError::ReadManifest)
+        fs::read_to_string(self.manifest_path()).map_err(CoreEnvironmentError::OpenManifest)
     }
 
     /// Lock the environment.
@@ -579,6 +579,8 @@ impl EditResult {
             Ok(Self::Unchanged)
         } else {
             // todo: use a single toml crate (toml_edit already implements serde traits)
+            // TODO: use different error variants, users _can_ fix errors in the _new_ manifest
+            //       but they _can't_ fix errors in the _old_ manifest
             let old_manifest: Manifest =
                 toml::from_str(old_manifest).map_err(CoreEnvironmentError::DeserializeManifest)?;
             let new_manifest: Manifest =

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -641,17 +641,13 @@ pub enum CoreEnvironmentError {
     #[error(transparent)]
     BadLockfilePath(CanonicalizeError),
 
-    #[error("could not open manifest file")]
-    ReadManifest(#[source] std::io::Error),
-
+    // todo: refactor upgrade to use `LockedManifest`
     #[error("unexpected output from pkgdb upgrade")]
     ParseUpgradeOutput(#[source] serde_json::Error),
-
     #[error("failed to upgrade environment")]
     UpgradeFailed(#[source] CallPkgDbError),
     // endregion
-    #[error("unexpected output from environment builder command")]
-    ParseBuildEnvOutput(#[source] serde_json::Error),
+
     // endregion
     #[error("unsupported system to build container: {0}")]
     ContainerizeUnsupportedSystem(String),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -123,9 +123,6 @@ pub enum ManagedEnvironmentError {
     #[error("could not commit generation")]
     CommitGeneration(#[source] GenerationsError),
 
-    #[error("could not link environment")]
-    Link(#[source] CoreEnvironmentError),
-
     #[error("could not build environment")]
     Build(#[source] CoreEnvironmentError),
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -38,7 +38,7 @@ use crate::providers::git::{
 };
 use crate::utils::mtime_of;
 
-const GENERATION_LOCK_FILENAME: &str = "env.lock";
+pub const GENERATION_LOCK_FILENAME: &str = "env.lock";
 
 #[derive(Debug)]
 pub struct ManagedEnvironment {
@@ -80,8 +80,7 @@ pub enum ManagedEnvironmentError {
     ReverseLink(std::io::Error),
     #[error("couldn't create links directory: {0}")]
     CreateLinksDir(std::io::Error),
-    #[error("attempted to open the empty path ''")]
-    EmptyPath,
+
     #[error("floxmeta branch name was malformed: {0}")]
     BadBranchName(String),
     #[error("project wasn't found at path {path}: {err}")]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -4,7 +4,6 @@ use std::{env, fs, io};
 
 use flox_types::version::Version;
 use log::debug;
-use runix::command_line::NixCommandLineRunJsonError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
@@ -342,16 +341,6 @@ pub enum EnvironmentError2 {
     WriteGitignore(#[source] std::io::Error),
     #[error("couldn't update manifest")]
     ManifestEdit(#[source] std::io::Error),
-    // endregion
-
-    // todo: rmove with "catalog()" method
-    // region: catalog
-    #[error("EvalCatalog")]
-    EvalCatalog(#[source] NixCommandLineRunJsonError),
-    #[error("ParseCatalog")]
-    ParseCatalog(#[source] serde_json::Error),
-    #[error("WriteCatalog")]
-    WriteCatalog(#[source] std::io::Error),
     // endregion
 
     // todo: move pointer related errors somewhere else?

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -333,8 +333,6 @@ pub enum EnvironmentError2 {
     EnvironmentExists(PathBuf),
     #[error("could not write .gitignore file")]
     WriteGitignore(#[source] std::io::Error),
-    #[error("couldn't update manifest")]
-    ManifestEdit(#[source] std::io::Error),
     // endregion
 
     // todo: move pointer related errors somewhere else?
@@ -392,6 +390,8 @@ pub enum EnvironmentError2 {
 
     #[error("could not read manifest")]
     ReadManifest(#[source] std::io::Error),
+    #[error("couldn't write manifest")]
+    WriteManifest(#[source] std::io::Error),
 
     #[error("failed to create GC roots directory")]
     CreateGcRootDir(#[source] std::io::Error),

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -25,6 +25,7 @@ use super::core_environment::CoreEnvironment;
 use super::{
     copy_dir_recursive,
     CanonicalPath,
+    CanonicalizeError,
     EditResult,
     Environment,
     EnvironmentError2,
@@ -81,7 +82,13 @@ impl PathEnvironment {
         pointer: PathPointer,
         temp_dir: impl AsRef<Path>,
     ) -> Result<Self, EnvironmentError2> {
-        let dot_flox_path = CanonicalPath::new(dot_flox_path)?;
+        let dot_flox_path =
+            CanonicalPath::new(dot_flox_path).map_err(|CanonicalizeError { path, err }| {
+                EnvironmentError2::InvalidDotFlox {
+                    path,
+                    source: Box::new(err),
+                }
+            })?;
 
         if &*dot_flox_path == Path::new("/") {
             return Err(EnvironmentError2::InvalidPath(

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -368,10 +368,10 @@ impl PathEnvironment {
             manifest_path.display(),
             system
         );
-        let contents = fs::read_to_string(&manifest_path).map_err(EnvironmentError2::ManifestEdit);
+        let contents = fs::read_to_string(&manifest_path).map_err(EnvironmentError2::ReadManifest);
         if let Err(e) = contents {
             debug!("couldn't open manifest to replace placeholder system");
-            fs::remove_dir_all(&env_dir).map_err(EnvironmentError2::ManifestEdit)?;
+            fs::remove_dir_all(&env_dir).map_err(EnvironmentError2::InitEnv)?;
             return Err(e);
         }
         let contents = contents.unwrap();
@@ -381,7 +381,7 @@ impl PathEnvironment {
             contents != replaced
         );
         let write_res =
-            fs::write(&manifest_path, replaced).map_err(EnvironmentError2::ManifestEdit);
+            fs::write(&manifest_path, replaced).map_err(EnvironmentError2::WriteManifest);
         if let Err(e) = write_res {
             debug!("overwriting manifest did not complete successfully");
             fs::remove_dir_all(&env_dir).map_err(EnvironmentError2::InitEnv)?;

--- a/cli/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/cli/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -30,8 +30,6 @@ pub enum FloxmetaV2Error {
     LoggedOut,
     #[error("floxmeta for {0} not found")]
     NotFound(String),
-    #[error("Currently only hub.flox.dev is supported as a remote")]
-    UnsupportedRemote,
     #[error("Could not open user environment directory {0}")]
     Open(GitCommandOpenError),
     #[error("Failed to check for branch: {0}")]

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -154,11 +154,7 @@ impl LockedManifest {
                 let canonical_lockfile_path =
                     CanonicalPath::new(lf_path).map_err(LockedManifestError::BadLockfilePath)?;
                 pkgdb_cmd.arg("--lockfile").arg(&canonical_lockfile_path);
-                serde_json::from_slice(
-                    &fs::read(canonical_lockfile_path)
-                        .map_err(LockedManifestError::ReadLockfile)?,
-                )
-                .map_err(LockedManifestError::ParseLockfile)
+                Self::read_from_file(&canonical_lockfile_path)
             })
             .transpose()?;
 
@@ -198,6 +194,11 @@ impl LockedManifest {
             Self::update_global_manifest(flox, vec![])?;
         }
         Ok(global_lockfile_path)
+    }
+
+    pub fn read_from_file(path: &CanonicalPath) -> Result<Self, LockedManifestError> {
+        let contents = fs::read(path).map_err(LockedManifestError::ReadLockfile)?;
+        serde_json::from_slice(&contents).map_err(LockedManifestError::ParseLockfile)
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -52,9 +52,8 @@ impl LockedManifest {
         existing_lockfile_path: &CanonicalPath,
         global_manifest_path: &Path,
     ) -> Result<Self, LockedManifestError> {
-        let canonical_manifest_path = manifest_path
-            .canonicalize()
-            .map_err(|e| LockedManifestError::BadManifestPath(e, manifest_path.to_path_buf()))?;
+        let canonical_manifest_path =
+            CanonicalPath::new(manifest_path).map_err(LockedManifestError::BadManifestPath)?;
 
         let mut pkgdb_cmd = Command::new(pkgdb);
         pkgdb_cmd
@@ -322,12 +321,10 @@ pub enum LockedManifestError {
     ParseBuildEnvOutput(#[source] serde_json::Error),
     #[error("failed to update environment")]
     UpdateFailed(#[source] CallPkgDbError),
-    #[error("failed to canonicalize manifest path: {0:?}")]
-    BadManifestPath(#[source] std::io::Error, PathBuf),
+    #[error(transparent)]
+    BadManifestPath(CanonicalizeError),
     #[error(transparent)]
     BadLockfilePath(CanonicalizeError),
-    #[error(transparent)]
-    CallPkgDbError(#[from] CallPkgDbError),
     #[error("could not open manifest file")]
     ReadLockfile(#[source] std::io::Error),
     /// when parsing the contents of a lockfile into a [LockedManifest]

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -14,8 +14,8 @@ use flox_rust_sdk::models::pkgdb::CallPkgDbError;
 use indoc::formatdoc;
 use log::debug;
 
-pub fn format_error(err: &'static EnvironmentError2) -> String {
-    debug!("formatting environment_error: {}", anyhow::Error::from(err));
+pub fn format_error(err: &EnvironmentError2) -> String {
+    debug!("formatting environment_error: {err:?}");
 
     match err {
         EnvironmentError2::DotFloxNotFound => display_chain(err),
@@ -184,7 +184,6 @@ pub fn format_error(err: &'static EnvironmentError2) -> String {
 }
 
 pub fn format_core_error(err: &CoreEnvironmentError) -> String {
-
     debug!("formatting core_error: {err:?}");
 
     match err {
@@ -272,7 +271,7 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
     }
 }
 
-pub fn format_managed_error(err: & ManagedEnvironmentError) -> String {
+pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
     debug!("formatting managed_environment_error: {err:?}");
 
     match err {
@@ -417,7 +416,7 @@ pub fn format_managed_error(err: & ManagedEnvironmentError) -> String {
             Could not read managed manifest.
 
             {err}
-        ", err = display_chain(err) },
+        ", err = display_chain(e) },
         ManagedEnvironmentError::CanonicalizePath(canonicalize_err) => formatdoc! {"
             Invalid path to environment: {canonicalize_err}
 
@@ -429,9 +428,8 @@ pub fn format_managed_error(err: & ManagedEnvironmentError) -> String {
     }
 }
 
-pub fn format_remote_error(err: & RemoteEnvironmentError) -> String {
+pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
     debug!("formatting remote_environment_error: {err:?}");
-
 
     match err {
         RemoteEnvironmentError::OpenManagedEnvironment(err) => formatdoc! {"
@@ -480,10 +478,7 @@ pub fn format_remote_error(err: & RemoteEnvironmentError) -> String {
     }
 }
 
-pub fn format_locked_manifest_error(
-    err: & LockedManifestError,
-) -> String {
-
+pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
     debug!("formatting locked_manifest_error: {err:?}");
     match err {
         LockedManifestError::CallContainerBuilder(_) => formatdoc! {"
@@ -561,7 +556,6 @@ fn format_pkgdb_error(
     parent: &dyn std::error::Error,
     context: &str,
 ) -> String {
-
     debug!("formatting pkgdb_error: {err:?}");
 
     match err {

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -302,6 +302,21 @@ fn format_remote_error(err: &'static RemoteEnvironmentError) -> String {
     }
 }
 
+fn format_pkgdb_error(
+    err: &CallPkgDbError,
+    parent: impl Into<anyhow::Error>,
+    context: &str,
+) -> String {
+    match err {
+        CallPkgDbError::PkgDbError(err) => formatdoc! {"
+            {context}
+
+            {err}
+        ", err = display_chain(err)},
+        _ => display_chain(parent),
+    }
+}
+
 fn display_chain(err: impl Into<anyhow::Error>) -> String {
     anyhow!(err).chain().join(": ")
 }

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -414,10 +414,37 @@ fn format_managed_error(err: &'static ManagedEnvironmentError) -> String {
 
 fn format_remote_error(err: &'static RemoteEnvironmentError) -> String {
     match err {
-        RemoteEnvironmentError::OpenManagedEnvironment(_) => todo!(),
-        RemoteEnvironmentError::GetLatestVersion(_) => todo!(),
-        RemoteEnvironmentError::UpdateUpstream(_) => todo!(),
-        RemoteEnvironmentError::InvalidTempPath(_) => todo!(),
+        RemoteEnvironmentError::OpenManagedEnvironment(err) => formatdoc! {"
+            Failed to open cloned remote environment: {err}
+
+            This may be due to a corrupt or incompatible environment.
+        ", err = display_chain(err)},
+
+        RemoteEnvironmentError::GetLatestVersion(err) => formatdoc! {"
+            Failed to get latest version of remote environment: {err}
+
+            ", err = display_chain(err)},
+        RemoteEnvironmentError::UpdateUpstream(ManagedEnvironmentError::Diverged) => formatdoc! {"
+            The remote environment has diverged.
+
+            This can happen if the environment is modified and pushed from another machine
+            at the same time.
+
+            Please try again after verifying the concurrent changes.
+        "},
+        RemoteEnvironmentError::UpdateUpstream(ManagedEnvironmentError::AccessDenied) => {
+            formatdoc! {"
+            Access denied to the remote environment.
+
+            This can happen if the remote is not owned by you
+            or the owner did not grant you access.
+
+            Please check the spelling of the remote environment
+            and make sure that you have access to it.
+        "}
+        },
+        RemoteEnvironmentError::UpdateUpstream(_) => display_chain(err),
+        RemoteEnvironmentError::InvalidTempPath(_) => display_chain(err),
     }
 }
 

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub mod colors;
 mod completion;
 pub mod dialog;
 pub mod didyoumean;
+pub mod errors;
 pub mod init;
 pub mod logger;
 pub mod metrics;

--- a/cli/tests/environment-containerize.bats
+++ b/cli/tests/environment-containerize.bats
@@ -89,7 +89,7 @@ function skip_if_linux() {
 
   run "$FLOX_BIN" containerize
   assert_failure
-  assert_output --partial "unsupported system"
+  assert_output "'containerize' is currently only supported on linux (found macos)."
 }
 
 # bats test_tags=containerize:default-to-file


### PR DESCRIPTION
* Adds methods to map internal library errors (`EnvironmentError2, ManagedEnvironmentError, RemoteEnvrionmentError, etc..`) to user facing error messages

* If the head of the "error chain" is a known type,
  we print the rich error and omit the rest of the chain.