### PR TITLE
fix: generate test data in setup

### DIFF
--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -168,17 +168,17 @@ rwildcard = $(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2)        \
 
 # Various file and target lists
 
-HEADERS        =  $(call rwildcard,include,*.hh)
-SRCS           =  $(call rwildcard,src,*.cc)
-test_SRCS      =  $(sort $(wildcard tests/*.cc))
-ALL_SRCS       =  $(SRCS) $(test_SRCS)
-BINS           =  bin/pkgdb
-TEST_UTILS     =  $(addprefix tests/,is_sqlite3 search-params)
-TESTS          =  $(filter-out $(TEST_UTILS),$(test_SRCS:.cc=))
+HEADERS        = $(call rwildcard,include,*.hh)
+SRCS           = $(call rwildcard,src,*.cc)
+test_SRCS      = $(sort $(wildcard tests/*.cc))
+ALL_SRCS       = $(SRCS) $(test_SRCS)
+BINS           = bin/pkgdb
+TEST_UTILS     = $(addprefix tests/,is_sqlite3 search-params)
+TESTS          = $(filter-out $(TEST_UTILS),$(test_SRCS:.cc=))
 TEST_DATA      =
 ALL_BINS       = $(TESTS) $(TEST_UTILS) $(BINS)
 CLEANDIRS      =
-CLEANFILES     =  $(ALL_SRCS:.cc=.o) $(ALL_BINS)
+CLEANFILES     = $(ALL_SRCS:.cc=.o) $(ALL_BINS)
 FULLCLEANDIRS  =
 FULLCLEANFILES =
 
@@ -522,33 +522,13 @@ lint: compile_commands.json $(HEADERS) $(ALL_SRCS)
 
 # ---------------------------------------------------------------------------- #
 
-# Generated Test Data
-# -------------------
-
-# Generate test data files
-.PHONY: test-data test-lockfiles
-test-data: test-lockfiles
-
-_TEST_LOCKFILE_DIRS      := $(wildcard $(TEST_DATA_DIR)/buildenv/lockfiles/*)
-_TEST_LOCKFILE_MANIFESTS := $(addsuffix /manifest.toml,$(_TEST_LOCKFILE_DIRS))
-_TEST_LOCKFILES          := $(addsuffix /manifest.lock,$(_TEST_LOCKFILE_DIRS))
-CLEANFILES               += $(_TEST_LOCKFILES)
-test-lockfiles: $(_TEST_LOCKFILES)
-$(_TEST_LOCKFILES): %/manifest.lock: %/manifest.toml bin/pkgdb
-	$(MKDIR_P) $(@D);
-	_PKGDB_GA_REGISTRY_REF_OR_REV="e8039594435c68eb4f780f3e9bf3972a7399c4b1"  \
-	  bin/pkgdb manifest lock --ga-registry --manifest $< > $@;
-
-
-# ---------------------------------------------------------------------------- #
-
 .PHONY: check cc-check bats-check
 
 #: Run all tests
 check: cc-check bats-check
 
 #: Run all C++ unit tests
-cc-check: $(TESTS:.cc=) test-data
+cc-check: $(TESTS:.cc=)
 	@_ec=0;                     \
 	echo '';                    \
 	for t in $(TESTS:.cc=); do  \
@@ -564,7 +544,7 @@ cc-check: $(TESTS:.cc=) test-data
 	exit "$$_ec";
 
 #: Run all bats tests
-bats-check: bin $(TEST_UTILS) test-data
+bats-check: bin $(TEST_UTILS)
 	PKGDB_BIN="$(PKGDB_ROOT)/bin/pkgdb"                          \
 	PKGDB_IS_SQLITE3_BIN="$(PKGDB_ROOT)/tests/is_sqlite3"        \
 	PKGDB_SEARCH_PARAMS_BIN="$(PKGDB_ROOT)/tests/search-params"  \
@@ -621,7 +601,7 @@ $(TESTS) $(TEST_UTILS): tests/%: tests/%.o
 bin: $(BINS)
 
 #: Build test executables and resources
-tests: $(TESTS) $(TEST_UTILS) test-data
+tests: $(TESTS) $(TEST_UTILS)
 
 #: Build binaries, tests, and generated `.gitignore' files
 all: bin tests ignores

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -30,8 +30,8 @@ setup_file() {
   : "${CAT:=cat}"
   : "${TEST:=test}"
   : "${MKDIR:=mkdir}"
-  export CAT TEST MKDIR;
-  export LOCKFILES="${BATS_FILE_TMPDIR?}/lockfiles";
+  export CAT TEST MKDIR
+  export LOCKFILES="${BATS_FILE_TMPDIR?}/lockfiles"
 
   # Always use a consistent `nixpkgs' input.
   export _PKGDB_GA_REGISTRY_REF_OR_REV="${NIXPKGS_REV?}"
@@ -39,10 +39,10 @@ setup_file() {
   # Generate lockfiles
   for dir in "${TESTS_DIR?}"/data/buildenv/lockfiles/*; do
     if $TEST -d "$dir"; then
-      _lockfile="${LOCKFILES?}/${dir##*/}/manifest.lock";
-      $MKDIR -p "${_lockfile%/*}";
-      ${PKGDB_BIN?} manifest lock --ga-registry --manifest              \
-                                  "$dir/manifest.toml" > "$_lockfile";
+      _lockfile="${LOCKFILES?}/${dir##*/}/manifest.lock"
+      $MKDIR -p "${_lockfile%/*}"
+      ${PKGDB_BIN?} manifest lock --ga-registry --manifest \
+        "$dir/manifest.toml" > "$_lockfile"
     fi
   done
 }
