### PR TITLE
fix: remove duplicate descriptions

### DIFF
--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -164,14 +164,14 @@ fn calculate_expiry(expires_in: i64) -> String {
     expiry.to_rfc3339()
 }
 
-/// floxHub authentication commands
+// FloxHub authentication commands
 #[derive(Clone, Debug, Bpaf)]
 pub enum Auth {
-    /// Login to floxhub (requires an existing github account)
+    /// Login to FloxHub (requires an existing GitHub account)
     #[bpaf(command)]
     Login,
 
-    /// Logout from floxhub
+    /// Logout from FloxHub
     #[bpaf(command)]
     Logout,
 

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -71,7 +71,7 @@ use crate::utils::didyoumean::{DidYouMean, InstallSuggestion};
 use crate::utils::errors::{format_core_error, format_locked_manifest_error};
 use crate::{subcommand_metric, utils};
 
-/// Edit declarative environment configuration
+// Edit declarative environment configuration
 #[derive(Bpaf, Clone)]
 pub struct Edit {
     #[bpaf(external(environment_select), fallback(Default::default()))]
@@ -80,8 +80,6 @@ pub struct Edit {
     #[bpaf(external(edit_action), fallback(EditAction::EditManifest{file: None}))]
     action: EditAction,
 }
-
-/// Edit declarative environment configuration
 #[derive(Bpaf, Clone)]
 pub enum EditAction {
     EditManifest {
@@ -284,7 +282,7 @@ impl Edit {
     }
 }
 
-/// Delete an environment
+// Delete an environment
 #[derive(Bpaf, Clone)]
 pub struct Delete {
     #[allow(dead_code)] // not yet handled in impl
@@ -338,8 +336,6 @@ impl Delete {
     }
 }
 
-/// Activate an environment
-///
 /// When called with no arguments `flox activate` will look for a `.flox` directory
 /// in the current directory. Calling `flox activate` in your home directory will
 /// activate a default environment. Environments in other directories and remote
@@ -1198,7 +1194,7 @@ impl Install {
     }
 }
 
-/// Uninstall installed packages from an environment
+// Uninstall installed packages from an environment
 #[derive(Bpaf, Clone)]
 pub struct Uninstall {
     #[bpaf(external(environment_select), fallback(Default::default()))]
@@ -1239,7 +1235,7 @@ impl Uninstall {
     }
 }
 
-/// delete builds of non-current versions of an environment
+// Delete builds of non-current versions of an environment
 #[derive(Bpaf, Clone)]
 pub struct WipeHistory {
     #[bpaf(external(environment_select), fallback(Default::default()))]
@@ -1254,7 +1250,7 @@ impl WipeHistory {
     }
 }
 
-/// list environment generations with contents
+// List environment generations with contents
 #[derive(Bpaf, Clone)]
 pub struct Generations {
     #[allow(dead_code)] // not yet handled in impl
@@ -1274,7 +1270,7 @@ impl Generations {
     }
 }
 
-/// show all versions of an environment
+// Show all versions of an environment
 #[derive(Bpaf, Clone)]
 pub struct History {
     #[allow(dead_code)] // not yet handled in impl
@@ -1294,7 +1290,7 @@ impl History {
     }
 }
 
-/// Send environment to floxhub
+// Send environment to FloxHub
 #[derive(Bpaf, Clone)]
 pub struct Push {
     /// Directory to push the environment from (default: current directory)
@@ -1499,7 +1495,7 @@ impl Default for PullSelect {
     }
 }
 
-/// Pull environment from FloxHub
+// Pull environment from FloxHub
 #[derive(Bpaf, Clone)]
 pub struct Pull {
     /// Directory in which to create a managed environment, or directory that already contains a managed environment (default: current directory)
@@ -1821,7 +1817,7 @@ impl Pull {
     }
 }
 
-/// rollback to the previous generation of an environment
+// Rollback to the previous generation of an environment
 #[derive(Bpaf, Clone)]
 pub struct Rollback {
     #[bpaf(long, short, argument("ENV"))]
@@ -1843,7 +1839,7 @@ impl Rollback {
     }
 }
 
-/// switch to a specific generation of an environment
+// Switch to a specific generation of an environment
 #[derive(Bpaf, Clone)]
 pub struct SwitchGeneration {
     #[allow(unused)] // Command currently forwarded
@@ -1877,7 +1873,7 @@ impl Default for EnvironmentOrGlobalSelect {
     }
 }
 
-/// Update the global base catalog or an environment's base catalog
+// Update the global base catalog or an environment's base catalog
 #[derive(Bpaf, Clone)]
 pub struct Update {
     #[bpaf(external(environment_or_global_select), fallback(Default::default()))]
@@ -2031,6 +2027,7 @@ impl Update {
     }
 }
 
+// Upgrade packages in an environment
 #[derive(Bpaf, Clone)]
 pub struct Upgrade {
     #[bpaf(external(environment_select), fallback(Default::default()))]
@@ -2075,6 +2072,7 @@ impl Upgrade {
     }
 }
 
+// Containerize an environment
 #[derive(Bpaf, Clone, Debug)]
 pub struct Containerize {
     #[bpaf(external(environment_select), fallback(Default::default()))]

--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -19,7 +19,7 @@ use crate::utils::metrics::{
     METRICS_UUID_FILE_NAME,
 };
 
-/// reset the metrics queue (if any), reset metrics ID, and re-prompt for consent
+// Reset the metrics queue (if any), reset metrics ID, and re-prompt for consent
 #[derive(Bpaf, Clone)]
 pub struct ResetMetrics {}
 impl ResetMetrics {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -365,6 +365,7 @@ enum AdditionalCommands {
     Documentation(
         #[bpaf(external(AdditionalCommands::documentation))] AdditionalCommandsDocumentation,
     ),
+    /// Update the global base catalog or an environment's base catalog
     #[bpaf(command, hide)]
     Update(#[bpaf(external(environment::update))] environment::Update),
     #[bpaf(command, hide, header(indoc! {"
@@ -385,8 +386,10 @@ enum AdditionalCommands {
     /// View and set configuration options
     #[bpaf(command, hide)]
     Config(#[bpaf(external(general::config_args))] general::ConfigArgs),
+    /// Delete builds of non-current versions of an environment
     #[bpaf(command("wipe-history"), hide)]
     WipeHistory(#[bpaf(external(environment::wipe_history))] environment::WipeHistory),
+    /// Show all versions of an environment
     #[bpaf(command, hide)]
     History(#[bpaf(external(environment::history))] environment::History),
 }
@@ -423,16 +426,21 @@ impl AdditionalCommandsDocumentation {
 #[derive(Bpaf, Clone)]
 #[bpaf(hide)]
 enum InternalCommands {
+    /// Reset the metrics queue (if any), reset metrics ID, and re-prompt for consent
     #[bpaf(command("reset-metrics"))]
     ResetMetrics(#[bpaf(external(general::reset_metrics))] general::ResetMetrics),
+    /// List environment generations with contents
     #[bpaf(command)]
     Generations(#[bpaf(external(environment::generations))] environment::Generations),
+    /// Switch to a specific generation of an environment
     #[bpaf(command("switch-generation"))]
     SwitchGeneration(
         #[bpaf(external(environment::switch_generation))] environment::SwitchGeneration,
     ),
+    /// Rollback to the previous generation of an environment
     #[bpaf(command)]
     Rollback(#[bpaf(external(environment::rollback))] environment::Rollback),
+    /// FloxHub authentication commands
     #[bpaf(command)]
     Auth(#[bpaf(external(auth::auth))] auth::Auth),
 }

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -6,7 +6,15 @@ use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::global_manifest_path;
 use flox_rust_sdk::models::search::{
-    do_search, PathOrJson, Query, SearchParams, SearchResult, SearchResults, SearchStrategy, ShowError, Subtree
+    do_search,
+    PathOrJson,
+    Query,
+    SearchParams,
+    SearchResult,
+    SearchResults,
+    SearchStrategy,
+    ShowError,
+    Subtree,
 };
 use indoc::formatdoc;
 use log::debug;
@@ -30,7 +38,7 @@ const FLOX_SHOW_HINT: &str = "Use 'flox show <package>' to see available version
 #[derive(Bpaf, Clone)]
 pub struct ChannelArgs {}
 
-/// Search for packages to install
+// Search for packages to install
 #[derive(Bpaf, Clone)]
 pub struct Search {
     /// print search as JSON
@@ -156,7 +164,7 @@ fn render_search_results_json(search_results: SearchResults) -> Result<()> {
     Ok(())
 }
 
-/// Show detailed package information
+// Show detailed package information
 #[derive(Bpaf, Clone)]
 pub struct Show {
     /// Whether to show all available package versions


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Remove duplicate descriptions from `flox` help text.

Previously the help looked like this:
```
> flox show --help
Show details about a single package

Usage: flox show [--all] <search-term>

Show detailed package information
```

The second description above has been removed.

Closes #922

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
