### PR TITLE
feat(edit): skip building/linking if manifest is unchanged

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -287,7 +287,14 @@ impl CoreEnvironment<ReadOnly> {
         contents: String,
     ) -> Result<EditResult, CoreEnvironmentError> {
         let old_contents = self.manifest_content()?;
-        // TODO we should probably skip this if the manifest hasn't changed
+
+        // skip the edit if the contents are unchanged
+        // note: consumers of this function may call [Self::link] separately,
+        //       causing an evaluation/build of the environment.
+        if contents == old_contents {
+            return Ok(EditResult::Unchanged);
+        }
+
         self.transact_with_manifest_contents(&contents, flox)?;
 
         EditResult::new(&old_contents, &contents)
@@ -511,7 +518,7 @@ impl CoreEnvironment<ReadWrite> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EditResult {
     /// The manifest was not modified.
     Unchanged,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -254,7 +254,7 @@ impl Environment for ManagedEnvironment {
             return Ok(result);
         }
 
-        dbg!("environment changed");
+        debug!("Environment changed, create generation, lock generation, build and link");
 
         generations
             .add_generation(&mut temporary, "manually edited".to_string())

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -250,13 +250,17 @@ impl Environment for ManagedEnvironment {
 
         let result = temporary.edit(flox, contents)?;
 
-        if matches!(result, EditResult::Success | EditResult::ReActivateRequired) {
-            generations
-                .add_generation(&mut temporary, "manually edited".to_string())
-                .map_err(ManagedEnvironmentError::CommitGeneration)?;
-            self.lock_pointer()?;
-            temporary.link(flox, &self.out_link)?;
+        if result == EditResult::Unchanged {
+            return Ok(result);
         }
+
+        dbg!("environment changed");
+
+        generations
+            .add_generation(&mut temporary, "manually edited".to_string())
+            .map_err(ManagedEnvironmentError::CommitGeneration)?;
+        self.lock_pointer()?;
+        temporary.link(flox, &self.out_link)?;
 
         Ok(result)
     }

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -222,8 +222,9 @@ impl Environment for PathEnvironment {
     fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.edit(flox, contents)?;
-        env_view.link(flox, self.out_link(&flox.system)?)?;
-
+        if result != EditResult::Unchanged {
+            env_view.link(flox, self.out_link(&flox.system)?)?;
+        }
         Ok(result)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -156,6 +156,9 @@ impl Environment for RemoteEnvironment {
     /// Atomically edit this environment, ensuring that it still builds
     fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError2> {
         let result = self.inner.edit(flox, contents)?;
+        if result == EditResult::Unchanged {
+            return Ok(result);
+        }
         self.inner
             .push(false)
             .map_err(RemoteEnvironmentError::UpdateUpstream)?;

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -7,6 +7,7 @@
 # ---------------------------------------------------------------------------- #
 
 load test_support.bash
+# bats file_tags=edit
 
 # ---------------------------------------------------------------------------- #
 
@@ -18,7 +19,6 @@ project_setup() {
   export MANIFEST_PATH="$PROJECT_DIR/.flox/env/manifest.toml"
   export TMP_MANIFEST_PATH="${BATS_TEST_TMPDIR}/manifest.toml"
   export EXTERNAL_MANIFEST_PATH="${TESTS_DIR}/edit/manifest.toml"
-
 
   export Hello_HOOK=$(
     cat << EOF
@@ -98,7 +98,6 @@ EOF
   "$FLOX_BIN" init
   cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
   sed "s/\[hook\]/${HOOK//$'\n'/\\n}/" "$MANIFEST_PATH" > "$TMP_MANIFEST_PATH"
-
 
   run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
   assert_success
@@ -235,4 +234,21 @@ EOF
   run "$FLOX_BIN" edit --remote "owner/name" --name "renamed"
   assert_failure
   assert_output --partial "Cannot rename environments on floxhub"
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=edit:unchanged
+@test "'flox edit' returns if it does not detect changes" {
+  "$FLOX_BIN" init
+
+  run "$FLOX_BIN" edit -f "$TESTS_DIR/edit/manifest.toml"
+  assert_success
+
+  # applying the same edit again should return early
+  # (simulates quiting the editor without saving)
+  run "$FLOX_BIN" edit -f "$TESTS_DIR/edit/manifest.toml"
+  assert_success
+  assert_output "⚠️  no changes made to environment"
+
 }


### PR DESCRIPTION
* core environment: detect if the literal content of **manifest.toml** is unchanged
  and return `EditResult::Unchanged` immediately
* `Environment` implementors: skip `link`ing/creating a generation/pushing
  if edit resulted in EditResult::Unchanged

closes #751 