### PR TITLE
feat: inject current system during init

### DIFF
--- a/assets/templateFloxEnv/manifest.toml
+++ b/assets/templateFloxEnv/manifest.toml
@@ -20,13 +20,21 @@
 # pass-in = "$some-env-var" 
 
 # An activation hook will be run when entering the environment.
-# You can define one in 'hook' table with an inline 'script' field,
+# You can define one in the 'hook' table inline via the 'script' field,
 # or provide a file using the 'file' field.
 # If 'file' is provided, the path should be relative to this file.
 # If both 'file' and 'script' are provided,
-# only the hook defined in 'file' will be run 
+# only the hook defined in 'file' will be run .
 
 [hook]
 # script = """
 #   echo "it's gettin flox in here";
 # """
+
+# An environment that works on one system is guaranteed to work on the
+# same type of system,
+# but other systems may not have the same packages available, etc.
+# In order to use the environment on a system you must explicitly
+# add it to this list.
+[options]
+systems = ["_FLOX_INIT_SYSTEM"]

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -675,7 +675,7 @@ pub mod tests {
         channels.register_channel("flox", "github:flox/floxpkgs/master".parse().unwrap());
 
         let flox = Flox {
-            system: "aarch64-darwin".to_string(),
+            system: env!("NIX_TARGET_SYSTEM").to_string(),
             cache_dir,
             data_dir,
             temp_dir,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -57,6 +57,7 @@ pub const FLOX_ENV_VAR: &str = "FLOX_ENV";
 pub const FLOX_ACTIVE_ENVIRONMENTS_VAR: &str = "FLOX_ACTIVE_ENVIRONMENTS";
 pub const FLOX_PROMPT_ENVIRONMENTS_VAR: &str = "FLOX_PROMPT_ENVIRONMENTS";
 pub const M4_BIN: &str = env!("M4_BIN");
+pub const FLOX_SYSTEM_PLACEHOLDER: &str = "_FLOX_INIT_SYSTEM";
 
 pub type UpdateResult = (Option<LockedManifest>, LockedManifest);
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -56,7 +56,6 @@ pub const ENV_DIR_NAME: &str = "env";
 pub const FLOX_ENV_VAR: &str = "FLOX_ENV";
 pub const FLOX_ACTIVE_ENVIRONMENTS_VAR: &str = "FLOX_ACTIVE_ENVIRONMENTS";
 pub const FLOX_PROMPT_ENVIRONMENTS_VAR: &str = "FLOX_PROMPT_ENVIRONMENTS";
-pub const M4_BIN: &str = env!("M4_BIN");
 pub const FLOX_SYSTEM_PLACEHOLDER: &str = "_FLOX_INIT_SYSTEM";
 
 pub type UpdateResult = (Option<LockedManifest>, LockedManifest);

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -56,6 +56,7 @@ pub const ENV_DIR_NAME: &str = "env";
 pub const FLOX_ENV_VAR: &str = "FLOX_ENV";
 pub const FLOX_ACTIVE_ENVIRONMENTS_VAR: &str = "FLOX_ACTIVE_ENVIRONMENTS";
 pub const FLOX_PROMPT_ENVIRONMENTS_VAR: &str = "FLOX_PROMPT_ENVIRONMENTS";
+pub const M4_BIN: &str = env!("M4_BIN");
 
 pub type UpdateResult = (Option<LockedManifest>, LockedManifest);
 
@@ -343,6 +344,8 @@ pub enum EnvironmentError2 {
     EnvironmentExists(PathBuf),
     #[error("could not write .gitignore file")]
     WriteGitignore(#[source] std::io::Error),
+    #[error("couldn't update manifest")]
+    ManifestEdit(#[source] std::io::Error),
     // endregion
 
     // todo: rmove with "catalog()" method

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -400,9 +400,6 @@ impl PathEnvironment {
 #[cfg(test)]
 mod tests {
 
-    use std::process::Command;
-    use std::str::FromStr;
-
     use super::*;
     use crate::flox::tests::flox_instance;
 
@@ -447,6 +444,7 @@ mod tests {
         assert!(actual.path.is_absolute());
     }
 
+    /// Write a manifest file with invalid toml to ensure we can catch
     #[test]
     fn cache_activation_path() {
         let (flox, temp_dir) = flox_instance();
@@ -461,20 +459,6 @@ mod tests {
             &flox.system,
         )
         .unwrap();
-        // building requires packages in the manifest, install one so the build succeeds and the outlink is built
-        let pkgs = vec![
-            PackageToInstall::from_str("hello").expect("couldn't create package from 'hello'")
-        ];
-        env.install(&pkgs, &flox).expect("couldn't install 'hello'");
-
-        // Need to touch the manifest so that its mtime is more recent than the outlink
-        Command::new("touch")
-            .arg(
-                env.manifest_path(&flox)
-                    .expect("couldn't get manifest path"),
-            )
-            .output()
-            .expect("couldn't touch manifest");
 
         assert!(env.needs_rebuild(&flox).unwrap());
 

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -560,7 +560,12 @@ impl Init {
                 .parse()?
         };
 
-        let env = PathEnvironment::init(PathPointer::new(env_name), &dir, flox.temp_dir.clone())?;
+        let env = PathEnvironment::init(
+            PathPointer::new(env_name),
+            &dir,
+            flox.temp_dir.clone(),
+            &flox.system,
+        )?;
 
         println!(
             indoc::indoc! {"

--- a/cli/tests/environment-init.bats
+++ b/cli/tests/environment-init.bats
@@ -146,12 +146,18 @@ function check_with_dir() {
   check_with_dir
 }
 
-# bats test_tags=init,init:gitignore
+# bats test_tags=init:gitignore
 @test "c9: flox init adds .gitingore that ignores run/ directory" {
   "$FLOX_BIN" init
   run cat .flox/.gitignore
   assert_success
   assert_line "run/"
+}
+
+@test "'flox init' injects current system" {
+  "$FLOX_BIN" init
+  init_system=$(tomlq -r '.options.systems[0]' .flox/env/manifest.toml)
+  assert_equal "$init_system" "$NIX_SYSTEM"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -23,6 +23,7 @@
   gnutar,
   jq,
   nix,
+  yq,
   nix-serve,
   openssh,
   parallel,
@@ -63,6 +64,7 @@
       parallel
       unixtools.util-linux
       which
+      yq
     ]
     # TODO: this hack is not going to be needed once we test against sutff on system
     ++ lib.optional stdenv.isDarwin (

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -3,7 +3,6 @@
   gcc,
   runCommandCC,
   stdenv,
-  darwin,
   lib,
   bash,
   zsh,

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -22,7 +22,6 @@
   installShellFiles,
   runCommand,
   fd,
-  gnum4,
   gnused,
   gitMinimal,
   nix,
@@ -63,7 +62,6 @@
         if flox-pkgdb == null
         then "pkgdb"
         else "${flox-pkgdb}/bin/pkgdb";
-      M4_BIN = "${gnum4}/bin/m4";
       PARSER_UTIL_BIN = "${parser-util}/bin/parser-util";
       FLOX_ETC_DIR = ../../assets/etc;
       FLOX_ZDOTDIR = ../../assets/flox.zdotdir;

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -22,11 +22,11 @@
   installShellFiles,
   runCommand,
   fd,
+  gnum4,
   gnused,
   gitMinimal,
   nix,
   pkgsFor,
-  pre-commit-check,
   flox-pkgdb,
 }: let
   flox-src = builtins.path {
@@ -63,6 +63,7 @@
         if flox-pkgdb == null
         then "pkgdb"
         else "${flox-pkgdb}/bin/pkgdb";
+      M4_BIN = "${gnum4}/bin/m4";
       PARSER_UTIL_BIN = "${parser-util}/bin/parser-util";
       FLOX_ETC_DIR = ../../assets/etc;
       FLOX_ZDOTDIR = ../../assets/flox.zdotdir;


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Adds the `options.systems` field during init populated with the current system. 

`m4` is used to inject the system into the template instead of `toml_edit` because `toml_edit` injects the `options` table between the `hook` table and the commented out script below it, so a user that uncomments the script hook will encounter an error.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users that create an environment will now explicitly have their sytem type added to the manifest.

<!-- Many thanks! -->
