### PR TITLE
feat: scrape database in update and some polish

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -20,6 +20,7 @@ use super::{
     EnvironmentError2,
     InstallationAttempt,
     ManagedPointer,
+    UpdateResult,
     ENVIRONMENT_POINTER_FILENAME,
 };
 use crate::flox::Flox;
@@ -233,7 +234,11 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Atomically update this environment's inputs
-    fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2> {
+    fn update(
+        &mut self,
+        flox: &Flox,
+        inputs: Vec<String>,
+    ) -> Result<UpdateResult, EnvironmentError2> {
         let mut generations = self
             .generations()
             .writable(flox.temp_dir.clone())
@@ -245,7 +250,8 @@ impl Environment for ManagedEnvironment {
 
         let message = temporary.update(flox, inputs)?;
 
-        let metadata = format!("updated environment: {message}");
+        // TODO: better message
+        let metadata = "updated environment".to_string();
 
         generations
             .add_generation(&mut temporary, metadata)

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -17,6 +17,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use self::remote_environment::RemoteEnvironmentError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
 use super::flox_package::FloxTriple;
+use super::lockfile::Lockfile;
 use super::manifest::PackageToInstall;
 use super::pkgdb::UpgradeResult;
 use crate::flox::{Flox, Floxhub};
@@ -55,6 +56,8 @@ pub const ENV_DIR_NAME: &str = "env";
 pub const FLOX_ENV_VAR: &str = "FLOX_ENV";
 pub const FLOX_ACTIVE_ENVIRONMENTS_VAR: &str = "FLOX_ACTIVE_ENVIRONMENTS";
 pub const FLOX_PROMPT_ENVIRONMENTS_VAR: &str = "FLOX_PROMPT_ENVIRONMENTS";
+
+pub type UpdateResult = (Option<Lockfile>, Lockfile);
 
 /// A path that is guaranteed to be canonicalized
 ///
@@ -127,7 +130,11 @@ pub trait Environment: Send {
     fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError2>;
 
     /// Atomically update this environment's inputs
-    fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2>;
+    fn update(
+        &mut self,
+        flox: &Flox,
+        inputs: Vec<String>,
+    ) -> Result<UpdateResult, EnvironmentError2>;
 
     /// Atomically upgrade packages in this environment
     fn upgrade(

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -30,6 +30,7 @@ use super::{
     EnvironmentPointer,
     InstallationAttempt,
     PathPointer,
+    UpdateResult,
     DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
     GCROOTS_DIR_NAME,
@@ -192,7 +193,11 @@ impl Environment for PathEnvironment {
     }
 
     /// Atomically update this environment's inputs
-    fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2> {
+    fn update(
+        &mut self,
+        flox: &Flox,
+        inputs: Vec<String>,
+    ) -> Result<UpdateResult, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.update(flox, inputs)?;
         env_view.link(flox, self.out_link(&flox.system)?)?;

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -13,6 +13,7 @@ use super::{
     Environment,
     EnvironmentError2,
     InstallationAttempt,
+    UpdateResult,
 };
 use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::environment_ref::EnvironmentName;
@@ -135,7 +136,11 @@ impl Environment for RemoteEnvironment {
     }
 
     /// Atomically update this environment's inputs
-    fn update(&mut self, flox: &Flox, inputs: Vec<String>) -> Result<String, EnvironmentError2> {
+    fn update(
+        &mut self,
+        flox: &Flox,
+        inputs: Vec<String>,
+    ) -> Result<UpdateResult, EnvironmentError2> {
         let result = self.inner.update(flox, inputs)?;
         self.inner
             .push(false)

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -21,12 +21,14 @@ pub struct Registry {
 
 /// An environment (or global) lockfile.
 ///
-/// The authoritative definition of this structure is in C++. This struct is
-/// used as the format to communicate with pkgdb. Many pkgdb commands will need
-/// to pass some of the information in the lockfile through to Rust. Although we
-/// could selectively pass fields through, I'm hoping it will be easier to parse
-/// the entirety of the lockfile in Rust rather than defining a separate set of
-/// fields for each different pkgdb command.
+/// The authoritative definition of this structure is in C++.
+/// This struct is used as the format to communicate with pkgdb.
+/// Many pkgdb commands will need to pass some of the information in the
+/// lockfile through to Rust.
+/// Although we could selectively pass fields through,
+/// I'm hoping it will be easier to parse the entirety of the lockfile in Rust,
+/// rather than defining a separate set of fields for each different pkgdb
+/// command.
 #[derive(Deserialize, Serialize)]
 pub struct Lockfile {
     pub registry: Registry,

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1,0 +1,35 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub type FlakeRef = Value;
+
+#[derive(Deserialize, PartialEq, Serialize)]
+pub struct Input {
+    pub from: FlakeRef,
+    #[serde(flatten)]
+    _json: Value,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct Registry {
+    pub inputs: BTreeMap<String, Input>,
+    #[serde(flatten)]
+    _json: Value,
+}
+
+/// An environment (or global) lockfile.
+///
+/// The authoritative definition of this structure is in C++. This struct is
+/// used as the format to communicate with pkgdb. Many pkgdb commands will need
+/// to pass some of the information in the lockfile through to Rust. Although we
+/// could selectively pass fields through, I'm hoping it will be easier to parse
+/// the entirety of the lockfile in Rust rather than defining a separate set of
+/// fields for each different pkgdb command.
+#[derive(Deserialize, Serialize)]
+pub struct Lockfile {
+    pub registry: Registry,
+    #[serde(flatten)]
+    _json: Value,
+}

--- a/cli/flox-rust-sdk/src/models/mod.rs
+++ b/cli/flox-rust-sdk/src/models/mod.rs
@@ -9,6 +9,7 @@ pub mod root;
 pub use runix::{flake_ref, registry};
 pub mod floxmeta;
 pub mod floxmetav2;
+pub mod lockfile;
 pub mod manifest;
 pub mod pkgdb;
 pub mod search;

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -13,13 +13,6 @@ use thiserror::Error;
 pub static PKGDB_BIN: Lazy<String> =
     Lazy::new(|| env::var("PKGDB_BIN").unwrap_or(env!("PKGDB_BIN").to_string()));
 
-/// The JSON output of a `pkgdb update` call
-#[derive(Deserialize)]
-pub struct UpdateResult {
-    pub message: String,
-    pub lockfile: Value,
-}
-
 /// The JSON output of a `pkgdb upgrade` call
 #[derive(Deserialize)]
 pub struct UpgradeResultJSON {

--- a/cli/flox-types/src/catalog/mod.rs
+++ b/cli/flox-types/src/catalog/mod.rs
@@ -18,7 +18,7 @@ pub use element::{Element, PublishElement};
 mod eval;
 pub use eval::Eval;
 mod source;
-pub use source::Source;
+pub use source::{Locked, Source};
 
 pub type StorePath = PathBuf;
 pub type AttrPath = Vec<String>;

--- a/cli/flox-types/src/catalog/mod.rs
+++ b/cli/flox-types/src/catalog/mod.rs
@@ -18,7 +18,7 @@ pub use element::{Element, PublishElement};
 mod eval;
 pub use eval::Eval;
 mod source;
-pub use source::{Locked, Source};
+pub use source::Source;
 
 pub type StorePath = PathBuf;
 pub type AttrPath = Vec<String>;

--- a/cli/flox-types/src/catalog/source.rs
+++ b/cli/flox-types/src/catalog/source.rs
@@ -18,7 +18,7 @@ pub struct Source {
 /// TODO use runix FlakeRef
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Locked {

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1,10 +1,10 @@
-use std::env;
 use std::fs::{self, File};
 use std::io::stdin;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
+use std::{env, vec};
 
 use anyhow::{anyhow, bail, Context, Result};
 use bpaf::Bpaf;
@@ -25,6 +25,7 @@ use flox_rust_sdk::models::environment::{
     ManagedPointer,
     PathPointer,
     UninitializedEnvironment,
+    UpdateResult,
     DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
     FLOX_ACTIVE_ENVIRONMENTS_VAR,
@@ -32,8 +33,9 @@ use flox_rust_sdk::models::environment::{
     FLOX_PROMPT_ENVIRONMENTS_VAR,
 };
 use flox_rust_sdk::models::floxmetav2::FloxmetaV2Error;
+use flox_rust_sdk::models::lockfile::{FlakeRef, Input, Lockfile};
 use flox_rust_sdk::models::manifest::{list_packages, PackageToInstall};
-use flox_rust_sdk::models::pkgdb::{call_pkgdb, UpdateResult, PKGDB_BIN};
+use flox_rust_sdk::models::pkgdb::{call_pkgdb, PKGDB_BIN};
 use flox_rust_sdk::nix::command::StoreGc;
 use flox_rust_sdk::nix::command_line::NixCommandLine;
 use flox_rust_sdk::nix::Run;
@@ -1223,6 +1225,20 @@ impl SwitchGeneration {
     }
 }
 
+#[derive(Debug, Bpaf, Clone)]
+pub enum EnvironmentOrGlobalSelect {
+    Environment(#[bpaf(external(environment_select))] EnvironmentSelect),
+    /// Update inputs used by search and show outside of an environment
+    #[bpaf(long("global"))]
+    Global,
+}
+
+impl Default for EnvironmentOrGlobalSelect {
+    fn default() -> Self {
+        EnvironmentOrGlobalSelect::Environment(Default::default())
+    }
+}
+
 /// Update an environment's inputs
 #[derive(Bpaf, Clone)]
 pub struct Update {
@@ -1230,12 +1246,8 @@ pub struct Update {
     #[bpaf(external(environment_args), group_help("Environment Options"))]
     environment_args: EnvironmentArgs,
 
-    #[bpaf(external(environment_select), fallback(Default::default()))]
-    environment: EnvironmentSelect,
-
-    /// Update inputs used by search and show outside of an environment
-    #[bpaf(long)]
-    global: bool,
+    #[bpaf(external(environment_or_global_select), fallback(Default::default()))]
+    environment_or_global: EnvironmentOrGlobalSelect,
 
     #[bpaf(positional("INPUTS"))]
     inputs: Vec<String>,
@@ -1244,18 +1256,115 @@ impl Update {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("update");
 
-        let message = if self.global {
-            self.update_global_manifest(flox)?
-        } else {
-            self.update_manifest(flox)?
+        let mut description = None;
+        let (old_lockfile, new_lockfile) = match self.environment_or_global {
+            EnvironmentOrGlobalSelect::Environment(ref environment_select) => {
+                let concrete_environment =
+                    environment_select.detect_concrete_environment(&flox, "update")?;
+
+                description = Some(environment_description(&concrete_environment)?);
+
+                self.update_manifest(flox, concrete_environment)?
+            },
+            EnvironmentOrGlobalSelect::Global => self.update_global_manifest(flox)?,
         };
 
-        info!("{}", message);
+        let global = matches!(
+            self.environment_or_global,
+            EnvironmentOrGlobalSelect::Global
+        );
+
+        if let Some(ref old_lockfile) = old_lockfile {
+            if new_lockfile.registry.inputs == old_lockfile.registry.inputs {
+                if global {
+                    info!("ℹ️  All global inputs are up-to-date.");
+                } else {
+                    info!(
+                        "ℹ️  All inputs are up-to-date in environment {}.",
+                        description.as_ref().unwrap()
+                    );
+                }
+
+                return Ok(());
+            }
+        }
+
+        let mut inputs_to_scrape: Vec<&Input> = vec![];
+
+        for (input_name, new_input) in &new_lockfile.registry.inputs {
+            if let Some(ref old_lockfile) = old_lockfile {
+                if let Some(old_input) = old_lockfile.registry.inputs.get(input_name) {
+                    if old_input != new_input {
+                        if global {
+                            info!("⬆️  Updated global input '{}'.", input_name);
+                        } else {
+                            info!(
+                                "⬆️  Updated input '{}' in environment {}.",
+                                input_name,
+                                description.as_ref().unwrap(),
+                            );
+                        }
+                        inputs_to_scrape.push(new_input);
+                    }
+                }
+            } else {
+                if global {
+                    info!("🔒️  Locked global input '{}'.", input_name);
+                } else {
+                    info!(
+                        "🔒️  Locked input '{}' in environment {}.",
+                        input_name,
+                        description.as_ref().unwrap(),
+                    );
+                }
+                inputs_to_scrape.push(new_input);
+            }
+        }
+        if let Some(old_lockfile) = old_lockfile {
+            for (input_name, _) in old_lockfile.registry.inputs {
+                if !new_lockfile.registry.inputs.contains_key(&input_name) {
+                    if global {
+                        info!(
+                            "🗑️  Removed unused input '{}' from global lockfile.",
+                            input_name
+                        );
+                    } else {
+                        info!(
+                            "🗑️  Removed unused input '{}' from lockfile for environment {}.",
+                            input_name,
+                            description.as_ref().unwrap()
+                        );
+                    }
+                }
+            }
+        }
+
+        if inputs_to_scrape.is_empty() {
+            return Ok(());
+        }
+
+        // TODO: make this async when scraping multiple inputs
+        let results: Vec<Result<()>> = Dialog {
+            message: "Generating databases for updated inputs...",
+            help_message: None,
+            typed: Spinner::new(|| {
+                inputs_to_scrape
+                    .iter()
+                    .map(|input| Self::scrape_input(&input.from))
+                    .collect()
+            }),
+        }
+        .spin();
+
+        for result in results {
+            result?;
+        }
 
         Ok(())
     }
 
-    fn update_global_manifest(self, flox: Flox) -> Result<String> {
+    /// TODO: factor out common code with [CoreEnvironment::update]
+    fn update_global_manifest(&self, flox: Flox) -> Result<UpdateResult> {
         let lockfile_path = global_manifest_lockfile_path(&flox);
 
         let mut pkgdb_cmd = Command::new(Path::new(&*PKGDB_BIN));
@@ -1264,37 +1373,53 @@ impl Update {
             .arg("--ga-registry")
             .arg("--global-manifest")
             .arg(global_manifest_path(&flox));
-        if lockfile_path.exists() {
+        let old_lockfile = if lockfile_path.exists() {
             let canonical_lockfile_path = lockfile_path.canonicalize().map_err(|e| {
                 CoreEnvironmentError::BadLockfilePath(e, lockfile_path.to_path_buf())
             })?;
-            pkgdb_cmd.arg("--lockfile").arg(canonical_lockfile_path);
-        }
-        pkgdb_cmd.args(self.inputs);
+            pkgdb_cmd.arg("--lockfile").arg(&canonical_lockfile_path);
+            Some(serde_json::from_slice(&fs::read(canonical_lockfile_path)?)?)
+        } else {
+            None
+        };
+        pkgdb_cmd.args(self.inputs.clone());
 
         debug!("updating global lockfile with command: {pkgdb_cmd:?}");
-        let result: UpdateResult = serde_json::from_value(call_pkgdb(pkgdb_cmd)?)
+        let lockfile: Lockfile = serde_json::from_value(call_pkgdb(pkgdb_cmd)?)
             .map_err(CoreEnvironmentError::ParseUpdateOutput)?;
 
         debug!("writing lockfile to {}", lockfile_path.display());
         std::fs::write(
             lockfile_path,
-            serde_json::to_string_pretty(&result.lockfile).unwrap(),
+            serde_json::to_string_pretty(&lockfile).unwrap(),
         )
         .context("updating global inputs failed")?;
-        Ok(result.message)
+        Ok((old_lockfile, lockfile))
     }
 
-    fn update_manifest(self, flox: Flox) -> Result<String> {
-        let concrete_environment = self
-            .environment
-            .detect_concrete_environment(&flox, "update")?;
-
+    fn update_manifest(
+        &self,
+        flox: Flox,
+        concrete_environment: ConcreteEnvironment,
+    ) -> Result<UpdateResult> {
         let mut environment = concrete_environment.into_dyn_environment();
 
         environment
-            .update(&flox, self.inputs)
+            .update(&flox, self.inputs.clone())
             .context("updating environment failed")
+    }
+
+    fn scrape_input(input: &FlakeRef) -> Result<()> {
+        let mut pkgdb_cmd = Command::new(Path::new(&*PKGDB_BIN));
+        pkgdb_cmd
+            .args(["scrape"])
+            .arg(serde_json::to_string(&input)?)
+            // TODO: this works for nixpkgs, but it won't work for anything else
+            .arg("legacyPackages");
+
+        debug!("scraping input: {pkgdb_cmd:?}");
+        call_pkgdb(pkgdb_cmd)?;
+        Ok(())
     }
 }
 

--- a/pkgdb/src/pkgdb/scrape.cc
+++ b/pkgdb/src/pkgdb/scrape.cc
@@ -76,7 +76,11 @@ ScrapeCommand::run()
   this->input->scrapePrefix( this->attrPath );
 
   /* Print path to database. */
-  std::cout << ( static_cast<std::string>( *this->dbPath ) ) << std::endl;
+  std::cout << nlohmann::json(
+                 { { "database-path",
+                     static_cast<std::string>( *this->dbPath ) } } )
+                 .dump()
+            << std::endl;
   return EXIT_SUCCESS; /* GG, GG */
 }
 

--- a/pkgdb/src/resolver/command.cc
+++ b/pkgdb/src/resolver/command.cc
@@ -165,9 +165,7 @@ UpdateCommand::run()
       this->setManifestRaw( ManifestRaw {} );
       global = true;
     }
-  nlohmann::json    lockfile;
-  std::stringstream message;
-  bool              changes = false;
+  nlohmann::json lockfile;
   if ( auto maybeLockfile = this->getLockfile(); maybeLockfile.has_value() )
     {
       auto lockedRaw         = maybeLockfile->getLockfileRaw();
@@ -203,26 +201,6 @@ UpdateCommand::run()
           lockedRaw.registry.defaults = manifestRegistry.defaults;
           lockedRaw.registry.priority = manifestRegistry.priority;
         }
-      /* Generate message with updated inputs. */
-      if ( global ) { message << "Updated global input(s):"; }
-      else { message << "Updated:"; }
-      for ( const auto & [inputName, input] : oldLockedRegistry.inputs )
-        {
-          if ( const auto & maybeUpdatedInput
-               = lockedRaw.registry.inputs.find( inputName );
-               maybeUpdatedInput != lockedRaw.registry.inputs.end() )
-            {
-              auto & [_, updatedInput] = *maybeUpdatedInput;
-              if ( input != updatedInput )
-                {
-                  changes = true;
-                  message << std::endl
-                          << "'" << inputName << "'"
-                          << " from '" << *input.from << "' to '"
-                          << *updatedInput.from << "'";
-                }
-            }
-        }
       lockfile = lockedRaw;
     }
   /* If the environment doesn't have a lockfile, create one from scratch. Note
@@ -232,18 +210,9 @@ UpdateCommand::run()
     {
       // TODO: `RegistryRaw' should drop empty fields.
       lockfile = this->getEnvironment().createLockfile().getLockfileRaw();
-      changes  = true;
-      if ( global ) { message << "Locked all global inputs."; }
-      else
-        {
-          message << "Locked all inputs for previously unlocked environment.";
-        }
     }
   /* Print that bad boii */
-  nlohmann::json result
-    = { { "lockfile", lockfile },
-        { "message", changes ? message.str() : "All inputs are up to date." } };
-  std::cout << result.dump() << std::endl;
+  std::cout << lockfile.dump() << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/pkgdb/tests/ga-registry.bats
+++ b/pkgdb/tests/ga-registry.bats
@@ -210,7 +210,7 @@ setup_file() {
     sh -c "$PKGDB_BIN manifest update --ga-registry                   \
                                   --lockfile '$PROJ1/manifest2.lock'  \
                                   --manifest '$PROJ1/manifest.toml'   \
-            |jq -r '.lockfile.registry.inputs.nixpkgs.from.rev';"
+            |jq -r '.registry.inputs.nixpkgs.from.rev';"
   assert_success
   assert_output "$NIXPKGS_REV"
 }


### PR DESCRIPTION
- Add a pkgdb scrape call for each updated input.
- Don't allow both --global and environment flags, i.e change: [-d=<path> | -r=<owner/name>] [--global] to [(-d=<path> | -r=<owner/name>) | --global]
- Move generation of messages to print to the user to Rust instead of C++, and make messages consistent with CLI guidelines.
