### PR TITLE
chore: rename `FLOX_COFIG_HOME` -> `FLOX_CONFIG_DIR`

### DIFF
--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -32,14 +32,14 @@ Config values are read from the following sources in order of descending priorit
    All config options may be set by prefixing with `FLOX_` and using
    SCREAMING_SNAKE_CASE.
    For example, `disable_metrics` may be set with `FLOX_DISABLE_METRICS=true`.
-1. User customizations from `$FLOX_CONFIG_HOME/flox.toml` if set or else
+1. User customizations from `$FLOX_CONFIG_DIR/flox.toml` if set or else
    `$XDG_CONFIG_HOME/flox/flox.toml`.
 1. User customizations from `flox/flox.toml` in any of `$XDG_CONFIG_DIRS`.
 1. System settings from `/etc/flox.toml`.
 1. `flox` provided defaults.
 
 `flox config` commands that mutate configuration always write to
-`${FLOX_CONFIG_HOME:-$XDG_CONFIG_HOME}/flox/flox.toml`.
+`${FLOX_CONFIG_DIR:-$XDG_CONFIG_HOME}/flox/flox.toml`.
 
 ## Key Format
 
@@ -80,7 +80,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 `config_dir`
 :   Directory where flox should load its configuration file
     (default: `$XDG_CONFIG_HOME/flox`).
-    This option will only take effect if set with `$FLOX_CONFIG_HOME`.
+    This option will only take effect if set with `$FLOX_CONFIG_DIR`.
     `$FLOX_CONFIG_DIR` and `config_dir` are ignored.
 
 `cache_dir`

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -18,8 +18,9 @@ use xdg::BaseDirectories;
 use self::features::Features;
 
 /// Name of flox managed directories (config, data, cache)
