### PR TITLE
refactor: path -> pkg-path

### DIFF
--- a/assets/templateFloxEnv/manifest.toml
+++ b/assets/templateFloxEnv/manifest.toml
@@ -8,7 +8,7 @@
 # the 'install' section
 
 [install]
-# hello.path = "hello"
+# hello.pkg-path = "hello"
 # nodejs = { version = "^18.4.2", path = "nodejs_18" }
 
 # Set an environment variable.

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -68,7 +68,7 @@ pub struct PackageInsertion {
 #[derive(Debug, PartialEq)]
 pub struct PackageToInstall {
     pub id: String,
-    pub path: String,
+    pub pkg_path: String,
     pub version: Option<String>,
     pub input: Option<String>,
 }
@@ -111,7 +111,10 @@ pub fn insert_packages(
     for pkg in pkgs {
         if !install_table.contains_key(&pkg.id) {
             let mut descriptor_table = InlineTable::new();
-            descriptor_table.insert("path", Value::String(Formatted::new(pkg.path.clone())));
+            descriptor_table.insert(
+                "pkg-path",
+                Value::String(Formatted::new(pkg.pkg_path.clone())),
+            );
             if let Some(ref version) = pkg.version {
                 descriptor_table.insert("version", Value::String(Formatted::new(version.clone())));
             }
@@ -121,7 +124,10 @@ pub fn insert_packages(
             descriptor_table.set_dotted(true);
             install_table.insert(&pkg.id, Item::Value(Value::InlineTable(descriptor_table)));
             already_installed.insert(pkg.id.clone(), false);
-            debug!("package newly installed: id={}, path={}", pkg.id, pkg.path);
+            debug!(
+                "package newly installed: id={}, pkg-path={}",
+                pkg.id, pkg.pkg_path
+            );
         } else {
             already_installed.insert(pkg.id.clone(), true);
             debug!("package already installed: id={}", pkg.id);
@@ -239,7 +245,8 @@ pub fn add_system(toml: &str, system: &str) -> Result<Document, TomlEditError> {
 #[derive(Debug, Deserialize)]
 pub struct ParsedDescriptor {
     pub name: Option<String>,
-    pub path: Option<Vec<String>>,
+    #[serde(rename = "pkg-path")]
+    pub pkg_path: Option<Vec<String>>,
     pub input: Option<Input>,
     pub version: Option<String>,
     pub semver: Option<String>,
@@ -267,7 +274,7 @@ pub fn temporary_parse_descriptor(descriptor: &str) -> Result<PackageToInstall, 
         .map_err(ManifestError::PkgDbCall)?;
     let parsed: Result<ParsedDescriptor, _> = serde_json::from_slice(&output.stdout);
     if let Ok(parsed) = parsed {
-        let (id, path) = if let Some(mut path) = parsed.path {
+        let (id, path) = if let Some(mut path) = parsed.pkg_path {
             // Quote any path components that need quoting
             path.iter_mut().for_each(|attr| {
                 if attr.contains('.') || attr.contains('"') {
@@ -304,7 +311,7 @@ pub fn temporary_parse_descriptor(descriptor: &str) -> Result<PackageToInstall, 
         let input = parsed.input.map(|input| input.id);
         Ok(PackageToInstall {
             id,
-            path,
+            pkg_path: path,
             version,
             input,
         })
@@ -443,7 +450,7 @@ ripgrep = {}
         let inserted_path = new_toml
             .get("install")
             .and_then(|t| t.get("qux"))
-            .and_then(|d| d.get("path"))
+            .and_then(|d| d.get("pkg-path"))
             .and_then(|p| p.as_str())
             .unwrap();
         assert_eq!(inserted_path, r#"foo."bar.baz".qux"#);
@@ -455,28 +462,28 @@ ripgrep = {}
         let parsed = temporary_parse_descriptor("hello").unwrap();
         assert_eq!(parsed, PackageToInstall {
             id: "hello".to_string(),
-            path: "hello".to_string(),
+            pkg_path: "hello".to_string(),
             version: None,
             input: None,
         });
         let parsed = temporary_parse_descriptor("nixpkgs:foo.bar@=1.2.3").unwrap();
         assert_eq!(parsed, PackageToInstall {
             id: "bar".to_string(),
-            path: "foo.bar".to_string(),
+            pkg_path: "foo.bar".to_string(),
             version: Some("=1.2.3".to_string()),
             input: Some("nixpkgs".to_string())
         });
         let parsed = temporary_parse_descriptor("nixpkgs:foo.bar@23.11").unwrap();
         assert_eq!(parsed, PackageToInstall {
             id: "bar".to_string(),
-            path: "foo.bar".to_string(),
+            pkg_path: "foo.bar".to_string(),
             version: Some("23.11".to_string()),
             input: Some("nixpkgs".to_string())
         });
         let parsed = temporary_parse_descriptor("nixpkgs:rubyPackages.\"http_parser.rb\"").unwrap();
         assert_eq!(parsed, PackageToInstall {
             id: "\"http_parser.rb\"".to_string(),
-            path: "rubyPackages.\"http_parser.rb\"".to_string(),
+            pkg_path: "rubyPackages.\"http_parser.rb\"".to_string(),
             version: None,
             input: Some("nixpkgs".to_string())
         });

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1128,7 +1128,7 @@ impl Install {
             .collect::<Result<Vec<_>, _>>()?;
         packages.extend(self.id.iter().map(|p| PackageToInstall {
             id: p.id.clone(),
-            path: p.path.clone(),
+            pkg_path: p.path.clone(),
             version: None,
             input: None,
         }));
@@ -1184,7 +1184,7 @@ impl Install {
                     flox_rust_sdk::models::pkgdb::CallPkgDbError::PkgDbError(pkgdberr),
                 ),
             )) if pkgdberr.exit_code == error_codes::RESOLUTION_FAILURE => 'error: {
-                let paths = packages.iter().map(|p| p.path.clone()).join(", ");
+                let paths = packages.iter().map(|p| p.pkg_path.clone()).join(", ");
 
                 if packages.len() > 1 {
                     break 'error anyhow!(formatdoc! {"
@@ -1192,7 +1192,7 @@ impl Install {
                         One or more of the packages you are trying to install does not exist.
                     "});
                 }
-                let path = packages[0].path.clone();
+                let path = packages[0].pkg_path.clone();
 
                 let head = format!("Could not find package {path}.");
 

--- a/cli/tests/container/manifest.toml
+++ b/cli/tests/container/manifest.toml
@@ -1,5 +1,5 @@
 [install]
-hello.path = "hello"
+hello.pkg-path = "hello"
 
 [vars]
 foo = "bar"

--- a/cli/tests/edit/manifest.toml
+++ b/cli/tests/edit/manifest.toml
@@ -1,2 +1,2 @@
 [install]
-hello.path = "hello"
+hello.pkg-path = "hello"

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -73,7 +73,7 @@ check_manifest_updated() {
   cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
   cat << "EOF" > "$TMP_MANIFEST_PATH"
 [install]
-hello.path = "hello"
+hello.pkg-path = "hello"
 EOF
 
   run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -62,7 +62,7 @@ teardown() {
   "$FLOX_BIN" init
   run "$FLOX_BIN" install hello
   assert_success
-  run grep 'hello.path = "hello"' "$PROJECT_DIR/.flox/env/manifest.toml"
+  run grep 'hello.pkg-path = "hello"' "$PROJECT_DIR/.flox/env/manifest.toml"
   assert_success
 }
 
@@ -83,7 +83,7 @@ teardown() {
   run "$FLOX_BIN" install hello
   assert_success
   run "$FLOX_BIN" uninstall hello
-  run grep '^hello.path = "hello"' "$PROJECT_DIR/.flox/env/manifest.toml"
+  run grep '^hello.pkg-path = "hello"' "$PROJECT_DIR/.flox/env/manifest.toml"
   assert_failure
 }
 
@@ -220,7 +220,7 @@ teardown() {
   assert_success
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
   # This also checks that it correctly infers the install ID
-  assert_regex "$manifest" 'hello\.path = "hello"'
+  assert_regex "$manifest" 'hello\.pkg-path = "hello"'
 }
 
 @test "'flox install' infers install ID" {
@@ -230,7 +230,7 @@ teardown() {
   assert_success
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
   # This also checks that it correctly infers the install ID
-  assert_regex "$manifest" 'rails\.path = "rubyPackages_3_2\.rails"'
+  assert_regex "$manifest" 'rails\.pkg-path = "rubyPackages_3_2\.rails"'
 }
 
 @test "'flox install' overrides install ID with '-i'" {
@@ -239,7 +239,7 @@ teardown() {
   run "$FLOX_BIN" install -i foo hello
   assert_success
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
-  assert_regex "$manifest" 'foo\.path = "hello"'
+  assert_regex "$manifest" 'foo\.pkg-path = "hello"'
 }
 
 @test "'flox install' overrides install ID with '--id'" {
@@ -248,7 +248,7 @@ teardown() {
   run "$FLOX_BIN" install --id foo hello
   assert_success
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
-  assert_regex "$manifest" 'foo\.path = "hello"'
+  assert_regex "$manifest" 'foo\.pkg-path = "hello"'
 }
 
 @test "'flox install' accepts mix of inferred and supplied install IDs" {
@@ -257,9 +257,9 @@ teardown() {
   run "$FLOX_BIN" install -i foo rubyPackages_3_2.webmention ripgrep -i bar rubyPackages_3_2.rails
   assert_success
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
-  assert_regex "$manifest" 'foo\.path = "rubyPackages_3_2\.webmention"'
-  assert_regex "$manifest" 'ripgrep\.path = "ripgrep"'
-  assert_regex "$manifest" 'bar\.path = "rubyPackages_3_2\.rails"'
+  assert_regex "$manifest" 'foo\.pkg-path = "rubyPackages_3_2\.webmention"'
+  assert_regex "$manifest" 'ripgrep\.pkg-path = "ripgrep"'
+  assert_regex "$manifest" 'bar\.pkg-path = "rubyPackages_3_2\.rails"'
 }
 
 @test "'flox i' aliases to 'install'" {
@@ -268,7 +268,7 @@ teardown() {
   run "$FLOX_BIN" i hello
   assert_success
   manifest=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
-  assert_regex "$manifest" 'hello\.path = "hello"'
+  assert_regex "$manifest" 'hello\.pkg-path = "hello"'
 }
 
 @test "'flox install' creates global lock" {

--- a/cli/tests/environment-list.bats
+++ b/cli/tests/environment-list.bats
@@ -110,8 +110,8 @@ EOF
     [options]
     systems = [ "$NIX_SYSTEM" ]
     [install]
-    hello.path = "hello"
-    htop = { path = "htop", systems = [] }
+    hello.pkg-path = "hello"
+    htop = { pkg-path = "htop", systems = [] }
 EOF
 
   )"

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -124,7 +124,7 @@ function add_incompatible_package() {
   git clone "$FLOX_FLOXHUB_PATH/$OWNER/floxmeta" "$PROJECT_DIR/floxmeta"
   pushd "$PROJECT_DIR/floxmeta" > /dev/null || return
   git checkout "$ENV_NAME"
-  tomlq --in-place --toml-output ".install.extra.path = $package" 2/env/manifest.toml
+  tomlq --in-place --toml-output ".install.extra.\"pkg-path\" = $package" 2/env/manifest.toml
   git add .
   git \
     -c "user.name=test" \
@@ -147,7 +147,7 @@ function add_insecure_package() {
   git clone "$FLOX_FLOXHUB_PATH/$OWNER/floxmeta" "$PROJECT_DIR/floxmeta"
   pushd "$PROJECT_DIR/floxmeta" > /dev/null || return
   git checkout "$ENV_NAME"
-  tomlq --in-place --toml-output '.install.extra.path = ["python2"]' 2/env/manifest.toml
+  tomlq --in-place --toml-output '.install.extra.\"pkg-path\" = ["python2"]' 2/env/manifest.toml
   git add .
   git \
     -c "user.name=test" \

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -147,7 +147,7 @@ function add_insecure_package() {
   git clone "$FLOX_FLOXHUB_PATH/$OWNER/floxmeta" "$PROJECT_DIR/floxmeta"
   pushd "$PROJECT_DIR/floxmeta" > /dev/null || return
   git checkout "$ENV_NAME"
-  tomlq --in-place --toml-output '.install.extra.\"pkg-path\" = ["python2"]' 2/env/manifest.toml
+  tomlq --in-place --toml-output '.install.extra."pkg-path" = ["python2"]' 2/env/manifest.toml
   git add .
   git \
     -c "user.name=test" \

--- a/cli/tests/ld-floxlib/manifest.toml
+++ b/cli/tests/ld-floxlib/manifest.toml
@@ -1,9 +1,9 @@
 [install]
-boost.path = "boost"
-curl.path = "curl"
-gcc.path = "gcc"
-gcc-unwrapped = { path = "gcc-unwrapped", priority = 4 }
-glibc.path = "glibc"
-libarchive.path = "libarchive"
-nix = { path = "nix", priority = 4 }
-patchelf.path = "patchelf"
+boost.pkg-path = "boost"
+curl.pkg-path = "curl"
+gcc.pkg-path = "gcc"
+gcc-unwrapped = { pkg-path = "gcc-unwrapped", priority = 4 }
+glibc.pkg-path = "glibc"
+libarchive.pkg-path = "libarchive"
+nix = { pkg-path = "nix", priority = 4 }
+patchelf.pkg-path = "patchelf"

--- a/pkgdb/docs/manifests.md
+++ b/pkgdb/docs/manifests.md
@@ -81,7 +81,7 @@ Descriptor ::= {
 , semver             = null | <STRING>
 , systems            = null | [<STRING>, ...]
 , path               = null | <STRING> | [<STRING>, ...]
-, abs-path           = null | <STRING> | [<STRING>, ...]
+, abspath           = null | <STRING> | [<STRING>, ...]
 , package-repository = null | <STRING> | FlakeAttrs
 , priority           = null | <INT>
 }
@@ -116,7 +116,7 @@ Fields:
   - `systems`: A list of systems on which to resolve this package.
     - When omitted or `null` only the current system is used for resolution.
   - `path`: Match a relative path within the registry input.
-  - `abs-path`: Match an exact path within the registry input.
+  - `abspath`: Match an exact path within the registry input.
   - `package-repository`: The named registry input or flake reference that this package should be resolved in.
   - `priority`: A priority used to resolve file conflicts.
     - When the attribute is missing or `null`, the package is assigned a priority of 5.

--- a/pkgdb/include/flox/resolver/descriptor.hh
+++ b/pkgdb/include/flox/resolver/descriptor.hh
@@ -72,8 +72,8 @@ public:
 
   /** @brief A dot separated attribut path, or list representation. */
   using Path = std::variant<std::string, flox::AttrPath>;
-  /** Match a relative path. */
-  std::optional<Path> path;
+  /** Match a relative pkgPath. */
+  std::optional<Path> pkgPath;
 
   /**
    * @brief A dot separated attribut path, or list representation.
@@ -118,7 +118,7 @@ public:
    *        throws an exception if the descriptor is invalid.
    *
    * This requires that the `abspath` field is valid, and consistent with
-   * `path` and/or `systems` fields if they are set.
+   * `pkgPath` and/or `systems` fields if they are set.
    */
   void
   check( const std::string iid = "*" ) const;
@@ -243,7 +243,7 @@ public:
   std::optional<std::vector<System>> systems;
 
   /** Match a relative attribute path. */
-  std::optional<flox::AttrPath> path;
+  std::optional<flox::AttrPath> pkgPath;
 
   /** Force resolution in a given input, _flake reference_. */
   std::optional<nix::FlakeRef> input;
@@ -269,9 +269,9 @@ public:
                                const ManifestDescriptorRaw & raw )
     : ManifestDescriptor( raw )
   {
-    if ( ( ! this->name.has_value() ) && ( ! this->path.has_value() ) )
+    if ( ( ! this->name.has_value() ) && ( ! this->pkgPath.has_value() ) )
       {
-        this->path = AttrPath { std::string( installID ) };
+        this->pkgPath = AttrPath { std::string( installID ) };
       }
   }
 

--- a/pkgdb/src/raw-package.cc
+++ b/pkgdb/src/raw-package.cc
@@ -29,7 +29,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
   assertIsJSONObject<flox::pkgdb::PkgDbException>( jfrom, "package" );
   for ( const auto & [key, value] : jfrom.items() )
     {
-      if ( key == "path" )
+      if ( key == "pkg-path" )
         {
           try
             {
@@ -38,7 +38,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
           catch ( nlohmann::json::exception & e )
             {
               throw flox::pkgdb::PkgDbException(
-                "couldn't interpret field 'path'",
+                "couldn't interpret field 'pkg-path'",
                 flox::extract_json_errmsg( e ) );
             }
         }
@@ -186,7 +186,7 @@ from_json( const nlohmann::json & jfrom, RawPackage & pkg )
 void
 to_json( nlohmann::json & jto, const flox::RawPackage & pkg )
 {
-  jto = { { "path", pkg.path },
+  jto = { { "pkg-path", pkg.path },
           {
             "name",
             pkg.name,

--- a/pkgdb/src/resolver/environment.cc
+++ b/pkgdb/src/resolver/environment.cc
@@ -225,7 +225,7 @@ Environment::groupIsLocked( const GroupName &          name,
 
           /* We ignore `priority' and handle `systems' below. */
           if ( ( descriptor.name != oldDescriptor.name )
-               || ( descriptor.path != oldDescriptor.path )
+               || ( descriptor.pkgPath != oldDescriptor.pkgPath )
                || ( descriptor.version != oldDescriptor.version )
                || ( descriptor.semver != oldDescriptor.semver )
                || ( descriptor.subtree != oldDescriptor.subtree )
@@ -371,9 +371,9 @@ Environment::tryResolveDescriptorIn( const ManifestDescriptor & descriptor,
                                      const System &             system )
 {
   std::string dPath;
-  if ( descriptor.path.has_value() )
+  if ( descriptor.pkgPath.has_value() )
     {
-      dPath = concatStringsSep( ".", *descriptor.path );
+      dPath = concatStringsSep( ".", *descriptor.pkgPath );
     }
   std::string dName;
   if ( descriptor.name.has_value() ) { dName = *descriptor.name; }
@@ -468,7 +468,7 @@ Environment::getGroupInput( const InstallDescriptors & group,
                    *   without effecting resolution.
                    * - `group' is handled below. */
                   if ( ( descriptor.name == oldDescriptor.name )
-                       && ( descriptor.path == oldDescriptor.path )
+                       && ( descriptor.pkgPath == oldDescriptor.pkgPath )
                        && ( descriptor.version == oldDescriptor.version )
                        && ( descriptor.semver == oldDescriptor.semver )
                        && ( descriptor.subtree == oldDescriptor.subtree )

--- a/pkgdb/tests/data/manifest/ga0.toml
+++ b/pkgdb/tests/data/manifest/ga0.toml
@@ -5,7 +5,7 @@ systems = ["x86_64-linux", "aarch64-darwin"]
 [install.charasay]
 version = "^3"
 [install.pip]
-path = "python310Packages.pip"
+pkg-path = "python310Packages.pip"
 # Expect failure
 [install.bad]
 optional = true

--- a/pkgdb/tests/data/manifest/ga0.yaml
+++ b/pkgdb/tests/data/manifest/ga0.yaml
@@ -8,7 +8,7 @@ install:
   charasay:
     version: ^2
   pip:
-    path: python310Packages.pip
+    pkg-path: python310Packages.pip
   # Expect failure
   bad:
     optional: true

--- a/pkgdb/tests/data/manifest/manifest0.toml
+++ b/pkgdb/tests/data/manifest/manifest0.toml
@@ -1,29 +1,29 @@
 [registry]
-priority = [ "nixpkgs", "floco" ]
+priority = ["nixpkgs", "floco"]
 
 [registry.inputs.nixpkgs]
-subtrees = [ "legacyPackages" ]
+subtrees = ["legacyPackages"]
 
-  [registry.inputs.nixpkgs.from]
-  type = "github"
-  owner = "NixOS"
-  repo = "nixpkgs"
-  rev = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+[registry.inputs.nixpkgs.from]
+type = "github"
+owner = "NixOS"
+repo = "nixpkgs"
+rev = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 [registry.inputs.floco]
-subtrees = [ "packages" ]
+subtrees = ["packages"]
 
-  [registry.inputs.floco.from]
-  type = "github"
-  owner = "aakropotkin"
-  repo = "floco"
-  rev = "1e84b4b16bba5746e1195fa3a4d8addaaf2d9ef4"
+[registry.inputs.floco.from]
+type = "github"
+owner = "aakropotkin"
+repo = "floco"
+rev = "1e84b4b16bba5746e1195fa3a4d8addaaf2d9ef4"
 
 [env-base]
 floxhub = "https://hub.flox.dev/owner/env"
 
 [options]
-systems = [ "x86_64-linux" ]
+systems = ["x86_64-linux"]
 activation-strategy = "etc-profiles"
 package-grouping-strategy = "auto"
 
@@ -34,11 +34,11 @@ owner = "NixOS"
 repo = "nixpkgs"
 rev = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
-  [install.charasay]
-  version = "^2"
+[install.charasay]
+version = "^2"
 
-  [install.pip]
-  path = "python310Packages.pip"
+[install.pip]
+pkg-path = "python310Packages.pip"
 
 [vars]
 message = "Howdy"

--- a/pkgdb/tests/data/manifest/manifest0.yaml
+++ b/pkgdb/tests/data/manifest/manifest0.yaml
@@ -39,7 +39,7 @@ install:
     version: ^2
 
   pip:
-    path: python310Packages.pip
+    pkg-path: python310Packages.pip
 
 vars:
   message: Howdy

--- a/pkgdb/tests/data/manifest/post-ga0.toml
+++ b/pkgdb/tests/data/manifest/post-ga0.toml
@@ -10,7 +10,7 @@ systems = ["x86_64-linux", "aarch64-darwin"]
 [install.charasay]
 version = "^2"
 [install.pip]
-path = "python310Packages.pip"
+pkg-path = "python310Packages.pip"
 # Expect failure
 [install.bad]
 optional = true

--- a/pkgdb/tests/descriptor.bats
+++ b/pkgdb/tests/descriptor.bats
@@ -62,7 +62,7 @@ setup_file() {
   query="packageset.hello@1.2"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["packageset","hello"]'
   assert_equal $(echo "$output" | jq -r '.semver') "1.2"
   unset output
   run "$PKGDB_BIN" parse descriptor --to query "$query"
@@ -75,7 +75,7 @@ setup_file() {
   query="legacyPackages.aarch64-darwin.hello@1.2"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["hello"]'
   assert_equal $(echo "$output" | jq -r '.subtree') "legacyPackages"
   assert_equal $(echo "$output" | jq -r '.semver') "1.2"
   unset output
@@ -90,7 +90,7 @@ setup_file() {
   query="legacyPackages.*.hello@1.2"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["hello"]'
   assert_equal $(echo "$output" | jq -r '.subtree') "legacyPackages"
   assert_equal $(echo "$output" | jq -r '.semver') "1.2"
   unset output
@@ -193,7 +193,7 @@ setup_file() {
 @test "parse descriptor 'nixpkgs:packageset.hello@1.2.3'" {
   run "$PKGDB_BIN" parse descriptor --to manifest "nixpkgs:packageset.hello@1.2.3"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["packageset","hello"]'
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs"
   assert_equal $(echo "$output" | jq -r '.version') "1.2.3"
   unset output
@@ -206,7 +206,7 @@ setup_file() {
 @test "parse descriptor 'nixpkgs:packageset.hello@=1.2.3'" {
   run "$PKGDB_BIN" parse descriptor --to manifest "nixpkgs:packageset.hello@=1.2.3"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["packageset","hello"]'
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs"
   assert_equal $(echo "$output" | jq -r '.version') "1.2.3"
   unset output
@@ -220,7 +220,7 @@ setup_file() {
   query="nixpkgs:legacyPackages.*.hello@1.2.3"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["hello"]'
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages"
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs"
   assert_equal $(echo "$output" | jq -r '.version') "1.2.3"
@@ -236,7 +236,7 @@ setup_file() {
   query="nixpkgs:legacyPackages.aarch64-darwin.hello@1.2"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["hello"]'
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages"
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs"
   assert_equal $(echo "$output" | jq -r '.semver') "1.2"
@@ -252,7 +252,7 @@ setup_file() {
   query="nixpkgs:legacyPackages.*.hello@1.2"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["hello"]'
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages"
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs"
   assert_equal $(echo "$output" | jq -r '.semver') "1.2"
@@ -268,7 +268,7 @@ setup_file() {
   query="myflake:packages.*.hello@1.2"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["hello"]'
   assert_equal $(echo "$output" | jq -r -c '.subtree') "packages"
   assert_equal $(echo "$output" | jq -r '.input.id') "myflake"
   assert_equal $(echo "$output" | jq -r '.semver') "1.2"
@@ -284,7 +284,7 @@ setup_file() {
   query="nixpkgs:legacyPackages.*.packageset.hello@1.2"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["packageset","hello"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["packageset","hello"]'
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages"
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs"
   assert_equal $(echo "$output" | jq -r '.semver') "1.2"
@@ -302,7 +302,7 @@ setup_file() {
   query="nixpkgs:legacyPackages.*.linuxKernel.packages.linux_4_19@1.2"
   run "$PKGDB_BIN" parse descriptor --to manifest "$query"
   assert_success
-  assert_equal $(echo "$output" | jq -r -c '.path') '["linuxKernel","packages","linux_4_19"]'
+  assert_equal $(echo "$output" | jq -r -c '."pkg-path"') '["linuxKernel","packages","linux_4_19"]'
   assert_equal $(echo "$output" | jq -r -c '.subtree') "legacyPackages"
   assert_equal $(echo "$output" | jq -r '.input.id') "nixpkgs"
   assert_equal $(echo "$output" | jq -r '.semver') "1.2"

--- a/pkgdb/tests/environment.cc
+++ b/pkgdb/tests/environment.cc
@@ -282,9 +282,10 @@ test_groupIsLocked1()
 {
   /* Create manifest with hello */
   ManifestRaw manifestRaw;
-  manifestRaw.install          = { { "hello",
-                                     ManifestDescriptorRaw(
-                              nlohmann::json( { { "path", "hello" } } ) ) } };
+  manifestRaw.install = {
+    { "hello",
+      ManifestDescriptorRaw( nlohmann::json( { { "pkg-path", "hello" } } ) ) }
+  };
   manifestRaw.options          = Options {};
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;
@@ -585,9 +586,10 @@ test_getGroupInput0()
 {
   /* Create manifest with hello */
   ManifestRaw manifestRaw;
-  manifestRaw.install          = { { "hello",
-                                     ManifestDescriptorRaw(
-                              nlohmann::json( { { "path", "hello" } } ) ) } };
+  manifestRaw.install = {
+    { "hello",
+      ManifestDescriptorRaw( nlohmann::json( { { "pkg-path", "hello" } } ) ) }
+  };
   manifestRaw.options          = Options {};
   manifestRaw.options->systems = { _system };
   manifestRaw.registry         = registryWithNixpkgs;

--- a/pkgdb/tests/lockfile.bats
+++ b/pkgdb/tests/lockfile.bats
@@ -37,11 +37,11 @@ setup_file() {
 systems = ["x86_64-linux", "x86_64-darwin"]
 
 [install.a]
-path = ["hello"]
+pkg-path = ["hello"]
 systems = ["x86_64-linux"]
 
 [install.b]
-path = ["hello"]
+pkg-path = ["hello"]
 systems = ["x86_64-darwin"]' > "$_MANIFEST";
 
   run sh -c "$PKGDB_BIN manifest lock --ga-registry --manifest '$_MANIFEST'  \

--- a/pkgdb/tests/manifest.cc
+++ b/pkgdb/tests/manifest.cc
@@ -226,8 +226,8 @@ test_parseManifestDescriptor_path0()
   EXPECT( descriptor.subtree.has_value() );
   EXPECT_EQ( *descriptor.subtree, flox::ST_LEGACY );
   EXPECT( ! descriptor.systems.has_value() );
-  EXPECT( descriptor.path.has_value() );
-  EXPECT( ( *descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+  EXPECT( descriptor.pkgPath.has_value() );
+  EXPECT( ( *descriptor.pkgPath ) == ( flox::AttrPath { "hello" } ) );
 
   return true;
 }
@@ -249,8 +249,8 @@ test_parseManifestDescriptor_path1()
   EXPECT( descriptor.subtree.has_value() );
   EXPECT_EQ( *descriptor.subtree, flox::ST_LEGACY );
   EXPECT( ! descriptor.systems.has_value() );
-  EXPECT( descriptor.path.has_value() );
-  EXPECT( ( *descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+  EXPECT( descriptor.pkgPath.has_value() );
+  EXPECT( ( *descriptor.pkgPath ) == ( flox::AttrPath { "hello" } ) );
 
   return true;
 }
@@ -272,8 +272,8 @@ test_parseManifestDescriptor_path2()
   EXPECT( descriptor.subtree.has_value() );
   EXPECT_EQ( *descriptor.subtree, flox::ST_LEGACY );
   EXPECT( ! descriptor.systems.has_value() );
-  EXPECT( descriptor.path.has_value() );
-  EXPECT( ( *descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+  EXPECT( descriptor.pkgPath.has_value() );
+  EXPECT( ( *descriptor.pkgPath ) == ( flox::AttrPath { "hello" } ) );
 
   return true;
 }
@@ -295,8 +295,8 @@ test_parseManifestDescriptor_path3()
   EXPECT( descriptor.subtree.has_value() );
   EXPECT_EQ( *descriptor.subtree, flox::ST_LEGACY );
   EXPECT( ! descriptor.systems.has_value() );
-  EXPECT( descriptor.path.has_value() );
-  EXPECT( ( *descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+  EXPECT( descriptor.pkgPath.has_value() );
+  EXPECT( ( *descriptor.pkgPath ) == ( flox::AttrPath { "hello" } ) );
 
   return true;
 }
@@ -320,8 +320,8 @@ test_parseManifestDescriptor_path4()
   EXPECT( descriptor.systems.has_value() );
   EXPECT( ( *descriptor.systems )
           == ( std::vector<std::string> { "x86_64-linux" } ) );
-  EXPECT( descriptor.path.has_value() );
-  EXPECT( ( *descriptor.path ) == ( flox::AttrPath { "hello" } ) );
+  EXPECT( descriptor.pkgPath.has_value() );
+  EXPECT( ( *descriptor.pkgPath ) == ( flox::AttrPath { "hello" } ) );
 
   return true;
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Renames the manifest descriptor field `path` to `pkg-path`.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
All environments on FloxHub will need to be edited and pushed again.

<!-- Many thanks! -->
