### PR TITLE
chore: replace backticks for single ticks in outputs

### DIFF
--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -190,7 +190,7 @@ extractAttrPath( nix::EvalState & state,
         {
           std::ostringstream str;
           output->value->print( state.symbols, str );
-          throw FloxException( "attribute `%s' not found in set `%s'",
+          throw FloxException( "attribute '%s' not found in set '%s'",
                                attrName,
                                str.str() );
         }
@@ -253,7 +253,7 @@ createFloxEnv( nix::EvalState &     state,
 
       if ( ! package_drv.has_value() )
         {
-          throw FloxException( "Failed to get derivation for package `"
+          throw FloxException( "Failed to get derivation for package '"
                                + nlohmann::json( package ).dump() + "'" );
         }
 

--- a/pkgdb/src/command.cc
+++ b/pkgdb/src/command.cc
@@ -80,7 +80,7 @@ argparse::Argument &
 InlineInputMixin::addSubtreeArg( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--subtree" )
-    .help( "a subtree name, being one of `packages` or `legacyPackages`, "
+    .help( "a subtree name, being one of 'packages' or 'legacyPackages', "
            "that should be processed. May be used multiple times." )
     .required()
     .metavar( "SUBTREE" )

--- a/pkgdb/src/eval.cc
+++ b/pkgdb/src/eval.cc
@@ -24,7 +24,7 @@ namespace flox {
 EvalCommand::EvalCommand() : parser( "eval" )
 {
   this->parser.add_description(
-    "Evaluate a `nix` expression with `flox` extensions" );
+    "Evaluate a 'nix' expression with 'flox' extensions" );
 
   this->parser.add_argument( "--json", "-j" )
     .help( "emit JSON values" )
@@ -35,7 +35,7 @@ EvalCommand::EvalCommand() : parser( "eval" )
         if ( this->style == STYLE_RAW )
           {
             throw FloxException(
-              "the options `--json' and `--raw' may not be used together" );
+              "the options '--json' and '--raw' may not be used together" );
           }
         this->style = STYLE_JSON;
       } );
@@ -49,14 +49,14 @@ EvalCommand::EvalCommand() : parser( "eval" )
         if ( this->style == STYLE_JSON )
           {
             throw FloxException(
-              "the options `--json' and `--raw' may not be used together" );
+              "the options '--json' and '--raw' may not be used together" );
           }
         this->style = STYLE_RAW;
       } );
 
   this->parser.add_argument( "--file", "-f" )
     .help( "read expression from a file. "
-           "Use `-' as filename to read `STDIN'" )
+           "Use '-' as filename to read 'STDIN'" )
     .nargs( 1 )
     .metavar( "FILE" )
     .action(
@@ -65,7 +65,7 @@ EvalCommand::EvalCommand() : parser( "eval" )
         if ( this->expr.has_value() )
           {
             throw FloxException(
-              "the option `--file' may not be used with an inline expression" );
+              "the option '--file' may not be used with an inline expression" );
           }
         this->file = file;
       } );
@@ -85,7 +85,7 @@ EvalCommand::EvalCommand() : parser( "eval" )
         if ( this->file.has_value() )
           {
             throw FloxException(
-              "the option `--file' may not be used with an inline expression" );
+              "the option '--file' may not be used with an inline expression" );
           }
         this->expr = expr;
       } );

--- a/pkgdb/src/flake-package.cc
+++ b/pkgdb/src/flake-package.cc
@@ -38,7 +38,7 @@ FlakePackage::init( bool checkDrv )
       throw PackageInitException(
         "Package::init(): Packages must be derivations but the attrset at '"
         + this->_cursor->getAttrPathStr()
-        + "' does not set `.type = \"derivation\"'." );
+        + "' does not set '.type = \"derivation\"'." );
     }
 
   /* Subtree type */

--- a/pkgdb/src/parse/command.cc
+++ b/pkgdb/src/parse/command.cc
@@ -51,7 +51,7 @@ DescriptorCommand::run()
     }
   else
     {
-      throw flox::FloxException( "unrecognized format: `" + this->format
+      throw flox::FloxException( "unrecognized format: '" + this->format
                                  + "'" );
       return EXIT_FAILURE;
     }
@@ -79,7 +79,7 @@ ParseCommand::run()
       return this->cmdDescriptor.run();
     }
   std::cerr << this->parser << std::endl;
-  throw flox::FloxException( "You must provide a valid `parse' subcommand" );
+  throw flox::FloxException( "You must provide a valid 'parse' subcommand" );
   return EXIT_FAILURE;
 }
 

