### PR TITLE
feat: add external database locking

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,11 @@ build-cdb:
 @build-pkgdb:
     make -C pkgdb -j;
 
+# Buidl pkgdb with debug symbols
+@build-pkgdb-debug:
+    # Note that you need to clean pkgdb first
+    make -C pkgdb -j -s DEBUG=1
+
 # Build only flox
 @build-cli: build-pkgdb
     pushd cli; cargo build -q; popd
@@ -47,6 +52,13 @@ build-cdb:
 # Build the binaries
 build: build-cli
 
+# Clean the pkgdb build cache
+@clean-pkgdb:
+    make -C pkgdb -j -s clean
+
+# Clear existing databases
+@clean-dbs:
+    pkgdb gc --min-age 0
 
 # ---------------------------------------------------------------------------- #
 

--- a/cli/tests/package-search.bats
+++ b/cli/tests/package-search.bats
@@ -273,6 +273,20 @@ setup_file() {
 }
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=special
+
+@test "'flox search' doesn't error when database is locked" {
+  "$PKGDB_BIN" gc -a 0 # clear out any existing databases
+  # This command launches three instances of `flox search` simultaneously
+  # ::: {1..3} -> launch one search command for each of these arguments
+  # -N0 -> don't pass the expanded arguments (1, 2, and 3) to the command
+  run --separate-stderr sh -c 'parallel -N0 "$FLOX_BIN" search hello ::: {1..3}'
+  assert_success
+  assert_equal "${#lines[@]}" 30 # 10 lines per search command instance
+}
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,12 @@
     # Use nix@2.17
     overlays.nix = final: prev: {
       nix = final.callPackage ./pkgs/nix {};
+      nix-debug = final.enableDebugging final.nix;
+    };
+
+    # Enable debug symbols
+    overlays.sqlite = final: prev: {
+      sqlite-debug = final.enableDebugging final.sqlite;
     };
 
     # Cherry pick `semver' recipe from `floco'.
@@ -107,6 +113,7 @@
       overlays.nlohmann
       overlays.semver
       overlays.nix
+      overlays.sqlite
       sqlite3pp.overlays.default
     ];
 
@@ -118,6 +125,9 @@
           pkgsFor = final;
         });
     in {
+      flox-pkgdb-debug = final.enableDebugging final.flox-pkgdb;
+      flox-debug = final.flox.override {flox-pkgdb = final.flox-pkgdb-debug;};
+
       # Use bleeding edge `rustfmt'.
       rustfmt = prev.rustfmt.override {asNightly = true;};
 

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -544,12 +544,13 @@ cc-check: $(TESTS:.cc=)
 	exit "$$_ec";
 
 #: Run all bats tests
+PKGDB_BATS_FILES="$(PKGDB_ROOT)/tests"
 bats-check: bin $(TEST_UTILS)
 	PKGDB_BIN="$(PKGDB_ROOT)/bin/pkgdb"                          \
 	PKGDB_IS_SQLITE3_BIN="$(PKGDB_ROOT)/tests/is_sqlite3"        \
 	PKGDB_SEARCH_PARAMS_BIN="$(PKGDB_ROOT)/tests/search-params"  \
 	  $(BATS) --print-output-on-failure --verbose-run --timing   \
-	          "$(PKGDB_ROOT)/tests";
+	          "$(PKGDB_BATS_FILES)";
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/docs/database-locking.md
+++ b/pkgdb/docs/database-locking.md
@@ -1,0 +1,147 @@
+# Database locking
+
+During testing, CI, or after a user's first install, it's entirely possible
+that more than one process could try to create the package database at the same
+time.
+This means that multiple process may end up trying to create the database
+without knowledge of the other processes also trying to create the database,
+which SQLite will helpfully prevent by locking the database during writes.
+Predicting where this "database is locked" error will occur is tricky,
+and getting it right is also tricky.
+For this reason we've decided to prevent more than one process from trying to
+create the database at all via a locking mechanism.
+
+## Algorithm
+Let's start with a single `pkgdb` process starting from scratch.
+The basic idea is:
+- Check whether the db lock exists.
+- If the lock doesn't exist, check if the db exists.
+- If the db doesn't exist, we get to create it.
+- Create the db lock.
+- Spawn a thread that will periodically touch the lock so other processes 
+interested in the lock know that the writer is still alive.
+- Create the db and make writes to it.
+- When done, the thread is terminated and the db lock is deleted.
+
+```mermaid
+sequenceDiagram
+    participant Process as pkgdb
+    participant Lock as abc123.lock
+    participant DB as abc123.sqlite
+    participant HeartbeatThread as Heartbeat Thread
+    Process->>Lock: Does it exist?
+    Lock-->>Process: No
+    Process->>DB: Does it exist?
+    DB-->>Process: No
+    Process->>Lock: Create lock
+    activate Lock
+    Process->>HeartbeatThread: Spawn
+    activate HeartbeatThread
+    Process->>DB: Create db
+    par HeartbeatThread periodically touches lock
+        HeartbeatThread->>Lock: Update mtime
+    and pkgdb interacts with db
+        Process->>DB: Read/Write
+    end
+    Process->>HeartbeatThread: Terminate thread
+    deactivate HeartbeatThread
+    Process->>Lock: Delete lock
+    deactivate Lock
+```
+
+Now let's see what happens from the point of view of a second `pkgdb` process that's created after the db lock is created.
+The basic idea is:
+- Append this `pkgdb` process's PID to the lock to register interest.
+- Periodically check the mtime of the lock.
+- If the last within some interval, the writer must still be alive.
+- Keep waiting until you notice the file has disappeared.
+- Once the lock disappears you know the writer has finished.
+- You can now read the database.
+
+```mermaid
+sequenceDiagram
+    participant pkgdb
+    participant lock as abc123.lock
+    participant db as abc123.sqlite
+    pkgdb->>lock: Does it exist?
+    lock-->>pkgdb: Yes
+    pkgdb->>lock: Append PID to file
+    loop Watch the lock
+        pkgdb->>lock: Check mtime
+        lock-->>pkgdb: (the time)
+    end
+    pkgdb->>lock: Check mtime
+    lock-->>pkgdb: File not found
+    pkgdb->>db: Read
+```
+ 
+If the mtime of the lock is stale, the original writer must have crashed.
+At this point all waiting `pkgdb` processes read the PIDs in the lock.
+The first PID in the file takes over the writing process and removes its PID
+from the db lock so that if it crashes the next `pkgdb` process can take over.
+
+There are several possible race conditions in this procedure,
+namely "time of check vs. time of use,"
+so care is taken to mitigate them.
+The check whether the lock exists is atomic in that it is a call to `open` that
+fails if the file exists.
+
+Writing the PID to the lock first happens in a temporary file that is then
+renamed to the lock.
+This can overwrite a PID write from another process so each process writing its
+PID does a check afterwards to ensure that its PID is in the lock.
+If the PID isn't found in the lock,
+the read, update, write, rename process is repeated.
+This means that the final waiting order may not be the same order that the
+original interests were registered,
+but we actually don't care about that,
+we only care that one process writes while others wait and there's _some_ order
+for taking over writing if the writer fails.
+
+```mermaid
+sequenceDiagram
+    participant copyA as Temp A
+    participant pkgdbA as pkgdb A
+    participant lock as abc123.lock
+    participant pkgdbB as pkgdb B
+    participant copyB as Temp B
+    lock->>pkgdbA: Read PIDs
+    Note left of pkgdbA: Append pkgdb A's PID
+    pkgdbA->>copyA: Write PIDs
+    lock->>pkgdbB: Read PIDs
+    Note right of pkgdbB: Append pkgdb B's PID
+    pkgdbB->>copyB: Write PIDs
+    copyA->>lock: Rename
+    Note right of lock: pkgdb A's update is lost
+    copyB->>lock: Rename
+```
+
+## Consequences
+
+Since we shouldn't touch the database unless we have the lock,
+this means we can't automatically initialize the database
+(someone else might be writing to it) without the lock.
+
+An initial draft of this required you to acquire the lock and manually call
+`PkgDbInput::init`,
+but this turned out to be error prone.
+As a compromise between nice APIs, practicallity, and safety,
+the lock is now acquired whenever a `PkgDbInput` is created,
+which means that the lock is acquired twice for every database during scraping.
+This turns out to add negligible overhead,
+so it's not really an issue in practice,
+but those of us that care about the utmost efficiency may turn their noses up.
+
+## Troubleshooting
+
+### "db lock unexpectedly missing"
+
+This error is reported by the heartbeat thread.
+The only entity responsible for deleting the lock is the process that has the
+lock,
+so if someone else deleted the lock it means that more than one process thinks
+it has the lock.
+This could either mean that multiple processes were launched at the same time
+and there was an error figuring out who would first take the lock,
+or it could mean that the original writer crashed and there was an error
+determining who would take over.

--- a/pkgdb/include/flox/core/exceptions.hh
+++ b/pkgdb/include/flox/core/exceptions.hh
@@ -78,7 +78,9 @@ enum error_category {
   /** EnvirontMixin exception/misuse. */
   EC_ENVIRONMENT_MIXIN,
   /** EnvirontMixin exception/misuse. */
-  EC_BUILDENV_CONFLICT
+  EC_BUILDENV_CONFLICT,
+  /** Database locking exception */
+  EC_DB_LOCKING
 
 }; /* End enum `error_category' */
 

--- a/pkgdb/include/flox/core/util.hh
+++ b/pkgdb/include/flox/core/util.hh
@@ -477,6 +477,12 @@ errorLog( const std::string & msg );
 
 /* -------------------------------------------------------------------------- */
 
+/**
+ * @brief Returns a path to a temporary file that has not yet been opened.
+ */
+std::filesystem::path
+tempfilePath();
+
 }  // namespace flox
 
 

