### PR TITLE
fix: remove async telemetry event handling

### DIFF
--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::prelude::*;
 
 use crate::commands::Verbosity;
 use crate::utils::logger::{self, LogFormatter};
-use crate::utils::metrics::PosthogLayer;
+use crate::utils::metrics::MetricsLayer;
 use crate::utils::TERMINAL_STDERR;
 
 struct LockingTerminalStderr;
@@ -35,7 +35,7 @@ impl std::io::Write for LockingTerminalStderr {
     }
 }
 
-type LayerType = tracing_subscriber::layer::Layered<PosthogLayer, tracing_subscriber::Registry>;
+type LayerType = tracing_subscriber::layer::Layered<MetricsLayer, tracing_subscriber::Registry>;
 type ReloadHandle<T> = tracing_subscriber::reload::Handle<T, LayerType>;
 
 #[allow(clippy::type_complexity)]
@@ -94,7 +94,7 @@ pub fn init_logger(verbosity: Option<Verbosity>, debug: Option<bool>) {
         let fmt_filtered = fmt_reloadable.with_filter(filter_reloadable);
 
         tracing_subscriber::registry()
-            .with(PosthogLayer::new())
+            .with(MetricsLayer::new())
             .with(fmt_filtered)
             .init();
 

--- a/cli/flox/src/utils/init/metrics.rs
+++ b/cli/flox/src/utils/init/metrics.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::utils::metrics::{
     MetricEntry,
-    PosthogEvent,
+    MetricEvent,
     METRICS_LOCK_FILE_NAME,
     METRICS_UUID_FILE_NAME,
 };
@@ -73,7 +73,7 @@ pub async fn init_telemetry(data_dir: impl AsRef<Path>, cache_dir: impl AsRef<Pa
     // Generate a real metric to use as an example so they can see the field contents are non-threatening
     let now = OffsetDateTime::now_utc();
     let example_metric_entry = MetricEntry::new(
-        PosthogEvent {
+        MetricEvent {
             subcommand: "[subcommand]".to_string().into(),
             extras: Default::default(),
         },

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -59,15 +59,15 @@ pub struct MetricEvent {
     pub extras: HashMap<String, String>,
 }
 
-pub struct PosthogLayer {}
+pub struct MetricsLayer {}
 
-impl PosthogLayer {
+impl MetricsLayer {
     pub fn new() -> Self {
-        PosthogLayer {}
+        MetricsLayer {}
     }
 }
 
-impl<S> tracing_subscriber::Layer<S> for PosthogLayer
+impl<S> tracing_subscriber::Layer<S> for MetricsLayer
 where
     S: tracing::Subscriber,
 {

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -54,7 +54,7 @@ impl<'a> tracing::field::Visit for PosthogVisitor<'a> {
     }
 }
 
-pub struct PosthogEvent {
+pub struct MetricEvent {
     pub subcommand: Option<String>,
     pub extras: HashMap<String, String>,
 }
@@ -85,7 +85,7 @@ where
         let mut visitor = PosthogVisitor(&mut subcommand, &mut extras);
         event.record(&mut visitor);
 
-        if let Err(err) = add_metric(PosthogEvent { subcommand, extras }) {
+        if let Err(err) = add_metric(MetricEvent { subcommand, extras }) {
             debug!("Error adding metric: {err}");
         }
     }
@@ -107,7 +107,7 @@ pub struct MetricEntry {
 
 impl MetricEntry {
     pub fn new(
-        PosthogEvent { subcommand, extras }: PosthogEvent,
+        MetricEvent { subcommand, extras }: MetricEvent,
         now: OffsetDateTime,
     ) -> MetricEntry {
         let linux_release = sys_info::linux_os_release().ok();
@@ -341,7 +341,7 @@ fn read_metrics_uuid(config: &Config) -> Result<Uuid> {
         })
 }
 
-fn add_metric(event: PosthogEvent) -> Result<()> {
+fn add_metric(event: MetricEvent) -> Result<()> {
     let config = Config::parse()?;
 
     if config.flox.disable_metrics {

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -37,9 +37,9 @@ macro_rules! subcommand_metric {
     }};
 }
 
-struct PosthogVisitor<'a>(&'a mut Option<String>, &'a mut HashMap<String, String>);
+struct MetricVisitor<'a>(&'a mut Option<String>, &'a mut HashMap<String, String>);
 
-impl<'a> tracing::field::Visit for PosthogVisitor<'a> {
+impl<'a> tracing::field::Visit for MetricVisitor<'a> {
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
         if field.name() == "subcommand" {
             *self.0 = Some(value.to_string());


### PR DESCRIPTION
The telemetry sending used to happen in an async context on a separate thread.
Events were sent to the telemetry thread using mpsc and handled concurrently with the main thread.
Both threads were using a handle to the same global `tokio` runtime.
When the execution of the main thread completes, the async runtime is dropped.
Any task still on the runtime is aborted.
As telemetry buffering **and transfer** used the same runtime on a parallel thread,
we observed frequent aborts of the telemetry transfer (https://github.com/flox/flox/issues/432).

This PR drops the concurrent telemetry thread in favour of immediate writes to the metrics buffer
and _occasional_ transfer.

* writing on the main thread _will_ incur a small amount of time,
  we hope the delay will be non-noticeable in practice
* every two hours the buffer is flushed to the upstream telemetry backend,
  this may be a longer delay.
  We should monitor whether this is noticeable and needs further refinement.
* since we write on the main thread, `panic` should be avoided at all cost.