--- a/pkgdb/src/pkgdb/gc.cc
+++ b/pkgdb/src/pkgdb/gc.cc
@@ -132,7 +132,7 @@ GCCommand::run()
       /* If the user explicitly gave a directory, throw an error. */
       if ( this->cacheDir.has_value() )
         {
-          throw FloxException( "no such cachedir: `" + cacheDir.string()
+          throw FloxException( "no such cachedir: '" + cacheDir.string()
                                + "'" );
           return EXIT_FAILURE;
         }

--- a/pkgdb/src/pkgdb/get.cc
+++ b/pkgdb/src/pkgdb/get.cc
@@ -31,7 +31,7 @@ GetCommand::GetCommand()
 {
   this->parser.add_description( "Get metadata from Package DB" );
 
-  this->pId.add_description( "Lookup an attribute set or package row `id`" );
+  this->pId.add_description( "Lookup an attribute set or package row 'id'" );
   this->pId.add_argument( "-p", "--pkg" )
     .help( "lookup package path" )
     .nargs( 0 )
@@ -49,12 +49,12 @@ GetCommand::GetCommand()
   this->pPath.add_description(
     "Lookup an (AttrSets|Packages).id attribute path" );
   this->pPath.add_argument( "-p", "--pkg" )
-    .help( "lookup `Packages.id'" )
+    .help( "lookup 'Packages.id'" )
     .nargs( 0 )
     .action( [&]( const auto & ) { this->isPkg = true; } );
   this->addTargetArg( this->pPath );
   this->pPath.add_argument( "id" )
-    .help( "row `id' to lookup" )
+    .help( "row 'id' to lookup" )
     .nargs( 1 )
     .action( [&]( const std::string & rowId )
              { this->id = std::stoull( rowId ); } );
@@ -73,7 +73,7 @@ GetCommand::GetCommand()
   /* In `runPkg' we check for a singleton and if it's an integer it
    * is interpreted as a row id. */
   this->pPkg.add_argument( "id-or-path" )
-    .help( "attribute path to package, or `Packages.id`" )
+    .help( "attribute path to package, or 'Packages.id'" )
     .metavar( "<ID|ATTRS...>" )
     .remaining()
     .action( [&]( const std::string & idOrPath )
@@ -198,7 +198,7 @@ GetCommand::run()
   if ( this->parser.is_subcommand_used( "done" ) ) { return this->runDone(); }
   if ( this->parser.is_subcommand_used( "pkg" ) ) { return this->runPkg(); }
   std::cerr << this->parser << std::endl;
-  throw flox::FloxException( "You must provide a valid `get' subcommand" );
+  throw flox::FloxException( "You must provide a valid 'get' subcommand" );
   return EXIT_FAILURE;
 }
 

--- a/pkgdb/src/pkgdb/pkg-query.cc
+++ b/pkgdb/src/pkgdb/pkg-query.cc
@@ -2,7 +2,7 @@
  *
  * @file pkgdb/pkg-query.cc
  *
- * @brief Interfaces for constructing complex `Packages' queries.
+ * @brief Interfaces for constructing complex 'Packages' queries.
  *
  *
  * -------------------------------------------------------------------------- */
@@ -47,14 +47,14 @@ PkgQueryArgs::check() const
             || this->semver.has_value() ) )
     {
       throw InvalidPkgQueryArg(
-        "queries may not mix `name' parameter with any of `pname', "
-        "`version', or `semver' parameters." );
+        "queries may not mix 'name' parameter with any of 'pname', "
+        "'version', or 'semver' parameters." );
     }
 
   if ( this->version.has_value() && this->semver.has_value() )
     {
       throw InvalidPkgQueryArg(
-        "queries may not mix `version' and `semver' parameters." );
+        "queries may not mix 'version' and 'semver' parameters." );
     }
 
   /* Check licenses don't contain the ' character */
@@ -87,7 +87,7 @@ PkgQueryArgs::check() const
   /* `partialMatch' and `partialNameMatch' cannot be used together. */
   if ( this->partialMatch.has_value() && this->partialNameMatch.has_value() )
     {
-      throw InvalidPkgQueryArg( "`partialmatch' and `partialNameMatch' filters "
+      throw InvalidPkgQueryArg( "'partialmatch' and 'partialNameMatch' filters "
                                 "may not be used together." );
     }
 }

--- a/pkgdb/src/pkgdb/read.cc
+++ b/pkgdb/src/pkgdb/read.cc
@@ -313,7 +313,7 @@ PkgDbReadOnly::getAttrSetPath( row_id row )
       /* Handle no such path. */
       if ( itr == qry.end() )
         {
-          throw PkgDbException( nix::fmt( "No such `AttrSet.id' %llu.", row ) );
+          throw PkgDbException( nix::fmt( "No such 'AttrSet.id' %llu.", row ) );
         }
       row = ( *itr ).get<long long>( 0 );
       path.push_front( ( *itr ).get<std::string>( 1 ) );
@@ -364,7 +364,7 @@ PkgDbReadOnly::getPackagePath( row_id row )
   /* Handle no such path. */
   if ( itr == qry.end() )
     {
-      throw PkgDbException( nix::fmt( "No such `Packages.id' %llu.", row ) );
+      throw PkgDbException( nix::fmt( "No such 'Packages.id' %llu.", row ) );
     }
   flox::AttrPath path = this->getAttrSetPath( ( *itr ).get<long long>( 0 ) );
   path.emplace_back( ( *itr ).get<std::string>( 1 ) );

--- a/pkgdb/src/pkgdb/write.cc
+++ b/pkgdb/src/pkgdb/write.cc
@@ -259,7 +259,7 @@ PkgDb::addOrGetAttrSetId( const std::string & attrName, row_id parent )
       if ( row == qryId.end() )
         {
           throw PkgDbException(
-            nix::fmt( "failed to add AttrSet.id `AttrSets[%ull].%s':(%d) %s",
+            nix::fmt( "failed to add AttrSet.id 'AttrSets[%ull].%s':(%d) %s",
                       parent,
                       attrName,
                       rcode,

--- a/pkgdb/src/raw-package.cc
+++ b/pkgdb/src/raw-package.cc
@@ -38,7 +38,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `path'",
+                "couldn't interpret field 'path'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -51,7 +51,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `name'",
+                "couldn't interpret field 'name'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -64,7 +64,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `pname'",
+                "couldn't interpret field 'pname'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -77,7 +77,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `version'",
+                "couldn't interpret field 'version'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -90,7 +90,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `semver'",
+                "couldn't interpret field 'semver'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -103,7 +103,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `license'",
+                "couldn't interpret field 'license'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -116,7 +116,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `outputs'",
+                "couldn't interpret field 'outputs'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -129,7 +129,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `outputsToInstall'",
+                "couldn't interpret field 'outputsToInstall'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -142,7 +142,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `broken'",
+                "couldn't interpret field 'broken'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -155,7 +155,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `unfree'",
+                "couldn't interpret field 'unfree'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -168,13 +168,13 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field `description'",
+                "couldn't interpret field 'description'",
                 flox::extract_json_errmsg( e ) );
             }
         }
       else
         {
-          throw flox::pkgdb::PkgDbException( "unrecognized field `" + key
+          throw flox::pkgdb::PkgDbException( "unrecognized field '" + key
                                              + "'" );
         }
     }

--- a/pkgdb/src/registry.cc
+++ b/pkgdb/src/registry.cc
@@ -104,7 +104,7 @@ from_json( const nlohmann::json & jfrom, RegistryInput & rip )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidRegistryException(
-                "couldn't interpret registry input field `subtrees'",
+                "couldn't interpret registry input field 'subtrees'",
                 flox::extract_json_errmsg( err ) );
             }
         }