--- a/pkgdb/include/flox/pkgdb/command.hh
+++ b/pkgdb/include/flox/pkgdb/command.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "flox/core/command.hh"
+#include "flox/core/nix-state.hh"
 #include "flox/pkgdb/input.hh"
 #include "flox/pkgdb/write.hh"
 
@@ -289,6 +290,44 @@ public:
 }; /* End class `GCCommand' */
 
 /* -------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Returns the fingerprint for a flake reference
+ */
+class FingerprintCommand
+{
+
+private:
+
+
+  command::VerboseParser parser;
+  NixState               state;
+  std::string            flakeref;
+
+public:
+
+  FingerprintCommand();
+
+  [[nodiscard]] command::VerboseParser &
+  getParser()
+  {
+    return this->parser;
+  }
+
+  /**
+   * @brief Execute the `fingerprint` routine.
+   * @return `EXIT_SUCCESS` or `EXIT_FAILURE`.
+   */
+  int
+  run();
+
+
+}; /* End class `FingerprintCommand' */
+
+/* -------------------------------------------------------------------------- */
+
 
 }  // namespace flox::pkgdb
 

--- a/pkgdb/include/flox/pkgdb/read.hh
+++ b/pkgdb/include/flox/pkgdb/read.hh
@@ -619,6 +619,13 @@ public:
    */
   DbLockState
   acquire();
+
+  /**
+   * @brief Releases the lock by terminating the heartbeat thread and deleting
+   * the db lock.
+   */
+  void
+  release();
 };
 
 /**

--- a/pkgdb/include/flox/pkgdb/read.hh
+++ b/pkgdb/include/flox/pkgdb/read.hh
@@ -13,6 +13,7 @@
 #include <functional>
 #include <queue>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <nix/eval-cache.hh>
@@ -24,7 +25,6 @@
 #include "flox/core/exceptions.hh"
 #include "flox/core/types.hh"
 #include "flox/package.hh"
-#include "flox/pkgdb/pkg-query.hh"
 
 
 /* -------------------------------------------------------------------------- */
