### PR TITLE
fix: print activation script for use in rc files

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -400,7 +400,6 @@ impl Activate {
 
         // Add to FLOX_ACTIVE_ENVIRONMENTS so we can detect what environments are active.
         let mut flox_active_environments = activated_environments();
-
         if flox_active_environments.is_active(&now_active) {
             bail!("Environment '{now_active}' is already active");
         }

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -335,7 +335,7 @@ impl Activate {
             }
         }
 
-        let last_active =
+        let now_active =
             UninitializedEnvironment::from_concrete_environment(&concrete_environment)?;
 
         let mut environment = concrete_environment.into_dyn_environment();
@@ -357,7 +357,12 @@ impl Activate {
 
         // Add to FLOX_ACTIVE_ENVIRONMENTS so we can detect what environments are active.
         let mut flox_active_environments = activated_environments();
-        flox_active_environments.set_last_active(last_active);
+
+        if flox_active_environments.is_active(&now_active) {
+            bail!("Environment '{now_active}' is already active");
+        }
+
+        flox_active_environments.set_last_active(now_active);
 
         // TODO more sophisticated detection?
         let shell = if let Ok(shell) = env::var("SHELL") {

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -403,7 +403,6 @@ impl Activate {
         if flox_active_environments.is_active(&now_active) {
             bail!("Environment '{now_active}' is already active");
         }
-
         flox_active_environments.set_last_active(now_active);
 
         // TODO more sophisticated detection?

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::fs::{self, File};
 use std::io::{stdin, stdout};
@@ -54,8 +55,8 @@ use crate::commands::{
     UninitializedEnvironment,
 };
 use crate::config::Config;
-use crate::subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog, Spinner};
+use crate::{subcommand_metric, utils};
 
 #[derive(Bpaf, Clone)]
 pub struct EnvironmentArgs {
@@ -407,11 +408,48 @@ impl Activate {
 
         // TODO more sophisticated detection?
         let shell = if let Ok(shell) = env::var("SHELL") {
-            shell
+            ShellType::try_from(Path::new(&shell))?
         } else {
             bail!("SHELL must be set");
         };
-        let mut command = Command::new(&shell);
+
+        let prompt_color_1 = env::var("FLOX_PROMPT_COLOR_1")
+            .unwrap_or(utils::colors::LIGHT_BLUE.to_ansi256().to_string());
+        let prompt_color_2 = env::var("FLOX_PROMPT_COLOR_2")
+            .unwrap_or(utils::colors::DARK_PEACH.to_ansi256().to_string());
+
+        // when output is not a tty, and no command is provided
+        // we just print an activation script to stdout
+        //
+        // That script can then be `eval`ed in the current shell,
+        // e.g. in a .bashrc or .zshrc file:
+        //
+        //    eval "$(flox activate)"
+        if !stdout().is_tty() && self.run_args.is_empty() {
+            let script: String = formatdoc! {"
+                export {FLOX_ENV_VAR}={activation_path}
+                export {FLOX_PROMPT_ENVIRONMENTS_VAR}={flox_prompt_environments}
+                export {FLOX_ACTIVE_ENVIRONMENTS_VAR}={flox_active_environments}
+                export FLOX_PROMPT_COLOR_1={prompt_color_1}
+                export FLOX_PROMPT_COLOR_2={prompt_color_2}
+
+                # to avoid infinite recursion sourcing bashrc
+                export FLOX_SOURCED_FROM_SHELL_RC=1
+
+                source {activation_path}/activate/{shell}
+
+                unset FLOX_SOURCED_FROM_SHELL_RC
+            ",
+            activation_path=shell_escape::escape(activation_path.to_string_lossy()),
+            flox_active_environments=shell_escape::escape(flox_active_environments.to_string().into()),
+            flox_prompt_environments=shell_escape::escape(Cow::from(&flox_prompt_environments)),
+            };
+
+            println!("{script}");
+
+            return Ok(());
+        }
+        let mut command = Command::new(shell.exe_path());
         command
             .env(FLOX_PROMPT_ENVIRONMENTS_VAR, flox_prompt_environments)
             .env(FLOX_ENV_VAR, &activation_path)
@@ -419,54 +457,47 @@ impl Activate {
                 FLOX_ACTIVE_ENVIRONMENTS_VAR,
                 flox_active_environments.to_string(),
             )
-            .env(
-                "FLOX_PROMPT_COLOR_1",
-                // default to SlateBlue3
-                env::var("FLOX_PROMPT_COLOR_1").unwrap_or("61".to_string()),
-            )
-            .env(
-                "FLOX_PROMPT_COLOR_2",
-                // default to LightSalmon1
-                env::var("FLOX_PROMPT_COLOR_2").unwrap_or("216".to_string()),
-            );
+            .env("FLOX_PROMPT_COLOR_1", prompt_color_1)
+            .env("FLOX_PROMPT_COLOR_2", prompt_color_2);
 
-        if shell.ends_with("bash") {
-            command
-                .arg("--rcfile")
-                .arg(activation_path.join("activate").join("bash"));
-        } else if shell.ends_with("zsh") {
-            // From man zsh:
-            // Commands are then read from $ZDOTDIR/.zshenv.  If the shell is a
-            // login shell, commands are read from /etc/zprofile and then
-            // $ZDOTDIR/.zprofile.  Then, if the shell is interactive, commands
-            // are read from /etc/zshrc and then $ZDOTDIR/.zshrc.  Finally, if
-            // the shell is a login shell, /etc/zlogin and $ZDOTDIR/.zlogin are
-            // read.
-            //
-            // We want to add our customizations as late as possible in the
-            // initialization process - if, e.g. the user has prompt
-            // customizations, we want ours to go last. So we put our
-            // customizations at the end of .zshrc, passing our customizations
-            // using FLOX_ZSH_INIT_SCRIPT.
-            // Otherwise, we want initialization to proceed as normal, so the
-            // files in our ZDOTDIR source global rcs and user rcs.
-            // We disable global rc files and instead source them manually so we
-            // can control the ZDOTDIR they are run with - this is important
-            // since macOS sets
-            // HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history
-            // in /etc/zshrc.
-            if let Ok(zdotdir) = env::var("ZDOTDIR") {
-                command.env("FLOX_ORIG_ZDOTDIR", zdotdir);
-            }
-            command
-                .env("ZDOTDIR", env!("FLOX_ZDOTDIR"))
-                .env(
-                    "FLOX_ZSH_INIT_SCRIPT",
-                    activation_path.join("activate").join("zsh"),
-                )
-                .arg("--no-globalrcs");
-        } else {
-            bail!("Unsupported SHELL '{shell}'");
+        match shell {
+            ShellType::Bash(_) => {
+                command
+                    .arg("--rcfile")
+                    .arg(activation_path.join("activate").join("bash"));
+            },
+            ShellType::Zsh(_) => {
+                // From man zsh:
+                // Commands are then read from $ZDOTDIR/.zshenv.  If the shell is a
+                // login shell, commands are read from /etc/zprofile and then
+                // $ZDOTDIR/.zprofile.  Then, if the shell is interactive, commands
+                // are read from /etc/zshrc and then $ZDOTDIR/.zshrc.  Finally, if
+                // the shell is a login shell, /etc/zlogin and $ZDOTDIR/.zlogin are
+                // read.
+                //
+                // We want to add our customizations as late as possible in the
+                // initialization process - if, e.g. the user has prompt
+                // customizations, we want ours to go last. So we put our
+                // customizations at the end of .zshrc, passing our customizations
+                // using FLOX_ZSH_INIT_SCRIPT.
+                // Otherwise, we want initialization to proceed as normal, so the
+                // files in our ZDOTDIR source global rcs and user rcs.
+                // We disable global rc files and instead source them manually so we
+                // can control the ZDOTDIR they are run with - this is important
+                // since macOS sets
+                // HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history
+                // in /etc/zshrc.
+                if let Ok(zdotdir) = env::var("ZDOTDIR") {
+                    command.env("FLOX_ORIG_ZDOTDIR", zdotdir);
+                }
+                command
+                    .env("ZDOTDIR", env!("FLOX_ZDOTDIR"))
+                    .env(
+                        "FLOX_ZSH_INIT_SCRIPT",
+                        activation_path.join("activate").join("zsh"),
+                    )
+                    .arg("--no-globalrcs");
+            },
         };
 
         if !self.run_args.is_empty() {

--- a/cli/flox/src/utils/colors.rs
+++ b/cli/flox/src/utils/colors.rs
@@ -84,6 +84,10 @@ pub struct FloxColor {
 }
 
 impl FloxColor {
+    pub fn to_ansi256(&self) -> u8 {
+        self.ansi256
+    }
+
     pub fn to_crossterm(&self) -> Option<crossterm::style::Color> {
         match supports_color::on(supports_color::Stream::Stderr) {
             Some(supports_color::ColorLevel { has_16m: true, .. }) => {

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -215,7 +215,7 @@ env_is_activated() {
   SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
-  SHELL=zsh  NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
+  SHELL=zsh NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
   assert_success
   assert_output --partial "baz"
 }
@@ -356,4 +356,22 @@ env_is_activated() {
   run "$FLOX_BIN" activate -- hello
   assert_success
   assert_output --partial "Hello, world!"
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate,activate:inplace
+@test "'flox activate' prints script to modify current shell" {
+  # Flox detects that the output is not a tty and prints the script to stdout
+  #
+  # TODO:
+  # better with a flag like '--print-script'
+  # this is confusing:
+  SHELL="bash" run "$FLOX_BIN" activate
+  assert_success
+  assert_output --regexp "source .*/activate/bash"
+
+  SHELL="zsh" run "$FLOX_BIN" activate
+  assert_success
+  assert_output --regexp "source .*/activate/zsh"
 }

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -48,7 +48,7 @@ namespace flox::buildenv {
 static const std::string BASH_ACTIVATE_SCRIPT = R"(
 # We use --rcfile to activate using bash which skips sourcing ~/.bashrc,
 # so source that here.
-if [ -f ~/.bashrc ]
+if [ -f ~/.bashrc -a "${FLOX_SOURCED_FROM_SHELL_RC:-}" != 1 ]
 then
     source ~/.bashrc
 fi


### PR DESCRIPTION
Print a short activation script that can be `eval`ed in a bashrc, if stdout is not a terminal and no command is provided.
The activation script simply exports the same variables we set for `exec` activations and sources the `activate` script for the active shell.

Activation script example:

```bash
export FLOX_ENV=/Users/yannik/.cache/flox/run/ysndr/aarch64-darwin.cli.fe47112ff9e1e0f6c10c29addea59a77d3da46c3063e54a0425d0e442695a4f8
export FLOX_PROMPT_ENVIRONMENTS=ysndr/cli
export FLOX_ACTIVE_ENVIRONMENTS='[{"type":"dot-flox","path":"/Volumes/Projects/Flox/flox/flox/cli","pointer":{"owner":"ysndr","name":"cli","floxhub_url":"https://saas-dev-main.floxdev.com/","version":1}}]'
export FLOX_PROMPT_COLOR_1=61
export FLOX_PROMPT_COLOR_2=216

# to avoid infinite recursion sourcing bashrc
export FLOX_SOURCED_FROM_SHELL_RC=1

source /Users/yannik/.cache/flox/run/ysndr/aarch64-darwin.cli.fe47112ff9e1e0f6c10c29addea59a77d3da46c3063e54a0425d0e442695a4f8/activate/zsh

unset FLOX_SOURCED_FROM_SHELL_RC
```
