### PR TITLE
docs: path -> pkg-path in man pages

### DIFF
--- a/cli/flox/doc/flox-install.md
+++ b/cli/flox/doc/flox-install.md
@@ -42,11 +42,11 @@ with long names such as `python310Packages.pip`.
 Install IDs also provide a way to give packages more semantically meaningful,
 convenient, or aesthetically pleasing names in the manifest
 (e.g. `node21` instead of `nodejs_21`).
-When not explicitly provided, the install ID is inferred based on the path.
+When not explicitly provided, the install ID is inferred based on the pkg-path.
 For pkg-paths that consist of a single attribute (e.g. `ripgrep`) the install
 ID is set to that attribute.
 For pkg-paths that consist of multiple attributes (e.g. `python310Packages.pip`)
-the install ID is set to the last attribute in the path (e.g. `pip`).
+the install ID is set to the last attribute in the pkg-path (e.g. `pip`).
 
 You may also specify packages to be installed via
 [`flox-edit(1)`](./flox-edit.md),

--- a/cli/flox/doc/flox-search.md
+++ b/cli/flox/doc/flox-search.md
@@ -44,7 +44,7 @@ More specific information for a single package is available via the
 ## Fuzzy search
 When only given a package name,
 `flox search` uses a fuzzy search mechanism that tries to match either the
-package name itself or some portion of the relative path.
+package name itself or some portion of the pkg-path.
 
 The search query can also include a version filter following the
 familiar semver syntax (`@` between the package and version).

--- a/cli/flox/doc/include/package-names.md
+++ b/cli/flox/doc/include/package-names.md
@@ -2,23 +2,14 @@
 Packages are organized in a hierarchical structure such that certain packages
 are found at the top level (e.g. `ripgrep`),
 and other packages are found under package sets (e.g. `python310Packages.pip`).
+We call this location within the catalog the "pkg-path".
 
-The full name of a package will be something like
-`legacyPackages.x86_64-linux.python310Packages.pip`
-and is referred to as its "attribute path"
-(note that "legacyPackages" has nothing to do with packages being out of date).
-This attribute path is a sequence of attributes
-(e.g. "python310Packages" and "pip") joined by a delimiter (".").
-For many use cases, the leading `legacyPackages.<system>` is left off.
-The remaining portion of the attribute path (e.g. `python310Packages.pip`) is
-referred to as the "relative path" or "path" for short.
-
-This is the portion that is searched when you execute a `flox search` command.
-The path is also the portion shown by `flox show`.
-Finally, the path appears in your manifest after a `flox install`.
+The pkg-path is searched when you execute a `flox search` command.
+The pkg-path is what's shown by `flox show`.
+Finally, the pkg-path appears in your manifest after a `flox install`.
 
 ```toml
 [install]
-ripgrep.path = "ripgrep"
-pip.path = "python310Packages.pip"
+ripgrep.pkg-path = "ripgrep"
+pip.pkg-path = "python310Packages.pip"
 ```


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Rename `path` -> `pkg-path` in the man pages.

Note: this will need to be rebased once the outstanding man pages PR is merged.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