@@ -118,11 +118,11 @@ from_json( const nlohmann::json & jfrom, RegistryInput & rip )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidRegistryException(
-                "couldn't interpret registry input field `from'",
+                "couldn't interpret registry input field 'from'",
                 flox::extract_json_errmsg( err ) );
             }
         }
-      else { throw InvalidRegistryException( "unknown field `" + key + "'" ); }
+      else { throw InvalidRegistryException( "unknown field '" + key + "'" ); }
     }
 }
 
@@ -164,7 +164,7 @@ from_json( const nlohmann::json & jfrom, RegistryRaw & reg )
               catch ( nlohmann::json::exception & err )
                 {
                   throw InvalidRegistryException(
-                    "couldn't extract input `" + ikey + "'",
+                    "couldn't extract input '" + ikey + "'",
                     flox::extract_json_errmsg( err ) );
                 }
               inputs.insert( { ikey, input } );
@@ -203,7 +203,7 @@ from_json( const nlohmann::json & jfrom, RegistryRaw & reg )
         }
       else
         {
-          throw InvalidRegistryException( "unrecognized registry field `" + key
+          throw InvalidRegistryException( "unrecognized registry field '" + key
                                           + "'" );
         }
     }
@@ -343,11 +343,11 @@ from_json( const nlohmann::json & jfrom, InputPreferences & prefs )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidRegistryException(
-                "couldn't interpret field `subtrees'",
+                "couldn't interpret field 'subtrees'",
                 flox::extract_json_errmsg( err ) );
             }
         }
-      else { throw InvalidRegistryException( "unknown field `" + key + "'" ); }
+      else { throw InvalidRegistryException( "unknown field '" + key + "'" ); }
     }
 }
 
@@ -384,7 +384,7 @@ getGARegistry()
   if ( nix::lvlTalkative < nix::verbosity )
     {
       nix::logger->log( nix::lvlTalkative,
-                        "GA Registry is using `nixpkgs' as `"
+                        "GA Registry is using 'nixpkgs' as '"
                           + nixpkgsRef.to_string() + "'." );
     }
   return RegistryRaw(

--- a/pkgdb/src/resolver/command.cc
+++ b/pkgdb/src/resolver/command.cc
@@ -79,7 +79,7 @@ DiffCommand::getManifestRaw()
         }
       if ( ! std::filesystem::exists( *this->manifestPath ) )
         {
-          throw InvalidManifestFileException( "manifest file `"
+          throw InvalidManifestFileException( "manifest file '"
                                               + this->manifestPath->string()
                                               + "'does not exist." );
         }
@@ -103,7 +103,7 @@ DiffCommand::getOldManifestRaw()
         }
       if ( ! std::filesystem::exists( *this->oldManifestPath ) )
         {
-          throw InvalidManifestFileException( "old manifest file `"
+          throw InvalidManifestFileException( "old manifest file '"
                                               + this->oldManifestPath->string()
                                               + "'does not exist." );
         }
@@ -191,7 +191,7 @@ UpdateCommand::run()
                   }
                 else
                   {
-                    throw FloxException( "input `" + inputName
+                    throw FloxException( "input '" + inputName
                                          + "' does not exist in manifest." );
                   }
               }
@@ -444,7 +444,7 @@ ManifestCommand::run()
       return this->cmdRegistry.run();
     }
   std::cerr << this->parser << std::endl;
-  throw flox::FloxException( "You must provide a valid `manifest' subcommand" );
+  throw flox::FloxException( "You must provide a valid 'manifest' subcommand" );
   return EXIT_FAILURE;
 }
 

--- a/pkgdb/src/resolver/descriptor.cc
+++ b/pkgdb/src/resolver/descriptor.cc
@@ -68,7 +68,7 @@ ManifestDescriptorRaw::check( std::string iid ) const
       if ( glob.size() < 3 )
         {
           throw InvalidManifestDescriptorException(
-            "`install." + iid + ".abspath' must have at least three parts." );
+            "'install." + iid + ".abspath' must have at least three parts." );
         }
       if ( ! glob.at( 0 ).has_value()
            || ( std::find( getDefaultSubtrees().begin(),
@@ -77,7 +77,7 @@ ManifestDescriptorRaw::check( std::string iid ) const
                 == getDefaultSubtrees().end() ) )
         {
           throw InvalidManifestDescriptorException(
-            "`install." + iid
+            "'install." + iid
             + ".abspath' must have a subtree as its first element" );
         }
 
@@ -88,13 +88,13 @@ ManifestDescriptorRaw::check( std::string iid ) const
               if ( ! part->has_value() )
                 {
                   throw InvalidManifestDescriptorException(
-                    "`install." + iid
+                    "'install." + iid
                     + ".abspath' may only have a glob as its "
                       "second element" );
                 }
             }
           throw InvalidManifestDescriptorException(
-            "`install." + iid + ".path' conflicts with `install.*.abspath'" );
+            "'install." + iid + ".path' conflicts with 'install.*.abspath'" );
         }
 
       if ( this->systems.has_value() && glob.at( 1 ).has_value() )
@@ -105,8 +105,8 @@ ManifestDescriptorRaw::check( std::string iid ) const
                == this->systems->end() )
             {
               throw InvalidManifestDescriptorException(
-                "`install." + iid
-                + ".systems' list conflicts with `install.*.abspath' "
+                "'install." + iid
+                + ".systems' list conflicts with 'install.*.abspath' "
                   "system specification" );
             }
         }
@@ -210,8 +210,8 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
   if ( ! raw.absPath.has_value() )
     {
       throw InvalidManifestDescriptorException(
-        "`abspath' must be set when calling "
-        "`flox::resolver::ManifestDescriptor::initManifestDescriptorAbsPath'" );
+        "'abspath' must be set when calling "
+        "'flox::resolver::ManifestDescriptor::initManifestDescriptorAbsPath'" );
     }
 
   /* You might need to parse a globbed attr path, so handle that first. */
