### PR TITLE
feat: store remote-envs persistently and centrally

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -579,7 +579,7 @@ impl ManagedEnvironment {
         floxmeta: &FloxmetaV2,
     ) -> Result<GenerationLock, ManagedEnvironmentError> {
         let lock_path = dot_flox_path.join(GENERATION_LOCK_FILENAME);
-        let maybe_lock: Option<GenerationLock> = GenerationLock::read_maybe(&lock_path)?;
+        let maybe_lock = GenerationLock::read_maybe(&lock_path)?;
 
         Ok(match maybe_lock {
             // Use local_rev if we have it

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -108,7 +108,7 @@ impl RemoteEnvironment {
     /// in `<FLOX_CACHE_DIR>/remote/<owner>/<name>`
     ///
     /// This function provides the sensible default directory to [RemoteEnvironment::new_in].
-    /// The direcory will be created by [RemoteEnvironment::new_in].
+    /// The directory will be created by [RemoteEnvironment::new_in].
     pub fn new(flox: &Flox, pointer: ManagedPointer) -> Result<Self, RemoteEnvironmentError> {
         let path = flox
             .cache_dir

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -34,7 +34,7 @@ pub enum RemoteEnvironmentError {
     #[error("open managed environment")]
     OpenManagedEnvironment(#[source] ManagedEnvironmentError),
 
-    #[error("could not get initial latest version of environment")]
+    #[error("could not get latest version of environment")]
     GetLatestVersion(#[source] FloxmetaV2Error),
 
     #[error("could not reset managed environment")]

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -91,6 +91,8 @@ impl RemoteEnvironment {
             ManagedEnvironment::open_with(floxmeta, flox, pointer, dot_flox_path, inner_out_link)
                 .map_err(RemoteEnvironmentError::OpenManagedEnvironment)?;
 
+        // (force) Pull latest changes of the environment from upstream.
+        // remote environments stay in sync with upstream without providing a local staging state.
         inner
             .pull(true)
             .map_err(RemoteEnvironmentError::ResetManagedEnvironment)?;

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -148,7 +148,7 @@ EOF
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
   SHELL=bash USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
-  assert_output --regexp "$FLOX_CACHE_HOME/run/owner/.+\..+\..+/bin/hello"
+  assert_output --partial "$FLOX_CACHE_HOME/remote/owner/test/.flox/run/bin/hello"
   refute_output "not found"
 }
 


### PR DESCRIPTION
* feat: store remote-envs persistently and centrally

store a single copy for each remote env in `$FLOX_CACHE_DIR/remote/<owner>/<name>`

* fix: reduce unnecessary rebuilds of remote and managed environments

Pulling a managed environment _always_ causes a rebuild even if no changes were pulled.
That is because each pull would (re) write the generation lockfile at `.flox/env.lock`.
Since rebuilding depends on the mtime of that file, we rebuilt unnecessarily often.

The solution for now is to skip writing the file iff
(1) the file exists
(2) the contents are unchanged

* feat: protect active environment state until push succeded 

The inner managed environment of a remote environment is first updated, _and then_ pushed.
If the push fails $FLOX_ENV will point to the updated but unpushed out_link of the inner environment.

RemoteEnvironment now refers to a separate `out_link`,
which is a symlink to the store path of the inner managed environment.
When the push succeeds, that link is updated to point to the new store path.