### PR TITLE
fix: ld-floxlib compatiblity, re-enable test

### DIFF
--- a/cli/tests/ld-floxlib.bats
+++ b/cli/tests/ld-floxlib.bats
@@ -11,21 +11,17 @@
 # * nix (a package that is guaranteed to be not available in FHS lib)
 # * curl, libarchive (runtime libraries required by libnixmain.so)
 #
-# It then activates the env to perform two distinct tests:
-# 1: load libraries found in $FLOX_ENV_LIBS last
-#   - compile the get-glibc-version program (using $FLOX_ENV/{include,lib})
-#   - remove its custom RUNPATH and ld interpreter so that it will use the
-#     "system" libc
-#   - run it having cleared the environment (with `env -i`) and observe the
-#     default glibc version, confirm this does NOT match the pinned version
-#   - repeat with LD_AUDIT defined and confirm that the version again does
-#     not change
-#   - repeat with LD_LIBRARY_PATH=$FLOX_ENV_LIBS and confirm that this rolls
-#     back glibc to the version installed to the environment
+# It then activates the env to perform three distinct tests:
+# 1: load libraries found in $FLOX_ENV_LIB_DIRS last, i.e. don't use env-
+#    provided libraries in preference to ones available on the system
+#   - invoke /bin/sh
+#   - confirm that the one version of glibc present in the namespace is
+#     the "system" glibc used by /bin/sh itself
 # 2: confirm LD_AUDIT can find missing libraries
 #   - compile the get-nix-version program
 #   - observe that it can run the compiled program
 #   - unset LD_AUDIT and confirm it cannot run the program
+# 3: confirm binary cannot find missing libraries without LD_AUDIT
 #
 # ---------------------------------------------------------------------------- #
 
