### PR TITLE
fix: handle 'null' packages in lockfile

### DIFF
--- a/pkgdb/src/resolver/lockfile.cc
+++ b/pkgdb/src/resolver/lockfile.cc
@@ -387,17 +387,25 @@ from_json( const nlohmann::json & jfrom, LockfileRaw & raw )
               SystemPackages sysPkgs;
               for ( const auto & [pid, descriptor] : descriptors.items() )
                 {
-                  try
+                  if ( descriptor.is_null() )
                     {
-                      sysPkgs.emplace( pid,
-                                       descriptor.get<LockedPackageRaw>() );
+                      sysPkgs.emplace( pid, std::nullopt );
+                      continue;
                     }
-                  catch ( nlohmann::json::exception & err )
+                  else
                     {
-                      throw InvalidLockfileException(
-                        "couldn't parse lockfile field `packages." + system
-                          + "." + pid + "'",
-                        extract_json_errmsg( err ) );
+                      try
+                        {
+                          sysPkgs.emplace( pid,
+                                           descriptor.get<LockedPackageRaw>() );
+                        }
+                      catch ( nlohmann::json::exception & err )
+                        {
+                          throw InvalidLockfileException(
+                            "couldn't parse lockfile field `packages." + system
+                              + "." + pid + "'",
+                            extract_json_errmsg( err ) );
+                        }
                     }
                 }
               raw.packages.emplace( system, std::move( sysPkgs ) );

--- a/pkgdb/src/resolver/mixins.cc
+++ b/pkgdb/src/resolver/mixins.cc
@@ -303,6 +303,7 @@ EnvironmentMixin::addManifestFileArg( argparse::ArgumentParser & parser,
     = parser.add_argument( "--manifest" )
         .help( "the path to the project's `manifest.{toml,yaml,json}' file." )
         .metavar( "PATH" )
+        .nargs( 1 )
         .action( [&]( const std::string & strPath )
                  { this->setManifestRaw( nix::absPath( strPath ) ); } );
   return required ? arg.required() : arg;
@@ -318,6 +319,7 @@ EnvironmentMixin::addLockfileOption( argparse::ArgumentParser & parser )
     .help( "the path to a lockfile, either the project's `manifest.lock` or "
            "the global lock" )
     .metavar( "PATH" )
+    .nargs( 1 )
     .action( [&]( const std::string & strPath )
              { this->setLockfileRaw( nix::absPath( strPath ) ); } );
 }

--- a/pkgdb/tests/lockfile.bats
+++ b/pkgdb/tests/lockfile.bats
@@ -1,0 +1,71 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# `pkgdb search' tests.
+#
+# ---------------------------------------------------------------------------- #
+
+load setup_suite.bash
+
+# bats file_tags=search
+
+setup_file() {
+  export TDATA="$TESTS_DIR/data/manifest"
+  export PROJ1="$TESTS_DIR/harnesses/proj1"
+
+  OTHER_REV="$(
+    jq -r '.registry.inputs.nixpkgs.from.rev' "$PROJ1/manifest2.lock"
+  )"
+  export OTHER_REV
+
+  # We don't parallelize these to avoid DB sync headaches and to recycle the
+  # cache between tests.
+  # Nonetheless this file makes an effort to avoid depending on past state in
+  # such a way that would make it difficult to eventually parallelize in
+  # the future.
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  # Change the rev used for the `--ga-registry' flag to align with our cached
+  # revision used by other tests.
+  # This is both an optimization and a way to ensure consistency of test output.
+  export _PKGDB_GA_REGISTRY_REF_OR_REV="$NIXPKGS_REV"
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=manifest:empty, lock:empty
+
+@test "lock a manifest with system specific packages" {
+  _MANIFEST="$BATS_TEST_TMPDIR/manifest.toml";
+  echo '[options]
+systems = ["x86_64-linux", "x86_64-darwin"]
+
+[install.a]
+path = ["hello"]
+systems = ["x86_64-linux"]
+
+[install.b]
+path = ["hello"]
+systems = ["x86_64-darwin"]' > "$_MANIFEST";
+
+  run sh -c "$PKGDB_BIN manifest lock --ga-registry --manifest '$_MANIFEST'  \
+               > '$BATS_TEST_TMPDIR/manifest.lock'";
+  assert_success;
+
+  run sh -c "$PKGDB_BIN manifest lock --ga-registry --manifest '$_MANIFEST'    \
+                                 --lockfile '$BATS_TEST_TMPDIR/manifest.lock'  \
+               > '$BATS_TEST_TMPDIR/manifest.lock2'";
+  assert_success;
+
+  run diff -q "$BATS_TEST_TMPDIR/manifest.lock"    \
+              "$BATS_TEST_TMPDIR/manifest.lock2";
+  assert_success;
+}
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #


### PR DESCRIPTION
## Proposed Changes

- Fixes a parse error when processing lockfiles with `null` entries
  for skipped `packages.<SYSTEM>.*` resolutions.
- Adds a test case covering this.


## Release Notes

N/A
