### PR TITLE
fix: use `command -v` to check for availability of python3, pip

### DIFF
--- a/pkgdb/src/buildenv/assets/etc/profile.d/0500_python.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0500_python.sh
@@ -5,7 +5,7 @@
 # ---------------------------------------------------------------------------- #
 
 # Only run if `python3' is in `PATH'
-if python3 --version > /dev/null 2> /dev/null; then
+if command -v python3 > /dev/null 2> /dev/null; then
   # Get the major/minor version from `python3' to determine the correct path.
   _env_pypath="$FLOX_ENV/lib/python$(
     python3 -c 'import sys
@@ -20,7 +20,7 @@ print( "{}.{}".format( sys.version_info[0], sys.version_info[1] ) )'
 fi
 
 # Only run if `pip' is in `PATH'
-if pip --version > /dev/null 2> /dev/null; then
+if command -v pip > /dev/null 2> /dev/null; then
   export PIP_CONFIG_FILE=$(@realpath@ --no-symlinks $FLOX_ENV/../../pip.ini)
   cat > $PIP_CONFIG_FILE << EOF
 [global]


### PR DESCRIPTION
fixes #638 