@@ -220,14 +220,14 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
   if ( glob.size() < 3 )
     {
       throw InvalidManifestDescriptorException(
-        "`abspath' must have at least three parts" );
+        "'abspath' must have at least three parts" );
     }
 
   const auto & first = glob.front();
   if ( ! first.has_value() )
     {
       throw InvalidManifestDescriptorException(
-        "`abspath' may only have a glob as its second element" );
+        "'abspath' may only have a glob as its second element" );
     }
   desc.subtree = Subtree( *first );
 
@@ -238,7 +238,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
       if ( ! elem.has_value() )
         {
           throw InvalidManifestDescriptorException(
-            "`abspath' may only have a glob as its second element" );
+            "'abspath' may only have a glob as its second element" );
         }
       desc.path = AttrPath {};
       for ( auto itr = glob.begin() + 3; itr != glob.end(); ++itr )
@@ -247,7 +247,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
           if ( ! elem.has_value() )
             {
               throw InvalidManifestDescriptorException(
-                "`abspath' may only have a glob as its second element" );
+                "'abspath' may only have a glob as its second element" );
             }
           desc.path->emplace_back( *elem );
         }
@@ -260,7 +260,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
       if ( ! elem.has_value() )
         {
           throw InvalidManifestDescriptorException(
-            "`abspath' may only have a glob as its second element" );
+            "'abspath' may only have a glob as its second element" );
         }
       desc.path->emplace_back( *elem );
     }
@@ -273,7 +273,7 @@ initManifestDescriptorAbsPath( ManifestDescriptor &          desc,
       if ( raw.systems.has_value() && ( *raw.systems != *desc.systems ) )
         {
           throw InvalidManifestDescriptorException(
-            "`systems' list conflicts with `abspath' system specification" );
+            "'systems' list conflicts with 'abspath' system specification" );
         }
     }
 }
@@ -305,7 +305,7 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `name'",
+                "couldn't interpret field 'name'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -318,7 +318,7 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `version'",
+                "couldn't interpret field 'version'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -331,7 +331,7 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `path'",
+                "couldn't interpret field 'path'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -344,7 +344,7 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `abspath'",
+                "couldn't interpret field 'abspath'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -357,7 +357,7 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `systems'",
+                "couldn't interpret field 'systems'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -370,7 +370,7 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `optional'",
+                "couldn't interpret field 'optional'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -383,7 +383,7 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `package-group'",
+                "couldn't interpret field 'package-group'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -396,7 +396,7 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `package-repository'",
+                "couldn't interpret field 'package-repository'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -409,14 +409,14 @@ from_json( const nlohmann::json & jfrom, ManifestDescriptorRaw & descriptor )
           catch ( nlohmann::json::exception & e )
             {
               throw ParseManifestDescriptorRawException(
-                "couldn't interpret field `priority'",
+                "couldn't interpret field 'priority'",
                 flox::extract_json_errmsg( e ) );
             }
         }
       else
         {
           throw ParseManifestDescriptorRawException(
-            "encountered unrecognized field `" + key
+            "encountered unrecognized field '" + key
             + "' while parsing manifest descriptor" );
         }
     }
@@ -499,7 +499,7 @@ ManifestDescriptorRaw::ManifestDescriptorRaw(
       if ( attr.has_value() && attr.value().empty() )
         {
           throw InvalidManifestDescriptorException(
-            "descriptor attribute name was malformed: `"
+            "descriptor attribute name was malformed: '"
             + std::string( attrsSubstr ) + "'" );
         }
     }
@@ -542,7 +542,7 @@ validatedSingleAttr( const AttrPathGlob & attrs )
 {
   if ( attrs[0].has_value() ) { return attrs[0]; }
   throw InvalidManifestDescriptorException(
-    "globs are only allowed to replace entire system names: `"
+    "globs are only allowed to replace entire system names: '"
     + displayableGlobbedPath( attrs ) + "'" );
 }
 
@@ -572,13 +572,13 @@ validatedRelativePath( const AttrPathGlob &             attrs,
   if ( containsGlobbedAttr )
     {
       throw InvalidManifestDescriptorException(
-        "globs are only allowed to replace entire system names: `"
+        "globs are only allowed to replace entire system names: '"
         + displayableGlobbedPath( attrs ) + "'" );
     }
   else if ( globInAttrName( attrs ) )
     {
       throw InvalidManifestDescriptorException(
-        "globs are only allowed to replace entire system names: `"
+        "globs are only allowed to replace entire system names: '"
         + displayableGlobbedPath( attrs ) + "'" );
     }
   else if ( attrs.size() < 2 )
@@ -601,7 +601,7 @@ validatedAbsolutePath( const AttrPathGlob & attrs )
        || ( ( nGlobs == 1 ) && systemNotGlobbed ) )
     {
       throw InvalidManifestDescriptorException(
-        "globs are only allowed to replace entire system names: `"
+        "globs are only allowed to replace entire system names: '"
         + displayableGlobbedPath( attrs ) + "'" );
     }
   return attrs;
@@ -660,7 +660,7 @@ ManifestDescriptor::ManifestDescriptor( const ManifestDescriptorRaw & raw )
           if ( this->path != path )
             {
               throw InvalidManifestDescriptorException(
-                "`path' conflicts with with `abspath'" );
+                "'path' conflicts with with 'abspath'" );
             }
         }
       else { this->path = path; }

