### PR TITLE
fix: do not add extra context to converted errors

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -987,7 +987,10 @@ impl ManagedEnvironment {
                 format!("{}:{}", project_branch, sync_branch),
                 force,
             )
-            .map_err(ManagedEnvironmentError::Push)?;
+            .map_err(|err| match err {
+                GitRemoteCommandError::AccessDenied => ManagedEnvironmentError::AccessDenied,
+                _ => ManagedEnvironmentError::Push(err),
+            })?;
 
         // update local envorinment branch, should be fast-forward and a noop if the branches didn't diverge
         self.pull(force)?;

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1043,8 +1043,7 @@ impl Push {
             EnvironmentPointer::Managed(managed_pointer) => {
                 let message = Self::push_existing_message(&managed_pointer, self.force);
 
-                Self::push_managed_env(&flox, managed_pointer, dir, self.force)
-                    .context("Could not push managed environment")?;
+                Self::push_managed_env(&flox, managed_pointer, dir, self.force)?;
 
                 info!("{message}");
             },
@@ -1067,8 +1066,7 @@ impl Push {
                         .parse::<EnvironmentOwner>()
                         .context("Invalid owner name")?
                 };
-                let env = Self::push_make_managed(&flox, path_pointer, &dir, owner, self.force)
-                    .context("Could not push new environment")?;
+                let env = Self::push_make_managed(&flox, path_pointer, &dir, owner, self.force)?;
 
                 info!("{}", Self::push_new_message(env.pointer(), self.force));
             },

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -50,7 +50,7 @@
 
   # build time environment variables
   envs = let
-    auth0BaseUrl = "https://flox.auth0.com";
+    auth0BaseUrl = "https://dev-j4tiszdm1f0b70xf.us.auth0.com";
   in
     {
       # 3rd party CLIs

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -50,7 +50,7 @@
 
   # build time environment variables
   envs = let
-    auth0BaseUrl = "https://dev-j4tiszdm1f0b70xf.us.auth0.com";
+    auth0BaseUrl = "https://flox.auth0.com";
   in
     {
       # 3rd party CLIs


### PR DESCRIPTION
Remove additional context from `flox push` error messages

before:
```
ERROR: Could not push new environment: ❌  You do not have permission to write to ghudgins/cli

```

after:
```
ERROR: ❌  You do not have permission to write to ghudgins/cli
```
