### PR TITLE
fix: better env name error message

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment_ref.rs
+++ b/cli/flox-rust-sdk/src/models/environment_ref.rs
@@ -18,7 +18,7 @@ impl FromStr for EnvironmentOwner {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if [' ', '/'].iter().any(|c| s.contains(*c)) {
-            Err(EnvironmentRefError::InvalidOwner)?
+            Err(EnvironmentRefError::InvalidOwner(s.to_string()))?
         }
 
         Ok(EnvironmentOwner(s.to_string()))
@@ -35,7 +35,7 @@ impl FromStr for EnvironmentName {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if [' ', '/'].iter().any(|c| s.contains(*c)) {
-            Err(EnvironmentRefError::InvalidName)?
+            Err(EnvironmentRefError::InvalidName(s.to_string()))?
         }
 
         Ok(EnvironmentName(s.to_string()))
@@ -58,7 +58,9 @@ impl FromStr for EnvironmentRef {
     type Err = EnvironmentRefError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (owner, name) = s.split_once('/').ok_or(EnvironmentRefError::InvalidOwner)?;
+        let (owner, name) = s
+            .split_once('/')
+            .ok_or(EnvironmentRefError::InvalidOwner(s.to_string()))?;
         Ok(Self {
             owner: EnvironmentOwner::from_str(owner)?,
             name: EnvironmentName::from_str(name)?,
@@ -68,11 +70,11 @@ impl FromStr for EnvironmentRef {
 
 #[derive(Error, Debug)]
 pub enum EnvironmentRefError {
-    #[error("Name format is invalid")]
-    InvalidName,
+    #[error("Name '{0}' is invalid.\nEnvironment names may only contain alphanumeric characters, '.', '_', and '-'.")]
+    InvalidName(String),
 
-    #[error("Name format is invalid")]
-    InvalidOwner,
+    #[error("Owner '{0}' is invalid.\nEnvironment owners may only contain alphanumeric characters, '.', '_', and '-'.")]
+    InvalidOwner(String),
 }
 
 impl EnvironmentRef {

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -13,13 +13,7 @@ use std::{env, vec};
 use anyhow::{anyhow, bail, Context, Result};
 use bpaf::Bpaf;
 use crossterm::tty::IsTty;
-use flox_rust_sdk::flox::{
-    EnvironmentName,
-    EnvironmentOwner,
-    EnvironmentRef,
-    EnvironmentRefError,
-    Flox,
-};
+use flox_rust_sdk::flox::{EnvironmentName, EnvironmentOwner, EnvironmentRef, Flox};
 use flox_rust_sdk::models::environment::managed_environment::{
     ManagedEnvironment,
     ManagedEnvironmentError,
@@ -894,15 +888,15 @@ impl Init {
         let home_dir = dirs::home_dir().unwrap();
 
         let env_name = if let Some(name) = self.env_name {
-            Init::validate_env_name(&name)?
+            EnvironmentName::from_str(&name)?
         } else if dir == home_dir {
-            "default".parse()?
+            EnvironmentName::from_str("default")?
         } else {
             let name = dir
                 .file_name()
                 .map(|n| n.to_string_lossy().to_string())
                 .context("Can't init in root")?;
-            Init::validate_env_name(&name)?
+            EnvironmentName::from_str(&name)?
         };
 
         let env = PathEnvironment::init(
@@ -925,17 +919,6 @@ impl Init {
             system = flox.system
         );
         Ok(())
-    }
-
-    fn validate_env_name(name: &str) -> Result<EnvironmentName, anyhow::Error> {
-        let parsed: Result<EnvironmentName, EnvironmentRefError> = name.parse();
-        if let Err(EnvironmentRefError::InvalidName) = parsed {
-            bail!(format!(
-                "Name '{}' is invalid. Environment names may not contain ' ' or '/'.",
-                name
-            ))
-        }
-        Ok(parsed.unwrap())
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Adds an error handling layer above parsing environment names so that a more informative error message can be shown to the user.

```
$ flox init --name foo/bar
ERROR: Name 'foo/bar' is invalid. Environment names may not contain ' ' or '/'.
```

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
