### PR TITLE
fix(activate): only detect python in `$FLOX_ENV`

### DIFF
--- a/pkgdb/src/buildenv/assets/etc/profile.d/0500_python.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0500_python.sh
@@ -5,10 +5,10 @@
 # ---------------------------------------------------------------------------- #
 
 # Only run if `python3' is in `PATH'
-if command -v python3 > /dev/null 2> /dev/null; then
+if [[ -x "$FLOX_ENV/bin/python3" ]]; then
   # Get the major/minor version from `python3' to determine the correct path.
   _env_pypath="$FLOX_ENV/lib/python$(
-    python3 -c 'import sys
+    "$FLOX_ENV/bin/python3" -c 'import sys
 print( "{}.{}".format( sys.version_info[0], sys.version_info[1] ) )'
   )/site-packages"
   # Only add the path if its missing
@@ -20,7 +20,7 @@ print( "{}.{}".format( sys.version_info[0], sys.version_info[1] ) )'
 fi
 
 # Only run if `pip' is in `PATH'
-if command -v pip > /dev/null 2> /dev/null; then
+if [[ -x "$FLOX_ENV/bin/pip3" ]]; then
   export PIP_CONFIG_FILE=$(@realpath@ --no-symlinks $FLOX_ENV/../../pip.ini)
   cat > $PIP_CONFIG_FILE << EOF
 [global]


### PR DESCRIPTION
The profile.d script managing the python setup used to detect _any_ `python3` available on the `$PATH` which summons an xcode wizard on macos.
This PR changes the profile.d script to look for `python3` within `$FLOX_ENV/bin` explicitly.


fixes #877