### PR TITLE
fix: change error text to refer to floxhub

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -868,7 +868,7 @@ impl Push {
                     let user_name = client
                         .get_username()
                         .await
-                        .context("Could not get username from github")?;
+                        .context("Could not get username from floxhub")?;
                     user_name
                         .parse::<EnvironmentOwner>()
                         .context("Invalid owner name")?


### PR DESCRIPTION

Replaces the reference to "github" with one to "floxhub" in the error text for determining username.