--- a/pkgdb/src/resolver/environment.cc
+++ b/pkgdb/src/resolver/environment.cc
@@ -669,7 +669,7 @@ Environment::tryResolveGroup( const GroupName &          name,
                = std::get_if<SystemPackages>( &maybeResolved ) )
             {
               nix::logger->log( nix::lvlInfo,
-                                nix::fmt( "upgrading group `%s' to avoid "
+                                nix::fmt( "upgrading group '%s' to avoid "
                                           "resolution failure",
                                           getGroupName( group ) ) );
 
@@ -701,10 +701,10 @@ describeResolutionFailure( std::stringstream &       msg,
                            const GroupName &         name,
                            const ResolutionFailure & failure )
 {
-  msg << "  in `" << name << "': '" << std::endl;
+  msg << "  in '" << name << "': '" << std::endl;
   for ( const auto & [iid, url] : failure )
     {
-      msg << "    failed to resolve `" << iid << "' in input `" << url << '\'';
+      msg << "    failed to resolve '" << iid << "' in input '" << url << '\'';
     }
   return msg;
 }

--- a/pkgdb/src/resolver/lockfile.cc
+++ b/pkgdb/src/resolver/lockfile.cc
@@ -80,7 +80,7 @@ Lockfile::checkGroups() const
                        && descriptor->second.group.has_value() )
                     {
                       throw InvalidLockfileException(
-                        "invalid group `" + *descriptor->second.group
+                        "invalid group '" + *descriptor->second.group
                         + "' uses multiple inputs" );
                     }
                   else
@@ -109,7 +109,7 @@ Lockfile::check() const
           if ( input.getFlakeRef()->input.getType() == "indirect" )
             {
               throw InvalidManifestFileException(
-                "manifest `registry.inputs." + name
+                "manifest 'registry.inputs." + name
                 + ".from.type' may not be \"indirect\"." );
             }
         }
@@ -188,7 +188,7 @@ from_json( const nlohmann::json & jfrom, LockedInputRaw & raw )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidLockfileException(
-                "couldn't parse locked input field `" + key + "'",
+                "couldn't parse locked input field '" + key + "'",
                 extract_json_errmsg( err ) );
             }
           catch ( nix::BadHash & err )
@@ -207,7 +207,7 @@ from_json( const nlohmann::json & jfrom, LockedInputRaw & raw )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidLockfileException(
-                "couldn't parse locked input field `" + key + "'",
+                "couldn't parse locked input field '" + key + "'",
                 extract_json_errmsg( err ) );
             }
         }
@@ -220,13 +220,13 @@ from_json( const nlohmann::json & jfrom, LockedInputRaw & raw )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidLockfileException(
-                "couldn't parse locked input field `" + key + "'",
+                "couldn't parse locked input field '" + key + "'",
                 extract_json_errmsg( err ) );
             }
         }
       else
         {
-          throw InvalidLockfileException( "encountered unexpected field `" + key
+          throw InvalidLockfileException( "encountered unexpected field '" + key
                                           + "' while parsing locked input" );
         }
     }
@@ -269,7 +269,7 @@ from_json( const nlohmann::json & jfrom, LockedPackageRaw & raw )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidLockfileException(
-                "couldn't parse package input field `" + key + "'",
+                "couldn't parse package input field '" + key + "'",
                 extract_json_errmsg( err ) );
             }
         }
@@ -282,7 +282,7 @@ from_json( const nlohmann::json & jfrom, LockedPackageRaw & raw )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidLockfileException(
-                "couldn't parse package input field `" + key + "'",
+                "couldn't parse package input field '" + key + "'",
                 extract_json_errmsg( err ) );
             }
         }
@@ -295,14 +295,14 @@ from_json( const nlohmann::json & jfrom, LockedPackageRaw & raw )
           catch ( nlohmann::json::exception & err )
             {
               throw InvalidLockfileException(
-                "couldn't parse package input field `" + key + "'",
+                "couldn't parse package input field '" + key + "'",
                 extract_json_errmsg( err ) );
             }
         }
       else if ( key == "info" ) { raw.info = value; }
       else
         {
-          throw InvalidLockfileException( "encountered unexpected field `" + key
+          throw InvalidLockfileException( "encountered unexpected field '" + key
                                           + "' while parsing locked package" );
         }
     }
@@ -356,7 +356,7 @@ from_json( const nlohmann::json & jfrom, LockfileRaw & raw )
             }
           catch ( nlohmann::json::exception & err )
             {
-              throw InvalidLockfileException( "couldn't parse lockfile field `"
+              throw InvalidLockfileException( "couldn't parse lockfile field '"
                                                 + key + "'",
                                               extract_json_errmsg( err ) );
             }
@@ -369,7 +369,7 @@ from_json( const nlohmann::json & jfrom, LockfileRaw & raw )
             }
           catch ( nlohmann::json::exception & err )
             {
-              throw InvalidLockfileException( "couldn't parse lockfile field `"
+              throw InvalidLockfileException( "couldn't parse lockfile field '"
                                                 + key + "'",
                                               extract_json_errmsg( err ) );
             }
@@ -380,7 +380,7 @@ from_json( const nlohmann::json & jfrom, LockfileRaw & raw )
             {
               assertIsJSONObject<InvalidLockfileException>(
                 jfrom,
-                "lockfile `packages' field" );
+                "lockfile 'packages' field" );
             }
           for ( const auto & [system, descriptors] : value.items() )
             {
@@ -402,7 +402,7 @@ from_json( const nlohmann::json & jfrom, LockfileRaw & raw )
                       catch ( nlohmann::json::exception & err )
                         {
                           throw InvalidLockfileException(
-                            "couldn't parse lockfile field `packages." + system
+                            "couldn't parse lockfile field 'packages." + system
                               + "." + pid + "'",
                             extract_json_errmsg( err ) );
                         }
@@ -419,14 +419,14 @@ from_json( const nlohmann::json & jfrom, LockfileRaw & raw )
             }
           catch ( nlohmann::json::exception & err )
             {
-              throw InvalidLockfileException( "couldn't parse lockfile field `"
+              throw InvalidLockfileException( "couldn't parse lockfile field '"
                                                 + key + "'",
                                               extract_json_errmsg( err ) );
             }
         }
       else
         {
-          throw InvalidLockfileException( "encountered unexpected field `" + key
+          throw InvalidLockfileException( "encountered unexpected field '" + key
                                           + "' while parsing locked package" );
         }
     }

