### PR TITLE
fix: filter packages not installed for the current system

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -236,7 +236,7 @@ impl ToString for LockedManifest {
 pub struct TypedLockedManifest {
     #[serde(rename = "lockfile-version")]
     lockfile_version: Version<0>,
-    packages: BTreeMap<System, BTreeMap<String, LockedPackage>>,
+    packages: BTreeMap<System, BTreeMap<String, Option<LockedPackage>>>,
     registry: Registry,
 }
 
@@ -287,12 +287,14 @@ impl TypedLockedManifest {
         let mut packages = vec![];
         if let Some(system_packages) = self.packages.get(system) {
             for (name, locked_package) in system_packages {
-                packages.push(InstalledPackage {
-                    name: name.clone(),
-                    rel_path: locked_package.rel_path(),
-                    info: locked_package.info.clone(),
-                    priority: locked_package.priority,
-                });
+                if let Some(locked_package) = locked_package {
+                    packages.push(InstalledPackage {
+                        name: name.clone(),
+                        rel_path: locked_package.rel_path(),
+                        info: locked_package.info.clone(),
+                        priority: locked_package.priority,
+                    });
+                };
             }
         }
         packages

--- a/cli/tests/environment-list.bats
+++ b/cli/tests/environment-list.bats
@@ -108,7 +108,7 @@ EOF
   MANIFEST_CONTENT="$(
     cat <<- EOF
     [options]
-    systems = [ "$NIX_TARGET_SYSTEM" ]
+    systems = [ "$NIX_SYSTEM" ]
     [install]
     hello.path = "hello"
     htop = { path = "htop", systems = [] }

--- a/cli/tests/environment-list.bats
+++ b/cli/tests/environment-list.bats
@@ -99,3 +99,26 @@ EOF
   assert_success
   assert_output "$MANIFEST_CONTENT"
 }
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=list,list:not-applicable
+@test "'flox list' hides packages not installed for the current system" {
+  "$FLOX_BIN" init
+  MANIFEST_CONTENT="$(
+    cat <<- EOF
+    [options]
+    systems = [ "$NIX_TARGET_SYSTEM" ]
+    [install]
+    hello.path = "hello"
+    htop = { path = "htop", systems = [] }
+EOF
+
+  )"
+
+  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+
+  run "$FLOX_BIN" list -n
+  assert_success
+  assert_output "hello"
+}


### PR DESCRIPTION
Detect missing packages for the current system in the lockfile
and omit them when listing.

Future changes could change the `list` output to include these packages
with a note that they are _not_ installed for the current system.

closes flox/flox#761


