### PR TITLE
fix: improve containerize tests and touch up command implementation

### DIFF
--- a/cli/flox-rust-sdk/src/models/container_builder.rs
+++ b/cli/flox-rust-sdk/src/models/container_builder.rs
@@ -4,6 +4,14 @@ use std::process::{Command, Stdio};
 
 use thiserror::Error;
 
+/// Type representing a container builder script,
+/// i.e. the output of `pkgdb buildenv --container`
+/// ([LockedManifest::build_container](crate::models::lockfile::LockedManifest::build_container)).
+///
+/// The script is executed with no arguments
+/// and writes a container tarball to stdout.
+///
+/// [ContainerBuilder::stream_container] can be used to write that tarball to a sink.
 pub struct ContainerBuilder {
     path: PathBuf,
 }
@@ -16,6 +24,8 @@ impl ContainerBuilder {
         Self { path }
     }
 
+    /// Run the container builder script
+    /// and write the container tarball to the given sink
     pub fn stream_container(&self, mut sink: impl Write) -> Result<(), ContainerBuilderError> {
         let mut container_builder_command = Command::new(&self.path);
         container_builder_command.stdout(Stdio::piped());

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1746,12 +1746,12 @@ impl Containerize {
                 .join(format!("{}-container.tar.gz", env.name())),
         };
 
-        let output: Box<dyn Write> = if output_path == Path::new("-") {
-            debug!("writing container to stdout");
+        let (output, output_name): (Box<dyn Write>, String) = if output_path == Path::new("-") {
+            debug!("output=stdout");
 
-            Box::new(std::io::stdout())
+            (Box::new(std::io::stdout()), "stdout".to_string())
         } else {
-            debug!("writing container to {}", output_path.display());
+            debug!("output={}", output_path.display());
 
             let file = fs::OpenOptions::new()
                 .write(true)
@@ -1760,7 +1760,7 @@ impl Containerize {
                 .open(&output_path)
                 .context("Could not open output file")?;
 
-            Box::new(file)
+            (Box::new(file), output_path.display().to_string())
         };
 
         let builder = Dialog {
@@ -1771,10 +1771,13 @@ impl Containerize {
         .spin()
         .context("could not create container builder")?;
 
+        info!("Writing container to '{output_name}'");
+
         builder
             .stream_container(output)
             .context("could not write container to output")?;
 
+        info!("✨  Container written to '{output_name}'");
         Ok(())
     }
 }

--- a/cli/tests/environment-containerize.bats
+++ b/cli/tests/environment-containerize.bats
@@ -39,6 +39,7 @@ env_setup() {
 podman_cache_reset() {
   echo "Resetting podman cache" >&3
   is_linux && podman system reset --force
+  true
 }
 
 # ---------------------------------------------------------------------------- #
@@ -53,9 +54,12 @@ setup() {
 }
 
 teardown() {
-  podman_cache_reset
   project_teardown
   common_test_teardown
+}
+
+teardown_file() {
+  podman_cache_reset
 }
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/src/search/command.cc
+++ b/pkgdb/src/search/command.cc
@@ -104,7 +104,8 @@ SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
              { this->params.query.partialNameMatch = arg; } );
 
   parser.add_argument( "--match-name-or-rel-path" )
-    .help( "search for packages by partially matching `pname' or '.' joined `relPath'." )
+    .help( "search for packages by partially matching `pname' or '.' joined "
+           "`relPath'." )
     .metavar( "MATCH" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )

--- a/pkgdb/src/search/params.cc
+++ b/pkgdb/src/search/params.cc
@@ -139,14 +139,14 @@ from_json( const nlohmann::json & jfrom, SearchQuery & qry )
 void
 to_json( nlohmann::json & jto, const SearchQuery & qry )
 {
-  jto["name"]                  = qry.name;
-  jto["pname"]                 = qry.pname;
-  jto["version"]               = qry.version;
-  jto["semver"]                = qry.semver;
-  jto["match"]                 = qry.partialMatch;
-  jto["match-name"]            = qry.partialNameMatch;
+  jto["name"]                   = qry.name;
+  jto["pname"]                  = qry.pname;
+  jto["version"]                = qry.version;
+  jto["semver"]                 = qry.semver;
+  jto["match"]                  = qry.partialMatch;
+  jto["match-name"]             = qry.partialNameMatch;
   jto["match-name-or-rel-path"] = qry.partialNameOrRelPathMatch;
-  jto["limit"]                 = qry.limit;
+  jto["limit"]                  = qry.limit;
 }
 
 


### PR DESCRIPTION
* test: add `-q` to all `podman run` calls
* test: remove `\r` filtering (removing `--tty` flag from `podman run` earlier made this unnecessary)
* test: clear podman cache in `file_teardown`
  improves caching of container layers and speeds up all tests reusing the same layers (~2x)
* style: add more messaging to containerize
* docs: document `ContainerBuilder`
* test: add tests for `ContainerBuilder`
