### PR TITLE
fix: remove "weird" from our debug message

### DIFF
--- a/cli/flox/src/utils/init/mod.rs
+++ b/cli/flox/src/utils/init/mod.rs
@@ -69,7 +69,7 @@ pub fn init_access_tokens(
         }
         tokens
     } else {
-        debug!("no default user nix.conf found - weird");
+        debug!("no default user nix.conf found");
         Default::default()
     };
 


### PR DESCRIPTION
Previously the message had a suffix that said " - weird". It's not ideal to
tell a user that their freshly installed flox has a weird setup if they've done
nothing. So, let's just take out the word weird.

## Release Notes
N/A