### PR TITLE
fix: hide containerize from help

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -334,7 +334,7 @@ enum SharingCommands {
     /// Pull environment from flox hub
     Pull(#[bpaf(external(environment::pull))] environment::Pull),
     /// Containerize an environment
-    #[bpaf(command)]
+    #[bpaf(command, hide)]
     Containerize(#[bpaf(external(environment::containerize))] environment::Containerize),
 }
 impl SharingCommands {

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -72,8 +72,6 @@ EOF
   assert_line -n "$line" --regexp '^    push[ ]+[\w .,]+'
   line=$((line + 1))
   assert_line -n "$line" --regexp '^    pull[ ]+[\w .,]+'
-  line=$((line + 1))
-  assert_line -n "$line" --regexp '^    containerize[ ]+[\w .,]+'
 }
 
 @test "f5: command grouping changes 3: move lesser used or not polished commands to 'Additional Commands' section with help tip." {


### PR DESCRIPTION
containerize is not yet implemented so it should not be visible in help