### PR TITLE
feat: append search of curated terms if possible

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -65,7 +65,7 @@ use crate::commands::{
 };
 use crate::config::Config;
 use crate::utils::dialog::{Confirm, Dialog, Spinner};
-use crate::utils::didyoumean::DidYouMean;
+use crate::utils::didyoumean::{DidYouMean, InstallSuggestion};
 use crate::{subcommand_metric, utils};
 
 #[derive(Bpaf, Clone)]
@@ -913,7 +913,7 @@ impl Install {
                 }
                 let path = packages[0].path.clone();
 
-                let suggestion = DidYouMean::new(flox, environment, &path);
+                let suggestion = DidYouMean::<InstallSuggestion>::new(flox, environment, &path);
                 if !suggestion.has_suggestions() {
                     break 'error anyhow!(head);
                 }

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -138,7 +138,7 @@ impl Search {
             .spin()?;
 
             if !exit_status.success() {
-                debug!("failed to search for suggestions {exit_status}");
+                debug!("failed to search for suggestions: status={exit_status}");
                 return Ok(());
             }
 

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -138,17 +138,18 @@ impl Search {
             let results = render_search_results_user_facing(&self.search_term, results)?;
             println!("{results}");
 
+            info!("");
+
             if let Some(hint) = results.hint() {
-                eprintln!();
                 info!("{hint}");
             }
+
+            info!("{FLOX_SHOW_HINT}");
 
             if suggestion.has_suggestions() {
                 eprintln!();
                 eprintln!("{suggestion}");
             };
-
-            info!("{FLOX_SHOW_HINT}");
         }
         Ok(())
     }

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -20,10 +20,10 @@ use log::{debug, info};
 
 use crate::config::features::Features;
 use crate::config::Config;
-use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::didyoumean;
 use crate::utils::search::{construct_search_params, manifest_and_lockfile};
+use crate::{subcommand_metric, utils};
 
 const SEARCH_INPUT_SEPARATOR: &'_ str = ":";
 const DEFAULT_DESCRIPTION: &'_ str = "<no description provided>";