@@ -51,6 +51,12 @@ setup_file() {
 
 # bats test_tags=single,smoke
 @test "Simple environment builds successfully" {
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/single-package/manifest.lock"
+  assert_success
+}
+
+# bats test_tags=single,smoke
+@test "Inline JSON builds successfully" {
   run "$PKGDB_BIN" buildenv "$(< "$LOCKFILES/single-package/manifest.lock")"
   assert_success
 }
@@ -58,7 +64,7 @@ setup_file() {
 # bats test_tags=single,binaries
 @test "Built environment contains binaries" {
   run "$PKGDB_BIN" buildenv \
-    "$(< "$LOCKFILES/single-package/manifest.lock")" \
+    "$LOCKFILES/single-package/manifest.lock" \
     --out-link "$BATS_TEST_TMPDIR/env"
   assert_success
   assert "$TEST" -x "$BATS_TEST_TMPDIR/env/bin/vim"
@@ -67,7 +73,7 @@ setup_file() {
 # bats test_tags=single,activate-files
 @test "Built environment contains activate files" {
   run "$PKGDB_BIN" buildenv \
-    "$(< "$LOCKFILES/single-package/manifest.lock")" \
+    "$LOCKFILES/single-package/manifest.lock" \
     --out-link "$BATS_TEST_TMPDIR/env"
   assert_success
   assert "$TEST" -f "$BATS_TEST_TMPDIR/env/activate/bash"
@@ -79,7 +85,7 @@ setup_file() {
 
 # bats test_tags=hook,script
 @test "Built environment includes hook script" {
-  run "$PKGDB_BIN" buildenv "$(< "$LOCKFILES/hook-script/manifest.lock")" \
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/hook-script/manifest.lock" \
     --out-link "$BATS_TEST_TMPDIR/env"
   assert_success
   assert "$TEST" -f "$BATS_TEST_TMPDIR/env/activate/hook.sh"
@@ -90,7 +96,7 @@ setup_file() {
 # bats test_tags=hook,file
 @test "Built environment includes hook file" {
   skip "Hook files require path"
-  run "$PKGDB_BIN" buildenv "$(< "$LOCKFILES/hook-file/manifest.lock")" \
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/hook-file/manifest.lock" \
     --out-link "$BATS_TEST_TMPDIR/env"
   assert_success
   assert "$TEST" -f "$BATS_TEST_TMPDIR/env/activate/hook.sh"
@@ -102,7 +108,7 @@ setup_file() {
 
 # bats test_tags=conflict,detect
 @test "Detects conflicting packages" {
-  run "$PKGDB_BIN" buildenv "$(< "$LOCKFILES/conflict/manifest.lock")" \
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/conflict/manifest.lock" \
     --out-link "$BATS_TEST_TMPDIR/env"
   assert_failure
   assert_output --partial "file conflict between packages"
@@ -111,7 +117,7 @@ setup_file() {
 # bats test_tags=conflict,resolve
 @test "Allows to resolve conflicting with priority" {
   run "$PKGDB_BIN" buildenv \
-    "$(< "$LOCKFILES/conflict-resolved/manifest.lock")" \
+    "$LOCKFILES/conflict-resolved/manifest.lock" \
     --out-link "$BATS_TEST_TMPDIR/env"
   assert_success
 }
@@ -121,7 +127,7 @@ setup_file() {
 # bats test_tags=propagated
 @test "Environment includes propagated packages" {
   skip "ansi does not work on all systems"
-  run "$PKGDB_BIN" buildenv "$(< "$LOCKFILES/propagated/manifest.lock")" \
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/propagated/manifest.lock" \
     --out-link "$BATS_TEST_TMPDIR/env"
   assert_success
   # environment contains anki

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -27,16 +27,24 @@ load setup_suite.bash
 # --------------------------------------------------------------------------- #
 
 setup_file() {
-  : "${LOCKFILES:=${TESTS_DIR?}/data/buildenv/lockfiles}"
   : "${CAT:=cat}"
   : "${TEST:=test}"
-  export LOCKFILES CAT TEST
-}
+  : "${MKDIR:=mkdir}"
+  export CAT TEST MKDIR;
+  export LOCKFILES="${BATS_FILE_TMPDIR?}/lockfiles";
 
-# ---------------------------------------------------------------------------- #
+  # Always use a consistent `nixpkgs' input.
+  export _PKGDB_GA_REGISTRY_REF_OR_REV="${NIXPKGS_REV?}"
 
-mk_lock() {
-  $PKGDB_BIN manifest lock --ga-registry "$1"
+  # Generate lockfiles
+  for dir in "${TESTS_DIR?}"/data/buildenv/lockfiles/*; do
+    if $TEST -d "$dir"; then
+      _lockfile="${LOCKFILES?}/${dir##*/}/manifest.lock";
+      $MKDIR -p "${_lockfile%/*}";
+      ${PKGDB_BIN?} manifest lock --ga-registry --manifest              \
+                                  "$dir/manifest.toml" > "$_lockfile";
+    fi
+  done
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes
- Remove `test-data` target from `Makefile`.
- Create resources previously produced by `test-data` in the `setup_file` hook of the relevant `bats` tests.
- Use plain paths in `buildenv.bats` invocations of `pkgdb buildenv`.
- Add single test that checks inline JSON parsing for `pkgdb buildenv`.
- fix: Use consistent `--ga-registry` revision in `pkgdb/tests/buildenv.bats`.
