### PR TITLE
fix: skip build if modified after `outlink` was modified

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -688,6 +688,8 @@ pub mod tests {
             floxhub_token: None,
         };
 
+        init_global_manifest(&global_manifest_path(&flox)).unwrap();
+
         (flox, tempdir_handle)
     }
 
@@ -710,6 +712,7 @@ pub mod tests {
     use mockito;
 
     use crate::flox::Auth0Client;
+    use crate::models::environment::{global_manifest_path, init_global_manifest};
 
     #[tokio::test]
     async fn test_get_username() {

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -318,7 +318,7 @@ impl Environment for ManagedEnvironment {
                 break 'time SystemTime::UNIX_EPOCH;
             };
 
-            metadate.modified().unwrap_or(SystemTime::UNIX_EPOCH)
+            metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH)
         };
 
         let out_link_modified_at = 'time: {

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -306,7 +306,7 @@ impl Environment for ManagedEnvironment {
 
     fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
         let pointer_lock_modified_at = 'time: {
-            let Ok(metadate) = self
+            let Ok(metadata) = self
             .path
             .join(GENERATION_LOCK_FILENAME)
             .metadata()

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -16,6 +16,7 @@
 use std::ffi::OsStr;
 use std::fs::{self};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use flox_types::catalog::System;
 use log::debug;
@@ -240,8 +241,33 @@ impl Environment for PathEnvironment {
     }
 
     fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError2> {
-        self.build(flox)?;
-        self.out_link(&flox.system)
+        let manifest_modified_at = 'time: {
+            let manifest_path = self.manifest_path(flox)?;
+            let Ok(metadata) = manifest_path.metadata() else {
+                debug!("Could not get metadata for {manifest_path:?} using default time");
+                break 'time SystemTime::UNIX_EPOCH;
+            };
+            metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH)
+        };
+
+        let out_link = self.out_link(&flox.system)?;
+
+        let out_link_modified_at = 'time: {
+            let Ok(metadata) = fs::symlink_metadata(&out_link) else {
+                debug!("Could not get metadata for {out_link:?} using default time");
+                break 'time SystemTime::UNIX_EPOCH;
+            };
+            metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH)
+        };
+
+        debug!(
+            "manifest_modified_at: {manifest_modified_at:?},
+             out_link_modified_at: {out_link_modified_at:?}"
+        );
+        if manifest_modified_at >= out_link_modified_at {
+            self.build(flox)?;
+        }
+        Ok(out_link)
     }
 
     /// Path to the environment's parent directory

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod errors;
 pub mod guard;
 pub mod rnix;
 use std::path::Path;
+use std::time::SystemTime;
 use std::{fs, io};
 
 use ::log::debug;
@@ -95,4 +96,31 @@ pub fn copy_file_without_permissions(
         err: io_err,
     })?;
     Ok(())
+}
+
+/// Get the mtime of a file, directory or symlink
+///
+/// Unlike `std::fs::metadata`, this function will not follow symlinks,
+/// but return the mtime of the symlink itself.
+///
+/// If the file or directory does not exist,
+/// or if the mtime cannot be determined, return [SystemTime::UNIX_EPOCH]
+pub fn mtime_of(path: impl AsRef<Path>) -> SystemTime {
+    let path = path.as_ref();
+    'time: {
+        let metadata = if path.is_symlink() {
+            let Ok(metadata) = fs::symlink_metadata(path) else {
+                debug!("Could not get metadata for {path:?} using default time");
+                break 'time SystemTime::UNIX_EPOCH;
+            };
+            metadata
+        } else {
+            let Ok(metadata) = path.metadata() else {
+                debug!("Could not get metadata for {path:?} using default time");
+                break 'time SystemTime::UNIX_EPOCH;
+            };
+            metadata
+        };
+        metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH)
+    }
 }


### PR DESCRIPTION
Do not build to provide `activation_path` if the manifest (or pointer lockfile) was not updated after the `out_link` was set.

This should guarantee quicker (second) activations unless the out_link is modified externally
