### PR TITLE
fix: eliminate double-printing of error messages

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -387,7 +387,7 @@ pub enum EnvironmentError2 {
     #[error("invalid internal state; couldn't remove last element from path: {0}")]
     InvalidPath(PathBuf),
 
-    #[error("invalid .flox directory at {path}: {source}")]
+    #[error("invalid .flox directory at {path}")]
     InvalidDotFlox {
         path: PathBuf,
         #[source]


### PR DESCRIPTION
Observed that error messages were being printed twice, e.g.:
```
Michaels-MacBook-Pro% echo broken > /tmp/debug/.flox/env.json         
Michaels-MacBook-Pro% ~/src/flox/result/bin/flox install foo
ERROR: invalid .flox directory at /private/tmp/debug/.flox: Failed parsing contents of env.json file: Failed parsing contents of env.json file: expected value at line 1 column 1
Michaels-MacBook-Pro% ~/src/flox/result/bin/flox install foo
```
## Proposed Changes
Discussed with Yannik who noted that the error was being printed both in the error description string and also by way of the error handler automatically appending it as well. The suggested fix is to stop including the "source" error message as part of the error description string.

## Release Notes

N/A