### PR TITLE
fix: return an error early if specified path does not contain `.flox`

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -267,6 +267,10 @@ impl EnvironmentPointer {
     /// on either [PathEnvironment] or [ManagedEnvironment].
     pub fn open(path: impl AsRef<Path>) -> Result<EnvironmentPointer, EnvironmentError2> {
         let dot_flox_path = path.as_ref().join(DOT_FLOX);
+        if !dot_flox_path.exists() {
+            debug!("couldn't find .flox at {}", dot_flox_path.display());
+            Err(EnvironmentError2::DotFloxNotFound)?
+        }
         let pointer_path = dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME);
         let pointer_contents = match fs::read(&pointer_path) {
             Ok(contents) => contents,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -277,7 +277,7 @@ impl EnvironmentPointer {
             Err(err) => match err.kind() {
                 io::ErrorKind::NotFound => {
                     debug!("couldn't find env.json at {}", pointer_path.display());
-                    Err(EnvironmentError2::EnvNotFound)?
+                    Err(EnvironmentError2::EnvPointerNotFound)?
                 },
                 _ => Err(EnvironmentError2::ReadEnvironmentMetadata(err))?,
             },
@@ -333,7 +333,9 @@ pub enum EnvironmentError2 {
     #[error("could not initialize environment")]
     InitEnv(#[source] std::io::Error),
     #[error("could not find environment definition directory")]
-    EnvNotFound,
+    EnvDirNotFound,
+    #[error("could not find environment pointer file")]
+    EnvPointerNotFound,
     #[error("an environment already exists at {0:?}")]
     EnvironmentExists(PathBuf),
     #[error("could not write .gitignore file")]

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -98,7 +98,7 @@ impl PathEnvironment {
 
         let env_path = dot_flox_path.join(ENV_DIR_NAME);
         if !env_path.exists() {
-            Err(EnvironmentError2::EnvNotFound)?;
+            Err(EnvironmentError2::EnvDirNotFound)?;
         }
 
         if !env_path.join(MANIFEST_FILENAME).exists() {
@@ -452,7 +452,7 @@ mod tests {
         );
 
         assert!(
-            matches!(before, Err(EnvironmentError2::EnvNotFound)),
+            matches!(before, Err(EnvironmentError2::EnvDirNotFound)),
             "{before:?}"
         );
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -343,7 +343,7 @@ impl PathEnvironment {
     ) -> Result<Self, EnvironmentError2> {
         let system: &str = system.as_ref();
         match EnvironmentPointer::open(dot_flox_parent_path.as_ref()) {
-            Err(EnvironmentError2::EnvNotFound) => {},
+            Err(EnvironmentError2::DotFloxNotFound) => {},
             Err(e) => Err(e)?,
             Ok(_) => Err(EnvironmentError2::EnvironmentExists(
                 dot_flox_parent_path.as_ref().to_path_buf(),

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -21,7 +21,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
         EnvironmentError2::DotFloxNotFound => display_chain(err),
 
         // todo: enrich with a path?
-        EnvironmentError2::EnvNotFound => formatdoc! {"
+        EnvironmentError2::EnvDirNotFound => formatdoc! {"
             Found a '.flox' directory, but was unable to locate an environment directory.
 
             This is likely due to a corrupt environment.
@@ -29,6 +29,16 @@ pub fn format_error(err: &EnvironmentError2) -> String {
             Try deleting the '.flox' directory and reinitializing the environment.
             If you cloned this environment from a remote repository, verify that
             `.flox/env/maifest.toml` is commited to the version control system.
+        "},
+        // todo: enrich with a path?
+        EnvironmentError2::EnvPointerNotFound => formatdoc! {"
+            Found a '.flox' directory, but was unable to locate an 'env.json' in it.
+
+            This is likely due to a corrupt environment.
+
+            Try deleting the '.flox' directory and reinitializing the environment.
+            If you cloned this environment from a remote repository, verify that
+            `.flox/env.json` is commited to the version control system.
         "},
 
         // todo: enrich with a path?

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -22,7 +22,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
 
         // todo: enrich with a path?
         EnvironmentError2::EnvNotFound => formatdoc! {"
-            Found a '.flox' directory, but were unable to locate an environment directory.
+            Found a '.flox' directory, but was unable to locate an environment directory.
 
             This is likely due to a corrupt environment.
 
@@ -33,7 +33,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
 
         // todo: enrich with a path?
         EnvironmentError2::ManifestNotFound => formatdoc! {"
-            Found a '.flox' directory, but were unable to locate a manifest file.
+            Found a '.flox' directory, but was unable to locate a manifest file.
 
             This is likely due to a corrupt environment.
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -22,7 +22,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
 
         // todo: enrich with a path?
         EnvironmentError2::EnvDirNotFound => formatdoc! {"
-            Found a '.flox' directory, but was unable to locate an environment directory.
+            Found a '.flox' directory but unable to locate an environment directory.
 
             This is likely due to a corrupt environment.
 
@@ -32,7 +32,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
         "},
         // todo: enrich with a path?
         EnvironmentError2::EnvPointerNotFound => formatdoc! {"
-            Found a '.flox' directory, but was unable to locate an 'env.json' in it.
+            Found a '.flox' directory but unable to locate an 'env.json' in it.
 
             This is likely due to a corrupt environment.
 
@@ -43,7 +43,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
 
         // todo: enrich with a path?
         EnvironmentError2::ManifestNotFound => formatdoc! {"
-            Found a '.flox' directory, but was unable to locate a manifest file.
+            Found a '.flox' directory but unable to locate a manifest file.
 
             This is likely due to a corrupt environment.
 


### PR DESCRIPTION
fixes #926 
