### PR TITLE
style: lighter post processing of user facing output

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -717,6 +717,7 @@ dependencies = [
  "sys-info",
  "temp-env",
  "tempfile",
+ "textwrap 0.16.0",
  "thiserror",
  "time",
  "tokio",
@@ -1269,6 +1270,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,7 +1293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix",
+ "rustix 0.38.24",
  "windows-sys 0.48.0",
 ]
 
@@ -1369,6 +1381,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2133,6 +2151,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
@@ -2140,7 +2172,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.11",
  "windows-sys 0.48.0",
 ]
 
@@ -2471,6 +2503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "smol_str"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,7 +2655,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.38.24",
  "windows-sys 0.48.0",
 ]
 
@@ -2628,6 +2666,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.27",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2645,6 +2693,18 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "terminal_size",
+ "unicode-linebreak",
  "unicode-width",
 ]
 
@@ -2985,6 +3045,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,5 +62,6 @@ walkdir = "2"
 xdg = "2.4"
 oauth2 = "4.4"
 jsonwebtoken = "9.2"
+textwrap = "0.16.0"
 
 [patch.crates-io]

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -51,6 +51,7 @@ url.workspace = true
 openssl.workspace = true
 chrono.workspace = true
 oauth2.workspace = true
+textwrap = {workspace = true, features = ["terminal_size"]}
 
 [dev-dependencies]
 temp-env = "0.3.2"

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -116,7 +116,7 @@ pub struct FloxArgs {
     pub verbosity: Verbosity,
 
     /// Debug mode
-    #[bpaf(long, req_flag(()), many, map(vec_not_empty))]
+    #[bpaf(long, req_flag(()), many, map(vec_not_empty), hide)]
     pub debug: bool,
 
     /// Print the version of the program

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -9,7 +9,7 @@ use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironmentError;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentError;
 use flox_rust_sdk::models::environment::{init_global_manifest, EnvironmentError2};
-use log::{error, warn};
+use log::{debug, error, warn};
 use utils::init::init_logger;
 
 use crate::utils::errors::{format_error, format_managed_error, format_remote_error};
@@ -20,7 +20,7 @@ mod config;
 mod utils;
 
 async fn run(args: FloxArgs) -> Result<()> {
-    init_logger(Some(args.verbosity.clone()), args.debug);
+    init_logger(Some(args.verbosity.clone()));
     set_user()?;
     set_parent_process_id();
     let config = config::Config::parse()?;
@@ -33,7 +33,7 @@ async fn run(args: FloxArgs) -> Result<()> {
 async fn main() -> ExitCode {
     // initialize logger with "best guess" defaults
     // updating the logger conf is cheap, so we reinitialize whenever we get more information
-    init_logger(None, false);
+    init_logger(None);
 
     // Quit early if `--prefix` is present
     if Prefix::check() {
@@ -48,7 +48,7 @@ async fn main() -> ExitCode {
     }
 
     // Parse verbosity flags to affect help message/parse errors
-    let (verbosity, debug) = {
+    let (verbosity, _debug) = {
         let verbosity_parser = commands::verbosity();
         let debug_parser = bpaf::long("debug").switch();
         let other_parser = bpaf::any("ANY", Some::<String>).many();
@@ -59,7 +59,7 @@ async fn main() -> ExitCode {
             .run_inner(Args::current_args())
             .unwrap_or_default()
     };
-    init_logger(Some(verbosity), debug);
+    init_logger(Some(verbosity));
 
     // Run the argument parser
     //
@@ -95,9 +95,7 @@ async fn main() -> ExitCode {
 
         Err(e) => {
             // todo: figure out how to deal with context, properly
-            if debug {
-                error!("{:#}", e);
-            }
+            debug!("{:#}", e);
 
             // Do not print any error if caused by wrapped flox (sh)
             if e.is::<FloxShellErrorCode>() {

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -20,7 +20,7 @@ mod config;
 mod utils;
 
 async fn run(args: FloxArgs) -> Result<()> {
-    init_logger(Some(args.verbosity.clone()), Some(args.debug));
+    init_logger(Some(args.verbosity.clone()), args.debug);
     set_user()?;
     set_parent_process_id();
     let config = config::Config::parse()?;
@@ -33,7 +33,7 @@ async fn run(args: FloxArgs) -> Result<()> {
 async fn main() -> ExitCode {
     // initialize logger with "best guess" defaults
     // updating the logger conf is cheap, so we reinitialize whenever we get more information
-    init_logger(None, None);
+    init_logger(None, false);
 
     // Quit early if `--prefix` is present
     if Prefix::check() {
@@ -59,7 +59,7 @@ async fn main() -> ExitCode {
             .run_inner(Args::current_args())
             .unwrap_or_default()
     };
-    init_logger(Some(verbosity), Some(debug));
+    init_logger(Some(verbosity), debug);
 
     // Run the argument parser
     //

--- a/cli/flox/src/utils/colors.rs
+++ b/cli/flox/src/utils/colors.rs
@@ -27,6 +27,7 @@ pub enum BasicColor {
 
 impl BasicColor {
     /// Create crossterm compatible types
+    #[allow(dead_code)] // todo: discuss how/where to integrate colors
     pub fn to_crossterm(&self) -> crossterm::style::Color {
         match self {
             BasicColor::Black => crossterm::style::Color::Black,
@@ -88,6 +89,7 @@ impl FloxColor {
         self.ansi256
     }
 
+    #[allow(dead_code)] // todo: discuss how/where to integrate colors
     pub fn to_crossterm(&self) -> Option<crossterm::style::Color> {
         match supports_color::on(supports_color::Stream::Stderr) {
             Some(supports_color::ColorLevel { has_16m: true, .. }) => {

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -12,10 +12,10 @@ use flox_rust_sdk::models::environment::{
 use flox_rust_sdk::models::lockfile::LockedManifestError;
 use flox_rust_sdk::models::pkgdb::CallPkgDbError;
 use indoc::formatdoc;
-use log::debug;
+use log::trace;
 
 pub fn format_error(err: &EnvironmentError2) -> String {
-    debug!("formatting environment_error: {err:?}");
+    trace!("formatting environment_error: {err:?}");
 
     match err {
         EnvironmentError2::DotFloxNotFound => display_chain(err),
@@ -147,7 +147,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
         EnvironmentError2::DiscoverGitDirectory(_) => formatdoc! {"
             Failed to discover git directory.
 
-            See the '--debug' log for more information.
+            See the run again with `--verbose` for more information.
         "},
         // todo: enrich with path
         EnvironmentError2::DeleteEnvironment(err) => formatdoc! {"
@@ -184,7 +184,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
 }
 
 pub fn format_core_error(err: &CoreEnvironmentError) -> String {
-    debug!("formatting core_error: {err:?}");
+    trace!("formatting core_error: {err:?}");
 
     match err {
         CoreEnvironmentError::ModifyToml(toml_error) => formatdoc! {"
@@ -272,7 +272,7 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
 }
 
 pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
-    debug!("formatting managed_environment_error: {err:?}");
+    trace!("formatting managed_environment_error: {err:?}");
 
     match err {
         // todo: communicate reasons for this error
@@ -429,7 +429,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
 }
 
 pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
-    debug!("formatting remote_environment_error: {err:?}");
+    trace!("formatting remote_environment_error: {err:?}");
 
     match err {
         RemoteEnvironmentError::OpenManagedEnvironment(err) => formatdoc! {"
@@ -479,7 +479,7 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
 }
 
 pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
-    debug!("formatting locked_manifest_error: {err:?}");
+    trace!("formatting locked_manifest_error: {err:?}");
     match err {
         LockedManifestError::CallContainerBuilder(_) => formatdoc! {"
             Failed to call container builder.
@@ -556,7 +556,7 @@ fn format_pkgdb_error(
     parent: &dyn std::error::Error,
     context: &str,
 ) -> String {
-    debug!("formatting pkgdb_error: {err:?}");
+    trace!("formatting pkgdb_error: {err:?}");
 
     match err {
         CallPkgDbError::PkgDbError(err) => formatdoc! {"

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -51,9 +51,9 @@ static LOGGER_HANDLE: OnceCell<(
     >,
 )> = OnceCell::new();
 
-pub fn init_logger(verbosity: Option<Verbosity>, debug: Option<bool>) {
+pub fn init_logger(verbosity: Option<Verbosity>, debug: bool) {
     let verbosity = verbosity.unwrap_or_default();
-    let debug = debug.unwrap_or(false);
+    let debug = debug || matches!(verbosity, Verbosity::Verbose(2..));
 
     let log_filter = match verbosity {
         // Show only errors

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -55,25 +55,20 @@ pub fn init_logger(verbosity: Option<Verbosity>, debug: Option<bool>) {
     let verbosity = verbosity.unwrap_or_default();
     let debug = debug.unwrap_or(false);
 
-    let log_filter = match (debug, verbosity) {
+    let log_filter = match verbosity {
         // Show only errors
-        (false, Verbosity::Quiet) => "off,flox=error",
+        Verbosity::Quiet => "off,flox=error",
         // Show our own info logs
-        (false, Verbosity::Verbose(0)) => "off,flox=info",
-        // Also show POSIX info
-        (false, Verbosity::Verbose(1)) => "off,flox=info,posix=info",
-        // Also show info from our libraries and POSIX debug
-        (false, Verbosity::Verbose(2)) => {
-            "off,flox=debug,flox-rust-sdk=info,runix=info,posix=debug"
-        },
+        Verbosity::Verbose(0) => "off,flox=info",
+        // Also POSIX debug
+        Verbosity::Verbose(1) => "off,flox=info,posix=debug",
         // Also show debug from our libraries
-        (true, Verbosity::Quiet) | (false, Verbosity::Verbose(3)) => {
-            "off,flox=debug,flox-rust-sdk=debug,runix=debug,posix=debug"
-        },
-        // Also show debug from everything
-        (true, Verbosity::Verbose(0)) | (false, Verbosity::Verbose(4)) => "debug",
-        // Also show trace from everything
-        (true, Verbosity::Verbose(_)) | (false, Verbosity::Verbose(_)) => "trace",
+        Verbosity::Verbose(2) => "off,flox=debug,flox-rust-sdk=debug,runix=debug,posix=debug",
+        // Also show trace from our libraries and POSIX
+        Verbosity::Verbose(3) => "off,flox=trace,flox-rust-sdk=trace,runix=trace,posix=trace",
+        // Also show trace from our libraries and POSIX
+        Verbosity::Verbose(4) => "debug,flox=trace,flox-rust-sdk=trace,runix=trace,posix=trace",
+        Verbosity::Verbose(_) => "trace",
     };
 
     let (filter_handle, fmt_handle) = LOGGER_HANDLE.get_or_init(|| {

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -53,21 +53,19 @@ static LOGGER_HANDLE: OnceCell<(
 
 pub fn init_logger(verbosity: Option<Verbosity>, debug: bool) {
     let verbosity = verbosity.unwrap_or_default();
-    let debug = debug || matches!(verbosity, Verbosity::Verbose(2..));
+    let debug = debug || matches!(verbosity, Verbosity::Verbose(1..));
 
     let log_filter = match verbosity {
         // Show only errors
         Verbosity::Quiet => "off,flox=error",
         // Show our own info logs
         Verbosity::Verbose(0) => "off,flox=info",
-        // Also POSIX debug
-        Verbosity::Verbose(1) => "off,flox=info,posix=debug",
         // Also show debug from our libraries
-        Verbosity::Verbose(2) => "off,flox=debug,flox-rust-sdk=debug,runix=debug,posix=debug",
+        Verbosity::Verbose(1) => "off,flox=debug,flox-rust-sdk=debug,runix=debug",
         // Also show trace from our libraries and POSIX
-        Verbosity::Verbose(3) => "off,flox=trace,flox-rust-sdk=trace,runix=trace,posix=trace",
+        Verbosity::Verbose(2) => "off,flox=trace,flox-rust-sdk=trace,runix=trace",
         // Also show trace from our libraries and POSIX
-        Verbosity::Verbose(4) => "debug,flox=trace,flox-rust-sdk=trace,runix=trace,posix=trace",
+        Verbosity::Verbose(3) => "debug,flox=trace,flox-rust-sdk=trace,runix=trace",
         Verbosity::Verbose(_) => "trace",
     };
 

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -51,9 +51,9 @@ static LOGGER_HANDLE: OnceCell<(
     >,
 )> = OnceCell::new();
 
-pub fn init_logger(verbosity: Option<Verbosity>, debug: bool) {
+pub fn init_logger(verbosity: Option<Verbosity>) {
     let verbosity = verbosity.unwrap_or_default();
-    let debug = debug || matches!(verbosity, Verbosity::Verbose(1..));
+    let debug = matches!(verbosity, Verbosity::Verbose(1..));
 
     let log_filter = match verbosity {
         // Show only errors

--- a/cli/flox/src/utils/logger.rs
+++ b/cli/flox/src/utils/logger.rs
@@ -67,7 +67,7 @@ where
         let mut visitor = LoggerVisitor(&mut fields);
         event.record(&mut visitor);
 
-        let mut message = match fields.message {
+        let message = match fields.message {
             Some(m) => m,
             None => return Ok(()),
         };
@@ -81,8 +81,6 @@ where
         // pretend all messages from `flox` are user facing
         // unless they are posix command prints
         if is_flox && !self.debug && !is_posix {
-            let wrap_options = textwrap::Options::with_termwidth();
-            let message = textwrap::fill(&message, wrap_options);
             writeln!(f, "{message}")?;
             return Ok(());
         }
@@ -130,11 +128,7 @@ where
 
         let head = format!("{level_prefix} {time_prefix} {origin_prefix}").bold();
 
-        let combined_message = format!("{head}:\n{message}");
-
-        let wrap_options = textwrap::Options::with_termwidth().break_words(false);
-
-        message = textwrap::fill(&combined_message, wrap_options);
+        let message = format!("{head}:\n{message}");
 
         writeln!(f, "{}", message)?;
 

--- a/cli/flox/src/utils/logger.rs
+++ b/cli/flox/src/utils/logger.rs
@@ -1,7 +1,6 @@
-use std::fmt::{self, Write};
+use std::fmt;
 
 use crossterm::style::Stylize;
-use tracing::Level;
 
 #[derive(Default, Debug)]
 struct LogFields {
@@ -82,12 +81,7 @@ where
         // pretend all messages from `flox` are user facing
         // unless they are posix command prints
         if is_flox && !self.debug && !is_posix {
-            let wrap_options = if *level > Level::DEBUG {
-                textwrap::Options::new(80)
-            } else {
-                textwrap::Options::with_termwidth()
-            };
-
+            let wrap_options = textwrap::Options::with_termwidth();
             let message = textwrap::fill(&message, wrap_options);
             writeln!(f, "{message}")?;
             return Ok(());

--- a/cli/flox/src/utils/logger.rs
+++ b/cli/flox/src/utils/logger.rs
@@ -45,17 +45,6 @@ pub struct LogFormatter {
     pub debug: bool,
 }
 
-struct IndentWrapper<'a, 'b> {
-    buf: &'a mut tracing_subscriber::fmt::format::Writer<'b>,
-}
-
-impl std::fmt::Write for IndentWrapper<'_, '_> {
-    fn write_str(&mut self, s: &str) -> Result<(), std::fmt::Error> {
-        write!(self.buf, "{}", textwrap::fill(s, 80))?;
-        Ok(())
-    }
-}
-
 impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for LogFormatter
 where
     S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,


### PR DESCRIPTION
* remove bold errors
* remove indentation of following log lines
* add timestamp, file, and line number in `--debug` mode

This still uses `log` for both "logging" and "communicating" for now as the change to this is less invasive then either formally splitting `tracing` for logging from `log` (or custom wrappers) for logging.
This reduced scope was discussed in #849