### PR TITLE
feat: Use flox-dev Auth0 tenant instead of legacy dev

### DIFF
--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -50,7 +50,7 @@
 
   # build time environment variables
   envs = let
-    auth0BaseUrl = "https://dev-j4tiszdm1f0b70xf.us.auth0.com";
+    auth0BaseUrl = "https://flox-dev.us.auth0.com";
   in
     {
       # 3rd party CLIs
@@ -76,7 +76,7 @@
       METRICS_EVENTS_API_KEY = "5pAQnBqz5Q7dpqVD9BEXQ4Kdc3D2fGTd3ZgP0XXK";
 
       # oauth client id
-      OAUTH_CLIENT_ID = "s4BF6zGVcYh3gZUHwp6C4cGf3ey5Bwio";
+      OAUTH_CLIENT_ID = "e8BGlekBE8w88LyrqGifts588wHtw03Q";
       OAUTH_BASE_URL = "${auth0BaseUrl}";
       OAUTH_AUTH_URL = "${auth0BaseUrl}/authorize";
       OAUTH_TOKEN_URL = "${auth0BaseUrl}/oauth/token";


### PR DESCRIPTION
This updates the Auth0 base URL and client ID to point to the new
flox-dev tenant.


## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->