### PR TITLE
fix: handle `path_helper` and activate non-interactively without error

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::error::Error;
 use std::ffi::{OsStr, OsString};
 use std::fmt::Display;
@@ -529,6 +530,25 @@ impl Activate {
             .unwrap_or(utils::colors::LIGHT_BLUE.to_ansi256().to_string());
         let prompt_color_2 = env::var("FLOX_PROMPT_COLOR_2")
             .unwrap_or(utils::colors::DARK_PEACH.to_ansi256().to_string());
+
+        let exports = HashMap::from([
+            (FLOX_ENV_VAR, activation_path.to_string_lossy().to_string()),
+            (FLOX_PROMPT_ENVIRONMENTS_VAR, flox_prompt_environments),
+            (
+                FLOX_ACTIVE_ENVIRONMENTS_VAR,
+                flox_active_environments.to_string(),
+            ),
+            (
+                FLOX_ENV_DIRS_VAR,
+                flox_env_dirs_joined.to_string_lossy().to_string(),
+            ),
+            (
+                FLOX_ENV_LIB_DIRS_VAR,
+                flox_env_lib_dirs_joined.to_string_lossy().to_string(),
+            ),
+            ("FLOX_PROMPT_COLOR_1", prompt_color_1),
+            ("FLOX_PROMPT_COLOR_2", prompt_color_2),
+        ]);
 
         // when output is not a tty, and no command is provided
         // we just print an activation script to stdout

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -450,8 +450,8 @@ impl Activate {
 
         let in_place = self.in_place || (!stdout().is_tty() && self.run_args.is_empty());
         // Don't spin in bashrcs and similar contexts
-        let activation_path = if in_place {
-            environment.activation_path(&flox)?
+        let activation_path_result = if in_place {
+            environment.activation_path(&flox)
         } else {
             Dialog {
                 message: &format!("Getting ready to use environment {now_active}..."),

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -488,8 +488,17 @@ impl Activate {
 
         // Add to FLOX_ACTIVE_ENVIRONMENTS so we can detect what environments are active.
         let mut flox_active_environments = activated_environments();
+
+        // Detect if the current environment is already active
         if flox_active_environments.is_active(&now_active) {
-            bail!("Environment '{now_active}' is already active");
+            debug!("Environment is already active: environment={now_active}");
+
+            if stdout().is_tty() || !self.run_args.is_empty() {
+                // Error if interactive and already active
+                bail!("Environment '{now_active}' is already active");
+            }
+
+            return Ok(());
         }
         flox_active_environments.set_last_active(now_active.clone());
 

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -764,7 +764,6 @@ impl Activate {
             );
         } else {
             debug!("No path patching needed");
-            println!("true");
         };
         Ok(())
     }

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -498,14 +498,11 @@ impl Activate {
 
         // Detect if the current environment is already active
         if flox_active_environments.is_active(&now_active) {
-            debug!("Environment is already active: environment={now_active}");
-
             if !in_place {
                 // Error if interactive and already active
-                bail!("Environment '{now_active}' is already active");
+                bail!("Environment '{now_active}' is already active.");
             }
-
-            debug!("Non-interactive shell, ignoring activation (may patch PATH)");
+            debug!("Environment is already active: environment={now_active}. Ignoring activation (may patch PATH)");
             Self::reactivate_non_interactive()?;
             return Ok(());
         }

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -753,10 +753,7 @@ impl Activate {
             .map(env::split_paths)
             .map(IndexSet::from_iter)
             .unwrap_or_default();
-        if let Some(fixed_up_path) = Self::fixup_path(flox_env_dirs) {
-            let fixed_up_path_joined = env::join_paths(fixed_up_path).context(
-                "Cannot activate environment because its path contains an invalid character",
-            )?;
+        if let Some(fixed_up_path_joined) = Self::fixup_path(flox_env_dirs).transpose()? {
             debug!(
                 "Patching PATH to {}",
                 fixed_up_path_joined.to_string_lossy()

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -413,3 +413,16 @@ env_is_activated() {
   assert_line --partial "hello is $(realpath $PROJECT_DIR)/.flox/run/"
   assert_line "baz"
 }
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate,activate:inplace-reactivate
+@test "'flox activate' modifies the current shell (bash) when already activated" {
+  run "$FLOX_BIN" activate -- "$FLOX_BIN" activate --in-place
+  assert_success
+  if [[ -e  /usr/libexec/path_helper ]]; then
+    assert_output --regexp "^(export PATH=.+)$"
+  else
+    assert_output --regexp "^true$"
+  fi
+}

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -417,12 +417,19 @@ env_is_activated() {
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:inplace-reactivate
-@test "'flox activate' modifies the current shell (bash) when already activated" {
-  run "$FLOX_BIN" activate -- "$FLOX_BIN" activate --in-place
+@test "'flox activate' only patches PATH when already activated" {
+  run bash -c 'eval "$("$FLOX_BIN" activate --in-place)"; "$FLOX_BIN" activate --in-place'
   assert_success
   if [[ -e  /usr/libexec/path_helper ]]; then
     assert_output --regexp "^(export PATH=.+)$"
   else
     assert_output --regexp "^true$"
   fi
+}
+
+# bats test_tags=activate,activate:inplace-reactivate
+@test "'flox activate' does not patch PATH when not activated" {
+  run "$FLOX_BIN" activate --in-place
+  assert_success
+  refute_output --regexp "^(export PATH=.+)$"
 }

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -420,10 +420,14 @@ env_is_activated() {
 @test "'flox activate' only patches PATH when already activated" {
   run bash -c 'eval "$("$FLOX_BIN" activate --in-place)"; "$FLOX_BIN" activate --in-place'
   assert_success
+  # on macos activating an already activated environment using
+  # `eval "$(flox activate [--in-place])"
+  # will only fix the PATH
   if [[ -e  /usr/libexec/path_helper ]]; then
     assert_output --regexp "^(export PATH=.+)$"
   else
-    assert_output --regexp "^true$"
+    # on linux reactivation is ignored
+    assert_output ""
   fi
 }
 

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0100_common-paths.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0100_common-paths.sh
@@ -57,22 +57,21 @@ export MANPATH
 
 # ---------------------------------------------------------------------------- #
 
-
 if [ -n "${FLOX_ENV_LIB_DIRS:-}" ]; then
   case "$(uname -s)" in
-  Linux*)
-    # N.B. ld-floxlib.so makes use of FLOX_ENV_LIB_DIRS directly.
-    if [ -z "${FLOX_NOSET_LD_AUDIT:-}" -a -e "$LD_FLOXLIB" ]; then
-      LD_AUDIT="$LD_FLOXLIB";
-      export LD_AUDIT;
-    fi
-    ;;
-  Darwin*)
-    if [ -z "${FLOX_NOSET_DYLD_FALLBACK_LIBRARY_PATH:-}" ]; then
-      DYLD_FALLBACK_LIBRARY_PATH="$FLOX_ENV_LIB_DIRS:${DYLD_FALLBACK_LIBRARY_PATH:-/usr/local/lib:/usr/lib}";
-      export DYLD_FALLBACK_LIBRARY_PATH;
-    fi
-    ;;
+    Linux*)
+      # N.B. ld-floxlib.so makes use of FLOX_ENV_LIB_DIRS directly.
+      if [ -z "${FLOX_NOSET_LD_AUDIT:-}" -a -e "$LD_FLOXLIB" ]; then
+        LD_AUDIT="$LD_FLOXLIB"
+        export LD_AUDIT
+      fi
+      ;;
+    Darwin*)
+      if [ -z "${FLOX_NOSET_DYLD_FALLBACK_LIBRARY_PATH:-}" ]; then
+        DYLD_FALLBACK_LIBRARY_PATH="$FLOX_ENV_LIB_DIRS:${DYLD_FALLBACK_LIBRARY_PATH:-/usr/local/lib:/usr/lib}"
+        export DYLD_FALLBACK_LIBRARY_PATH
+      fi
+      ;;
   esac
 fi
 

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0100_common-paths.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0100_common-paths.sh
@@ -38,7 +38,7 @@ export \
 # to the front.
 # The PATH items corresponding to the current activation
 # are subsequently prepended to the patched path as usual.
-if [ ! -z "${FLOX_PATH_PATCHED+x}" ]; then
+if [ -n "${FLOX_PATH_PATCHED:-}" ]; then
   PATH="$FLOX_PATH_PATCHED"
   unset FLOX_PATH_PATCHED
 fi

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0100_common-paths.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0100_common-paths.sh
@@ -4,7 +4,6 @@
 #
 # ---------------------------------------------------------------------------- #
 
-PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin${PATH:+:$PATH}"
 FPATH="$FLOX_ENV/share/zsh/vendor-completions${FPATH:+:$FPATH}"
 FPATH="$FLOX_ENV/share/zsh/site-functions:$FPATH"
 INFOPATH="$FLOX_ENV/share/info${INFOPATH:+:$INFOPATH}"
@@ -16,7 +15,6 @@ ACLOCAL_PATH="$FLOX_ENV/share/aclocal${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
 XDG_DATA_DIRS="$FLOX_ENV/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
 
 export \
-  PATH \
   FPATH \
   INFOPATH \
   CPATH \
@@ -25,6 +23,28 @@ export \
   ACLOCAL_PATH \
   XDG_DATA_DIRS \
   ;
+
+# ---------------------------------------------------------------------------- #
+
+# Set the PATH environment variable.
+# In the general case, we prepend the flox environments `bin/` and `sbin/`
+# macOS uses `path_helper` to always move system paths at the front of PATH.
+# We can't do much about that, but we can try to fight back
+# by likewise moving the flox environment paths to the front.
+#
+# `FLOX_PATH_PATCHED` is set by `flox activate`
+# *iff* there is a `/usr/libexec/path_helper`.
+# In that case, the existing PATH is patched to move the flox environment paths
+# to the front.
+# The PATH items corresponding to the current activation
+# are subsequently prepended to the patched path as usual.
+if [ ! -z "${FLOX_PATH_PATCHED+x}" ]; then
+  PATH="$FLOX_PATH_PATCHED"
+  unset FLOX_PATH_PATCHED
+fi
+
+PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin${PATH:+:$PATH}"
+export PATH
 
 # ---------------------------------------------------------------------------- #
 


### PR DESCRIPTION
In non-interactive, non-executing mode (i.e. when used as `eval "$(flox activate)"` allow activating an already active environment.

When spawning interactive subhells regularly (e.g. with `tmux`), users observe errors reading "Environment <env> already active". #812 

This PR adds a check after detecting double activation and permits activation.

[fix: do not fail if run non-interactive (with eval)](https://github.com/flox/flox/commit/0963d94d674ce44c891d1433fac66aec14524e0b) implements this by simply returning early, printing _nothing_.

The following commits add a mitigation to the effects of the `path_helper` on macos machines.
The `path_helper`'s intent is to construct a valid `PATH` by _appending_ default system paths.
Unfortunately, contrary to that intent, the elements of `$PATH` end up being appended to the default paths.
This causes issues in subshells where the order of the PATH changes causing system default paths to be preferred over custom PATH values (such as `$FLOX_ENV/bin`). #811 

As a remedy we filter out PATH segments of known environment paths and nix store directories and _prepend_ tem to the rest of PATH.

If `/usr/libexec/path_helper` exists: 
* When "reactivating"  (see above) we will return this modified path exactly:
```
eval "$(flox activate)" -> eval "export PATH=<flox_env_dirs>:$PATH"
``` 
* In case of normal activation we set `FLOX_PATH_PATCHED=<flox_env_dirs>:$PATH`
  and substitute `PATH` through `etc/profile.d/0100_common-paths.sh`

