### PR TITLE
feat: use same LLVM across development tooling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -159,7 +159,7 @@
           rust.cargoManifestPath = "cli/Cargo.toml";
         };
         tools = {
-          clang-tools = final.clang-tools_16;
+          clang-tools = final.clang-tools_15;
         };
       };
 
@@ -247,6 +247,10 @@
     in {
       default = pkgs.callPackage ./shells/default {
         inherit (checksFor) pre-commit-check;
+      };
+      ci = pkgs.callPackage ./shells/default {
+        inherit (checksFor) pre-commit-check;
+        ci = true;
       };
     });
   }; # End `outputs'

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -223,7 +223,6 @@ in
 
         ciPackages = [];
 
-
         devPackages = [
           rustfmt
           clippy

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -5,6 +5,7 @@
   doxygen,
   bear,
   boost,
+  llvmPackages_15,
   ccls,
   clang-tools_16,
   include-what-you-use,
@@ -27,13 +28,15 @@
   git,
   coreutils,
   parallel,
-  llvm, # for `llvm-symbolizer'
+  llvm_15, # for `llvm-symbolizer'
   gdb ? throw "`gdb' is required for debugging with `g++'",
   lldb ? throw "`lldb' is required for debugging with `clang++'",
   valgrind ? throw "`valgrind' is required for memory sanitization on Linux",
   substituteAll,
   symlinkJoin,
 }: let
+  llvmPackages = llvmPackages_15;
+  llvm = llvm_15;
   batsWith = bats.withLibraries (p: [
     p.bats-assert
     p.bats-file
@@ -204,7 +207,9 @@ in
             lcov
             remake
             # For IDEs
-            ccls
+            (ccls.override (old: {
+              llvmPackages = llvmPackages;
+            }))
             bear
             # For lints/fmt
             clang-tools_16

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -208,7 +208,9 @@ in
             bear
             # For lints/fmt
             clang-tools_16
-            include-what-you-use
+            (include-what-you-use.override (old: {
+              llvmPackages = llvmPackages;
+            }))
             llvm # for `llvm-symbolizer'
             # For debugging
             (

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -45,7 +45,7 @@ in
       shellHook =
         flox-pkgdb.devShellHook
         + flox-cli.devShellHook
-        + pre-commit-check.shellHook;
+        + lib.optionalString (!ci) pre-commit-check.shellHook;
     }
     // flox-pkgdb.devEnvs
     // flox-cli.devEnvs


### PR DESCRIPTION
## Proposed Changes
- Ensure we use the same version of llvm/clang/etc throughout development.
- adds ci devShell (so far not used)

Are the clang-14 or clang-16 versions required or necessary for something?

Alternative: override llvmPackages_* and llvm_* and clang-tools_* in the overlay; that is more comprehensive, but less targeted/precise.

Note: overall bump to release-23.11 would make clang_16 the default. release-23.05 uses 11.1 by default.

## Release Notes
N/A