### PR TITLE
fix: increase busy wait timeout

### DIFF
--- a/pkgdb/include/flox/pkgdb/read.hh
+++ b/pkgdb/include/flox/pkgdb/read.hh
@@ -48,7 +48,7 @@ namespace flox::pkgdb {
  * but set a large number of retries so that a slow database operation isn't
  * terminated too early. */
 const DurationMillis DB_RETRY_PERIOD = DurationMillis( 100 );
-const int            DB_MAX_RETRIES  = 1000;
+const int            DB_MAX_RETRIES  = 2500;
 
 #define RETRY_WHILE_BUSY( op )                                    \
   int _retry_while_busy_rcode   = op;                             \


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Increases the database retry timeout  from 100s to 250s so that slow CI operations don't spuriously fail.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
