### PR TITLE
feat: allow running without catching

### DIFF
--- a/pkgdb/src/main.cc
+++ b/pkgdb/src/main.cc
@@ -151,6 +151,20 @@ printAndReturnException( const flox::FloxException & err )
 int
 main( int argc, char * argv[] )
 {
+  /* Allows you to run without catching which is useful for
+   * `gdb'/`lldb' backtraces. */
+  auto maybeNC = std::getenv( "PKGDB_NO_CATCH" );
+  if ( maybeNC != nullptr )
+    {
+      std::string noCatch = std::string( maybeNC );
+      if ( ( maybeNC != std::string( "" ) )
+           && ( maybeNC != std::string( "0" ) ) )
+        {
+          return run( argc, argv );
+        }
+    }
+
+  /* Wrap all execution in an error handler that pretty prints exceptions. */
   try
     {
       return run( argc, argv );


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Run `pkgdb` without catching exceptions by setting `PKGDB_NO_CATCH` to something non-empty and non-`"0"`. This is only useful for debugging as exception-catching machinery clutters backtraces.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