@@ -41,6 +41,36 @@
 namespace flox::pkgdb {
 
 /* -------------------------------------------------------------------------- */
+
+/** @brief Returns `true` if the SQLite return code indicates an error. */
+inline bool
+isSQLError( int rcode )
+{
+  switch ( rcode )
+    {
+      case SQLITE_OK:
+      case SQLITE_ROW:
+      case SQLITE_DONE: return false; break;
+      default: return true; break;
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Returns `true` if the SQLite database was locked during the
+ * operation.*/
+bool
+dbIsBusy( int rcode );
+
+/** @brief Executes the SQL command in a loop that retries when the database is
+ * locked.*/
+int
+retryWhileBusy( sqlite3pp::command & cmd );
+
+/** @brief Executes all SQL commands in a loop that retries when the database is
+ * locked.*/
+int
+retryAllWhileBusy( sqlite3pp::command & cmd );
 
 /** @brief SQLite3 schema versions. */
 struct SqlVersions
@@ -402,6 +432,240 @@ isSQLError( int rcode );
 
 
 /* -------------------------------------------------------------------------- */
+
+using DurationMillis = std::chrono::duration<double, std::milli>;
+const DurationMillis DB_LOCK_TOUCH_INTERVAL = DurationMillis( 100 );
+/* Don't set update and check intervals to the same value, jitter in wakeup time
+ * might cause flakiness
+ */
+const DurationMillis DB_LOCK_MAX_UPDATE_AGE = 1.5 * DB_LOCK_TOUCH_INTERVAL;
+
+/**
+ * @brief The different values that can be returned by @a DbLock::acquire.
+ */
+enum DbLockState {
+  /* The initial state of the lock. If this is ever returned by 'acquire' that's
+     a bug.*/
+  DB_LOCK_INIT,
+  /* You're free to do what you want with the database. */
+  DB_LOCK_FREE,
+  /* The database requires cleanup, but otherwise you're free to do what you
+     want. */
+  DB_LOCK_ACTION_NEEDED,
+};
+
+/**
+ * @brief The different outcomes when monitoring the heartbeat on the db lock.
+ */
+enum DbLockActivity {
+  /* The initial state. If this is ever returned by 'waitForLockActivity' that's
+     a bug. */
+  DB_LOCK_ACTIVITY_INIT,
+  /* Whoever was writing the database finished writing it. */
+  DB_LOCK_ACTIVITY_DELETED,
+  /* The most recent lock update became stale. */
+  DB_LOCK_ACTIVITY_WRITER_DIED,
+};
+
+class DbLock
+{
+
+protected:
+
+  Fingerprint                          fingerprint;
+  std::optional<std::filesystem::path> dbPath;
+  std::optional<std::filesystem::path> dbLockPath;
+  std::optional<pid_t>                 pid;
+  std::optional<std::thread>           heartbeatThread;
+
+  /**
+   * @brief Starts a thread that touches the db lock while this lock is held.
+   *
+   * This will throw an exception if called more than once.
+   */
+  void
+  spawnHeartbeatThread( std::filesystem::path db_lock,
+                        DurationMillis        interval );
+
+  /**
+   * @brief Returns the PID of this process.
+   */
+  pid_t
+  getPID();
+
+  /**
+   * @brief Atomically writes a list of PIDs to the db lock.
+   *
+   * Note that there may be a race condition between more than one process
+   * writing their PID to the lockfile, so you need to check afterwards whether
+   * the PID was actually written (e.g. the second of two atomic writes may
+   * overwrite the first). We don't _really_ care which of the two processes
+   * goes first, but we _do_ care that both are registered as waiting.
+   */
+  void
+  writePIDsToLock( const std::vector<pid_t> & pids );
+
+  /**
+   * @brief Reads the PIDs in the db lock. Returns @a std::nullopt if the db
+   * lock no longer exists.
+   */
+  std::optional<std::vector<pid_t>>
+  readPIDsFromLock();
+
+  /**
+   * @brief Registers this process as waiting on the database to be created. If
+   * the original writer dies the next waiter may pick up where the previous
+   * writer left off.
+   */
+  void
+  registerInterest();
+
+  /**
+   * @brief Unregister's this process as waiting on the database to be created.
+   * This is mostly useful when a process is taking over database creation from
+   * another process that has crashed, in which case we want the next process in
+   * line to become responsible if _this_ process crashes.
+   */
+  void
+  unregisterInterest();
+
+  /**
+   * @brief Periodically check whether the lock is still active, blocking until
+   * it becomes stale or until the lock is deleted.
+   *
+   * Returns @a std::nullopt if the lock was deleted, indicating that the
+   * database was created successfully, otherwise returns the last @a
+   * std::filesystem::file_time_type at which the lock was touched.
+   */
+  DbLockActivity
+  waitForLockActivity();
+
+  /**
+   * @brief Returns true if this process should take over creating the database.
+   * This only needs to be called if @a DbLock::waitForLockActivity returned
+   * something other DB_LOCK_ACTIVITY_WRITER_DIED.
+   */
+  bool
+  shouldTakeOverDbCreation();
+
+  /**
+   * @brief Creates the database lock, returning false if it already
+   * exists.
+   *
+   * There is a race condition between multiple processes that are launched very
+   * shortly after one another. If two processes are launched at essentially the
+   * same time, then they will both see that the lockfile does not exist, both
+   * create the lockfile, and both spawn a heartbeat thread. Eventually one
+   * process will finish and delete the lockfile. The heartbeat thread doesn't
+   * expect that anyone else could delete the lockfile, so it will crash if
+   * another process deletes it out from under it.
+   */
+  bool
+  wasAbleToCreateDbLock();
+
+public:
+
+  DbLock( Fingerprint & fingerprint, std::filesystem::path & dbPath )
+    : fingerprint( fingerprint ), dbPath( dbPath ) {};
+  DbLock( Fingerprint & fingerprint ) : fingerprint( fingerprint ) {};
+  DbLock( DbLock && ) = default;
+  ~DbLock();
+  /* TODO: make this not copyable */
+
+  /**
+   * @brief Returns the path to the db lock.
+   */
+  [[nodiscard]] std::filesystem::path
+  getDbLockPath();
+
+  /**
+   * @brief Returns the path to the db that this lock is protecting.
+   */
+  [[nodiscard]] std::filesystem::path
+  getDbPath();
+
+  /**
+   * @brief Set an alternative db lock path.
+   *
+   * Setting this means that for all lock operations the @a DbLock will look in
+   * this new location for the lockfile rather than the default location, which
+   * is `~/.cache/flox/pkgdb-vX/<fingerprint>.lock`.
+   */
+  void
+  setDbLockPath( const std::filesystem::path & path );
+
+  /**
+   * @brief Use the existing fingerprint but store the lock in the provided
+   * directory.
+   */
+  void
+  inDir( const std::filesystem::path & dir );
+
+  /**
+   * @brief Use the existing fingerprint but store the lock in the same parent
+   * directory as the provided file.
+   */
+  void
+  inSameDirAs( const std::filesystem::path & file );
+
+  /** @brief Blocks until the lock can be acquired.
+   *
+   * The return value is a @a flox::pkgdb::DbLockState. This function should
+   * only ever return @a DB_LOCK_FREE or @a DB_LOCK_ACTION_NEEDED. The
+   * `DB_LOCK_FREE` value indicates that the database was already created and
+   * you don't need to recreate it. The `DB_LOCK_ACTION_NEEDED` value indicates
+   * that the original writer crashed while creating the database and it's now
+   * your responsibility to create it.
+   */
+  DbLockState
+  acquire();
+};
+
+/**
+ * @brief Periodically touches the db lock.
+ *
+ * Meant to be called from a separate thread as it will never return.
+ */
+void
+periodicallyTouchDbLock( const std::filesystem::path db_lock,
+                         const DurationMillis        interval );
+
+/**
+ * Process A checks for the existence of <fingerprint>.lock
+ * Process A sees that it doesn't exist
+ * Process A checks for existence of the <fingerprint>.sqlite
+ * Process A sees that it doesn't exist
+ * Process A creates <fingerprint>.lock
+ * Process A creates <fingerprint>.sqlite
+ * Process A starts a thread that periodically touches <fingerprint>.lock
+ * Process A begins writing to the database
+ * Process A deletes <fingerprint.lock> when it's done constructing the database
+ *
+ * Process B is launched after Process A
+ * Process B checks for existence of <fingerprint>.lock
+ * Process B sees that it exists
+ * Process B appends its PID to the lockfile
+ * In a loop:
+ *  Process B tries to read the mtime of <fingerprint>.lock
+ *  If the file doesn't exist, it proceeds to read the database
+ *  If the file does exist, it checks whether the mtime was within some interval
+ * from the past If the mtime was within this interval, the original writer must
+ * still be alive sleep for some period If the mtime wasn't within the interval,
+ * the original writer died Process B reads the first line of the file If it
+ * matches its own PID then it gets to take control
+ */
+
+
+/**
+ * @class flox::DbLockingException
+ * @brief An exception thrown when locking a package database.
+ *
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( DbLockingException,
+                       EC_DB_LOCKING,
+                       "error locking package database" )
+/** @} */
 
 }  // namespace flox::pkgdb
 

--- a/pkgdb/include/flox/pkgdb/read.hh
+++ b/pkgdb/include/flox/pkgdb/read.hh
@@ -490,7 +490,7 @@ protected:
   /**
    * @brief Returns the PID of this process.
    */
-  pid_t
+  [[nodiscard]] pid_t
   getPID();
 
   /**
@@ -509,7 +509,7 @@ protected:
    * @brief Reads the PIDs in the db lock. Returns @a std::nullopt if the db
    * lock no longer exists.
    */
-  std::optional<std::vector<pid_t>>
+  [[nodiscard]] std::optional<std::vector<pid_t>>
   readPIDsFromLock();
 
   /**
@@ -537,7 +537,7 @@ protected:
    * database was created successfully, otherwise returns the last @a
    * std::filesystem::file_time_type at which the lock was touched.
    */
-  DbLockActivity
+  [[nodiscard]] DbLockActivity
   waitForLockActivity();
 
   /**
@@ -545,7 +545,7 @@ protected:
    * This only needs to be called if @a DbLock::waitForLockActivity returned
    * something other DB_LOCK_ACTIVITY_WRITER_DIED.
    */
-  bool
+  [[nodiscard]] bool
   shouldTakeOverDbCreation();
 
   /**
@@ -560,8 +560,15 @@ protected:
    * expect that anyone else could delete the lockfile, so it will crash if
    * another process deletes it out from under it.
    */
-  bool
+  [[nodiscard]] bool
   wasAbleToCreateDbLock();
+
+  /**
+   * @brief Returns a temporary db lock path on the same filesystem as the
+   * current db lock.
+   */
+  [[nodiscard]] std::filesystem::path
+  tempDbLockPath();
 
 public:
 
@@ -617,7 +624,7 @@ public:
    * that the original writer crashed while creating the database and it's now
    * your responsibility to create it.
    */
-  DbLockState
+  [[nodiscard]] DbLockState
   acquire();
 
   /**

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -191,7 +191,7 @@ public:
   execute( const char * stmt )
   {
     sqlite3pp::command cmd( this->db, stmt );
-    return cmd.execute();
+    return retryWhileBusy( cmd );
   }
 
   /**
@@ -203,7 +203,7 @@ public:
   execute_all( const char * stmt )
   {
     sqlite3pp::command cmd( this->db, stmt );
-    return cmd.execute_all();
+    return retryAllWhileBusy( cmd );
   }
 
 

--- a/pkgdb/src/main.cc
+++ b/pkgdb/src/main.cc
@@ -105,6 +105,9 @@ run( int argc, char * argv[] )
   flox::buildenv::BuildEnvCommand cmdBuildEnv;
   prog.add_subparser( cmdBuildEnv.getParser() );
 
+  flox::pkgdb::FingerprintCommand cmdFingerprint;
+  prog.add_subparser( cmdFingerprint.getParser() );
+
 
   /* Parse Args */
   try
@@ -127,6 +130,10 @@ run( int argc, char * argv[] )
   if ( prog.is_subcommand_used( "repl" ) ) { return cmdRepl.run(); }
   if ( prog.is_subcommand_used( "eval" ) ) { return cmdEval.run(); }
   if ( prog.is_subcommand_used( "buildenv" ) ) { return cmdBuildEnv.run(); }
+  if ( prog.is_subcommand_used( "fingerprint" ) )
+    {
+      return cmdFingerprint.run();
+    }
 
   // TODO: better error for this,
   // likely only occurs if we add a new command without handling it (?)

--- a/pkgdb/src/pkgdb/command.cc
+++ b/pkgdb/src/pkgdb/command.cc
@@ -193,6 +193,32 @@ template struct PkgDbMixin<PkgDb>;
 
 /* -------------------------------------------------------------------------- */
 
+FingerprintCommand::FingerprintCommand() : parser( "fingerprint" )
+{
+  this->parser.add_description( "Get the fingerprint for a flake reference." );
+  this->parser.add_argument( "flakeref" )
+    .help( "The flake reference to fingerprint" )
+    .action( [&]( const std::string & flakeref )
+             { this->flakeref = flakeref; } );
+}
+
+/* -------------------------------------------------------------------------- */
+
+int
+FingerprintCommand::run()
+{
+  auto flakeref = nix::parseFlakeRef( this->flakeref );
+  auto state    = this->state;
+  auto locked
+    = nix::flake::lockFlake( *state.getState(), flakeref, defaultLockFlags );
+  std::string fingerprint
+    = locked.getFingerprint().to_string( nix::Base16, false );
+  std::cout << fingerprint << std::endl;
+  return EXIT_SUCCESS;
+}
+
+/* -------------------------------------------------------------------------- */
+
 }  // namespace flox::pkgdb
 
 

--- a/pkgdb/src/pkgdb/input.cc
+++ b/pkgdb/src/pkgdb/input.cc
@@ -44,6 +44,9 @@ namespace flox::pkgdb {
 void
 PkgDbInput::init()
 {
+
+  if ( this->hasBeenInitialized ) { return; }
+
   /* Initialize DB if missing. */
   if ( ! std::filesystem::exists( this->dbPath ) )
     {
@@ -86,6 +89,8 @@ PkgDbInput::init()
                   dbVersions.tables,
                   dbVersions.views ) );
     }
+
+  this->hasBeenInitialized = true;
 }
 
 
