### PR TITLE
fix: substitute native dependencies intprofile.d scripts

### DIFF
--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -148,8 +148,8 @@ endif  # ifndef TOOLCHAIN
 VERSION := $(file < $(PKGDB_ROOT)/version)
 
 # Files used by `pkgdb buildenv' need to be added to the `nix' store.
-PROFILE_D_SCRIPT_DIR ?= $(shell                            \
-  $(NIX) store add-path -n profile.d src/buildenv/assets)
+PROFILE_D_SCRIPTS_DIR ?= $(shell                            \
+  $(NIX) nix build .\#flox-pkgdb.envs.PROFILE_D_SCRIPTS_DIR --print-out-paths)
 SET_PROMPT_BASH_SH ?= $(shell                                                  \
   $(NIX) store add-path -n set-prompt-bash.sh src/buildenv/set-prompt-bash.sh)
 
@@ -339,7 +339,7 @@ CXXFLAGS += '-DSEMVER_PATH="$(SEMVER_PATH)"'
 # ------------------------
 
 src/buildenv/realise.o: CXXFLAGS +=                   \
-	'-DPROFILE_D_SCRIPT_DIR="$(PROFILE_D_SCRIPT_DIR)"'
+	'-DPROFILE_D_SCRIPTS_DIR="$(PROFILE_D_SCRIPTS_DIR)"'
 
 src/buildenv/realise.o: CXXFLAGS +=               \
 	'-DSET_PROMPT_BASH_SH="$(SET_PROMPT_BASH_SH)"'

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0500_python.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0500_python.sh
@@ -21,7 +21,7 @@ fi
 
 # Only run if `pip' is in `PATH'
 if pip --version > /dev/null 2> /dev/null; then
-  export PIP_CONFIG_FILE=$(realpath --no-symlinks $FLOX_ENV/../../pip.ini)
+  export PIP_CONFIG_FILE=$(@realpath@ --no-symlinks $FLOX_ENV/../../pip.ini)
   cat > $PIP_CONFIG_FILE << EOF
 [global]
 require-virtualenv = true

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -35,8 +35,8 @@ namespace flox::buildenv {
 
 /* -------------------------------------------------------------------------- */
 
-#ifndef PROFILE_D_SCRIPT_DIR
-#  error "PROFILE_D_SCRIPT_DIR must be set to the path of `etc/profile.d/'"
+#ifndef PROFILE_D_SCRIPTS_DIR
+#  error "PROFILE_D_SCRIPTS_DIR must be set to the path of `etc/profile.d/'"
 #endif
 
 #ifndef SET_PROMPT_BASH_SH
@@ -357,9 +357,10 @@ createFloxEnv( nix::EvalState &     state,
                      buildenv::Priority() );
 
   /* Insert profile.d scripts.
-   * The store path is provided at compile time via the `PROFILE_D_SCRIPT_DIR'
+   * The store path is provided at compile time via the `PROFILE_D_SCRIPTS_DIR'
    * environment variable. */
-  auto profileScriptsPath = state.store->parseStorePath( PROFILE_D_SCRIPT_DIR );
+  auto profileScriptsPath
+    = state.store->parseStorePath( PROFILE_D_SCRIPTS_DIR );
   state.store->ensurePath( profileScriptsPath );
   references.insert( profileScriptsPath );
   pkgs.emplace_back( state.store->printStorePath( profileScriptsPath ),


### PR DESCRIPTION
Use `substituteAll` to inject absolute paths to binaries used in `profile.d` scripts.

fixes #676