### PR TITLE
feat(auth): enable opening auth page using `[enter]`

### DIFF
--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use bpaf::Bpaf;
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
@@ -60,6 +60,10 @@ fn create_oauth_client() -> Result<BasicClient> {
 }
 
 pub async fn authorize(client: BasicClient) -> Result<Credential> {
+    if !Dialog::can_prompt() {
+        bail!("Cannot prompt for user input")
+    }
+
     let details: StandardDeviceAuthorizationResponse = client
         .exchange_device_code()
         .unwrap()

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -96,7 +96,7 @@ pub async fn authorize(client: BasicClient) -> Result<Credential> {
         details.expires_in().as_secs()
     );
 
-    // in he background listen for `[enter]` key presses
+    // in the background listen for `[enter]` key presses
     // if the user presses enter, open the browser using the system default opener
     // on linux this should be `xdg-open`
     // on macos this should be `open`

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -10,6 +10,7 @@ pub mod dialog;
 pub mod init;
 pub mod logger;
 pub mod metrics;
+pub mod openers;
 
 use regex::Regex;
 

--- a/cli/flox/src/utils/openers.rs
+++ b/cli/flox/src/utils/openers.rs
@@ -1,0 +1,80 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use itertools::Itertools;
+use log::debug;
+
+const OPENERS: &[&str] = &["xdg-open", "gnome-open", "kde-open"];
+
+const BROWSER_OPENERS: &[&str] = &["www-browser"];
+
+#[derive(Debug, Clone)]
+pub struct Browser(PathBuf);
+impl Browser {
+    /// Open a url in the default browser using the system's "opener" command
+    /// This is `xdg-open`, `gnome-open`, etc. on linux and `open` on macos
+    ///
+    /// In ssh sessions or TTYs without DISPLAY, a browser cannot be opened
+    pub fn detect() -> Result<Self, String> {
+        // in ssh sessions we can't open a browser
+        if std::env::var("SSH_TTY").is_ok() {
+            return Err("SSH session detected".into());
+        }
+
+        // if X11 or wayland is not available, we can't open a browser
+        if std::env::consts::OS == "linux"
+            && std::env::var("DISPLAY").is_err()
+            && std::env::var("WAYLAND_DISPLAY").is_err()
+        {
+            return Err("No X11 or Wayland display available".into());
+        }
+
+        let browser = match std::env::consts::OS {
+            "linux" => {
+                let path_var =
+                    env::var("PATH").map_err(|_| "Could not read PATH variable".to_string())?;
+                let Some((path, _)) = first_in_path([OPENERS, BROWSER_OPENERS].concat(), env::split_paths(&path_var)) else { return Err("No opener found in PATH".to_string()) };
+                Self(path)
+            },
+            "macos" => Self(PathBuf::from("/usr/bin/open")),
+            unsupported => {
+                debug!("Unsupported OS '{unsupported}' cannot open a browser");
+                return Err(format!(
+                    "Unsupported OS '{unsupported}'",
+                    unsupported = unsupported
+                ));
+            },
+        };
+
+        debug!("Detected browser opener: {browser:?}");
+        Ok(browser)
+    }
+
+    #[allow(unused)]
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+
+    #[allow(unused)]
+    pub fn name(&self) -> String {
+        self.0.file_name().unwrap().to_string_lossy().into_owned()
+    }
+
+    pub fn to_command(&self) -> Command {
+        Command::new(&self.0)
+    }
+}
+
+fn first_in_path<'a, I>(
+    candidates: I,
+    path: impl IntoIterator<Item = PathBuf>,
+) -> Option<(PathBuf, &'a str)>
+where
+    I: IntoIterator<Item = &'a str>,
+    I::IntoIter: Clone,
+{
+    path.into_iter()
+        .cartesian_product(candidates.into_iter())
+        .find(|(path, editor)| path.join(editor).exists())
+}

--- a/cli/tests/auth.bats
+++ b/cli/tests/auth.bats
@@ -72,8 +72,8 @@ teardown() {
 
   run expect -d "$TESTS_DIR/auth/loginPrompt.exp"
   assert_success
-  assert_output --partial "Verification Code:"
-  assert_output --partial "Press [enter] to open"
+  assert_line --partial "First copy your one-time code:"
+  assert_line --regexp "Press enter to open .+ in your browser\.\.\."
 }
 
 # ---------------------------------------------------------------------------- #
@@ -93,6 +93,6 @@ teardown() {
 
   run expect -d "$TESTS_DIR/auth/loginPrompt.exp"
   assert_success
-  assert_output --partial "First copy your one-time code:"
-  assert_output --regexp "visit .+ in your browser"
+  assert_line --regexp "Go to .+ in your browser"
+  assert_line --partial "Then enter your one-time code: "
 }

--- a/cli/tests/auth.bats
+++ b/cli/tests/auth.bats
@@ -1,0 +1,98 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test that we can have an authentication flow
+#
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=auth
+
+# ---------------------------------------------------------------------------- #
+
+setup_file() {
+  common_file_setup
+}
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  export PROJECT_NAME="${PROJECT_DIR##*/}"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" > /dev/null || return
+  unset FLOX_FLOXHUB_TOKEN
+  "$FLOX_BIN" auth logout
+}
+
+project_teardown() {
+  popd > /dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+  unset PROJECT_NAME
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  project_setup
+}
+
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=auth,auth:login:notty
+@test "auth login fails if not a tty" {
+  run "$FLOX_BIN" auth login
+  assert_failure
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=auth,auth:login:messages
+@test "'auth login' asks to press [enter]" {
+  # fixup linux ci systems:
+  # * ensure we simulate having a display
+  # * ensure we simulate having an opener
+  export DISPLAY="1"
+  mkdir -p ./bin
+  touch ./bin/xdg-open
+  export PATH="$PWD/bin:$PATH"
+
+  run expect -d "$TESTS_DIR/auth/loginPrompt.exp"
+  assert_success
+  assert_output --partial "Verification Code:"
+  assert_output --partial "Press [enter] to open"
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=auth,auth:login:in-ssh
+@test "'auth login' detects we are in an ssh session" {
+  # fixup linux ci systems:
+  # * ensure we simulate having a display
+  # * ensure we simulate having an opener
+  export DISPLAY="1"
+  mkdir -p ./bin
+  touch ./bin/xdg-open
+  export PATH="$PWD/bin:$PATH"
+
+  # emulate ssh environment
+  export SSH_TTY="1"
+
+  run expect -d "$TESTS_DIR/auth/loginPrompt.exp"
+  assert_success
+  assert_output --partial "First copy your one-time code:"
+  assert_output --regexp "visit .+ in your browser"
+}

--- a/cli/tests/auth/loginPrompt.exp
+++ b/cli/tests/auth/loginPrompt.exp
@@ -1,0 +1,9 @@
+set flox $env(FLOX_BIN)
+
+
+spawn $flox auth login
+
+set timeout 3
+expect {
+   timeout { exit 0 }
+}


### PR DESCRIPTION
Listen for `[enter]` events and open the token url with either `xdg-open` or `open` 
on linux or mac respectively.

closes #719 