-const FLOX_DIR_NAME: &'_ str = "flox";
-pub const FLOX_CONFIG_FILE: &'_ str = "flox.toml";
+const FLOX_DIR_NAME: &str = "flox";
+const FLOX_CONFIG_DIR_VAR: &str = "FLOX_CONFIG_DIR";
+pub const FLOX_CONFIG_FILE: &str = "flox.toml";
 
 #[derive(Clone, Debug, Deserialize, Default, Serialize)]
 pub struct Config {
@@ -121,22 +122,23 @@ impl Config {
 
             let cache_dir = flox_dirs.get_cache_home();
             let data_dir = flox_dirs.get_data_home();
-            let config_dir = match env::var("FLOX_CONFIG_HOME") {
+
+            let config_dir = match env::var(FLOX_CONFIG_DIR_VAR) {
                 Ok(v) => {
-                    debug!("`$FLOX_CONFIG_HOME` set: {v}");
+                    debug!("`${FLOX_CONFIG_DIR_VAR}` set: {v}");
                     fs::create_dir_all(&v)
                         .context(format!("Could not create config directory: {v:?}"))?;
                     v.into()
                 },
                 Err(_) => {
                     let config_dir = flox_dirs.get_config_home();
-                    debug!("`$FLOX_CONFIG_HOME` not set, using {config_dir:?}");
+                    debug!("`${FLOX_CONFIG_DIR_VAR}` not set, using {config_dir:?}");
                     fs::create_dir_all(&config_dir)
                         .context(format!("Could not create config directory: {config_dir:?}"))?;
                     let config_dir = config_dir
                         .canonicalize()
                         .context("Could not canonicalize config directory '{config_dir:?}'")?;
-                    env::set_var("FLOX_CONFIG_HOME", &config_dir);
+                    env::set_var(FLOX_CONFIG_DIR_VAR, &config_dir);
                     config_dir
                 },
             };
@@ -162,7 +164,7 @@ impl Config {
                     builder.add_source(config::File::from(file).format(config::FileFormat::Toml));
             }
 
-            // Add explicit FLOX_CONFIG_HOME file last
+            // Add explicit FLOX_CONFIG_DIR file last
             builder = builder.add_source(
                 config::File::from(config_dir.join(FLOX_CONFIG_FILE))
                     .format(config::FileFormat::Toml)
@@ -373,7 +375,7 @@ mod tests {
                     config.get(&Key::parse("floxhub_url").unwrap()).unwrap(),
                     "\"https://example.com/\"".to_string()
                 );
-                env::remove_var("FLOX_CONFIG_HOME");
+                env::remove_var(FLOX_CONFIG_DIR_VAR);
             },
         );
     }

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -147,7 +147,7 @@ impl Config {
                 .set_default("data_dir", data_dir.to_str().unwrap())?
                 // Config dir is added to the config for completeness;
                 // the config file cannot change the config dir.
-                .set_default("config_dir", config_dir.to_str().unwrap())?;
+                .set_override("config_dir", config_dir.to_str().unwrap())?;
 
             // read from /etc
             builder = builder.add_source(

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -80,14 +80,14 @@ floxtest_gitforge_setup() {
   # gitforge. This obviously won't be recognised as a valid token by the
   # GitHub API, but that's OK because we've hard-coded this identity both
   # in flox-gh and on our gitforge proxy.
-  mkdir -p $FLOX_CONFIG_HOME/gh
-  cat > $FLOX_CONFIG_HOME/gh/hosts.yml << EOF
+  mkdir -p $FLOX_CONFIG_DIR/gh
+  cat > $FLOX_CONFIG_DIR/gh/hosts.yml << EOF
 github.com:
     oauth_token: flox_testOAuthToken
     user: floxtest
     git_protocol: https
 EOF
-  chmod 600 $FLOX_CONFIG_HOME/gh/hosts.yml
+  chmod 600 $FLOX_CONFIG_DIR/gh/hosts.yml
   export __FT_RAN_FLOXTEST_GITFORGE_SETUP=:
 }
 
@@ -387,14 +387,14 @@ pkgdb_vars_setup() {
 flox_vars_setup() {
   xdg_vars_setup
   export FLOX_CACHE_HOME="$XDG_CACHE_HOME/flox"
-  export FLOX_CONFIG_HOME="$XDG_CONFIG_HOME/flox"
+  export FLOX_CONFIG_DIR="$XDG_CONFIG_HOME/flox"
   export FLOX_DATA_HOME="$XDG_DATA_HOME/flox"
   export FLOX_STATE_HOME="$XDG_STATE_HOME/flox"
   export FLOX_META="$FLOX_CACHE_HOME/meta"
   export FLOX_ENVIRONMENTS="$FLOX_DATA_HOME/environments"
   export USER="flox-test"
   export HOME="${FLOX_TEST_HOME:-$HOME}"
-  export GLOBAL_MANIFEST_LOCK="$FLOX_CONFIG_HOME/global-manifest.lock"
+  export GLOBAL_MANIFEST_LOCK="$FLOX_CONFIG_DIR/global-manifest.lock"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -463,7 +463,7 @@ common_suite_setup() {
     print_var XDG_DATA_HOME
     print_var XDG_STATE_HOME
     print_var FLOX_CACHE_HOME
-    print_var FLOX_CONFIG_HOME
+    print_var FLOX_CONFIG_DIR
     print_var FLOX_DATA_HOME
     print_var FLOX_STATE_HOME
     print_var FLOX_META

--- a/pkgs/flox-gh/default.nix
+++ b/pkgs/flox-gh/default.nix
@@ -51,7 +51,7 @@ in
       wrapProgram "$out/bin/flox-gh"                                             \
         --run '# This should only be invoked by flox with $FLOX_*_HOME defined.' \
         --run 'set -eu'                                                          \
-        --run 'export XDG_CONFIG_HOME="$FLOX_CONFIG_HOME"'                       \
+        --run 'export XDG_CONFIG_HOME="$FLOX_CONFIG_DIR"'                       \
         --run 'export XDG_STATE_HOME="$FLOX_STATE_HOME"'                         \
         --run 'export XDG_DATA_HOME="$FLOX_DATA_HOME"'                           \
         --run '# Unset gh-related environment variables.'                        \

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -80,14 +80,14 @@ floxtest_gitforge_setup() {
   # gitforge. This obviously won't be recognised as a valid token by the
   # GitHub API, but that's OK because we've hard-coded this identity both
   # in flox-gh and on our gitforge proxy.
-  mkdir -p $FLOX_CONFIG_HOME/gh
-  cat > $FLOX_CONFIG_HOME/gh/hosts.yml << EOF
+  mkdir -p $FLOX_CONFIG_DIR/gh
+  cat > $FLOX_CONFIG_DIR/gh/hosts.yml << EOF
 github.com:
     oauth_token: flox_testOAuthToken
     user: floxtest
     git_protocol: https
 EOF
-  chmod 600 $FLOX_CONFIG_HOME/gh/hosts.yml
+  chmod 600 $FLOX_CONFIG_DIR/gh/hosts.yml
   export __FT_RAN_FLOXTEST_GITFORGE_SETUP=:
 }
 
@@ -359,7 +359,7 @@ pkgdb_vars_setup() {
 flox_vars_setup() {
   xdg_vars_setup
   export FLOX_CACHE_HOME="$XDG_CACHE_HOME/flox"
-  export FLOX_CONFIG_HOME="$XDG_CONFIG_HOME/flox"
+  export FLOX_CONFIG_DIR="$XDG_CONFIG_HOME/flox"
   export FLOX_DATA_HOME="$XDG_DATA_HOME/flox"
   export FLOX_STATE_HOME="$XDG_STATE_HOME/flox"
   export FLOX_META="$FLOX_CACHE_HOME/meta"
@@ -429,7 +429,7 @@ common_suite_setup() {
     print_var XDG_DATA_HOME
     print_var XDG_STATE_HOME
     print_var FLOX_CACHE_HOME
-    print_var FLOX_CONFIG_HOME
+    print_var FLOX_CONFIG_DIR
     print_var FLOX_DATA_HOME
     print_var FLOX_STATE_HOME
     print_var FLOX_META


### PR DESCRIPTION
* Sets `config_dir` config value as a constant,
  thus making resolution consistent.
  If explicitly provided in a config file, the value will be ignored.
* Read `config_dir` value from `FLOX_CONFIG_DIR` rather than `FLOX_COFIG_HOME`