@@ -44,9 +40,6 @@ setup_file() {
 # Helpers for project based tests.
 
 project_setup() {
-  skip "this self-backgrounds for an unknown reason when calling a nested activate - bash"
-
-
   export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
   export PROJECT_NAME="${PROJECT_DIR##*/}"
   rm -rf "$PROJECT_DIR"
@@ -118,10 +111,7 @@ teardown() {
   run "$FLOX_BIN" activate -- bash -exc '" \
     g++ -std=c++17 -o get-nix-version ./get-nix-version.cc -I"$FLOX_ENV"/include -L"$FLOX_ENV"/lib -lnixmain && \
     patchelf --remove-rpath ./get-nix-version && \
-    patchelf --set-interpreter "$( \
-      patchelf --print-interpreter /bin/sh \
-    )" ./get-nix-version && \
-    LD_FLOXLIB_DEBUG=1 ./get-nix-version"'
+    LD_FLOXLIB_AUDIT=1 ./get-nix-version"'
   assert_success
   assert_output --partial "testing (Nix) 2.10.3"
 

--- a/cli/tests/ld-floxlib/get-glibc-version.c
+++ b/cli/tests/ld-floxlib/get-glibc-version.c
@@ -1,7 +1,0 @@
-#include <gnu/libc-version.h>
-#include <stdio.h>
-
-int main() {
-  printf("GNU C Library (glibc) version: %s\n", gnu_get_libc_version());
-  return 0;
-}

--- a/cli/tests/ld-floxlib/test-load-library-last.sh
+++ b/cli/tests/ld-floxlib/test-load-library-last.sh
@@ -15,58 +15,59 @@ test -e "$LD_AUDIT"
 # LD_LIBRARY_PATH is not defined
 test -z "$LD_LIBRARY_PATH"
 
-### Test 1: load libraries found in $FLOX_ENV_LIBS last
+# Enable auditing so that the logs clearly highlight any instances where
+# ld-floxlib.so serves up a library from $FLOX_ENV.
+export LD_FLOXLIB_AUDIT=1
 
-# Build glibc version probe using [assumed] older "env" version of glibc.
-# We build it with the older version because glibc is backwards-compatible
-# to support old binaries, but newer binaries will be looking for symbols
-# not necessarily found in older versions of glibc.
-cc -o get-glibc-version ./get-glibc-version.c -I"$FLOX_ENV"/include -L"$FLOX_ENV"/lib
+# Our aim in this test is to prove that our use of LD_AUDIT will not
+# serve up Nix libraries to native "system" binaries, and to do that
+# we need a representative binary and a library that it depends upon.
+# As it happens, /bin/sh is the _the only_ "system" path guaranteed
+# to be present on Linux variants, including NixOS, and the one shared
+# library that it will always depend upon is libc itself.
 
-# In order to simulate a binary created on any old Linux version we
-# must first unwind the [2] tricks that Nix performs to force executables
-# to run with the exact version of glibc that it was compiled with.
+# This test invokes /bin/sh to examine its own shared libraries (as
+# found in /proc/$$/maps) to confirm that only one copy of libc is
+# present as provided from the "system" location, and not the one
+# as provided from $FLOX_ENV/lib.
 
-# 1. Remove the custom RUNPATH added by gcc-wrapper.
-patchelf --remove-rpath ./get-glibc-version
+# Gather full paths to required tools for the logs.
+_env="$(type -P env)"
+_patchelf="$(type -P patchelf)"
+_awk="$(type -P awk)"
+_realpath="$(type -P realpath)"
+_realshell="$($_realpath /bin/sh)"
 
-# 2. set the interpreter to the one used by the default system.
-#    This is somewhat more challenging because we need to derive
-#    what LD interpreter is being used by default on this variant of
-#    Linux, and that is most reliably done by observing the one used
-#    for /bin/sh, _the only_ path guaranteed to be present on all
-#    variants of Linux, including NixOS.
-original_interpreter=$(patchelf --print-interpreter ./get-glibc-version)
-system_interpreter=$(patchelf --print-interpreter /bin/sh)
-patchelf --set-interpreter \
-  "$system_interpreter" ./get-glibc-version
+# Start by using the interpreter to discern the "system" libc from /bin/sh.
+system_interpreter="$($_env -i $_patchelf --print-interpreter $_realshell)"
+system_libc="$($_env -i $system_interpreter --list $_realshell | $_awk '/libc.* => / {print $3; exit}')"
+system_libc_realpath="$($_realpath ${system_libc})"
 
-# Invoke it once just to record the default behaviour for the logs.
-LD_FLOXLIB_DEBUG=1 ./get-glibc-version
+# Invoke /bin/sh to examine the contents of /proc/$$/maps and assert
+# that it has loaded a copy of the one expected libc version. Take care
+# to avoid using `cat` to examine the contents of /proc/$$/maps because
+# that has the effect of reporting the version of libc that it is using,
+# and to invoke the while loop in the foreground so that it can set the
+# found_* variables for inspection afterwards.
+declare -i found_system_libc=0
+declare -i found_other_libc=0
+while read -a maps_line; do
+    numwords=${#maps_line[@]}
+    lastword="${maps_line[$((numwords-1))]}"
+    case "$lastword" in
+    "$system_libc_realpath")
+        found_system_libc=1
+        ;;
+    "*/libc.so.*")
+        found_other_libc=1
+        ;;
+    esac
+done < <($_realshell -c 'while read line; do echo $line; done < /proc/$$/maps')
 
-# Glean "system" glibc version by first clearing the environment with "env -i".
-system_glibc_version="$( env -i -- ./get-glibc-version )"
+echo "Assert we found the system libc" 1>&2
+[ $found_system_libc -eq 1 ]
 
-# Glean "environment" glibc version.
-environment_glibc_version="$( ./get-glibc-version )"
+echo "Assert we did not encounter another libc" 1>&2
+[ $found_other_libc -eq 0 ]
 
-# Force use of "environment" glibc first with LD_LIBRARY_PATH. Unlike other
-# libraries, with a change of glibc versions it's essential that the version
-# of the ld interpreter exactly matches that of glibc, so before running this
-# test we have to first set the interpreter back to the matching version.
-patchelf --set-interpreter $FLOX_ENV/lib/ld-linux-*.so.* ./get-glibc-version
-# Take note of the result for the logs
-realpath "$(patchelf --print-interpreter ./get-glibc-version)"
-forced_environment_glibc_version="$(
-  LD_DEBUG=libs LD_LIBRARY_PATH="$FLOX_ENV_LIB_DIRS" ./get-glibc-version
-)"
-
-# Confirm that the system and environment invocations serve up the same version.
-[ "$system_glibc_version" = "$environment_glibc_version" ]
-
-# Confirm that the the forced environment version is different.
-[ "$system_glibc_version" != "$forced_environment_glibc_version" ]
-
-# Finally confirm that the environment is serving up the exact string for
-# version 2.34 as found in the nixpkgs $PKGDB_NIXPKGS_REV_OLDER revision.
-[ "$forced_environment_glibc_version" = "GNU C Library (glibc) version: 2.34" ]
+# If we get this far without failing, that's success.

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -612,7 +612,8 @@ $(BINS): %: $(SRCS:.cc=.o)
 
 lib/ld-floxlib.so: src/ld-floxlib.c
 	$(MKDIR_P) $(@D);
-	$(CC) $(CFLAGS) -shared -fPIC $< -o $@ -ldl;
+	$(CC) -shared -fPIC $< -o $@;
+	patchelf --remove-rpath $@;
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -632,14 +632,17 @@ $(TESTS) $(TEST_UTILS): tests/%: tests/%.o tests/test.hh
 #: Build binaries
 bin: $(BINS)
 
+#: Build libs
+lib: $(ALL_LIBS)
+
 #: Build test executables and resources
 tests: $(TESTS) $(TEST_UTILS)
 
-#: Build binaries, tests, and generated `.gitignore' files
-all: bin tests ignores
+#: Build binaries, tests, libs, and generated `.gitignore' files
+all: bin lib tests ignores
 
-#: Build binaries and generated `.gitignore' files
-most: bin ignores
+#: Build binaries, libs, and generated `.gitignore' files
+most: bin lib ignores
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -173,14 +173,6 @@ in
         runHook postConfigure;
       '';
 
-      # The ld-floxlib.so library only requires libc, which is guaranteed
-      # to either be already loaded or available by way of a default provided
-      # by the linker itself, so to avoid loading a different libc than the
-      # one already loaded we remove RPATH/RUNPATH from the shared library.
-      postFixup = lib.optionalString stdenv.isLinux ''
-        patchelf --remove-rpath $out/lib/ld-floxlib.so
-      '';
-
       # Checks require internet
       doCheck = false;
       doInstallCheck = false;


### PR DESCRIPTION
- Revert skipping ld-floxlib test. The test appears to have been failing because bats was backgrounding a `flox activate -- ...` command. At the time `flox activate` invoked `bash -i -c`. If a background process tries to read from stdin it is sent SIGTTIN. We've since merged https://github.com/flox/flox/pull/889 which no longer invokes `bash` with `-i`, so it's no longer attempting to read from stdin
- Build ld-floxlib for default make target. Without this change, ld-floxlib is not built by `just integ-tests`
- Update `ld-floxlib.c` to "pin" GLIBC symbol versions to the minimum available (varies by architecture type) so as to maximise compatibility with older versions of GLIBC.
- Update `ld-floxlib.c` to replace the use of `stat()` with `open()`, which is a) a function symbol in glibc that can be bound to a specific version (unlike `stat()`) and b) able to assess both the existence and the "readability" of a given library in a single step, which is something that `stat()` did not do.
- Continue invoking `patchelf` to remove the runpath from `ld-floxlib.so`, but do it from within the Makefile target rather than post-processing the binary in the Nix expression following the build.