### PR TITLE
fix: don't re-lock already locked inputs

### DIFF
--- a/pkgdb/include/flox/resolver/manifest.hh
+++ b/pkgdb/include/flox/resolver/manifest.hh
@@ -159,7 +159,9 @@ public:
   }
 
   /* Ignore linter warning about copying params because `nix::ref` is just
-   * a pointer ( `std::shared_pointer' with a `nullptr` check ). */
+   * a pointer ( `std::shared_pointer' with a `nullptr` check ).
+   * Note: don't call this function if a lock for the registry can be found
+   * elsewhere. Re-locking will download flakes. */
   [[nodiscard]] RegistryRaw
   getLockedRegistry( const nix::ref<nix::Store> & store
                      = NixStoreMixin().getStore() ) const

--- a/pkgdb/src/resolver/environment.cc
+++ b/pkgdb/src/resolver/environment.cc
@@ -59,18 +59,17 @@ Environment::getCombinedRegistryRaw()
       if ( auto maybeGlobal = this->getGlobalManifest();
            maybeGlobal.has_value() )
         {
-          this->combinedRegistryRaw = maybeGlobal->getLockedRegistry();
+          this->combinedRegistryRaw = maybeGlobal->getRegistryRaw();
           this->combinedRegistryRaw->merge(
-            this->getManifest().getLockedRegistry() );
+            this->getManifest().getRegistryRaw() );
         }
-      else
-        {
-          this->combinedRegistryRaw = this->getManifest().getLockedRegistry();
-        }
+      else { this->combinedRegistryRaw = this->getManifest().getRegistryRaw(); }
 
       /* If there's a lockfile, use pinned inputs.
        * However, do not preserve any inputs that were removed from
        * the manifest. */
+      std::optional<nix::ref<nix::Store>>  store;
+      std::optional<FloxFlakeInputFactory> factory;
       if ( auto maybeLock = this->getOldLockfile(); maybeLock.has_value() )
         {
           auto lockedRegistry = maybeLock->getRegistryRaw();
@@ -81,6 +80,20 @@ Environment::getCombinedRegistryRaw()
                    locked != lockedRegistry.inputs.end() )
                 {
                   input = locked->second;
+                }
+              /* Lock the input if it's not in the lock. */
+              else
+                {
+                  if ( ! store.has_value() )
+                    {
+                      store = NixStoreMixin().getStore();
+                    }
+                  if ( ! factory.has_value() )
+                    {
+                      factory = FloxFlakeInputFactory( *store );
+                    }
+                  auto flakeInput = factory->mkInput( name, input );
+                  input           = flakeInput->getLockedInput();
                 }
             }
         }

--- a/pkgdb/src/resolver/environment.cc
+++ b/pkgdb/src/resolver/environment.cc
@@ -97,6 +97,19 @@ Environment::getCombinedRegistryRaw()
                 }
             }
         }
+      /* Lock all inputs since we don't have a lock. */
+      else
+        {
+          store   = NixStoreMixin().getStore();
+          factory = FloxFlakeInputFactory( *store );
+          {
+            for ( auto & [name, input] : this->combinedRegistryRaw->inputs )
+              {
+                auto flakeInput = factory->mkInput( name, input );
+                input           = flakeInput->getLockedInput();
+              }
+          }
+        }
     }
   return *this->combinedRegistryRaw;
 }

--- a/pkgdb/tests/environment.cc
+++ b/pkgdb/tests/environment.cc
@@ -927,6 +927,10 @@ test_createLockfile_error()
  *        unlocked input in an environment's manifest.
  *
  * Re-locking the locked input causes a useless download of nixpkgs.
+ *
+ * To test this, we put an invalid nixpkgs ref in the manifest but put valid
+ * data in the lock. If an attempt to lock the invalid input is ever made, it
+ * will throw an exception and fail the test.
  */
 bool
 test_getCombinedRegistryRaw_uses_lock()
@@ -973,6 +977,10 @@ test_getCombinedRegistryRaw_uses_lock()
  *        unlocked input in a global manifest.
  *
  * Re-locking the locked input causes a useless download of nixpkgs.
+ *
+ * To test this, we put an invalid nixpkgs ref in the manifest but put valid
+ * data in the lock. If an attempt to lock the invalid input is ever made, it
+ * will throw an exception and fail the test.
  */
 bool
 test_getCombinedRegistryRaw_uses_lock_for_global_manifest()

--- a/pkgdb/tests/environment.cc
+++ b/pkgdb/tests/environment.cc
@@ -57,6 +57,24 @@ RegistryRaw registryWithNixpkgs( registryWithNixpkgsJSON );
 
 /* -------------------------------------------------------------------------- */
 
+nlohmann::json registryWithNixpkgsLockedJSON {
+  { "inputs",
+    { { "nixpkgs",
+        { { "from",
+            { { "type", "github" },
+              { "owner", "NixOS" },
+              { "repo", "nixpkgs" },
+              { "rev", nixpkgsRev },
+              { "lastModified", 1704300003 },
+              { "narHash",
+                "sha256-FRC/OlLVvKkrdm+RtrODQPufD0vVZYA0hpH9RPaHmp4=" } } },
+          { "subtrees", { "legacyPackages" } } } } } }
+};
+RegistryRaw registryWithNixpkgsLocked( registryWithNixpkgsLockedJSON );
+
+
+/* -------------------------------------------------------------------------- */
+
 nlohmann::json inputWithNixpkgsJSON {
   "input",
   { { "fingerprint", nixpkgsFingerprintStr },
@@ -904,6 +922,104 @@ test_createLockfile_error()
 
 /* -------------------------------------------------------------------------- */
 
+/**
+ * @brief `getCombinedRegistryRaw()` uses the locked input and doesn't lock the
+ *        unlocked input in an environment's manifest.
+ *
+ * Re-locking the locked input causes a useless download of nixpkgs.
+ */
+bool
+test_getCombinedRegistryRaw_uses_lock()
+{
+  /* Create manifest with a registry with an invalid nixpkgs ref */
+  ManifestRaw manifestRaw;
+  manifestRaw.install          = {};
+  manifestRaw.options          = Options {};
+  manifestRaw.options->systems = { _system };
+  nlohmann::json registryWithInvalidNixpkgsJSON( registryWithNixpkgsJSON );
+  registryWithInvalidNixpkgsJSON.at( "inputs" )
+    .at( "nixpkgs" )
+    .at( "from" )
+    .erase( "rev" );
+  registryWithInvalidNixpkgsJSON.at( "inputs" )
+    .at( "nixpkgs" )
+    .at( "from" )["ref"]
+    = "not-a-ref";
+  RegistryRaw registryWithInvalidNixpkgs( registryWithInvalidNixpkgsJSON );
+  manifestRaw.registry = registryWithInvalidNixpkgs;
+  EnvironmentManifest manifest( manifestRaw );
+
+  /* Create lockfile */
+  LockfileRaw existingLockfileRaw;
+  existingLockfileRaw.manifest = manifestRaw;
+  existingLockfileRaw.registry = registryWithNixpkgsLocked;
+  Lockfile existingLockfile( existingLockfileRaw );
+
+  /* Test getCombinedRegistryRaw doesn't lock registryWithInvalidNixpkgsJSON */
+  Environment environment( std::nullopt, manifest, existingLockfile );
+  (void) environment.getCombinedRegistryRaw();
+  /* Just for good measure, make sure nothing in createLockfile locks
+   * registryWithInvalidNixpkgsJSON */
+  (void) environment.createLockfile();
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief `getCombinedRegistryRaw()` uses the locked input and doesn't lock the
+ *        unlocked input in a global manifest.
+ *
+ * Re-locking the locked input causes a useless download of nixpkgs.
+ */
+bool
+test_getCombinedRegistryRaw_uses_lock_for_global_manifest()
+{
+  /* Create manifest with a registry with an invalid nixpkgs ref */
+  ManifestRaw manifestRaw;
+  manifestRaw.install          = {};
+  manifestRaw.options          = Options {};
+  manifestRaw.options->systems = { _system };
+  nlohmann::json registryWithInvalidNixpkgsJSON( registryWithNixpkgsJSON );
+  registryWithInvalidNixpkgsJSON.at( "inputs" )
+    .at( "nixpkgs" )
+    .at( "from" )
+    .erase( "rev" );
+  registryWithInvalidNixpkgsJSON.at( "inputs" )
+    .at( "nixpkgs" )
+    .at( "from" )["ref"]
+    = "not-a-ref";
+  RegistryRaw registryWithInvalidNixpkgs( registryWithInvalidNixpkgsJSON );
+  manifestRaw.registry = registryWithInvalidNixpkgs;
+  EnvironmentManifest manifest( manifestRaw );
+
+  /* Create lockfile */
+  LockfileRaw existingLockfileRaw;
+  existingLockfileRaw.manifest = manifestRaw;
+  existingLockfileRaw.registry = registryWithNixpkgsLocked;
+  Lockfile existingLockfile( existingLockfileRaw );
+
+  /* Create global manifest */
+  GlobalManifestRaw globalManifestRaw( registryWithInvalidNixpkgs,
+                                       std::nullopt );
+  GlobalManifest    globalManifest( globalManifestRaw );
+
+
+  /* Test getCombinedRegistryRaw doesn't lock registryWithInvalidNixpkgsJSON */
+  Environment environment( globalManifest, manifest, existingLockfile );
+  (void) environment.getCombinedRegistryRaw();
+  /* Just for good measure, make sure nothing in createLockfile locks
+   * registryWithInvalidNixpkgsJSON */
+  (void) environment.createLockfile();
+
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 int
 main()
 {
@@ -930,6 +1046,9 @@ main()
   RUN_TEST( createLockfile_existing );
   RUN_TEST( createLockfile_both );
   RUN_TEST( createLockfile_error );
+
+  RUN_TEST( getCombinedRegistryRaw_uses_lock )
+  RUN_TEST( getCombinedRegistryRaw_uses_lock_for_global_manifest )
 
   return exitCode;
 }


### PR DESCRIPTION
Currently we lock all unlocked inputs and then afterwards merge in locked inputs from the lockfile. Instead, only lock inputs that aren't present in the lockfile.