### PR TITLE
fix: column formatting of search results

### DIFF
--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -233,7 +233,7 @@ impl Display for DisplaySearchResults {
 
         while let Some(d) = items.next() {
             let desc = d.description.as_deref().unwrap_or(DEFAULT_DESCRIPTION);
-            write!(f, "{d:<column_width$}  {desc}")?;
+            write!(f, "{d:<column_width$}  {desc}", d = d.to_string())?;
             // Only print a newline if there are more items to print
             if items.peek().is_some() {
                 writeln!(f)?;


### PR DESCRIPTION
Apply format to a `String` rather than passing it on to the `DisplayItem` formatter.

fixes #876
