### PR TITLE
feat: deduplicate multi-system search results

### DIFF
--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -25,7 +25,7 @@ use crate::utils::didyoumean::{DidYouMean, SearchSuggestion};
 use crate::utils::search::{
     construct_search_params,
     manifest_and_lockfile,
-    render_search_results_user_facing,
+    DisplaySearchResults,
     DEFAULT_DESCRIPTION,
     SEARCH_INPUT_SEPARATOR,
 };
@@ -135,7 +135,7 @@ impl Search {
                 bail!(message);
             }
 
-            let results = render_search_results_user_facing(&self.search_term, results)?;
+            let results = DisplaySearchResults::from_search_results(&self.search_term, results)?;
             println!("{results}");
 
             info!("");
@@ -224,10 +224,11 @@ fn construct_show_params(
         _ => Err(ShowError::InvalidSearchTerm(search_term.to_owned()))?,
     };
 
-    let query = Query::from_term_and_limit(
+    let query = Query::new(
         package_name.as_ref().unwrap(), // We already know it's Some(_)
         Features::parse()?.search_strategy,
         None,
+        false,
     )?;
     let search_params = SearchParams {
         manifest,

--- a/cli/flox/src/utils/didyoumean.rs
+++ b/cli/flox/src/utils/didyoumean.rs
@@ -7,7 +7,7 @@ use flox_rust_sdk::models::lockfile::LockedManifest;
 use flox_rust_sdk::models::search::{do_search, PathOrJson, SearchResults};
 use log::debug;
 
-use super::search::render_search_results_user_facing;
+use super::search::{DisplayItems, DisplaySearchResults};
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::search::construct_search_params;
 
@@ -136,12 +136,9 @@ impl Display for DidYouMean<'_, InstallSuggestion> {
             None => "more".to_string(),
         };
 
-        for result in self.search_results.results.iter() {
-            writeln!(
-                f,
-                "  $ flox install {path}",
-                path = result.rel_path.join(".")
-            )?;
+        let display_items = DisplayItems::from_search_results(self.search_results.results.clone());
+        for result in display_items.0.iter() {
+            writeln!(f, "  $ flox install {result}",)?;
         }
 
         write!(
@@ -248,7 +245,7 @@ impl Display for DidYouMean<'_, SearchSuggestion> {
         };
 
         let search_results_rendered =
-            match render_search_results_user_facing(curated, self.search_results.clone()) {
+            match DisplaySearchResults::from_search_results(curated, self.search_results.clone()) {
                 Ok(rendered) => rendered,
                 Err(err) => {
                     debug!("failed to render search results: {}", err);

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -1,12 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
-use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
-use anyhow::{bail, Context, Result};
+use anyhow::Result;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::lockfile::LockedManifest;
-use flox_rust_sdk::models::search::{PathOrJson, Query, SearchParams, SearchResults};
+use flox_rust_sdk::models::search::{PathOrJson, Query, SearchParams, SearchResult, SearchResults};
 use log::debug;
 
 use crate::commands::detect_environment;
@@ -72,10 +71,11 @@ pub(crate) fn construct_search_params(
     global_manifest: PathOrJson,
     lockfile: PathOrJson,
 ) -> Result<SearchParams> {
-    let query = Query::from_term_and_limit(
+    let query = Query::new(
         search_term,
         Features::parse()?.search_strategy,
         results_limit,
+        true,
     )?;
     let params = SearchParams {
         manifest,
@@ -87,108 +87,148 @@ pub(crate) fn construct_search_params(
     Ok(params)
 }
 
-/// Deduplicate and disambiguate display items.
-///
-/// This gets complicated because we have to satisfy a few constraints:
-/// - The order of results from `pkgdb` is important (best matches come first),
-///   so that order must be preserved.
-/// - Versions shouldn't appear in the output, so multiple package versions from a single
-///   input should be deduplicated.
-/// - Packages that appear in more than one input need to be disambiguated by prepending
-///   the name of the input and a separator.
-fn dedup_and_disambiguate_display_items(mut display_items: Vec<DisplayItem>) -> Vec<DisplayItem> {
-    let mut package_to_inputs: HashMap<String, HashSet<String>> = HashMap::new();
-    for d in display_items.iter() {
-        // Build a collection of packages and which inputs they are seen in so we can tell
-        // which packages need to be disambiguated when rendering search results.
-        package_to_inputs
-            .entry(d.package.clone())
-            .and_modify(|inputs| {
-                inputs.insert(d.input.clone());
-            })
-            .or_insert_with(|| HashSet::from_iter([d.input.clone()]));
-    }
-
-    // For any package that comes from more than one input, mark it as needing to be joined
-    for d in display_items.iter_mut() {
-        if let Some(inputs) = package_to_inputs.get(&d.package) {
-            d.render_with_input = inputs.len() > 1;
-        }
-    }
-
-    // For each package in the search results, `package_to_inputs` contains the set of
-    // inputs that the package is found in. Logically `package_to_inputs` contains
-    // (package, input) pairs. If the `package` and `input` from a `DisplayItem` are
-    // found in `package_to_inputs` it means that we have not yet seen this (package, input)
-    // pair and we should render it (e.g. add it to `deduped_display_items`). Once we've
-    // done that we remove this (package, input) pair from `package_to_inputs` so that
-    // we never see that pair again.
-    let mut deduped_display_items = Vec::new();
-    for d in display_items.into_iter() {
-        if let Some(inputs) = package_to_inputs.get_mut(d.package.as_str()) {
-            // Remove this input so this (package, input) pair is never seen again
-            if inputs.remove(&d.input) {
-                deduped_display_items.push(d.clone());
-            }
-            if inputs.is_empty() {
-                package_to_inputs.remove(&d.package);
-            }
-        }
-    }
-
-    deduped_display_items
-}
-
 /// An intermediate representation of a search result used for rendering
 #[derive(Debug, PartialEq, Clone)]
-struct DisplayItem {
+pub struct DisplayItem {
     /// The input that the package came from
     input: String,
-    /// The displayable part of the package's attribute path
-    package: String,
+    /// The attribute path of the package, excluding subtree and system
+    rel_path: Vec<String>,
     /// The package description
     description: Option<String>,
     /// Whether to join the `input` and `package` fields with a separator when rendering
     render_with_input: bool,
 }
 
+impl Display for DisplayItem {
+    /// Render a display item in the format that should be output by
+    /// `flox search`.
+    ///
+    /// It should be possible to copy and paste this as an argument to
+    /// `flox install`.
+    ///
+    /// If we change this function, we will likely need to update what the
+    /// deduplicate field controls in pkgdb.
+    /// Technically, pkgdb shouldn't have knowledge of this format,
+    /// but it's nicer to perform deduplication in SQL.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.render_with_input {
+            write!(f, "{}{SEARCH_INPUT_SEPARATOR}", self.input)?;
+        }
+        write!(f, "{}", self.rel_path.join("."))
+    }
+}
+
+/// Contains [DisplayItem]s that have been disambiguated.
+///
+/// This should be used for printing search results when the format output by
+/// [DisplaySearchResults] is not desired.
+pub struct DisplayItems(pub Vec<DisplayItem>);
+
+impl DisplayItems {
+    pub fn from_search_results(search_results: Vec<SearchResult>) -> Self {
+        // Search results contain a lot of information, but all we need for rendering are
+        // the input, the package subpath (e.g. "python310Packages.flask"), and the description.
+        let mut display_items = search_results
+            .into_iter()
+            .map(|r| DisplayItem {
+                input: r.input,
+                rel_path: r.rel_path,
+                description: r.description.map(|s| s.replace('\n', " ")),
+                render_with_input: false,
+            })
+            .collect::<Vec<_>>();
+
+        // TODO: we could disambiguate as we're collecting above
+        Self::disambiguate_display_items(&mut display_items);
+
+        Self(display_items)
+    }
+
+    /// Disambiguate display items.
+    ///
+    /// This gets complicated because we have to satisfy a few constraints:
+    /// - The order of results from `pkgdb` is important (best matches come first),
+    ///   so that order must be preserved.
+    /// - Packages that appear in more than one input need to be disambiguated by prepending
+    ///   the name of the input and a separator.
+    fn disambiguate_display_items(display_items: &mut [DisplayItem]) {
+        let mut package_to_inputs: HashMap<Vec<String>, HashSet<String>> = HashMap::new();
+        for d in display_items.iter() {
+            // Build a collection of packages and which inputs they are seen in so we can tell
+            // which packages need to be disambiguated when rendering search results.
+            package_to_inputs
+                .entry(d.rel_path.clone())
+                .and_modify(|inputs| {
+                    inputs.insert(d.input.clone());
+                })
+                .or_insert_with(|| HashSet::from_iter([d.input.clone()]));
+        }
+
+        // For any package that comes from more than one input, mark it as needing to be joined
+        for d in display_items.iter_mut() {
+            if let Some(inputs) = package_to_inputs.get(&d.rel_path) {
+                d.render_with_input = inputs.len() > 1;
+            }
+        }
+    }
+}
+
+///
 pub struct DisplaySearchResults {
     /// original search term
     search_term: String,
     /// deduplicated and disambiguated search results
-    deduped_display_items: Vec<DisplayItem>,
+    display_items: DisplayItems,
     /// reported number of results
     count: Option<u64>,
     /// number of actual results (including duplicates)
     n_results: u64,
 }
 
+/// A struct that wraps the functionality needed to print [SearchResults] to a
+/// user.
+impl DisplaySearchResults {
+    /// Display a list of search results for a given search term
+    /// This function is responsible for disambiguating search results
+    /// and printing them to stdout in a user-friendly table-ish format.
+    ///
+    /// If no results are found, this function will print nothing
+    /// it's the caller's responsibility to print a message,
+    /// or error if no results are found.
+    pub(crate) fn from_search_results(
+        search_term: &str,
+        search_results: SearchResults,
+    ) -> Result<DisplaySearchResults> {
+        let n_results = search_results.results.len();
+
+        let display_items = DisplayItems::from_search_results(search_results.results);
+
+        Ok(DisplaySearchResults {
+            search_term: search_term.to_string(),
+            display_items,
+            count: search_results.count,
+            n_results: n_results as u64,
+        })
+    }
+}
+
 impl Display for DisplaySearchResults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let column_width = self
-            .deduped_display_items
+            .display_items
+            .0
             .iter()
-            .map(|d| {
-                if d.render_with_input {
-                    d.input.len() + d.package.len() + SEARCH_INPUT_SEPARATOR.len()
-                } else {
-                    d.package.len()
-                }
-            })
+            .map(|d| d.to_string().len())
             .max()
             .unwrap_or_default();
 
         // Finally print something
-        let mut items = self.deduped_display_items.iter().peekable();
+        let mut items = self.display_items.0.iter().peekable();
 
         while let Some(d) = items.next() {
             let desc = d.description.as_deref().unwrap_or(DEFAULT_DESCRIPTION);
-            let package = if d.render_with_input {
-                [&*d.input, &*d.package].join(SEARCH_INPUT_SEPARATOR)
-            } else {
-                d.package.to_string()
-            };
-            write!(f, "{package:<column_width$}  {desc}")?;
+            write!(f, "{d:<column_width$}  {desc}")?;
             // Only print a newline if there are more items to print
             if items.peek().is_some() {
                 writeln!(f)?;
@@ -217,50 +257,9 @@ impl DisplaySearchResults {
         }
 
         Some(format!(
-                "Showing {n_deduplicated} of {count} results. Use `flox search {search_term} --all` to see the full list.",
-                n_deduplicated = self.deduped_display_items.len(),
+                "Showing {n_results} of {count} results. Use `flox search {search_term} --all` to see the full list.",
+                n_results = self.n_results,
                 search_term = self.search_term
             ))
     }
-}
-
-/// Display a list of search results for a given search term
-/// This function is responsible for deduplicating and disambiguating search results
-/// and printing them to stdout in a user-friendly table-ish format.
-///
-/// If no results are found, this function will print nothing
-/// it's the caller's responsibility to print a message,
-/// or error if no results are found.
-pub(crate) fn render_search_results_user_facing(
-    search_term: &str,
-    search_results: SearchResults,
-) -> Result<DisplaySearchResults> {
-    let n_results = search_results.results.len();
-
-    // Search results contain a lot of information, but all we need for rendering are
-    // the input, the package subpath (e.g. "python310Packages.flask"), and the description.
-    let display_items = search_results
-        .results
-        .into_iter()
-        .map(|r| {
-            Ok(DisplayItem {
-                input: r.input,
-                package: r.rel_path.join("."),
-                description: r.description.map(|s| s.replace('\n', " ")),
-                render_with_input: false,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let deduped_display_items = dedup_and_disambiguate_display_items(display_items);
-    if deduped_display_items.is_empty() {
-        bail!("deduplicating search results failed");
-    }
-
-    Ok(DisplaySearchResults {
-        search_term: search_term.to_string(),
-        deduped_display_items,
-        count: search_results.count,
-        n_results: n_results as u64,
-    })
 }

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -20,6 +20,7 @@ project_setup() {
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" > /dev/null || return
   export LOCKFILE_PATH="$PROJECT_DIR/.flox/env/manifest.lock"
+  export MANIFEST_PATH="$PROJECT_DIR/.flox/env/manifest.toml"
 }
 
 project_teardown() {
@@ -27,6 +28,7 @@ project_teardown() {
   rm -rf "${PROJECT_DIR?}"
   unset PROJECT_DIR
   unset LOCKFILE_PATH
+  unset MANIFEST_PATH
 }
 
 # ---------------------------------------------------------------------------- #
@@ -98,6 +100,18 @@ teardown() {
   assert_failure
   assert_output --partial "Here are a few other similar options:"
   assert_output --partial "options with 'flox search package'"
+}
+
+@test "'flox install' doesn't provide duplicate suggestions for a multi-system environment" {
+  "$FLOX_BIN" init
+  sed -i 's/systems = \[/systems = \["'"$(get_system_other_than_current)"'", /' "$MANIFEST_PATH"
+  run "$FLOX_BIN" install npm
+  assert_failure
+  # TODO: it would be less lazy to assert 3 distinct packages are returned
+  # rather than hardcoding package names.
+  assert_output --partial "flox install nodejs"
+  assert_output --partial "flox install elmPackages.nodejs"
+  assert_output --partial "flox install nodejs_20"
 }
 
 @test "'flox install' provides curated suggestions when package not found" {

--- a/cli/tests/environment-push.bats
+++ b/cli/tests/environment-push.bats
@@ -187,16 +187,7 @@ function update_dummy_env() {
 
   run "$FLOX_BIN" init
 
-  init_system=
-  # replace linux with darwin or darwin with linux
-  if [ -z "${NIX_SYSTEM##*-linux}" ]; then
-    init_system="${NIX_SYSTEM%%-linux}-darwin"
-  elif [ -z "${NIX_SYSTEM#*-darwin}" ]; then
-    init_system="${NIX_SYSTEM%%-darwin}-linux"
-  else
-    echo "unknown system: '$NIX_SYSTEM'"
-    exit 1
-  fi
+  init_system=$(get_system_other_than_current)
 
   tomlq --in-place -t ".options.systems=[\"$init_system\"]" .flox/env/manifest.toml
 

--- a/cli/tests/package-search.bats
+++ b/cli/tests/package-search.bats
@@ -22,12 +22,14 @@ project_setup() {
   run "$FLOX_BIN" init
   assert_success
   unset output
+  export MANIFEST_PATH="$PROJECT_DIR/.flox/env/manifest.toml"
 }
 
 project_teardown() {
   popd > /dev/null || return
   rm -rf "${PROJECT_DIR?}"
   unset PROJECT_DIR
+  unset MANIFEST_PATH
 }
 
 # ---------------------------------------------------------------------------- #
@@ -292,6 +294,40 @@ setup_file() {
   run "$FLOX_BIN" search Packages.req
   assert_success
   assert_output --partial 'Showing 10 of'
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox search' - same number of results for single and multi system environments" {
+  local extra_system
+  run --separate-stderr "$FLOX_BIN" search neovim
+  assert_success
+
+  num_lines="${#lines[@]}"
+
+  # extract total from '* of XX results*'
+  total="${stderr#* of }"
+  total="${total% results*}"
+
+  sed -i 's/systems = \[/systems = \["'"$(get_system_other_than_current)"'", /' "$MANIFEST_PATH"
+  run --separate-stderr "$FLOX_BIN" search neovim
+  assert_success
+
+  multi_system_num_lines="${#lines[@]}"
+
+  # extract showing from '*Showing XX of*
+  multi_system_showing="${stderr#*Showing }"
+  multi_system_showing="${multi_system_showing% of*}"
+
+  # extract total from '* of XX results*'
+  multi_system_total="${stderr#* of }"
+  multi_system_total="${multi_system_total% results*}"
+
+  # We chould be displaying the number of lines we say we are.
+  assert_equal "$multi_system_num_lines" "$multi_system_showing"
+  # We should have the same numbers before and after adding the second system.
+  assert_equal "$num_lines" "$multi_system_num_lines"
+  assert_equal "$total" "$multi_system_total"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -150,6 +150,22 @@ common_test_teardown() {
 
 teardown() { common_test_teardown; }
 
+# Get a system different from the current one.
+get_system_other_than_current() {
+  # replace linux with darwin or darwin with linux
+  case "$NIX_SYSTEM" in
+    *-darwin)
+      extra_system="${NIX_SYSTEM%%-darwin}-linux"
+      ;;
+    *-linux)
+      extra_system="${NIX_SYSTEM%%-linux}-darwin"
+      ;;
+    *)
+      echo "Unsupported system: $NIX_SYSTEM"
+      return 1
+  esac
+  echo "$extra_system"
+}
 # ---------------------------------------------------------------------------- #
 #
 #

--- a/pkgdb/include/flox/pkgdb/pkg-query.hh
+++ b/pkgdb/include/flox/pkgdb/pkg-query.hh
@@ -78,7 +78,16 @@ struct PkgQueryArgs
   std::optional<std::string> pname;   /**< Filter results by exact `pname`. */
   std::optional<std::string> version; /**< Filter results by exact version. */
   std::optional<std::string> semver;  /**< Filter results by version range. */
-  std::optional<uint8_t>     limit;   /**< Limit the number of results */
+  /**
+   * Limit the number of results
+   * TODO: limit is unused except in the search command. */
+  std::optional<uint8_t> limit;
+  /**
+   * Return a single result for each package descriptor used by `search` and
+   * `install`. This is a bit hacky as pkgdb shouldn't really have knowledge of
+   * that format. But it's nicer to perform deduplication in SQL.
+   */
+  bool deduplicate = false;
 
   // TODO: would it be better to expose matchPname, matchAttrName,
   // matchDescription, and matchRelPath fields that we join with OR rather than

--- a/pkgdb/include/flox/search/params.hh
+++ b/pkgdb/include/flox/search/params.hh
@@ -47,6 +47,12 @@ struct SearchQuery
   std::optional<std::string> version; /**< Filter results by exact version. */
   std::optional<std::string> semver;  /**< Filter results by version range. */
   std::optional<uint8_t> limit; /**< Limit to a particular number of results. */
+  /**
+   * Return a single result for each package descriptor used by `search` and
+   * `install`. This is a bit hacky as pkgdb shouldn't really have knowledge of
+   * that format. But it's nicer to perform deduplication in SQL.
+   */
+  bool deduplicate = false;
 
   /** Filter results by partial match on pname, attrName, or description */
   std::optional<std::string> partialMatch;

--- a/pkgdb/src/pkgdb/pkg-query.cc
+++ b/pkgdb/src/pkgdb/pkg-query.cc
@@ -111,6 +111,8 @@ to_json( nlohmann::json & jto, const PkgQueryArgs & args )
     { "subtrees", args.subtrees },
     { "systems", args.systems },
     { "relPath", args.relPath },
+    { "limit", args.limit },
+    { "deduplicate", args.deduplicate },
   };
 }
 
@@ -536,6 +538,7 @@ PkgQuery::str() const
   else { qry << this->selects.str(); }
   qry << " FROM v_PackagesSearch";
   if ( ! this->firstWhere ) { qry << " WHERE " << this->wheres.str(); }
+  if ( this->deduplicate ) { qry << "\n GROUP BY relPath\n"; }
   if ( ! this->firstOrder ) { qry << " ORDER BY " << this->orders.str(); }
   qry << " )";
   return qry.str();

--- a/pkgdb/src/search/params.cc
+++ b/pkgdb/src/search/params.cc
@@ -113,6 +113,10 @@ from_json( const nlohmann::json & jfrom, SearchQuery & qry )
       else if ( key == "limit" ) { getOrFail( key, value, qry.limit ); }
       else if ( key == "semver" ) { getOrFail( key, value, qry.semver ); }
       else if ( key == "match" ) { getOrFail( key, value, qry.partialMatch ); }
+      else if ( key == "deduplicate" )
+        {
+          getOrFail( key, value, qry.deduplicate );
+        }
       else if ( key == "match-name" )
         {
           getOrFail( key, value, qry.partialNameMatch );
@@ -147,6 +151,7 @@ to_json( nlohmann::json & jto, const SearchQuery & qry )
   jto["match-name"]             = qry.partialNameMatch;
   jto["match-name-or-rel-path"] = qry.partialNameOrRelPathMatch;
   jto["limit"]                  = qry.limit;
+  jto["deduplicate"]            = qry.deduplicate;
 }
 
 
@@ -164,6 +169,7 @@ SearchQuery::fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const
   pqa.partialNameMatch          = this->partialNameMatch;
   pqa.partialNameOrRelPathMatch = this->partialNameOrRelPathMatch;
   pqa.limit                     = this->limit;
+  pqa.deduplicate               = this->deduplicate;
   return pqa;
 }
 


### PR DESCRIPTION
Currently, search results are deduplicated in Rust, which means:
- Search limit is not implemented correctly, because results are deduplicated after the limit is applied rather than before.
- Deduplication is not applied everywhere it should be: DidYouMean doesn't deduplicate results for InstallSuggestions.

Instead, use a `GROUP BY relPath` in pkgdb to deduplicate results. While this violates the separation of knowledge between search/install and pkgdb, it seems like the best way to get deduplication done for now. If we want to restore the separation of knowledge, we could expose fields that toggle `GROUP BY` statements.

Additionally, clean up how search results are handled in Rust. Ensure that all search results are disambiguated and displayed correctly by only printing search results with the DisplayItem::fmt method.

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
