### PR TITLE
fix: drop `flox config` cruft

### DIFF
--- a/assets/etc/flox.toml
+++ b/assets/etc/flox.toml
@@ -1,4 +1,0 @@
-# Package-specific defaults here.
-# Company-specific defaults in /etc/flox.toml.
-# User-specific overrides in ~/.config/flox/flox.toml.
-git_base_url = "https://git.hub.flox.dev/"

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -143,10 +143,10 @@ impl Config {
 
             let mut builder = HierarchicalConfig::builder()
                 .set_default("default_substituter", "https://cache.floxdev.com/")?
-                .set_default("git_base_url", "https://git.hub.flox.dev/")?
                 .set_default("cache_dir", cache_dir.to_str().unwrap())?
                 .set_default("data_dir", data_dir.to_str().unwrap())?
-                // config dir is added to the config for completeness, the config file cannot change the config dir
+                // Config dir is added to the config for completeness;
+                // the config file cannot change the config dir.
                 .set_default("config_dir", config_dir.to_str().unwrap())?;
 
             // read from /etc

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -20,7 +20,6 @@ use self::features::Features;
 
 /// Name of flox managed directories (config, data, cache)
 const FLOX_DIR_NAME: &'_ str = "flox";
-const FLOX_ETC_DIR: &'_ str = env!("FLOX_ETC_DIR");
 pub const FLOX_CONFIG_FILE: &'_ str = "flox.toml";
 
 #[derive(Clone, Debug, Deserialize, Default, Serialize)]
@@ -162,23 +161,17 @@ impl Config {
 
             let mut builder = HierarchicalConfig::builder()
                 .set_default("default_substituter", "https://cache.floxdev.com/")?
-                .set_default("git_base_url", "https://github.com/")?
+                .set_default("git_base_url", "https://git.hub.flox.dev/")?
                 .set_default("cache_dir", cache_dir.to_str().unwrap())?
                 .set_default("data_dir", data_dir.to_str().unwrap())?
-                // config dir is added to the config for completeness, the config file cannot chenge the config dir
+                // config dir is added to the config for completeness, the config file cannot change the config dir
                 .set_default("config_dir", config_dir.to_str().unwrap())?;
 
-            // read from installation
+            // read from /etc
             builder = builder.add_source(
                 config::File::from(PathBuf::from("/etc").join(FLOX_CONFIG_FILE))
                     .format(config::FileFormat::Toml)
                     .required(false),
-            );
-
-            // read from installation
-            builder = builder.add_source(
-                config::File::from(PathBuf::from(FLOX_ETC_DIR).join(FLOX_CONFIG_FILE))
-                    .format(config::FileFormat::Toml),
             );
 
             // look for files in XDG_CONFIG_DIRS locations

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -5,7 +5,6 @@ use std::{env, fs};
 use anyhow::{Context, Result};
 use config::{Config as HierarchicalConfig, Environment};
 use flox_rust_sdk::flox::{EnvironmentRef, FloxhubToken};
-use flox_types::stability::Stability;
 use itertools::{Either, Itertools};
 use log::{debug, trace};
 use once_cell::sync::OnceCell;
@@ -50,15 +49,6 @@ pub struct FloxConfig {
     pub data_dir: PathBuf,
     pub config_dir: PathBuf,
 
-    pub stability: Option<Stability>,
-
-    /// The url we push _to_
-    pub cache_url: Option<Url>,
-    /// The url we pull _from_
-    pub public_cache_url: Option<Url>,
-    /// Path to signing key
-    pub signing_key: Option<PathBuf>,
-
     /// Token to authenticate on floxhub
     pub floxhub_token: Option<FloxhubToken>,
 
@@ -71,9 +61,6 @@ pub struct FloxConfig {
 
     /// The url of the floxhub instance to use
     pub floxhub_url: Option<Url>,
-
-    #[serde(flatten)]
-    pub instance: InstanceConfig,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -81,11 +68,6 @@ pub struct FloxConfig {
 pub enum EnvironmentTrust {
     Trust,
     Deny,
-}
-
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
-pub struct InstanceConfig {
-    pub git_base_url: String, // Todo: use Url type?
 }
 
 // TODO: move to runix?
@@ -362,20 +344,6 @@ mod tests {
     use indoc::indoc;
 
     use super::*;
-
-    #[test]
-    fn test_read_flattened() {
-        let mut config = Config::default();
-        config.flox.instance.git_base_url = "hello".to_string();
-        assert!(matches!(
-            config.get(&Key::parse("flox.instance.git_base_url").unwrap()),
-            Err(ReadWriteError::InvalidKey(_))
-        ));
-        assert_eq!(
-            config.get(&Key::parse("git_base_url").unwrap()).unwrap(),
-            "\"hello\"".to_string()
-        );
-    }
 
     #[test]
     fn test_read_bool() {

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -64,7 +64,6 @@
         then "ld-floxlib.so"
         else "${flox-pkgdb}/lib/ld-floxlib.so";
       PARSER_UTIL_BIN = "${parser-util}/bin/parser-util";
-      FLOX_ETC_DIR = ../../assets/etc;
       FLOX_ZDOTDIR = ../../assets/flox.zdotdir;
 
       # bundling of internally used nix scripts
@@ -172,7 +171,6 @@ in
 
       # bundle manpages and completion scripts
       postInstall = ''
-        ln -s "${envs.FLOX_ETC_DIR}" "$out/etc"
         installShellCompletion --cmd flox                         \
           --bash <( "$out/bin/flox" --bpaf-complete-style-bash; ) \
           --fish <( "$out/bin/flox" --bpaf-complete-style-fish; ) \


### PR DESCRIPTION
- Drop unneeded config file. Set package defaults in Rust rather than reading defaults from a RO config file in the nix store.
- Drop unused config fields