### PR TITLE
feat: allow partial relPath matches

### DIFF
--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -21,7 +21,7 @@ use flox_rust_sdk::models::search::{
 use log::{debug, info};
 
 use crate::commands::detect_environment;
-use crate::config::features::{Features, SearchStrategy};
+use crate::config::features::Features;
 use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
@@ -128,7 +128,7 @@ fn construct_search_params(
 ) -> Result<SearchParams> {
     let query = Query::from_term_and_limit(
         search_term,
-        Features::parse()?.search_strategy == SearchStrategy::MatchName,
+        Features::parse()?.search_strategy,
         results_limit,
     )?;
     let params = SearchParams {
@@ -345,7 +345,7 @@ fn construct_show_params(
 
     let query = Query::from_term_and_limit(
         package_name.as_ref().unwrap(), // We already know it's Some(_)
-        Features::parse()?.search_strategy == SearchStrategy::MatchName,
+        Features::parse()?.search_strategy,
         None,
     )?;
     let search_params = SearchParams {

--- a/cli/flox/src/config/features.rs
+++ b/cli/flox/src/config/features.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use flox_rust_sdk::models::search::SearchStrategy;
 use serde::{Deserialize, Serialize};
 
 use super::Config;
@@ -12,12 +13,4 @@ impl Features {
     pub fn parse() -> Result<Self> {
         Ok(Config::parse()?.features)
     }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum SearchStrategy {
-    Match,
-    #[default]
-    MatchName,
 }

--- a/cli/tests/package-search.bats
+++ b/cli/tests/package-search.bats
@@ -273,6 +273,26 @@ setup_file() {
 }
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=python
+
+@test "'flox search' - python310Packages" {
+  run "$FLOX_BIN" search python310Packages
+  assert_success
+  assert_output --partial 'Showing 10 of'
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=python
+
+@test "'flox search' - Packages.req" {
+  run "$FLOX_BIN" search Packages.req
+  assert_success
+  assert_output --partial 'Showing 10 of'
+}
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/pkgdb/include/flox/pkgdb/pkg-query.hh
+++ b/pkgdb/include/flox/pkgdb/pkg-query.hh
@@ -80,11 +80,20 @@ struct PkgQueryArgs
   std::optional<std::string> semver;  /**< Filter results by version range. */
   std::optional<uint8_t>     limit;   /**< Limit the number of results */
 
+  // TODO: would it be better to expose matchPname, matchAttrName,
+  // matchDescription, and matchRelPath fields that we join with OR rather than
+  // exposing fields that match against multiple columns?
+
   /** Filter results by partial match on pname, attrName, or description. */
   std::optional<std::string> partialMatch;
 
   /** Filter results by partial match on pname or attrName. */
   std::optional<std::string> partialNameMatch;
+
+  /**
+   * Filter results by partial match on pname or '.' joined relPath.
+   */
+  std::optional<std::string> partialNameOrRelPathMatch;
 
   /** Filter results by an exact match on either `pname` or `attrName`. */
   std::optional<std::string> pnameOrAttrName;

--- a/pkgdb/include/flox/search/params.hh
+++ b/pkgdb/include/flox/search/params.hh
@@ -54,6 +54,9 @@ struct SearchQuery
   /** Filter results by partial match on pname or attrName */
   std::optional<std::string> partialNameMatch;
 
+  /** Filter results by partial match on pname or '.' joined relPath. */
+  std::optional<std::string> partialNameOrRelPathMatch;
+
   /** @brief Reset to default state. */
   void
   clear();

--- a/pkgdb/src/search/command.cc
+++ b/pkgdb/src/search/command.cc
@@ -103,6 +103,13 @@ SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
     .action( [&]( const std::string & arg )
              { this->params.query.partialNameMatch = arg; } );
 
+  parser.add_argument( "--match-name-or-rel-path" )
+    .help( "search for packages by partially matching `pname' or '.' joined `relPath'." )
+    .metavar( "MATCH" )
+    .nargs( 1 )
+    .action( [&]( const std::string & arg )
+             { this->params.query.partialNameOrRelPathMatch = arg; } );
+
   parser.add_argument( "--dump-query" )
     .help( "print the generated SQL query and exit." )
     .nargs( 0 )

--- a/pkgdb/src/search/params.cc
+++ b/pkgdb/src/search/params.cc
@@ -34,47 +34,47 @@ SearchQuery::clear()
 void
 SearchQuery::check() const
 {
-  /* `name' and `pname' or `version' cannot be used together. */
+  /* 'name' and 'pname' or 'version' cannot be used together. */
   if ( this->name.has_value() && this->pname.has_value() )
     {
       throw ParseSearchQueryException(
-        "`name' and `pname' filters may not be used together." );
+        "'name' and 'pname' filters may not be used together." );
     }
   if ( this->name.has_value() && this->version.has_value() )
     {
       throw ParseSearchQueryException(
-        "`name' and `version' filters may not be used together." );
+        "'name' and 'version' filters may not be used together." );
     }
 
-  /* `version' and `semver' cannot be used together. */
+  /* 'version' and 'semver' cannot be used together. */
   if ( this->version.has_value() && this->semver.has_value() )
     {
       throw ParseSearchQueryException(
-        "`version' and `semver' filters may not be used together." );
+        "'version' and 'semver' filters may not be used together." );
     }
 
-  /* `partialMatch' and `partialNameMatch' cannot be used together. */
+  /* 'partialMatch' and 'partialNameMatch' cannot be used together. */
   if ( this->partialMatch.has_value() && this->partialNameMatch.has_value() )
     {
       throw ParseSearchQueryException(
-        "`partialMatch' and `partialNameMatch' filters "
+        "'partialMatch' and 'partialNameMatch' filters "
         "may not be used together." );
     }
-  /* `partialMatch' and `partialNameOrRelPathMatch' cannot be used together. */
+  /* 'partialMatch' and 'partialNameOrRelPathMatch' cannot be used together. */
   if ( this->partialMatch.has_value()
        && this->partialNameOrRelPathMatch.has_value() )
     {
       throw ParseSearchQueryException(
-        "`partialMatch' and `partialNameOrRelPathMatch' filters "
+        "'partialMatch' and 'partialNameOrRelPathMatch' filters "
         "may not be used together." );
     }
-  /* `partialMatchNameMatch' and `partialNameOrRelPathMatch' cannot be used
+  /* 'partialMatchNameMatch' and 'partialNameOrRelPathMatch' cannot be used
    * together. */
   if ( this->partialNameMatch.has_value()
        && this->partialNameOrRelPathMatch.has_value() )
     {
       throw ParseSearchQueryException(
-        "`partialNameMatch' and `partialNameOrRelPathMatch' filters "
+        "'partialNameMatch' and 'partialNameOrRelPathMatch' filters "
         "may not be used together." );
     }
 }
@@ -120,8 +120,8 @@ from_json( const nlohmann::json & jfrom, SearchQuery & qry )
       else if ( key == "name-match" )
         {
           throw ParseSearchQueryException(
-            "unrecognized key `query.name-match' , did you "
-            "mean `query.match-name'?" );
+            "unrecognized key 'query.name-match' , did you "
+            "mean 'query.match-name'?" );
         }
       else if ( key == "match-name-or-rel-path" )
         {
@@ -277,7 +277,7 @@ from_json( const nlohmann::json & jfrom, SearchParams & params )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseSearchQueryException(
-                "couldn't interpret search query field `global-manifest'",
+                "couldn't interpret search query field 'global-manifest'",
                 extract_json_errmsg( e ) );
             }
         }
@@ -290,7 +290,7 @@ from_json( const nlohmann::json & jfrom, SearchParams & params )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseSearchQueryException(
-                "couldn't interpret search query field `lockfile'",
+                "couldn't interpret search query field 'lockfile'",
                 extract_json_errmsg( e ) );
             }
         }
@@ -303,7 +303,7 @@ from_json( const nlohmann::json & jfrom, SearchParams & params )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseSearchQueryException(
-                "couldn't interpret search query field `lockfile'",
+                "couldn't interpret search query field 'lockfile'",
                 extract_json_errmsg( e ) );
             }
         }
@@ -317,13 +317,13 @@ from_json( const nlohmann::json & jfrom, SearchParams & params )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseSearchQueryException(
-                "couldn't interpret search query field `query'",
+                "couldn't interpret search query field 'query'",
                 extract_json_errmsg( e ) );
             }
         }
       else
         {
-          throw ParseSearchQueryException( "unrecognized field `" + key
+          throw ParseSearchQueryException( "unrecognized field '" + key
                                            + "' in search query" );
         }
     }


### PR DESCRIPTION
The current match-name and match search strategies will find exact matches for relPath (e.g. python310Packages.requests), but they will not return partial matches (e.g. Packages.requests).

Instead:
- Change the match-name and match strategies to no longer return results when an exact relPath is provided. Only match against pname, attrName, and in the case of match, description.
- Add a match-name-or-rel-path search strategy that returns partial matches against relPath. Make this the default search strategy.