### PR TITLE
fix: rust unit test "Text file busy"

### DIFF
--- a/cli/flox-rust-sdk/src/models/container_builder.rs
+++ b/cli/flox-rust-sdk/src/models/container_builder.rs
@@ -93,7 +93,7 @@ mod tests {
         let mut tries = 0;
         loop {
             if tries >= 3 {
-                panic!("Calling the container builder script failed too many times: with 'Text file busy'")
+                panic!("Test flaked with 'Text file busy' and can be re-run")
             }
             match container_builder.stream_container(&mut buf) {
                 Err(ContainerBuilderError::CallContainerBuilder(e))
@@ -122,7 +122,7 @@ mod tests {
         let mut tries = 0;
         loop {
             if tries >= 3 {
-                panic!("Calling the container builder script failed too many times: with 'Text file busy'")
+                panic!("Test flaked with 'Text file busy' and can be re-run")
             }
             match container_builder.stream_container(&mut file) {
                 Err(ContainerBuilderError::CallContainerBuilder(e))


### PR DESCRIPTION
Resolve issues with rust unit tests in `models::container_builder::tests::*`.

The container builder tests spuriously failed with `Text file busy`:

```
thread 'models::container_builder::tests::test_writes_output_to_writer' panicked at flox-rust-sdk/src/models/container_builder.rs:81:54:
called `Result::unwrap()` on an `Err` value: CallContainerBuilder(Os { code: 26, kind: ExecutableFileBusy, message: "Text file busy" })
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: core::result::Result<T,E>::unwrap
             at /build/rustc-1.73.0-src/library/core/src/result.rs:1077:23
   4: flox_rust_sdk::models::container_builder::tests::test_writes_output_to_writer
             at ./src/models/container_builder.rs:81:9
   5: flox_rust_sdk::models::container_builder::tests::test_writes_output_to_writer::{{closure}}
             at ./src/models/container_builder.rs:76:39
   6: core::ops::function::FnOnce::call_once
             at /build/rustc-1.73.0-src/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```

`Text file busy (26)` may occur when executing a script 
that is has been written to immediately prior.
This is a known bug in rust (and allegedly other languages)
which is tracked in https://github.com/rust-lang/rust/issues/114554.

We typically see this error in tests, where we write a new container builder script
and immediately execute it within the same process:

https://github.com/flox/flox/blob/main/cli/flox-rust-sdk/src/models/container_builder.rs#L76-L83


In production use, this should not be a problem as the script will be written
by a different process, i.e. `pkgdb`.

