### PR TITLE
feat: add database locking

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,15 @@ build-cdb:
 @build-pkgdb:
     make -C pkgdb -j;
 
+# Build pkgdb with debug symbols
+@build-pkgdb-debug:
+    # Note that you need to clean pkgdb first
+    make -C pkgdb -j -s DEBUG=1
+
+# Clean the pkgdb build cache
+@clean-pkgdb:
+    make -C pkgdb -j -s clean
+
 # Build only flox
 @build-cli: build-pkgdb
     pushd cli; cargo build -q; popd
@@ -125,6 +134,10 @@ test-all: test-pkgdb impure-tests integ-tests functional-tests
 @flox +args="": build
     cli/target/debug/flox {{args}}
 
+
+# Run a `pkgdb` command
+@pkgdb +args="": build-pkgdb
+    pkgdb/bin/pkgdb {{args}}
 
 # ---------------------------------------------------------------------------- #
 #

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -544,12 +544,13 @@ cc-check: $(TESTS:.cc=)
 	exit "$$_ec";
 
 #: Run all bats tests
+PKGDB_BATS_FILES ?= "$(PKGDB_ROOT)/tests"
 bats-check: bin $(TEST_UTILS)
 	PKGDB_BIN="$(PKGDB_ROOT)/bin/pkgdb"                          \
 	PKGDB_IS_SQLITE3_BIN="$(PKGDB_ROOT)/tests/is_sqlite3"        \
 	PKGDB_SEARCH_PARAMS_BIN="$(PKGDB_ROOT)/tests/search-params"  \
 	  $(BATS) --print-output-on-failure --verbose-run --timing   \
