### PR TITLE
fix: do not pull managed env into a tempdir

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1387,34 +1387,23 @@ impl Pull {
         let pointer_content =
             serde_json::to_string_pretty(&pointer).context("Could not serialize pointer")?;
 
-        let dot_flox_parent = dot_flox_path
-            .parent()
-            .context("Could not get .flox/ parent")?;
-        fs::create_dir_all(dot_flox_parent).context("Could not create .flox/ parent directory")?;
+        fs::create_dir_all(&dot_flox_path).context("Could not create .flox/ directory")?;
 
-        // Pulls the environment into a temp directory which is later renamed to `.flox`.
-        // We do this to avoid populating the floxmeta branch `owner/name.encode(path to .flox)`
-        // in case building fails or the user aborts the fixup.
-        // The branch will be adjusted when the environment is opened the next time
-        // by the `ensure_branch` routine.
-        let temp_dot_flox_dir = tempfile::TempDir::with_prefix_in(DOT_FLOX, dot_flox_parent)
-            .context("Could not create temporary directory for cloning environment")?;
-
-        let pointer_path = temp_dot_flox_dir.path().join(ENVIRONMENT_POINTER_FILENAME);
+        let pointer_path = dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME);
         fs::write(pointer_path, pointer_content).context("Could not write pointer")?;
 
         let mut env = {
             let result = Dialog {
                 message,
                 help_message: None,
-                typed: Spinner::new(|| ManagedEnvironment::open(flox, pointer, &temp_dot_flox_dir)),
+                typed: Spinner::new(|| ManagedEnvironment::open(flox, pointer, &dot_flox_path)),
             }
             .spin()
             .map_err(Self::convert_error);
 
             match result {
                 Err(err) => {
-                    fs::remove_dir_all(&temp_dot_flox_dir)
+                    fs::remove_dir_all(&dot_flox_path)
                         .context("Could not clean up .flox/ directory")?;
                     Err(err)?
                 },
@@ -1430,10 +1419,7 @@ impl Pull {
         .spin();
 
         match result {
-            Ok(_) => {
-                fs::rename(temp_dot_flox_dir, dot_flox_path)
-                    .context("Could not move .flox/ directory")?;
-            },
+            Ok(_) => {},
             Err(
                 e @ EnvironmentError2::Core(CoreEnvironmentError::LockedManifest(
                     LockedManifestError::BuildEnv(CallPkgDbError::PkgDbError(PkgDbError {
@@ -1473,12 +1459,9 @@ impl Pull {
                         err = anyhow!(broken_error)
                     });
                 };
-
-                fs::rename(temp_dot_flox_dir, dot_flox_path)
-                    .context("Could not move .flox/ directory")?;
             },
             Err(e) => {
-                fs::remove_dir_all(&temp_dot_flox_dir)
+                fs::remove_dir_all(&dot_flox_path)
                     .context("Could not clean up .flox/ directory")?;
                 Err(e)?
             },


### PR DESCRIPTION
Environments were pulled into a temp directory which would later be renamed to `.flox`. We did this to avoid populating the floxmeta branch `owner/name.encode(path to .flox)` in case building fails or the user aborts the fixup. The branch would be adjusted when the environment is opened the next time by the `ensure_branch` routine.

Unfortunately, we would be missing the `out_link` linked to the tempdir, which causes `flox activate` (or any other activity requiring the activation path) to issue a rebuild of the environment.

Addressing the original concern:
(1) `ensure_branch` is already resetting the env branch if there is a race condition
    <https://github.com/flox/flox/blob/8a69e2d2ab41c1c659dbbb99103ce31bdb3c48fc/cli/flox-rust-sdk/src/models/environment/managed_environment.rs#L684-L699>
(2) if the pull is aborted we could `delete` the environment explicitly (ctrl+c cases would still need to be covered by (1)

fixes #885 