### PR TITLE
feat: don't set tarballTtl to 24 hours

### DIFF
--- a/pkgdb/src/nix-state.cc
+++ b/pkgdb/src/nix-state.cc
@@ -49,9 +49,6 @@ initNix()
   nix::experimentalFeatureSettings.experimentalFeatures.assign(
     std::set( { nix::Xp::Flakes } ) );
 
-  /* Only refresh the global registry once per 24 hours. */
-  nix::settings.tarballTtl = 60 * 60 * 24;
-
   /* Use custom logger */
   bool printBuildLogs = nix::logger->isVerbose();
   if ( nix::logger != nullptr ) { delete nix::logger; }


### PR DESCRIPTION
Now that pkgdb databases are explicitly generated with `flox update`, we can use the shorter default Nix tarballTtl without triggering random slowdowns.