-	          "$(PKGDB_ROOT)/tests";
+	          "$(PKGDB_BATS_FILES)";
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/include/flox/core/types.hh
+++ b/pkgdb/include/flox/core/types.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -60,6 +61,11 @@ using Cursor = nix::ref<nix::eval_cache::AttrCursor>;
  *   `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, or `aarch64-darwin`
  */
 using System = std::string;
+
+
+/* -------------------------------------------------------------------------- */
+
+using DurationMillis = std::chrono::duration<double, std::milli>;
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/pkgdb/input.hh
+++ b/pkgdb/include/flox/pkgdb/input.hh
@@ -171,10 +171,7 @@ public:
 
   /** @brief Close the read/write database connection if it is open. */
   void
-  closeDbReadWrite()
-  {
-    this->dbRW = nullptr;
-  }
+  closeDbReadWrite();
 
   /** @return Filesystem path to the flake's package database. */
   [[nodiscard]] std::filesystem::path

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -128,10 +128,6 @@ public:
 
   /**
    * @brief Tries to connect to the database, acquiring an exclusive lock on it.
-   *
-   * The database may be locked by another process that is currently scraping
-   * it. This function will block until that lock is released. If the database
-   * has already been scraped it will not re-scrape it.
    */
   void
   connect();

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -124,6 +124,19 @@ public:
     : PkgDb( flake, genPkgDbName( flake.getFingerprint() ).string() )
   {}
 
+  /* Connecting and locking */
+
+  /**
+   * @brief Tries to connect to the database, acquiring an exclusive lock on it.
+   *
+   * The database may be locked by another process that is currently scraping
+   * it. This function will block until that lock is released. If the database
+   * has already been scraped it will not re-scrape it.
+   */
+  void
+  connect();
+
+
   /* Basic Operations */
 
   /**

--- a/pkgdb/src/pkgdb/read.cc
+++ b/pkgdb/src/pkgdb/read.cc
@@ -91,8 +91,21 @@ PkgDbReadOnly::init()
     {
       throw NoSuchDatabase( *this );
     }
-  this->db.connect( this->dbPath.string().c_str(), SQLITE_OPEN_READONLY );
+  this->connect();
   this->loadLockedFlake();
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+PkgDbReadOnly::connect()
+{
+  this->db.connect( this->dbPath.string().c_str(), SQLITE_OPEN_READONLY );
+  /* Just try to execute any query to see if it blocks, which would mean that
+   * someone else has the database lock. */
+  std::string qry = "select * from DbVersions";
+  RETRY_WHILE_BUSY( this->db.execute( qry ) );
 }
 
 

--- a/pkgdb/src/pkgdb/write.cc
+++ b/pkgdb/src/pkgdb/write.cc
@@ -145,9 +145,8 @@ initVersions( SQLiteDb & pdb )
   defineVersions.bind( 2, static_cast<int>( sqlVersions.views ) );
   if ( sql_rc rcode = defineVersions.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException( nix::fmt( "failed to write DbVersions info:(%d) %s",
-                                      rcode,
-                                      pdb.error_msg() ) );
+      throw PkgDbException( "failed to write DbVersions info",
+                            pdb.error_msg() );
     }
 }
 
@@ -188,10 +187,8 @@ writeInput( PkgDb & pdb )
   cmd.bind( 3, pdb.lockedRef.attrs.dump(), sqlite3pp::copy );
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException(
-        nix::fmt( "failed to write LockedFlaked info:(%d) %s",
-                  rcode,
-                  pdb.db.error_msg() ) );
+      throw PkgDbException( "failed to write LockedFlaked info",
+                            pdb.db.error_msg() );
     }
 }
 
@@ -202,13 +199,31 @@ PkgDb::PkgDb( const nix::flake::LockedFlake & flake, std::string_view dbPath )
 {
   this->dbPath      = dbPath;
   this->fingerprint = flake.getFingerprint();
-  this->db.connect( this->dbPath.c_str(),
-                    SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE );
+  this->connect();
   this->init();
   this->lockedRef
     = { flake.flake.lockedRef.to_string(),
         nix::fetchers::attrsToJSON( flake.flake.lockedRef.toAttrs() ) };
   writeInput( *this );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+PkgDb::connect()
+{
+  /* We need to try to write to a junk table, it's unclear whether setting a
+   * PRAGMA counts as a write. */
+  static const char * acquire_lock = R"SQL(
+  BEGIN EXCLUSIVE TRANSACTION;
+  CREATE TABLE IF NOT EXISTS _lock (foo int);
+  COMMIT TRANSACTION
+  )SQL";
+  this->db.connect( this->dbPath.string().c_str(),
+                    SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE );
+  sqlite3pp::command cmd( this->db, acquire_lock );
+  RETRY_WHILE_BUSY( cmd.execute_all() );
 }
 
 
@@ -386,10 +401,9 @@ PkgDb::addPackage( row_id               parentId,
     }
   if ( sql_rc rcode = cmd.execute(); isSQLError( rcode ) )
     {
-      throw PkgDbException( nix::fmt( "failed to write Package '%s':(%d) %s",
-                                      pkg._fullName,
-                                      rcode,
-                                      this->db.error_msg() ) );
+      throw PkgDbException(
+        nix::fmt( "failed to write Package '%s'", pkg._fullName ),
+        this->db.error_msg() );
     }
   return this->db.last_insert_rowid();
 }
@@ -448,11 +462,8 @@ PkgDb::scrape( nix::SymbolTable & syms, const Target & target, Todos & todo )
 
   bool tryRecur = prefix.front() != "packages";
 
-  nix::Activity act( *nix::logger,
-                     nix::lvlInfo,
-                     nix::actUnknown,
-                     nix::fmt( "evaluating package set '%s'",
-                               concatStringsSep( ".", prefix ) ) );
+  debugLog( nix::fmt( "evaluating package set '%s'",
+                      concatStringsSep( ".", prefix ) ) );
 
   /* Scrape loop over attrs */
   for ( nix::Symbol & aname : cursor->getAttrs() )
@@ -465,10 +476,7 @@ PkgDb::scrape( nix::SymbolTable & syms, const Target & target, Todos & todo )
             ? concatStringsSep( ".", prefix ) + "." + syms[aname]
             : "";
 
-      nix::Activity act( *nix::logger,
-                         nix::lvlTalkative,
-                         nix::actUnknown,
-                         "\tevaluating attribute '" + pathS + "'" );
+      traceLog( "\tevaluating attribute '" + pathS + "'" );
 
       try
         {

--- a/pkgdb/tests/search.bats
+++ b/pkgdb/tests/search.bats
@@ -531,7 +531,7 @@ genParamsNixpkgsFlox() {
 @test "'pkgdb search' doesn't crash when run in parallel" {
   # We don't want other tests polluting parallel test runs so we do this test
   # with a unique cache directory.
-  run sh -c 'PKGDB_CACHEDIR="$(mktemp -d)" parallel "sleep 0.{}; \"$PKGDB_BIN\" search --ga-registry --match-name hello" ::: $(seq 10)'
+  run --separate-stderr sh -c 'PKGDB_CACHEDIR="$(mktemp -d)" parallel "sleep 0.{}; \"$PKGDB_BIN\" search --ga-registry --match-name hello" ::: $(seq 10)'
   assert_success
   n_lines="${#lines[@]}"
   assert_equal "$n_lines" 100 # 10x number of results from hello

--- a/pkgdb/tests/search.bats
+++ b/pkgdb/tests/search.bats
@@ -525,6 +525,18 @@ genParamsNixpkgsFlox() {
   assert_success
 }
 
+
+# ---------------------------------------------------------------------------- #
+
+@test "'pkgdb search' doesn't crash when run in parallel" {
+  # We don't want other tests polluting parallel test runs so we do this test
+  # with a unique cache directory.
+  run sh -c 'PKGDB_CACHEDIR="$(mktemp -d)" parallel "sleep 0.{}; \"$PKGDB_BIN\" search --ga-registry --match-name hello" ::: $(seq 10)'
+  assert_success
+  n_lines="${#lines[@]}"
+  assert_equal "$n_lines" 100 # 10x number of results from hello
+}
+
 # ---------------------------------------------------------------------------- #
 #
 #

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -26,6 +26,7 @@
   bats,
   git,
   coreutils,
+  parallel,
   llvm, # for `llvm-symbolizer'
   gdb ? throw "`gdb' is required for debugging with `g++'",
   lldb ? throw "`lldb' is required for debugging with `clang++'",
@@ -166,6 +167,7 @@ in
           bash
           git
           sqlite
+          parallel
           # For docs
           doxygen
         ];


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Adds simple database locking so that more than one search process launched shortly after one another don't step on each other.

Note that this isn't bulletproof and you'll notice in the tests that the processes aren't launched at exactly the same time. Instead, the processes are launched with a slight delay between them. This is good enough because the processes will *most likely* never be launched at **exactly** the same time in any real use case.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
