### PR TITLE
feat: handle package build and eval failures

### DIFF
--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -13,6 +13,29 @@ use thiserror::Error;
 pub static PKGDB_BIN: Lazy<String> =
     Lazy::new(|| env::var("PKGDB_BIN").unwrap_or(env!("PKGDB_BIN").to_string()));
 
+/// Error codes emitted by pkgdb
+/// matching the definitions in `pkgdb/include/flox/core/exceptions.hh`
+/// for brevity, only the ones we expliticly match are included here.
+/// TODO: find a way to _share_ these constants between the Rust and C++ code.
+pub mod error_codes {
+    /// Manifest file has invalid format
+    pub const INVALID_MANIFEST_FILE: u64 = 105;
+    /// Parsing of the manifest.toml file failed
+    pub const TOML_TO_JSON: u64 = 116;
+    /// The package is not found in the package database
+    pub const RESOLUTION_FAILURE: u64 = 120;
+    /// Conflict between two packages
+    pub const BUILDENV_CONFLICT: u64 = 122;
+    /// The environment is not compatible with the current system
+    pub const LOCKFILE_INCOMPATIBLE_SYSTEM: u64 = 123;
+    /// The package is not compatible with the current system
+    pub const PACKAGE_EVAL_INCOMPATIBLE_SYSTEM: u64 = 124;
+    /// The package failed to evaluate
+    pub const PACKAGE_EVAL_FAILURE: u64 = 125;
+    /// The package failed to build
+    pub const PACKAGE_BUILD_FAILURE: u64 = 126;
+}
+
 /// The JSON output of a `pkgdb upgrade` call
 #[derive(Deserialize)]
 pub struct UpgradeResultJSON {

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1504,9 +1504,9 @@ pub struct Pull {
 
     /// Forceably pull the environment
     /// When pulling a new environment, adds the system to the manifest if the lockfile is incompatible
-    /// and ignores eval and build errors
+    /// and ignores eval and build errors.
     /// When pulling an existing environment, overrides local changes.
-    #[bpaf(long("add-system"), short)]
+    #[bpaf(long, short)]
     force: bool,
 
     #[bpaf(external(pull_select), fallback(Default::default()))]

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -616,7 +616,7 @@ fn format_pkgdb_error(
     }
 }
 
-fn display_chain(mut err: &dyn std::error::Error) -> String {
+pub fn display_chain(mut err: &dyn std::error::Error) -> String {
     let mut fmt = err.to_string();
     while let Some(source) = err.source() {
         fmt = format!("{}: {}", fmt, source);

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -294,11 +294,11 @@ function add_insecure_package() {
 # bats test_tags=pull:add-system-flag
 # pulling an environment without packages for the current platform
 #should fail with an error
-@test "pull environment without packages for the current platform succeeds with '--add-system' flag" {
+@test "pull environment without packages for the current platform succeeds with '--force' flag" {
   update_dummy_env "owner" "name"
   make_incompatible "owner" "name"
 
-  run "$FLOX_BIN" pull --remote owner/name --add-system
+  run "$FLOX_BIN" pull --remote owner/name --force
   assert_success
 }
 
@@ -336,13 +336,13 @@ function add_insecure_package() {
 # due to the current system missing <system> in `option.systems`
 # AND a package that is indeed not able to be built for the current system
 # should show a warning, but otherwise succeed to pull
-@test "pull unsupported environment succeeds with '--add-system' flag but shows warning if unable to build still" {
+@test "pull unsupported environment succeeds with '--force' flag but shows warning if unable to build still" {
   update_dummy_env "owner" "name"
 
   make_incompatible "owner" "name"
   add_incompatible_package "owner" "name"
 
-  run "$FLOX_BIN" pull --remote owner/name --add-system
+  run "$FLOX_BIN" pull --remote owner/name --force
   assert_success
   assert_line --partial "Could not build modified environment, build errors need to be resolved manually."
 

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -403,7 +403,7 @@ function add_insecure_package() {
 # bats test_tags=pull:eval-failure
 # pulling an environment with a package that fails to evaluate
 # should fail with an error
-@test "pull environment with package not available for the current platform fails" {
+@test "pull environment with insecure package fails to evaluate" {
   update_dummy_env "owner" "name"
   add_insecure_package "owner" "name"
 
@@ -414,10 +414,10 @@ function add_insecure_package() {
 }
 
 # bats test_tags=pull:eval-failure:prompt-fail
-# pulling an environment with a package that fails to evaluate
+# pulling an environment with an insecure package that fails to evaluate
 # should prompt to ignore the error and pull the environment anyway.
 # When answering no, an error should be shown and the environment should not be pulled.
-@test "pull environment with package not available for the current platform prompts to abort or ignore -- aborts cleanly" {
+@test "pull environment with insecure package prompts to abort or ignore -- aborts cleanly" {
   update_dummy_env "owner" "name"
   add_insecure_package "owner" "name"
 
@@ -432,7 +432,7 @@ function add_insecure_package() {
 # pulling an environment with a package that fails to evaluate
 # should prompt to ignore the error and pull the environment anyway.
 # When answering yes, the environment should be pulled in a potentially broken state.
-@test "pull environment with package not available for the current platform prompts to abort or ignore -- ingores" {
+@test "pull environment with insecure package prompts to abort or ignore -- ignores" {
   update_dummy_env "owner" "name"
   add_insecure_package "owner" "name"
 

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -34,6 +34,8 @@ setup() {
   project_setup
   floxhub_setup "owner"
   make_dummy_env "owner" "name"
+
+  export UNSUPPORTED_SYSTEM_PROMPT="The environment you are trying to pull is not yet compatible with your system ($NIX_SYSTEM)."
 }
 teardown() {
   unset _FLOX_FLOXHUB_GIT_URL
@@ -98,7 +100,6 @@ function make_incompatible() {
   popd > /dev/null || return
   rm -rf "$PROJECT_DIR/floxmeta"
 }
-
 
 # make the environment with specified owner and name incompatible with the current system
 # by adding a package that fails nix evaluation due to being on an unsupported system.
@@ -284,7 +285,7 @@ function add_incompatible_package() {
   update_dummy_env "owner" "name"
   make_incompatible "owner" "name"
 
-  run -0 expect -d "$TESTS_DIR/pull/promptAmendSystem.exp" owner/name "$NIX_SYSTEM" no
+  run -0 expect -d "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_SYSTEM_PROMPT" no
   assert_success
   assert_output --partial "The environment you are trying to pull is not yet compatible with your system ($NIX_SYSTEM)"
   assert_line --partial "Did not pull the environment."
@@ -294,12 +295,12 @@ function add_incompatible_package() {
 
 # bats test_tags=pull:unsupported:prompt-success
 # pulling an environment without packages for the current platform
-#should fail with an error
+# should fail with an error
 @test "pull environment without packages for the current platform prompts for about adding system: produces env" {
   update_dummy_env "owner" "name"
   make_incompatible "owner" "name"
 
-  run -0 expect -d "$TESTS_DIR/pull/promptAmendSystem.exp" owner/name "$NIX_SYSTEM" yes
+  run -0 expect -d "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_SYSTEM_PROMPT" yes
   assert_success
 
   run "$FLOX_BIN" list

--- a/cli/tests/pull/answerPrompt.exp
+++ b/cli/tests/pull/answerPrompt.exp
@@ -1,10 +1,10 @@
 set env_ref [lindex $argv 0]
-set system [lindex $argv 1]
+set question [lindex $argv 1]
 set answer [lindex $argv 2]
 set flox $env(FLOX_BIN)
 
 # activate environment 1
-set timeout 20
+set timeout 40
 spawn $flox pull --remote $env_ref
 expect_after {
   timeout { exit 1 }
@@ -13,7 +13,7 @@ expect_after {
   "*\r" { exp_continue }
 }
 
-expect -ex "The environment you are trying to pull is not yet compatible with your system ($system)." {}
+expect -ex "$question" {}
 
 if { $answer == "yes" } {
   # Down arrow

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -47,10 +47,46 @@ FLOX_DEFINE_EXCEPTION( SystenNotSupportedByLockfile,
  * @brief An exception thrown when two packages conflict.
  * I.e. the same file path is found in two different packages with the same
  * priority.
+ * @{
  */
 FLOX_DEFINE_EXCEPTION( PackageConflictException,
                        EC_BUILDENV_CONFLICT,
                        "conflicting packages" )
+/** @} */
+
+
+/**
+ * @class flox::buildenv::PackageUnsupportedSystem
+ * @brief An exception thrown when a package fails to evaluate,
+ * because the system is not supported.
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( PackageUnsupportedSystem,
+                       EC_PACKAGE_EVAL_INCOMPATIBLE_SYSTEM,
+                       "system unsupported by package" )
+/** @} */
+
+/**
+ * @class flox::buildenv::PackageEvalFailure
+ * @brief An exception thrown when a package fails to evaluate.
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( PackageEvalFailure,
+                       EC_PACKAGE_EVAL_FAILURE,
+                       "general package eval failure" )
+/** @} */
+
+
+/**
+ * @class flox::buildenv::PackageBuildFailure
+ * @brief An exception thrown when a package fails to build.
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( PackageBuildFailure,
+                       EC_PACKAGE_BUILD_FAILURE,
+                       "build failure" )
+/** @} */
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/include/flox/core/exceptions.hh
+++ b/pkgdb/include/flox/core/exceptions.hh
@@ -77,7 +77,7 @@ enum error_category {
   EC_RESOLUTION_FAILURE,
   /** EnvirontMixin exception/misuse. */
   EC_ENVIRONMENT_MIXIN,
-  /** EnvirontMixin exception/misuse. */
+  /** Conflict between two packages while realizing an environment */
   EC_BUILDENV_CONFLICT,
   /**
    * Lockfile does not support the specified system.
@@ -85,6 +85,16 @@ enum error_category {
    * `packages.<system>` in the lockfile.
    */
   EC_LOCKFILE_INCOMPATIBLE_SYSTEM,
+  /**
+   * Package is incompatible with the system.
+   * Thrown if `flox::buildenv::createFloxEnv` encounters an evaluation error
+   * from nixpkgs' meta checks of supported systems.
+   */
+  EC_PACKAGE_EVAL_INCOMPATIBLE_SYSTEM,
+  /** Package evaluation failure, other than unsupported systems */
+  EC_PACKAGE_EVAL_FAILURE,
+  /** Package build failure. */
+  EC_PACKAGE_BUILD_FAILURE,
 }; /* End enum `error_category' */
 
 

--- a/tests/cross-system.bats
+++ b/tests/cross-system.bats
@@ -100,7 +100,7 @@ teardown() {
 
   name="created-on-$pull_system"
 
-  "$FLOX_BIN" pull "$OWNER/$name" --add-system
+  "$FLOX_BIN" pull "$OWNER/$name" --force
   # Close fd 3 because of
   # https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
   run "$FLOX_BIN" activate -- hello 3>&-


### PR DESCRIPTION
Catch specific eval and build errors of packages during the build of an environment.

Eval errors thrown by nixpkgs' metadata checks regarding the supported system
are caught early and reported as a distinct error.
Other eval errors (such as missing attrpaths, python version assertions, etc.)
are caught generically.
Build errors, e.g. for unfree software that is not cached are similarly caught
and reported as a separate category.