### PR TITLE
feat: integrate suggestions into `flox install`

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -646,7 +646,7 @@ pub enum ConcreteEnvironment {
 }
 
 impl ConcreteEnvironment {
-    fn into_dyn_environment(self) -> Box<dyn Environment> {
+    pub fn into_dyn_environment(self) -> Box<dyn Environment> {
         match self {
             ConcreteEnvironment::Path(path_env) => Box::new(path_env),
             ConcreteEnvironment::Managed(managed_env) => Box::new(managed_env),
@@ -676,7 +676,7 @@ pub enum UninitializedEnvironment {
 }
 
 impl UninitializedEnvironment {
-    fn from_concrete_environment(env: &ConcreteEnvironment) -> Result<Self> {
+    pub fn from_concrete_environment(env: &ConcreteEnvironment) -> Result<Self> {
         match env {
             ConcreteEnvironment::Path(path_env) => {
                 let pointer = path_env.pointer.clone().into();
@@ -702,7 +702,7 @@ impl UninitializedEnvironment {
     /// Open the contained environment and return a [ConcreteEnvironment]
     ///
     /// This function will fail if the contained environment is not available or invalid
-    fn into_concrete_environment(self, flox: &Flox) -> Result<ConcreteEnvironment> {
+    pub fn into_concrete_environment(self, flox: &Flox) -> Result<ConcreteEnvironment> {
         match self {
             UninitializedEnvironment::DotFlox(dot_flox) => {
                 let dot_flox_path = dot_flox.path.join(DOT_FLOX);

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -22,7 +22,7 @@ use crate::config::features::Features;
 use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
-use crate::utils::search::manifest_and_lockfile;
+use crate::utils::search::{construct_search_params, manifest_and_lockfile};
 
 const SEARCH_INPUT_SEPARATOR: &'_ str = ":";
 const DEFAULT_DESCRIPTION: &'_ str = "<no description provided>";
@@ -115,28 +115,6 @@ impl Search {
 
         Ok(())
     }
-}
-
-pub(crate) fn construct_search_params(
-    search_term: &str,
-    results_limit: Option<u8>,
-    manifest: Option<PathOrJson>,
-    global_manifest: PathOrJson,
-    lockfile: PathOrJson,
-) -> Result<SearchParams> {
-    let query = Query::from_term_and_limit(
-        search_term,
-        Features::parse()?.search_strategy,
-        results_limit,
-    )?;
-    let params = SearchParams {
-        manifest,
-        global_manifest,
-        lockfile,
-        query,
-    };
-    debug!("search params raw: {:?}", params);
-    Ok(params)
 }
 
 /// An intermediate representation of a search result used for rendering

--- a/cli/flox/src/utils/didyoumean.rs
+++ b/cli/flox/src/utils/didyoumean.rs
@@ -1,0 +1,128 @@
+use std::fmt::Display;
+
+use anyhow::Result;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::{global_manifest_path, Environment};
+use flox_rust_sdk::models::lockfile::LockedManifest;
+use flox_rust_sdk::models::search::{do_search, PathOrJson, SearchResults};
+use log::debug;
+
+use crate::utils::dialog::{Dialog, Spinner};
+use crate::utils::search::construct_search_params;
+
+const SUGGESTION_SEARCH_LIMIT: u8 = 3;
+
+fn suggest_curated_package(input: &str) -> Option<&'static str> {
+    let suggestion = match input {
+        "node" => "nodejs",
+        "npm" => "nodejs",
+        "rust" => "cargo",
+        _ => return None,
+    };
+    Some(suggestion)
+}
+
+fn suggest_searched_packages(
+    flox: &Flox,
+    environment: &dyn Environment,
+    term: &str,
+) -> Result<SearchResults> {
+    let lockfile_path = environment.lockfile_path(flox)?;
+
+    // Use the global lock if we don't have a lock yet
+    let lockfile = if lockfile_path.exists() {
+        PathOrJson::Path(lockfile_path)
+    } else {
+        PathOrJson::Path(LockedManifest::ensure_global_lockfile(flox)?)
+    };
+
+    let search_params = construct_search_params(
+        term,
+        Some(SUGGESTION_SEARCH_LIMIT),
+        Some(environment.manifest_path(flox)?.try_into()?),
+        global_manifest_path(flox).try_into()?,
+        lockfile,
+    )?;
+
+    let (results, _) = Dialog {
+        message: "Looking for suggestions...",
+        help_message: None,
+        typed: Spinner::new(|| do_search(&search_params)),
+    }
+    .spin()?;
+
+    Ok(results)
+}
+
+pub struct DidYouMean<'a> {
+    searched_term: &'a str,
+    curated: Option<&'static str>,
+    search_results: SearchResults,
+}
+
+impl<'a> DidYouMean<'a> {
+    pub fn new(flox: &Flox, environment: &dyn Environment, term: &'a str) -> Self {
+        let curated = suggest_curated_package(term);
+        let searched_term = curated.unwrap_or(term);
+        let search_results = match suggest_searched_packages(flox, environment, searched_term) {
+            Ok(results) => results,
+            Err(err) => {
+                debug!("failed to search for suggestions: {}", err);
+                SearchResults {
+                    results: Default::default(),
+                    count: Some(0),
+                }
+            },
+        };
+        Self {
+            term,
+            curated,
+            searched_term,
+        }
+    }
+
+    pub fn has_suggestions(&self) -> bool {
+        self.curated.is_some() || !self.search_results.results.is_empty()
+    }
+}
+
+impl Display for DidYouMean<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(curated) = self.curated {
+            writeln!(
+                f,
+                "Try 'flox install {curated}' instead.",
+                curated = curated
+            )?;
+        }
+
+        if self.search_results.results.is_empty() {
+            return Ok(());
+        }
+
+        writeln!(f)?;
+        writeln!(f, "Here are a few other similar options:")?;
+
+        // apparently its possible for pkgdb to _not_ return a count?
+        let count_message = match self.search_results.count {
+            Some(n) => format!("up to {n}"),
+            None => "more".to_string(),
+        };
+
+        for result in self.search_results.results.iter() {
+            writeln!(
+                f,
+                "  $ flox install {path}",
+                path = result.rel_path.join(".")
+            )?;
+        }
+
+        write!(
+            f,
+            "...or see {count_message} options with 'flox search {term}'",
+            term = self.searched_term
+        )?;
+
+        Ok(())
+    }
+}

--- a/cli/flox/src/utils/didyoumean.rs
+++ b/cli/flox/src/utils/didyoumean.rs
@@ -51,7 +51,7 @@ fn suggest_searched_packages(
     )?;
 
     let (results, _) = Dialog {
-        message: "Looking for suggestions...",
+        message: &format!("Could not find package for {term}. Looking for suggestions..."),
         help_message: None,
         typed: Spinner::new(|| do_search(&search_params)),
     }

--- a/cli/flox/src/utils/didyoumean.rs
+++ b/cli/flox/src/utils/didyoumean.rs
@@ -14,9 +14,15 @@ const SUGGESTION_SEARCH_LIMIT: u8 = 3;
 
 fn suggest_curated_package(input: &str) -> Option<&'static str> {
     let suggestion = match input {
+        "java" => "jdk",
         "node" => "nodejs",
         "npm" => "nodejs",
         "rust" => "cargo",
+        "sed" => "gnused",
+        "make" => "gnumake",
+        "awk" => "gawk",
+        "diff" => "diffutils",
+        "grep" => "gnugrep",
         _ => return None,
     };
     Some(suggestion)
@@ -75,9 +81,9 @@ impl<'a> DidYouMean<'a> {
             },
         };
         Self {
-            term,
-            curated,
             searched_term,
+            curated,
+            search_results,
         }
     }
 

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -10,5 +10,6 @@ pub mod init;
 pub mod logger;
 pub mod metrics;
 pub mod openers;
+pub mod search;
 
 pub static TERMINAL_STDERR: Lazy<Mutex<Stderr>> = Lazy::new(|| Mutex::new(std::io::stderr()));

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -6,6 +6,7 @@ use once_cell::sync::Lazy;
 pub mod colors;
 mod completion;
 pub mod dialog;
+pub mod didyoumean;
 pub mod init;
 pub mod logger;
 pub mod metrics;

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::lockfile::LockedManifest;
+use log::debug;
+
+use crate::commands::detect_environment;
+
+/// Return an optional manifest and a lockfile to use for search and show.
+///
+/// This searches for an environment to use,
+/// and if one is found, it returns the path to its manifest and optionally the
+/// path to its lockfile.
+///
+/// If no environment is found, or if environment does not have a lockfile, the
+/// global lockfile is used.
+/// The global lockfile is created if it does not exist.
+///
+/// Note that this may perform network operations to pull a
+/// [ManagedEnvironment],
+/// since a freshly cloned user repo with a [ManagedEnvironment] may not have a
+/// manifest or lockfile in floxmeta unless the environment is initialized.
+pub fn manifest_and_lockfile(flox: &Flox, message: &str) -> Result<(Option<PathBuf>, PathBuf)> {
+    let (manifest_path, lockfile_path) = match detect_environment(message)? {
+        None => {
+            debug!("no environment found");
+            (None, None)
+        },
+        Some(uninitialized) => {
+            debug!("using environment {uninitialized}");
+
+            let environment = uninitialized
+                .into_concrete_environment(flox)?
+                .into_dyn_environment();
+
+            let lockfile_path = environment.lockfile_path(flox)?;
+            debug!("checking lockfile: path={}", lockfile_path.display());
+            let lockfile = if lockfile_path.exists() {
+                debug!("lockfile exists");
+                Some(lockfile_path)
+            } else {
+                debug!("lockfile doesn't exist");
+                None
+            };
+            (Some(environment.manifest_path(flox)?), lockfile)
+        },
+    };
+
+    // Use the global lock if we don't have a lock yet
+    let lockfile_path = match lockfile_path {
+        Some(lockfile_path) => lockfile_path,
+        None => LockedManifest::ensure_global_lockfile(flox)?,
+    };
+    Ok((manifest_path, lockfile_path))
+}

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -88,7 +88,32 @@ teardown() {
   "$FLOX_BIN" init
   run "$FLOX_BIN" install not-a-package
   assert_failure
-  assert_output --partial "failed to resolve \`not-a-package'"
+  assert_output --partial "could not install not-a-package"
+}
+
+@test "'flox install' provides suggestions when package not found" {
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install package
+  assert_failure
+  assert_output --partial "Here are a few other similar options:"
+  assert_output --partial "options with 'flox search package'"
+}
+
+@test "'flox install' provides curated suggestions when package not found" {
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install java
+  assert_failure
+  assert_output --partial "Try 'flox install jdk' instead."
+  assert_output --partial "Here are a few other similar options:"
+  assert_output --partial "$ flox install "
+  assert_output --partial "options with 'flox search jdk'"
+}
+
+@test "'flox install' does not suggest packages if multiple packages provided" {
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install java make
+  assert_failure
+  assert_output --partial "could not install java, make"
 }
 
 @test "'flox uninstall' reports error when package not found" {


### PR DESCRIPTION
* Add a `DidYouMean` mechanism that matches terms with known package names
  and searches the top 3 packages using `pkgdb search`.
* Handle `120` ("resolution failure") errors emitted by `pkgdb manifest lock` during `install`.
* print suggestions iff **one** package was provided to install.
