### PR TITLE
feat: add messaging functions

### DIFF
--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -6,13 +6,13 @@ use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use fslock::LockFile;
 use indoc::indoc;
-use log::info;
 use serde::Serialize;
 use tokio::fs;
 use toml_edit::Key;
 
 use crate::config::{Config, ReadWriteError, FLOX_CONFIG_FILE};
 use crate::subcommand_metric;
+use crate::utils::message;
 use crate::utils::metrics::{
     METRICS_EVENTS_FILE_NAME,
     METRICS_LOCK_FILE_NAME,
@@ -56,7 +56,7 @@ impl ResetMetrics {
                 system-wide: update /etc/flox.toml as described in flox(1)
         "};
 
-        info!("{notice}");
+        message::plain(notice);
         Ok(())
     }
 }

--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -45,16 +45,16 @@ impl ResetMetrics {
         }
 
         let notice = indoc! {"
-                    Sucessfully reset telemetry ID for this machine!
+            Sucessfully reset telemetry ID for this machine!
 
-                    A new ID will be assigned next time you use flox.
+            A new ID will be assigned next time you use flox.
 
-                    The collection of metrics can be disabled in the following ways:
+            The collection of metrics can be disabled in the following ways:
 
-                      environment: FLOX_DISABLE_METRICS=true
-                        user-wide: flox config --set-bool disable_metrics true
-                      system-wide: update /etc/flox.toml as described in flox(1)
-                "};
+                environment: FLOX_DISABLE_METRICS=true
+                user-wide: flox config --set-bool disable_metrics true
+                system-wide: update /etc/flox.toml as described in flox(1)
+        "};
 
         info!("{notice}");
         Ok(())

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -23,6 +23,7 @@ use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::didyoumean::{DidYouMean, SearchSuggestion};
+use crate::utils::message;
 use crate::utils::search::{
     construct_search_params,
     manifest_and_lockfile,
@@ -151,7 +152,7 @@ impl Search {
                 writeln!(&mut hints, "{suggestion}")?;
             };
 
-            eprintln!("{hints}");
+            message::plain(hints);
         }
         Ok(())
     }

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -12,7 +12,6 @@ use flox_rust_sdk::models::search::{
     SearchParams,
     SearchResult,
     SearchResults,
-    SearchStrategy,
     ShowError,
     Subtree,
 };
