### PR TITLE
fix: match r and r/w db timeouts

### DIFF
--- a/pkgdb/src/pkgdb/input.cc
+++ b/pkgdb/src/pkgdb/input.cc
@@ -70,8 +70,8 @@ PkgDbInput::init()
         }
       catch ( ... )
         {
-          std::this_thread::sleep_for( DurationMillis( 250 ) );
-          if ( ++retries > 100 )
+          std::this_thread::sleep_for( DB_RETRY_PERIOD );
+          if ( ++retries > DB_MAX_RETRIES )
             {
               throw PkgDbException(
                 "couldn't initialize read-only package database" );


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
The timeouts while waiting for a database scrape were different while waiting to create a read/write connection vs. a read-only connection. The read-only timeout was roughly 20 seconds, whereas the read/write timeout is a little over 4 minutes. This PR makes the read-only timeout the same as the read/write timeout (~4 minutes).

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