--- a/pkgdb/src/resolver/manifest-raw.cc
+++ b/pkgdb/src/resolver/manifest-raw.cc
@@ -124,7 +124,7 @@ from_json( const nlohmann::json & jfrom, Options::Semver & semver )
 {
   assertIsJSONObject<InvalidManifestFileException>(
     jfrom,
-    "manifest field `options.semver'" );
+    "manifest field 'options.semver'" );
 
   /* Clear fields. */
   semver.preferPreReleases = std::nullopt;
@@ -140,7 +140,7 @@ from_json( const nlohmann::json & jfrom, Options::Semver & semver )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `options.semver."
+                "failed to parse manifest field 'options.semver."
                 "prefer-pre-releases' with value: "
                 + value.dump() );
             }
@@ -148,7 +148,7 @@ from_json( const nlohmann::json & jfrom, Options::Semver & semver )
       else
         {
           throw InvalidManifestFileException(
-            "unrecognized manifest field `options.semver." + key + "'." );
+            "unrecognized manifest field 'options.semver." + key + "'." );
         }
     }
 }
@@ -172,7 +172,7 @@ from_json( const nlohmann::json & jfrom, Options::Allows & allow )
 {
   assertIsJSONObject<InvalidManifestFileException>(
     jfrom,
-    "manifest field `options.allow'" );
+    "manifest field 'options.allow'" );
 
   /* Clear fields. */
   allow.licenses = std::nullopt;
@@ -190,7 +190,7 @@ from_json( const nlohmann::json & jfrom, Options::Allows & allow )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `options.allow.unfree' "
+                "failed to parse manifest field 'options.allow.unfree' "
                 "with value: "
                 + value.dump() );
             }
@@ -204,7 +204,7 @@ from_json( const nlohmann::json & jfrom, Options::Allows & allow )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `options.allow.broken' "
+                "failed to parse manifest field 'options.allow.broken' "
                 "with value: "
                 + value.dump() );
             }
@@ -218,7 +218,7 @@ from_json( const nlohmann::json & jfrom, Options::Allows & allow )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `options.allow.licenses' "
+                "failed to parse manifest field 'options.allow.licenses' "
                 "with value: "
                 + value.dump() );
             }
@@ -226,7 +226,7 @@ from_json( const nlohmann::json & jfrom, Options::Allows & allow )
       else
         {
           throw InvalidManifestFileException(
-            "unrecognized manifest field `options.allow." + key + "'." );
+            "unrecognized manifest field 'options.allow." + key + "'." );
         }
     }
 }
@@ -253,7 +253,7 @@ from_json( const nlohmann::json & jfrom, Options & opts )
 {
   assertIsJSONObject<InvalidManifestFileException>(
     jfrom,
-    "manifest field `options'" );
+    "manifest field 'options'" );
 
   for ( const auto & [key, value] : jfrom.items() )
     {
@@ -266,7 +266,7 @@ from_json( const nlohmann::json & jfrom, Options & opts )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `options.systems' with value: "
+                "failed to parse manifest field 'options.systems' with value: "
                 + value.dump() );
             }
         }
@@ -292,7 +292,7 @@ from_json( const nlohmann::json & jfrom, Options & opts )
             {
               throw InvalidManifestFileException(
                 "failed to parse manifest field "
-                "`options.package-grouping-strategy' with value: "
+                "'options.package-grouping-strategy' with value: "
                 + value.dump() );
             }
         }
@@ -306,14 +306,14 @@ from_json( const nlohmann::json & jfrom, Options & opts )
             {
               throw InvalidManifestFileException(
                 "failed to parse manifest field "
-                "`options.activation-strategy' with value: "
+                "'options.activation-strategy' with value: "
                 + value.dump() );
             }
         }
       else
         {
           throw InvalidManifestFileException(
-            "unrecognized manifest field `options." + key + "'." );
+            "unrecognized manifest field 'options." + key + "'." );
         }
     }
 }
@@ -349,7 +349,7 @@ GlobalManifestRaw::operator GlobalManifestRawGA() const
        && ( ( *this->registry ) != getGARegistry() ) )
     {
       throw InvalidManifestFileException(
-        "global manifest `registry' does not match the GA registry" );
+        "global manifest 'registry' does not match the GA registry" );
     }
   return GlobalManifestRawGA( this->options );
 }
@@ -369,7 +369,7 @@ from_json( const nlohmann::json & jfrom, GlobalManifestRaw & manifest )
       else
         {
           throw InvalidManifestFileException(
-            "unrecognized global manifest field: `" + key + "'." );
+            "unrecognized global manifest field: '" + key + "'." );
         }
     }
   manifest.check();
@@ -395,7 +395,7 @@ EnvBaseRaw::check() const
   if ( this->floxhub.has_value() && this->dir.has_value() )
     {
       throw InvalidManifestFileException(
-        "manifest may only define one of `env-base.floxhub' or `env-base.dir' "
+        "manifest may only define one of 'env-base.floxhub' or 'env-base.dir' "
         "fields." );
     }
 }
@@ -408,7 +408,7 @@ from_json( const nlohmann::json & jfrom, EnvBaseRaw & env )
 {
   assertIsJSONObject<InvalidManifestFileException>(
     jfrom,
-    "manifest field `env-base'" );
+    "manifest field 'env-base'" );
 
   /* Clear fields. */
   env.dir     = std::nullopt;
@@ -425,7 +425,7 @@ from_json( const nlohmann::json & jfrom, EnvBaseRaw & env )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `env-base.floxhub' with value: "
+                "failed to parse manifest field 'env-base.floxhub' with value: "
                 + value.dump() );
             }
         }
@@ -438,14 +438,14 @@ from_json( const nlohmann::json & jfrom, EnvBaseRaw & env )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `env-base.dir' with value: "
+                "failed to parse manifest field 'env-base.dir' with value: "
                 + value.dump() );
             }
         }
       else
         {
           throw InvalidManifestFileException(
-            "unrecognized manifest field `env-base." + key + "'." );
+            "unrecognized manifest field 'env-base." + key + "'." );
         }
     }
   env.check();