@@ -118,7 +118,7 @@ impl Search {
             // Try to find a curated package that matches the search term
             // and display search results
 
-            let Some(curated) = didyoumean::suggest_curated_package(&self.search_term) else {
+            let Some(curated) = utils::search::suggest_curated_package(&self.search_term) else {
                 return Ok(());
             };
 

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -1,5 +1,3 @@
-use std::collections::{HashMap, HashSet};
-use std::io::{BufWriter, Write};
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
@@ -16,18 +14,24 @@ use flox_rust_sdk::models::search::{
     ShowError,
     Subtree,
 };
+use indoc::formatdoc;
 use log::{debug, info};
 
 use crate::config::features::Features;
 use crate::config::Config;
+use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
-use crate::utils::didyoumean;
-use crate::utils::search::{construct_search_params, manifest_and_lockfile};
-use crate::{subcommand_metric, utils};
+use crate::utils::didyoumean::{DidYouMean, SearchSuggestion};
+use crate::utils::search::{
+    construct_search_params,
+    manifest_and_lockfile,
+    render_search_results_user_facing,
+    DEFAULT_DESCRIPTION,
+    SEARCH_INPUT_SEPARATOR,
+};
 
-const SEARCH_INPUT_SEPARATOR: &'_ str = ":";
-const DEFAULT_DESCRIPTION: &'_ str = "<no description provided>";
 const DEFAULT_SEARCH_LIMIT: Option<u8> = Some(10);
+const FLOX_SHOW_HINT: &str = "Use 'flox show <package>' to see available versions";
 
 #[derive(Bpaf, Clone)]
 pub struct ChannelArgs {}
@@ -74,6 +78,7 @@ impl Search {
             .context("failed while looking for manifest and lockfile")?;
 
         let manifest = manifest.map(|p| p.try_into()).transpose()?;
+        let lockfile = PathOrJson::Path(lockfile);
         let global_manifest: PathOrJson = global_manifest_path(&flox).try_into()?;
 
         let limit = if self.all {
@@ -87,7 +92,7 @@ impl Search {
             limit,
             manifest.clone(),
             global_manifest.clone(),
-            PathOrJson::Path(lockfile.clone()),
+            lockfile.clone(),
         )?;
 
         let (results, exit_status) = Dialog {
@@ -109,196 +114,50 @@ impl Search {
         } else {
             debug!("printing search results as user facing");
 
-            if results.results.is_empty() {
-                info!("No packages matched this search term: {}", self.search_term);
-            } else {
-                render_search_results_user_facing(&self.search_term, results)?;
-            }
-
-            // Try to find a curated package that matches the search term
-            // and display search results
-
-            let Some(curated) = utils::search::suggest_curated_package(&self.search_term) else {
-                return Ok(());
-            };
-
-            let search_params = construct_search_params(
-                curated,
-                Some(didyoumean::SUGGESTION_SEARCH_LIMIT),
+            let suggestion = DidYouMean::<SearchSuggestion>::new(
+                &self.search_term,
                 manifest,
                 global_manifest,
-                PathOrJson::Path(lockfile),
-            )?;
-
-            let (results, exit_status) = Dialog {
-                message: &format!("Searching alternatives for {curated}..."),
-                help_message: None,
-                typed: Spinner::new(|| do_search(&search_params)),
-            }
-            .spin()?;
-
-            if !exit_status.success() {
-                debug!("failed to search for suggestions: status={exit_status}");
-                return Ok(());
-            }
+                lockfile,
+            );
 
             if results.results.is_empty() {
-                debug!("no suggestions found");
-                return Ok(());
+                let mut message =
+                    format!("No packages matched this search term: {}", self.search_term);
+                if suggestion.has_suggestions() {
+                    message = formatdoc! {"
+                        {message}
+
+                        {suggestion}
+                        {FLOX_SHOW_HINT}
+                    "};
+                }
+                bail!(message);
             }
 
-            info!("");
-            info!("Related search results for '{curated}':");
-            render_search_results_user_facing(curated, results)?;
-        }
-        if !exit_status.success() {
-            bail!(
-                "pkgdb exited with status code: {}",
-                exit_status.code().unwrap_or(-1),
-            );
-        };
+            let results = render_search_results_user_facing(&self.search_term, results)?;
+            println!("{results}");
 
+            if let Some(hint) = results.hint() {
+                eprintln!();
+                info!("{hint}");
+            }
+
+            if suggestion.has_suggestions() {
+                eprintln!();
+                eprintln!("{suggestion}");
+            };
+
+            info!("{FLOX_SHOW_HINT}");
+        }
         Ok(())
     }
-}
-
-/// An intermediate representation of a search result used for rendering
-#[derive(Debug, PartialEq, Clone)]
-struct DisplayItem {
-    /// The input that the package came from
-    input: String,
-    /// The displayable part of the package's attribute path
-    package: String,
-    /// The package description
-    description: Option<String>,
-    /// Whether to join the `input` and `package` fields with a separator when rendering
-    render_with_input: bool,
-}
-
-fn render_search_results_user_facing(
-    search_term: &str,
-    search_results: SearchResults,
-) -> Result<()> {
-    let n_results = search_results.results.len();
-    // Nothing to display
-    if n_results == 0 {
-        bail!("No packages matched this search term: {}", search_term);
-    }
-    // Search results contain a lot of information, but all we need for rendering are
-    // the input, the package subpath (e.g. "python310Packages.flask"), and the description.
-    let display_items = search_results
-        .results
-        .into_iter()
-        .map(|r| {
-            Ok(DisplayItem {
-                input: r.input,
-                package: r.rel_path.join("."),
-                description: r.description.map(|s| s.replace('\n', " ")),
-                render_with_input: false,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let deduped_display_items = dedup_and_disambiguate_display_items(display_items);
-    if deduped_display_items.is_empty() {
-        bail!("deduplicating search results failed");
-    }
-
-    let column_width = deduped_display_items
-        .iter()
-        .map(|d| {
-            if d.render_with_input {
-                d.input.len() + d.package.len() + SEARCH_INPUT_SEPARATOR.len()
-            } else {
-                d.package.len()
-            }
-        })
-        .max()
-        .unwrap(); // SAFETY: could panic if `deduped_display_items` is empty, but we know it's not
-
-    // Finally print something
-    let mut writer = BufWriter::new(std::io::stdout());
-    let default_desc = String::from(DEFAULT_DESCRIPTION);
-    for d in deduped_display_items.into_iter() {
-        let package = if d.render_with_input {
-            [d.input, d.package].join(SEARCH_INPUT_SEPARATOR)
-        } else {
-            d.package
-        };
-        let desc: String = d.description.unwrap_or(default_desc.clone());
-        writeln!(&mut writer, "{package:<column_width$}  {desc}")?;
-    }
-    writer.flush().context("couldn't flush search results")?;
-    info!(""); // We need a blank line between search results and hints
-    if let Some(count) = search_results.count {
-        // Don't show the message if we have exactly the number of results as the limit,
-        // otherwise we would get messages like `Showing 10 of 10...`
-        if count != n_results as u64 {
-            info!(
-            "Showing {n_results} of {count} results. Use `flox search {search_term} --all` to see the full list.",
-        );
-        }
-    }
-    info!("Use `flox show <package>` to see available versions");
-    Ok(())
 }
 
 fn render_search_results_json(search_results: SearchResults) -> Result<()> {
     let json = serde_json::to_string(&search_results.results)?;
     println!("{}", json);
     Ok(())
-}
-
-/// Deduplicate and disambiguate display items.
-///
-/// This gets complicated because we have to satisfy a few constraints:
-/// - The order of results from `pkgdb` is important (best matches come first),
-///   so that order must be preserved.
-/// - Versions shouldn't appear in the output, so multiple package versions from a single
-///   input should be deduplicated.
-/// - Packages that appear in more than one input need to be disambiguated by prepending
-///   the name of the input and a separator.
-fn dedup_and_disambiguate_display_items(mut display_items: Vec<DisplayItem>) -> Vec<DisplayItem> {
-    let mut package_to_inputs: HashMap<String, HashSet<String>> = HashMap::new();
-    for d in display_items.iter() {
-        // Build a collection of packages and which inputs they are seen in so we can tell
-        // which packages need to be disambiguated when rendering search results.
-        package_to_inputs
-            .entry(d.package.clone())
-            .and_modify(|inputs| {
-                inputs.insert(d.input.clone());
-            })
-            .or_insert_with(|| HashSet::from_iter([d.input.clone()]));
-    }
-
-    // For any package that comes from more than one input, mark it as needing to be joined
-    for d in display_items.iter_mut() {
-        if let Some(inputs) = package_to_inputs.get(&d.package) {
-            d.render_with_input = inputs.len() > 1;
-        }
-    }
-
-    // For each package in the search results, `package_to_inputs` contains the set of
-    // inputs that the package is found in. Logically `package_to_inputs` contains
-    // (package, input) pairs. If the `package` and `input` from a `DisplayItem` are
-    // found in `package_to_inputs` it means that we have not yet seen this (package, input)
-    // pair and we should render it (e.g. add it to `deduped_display_items`). Once we've
-    // done that we remove this (package, input) pair from `package_to_inputs` so that
-    // we never see that pair again.
-    let mut deduped_display_items = Vec::new();
-    for d in display_items.into_iter() {
-        if let Some(inputs) = package_to_inputs.get_mut(d.package.as_str()) {
-            // Remove this input so this (package, input) pair is never seen again
-            if inputs.remove(&d.input) {
-                deduped_display_items.push(d.clone());
-            }
-            if inputs.is_empty() {
-                package_to_inputs.remove(&d.package);
-            }
-        }
-    }
-
-    deduped_display_items
 }
 
 /// Show detailed package information

--- a/cli/flox/src/utils/didyoumean.rs
+++ b/cli/flox/src/utils/didyoumean.rs
@@ -10,9 +10,9 @@ use log::debug;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::search::construct_search_params;
 
-const SUGGESTION_SEARCH_LIMIT: u8 = 3;
+pub const SUGGESTION_SEARCH_LIMIT: u8 = 3;
 
-fn suggest_curated_package(input: &str) -> Option<&'static str> {
+pub fn suggest_curated_package(input: &str) -> Option<&'static str> {
     let suggestion = match input {
         "java" => "jdk",
         "node" => "nodejs",

--- a/cli/flox/src/utils/didyoumean.rs
+++ b/cli/flox/src/utils/didyoumean.rs
@@ -7,70 +7,81 @@ use flox_rust_sdk::models::lockfile::LockedManifest;
 use flox_rust_sdk::models::search::{do_search, PathOrJson, SearchResults};
 use log::debug;
 
+use super::search::render_search_results_user_facing;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::search::construct_search_params;
 
 pub const SUGGESTION_SEARCH_LIMIT: u8 = 3;
 
-pub fn suggest_curated_package(input: &str) -> Option<&'static str> {
-    let suggestion = match input {
-        "java" => "jdk",
-        "node" => "nodejs",
-        "npm" => "nodejs",
-        "rust" => "cargo",
-        "sed" => "gnused",
-        "make" => "gnumake",
-        "awk" => "gawk",
-        "diff" => "diffutils",
-        "grep" => "gnugrep",
-        _ => return None,
-    };
-    Some(suggestion)
-}
-
-fn suggest_searched_packages(
-    flox: &Flox,
-    environment: &dyn Environment,
-    term: &str,
-) -> Result<SearchResults> {
-    let lockfile_path = environment.lockfile_path(flox)?;
-
-    // Use the global lock if we don't have a lock yet
-    let lockfile = if lockfile_path.exists() {
-        PathOrJson::Path(lockfile_path)
-    } else {
-        PathOrJson::Path(LockedManifest::ensure_global_lockfile(flox)?)
-    };
-
-    let search_params = construct_search_params(
-        term,
-        Some(SUGGESTION_SEARCH_LIMIT),
-        Some(environment.manifest_path(flox)?.try_into()?),
-        global_manifest_path(flox).try_into()?,
-        lockfile,
-    )?;
-
-    let (results, _) = Dialog {
-        message: &format!("Could not find package for {term}. Looking for suggestions..."),
-        help_message: None,
-        typed: Spinner::new(|| do_search(&search_params)),
-    }
-    .spin()?;
-
-    Ok(results)
-}
-
-pub struct DidYouMean<'a> {
+pub struct DidYouMean<'a, S> {
     searched_term: &'a str,
     curated: Option<&'static str>,
     search_results: SearchResults,
+    _suggestion: S,
 }
 
-impl<'a> DidYouMean<'a> {
+pub struct InstallSuggestion;
+
+impl<S> DidYouMean<'_, S> {
+    pub fn has_suggestions(&self) -> bool {
+        self.curated.is_some() || !self.search_results.results.is_empty()
+    }
+}
+
+impl<'a> DidYouMean<'a, InstallSuggestion> {
+    fn suggest_curated_package(input: &str) -> Option<&'static str> {
+        let suggestion = match input {
+            "java" => "jdk",
+            "node" => "nodejs",
+            "npm" => "nodejs",
+            "rust" => "cargo",
+            "sed" => "gnused",
+            "make" => "gnumake",
+            "awk" => "gawk",
+            "diff" => "diffutils",
+            "grep" => "gnugrep",
+            _ => return None,
+        };
+        Some(suggestion)
+    }
+
+    fn suggest_searched_packages(
+        flox: &Flox,
+        environment: &dyn Environment,
+        term: &str,
+    ) -> Result<SearchResults> {
+        let lockfile_path = environment.lockfile_path(flox)?;
+
+        // Use the global lock if we don't have a lock yet
+        let lockfile = if lockfile_path.exists() {
+            PathOrJson::Path(lockfile_path)
+        } else {
+            PathOrJson::Path(LockedManifest::ensure_global_lockfile(flox)?)
+        };
+
+        let search_params = construct_search_params(
+            term,
+            Some(SUGGESTION_SEARCH_LIMIT),
+            Some(environment.manifest_path(flox)?.try_into()?),
+            global_manifest_path(flox).try_into()?,
+            lockfile,
+        )?;
+
+        let (results, _) = Dialog {
+            message: &format!("Could not find package for {term}. Looking for suggestions..."),
+            help_message: None,
+            typed: Spinner::new(|| do_search(&search_params)),
+        }
+        .spin()?;
+
+        Ok(results)
+    }
+
     pub fn new(flox: &Flox, environment: &dyn Environment, term: &'a str) -> Self {
-        let curated = suggest_curated_package(term);
+        let curated = Self::suggest_curated_package(term);
         let searched_term = curated.unwrap_or(term);
-        let search_results = match suggest_searched_packages(flox, environment, searched_term) {
+        let search_results = match Self::suggest_searched_packages(flox, environment, searched_term)
+        {
             Ok(results) => results,
             Err(err) => {
                 debug!("failed to search for suggestions: {}", err);
@@ -84,15 +95,12 @@ impl<'a> DidYouMean<'a> {
             searched_term,
             curated,
             search_results,
+            _suggestion: InstallSuggestion,
         }
-    }
-
-    pub fn has_suggestions(&self) -> bool {
-        self.curated.is_some() || !self.search_results.results.is_empty()
     }
 }
 
-impl Display for DidYouMean<'_> {
+impl Display for DidYouMean<'_, InstallSuggestion> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(curated) = self.curated {
             writeln!(

--- a/cli/flox/src/utils/didyoumean.rs
+++ b/cli/flox/src/utils/didyoumean.rs
@@ -258,9 +258,6 @@ impl Display for DidYouMean<'_, SearchSuggestion> {
 
         writeln!(f, "Related search results for '{curated}':")?;
         write!(f, "{search_results_rendered}")?;
-        if let Some(hint) = search_results_rendered.hint() {
-            write!(f, "\n\n{hint}")?;
-        }
 
         Ok(())
     }

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -80,3 +80,17 @@ pub(crate) fn construct_search_params(
     debug!("search params raw: {:?}", params);
     Ok(params)
 }
+
+/// `search` specific curated terms
+pub(crate) fn suggest_curated_package(input: &str) -> Option<&'static str> {
+    let suggestion = match input {
+        "node" => "nodejs",
+        "java" => "jdk",
+        "npm" => "nodejs",
+        "rust" => "cargo",
+        "diff" => "diffutils",
+        "make" => "gnumake",
+        _ => return None,
+    };
+    Some(suggestion)
+}

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -1,13 +1,19 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
+use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::lockfile::LockedManifest;
-use flox_rust_sdk::models::search::{PathOrJson, Query, SearchParams};
+use flox_rust_sdk::models::search::{PathOrJson, Query, SearchParams, SearchResults};
 use log::debug;
 
 use crate::commands::detect_environment;
 use crate::config::features::Features;
+
+pub const SEARCH_INPUT_SEPARATOR: &'_ str = ":";
+pub const DEFAULT_DESCRIPTION: &'_ str = "<no description provided>";
 
 /// Return an optional manifest and a lockfile to use for search and show.
 ///
@@ -81,16 +87,180 @@ pub(crate) fn construct_search_params(
     Ok(params)
 }
 
-/// `search` specific curated terms
-pub(crate) fn suggest_curated_package(input: &str) -> Option<&'static str> {
-    let suggestion = match input {
-        "node" => "nodejs",
-        "java" => "jdk",
-        "npm" => "nodejs",
-        "rust" => "cargo",
-        "diff" => "diffutils",
-        "make" => "gnumake",
-        _ => return None,
-    };
-    Some(suggestion)
+/// Deduplicate and disambiguate display items.
+///
+/// This gets complicated because we have to satisfy a few constraints:
+/// - The order of results from `pkgdb` is important (best matches come first),
+///   so that order must be preserved.
+/// - Versions shouldn't appear in the output, so multiple package versions from a single
+///   input should be deduplicated.
+/// - Packages that appear in more than one input need to be disambiguated by prepending
+///   the name of the input and a separator.
+fn dedup_and_disambiguate_display_items(mut display_items: Vec<DisplayItem>) -> Vec<DisplayItem> {
+    let mut package_to_inputs: HashMap<String, HashSet<String>> = HashMap::new();
+    for d in display_items.iter() {
+        // Build a collection of packages and which inputs they are seen in so we can tell
+        // which packages need to be disambiguated when rendering search results.
+        package_to_inputs
+            .entry(d.package.clone())
+            .and_modify(|inputs| {
+                inputs.insert(d.input.clone());
+            })
+            .or_insert_with(|| HashSet::from_iter([d.input.clone()]));
+    }
+
+    // For any package that comes from more than one input, mark it as needing to be joined
+    for d in display_items.iter_mut() {
+        if let Some(inputs) = package_to_inputs.get(&d.package) {
+            d.render_with_input = inputs.len() > 1;
+        }
+    }
+
+    // For each package in the search results, `package_to_inputs` contains the set of
+    // inputs that the package is found in. Logically `package_to_inputs` contains
+    // (package, input) pairs. If the `package` and `input` from a `DisplayItem` are
+    // found in `package_to_inputs` it means that we have not yet seen this (package, input)
+    // pair and we should render it (e.g. add it to `deduped_display_items`). Once we've
+    // done that we remove this (package, input) pair from `package_to_inputs` so that
+    // we never see that pair again.
+    let mut deduped_display_items = Vec::new();
+    for d in display_items.into_iter() {
+        if let Some(inputs) = package_to_inputs.get_mut(d.package.as_str()) {
+            // Remove this input so this (package, input) pair is never seen again
+            if inputs.remove(&d.input) {
+                deduped_display_items.push(d.clone());
+            }
+            if inputs.is_empty() {
+                package_to_inputs.remove(&d.package);
+            }
+        }
+    }
+
+    deduped_display_items
+}
+
+/// An intermediate representation of a search result used for rendering
+#[derive(Debug, PartialEq, Clone)]
+struct DisplayItem {
+    /// The input that the package came from
+    input: String,
+    /// The displayable part of the package's attribute path
+    package: String,
+    /// The package description
+    description: Option<String>,
+    /// Whether to join the `input` and `package` fields with a separator when rendering
+    render_with_input: bool,
+}
+
+pub struct DisplaySearchResults {
+    /// original search term
+    search_term: String,
+    /// deduplicated and disambiguated search results
+    deduped_display_items: Vec<DisplayItem>,
+    /// reported number of results
+    count: Option<u64>,
+    /// number of actual results (including duplicates)
+    n_results: u64,
+}
+
+impl Display for DisplaySearchResults {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let column_width = self
+            .deduped_display_items
+            .iter()
+            .map(|d| {
+                if d.render_with_input {
+                    d.input.len() + d.package.len() + SEARCH_INPUT_SEPARATOR.len()
+                } else {
+                    d.package.len()
+                }
+            })
+            .max()
+            .unwrap_or_default();
+
+        // Finally print something
+        let mut items = self.deduped_display_items.iter().peekable();
+
+        while let Some(d) = items.next() {
+            let desc = d.description.as_deref().unwrap_or(DEFAULT_DESCRIPTION);
+            let package = if d.render_with_input {
+                [&*d.input, &*d.package].join(SEARCH_INPUT_SEPARATOR)
+            } else {
+                d.package.to_string()
+            };
+            write!(f, "{package:<column_width$}  {desc}")?;
+            // Only print a newline if there are more items to print
+            if items.peek().is_some() {
+                writeln!(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl DisplaySearchResults {
+    pub fn hint(&self) -> Option<String> {
+        let Some(count) = self.count else {
+            return None;
+        };
+
+        // Don't show the message if we have exactly the number of results as the limit,
+        // otherwise we would get messages like `Showing 10 of 10...`
+        // In addition after deduplication we may have fewer results than the limit,
+        // but we dont want to show a message like `Showing 5 of 9...`,
+        // when the requested number of results is 10.
+        // There is still an issue wit duplicate results where even when called with `--all`
+        // the number of elements in `deduped_display_items` may be less than `count`.
+        // That bug will be fixed separately.
+        if count == self.n_results {
+            return None;
+        }
+
+        Some(format!(
+                "Showing {n_deduplicated} of {count} results. Use `flox search {search_term} --all` to see the full list.",
+                n_deduplicated = self.deduped_display_items.len(),
+                search_term = self.search_term
+            ))
+    }
+}
+
+/// Display a list of search results for a given search term
+/// This function is responsible for deduplicating and disambiguating search results
+/// and printing them to stdout in a user-friendly table-ish format.
+///
+/// If no results are found, this function will print nothing
+/// it's the caller's responsibility to print a message,
+/// or error if no results are found.
+pub(crate) fn render_search_results_user_facing(
+    search_term: &str,
+    search_results: SearchResults,
+) -> Result<DisplaySearchResults> {
+    let n_results = search_results.results.len();
+
+    // Search results contain a lot of information, but all we need for rendering are
+    // the input, the package subpath (e.g. "python310Packages.flask"), and the description.
+    let display_items = search_results
+        .results
+        .into_iter()
+        .map(|r| {
+            Ok(DisplayItem {
+                input: r.input,
+                package: r.rel_path.join("."),
+                description: r.description.map(|s| s.replace('\n', " ")),
+                render_with_input: false,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let deduped_display_items = dedup_and_disambiguate_display_items(display_items);
+    if deduped_display_items.is_empty() {
+        bail!("deduplicating search results failed");
+    }
+
+    Ok(DisplaySearchResults {
+        search_term: search_term.to_string(),
+        deduped_display_items,
+        count: search_results.count,
+        n_results: n_results as u64,
+    })
 }

--- a/cli/tests/package-search.bats
+++ b/cli/tests/package-search.bats
@@ -45,7 +45,7 @@ teardown() {
 setup_file() {
   common_file_setup
 
-  export SHOW_HINT="Use \`flox show <package>\` to see available versions"
+  export SHOW_HINT="Use 'flox show <package>' to see available versions"
   # Separator character for ambiguous package sources
   export SEP=":"
 
@@ -79,6 +79,7 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=search:match-stategy
 @test "'FLOX_FEATURES_SEARCH_STRATEGY=match flox search' expected number of results: 'hello'" {
   FLOX_FEATURES_SEARCH_STRATEGY=match run --separate-stderr "$FLOX_BIN" search hello --all
   assert_equal "${#lines[@]}" 11
@@ -246,6 +247,7 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=search:hint
 @test "'flox search' includes search term in hint" {
   run --separate-stderr "$FLOX_BIN" search python
   assert_regex "$stderr" "flox search python --all"


### PR DESCRIPTION
Implementation of #804


currently it's using the "maximalist" alternate design since that allowed for the most code reuse currently..

Current example output:

```
$ flox search make
gnustep.make                             A build manager for GNUstep
chickenPackages_5.chickenEggs.make       The PLT 'make' macro
vimPlugins.nvim-treesitter-parsers.make  <no description provided>
alpine-make-vm-image                     Make customized Alpine Linux disk image for virtual machines
automake                                 GNU standard-compliant makefile generator
automake116x                             GNU standard-compliant makefile generator
automake115x                             GNU standard-compliant makefile generator
automake111x                             GNU standard-compliant makefile generator
bmake                                    Portable version of NetBSD 'make'
cargo-make                               A Rust task runner and build tool

Showing 10 of 217 results. Use `flox search make --all` to see the full list.
Use `flox show <package>` to see available versions

Related search results for 'gnumake':
gnumake                    A tool to control the generation of non-source files from sources
minimal-bootstrap.gnumake  A tool to control the generation of non-source files from sources
gnumake42                  A tool to control the generation of non-source files from sources

Use `flox show <package>` to see available versions

```
