### PR TITLE
refactor: use CASE and COALESCE not IIF

### DIFF
--- a/pkgdb/include/flox/pkgdb/read.hh
+++ b/pkgdb/include/flox/pkgdb/read.hh
@@ -108,7 +108,7 @@ operator<<( std::ostream & oss, const SqlVersions & versions );
 
 
 /** The current SQLite3 schema versions. */
-constexpr SqlVersions sqlVersions = { .tables = 2, .views = 3 };
+constexpr SqlVersions sqlVersions = { .tables = 2, .views = 4 };
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/src/pkgdb/db-package.cc
+++ b/pkgdb/src/pkgdb/db-package.cc
@@ -29,8 +29,12 @@ DbPackage::initRawPackage( PkgDbReadOnly & pkgdb )
       , 'license',          license
       , 'outputs',          json( outputs )
       , 'outputsToInstall', json( outputsToInstall )
-      , 'broken',           iif( broken, json( 'true' ), json( 'false' ) )
-      , 'unfree',           iif( broken, json( 'true' ), json( 'false' ) )
+      , 'broken',           CASE WHEN broken THEN json( 'true' )
+                                             ELSE json( 'false' )
+                            END
+      , 'unfree',           CASE WHEN unfree THEN json( 'true' )
+                                             ELSE json( 'false' )
+                            END
       , 'description',      description
       ) AS json
       FROM Packages

--- a/pkgdb/src/pkgdb/read.cc
+++ b/pkgdb/src/pkgdb/read.cc
@@ -393,14 +393,14 @@ PkgDbReadOnly::getPackage( row_id row )
       , 'version',     version
       , 'description', Descriptions.description
       , 'license',     license
-      , 'broken',      iif( ( broken IS NULL )
-                          , json( 'null' )
-                          , iif( broken, json( 'true' ), json( 'false' ) )
-                          )
-      , 'unfree',      iif( ( unfree IS NULL )
-                          , json( 'null' )
-                          , iif( unfree, json( 'true' ), json( 'false' ) )
-                          )
+      , 'broken',      CASE WHEN broken IS NULL THEN json( 'null' )
+                            WHEN broken         THEN JSON( 'true' )
+                                                ELSE JSON( 'false' )
+                       END
+      , 'unfree',      CASE WHEN unfree IS NULL THEN json( 'null' )
+                            WHEN unfree         THEN JSON( 'true' )
+                                                ELSE JSON( 'false' )
+                       END
       ) AS json
       FROM Packages
            LEFT JOIN Descriptions ON ( descriptionId = Descriptions.id )

--- a/pkgdb/src/pkgdb/schemas.hh
+++ b/pkgdb/src/pkgdb/schemas.hh
@@ -131,8 +131,8 @@ CREATE VIEW IF NOT EXISTS v_Semvers AS SELECT
   semver
 , major
 , minor
-, ( iif( ( length( mPatch ) < 1 ), rest, mPatch ) ) AS patch
-, ( iif( ( length( mPatch ) < 1 ), NULL, rest ) )   AS preTag
+, CASE WHEN ( length( mPatch ) < 1 ) THEN rest ELSE mPatch END AS patch
+, CASE WHEN ( length( mPatch ) < 1 ) THEN NULL ELSE rest END   AS preTag
 FROM (
   SELECT semver
        , major

--- a/pkgdb/src/pkgdb/schemas.hh
+++ b/pkgdb/src/pkgdb/schemas.hh
@@ -119,7 +119,7 @@ CREATE VIEW IF NOT EXISTS v_AttrPaths AS
     UNION ALL SELECT O.id, O.parent
                    , O.attrName
                    , Parent.subtree
-                   , iif( ( Parent.system IS NULL ), O.attrName, Parent.system )
+                   , COALESCE( Parent.system, O.attrName )
                      AS system
                    , json_insert( Parent.path, '$[#]', O.attrName ) AS path
     FROM AttrSets O INNER JOIN Tree as Parent ON ( Parent.id = O.parent )
@@ -158,24 +158,17 @@ FROM (
 -- and categorizes versions into _types_.
 CREATE VIEW IF NOT EXISTS v_PackagesVersions AS SELECT
   Packages.id
-, iif( ( Packages.version IS NULL ), NULL
-  , iif( ( Packages.semver IS NOT NULL ), NULL
-       , iif( ( ( SELECT Packages.version = date( Packages.version ) )
-                IS NOT NULL )
-            , date( Packages.version ), NULL
-            )
-       )
-  ) AS versionDate
-, iif( ( Packages.version IS NULL ), 3
-     , iif( ( Packages.semver IS NOT NULL ), 0
-       , iif( ( ( SELECT Packages.version = date( Packages.version ) )
-                IS NOT NULL )
-            , 1
-            , 3
-            )
-       )
-     )
-  AS versionType
+, CASE WHEN Packages.version IS NULL    THEN NULL
+       WHEN Packages.semver IS NOT NULL THEN NULL
+       WHEN ( SELECT Packages.version = date( Packages.version ) )
+         THEN date( Packages.version )
+       ELSE NULL
+  END AS versionDate
+, CASE WHEN Packages.version IS NULL                               THEN 3
+       WHEN Packages.semver IS NOT NULL                            THEN 0
+       WHEN ( SELECT Packages.version = date( Packages.version ) ) THEN 1
+                                                                   ELSE 2
+  END AS versionType
 FROM Packages
 LEFT OUTER JOIN v_Semvers ON ( Packages.semver = v_Semvers.semver );
 
@@ -215,9 +208,15 @@ CREATE VIEW IF NOT EXISTS v_PackagesSearch AS SELECT
 , v_PackagesVersions.versionType
 , Packages.license
 , Packages.broken
-, iif( ( broken IS NULL ), 1, iif( broken, 2, 0 ) ) AS brokenRank
+, CASE WHEN broken IS NULL THEN 1
+       WHEN broken THEN 2
+       ELSE 0
+  END AS brokenRank
 , Packages.unfree
-, iif( ( unfree IS NULL ), 1, iif( unfree, 2, 0 ) ) AS unfreeRank
+, CASE WHEN unfree IS NULL THEN 1
+       WHEN unfree THEN 2
+       ELSE 0
+  END AS unfreeRank
 , Descriptions.description
 FROM Packages
 LEFT OUTER JOIN Descriptions ON ( Packages.descriptionId = Descriptions.id )


### PR DESCRIPTION
Improves portability and readability of some SQL statements.
This is potentially useful when migrating to another SQL backend in the future.
Provides a marginal performance improvement.

- Drop `IIF( COND, VALUE-TRUE, VALUE-FALSE )` for `CASE WHEN ... END`
- Drop `IIF( VALUE IS NULL, VALUE-OTHER, VALUE )` for 
  `COALESCE( VALUE, VALUE-OTHER )`