@@ -468,7 +468,7 @@ static void
 from_json( const nlohmann::json & jfrom, HookRaw & hook )
 {
   assertIsJSONObject<InvalidManifestFileException>( jfrom,
-                                                    "manifest field `hook'" );
+                                                    "manifest field 'hook'" );
 
   /* Clear fields. */
   hook.file   = std::nullopt;
@@ -485,7 +485,7 @@ from_json( const nlohmann::json & jfrom, HookRaw & hook )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `hook.script' with value: "
+                "failed to parse manifest field 'hook.script' with value: "
                 + value.dump() );
             }
         }
@@ -498,14 +498,14 @@ from_json( const nlohmann::json & jfrom, HookRaw & hook )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse manifest field `hook.file' with value: "
+                "failed to parse manifest field 'hook.file' with value: "
                 + value.dump() );
             }
         }
       else
         {
           throw InvalidManifestFileException(
-            "unrecognized manifest field `hook." + key + "'." );
+            "unrecognized manifest field 'hook." + key + "'." );
         }
     }
 
@@ -531,7 +531,7 @@ HookRaw::check() const
   if ( this->script.has_value() && this->file.has_value() )
     {
       throw InvalidManifestFileException(
-        "hook may only define one of `hook.script' or `hook.file' fields." );
+        "hook may only define one of 'hook.script' or 'hook.file' fields." );
     }
 }
 
@@ -541,7 +541,7 @@ HookRaw::check() const
 static std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>>
 installFromJSON( const nlohmann::json & install )
 {
-  assertIsJSONObject( install, "manifest field `install'" );
+  assertIsJSONObject( install, "manifest field 'install'" );
   std::unordered_map<std::string, std::optional<ManifestDescriptorRaw>> result;
   for ( const auto & [name, desc] : install.items() )
     {
@@ -555,7 +555,7 @@ installFromJSON( const nlohmann::json & install )
           catch ( const nlohmann::json::exception & )
             {
               throw InvalidManifestFileException(
-                "failed to parse field `install." + name
+                "failed to parse field 'install." + name
                 + "' with value: " + desc.dump() );
             }
         }
@@ -570,7 +570,7 @@ static std::unordered_map<std::string, std::string>
 varsFromJSON( const nlohmann::json & jfrom )
 {
   assertIsJSONObject<InvalidManifestFileException>( jfrom,
-                                                    "manifest field `vars'" );
+                                                    "manifest field 'vars'" );
   std::unordered_map<std::string, std::string> vars;
   for ( const auto & [key, value] : jfrom.items() )
     {
@@ -581,7 +581,7 @@ varsFromJSON( const nlohmann::json & jfrom )
         }
       catch ( const nlohmann::json::exception & err )
         {
-          throw InvalidManifestFileException( "failed to parse field `vars."
+          throw InvalidManifestFileException( "failed to parse field 'vars."
                                               + key + "' with value: "
                                               + value.dump() );
         }
@@ -637,7 +637,7 @@ from_json( const nlohmann::json & jfrom, ManifestRaw & manifest )
       else if ( key == "env-base" ) { value.get_to( manifest.envBase ); }
       else
         {
-          throw InvalidManifestFileException( "unrecognized manifest field: `"
+          throw InvalidManifestFileException( "unrecognized manifest field: '"
                                               + key + "'." );
         }
     }
@@ -687,7 +687,7 @@ ManifestRaw::check() const
           if ( input.getFlakeRef()->input.getType() == "indirect" )
             {
               throw InvalidManifestFileException(
-                "manifest `registry.inputs." + name
+                "manifest 'registry.inputs." + name
                 + ".from.type' may not be \"indirect\"." );
             }
         }
@@ -717,7 +717,7 @@ from_json( const nlohmann::json & jfrom, GlobalManifestRawGA & manifest )
       else
         {
           throw InvalidManifestFileException(
-            "unrecognized global manifest field: `" + key + "'." );
+            "unrecognized global manifest field: '" + key + "'." );
         }
     }
   manifest.check();
@@ -765,7 +765,7 @@ from_json( const nlohmann::json & jfrom, ManifestRawGA & manifest )
       else if ( key == "options" ) { value.get_to( manifest.options ); }
       else
         {
-          throw InvalidManifestFileException( "unrecognized manifest field: `"
+          throw InvalidManifestFileException( "unrecognized manifest field: '"
                                               + key + "'." );
         }
     }

