### PR TITLE
fix: drop unused variable

### DIFF
--- a/pkgdb/src/resolver/command.cc
+++ b/pkgdb/src/resolver/command.cc
@@ -159,11 +159,9 @@ UpdateCommand::run()
   /* If the manifest doesn't have a value, assume we're updating the global
    * manifest, and set a dummy empty manifest.
    * TODO: be less hacky. */
-  bool global = false;
   if ( ! this->getManifestRaw().has_value() )
     {
       this->setManifestRaw( ManifestRaw {} );
-      global = true;
     }
   nlohmann::json lockfile;
   if ( auto maybeLockfile = this->getLockfile(); maybeLockfile.has_value() )


### PR DESCRIPTION
Thanks goes to the compiler