### PR TITLE
feat(pkgdb): add `buildenv --containerize` command

### DIFF
--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -348,6 +348,11 @@ src/buildenv/realise.o: CXXFLAGS +=                   \
 src/buildenv/realise.o: CXXFLAGS +=               \
 	'-DSET_PROMPT_BASH_SH="$(SET_PROMPT_BASH_SH)"'
 
+src/buildenv/realise.o: CXXFLAGS +=               \
+	'-DSET_PROMPT_ZSH_SH="$(SET_PROMPT_ZSH_SH)"'
+
+src/buildenv/realise.o: CXXFLAGS +=               \
+	'-DCONTAINER_BUILDER_PATH="$(CONTAINER_BUILDER_PATH)"'
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -157,6 +157,8 @@ SET_PROMPT_ZSH_SH ?= $(shell                                                  \
 CONTAINER_BUILDER_PATH ?= $(shell                                                  \
   $(NIX) store add-path -n mkContainer.nix src/buildenv/assets/mkContainer.nix)
 
+COMMON_NIXPKGS_URL ?= $(shell \
+  $(NIX) eval --raw .\#flox-pkgdb.envs.COMMON_NIXPKGS_URL)
 
 # ---------------------------------------------------------------------------- #
 
@@ -354,6 +356,8 @@ src/buildenv/realise.o: CXXFLAGS +=               \
 src/buildenv/realise.o: CXXFLAGS +=               \
 	'-DCONTAINER_BUILDER_PATH="$(CONTAINER_BUILDER_PATH)"'
 
+src/buildenv/realise.o: CXXFLAGS +=               \
+	'-DCOMMON_NIXPKGS_URL="$(COMMON_NIXPKGS_URL)"'
 
 # ---------------------------------------------------------------------------- #
 

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -151,9 +151,12 @@ VERSION := $(file < $(PKGDB_ROOT)/.version)
 PROFILE_D_SCRIPTS_DIR ?= $(shell                            \
   $(NIX) build .\#flox-pkgdb.envs.PROFILE_D_SCRIPTS_DIR --print-out-paths)
 SET_PROMPT_BASH_SH ?= $(shell                                                  \
-  $(NIX) store add-path -n set-prompt.bash.sh src/buildenv/assets/set-prompt-bash.sh)
+  $(NIX) store add-path -n set-prompt.bash.sh src/buildenv/assets/set-prompt.bash.sh)
 SET_PROMPT_ZSH_SH ?= $(shell                                                  \
   $(NIX) store add-path -n set-prompt.zsh.sh src/buildenv/assets/set-prompt.zsh.sh)
+CONTAINER_BUILDER_PATH ?= $(shell                                                  \
+  $(NIX) store add-path -n mkContainer.nix src/buildenv/assets/mkContainer.nix)
+
 
 # ---------------------------------------------------------------------------- #
 
@@ -344,10 +347,6 @@ src/buildenv/realise.o: CXXFLAGS +=                   \
 
 src/buildenv/realise.o: CXXFLAGS +=               \
 	'-DSET_PROMPT_BASH_SH="$(SET_PROMPT_BASH_SH)"'
-
-src/buildenv/realise.o: CXXFLAGS +=               \
-	'-DSET_PROMPT_ZSH_SH="$(SET_PROMPT_ZSH_SH)"'
-
 
 
 

--- a/pkgdb/include/flox/buildenv/buildenv.hh
+++ b/pkgdb/include/flox/buildenv/buildenv.hh
@@ -1,0 +1,164 @@
+/* ========================================================================== *
+ *
+ * @file flox/buildenv/realise.hh
+ *
+ * @brief Compose packages and handle conflicts.
+ *        Modified version of `nix/builtins/buildenv`
+ *        that has special handling for flox packages.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#include <optional>
+#include <vector>
+
+
+#include "flox/core/exceptions.hh"
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::buildenv {
+
+struct Priority
+{
+  unsigned                   priority;
+  std::optional<std::string> parentPath;
+  unsigned                   internalPriority;
+
+  ~Priority()                  = default;
+  Priority()                   = default;
+  Priority( const Priority & ) = default;
+  Priority( Priority && )      = default;
+
+  explicit Priority( unsigned                   priority,
+                     std::optional<std::string> parentPath       = std::nullopt,
+                     unsigned                   internalPriority = 0 )
+    : priority( priority )
+    , parentPath( parentPath )
+    , internalPriority( internalPriority )
+  {}
+
+  Priority &
+  operator=( const Priority & )
+    = default;
+  Priority &
+  operator=( Priority && )
+    = default;
+
+}; /* End struct `Priority' */
+
+
+/* -------------------------------------------------------------------------- */
+
+struct RealisedPackage
+{
+  std::string path;
+  bool        active;
+  Priority    priority;
+
+  ~RealisedPackage()                         = default;
+  RealisedPackage()                          = default;
+  RealisedPackage( const RealisedPackage & ) = default;
+  RealisedPackage( RealisedPackage && )      = default;
+
+  explicit RealisedPackage( std::string path,
+                            bool        active   = false,
+                            Priority    priority = {} )
+    : path( path ), active( active ), priority( priority )
+  {}
+
+  RealisedPackage &
+  operator=( const RealisedPackage & )
+    = default;
+  RealisedPackage &
+  operator=( RealisedPackage && )
+    = default;
+
+}; /* End struct `RealisedPackage' */
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief A conflict between two files with the same priority. */
+class BuildEnvFileConflictError : public FloxException
+{
+
+private:
+
+  const std::string fileA;
+  const std::string fileB;
+  const int         priority;
+
+
+public:
+
+  BuildEnvFileConflictError( const std::string fileA,
+                             const std::string fileB,
+                             int               priority )
+    : FloxException(
+      "buildenv file conflict",
+      nix::fmt(
+        "there is a conflict for the files with priority %zu: `%s' and `%s'",
+        priority,
+        fileA,
+        fileB ) )
+    , fileA( fileA )
+    , fileB( fileB )
+    , priority( priority )
+  {}
+
+  [[nodiscard]] error_category
+  getErrorCode() const noexcept override
+  {
+    return EC_BUILDENV_CONFLICT;
+  }
+
+  [[nodiscard]] std::string_view
+  getCategoryMessage() const noexcept override
+  {
+    return "buildenv file conflict";
+  }
+
+  const std::string &
+  getFileA() const
+  {
+    return this->fileA;
+  }
+
+  const std::string &
+  getFileB() const
+  {
+    return this->fileB;
+  }
+
+  int
+  getPriority() const
+  {
+    return this->priority;
+  }
+
+
+}; /* End class `BuildEnvFileConflictError' */
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Modified version of `nix/builtins/buildenv::buildProfile` that has
+ *         special handling for flox packages.
+ * @param out the path to a build directory.
+ *            ( This directory will be loaded into the store by the caller )
+ * @param pkgs a list of packages to include in the build environment.
+ */
+void
+buildEnvironment( const std::string &             out,
+                  std::vector<RealisedPackage> && pkgs );
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox::buildenv
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/pkgdb/include/flox/buildenv/command.hh
+++ b/pkgdb/include/flox/buildenv/command.hh
@@ -37,6 +37,7 @@ private:
   nlohmann::json             lockfileContent;
   std::optional<std::string> outLink;
   std::optional<System>      system;
+  bool                       buildContainer;
 
 
 public:

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -20,6 +20,11 @@
 #include "flox/buildenv/buildenv.hh"
 #include "flox/core/exceptions.hh"
 #include "flox/resolver/lockfile.hh"
+#include <nix/build-result.hh>
+#include <nix/flake/flake.hh>
+#include <nix/get-drvs.hh>
+#include <nix/path-with-outputs.hh>
+
 
 /* -------------------------------------------------------------------------- */
 
@@ -59,6 +64,20 @@ createEnvironmentStorePath(
   std::map<nix::StorePath, std::pair<std::string, resolver::LockedPackageRaw>> &
     originalPackage );
 
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Create a @a nix::StorePath containing a buildscript for a container.
+ * @param state A `nix` evaluator.
+ * @param environmentStorePath A storepath containing a realised environment.
+ * @param system system to build the environment for.
+ * @return A @a nix::StorePath to a container builder.
+ */
+nix::StorePath
+createContainerBuilder( nix::EvalState & state,
+                        nix::StorePath   environmentStorePath,
+                        const System &   system );
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -14,154 +14,16 @@
 #include <string>
 #include <vector>
 
-#include <nix/builtins/buildenv.hh>
 #include <nix/eval.hh>
 #include <nix/store-api.hh>
 
+#include "flox/buildenv/buildenv.hh"
 #include "flox/core/exceptions.hh"
 #include "flox/resolver/lockfile.hh"
-
 
 /* -------------------------------------------------------------------------- */
 
 namespace flox::buildenv {
-
-/* -------------------------------------------------------------------------- */
-
-struct Priority
-{
-  unsigned                   priority;
-  std::optional<std::string> parentPath;
-  unsigned                   internalPriority;
-
-  ~Priority()                  = default;
-  Priority()                   = default;
-  Priority( const Priority & ) = default;
-  Priority( Priority && )      = default;
-
-  explicit Priority( unsigned                   priority,
-                     std::optional<std::string> parentPath       = std::nullopt,
-                     unsigned                   internalPriority = 0 )
-    : priority( priority )
-    , parentPath( parentPath )
-    , internalPriority( internalPriority )
-  {}
-
-  Priority &
-  operator=( const Priority & )
-    = default;
-  Priority &
-  operator=( Priority && )
-    = default;
-
-}; /* End struct `Priority' */
-
-
-/* -------------------------------------------------------------------------- */
-
-struct RealisedPackage
-{
-  std::string path;
-  bool        active;
-  Priority    priority;
-
-  ~RealisedPackage()                         = default;
-  RealisedPackage()                          = default;
-  RealisedPackage( const RealisedPackage & ) = default;
-  RealisedPackage( RealisedPackage && )      = default;
-
-  explicit RealisedPackage( std::string path,
-                            bool        active   = false,
-                            Priority    priority = {} )
-    : path( path ), active( active ), priority( priority )
-  {}
-
-  RealisedPackage &
-  operator=( const RealisedPackage & )
-    = default;
-  RealisedPackage &
-  operator=( RealisedPackage && )
-    = default;
-
-}; /* End struct `RealisedPackage' */
-
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief A conflict between two files with the same priority. */
-class BuildEnvFileConflictError : public FloxException
-{
-
-private:
-
-  const std::string fileA;
-  const std::string fileB;
-  const int         priority;
-
-
-public:
-
-  BuildEnvFileConflictError( const std::string fileA,
-                             const std::string fileB,
-                             int               priority )
-    : FloxException(
-      "buildenv file conflict",
-      nix::fmt(
-        "there is a conflict for the files with priority %zu: `%s' and `%s'",
-        priority,
-        fileA,
-        fileB ) )
-    , fileA( fileA )
-    , fileB( fileB )
-    , priority( priority )
-  {}
-
-  [[nodiscard]] error_category
-  getErrorCode() const noexcept override
-  {
-    return EC_BUILDENV_CONFLICT;
-  }
-
-  [[nodiscard]] std::string_view
-  getCategoryMessage() const noexcept override
-  {
-    return "buildenv file conflict";
-  }
-
-  const std::string &
-  getFileA() const
-  {
-    return this->fileA;
-  }
-
-  const std::string &
-  getFileB() const
-  {
-    return this->fileB;
-  }
-
-  int
-  getPriority() const
-  {
-    return this->priority;
-  }
-
-
-}; /* End class `BuildEnvFileConflictError' */
-
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief Modified version of `nix/builtins/buildenv::buildProfile` that has
- *         special handling for flox packages.
- * @param out the path to a build directory.
- *            ( This directory will be loaded into the store by the caller )
- * @param pkgs a list of packages to include in the build environment.
- */
-void
-buildEnvironment( const std::string &             out,
-                  std::vector<RealisedPackage> && pkgs );
-
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/src/buildenv/assets/mkContainer.nix
+++ b/pkgdb/src/buildenv/assets/mkContainer.nix
@@ -41,6 +41,8 @@
       Env = lib.mapAttrsToList (name: value: "${name}=${value}") {
         "FLOX_ENV" = environment;
         "FLOX_PROMPT_ENVIRONMENTS" = "floxenv";
+        "FLOX_PROMPT_COLOR_1" = "61";
+        "FLOX_PROMPT_COLOR_2" = "216";
         "FLOX_ACTIVE_ENVIRONMENTS" = "[]";
         "FLOX_SOURCED_FROM_SHELL_RC" = "1"; # don't source from shell rc (again)
         "BASH_ENV" = "${environment}/activate/bash";

--- a/pkgdb/src/buildenv/assets/mkContainer.nix
+++ b/pkgdb/src/buildenv/assets/mkContainer.nix
@@ -9,6 +9,8 @@
   system,
 }: let
   pkgs = nixpkgsFlake.legacyPackages.${system};
+  lowPriority = pkg: pkg.overrideAttrs (old: old // {meta = (old.meta or {}) // {priority = 10000;};});
+
   buildLayeredImageArgs = {
     name = "flox-env-container";
     # symlinkJoin fails when drv contains a symlinked bin directory, so wrap in an additional buildEnv
@@ -16,8 +18,8 @@
       name = "contents";
       paths = [
         environmentOutPath
-        pkgs.bashInteractive # for a usable shell
-        pkgs.coreutils # for just the basic utils
+        (lowPriority pkgs.bashInteractive) # for a usable shell
+        (lowPriority pkgs.coreutils) # for just the basic utils
       ];
     };
     config = {};

--- a/pkgdb/src/buildenv/assets/mkContainer.nix
+++ b/pkgdb/src/buildenv/assets/mkContainer.nix
@@ -8,6 +8,7 @@
   # the system to build for
   system,
 }: let
+  environmentOutPath' = builtins.storePath environmentOutPath;
   pkgs = nixpkgsFlake.legacyPackages.${system};
   lowPriority = pkg: pkg.overrideAttrs (old: old // {meta = (old.meta or {}) // {priority = 10000;};});
 
@@ -17,7 +18,7 @@
     contents = pkgs.buildEnv {
       name = "contents";
       paths = [
-        environmentOutPath
+        environmentOutPath'
         (lowPriority pkgs.bashInteractive) # for a usable shell
         (lowPriority pkgs.coreutils) # for just the basic utils
       ];

--- a/pkgdb/src/buildenv/assets/mkContainer.nix
+++ b/pkgdb/src/buildenv/assets/mkContainer.nix
@@ -1,0 +1,26 @@
+# A wrapper around dockerTools.streamLayeredImage that
+# composes a storePath to an environment with a shell and core utils
+{
+  # the (bundled) nixpkgs flake
+  nixpkgsFlake,
+  # the path to the environment that was built previously
+  environmentOutPath,
+  # the system to build for
+  system,
+}: let
+  pkgs = nixpkgsFlake.legacyPackages.${system};
+  buildLayeredImageArgs = {
+    name = "flox-env-container";
+    # symlinkJoin fails when drv contains a symlinked bin directory, so wrap in an additional buildEnv
+    contents = pkgs.buildEnv {
+      name = "contents";
+      paths = [
+        environmentOutPath
+        pkgs.bashInteractive # for a usable shell
+        pkgs.coreutils # for just the basic utils
+      ];
+    };
+    config = {};
+  };
+in
+  pkgs.dockerTools.streamLayeredImage buildLayeredImageArgs

--- a/pkgdb/src/buildenv/assets/mkContainer.nix
+++ b/pkgdb/src/buildenv/assets/mkContainer.nix
@@ -7,9 +7,12 @@
   environmentOutPath,
   # the system to build for
   system,
+  containerSystem,
 }: let
-  environmentOutPath' = builtins.storePath environmentOutPath;
+  environment = builtins.storePath environmentOutPath;
   pkgs = nixpkgsFlake.legacyPackages.${system};
+  containerPkgs = nixpkgsFlake.legacyPackages.${containerSystem};
+  lib = pkgs.lib;
   lowPriority = pkg: pkg.overrideAttrs (old: old // {meta = (old.meta or {}) // {priority = 10000;};});
 
   buildLayeredImageArgs = {
@@ -18,9 +21,9 @@
     contents = pkgs.buildEnv {
       name = "contents";
       paths = [
-        environmentOutPath'
-        (lowPriority pkgs.bashInteractive) # for a usable shell
-        (lowPriority pkgs.coreutils) # for just the basic utils
+        environment
+        (lowPriority containerPkgs.bashInteractive) # for a usable shell
+        (lowPriority containerPkgs.coreutils) # for just the basic utils
       ];
     };
     config = {};

--- a/pkgdb/src/buildenv/buildenv.cc
+++ b/pkgdb/src/buildenv/buildenv.cc
@@ -8,7 +8,6 @@
  * -------------------------------------------------------------------------- */
 
 #include <algorithm>
-#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -44,7 +44,8 @@ namespace flox::buildenv {
 
 BuildEnvCommand::BuildEnvCommand() : parser( "buildenv" )
 {
-  this->parser.add_description( "Evaluate and build a locked environment" );
+  this->parser.add_description( "Evaluate and build a locked environment, "
+                                "optionally produce a container build script" );
   this->parser.add_argument( "lockfile" )
     .help( "inline JSON or path to lockfile" )
     .required()
@@ -53,7 +54,7 @@ BuildEnvCommand::BuildEnvCommand() : parser( "buildenv" )
              { this->lockfileContent = parseOrReadJSONObject( str ); } );
 
   this->parser.add_argument( "--out-link", "-o" )
-    .help( "path to link resulting environment" )
+    .help( "path to link resulting environment or builder to" )
     .metavar( "OUT-LINK" )
     .action( [&]( const std::string & str ) { this->outLink = str; } );
 
@@ -64,7 +65,7 @@ BuildEnvCommand::BuildEnvCommand() : parser( "buildenv" )
     .action( [&]( const std::string & str ) { this->system = str; } );
 
   this->parser.add_argument( "--container", "-c" )
-    .help( "build a container" )
+    .help( "build a container builder script" )
     .nargs( 0 )
     .action( [&]( const auto & ) { this->buildContainer = true; } );
 }

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -40,6 +40,11 @@ BuildEnvCommand::BuildEnvCommand() : parser( "buildenv" )
     .metavar( "SYSTEM" )
     .nargs( 1 )
     .action( [&]( const std::string & str ) { this->system = str; } );
+
+  this->parser.add_argument( "--container", "-c" )
+    .help( "build a container" )
+    .nargs( 0 )
+    .action( [&]( const auto & ) { this->buildContainer = true; } );
 }
 
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -52,6 +52,10 @@ namespace flox::buildenv {
     "CONTAINER_BUILDER_PATH must be set to a store path of 'mkContainer.nix'"
 #endif
 
+#ifndef COMMON_NIXPKGS_URL
+#  error "COMMON_NIXPKGS_URL must be set to a locked flakeref of nixpkgs to use"
+#endif
+
 /* -------------------------------------------------------------------------- */
 
 static const std::string BASH_ACTIVATE_SCRIPT = R"(
@@ -405,12 +409,8 @@ createContainerBuilder( nix::EvalState & state,
                         nix::StorePath   environmentStorePath,
                         const System &   system )
 {
-
-  static const std::string refOrRev
-    = nix::getEnv( "_PKGDB_GA_REGISTRY_REF_OR_REV" )
-        .value_or( "release-23.05" );
   static const nix::FlakeRef nixpkgsRef
-    = nix::parseFlakeRef( "github:NixOS/nixpkgs/" + refOrRev );
+    = nix::parseFlakeRef( COMMON_NIXPKGS_URL );
 
   auto lockedNixpkgs
     = nix::flake::lockFlake( state, nixpkgsRef, nix::flake::LockFlags() );

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -430,7 +430,7 @@ createContainerBuilder( nix::EvalState & state,
   vEnvironmentStorePath.mkPath( sStorePath.c_str() );
 
   nix::Value vSystem;
-  vSystem.mkString( system );
+  vSystem.mkString( nix::nativeSystem );
 
 
   nix::Value vBindings;

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -432,14 +432,19 @@ createContainerBuilder( nix::EvalState & state,
   nix::Value vSystem;
   vSystem.mkString( nix::nativeSystem );
 
+  nix::Value vContainerSystem;
+  vContainerSystem.mkString( system );
 
   nix::Value vBindings;
-  auto       bindings = state.buildBindings( 3 );
+  auto       bindings = state.buildBindings( 4 );
   bindings.push_back(
     { state.symbols.create( "nixpkgsFlake" ), &vNixpkgsFlake } );
   bindings.push_back(
     { state.symbols.create( "environmentOutPath" ), &vEnvironmentStorePath } );
   bindings.push_back( { state.symbols.create( "system" ), &vSystem } );
+  bindings.push_back(
+    { state.symbols.create( "containerSystem" ), &vContainerSystem } );
+
   vBindings.mkAttrs( bindings );
 
   nix::Value vContainerBuilderDrv;

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -162,6 +162,30 @@ setup_file() {
 }
 
 # ---------------------------------------------------------------------------- #
+
+# With '--container' produces a script that can be used to build a container.
+# bats test_tags=buildenv:container
+@test "Environment builds container" {
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/single-package/manifest.lock" \
+    --container \
+    --out-link "$BATS_TEST_TMPDIR/container-builder"
+  assert_success
+
+  # Run the container builder script.
+  run bash -c '"$BATS_TEST_TMPDIR/container-builder" > "$BATS_TEST_TMPDIR/container"'
+  assert_success
+
+  # Check that the container is a tar archive.
+  run tar -tf "$BATS_TEST_TMPDIR/container"
+  # Check that the container contains layer(s)
+  assert_output --regexp '([a-z0-9]{64}/layer.tar)+'
+  # Check that the container contains a config file.
+  assert_output --regexp '([a-z0-9]{64}\.json)'
+  # Check that the container contains a manifest file.
+  assert_line 'manifest.json'
+}
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -89,6 +89,18 @@
       name = "mkContainer.nix";
       path = ../../pkgdb/src/buildenv/assets/mkContainer.nix;
     };
+
+    # Used by `buildenv --container' to access `dockerTools` at a known version
+    # When utilities from nixpkgs are used by flox at runtime,
+    # they should be
+    # a) bundled at buildtime if possible (binaries/packages)
+    # b) use this version of nixpkgs i.e. (nix library utils such as `dockerTools`)
+    COMMON_NIXPKGS_URL = let
+      lockfile = builtins.fromJSON (builtins.readFile ./../../flake.lock);
+      root = lockfile.nodes.${lockfile.root};
+      nixpkgs = lockfile.nodes.${root.inputs.nixpkgs}.locked;
+    in
+      builtins.flakeRefToString nixpkgs;
   };
 in
   stdenv.mkDerivation ({

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -83,6 +83,12 @@
       name = "set-prompt.zsh.sh";
       path = ../../pkgdb/src/buildenv/assets/set-prompt.zsh.sh;
     };
+
+    # Used by `buildenv --container' to create a container builder script.
+    CONTAINER_BUILDER_PATH = builtins.path {
+      name = "mkContainer.nix";
+      path = ../../pkgdb/src/buildenv/assets/mkContainer.nix;
+    };
   };
 in
   stdenv.mkDerivation ({

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -100,7 +100,8 @@
       root = lockfile.nodes.${lockfile.root};
       nixpkgs = lockfile.nodes.${root.inputs.nixpkgs}.locked;
     in
-      builtins.flakeRefToString nixpkgs;
+      # todo: use `builtins.flakerefToString` once flox ships with nix 2.18+
+      "github:NixOS/nixpkgs/${nixpkgs.rev}";
   };
 in
   stdenv.mkDerivation ({


### PR DESCRIPTION
Build a container builder using `dockerTools.streamLayeredImage`

- builds the environment 
- if `--container` provided calls vendored `mkContainer.nix` script with 
  (1) a `nixpkgs` flake,
  (2) the storePath of the built environment
  (3) the host system
- `mkContainer.nix` creates a container builder that contains 
  (1) the environment
  (2) `bashInteractive`
  (3) `coreutils`