--- a/pkgdb/src/resolver/mixins.cc
+++ b/pkgdb/src/resolver/mixins.cc
@@ -37,13 +37,13 @@ namespace flox::resolver {
 #define ENV_MIXIN_THROW_IF_SET( member )                              \
   if ( this->member.has_value() )                                     \
     {                                                                 \
-      throw EnvironmentMixinException( "`" #member                    \
+      throw EnvironmentMixinException( "'" #member                    \
                                        "' was already initialized" ); \
     }                                                                 \
   if ( this->environment.has_value() )                                \
     {                                                                 \
       throw EnvironmentMixinException(                                \
-        "`" #member "' cannot be initialized after `environment'" );  \
+        "'" #member "' cannot be initialized after 'environment'" );  \
     }
 
 
@@ -273,7 +273,7 @@ EnvironmentMixin::addGlobalManifestFileOption(
   argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--global-manifest" )
-    .help( "the path to the user's global `manifest.{toml,yaml,json}' file." )
+    .help( "the path to the user's global 'manifest.{toml,yaml,json}' file." )
     .metavar( "PATH" )
     .action( [&]( const std::string & strPath )
              { this->setGlobalManifestRaw( nix::absPath( strPath ) ); } );
@@ -286,7 +286,7 @@ argparse::Argument &
 EnvironmentMixin::addManifestFileOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--manifest" )
-    .help( "the path to the `manifest.{toml,yaml,json}' file." )
+    .help( "the path to the 'manifest.{toml,yaml,json}' file." )
     .metavar( "PATH" )
     .action( [&]( const std::string & strPath )
              { this->setManifestRaw( nix::absPath( strPath ) ); } );
@@ -301,7 +301,7 @@ EnvironmentMixin::addManifestFileArg( argparse::ArgumentParser & parser,
 {
   argparse::Argument & arg
     = parser.add_argument( "--manifest" )
-        .help( "the path to the project's `manifest.{toml,yaml,json}' file." )
+        .help( "the path to the project's 'manifest.{toml,yaml,json}' file." )
         .metavar( "PATH" )
         .nargs( 1 )
         .action( [&]( const std::string & strPath )
@@ -316,7 +316,7 @@ argparse::Argument &
 EnvironmentMixin::addLockfileOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--lockfile" )
-    .help( "the path to a lockfile, either the project's `manifest.lock` or "
+    .help( "the path to a lockfile, either the project's 'manifest.lock' or "
            "the global lock" )
     .metavar( "PATH" )
     .nargs( 1 )
@@ -330,8 +330,8 @@ argparse::Argument &
 EnvironmentMixin::addFloxDirectoryOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--dir", "-d" )
-    .help( "the directory to search for `manifest.{json,yaml,toml}' and "
-           "`manifest.lock`." )
+    .help( "the directory to search for 'manifest.{json,yaml,toml}' and "
+           "'manifest.lock'." )
     .metavar( "PATH" )
     .nargs( 1 )
     .action(
@@ -361,7 +361,7 @@ EnvironmentMixin::addFloxDirectoryOption( argparse::ArgumentParser & parser )
         else
           {
             throw EnvironmentMixinException(
-              "unable to locate a `manifest.{json,yaml,toml}' file "
+              "unable to locate a 'manifest.{json,yaml,toml}' file "
               "in directory: "
               + strPath );
           }
@@ -410,7 +410,7 @@ argparse::Argument &
 GAEnvironmentMixin::addGARegistryOption( argparse::ArgumentParser & parser )
 {
   return parser.add_argument( "--ga-registry" )
-    .help( "use a hard coded manifest ( for `flox' GA )." )
+    .help( "use a hard coded manifest ( for 'flox' GA )." )
     .nargs( 0 )
     .action( [&]( const auto & ) { this->gaRegistry = true; } );
 }

--- a/pkgdb/src/search/command.cc
+++ b/pkgdb/src/search/command.cc
@@ -61,21 +61,21 @@ void
 SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
 {
   parser.add_argument( "--name" )
-    .help( "search for packages by exact `name' match." )
+    .help( "search for packages by exact 'name' match." )
     .metavar( "NAME" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.name = arg; } );
 
   parser.add_argument( "--pname" )
-    .help( "search for packages by exact `pname' match." )
+    .help( "search for packages by exact 'pname' match." )
     .metavar( "PNAME" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.pname = arg; } );
 
   parser.add_argument( "--version" )
-    .help( "search for packages by exact `version' match." )
+    .help( "search for packages by exact 'version' match." )
     .metavar( "VERSION" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
@@ -89,23 +89,23 @@ SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
              { this->params.query.semver = arg; } );
 
   parser.add_argument( "--match" )
-    .help( "search for packages by partially matching `pname', "
-           "`description', or `attrName'." )
+    .help( "search for packages by partially matching 'pname', "
+           "'description', or 'attrName'." )
     .metavar( "MATCH" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.partialMatch = arg; } );
 
   parser.add_argument( "--match-name" )
-    .help( "search for packages by partially matching `pname' or `attrName'." )
+    .help( "search for packages by partially matching 'pname' or 'attrName'." )
     .metavar( "MATCH" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )
              { this->params.query.partialNameMatch = arg; } );
 
   parser.add_argument( "--match-name-or-rel-path" )
-    .help( "search for packages by partially matching `pname' or '.' joined "
-           "`relPath'." )
+    .help( "search for packages by partially matching 'pname' or '.' joined "
+           "'relPath'." )
     .metavar( "MATCH" )
     .nargs( 1 )
     .action( [&]( const std::string & arg )

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -103,7 +103,7 @@ readAndCoerceJSON( const std::filesystem::path & path )
 {
   if ( ! std::filesystem::exists( path ) )
     {
-      throw flox::FloxException( "File `" + path.string()
+      throw flox::FloxException( "File '" + path.string()
                                  + "' does not exist" );
     }
 
@@ -128,7 +128,7 @@ readAndCoerceJSON( const std::filesystem::path & path )
     }
   else
     {
-      throw flox::FloxException( "Cannot convert file extension `"
+      throw flox::FloxException( "Cannot convert file extension '"
                                  + ext.string() + "' to JSON" );
     }
 }

--- a/pkgdb/tests/groups.bats
+++ b/pkgdb/tests/groups.bats
@@ -173,7 +173,7 @@ jq_edit() {
   run sh -c '$PKGDB_BIN manifest lock --lockfile manifest.lock --manifest manifest.json  \
                |tee manifest.lock3;'
   assert_success
-  assert_output --partial "upgrading group \`default'"
+  assert_output --partial "upgrading group 'default'"
   # Ensure we didn't produce an error.
   run jq -r '.category_message' manifest.lock3
   assert_output "null"

--- a/pkgdb/tests/search.bats
+++ b/pkgdb/tests/search.bats
@@ -418,7 +418,7 @@ genParamsNixpkgsFlox() {
   category_msg="$(echo "$output" | jq '.category_message')"
   context_msg="$(echo "$output" | jq -r '.context_message')"
   assert_equal "$category_msg" '"invalid lockfile"'
-  assert_equal "$context_msg" "encountered unexpected field \`foo' while parsing locked package"
+  assert_equal "$context_msg" "encountered unexpected field 'foo' while parsing locked package"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Aligning pkgdb outputs with style guide, i.e. single quotes around code words as discussed in https://github.com/flox/product/issues/596

Left  `` `...' `` in place where they were used in comments