@@ -139,7 +138,7 @@ impl Search {
 
             let mut hints = String::new();
 
-            if let Some(hint) = results.hint() {
+            if let Some(hint) = results.search_results_truncated_hint() {
                 writeln!(&mut hints)?;
                 writeln!(&mut hints, "{hint}")?;
             }

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -1,0 +1,32 @@
+use std::fmt::Display;
+/// Write a message to stderr.
+///
+/// This is a wrapper around `eprintln!` that can be further extended
+/// to include logging, word wrapping, ANSI filtereing etc.
+///
+/// It is not called directly, but through the [message!] macro.
+fn print_message(v: impl Display) {
+    eprintln!("{v}");
+}
+
+/// alias for [print_message]
+pub(crate) fn plain(v: impl Display) {
+    print_message(v);
+}
+pub(crate) fn error(v: impl Display) {
+    print_message(std::format_args!("❌ ERROR: {v}"));
+}
+pub(crate) fn created(v: impl Display) {
+    print_message(std::format_args!("✨ {v}"));
+}
+/// double width chracter, add an additional space for alignment
+pub(crate) fn deleted(v: impl Display) {
+    print_message(std::format_args!("🗑️  {v}"));
+}
+pub(crate) fn updated(v: impl Display) {
+    print_message(std::format_args!("✅ {v}"));
+}
+/// double width chracter, add an additional space for alignment
+pub(crate) fn warning(v: impl Display) {
+    print_message(std::format_args!("⚠️  {v}"));
+}

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -10,6 +10,7 @@ pub mod didyoumean;
 pub mod errors;
 pub mod init;
 pub mod logger;
+pub mod message;
 pub mod metrics;
 pub mod openers;
 pub mod search;

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -244,7 +244,7 @@ impl Display for DisplaySearchResults {
 }
 
 impl DisplaySearchResults {
-    pub fn hint(&self) -> Option<String> {
+    pub fn search_results_truncated_hint(&self) -> Option<String> {
         let Some(count) = self.count else {
             return None;
         };

--- a/cli/tests/edit/re-activate.exp
+++ b/cli/tests/edit/re-activate.exp
@@ -19,7 +19,7 @@ expect -ex "Getting ready to use environment"
 # edit environment and check for message prompting to re-activate
 send "$flox edit -f $manifest\n"
 expect  "Your manifest has changes that cannot be automatically applied to your current environment." {}
-expect "Please `exit` the environment and run `flox activate` to see these changes." {}
+expect "Please 'exit' the environment and run 'flox activate' to see these changes." {}
 
 send "exit\n"
 expect eof

--- a/cli/tests/environment-containerize.bats
+++ b/cli/tests/environment-containerize.bats
@@ -89,7 +89,7 @@ function skip_if_linux() {
 
   run "$FLOX_BIN" containerize
   assert_failure
-  assert_output "'containerize' is currently only supported on linux (found macos)."
+  assert_output --partial "'containerize' is currently only supported on linux (found macos)."
 }
 
 # bats test_tags=containerize:default-to-file

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -78,7 +78,7 @@ EOF
 
   run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
   assert_success
-  assert_output --partial "✅  Environment successfully updated."
+  assert_output --partial "✅ Environment successfully updated."
 }
 
 # ---------------------------------------------------------------------------- #
@@ -101,7 +101,7 @@ EOF
 
   run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
   assert_success
-  assert_output --partial "✅  Environment successfully updated."
+  assert_output --partial "✅ Environment successfully updated."
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -108,7 +108,7 @@ EOF
 
   run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
   assert_success
-  assert_output --partial "✅  Environment successfully updated."
+  assert_output --partial "✅ Environment successfully updated."
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -129,7 +129,7 @@ EOF
 
   run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH" --remote "$OWNER/test"
   assert_success
-  assert_output --partial "✅  Environment successfully updated."
+  assert_output --partial "✅ Environment successfully updated."
 
   run --separate-stderr "$FLOX_BIN" list --name --remote "$OWNER/test"
   assert_success

--- a/cli/tests/package-search.bats
+++ b/cli/tests/package-search.bats
@@ -180,8 +180,7 @@ setup_file() {
 @test "'flox search' error message when no results" {
   run "$FLOX_BIN" search surely_doesnt_exist
   assert_equal "${#lines[@]}" 1
-  # There's a leading `ERROR: ` that's left off when run non-interactively
-  assert_output "No packages matched this search term: surely_doesnt_exist"
+  assert_output --partial "No packages matched this search term: surely_doesnt_exist"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
> **tl;dr:** 
>
> This PR should make the messaging across `flox` more consistent
> If we provide _messages_ to users (success, error, warning, creation, update,...)
> We can do so through the new `message` module introduced here.
> Lifting this responsibility from the logging subsystem,
> which can now be used for its intended purpose, logging --
> optional semi user facing (structured) messages.


We are currently using a mix of `println!`, `eprintln!`, `log::info!`, `log::error!`
to display _messages_ to users on the CLI.

* `println!` => processable output.
* `log::error!` => error messages, prefixed with `ERROR:`
* `eprintln!` and `log::info` => other user facing messages without or limited processing

Using `log` for user output is suboptimal since `log` will do double duty
for logging and messaging.
While `log::error` applied styling and was used semantically correct,
where we wanted to express _errors_, `log::info` is overloaded for all kinds of messages
and thus requires styling to be applied by the caller.

The `message` module now provides explicit functions for several kinds of user facing messages, making it a nudging towards deliberate use of message styles in accordance with the style guide.