### PR TITLE
fix: use main branch of install-flox-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         uses: "cachix/install-nix-action@v24"
 
       - name: "Install flox"
-        uses: "flox/install-flox-action@upload-more-to-cache"
+        uses: "flox/install-flox-action@main"
         with:
           github-access-token:      "${{ secrets.NIX_GIT_TOKEN }}"
           substituter:              "${{ vars.FLOX_CACHE_PUBLIC_BUCKET }}"
@@ -113,7 +113,7 @@ jobs:
         uses: "cachix/install-nix-action@v24"
 
       - name: "Install flox"
-        uses: "flox/install-flox-action@upload-more-to-cache"
+        uses: "flox/install-flox-action@main"
         with:
           github-access-token:      "${{ secrets.NIX_GIT_TOKEN }}"
           substituter:              "${{ vars.FLOX_CACHE_PUBLIC_BUCKET }}"
@@ -216,7 +216,7 @@ jobs:
         uses: "cachix/install-nix-action@v24"
 
       - name: "Install flox"
-        uses: "flox/install-flox-action@upload-more-to-cache"
+        uses: "flox/install-flox-action@main"
         with:
           github-access-token:      "${{ secrets.NIX_GIT_TOKEN }}"
           substituter:              "${{ vars.FLOX_CACHE_PUBLIC_BUCKET }}"
@@ -330,7 +330,7 @@ jobs:
       - name: "Install newer Nix"
         uses: "cachix/install-nix-action@v24"
       - name: "Install flox"
-        uses: "flox/install-flox-action@upload-more-to-cache"
+        uses: "flox/install-flox-action@main"
         with:
           github-access-token:      "${{ secrets.NIX_GIT_TOKEN }}"
           substituter:              "${{ vars.FLOX_CACHE_PUBLIC_BUCKET }}"


### PR DESCRIPTION
## Proposed Changes

use main branch of install action, this should have the effect of trimming down our post-install-action to be faster (and smaller in terms of taking less space)


## Release Notes

N/A