@@ -181,6 +186,15 @@ PkgDbInput::getRowJSON( row_id row )
   auto rsl  = dbRO->getPackage( row );
   rsl.emplace( "input", this->getNameOrURL() );
   return rsl;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+Fingerprint
+PkgDbInput::getFingerprint()
+{
+  return this->getFlake()->lockedFlake.getFingerprint();
 }
 
 

--- a/pkgdb/src/pkgdb/read.cc
+++ b/pkgdb/src/pkgdb/read.cc
@@ -7,11 +7,14 @@
  *
  * -------------------------------------------------------------------------- */
 
+#include <chrono>
+#include <fstream>
 #include <functional>
 #include <limits>
 #include <list>
 #include <memory>
 #include <string>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 
@@ -25,25 +28,41 @@ namespace flox::pkgdb {
 
 /* -------------------------------------------------------------------------- */
 
-bool
-isSQLError( int rcode )
-{
-  switch ( rcode )
-    {
-      case SQLITE_OK:
-      case SQLITE_ROW:
-      case SQLITE_DONE: return false; break;
-      default: return true; break;
-    }
-}
-
+std::atomic_flag shouldStopFlag = ATOMIC_FLAG_INIT;
 
 /* -------------------------------------------------------------------------- */
 
-std::ostream &
-operator<<( std::ostream & oss, const SqlVersions & versions )
+bool
+dbIsBusy( int rcode )
 {
-  return oss << "tables: " << versions.tables << ", views: " << versions.views;
+  traceLog( "sqlite return code was " + std::to_string( rcode ) );
+  return ( rcode == SQLITE_BUSY ) || ( rcode == SQLITE_BUSY_SNAPSHOT );
+}
+
+int
+retryWhileBusy( sqlite3pp::command & cmd )
+{
+  using namespace std::chrono_literals;
+  int rcode = cmd.execute();
+  while ( dbIsBusy( rcode ) )
+    {
+      std::this_thread::sleep_for( 500ms );
+      rcode = cmd.execute();
+    }
+  return rcode;
+}
+
+int
+retryAllWhileBusy( sqlite3pp::command & cmd )
+{
+  using namespace std::chrono_literals;
+  int rcode = cmd.execute_all();
+  while ( dbIsBusy( rcode ) )
+    {
+      std::this_thread::sleep_for( 500ms );
+      rcode = cmd.execute_all();
+    }
+  return rcode;
 }
 
 
@@ -78,6 +97,14 @@ genPkgDbName( const Fingerprint &           fingerprint,
 {
   std::string fpStr = fingerprint.to_string( nix::Base16, false );
   return cacheDir.string() + "/" + fpStr + ".sqlite";
+}
+
+/* -------------------------------------------------------------------------- */
+
+std::ostream &
+operator<<( std::ostream & oss, const SqlVersions & versions )
+{
+  return oss << "tables: " << versions.tables << ", views: " << versions.views;
 }
 
 
@@ -414,6 +441,370 @@ nlohmann::json
 PkgDbReadOnly::getPackage( const flox::AttrPath & path )
 {
   return this->getPackage( this->getPackageId( path ) );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+DbLock::inDir( const std::filesystem::path & dir )
+{
+  auto lockPath
+    = dir / ( this->fingerprint.to_string( nix::Base16, false ) + ".lock" );
+  this->setDbLockPath( lockPath );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+DbLock::inSameDirAs( const std::filesystem::path & file )
+{
+  auto lockPath = file;
+  lockPath.replace_filename( this->fingerprint.to_string( nix::Base16, false )
+                             + ".lock" );
+  this->setDbLockPath( lockPath );
+}
+
+
+/* -------------------------------------------------------------------------- */
+DbLock::~DbLock()
+{
+  /* Tell the heartbeat thread to stop */
+  shouldStopFlag.test_and_set( std::memory_order_seq_cst );
+  if ( this->heartbeatThread.has_value() )
+    {
+      /* This thread should always be here, but if by some chance it's not it's
+       * better to check than just deref the optional and crash. */
+      this->heartbeatThread->join();
+    }
+
+  /* Delete the db lock */
+  std::filesystem::remove( this->getDbLockPath() );
+}
+
+void
+DbLock::spawnHeartbeatThread( std::filesystem::path db_lock,
+                              DurationMillis        interval )
+{
+  if ( ! this->heartbeatThread.has_value() )
+    {
+      this->heartbeatThread
+        = std::thread( periodicallyTouchDbLock, db_lock, interval );
+    }
+  else
+    {
+      // TODO: `flox` should catch this error and display a better one
+      throw DbLockingException( "spawned heartbeat thread twice" );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::filesystem::path
+DbLock::getDbLockPath()
+{
+  if ( this->dbLockPath.has_value() ) { return *( this->dbLockPath ); }
+  else
+    {
+      this->dbLockPath = this->getDbPath();
+      this->dbLockPath->replace_filename(
+        this->fingerprint.to_string( nix::Base16, false ) + ".lock" );
+      return *this->dbLockPath;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::filesystem::path
+DbLock::getDbPath()
+{
+  if ( this->dbPath.has_value() ) { return *( this->dbPath ); }
+  else
+    {
+      this->dbPath = getPkgDbCachedir().append(
+        this->fingerprint.to_string( nix::Base16, false ) + ".lock" );
+      return *( this->dbPath );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+DbLock::setDbLockPath( const std::filesystem::path & path )
+{
+  this->dbLockPath = path;
+}
+
+/* -------------------------------------------------------------------------- */
+
+pid_t
+DbLock::getPID()
+{
+  if ( this->pid.has_value() ) { return *( this->pid ); }
+  else
+    {
+      auto pid  = ::getpid();
+      this->pid = pid;
+      return pid;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+DbLock::writePIDsToLock( const std::vector<pid_t> & pids )
+{
+  /* Create a path to a non-existent temporary file, copy the contents of the
+   * existing lockfile to the temp file, write to it, then mv it back. */
+  auto          tmpPath = tempfilePath();
+  std::ofstream tmpFile;
+  tmpFile.open( tmpPath, std::ios_base::app );
+  if ( ! tmpFile.good() )
+    {
+      throw DbLockingException( "failed to open temporary db lock copy" );
+    }
+  for ( auto & pid : pids )
+    {
+      tmpFile << std::to_string( pid ) << std::endl;
+      //
+    }
+  std::filesystem::rename( tmpPath, this->getDbLockPath() );
+  return;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::optional<std::vector<pid_t>>
+DbLock::readPIDsFromLock()
+{
+  std::ifstream     lock;
+  std::stringstream contents;
+  lock.open( this->getDbLockPath(), std::ios_base::in );
+  if ( ! lock.good() ) { return std::nullopt; }
+  contents << lock.rdbuf();
+  lock.close();
+  std::string        line;
+  std::vector<pid_t> pids;
+  while ( std::getline( contents, line ) )
+    {
+      pid_t pid = std::stoi( line );
+      pids.emplace_back( pid );
+      line.clear();
+    }
+  return pids;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+DbLock::registerInterest()
+{
+  /* The write to the lock may fail due to a race condition between processes,
+   * so keep trying until this PID shows up. */
+  while ( true )
+    {
+      auto pids = this->readPIDsFromLock();
+      if ( ! pids.has_value() ) { return; }
+      if ( std::find( pids->begin(), pids->end(), this->getPID() )
+           != pids->end() )
+        {
+          break;
+        }
+      pids->emplace_back( this->getPID() );
+      this->writePIDsToLock( *pids );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+DbLock::unregisterInterest()
+{
+  /* The write to the lock may fail due to a race condition between processes,
+   * so keep trying until this PID is gone. */
+  while ( true )
+    {
+      auto pids = this->readPIDsFromLock();
+      if ( ! pids.has_value() ) { return; }
+      if ( pids->size() > 0 )
+        {
+          auto it = std::find( pids->begin(), pids->end(), this->getPID() );
+          if ( it != pids->end() )
+            {
+              pids->erase( it );
+              this->writePIDsToLock( *pids );
+            }
+          else { break; }
+        }
+      else { break; }
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+DbLockActivity
+DbLock::waitForLockActivity()
+{
+  while ( true )
+    {
+      /* If the lock no longer exists, return DB_LOCK_ACTIVITY_DELETED to
+       * indicate that someone else created the database successfully*/
+      if ( ! std::filesystem::exists( this->getDbLockPath() ) )
+        {
+          return DB_LOCK_ACTIVITY_DELETED;
+        }
+      /* The lock may get deleted between checking that it exists and checking
+       * its write time.*/
+      std::filesystem::file_time_type updateTime;
+      try
+        {
+          /* If the lock still exists, check whether the last update was too
+           * long ago.*/
+          updateTime
+            = std::filesystem::last_write_time( this->getDbLockPath() );
+        }
+      catch ( std::filesystem::filesystem_error & e )
+        {
+          return DB_LOCK_ACTIVITY_DELETED;
+        }
+      auto durationSinceUpdate = std::chrono::file_clock::now() - updateTime;
+      if ( durationSinceUpdate > DB_LOCK_MAX_UPDATE_AGE )
+        {
+          return DB_LOCK_ACTIVITY_WRITER_DIED;
+        }
+      std::this_thread::sleep_for( DB_LOCK_TOUCH_INTERVAL );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+bool
+DbLock::wasAbleToCreateDbLock()
+{
+  debugLog( "checking db lock existence: path=" + this->getDbLockPath().string()
+            + " pid=" + std::to_string( this->getPID() ) );
+  auto f = ::open( this->getDbLockPath().c_str(), O_WRONLY | O_CREAT | O_EXCL );
+  if ( f < 0 )
+    {
+      debugLog( "db lock existed, not creating one: pid="
+                + std::to_string( this->getPID() ) );
+      return false;
+    }
+  ::close( f );
+  debugLog( "created db lock: path=" + this->getDbLockPath().string()
+            + " pid=" + std::to_string( this->getPID() ) );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+DbLockState
+DbLock::acquire()
+{
+  debugLog( "attempting to acquire db lock: pid="
+            + std::to_string( this->getPID() ) );
+  /* Atomically create or check that the lock exists, waiting for an in-progress
+   * db operation to complete if the lock already exists. */
+  if ( ! this->wasAbleToCreateDbLock() )
+    {
+      debugLog( "waiting for db lock to become free: pid="
+                + std::to_string( this->getPID() ) );
+      this->registerInterest();
+      while ( true )
+        {
+          auto lockActivity = this->waitForLockActivity();
+          /* If the lock was deleted, the database has been created and we're
+           * good to read it.*/
+          if ( lockActivity == DB_LOCK_ACTIVITY_DELETED )
+            {
+              debugLog( "detected that db lock was deleted: pid="
+                        + std::to_string( this->getPID() ) );
+              return DB_LOCK_FREE;
+            }
+          /* The lock became stale, either it's our turn to take over or we
+           * should keep waiting. */
+          if ( lockActivity == DB_LOCK_ACTIVITY_WRITER_DIED )
+            {
+              debugLog( "detected that db lock became stale: pid="
+                        + std::to_string( this->getPID() ) );
+              if ( this->shouldTakeOverDbCreation() )
+                {
+                  //
+                  debugLog( "this process should take over db creation: pid="
+                            + std::to_string( this->getPID() ) );
+                  this->unregisterInterest();
+                  return DB_LOCK_ACTION_NEEDED;
+                }
+            }
+        }
+      return DB_LOCK_FREE;
+    }
+  /* The lock didn't exist, which could mean the database already exists or it
+   * means no one has tried to create the database yet. */
+  else if ( std::filesystem::exists( this->getDbPath() ) )
+    {
+      debugLog( "database existed, no need to wait for lock: pid="
+                + std::to_string( this->getPID() ) );
+      return DB_LOCK_FREE;
+    }
+  /* It's up to us to create the database. */
+  debugLog( "spawning heartbeat thread: pid="
+            + std::to_string( this->getPID() ) );
+  this->spawnHeartbeatThread( this->getDbLockPath(), DB_LOCK_TOUCH_INTERVAL );
+  return DB_LOCK_FREE;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+bool
+DbLock::shouldTakeOverDbCreation()
+{
+  auto pids = this->readPIDsFromLock();
+  if ( ! pids.has_value() ) { return false; }
+  if ( pids->size() == 0 )
+    {
+      throw DbLockingException( "no PIDs found in the db lock: PID="
+                                + std::to_string( this->getPID() ) );
+    }
+  return ( *pids )[0] == this->getPID();
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+periodicallyTouchDbLock( std::filesystem::path db_lock,
+                         DurationMillis        interval )
+{
+  while ( ! shouldStopFlag.test( std::memory_order_seq_cst ) )
+    {
+      auto now = std::chrono::file_clock::now();
+      try
+        {
+          std::filesystem::last_write_time( db_lock, now );
+        }
+      catch ( const std::filesystem::filesystem_error & e )
+        {
+          /* No one should have deleted this file. If they did, it means more
+           * than one process (mistakenly) thinks it has the lock. */
+          throw DbLockingException( "db lock unexpectedly missing (PID="
+                                      + std::to_string( ::getpid() ) + ")",
+                                    e.what() );
+        }
+      std::this_thread::sleep_for( interval );
+    }
 }
 
 

--- a/pkgdb/src/pkgdb/scrape.cc
+++ b/pkgdb/src/pkgdb/scrape.cc
@@ -90,6 +90,7 @@ ScrapeCommand::run()
       this->input->scrapePrefix( this->attrPath );
     }
 
+  lock.release();
   /* Print path to database. */
   std::cout << ( static_cast<std::string>( *this->dbPath ) ) << std::endl;
   return EXIT_SUCCESS; /* GG, GG */

--- a/pkgdb/src/resolver/environment.cc
+++ b/pkgdb/src/resolver/environment.cc
@@ -120,6 +120,7 @@ Environment::getPkgDbRegistry()
             {
               input->scrapeSystems( this->getSystems() );
             }
+          lock.release();
         }
     }
   return static_cast<nix::ref<Registry<pkgdb::PkgDbInputFactory>>>( this->dbs );

--- a/pkgdb/src/search/command.cc
+++ b/pkgdb/src/search/command.cc
@@ -191,8 +191,7 @@ SearchCommand::run()
         *this->getEnvironment().getPkgDbRegistry() )
     {
       debugLog( "querying input: " + name );
-      auto dbRO = input->getDbReadOnly();
-      debugLog( "got read-only database " );
+      auto                       dbRO = input->getDbReadOnly();
       std::vector<pkgdb::row_id> inputIds;
       for ( const auto & id : query.execute( dbRO->db ) )
         {

--- a/pkgdb/src/search/command.cc
+++ b/pkgdb/src/search/command.cc
@@ -191,7 +191,8 @@ SearchCommand::run()
         *this->getEnvironment().getPkgDbRegistry() )
     {
       debugLog( "querying input: " + name );
-      auto                       dbRO = input->getDbReadOnly();
+      auto dbRO = input->getDbReadOnly();
+      debugLog( "got read-only database " );
       std::vector<pkgdb::row_id> inputIds;
       for ( const auto & id : query.execute( dbRO->db ) )
         {

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -388,7 +388,6 @@ tempfilePath()
   /* mkstemp will turn the X's into a random file path */
   std::string pathTemplate = tmpdir.string() + "/XXXXXX";
   auto        file         = ::mkstemp( (char *) pathTemplate.c_str() );
-  debugLog( "generated temp file path " + pathTemplate );
   ::close( file );
   /* mkstemp creates the file, so copying to this tempfile will always fail
    * unless we delete it.*/

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -378,6 +378,25 @@ errorLog( const std::string & msg )
   printLog( nix::Verbosity::lvlError, msg );
 }
 
+
+/* -------------------------------------------------------------------------- */
+
+std::filesystem::path
+tempfilePath()
+{
+  auto tmpdir = std::filesystem::temp_directory_path();
+  /* mkstemp will turn the X's into a random file path */
+  std::string pathTemplate = tmpdir.string() + "/XXXXXX";
+  auto        file         = ::mkstemp( (char *) pathTemplate.c_str() );
+  debugLog( "generated temp file path " + pathTemplate );
+  ::close( file );
+  /* mkstemp creates the file, so copying to this tempfile will always fail
+   * unless we delete it.*/
+  std::filesystem::path tempPath( pathTemplate );
+  std::filesystem::remove( tempPath );
+  return tempPath;
+}
+
 }  // namespace flox
 
 

--- a/pkgdb/tests/.gitignore
+++ b/pkgdb/tests/.gitignore
@@ -1,3 +1,4 @@
+db_locking
 environment
 exceptions
 gc

--- a/pkgdb/tests/db_locking.cc
+++ b/pkgdb/tests/db_locking.cc
@@ -1,0 +1,176 @@
+
+#include <fstream>
+
+#include "flox/core/util.hh"
+#include "flox/pkgdb/write.hh"
+#include "nix/hash.hh"
+#include "test.hh"
+
+/* -------------------------------------------------------------------------- */
+
+using namespace flox;
+using namespace flox::pkgdb;
+
+/* -------------------------------------------------------------------------- */
+
+class TestDbLock : public DbLock
+{
+public:
+
+  using DbLock::DbLock;
+  using DbLock::getPID;
+  using DbLock::readPIDsFromLock;
+  using DbLock::registerInterest;
+  using DbLock::setDbLockPath;
+  using DbLock::shouldTakeOverDbCreation;
+  using DbLock::unregisterInterest;
+  using DbLock::waitForLockActivity;
+  using DbLock::wasAbleToCreateDbLock;
+  using DbLock::writePIDsToLock;
+};
+
+Fingerprint
+dummyFingerprint()
+{
+  return nix::hashString( nix::htSHA256, "fingerprint" );
+}
+
+void
+touchDbLock( const std::filesystem::path & path )
+{
+  std::ofstream lockfile;
+  lockfile.open( path, std::ios_base::out );
+  lockfile.close();
+}
+
+TestDbLock
+dbLockAtRandomPath()
+{
+  Fingerprint fingerprint = dummyFingerprint();
+  TestDbLock  lock( fingerprint );
+  auto        lockPath
+    = std::filesystem::temp_directory_path() / std::to_string( std::rand() );
+  lock.setDbLockPath( lockPath );
+  return lock;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+bool
+test_writesAndReadsPID()
+{
+  TestDbLock lock = dbLockAtRandomPath();
+  touchDbLock( lock.getDbLockPath() );
+  std::vector<pid_t> pidsToWrite = { 1, 2, 3, 4, 5 };
+  lock.writePIDsToLock( pidsToWrite );
+  auto pidsRead = lock.readPIDsFromLock();
+  return *pidsRead == pidsToWrite;
+}
+
+bool
+test_detectsShouldTakeOverDbCreation()
+{
+  TestDbLock lock = dbLockAtRandomPath();
+  touchDbLock( lock.getDbLockPath() );
+  /* With only process waiting on this lock, we should always be the process
+   * that should take over creation of the database.*/
+  lock.registerInterest();
+  return lock.shouldTakeOverDbCreation();
+}
+
+bool
+test_detectsShouldntTakeOverDbCreation()
+{
+  TestDbLock lock = dbLockAtRandomPath();
+  touchDbLock( lock.getDbLockPath() );
+  std::vector<pid_t> dummyPIDs = { 0 };
+  lock.writePIDsToLock( dummyPIDs );
+  /* Since we haven't registered interest in the lock we should never be the one
+   * responsible for creating the database. */
+  return ! lock.shouldTakeOverDbCreation();
+}
+
+bool
+test_detectsStaleDbLock()
+{
+  TestDbLock lock = dbLockAtRandomPath();
+  touchDbLock( lock.getDbLockPath() );
+  /* sleep longer than the time it takes to become stale */
+  std::this_thread::sleep_for( 1.5 * DB_LOCK_MAX_UPDATE_AGE );
+  auto result = lock.waitForLockActivity();
+  return result == DB_LOCK_ACTIVITY_WRITER_DIED;
+}
+
+bool
+test_detectsDeletedDbLock()
+{
+  TestDbLock lock = dbLockAtRandomPath();
+  std::filesystem::remove( lock.getDbLockPath() );
+  auto result = lock.waitForLockActivity();
+  return result == DB_LOCK_ACTIVITY_DELETED;
+}
+
+bool
+test_waitsForLockActivity()
+{
+  TestDbLock lock = dbLockAtRandomPath();
+  touchDbLock( lock.getDbLockPath() );
+  auto now    = std::filesystem::last_write_time( lock.getDbLockPath() );
+  auto result = lock.waitForLockActivity();
+  auto later  = std::chrono::file_clock::now();
+  EXPECT_EQ( result, DB_LOCK_ACTIVITY_WRITER_DIED );
+  auto durationWaited = later - now;
+  return durationWaited > DB_LOCK_TOUCH_INTERVAL;
+}
+
+bool
+test_registersAndUnregistersLockInterest()
+{
+  TestDbLock lock = dbLockAtRandomPath();
+  touchDbLock( lock.getDbLockPath() );
+  lock.registerInterest();
+  auto pids = lock.readPIDsFromLock();
+  auto it   = std::find( pids->begin(), pids->end(), lock.getPID() );
+  EXPECT( it != pids->end() );
+  lock.unregisterInterest();
+  pids = lock.readPIDsFromLock();
+  it   = std::find( pids->begin(), pids->end(), lock.getPID() );
+  return it == pids->end();
+}
+
+bool
+test_detectsExistingLock()
+{
+  TestDbLock lock = dbLockAtRandomPath();
+  touchDbLock( lock.getDbLockPath() );
+  return ! lock.wasAbleToCreateDbLock();
+}
+
+/* -------------------------------------------------------------------------- */
+
+int
+main( int argc, char * argv[] )
+{
+  int ec = EXIT_SUCCESS;
+#define RUN_TEST( ... ) _RUN_TEST( ec, __VA_ARGS__ )
+
+  nix::verbosity = nix::lvlWarn;
+  if ( ( 1 < argc ) && ( std::string_view( argv[1] ) == "-v" ) )
+    {
+      nix::verbosity = nix::lvlDebug;
+    }
+
+  {
+    RUN_TEST( writesAndReadsPID );
+    RUN_TEST( detectsShouldTakeOverDbCreation );
+    RUN_TEST( detectsShouldntTakeOverDbCreation );
+    RUN_TEST( detectsStaleDbLock );
+    RUN_TEST( detectsDeletedDbLock );
+    RUN_TEST( waitsForLockActivity );
+    RUN_TEST( registersAndUnregistersLockInterest );
+    RUN_TEST( detectsExistingLock );
+  }
+
+  return ec;
+}

--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -10,50 +10,55 @@
 #
 #
 # ---------------------------------------------------------------------------- #
-{nixVersions}:
-nixVersions.nix_2_17.overrideAttrs (prev: {
-  # Apply patch files.
-  patches =
-    prev.patches
-    ++ [
-      (builtins.path {path = ./patches/nix-9147.patch;})
-      (builtins.path {path = ./patches/multiple-github-tokens.2.13.2.patch;})
-    ];
+{
+  nixVersions,
+  stdenv,
+}: let
+  nixWithStdenv = nixVersions.nix_2_17.override {inherit stdenv;};
+in
+  nixWithStdenv.overrideAttrs (prev: {
+    # Apply patch files.
+    patches =
+      prev.patches
+      ++ [
+        (builtins.path {path = ./patches/nix-9147.patch;})
+        (builtins.path {path = ./patches/multiple-github-tokens.2.13.2.patch;})
+      ];
 
-  postFixup = ''
-    # Generate a `sed' pattern to fix up public header `#includes'.
-    # All header names separated by '\|'.
-    _patt="$( find "$dev/include/nix" -type f -name '*.h*' -printf '%P\|'; )";
-    # Strip leading/trailing '\|'.
-    _patt="''${_patt%\\|}";
-    _patt="''${_patt#\\|}";
-    _patt="s,#include \+\"\($_patt\)\",#include <nix/\1>,";
-    # Perform the substitution.
-    find "$dev/include/nix" -type f -name '*.h*' -print                        \
-      |xargs sed -i                                                            \
-                 -e "$_patt"                                                   \
-                 -e 's,#include \+"\(nlohmann/json_fwd\.hpp\)",#include <\1>,';
+    postFixup = ''
+      # Generate a `sed' pattern to fix up public header `#includes'.
+      # All header names separated by '\|'.
+      _patt="$( find "$dev/include/nix" -type f -name '*.h*' -printf '%P\|'; )";
+      # Strip leading/trailing '\|'.
+      _patt="''${_patt%\\|}";
+      _patt="''${_patt#\\|}";
+      _patt="s,#include \+\"\($_patt\)\",#include <nix/\1>,";
+      # Perform the substitution.
+      find "$dev/include/nix" -type f -name '*.h*' -print                        \
+        |xargs sed -i                                                            \
+                  -e "$_patt"                                                   \
+                  -e 's,#include \+"\(nlohmann/json_fwd\.hpp\)",#include <\1>,';
 
-    # Fixup `pkg-config' files.
-    find "$dev" -type f -name '*.pc'                       \
-      |xargs sed -i -e 's,\(-I\''${includedir}\)/nix,\1,'  \
-                    -e 's,-I,-isystem ,';
+      # Fixup `pkg-config' files.
+      find "$dev" -type f -name '*.pc'                       \
+        |xargs sed -i -e 's,\(-I\''${includedir}\)/nix,\1,'  \
+                      -e 's,-I,-isystem ,';
 
-    # Create `nix-fetchers.pc'.
-    cat <<EOF > "$dev/lib/pkgconfig/nix-fetchers.pc"
-    prefix=$out
-    libdir=$out/lib
-    includedir=$dev/include
+      # Create `nix-fetchers.pc'.
+      cat <<EOF > "$dev/lib/pkgconfig/nix-fetchers.pc"
+      prefix=$out
+      libdir=$out/lib
+      includedir=$dev/include
 
-    Name: Nix
-    Description: Nix Package Manager
-    Version: 2.17.1
-    Requires: nix-store bdw-gc
-    Libs: -L\''${libdir} -lnixfetchers
-    Cflags: -isystem \''${includedir} -std=c++2a
-    EOF
-  '';
-})
+      Name: Nix
+      Description: Nix Package Manager
+      Version: 2.17.1
+      Requires: nix-store bdw-gc
+      Libs: -L\''${libdir} -lnixfetchers
+      Cflags: -isystem \''${includedir} -std=c++2a
+      EOF
+    '';
+  })
 # ---------------------------------------------------------------------------- #
 #
 #

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,6 @@
+# flox scripts
+
+This directory is meant to contain scripts that aren't part of the `flox`
+executable itself.
+This directory is for scripts and tools that are useful for `flox`
+developers so that they can reuse tools that they write for each other.

--- a/scripts/profile_parallel_scrape.py
+++ b/scripts/profile_parallel_scrape.py
@@ -1,0 +1,79 @@
+import sys
+import subprocess
+from subprocess import Popen
+from time import perf_counter
+from pprint import pprint
+from pathlib import Path
+
+CACHE_DIR = Path.home() / ".cache/flox/pkgdb-v2"
+
+
+def show_output(p):
+    (stdout, stderr) = p.communicate()
+    print(f"stdout: {stdout}", file=sys.stderr)
+    print(f"stderr: {stderr}", file=sys.stderr)
+
+
+def main():
+    # Make sure we're using the latest changes
+    print("Rebuilding pkgdb...", file=sys.stderr)
+    subprocess.run(["just", "build-pkgdb"], capture_output=True)
+    iterations = 10
+    all_times = dict()
+    prefixes = [
+        "python310Packages",
+        "python311Packages",
+        "rubyPackages",
+        "nodePackages",
+        "linuxKernel",
+    ]
+    scrape_args = [
+        "pkgdb",
+        "scrape",
+        "github:NixOS/nixpkgs/release-23.05",
+        "legacyPackages",
+        "aarch64-darwin",
+    ]
+    # Scrape one at a time
+    durations = list()
+    for i in range(iterations):
+        print(f"iteration {i}", file=sys.stderr)
+        for item in CACHE_DIR.iterdir():
+            item.unlink()
+        start = perf_counter()
+        for prefix in prefixes:
+            proc = Popen(scrape_args + [prefix], stdout=subprocess.PIPE)
+            proc.wait()
+            if proc.returncode != 0:
+                print("==== Failed ====", file=sys.stderr)
+                show_output(proc)
+                return
+        stop = perf_counter()
+        durations.append(stop - start)
+    all_times["serial"] = sum(durations) / iterations
+    pprint(all_times)
+    # Scrape in parallel
+    durations = list()
+    for _ in range(iterations):
+        print(f"iteration {i}", file=sys.stderr)
+        for item in CACHE_DIR.iterdir():
+            item.unlink()
+        procs = list()
+        start = perf_counter()
+        for prefix in prefixes:
+            proc = Popen(scrape_args + [prefix], stdout=subprocess.PIPE)
+            procs.append(proc)
+        for p in procs:
+            p.wait()
+            if p.returncode != 0:
+                print("==== Failed ====", file=sys.stderr)
+                show_output(proc)
+                return
+        stop = perf_counter()
+        durations.append(stop - start)
+    all_times["parallel"] = sum(durations) / iterations
+    pprint(all_times)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_search.py
+++ b/scripts/profile_search.py
@@ -1,0 +1,68 @@
+import sys
+import subprocess
+from subprocess import Popen
+from time import perf_counter
+from pprint import pprint
+from pathlib import Path
+
+CACHE_DIR = Path.home() / ".cache/flox/pkgdb-v2"
+
+
+def show_output(p):
+    (stdout, stderr) = p.communicate()
+    print(f"stdout: {stdout}", file=sys.stderr)
+    print(f"stderr: {stderr}", file=sys.stderr)
+
+
+def main():
+    # Make sure we're using the latest changes
+    print("Rebuilding pkgdb...", file=sys.stderr)
+    subprocess.run(["just", "build-pkgdb"], capture_output=True)
+    max_procs = 10
+    iterations = 10
+    all_times = dict()
+    # Scan over the number of concurrent search processes to see how contention
+    # affects the performance
+    for n in range(1, max_procs + 1):
+        print(f"Running {n} search processes...", file=sys.stderr)
+        durations = list()
+        # Run `n` concurrent processes `iterations` times so we have decent
+        # statistics
+        for _ in range(iterations):
+            subprocess.run(["pkgdb", "gc", "-a", "0"], capture_output=True)
+            for item in CACHE_DIR.iterdir():
+                item.unlink()
+            procs = list()
+            start = perf_counter()
+            # Start `n` search processes
+            for i in range(n):
+                procs.append(
+                    Popen(
+                        [
+                            "pkgdb",
+                            "search",
+                            "--ga-registry",
+                            "-q",
+                            "--match-name",
+                            "hello",
+                        ],
+                        stdout=subprocess.PIPE,
+                    )
+                )
+            # Wait for all of the processes to finish
+            for p in procs:
+                p.wait()
+            stop = perf_counter()
+            durations.append(stop - start)
+            # See if any of them failed, print the error if one did
+            for p in procs:
+                if p.returncode != 0:
+                    print("==== Failed ====", file=sys.stderr)
+                    show_output(p)
+                    return
+        all_times[n] = sum(durations) / iterations
+    pprint(all_times)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/search_flamegraph.sh
+++ b/scripts/search_flamegraph.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Note: this only works on macOS and must be run as root since DTrace requires root
+#       to collect traces. It also requires the `inferno` flamegraph toolkit.
+
+SAMPLES="${PWD}/out.stacks"
+COLLAPSED="${PWD}/stacks.collapsed"
+SVG="${PWD}/flamegraph.svg"
+
+# Delete any existing databases
+rm -rf /var/root/.cache/flox
+
+# Collect the traces
+sudo dtrace -c 'pkgdb search --ga-registry --match-name hello' -o "$SAMPLES" -n 'profile-997 /execname == "pkgdb"/ { @[ustack(100)] = count(); }'
+
+# Turn the traces into a flamegraph
+inferno-collapse-dtrace "$SAMPLES" > "$COLLAPSED"
+inferno-flamegraph --colordiffusion --truncate-text-right "$COLLAPSED" > "$SVG"
+
+# Delete the intermediate files
+rm "$SAMPLES" "$COLLAPSED"

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -7,6 +7,7 @@
   mkShell,
   pre-commit-check,
   shfmt,
+  parallel,
   flox-cli,
   flox-cli-tests,
   flox-pkgdb,
@@ -29,6 +30,7 @@
       commitizen
       alejandra
       shfmt
+      parallel
     ];
 in
   mkShell (


### PR DESCRIPTION
Several process may all be started at once that interact with the
database. Only one of them will be able to write to the database,
and the others will block until that database operation is done.

In addition to the database locking procedures there are retry loops that are triggered whenever SQLite returns an error code corresponding to a locked database.

There are associated docs in the `pkgdb/docs` directory with sequence diagrams describing the high level procedure.

This also adds a `pkgdb fingerprint` command which will return the
fingerprint of the flake reference passed on the command line. This
flake reference will be locked before returning the fingerprint.
This command is only meant for testing purposes.

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
