### PR TITLE
feat: handle env not found in install/uninstall

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -269,7 +269,12 @@ impl EnvironmentPointer {
         let dot_flox_path = path.as_ref().join(DOT_FLOX);
         if !dot_flox_path.exists() {
             debug!("couldn't find .flox at {}", dot_flox_path.display());
-            Err(EnvironmentError2::DotFloxNotFound)?
+            Err(EnvironmentError2::DotFloxNotFound(
+                dot_flox_path
+                    .parent()
+                    .unwrap_or(&dot_flox_path)
+                    .to_path_buf(),
+            ))?
         }
         let pointer_path = dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME);
         let pointer_contents = match fs::read(&pointer_path) {
@@ -317,8 +322,8 @@ pub enum EnvironmentError2 {
     // todo: candidate for impl specific error
     // * only path and managed env are defined in .Flox
     // region: path env open
-    #[error("Did not find an environment in the current directory.")]
-    DotFloxNotFound,
+    #[error("Did not find an environment in '{0}'")]
+    DotFloxNotFound(PathBuf),
 
     #[error("could not locate the manifest for this environment")]
     ManifestNotFound,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -332,6 +332,7 @@ pub enum EnvironmentError2 {
     // * three distinct errors map to this
     #[error("could not initialize environment")]
     InitEnv(#[source] std::io::Error),
+    /// .flox exists but .flox/env does not
     #[error("could not find environment definition directory")]
     EnvDirNotFound,
     #[error("could not find environment pointer file")]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -317,7 +317,7 @@ pub enum EnvironmentError2 {
     // todo: candidate for impl specific error
     // * only path and managed env are defined in .Flox
     // region: path env open
-    #[error(".flox directory not found")]
+    #[error("Did not find an environment in the current directory.")]
     DotFloxNotFound,
 
     #[error("could not locate the manifest for this environment")]

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -277,7 +277,9 @@ impl Environment for PathEnvironment {
         if Some(OsStr::new(".flox")) == dot_flox.file_name() {
             std::fs::remove_dir_all(dot_flox).map_err(EnvironmentError2::DeleteEnvironment)?;
         } else {
-            return Err(EnvironmentError2::DotFloxNotFound);
+            return Err(EnvironmentError2::DotFloxNotFound(
+                self.path.parent().unwrap_or(&self.path).to_path_buf(),
+            ));
         }
         Ok(())
     }
@@ -326,7 +328,9 @@ impl PathEnvironment {
         let dot_flox = dot_flox_path.as_ref();
         log::debug!("attempting to open .flox directory: {}", dot_flox.display());
         if !dot_flox.exists() {
-            Err(EnvironmentError2::DotFloxNotFound)?;
+            Err(EnvironmentError2::DotFloxNotFound(
+                dot_flox.parent().unwrap_or(dot_flox).to_path_buf(),
+            ))?;
         }
 
         PathEnvironment::new(dot_flox, pointer, temp_dir)
@@ -343,7 +347,7 @@ impl PathEnvironment {
     ) -> Result<Self, EnvironmentError2> {
         let system: &str = system.as_ref();
         match EnvironmentPointer::open(dot_flox_parent_path.as_ref()) {
-            Err(EnvironmentError2::DotFloxNotFound) => {},
+            Err(EnvironmentError2::DotFloxNotFound(_)) => {},
             Err(e) => Err(e)?,
             Ok(_) => Err(EnvironmentError2::EnvironmentExists(
                 dot_flox_parent_path.as_ref().to_path_buf(),

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1122,7 +1122,16 @@ impl Install {
             .detect_concrete_environment(&flox, "install to")
         {
             Ok(concrete_environment) => concrete_environment,
-            Err(EnvironmentSelectError::Environment(e @ EnvironmentError2::DotFloxNotFound)) => {
+            Err(EnvironmentSelectError::Environment(
+                ref e @ EnvironmentError2::DotFloxNotFound(ref dir),
+            )) => {
+                bail!(formatdoc! {"
+                {e}
+
+                Create an environment with 'flox init --dir {}'", dir.to_string_lossy()
+                })
+            },
+            Err(e @ EnvironmentSelectError::EnvNotFoundInCurrentDirectory) => {
                 bail!(formatdoc! {"
                 {e}
 
@@ -1248,7 +1257,16 @@ impl Uninstall {
             .detect_concrete_environment(&flox, "uninstall from")
         {
             Ok(concrete_environment) => concrete_environment,
-            Err(EnvironmentSelectError::Environment(e @ EnvironmentError2::DotFloxNotFound)) => {
+            Err(EnvironmentSelectError::Environment(
+                ref e @ EnvironmentError2::DotFloxNotFound(ref dir),
+            )) => {
+                bail!(formatdoc! {"
+                {e}
+
+                Create an environment with 'flox init --dir {}'", dir.to_string_lossy()
+                })
+            },
+            Err(e @ EnvironmentSelectError::EnvNotFoundInCurrentDirectory) => {
                 bail!(formatdoc! {"
                 {e}
 

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1122,9 +1122,9 @@ impl Install {
             .detect_concrete_environment(&flox, "install to")
         {
             Ok(concrete_environment) => concrete_environment,
-            Err(EnvironmentSelectError::Environment(EnvironmentError2::DotFloxNotFound)) => {
+            Err(EnvironmentSelectError::Environment(e @ EnvironmentError2::DotFloxNotFound)) => {
                 bail!(formatdoc! {"
-                Did not find an environment in the current directory.
+                {e}
 
                 Create an environment with 'flox init' or install to an environment found elsewhere with 'flox install {} --dir <PATH>'",
                 self.packages.join(" ")})
@@ -1248,9 +1248,9 @@ impl Uninstall {
             .detect_concrete_environment(&flox, "uninstall from")
         {
             Ok(concrete_environment) => concrete_environment,
-            Err(EnvironmentSelectError::Environment(EnvironmentError2::DotFloxNotFound)) => {
+            Err(EnvironmentSelectError::Environment(e @ EnvironmentError2::DotFloxNotFound)) => {
                 bail!(formatdoc! {"
-                Did not find an environment in the current directory.
+                {e}
 
                 Create an environment with 'flox init' or uninstall packages from an environment found elsewhere with 'flox uninstall {} --dir <path>'",
                 self.packages.join(" ")})

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::{env, fmt, fs, mem};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use bpaf::{Args, Bpaf, ParseFailure, Parser};
 use flox_rust_sdk::flox::{EnvironmentRef, Flox, Floxhub, DEFAULT_FLOXHUB_URL, FLOX_VERSION};
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
@@ -19,6 +19,7 @@ use flox_rust_sdk::models::environment::{
     find_dot_flox,
     DotFlox,
     Environment,
+    EnvironmentError2,
     EnvironmentPointer,
     ManagedPointer,
     DOT_FLOX,
@@ -31,6 +32,7 @@ use log::{debug, info};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
+use thiserror::Error;
 use toml_edit::Key;
 use url::Url;
 
@@ -524,6 +526,14 @@ pub enum EnvironmentSelect {
     Unspecified,
 }
 
+#[derive(Debug, Error)]
+pub enum EnvironmentSelectError {
+    #[error(transparent)]
+    Environment(#[from] EnvironmentError2),
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
 impl EnvironmentSelect {
     /// Open a concrete environment, not detecting the currently active
     /// environment.
@@ -532,17 +542,21 @@ impl EnvironmentSelect {
     /// behavior based on whether an environment is already active. For example,
     /// `flox activate` should never re-activate the last activated environment;
     /// it should default to an environment in the current directory.
-    pub fn to_concrete_environment(&self, flox: &Flox) -> Result<ConcreteEnvironment> {
+    pub fn to_concrete_environment(
+        &self,
+        flox: &Flox,
+    ) -> Result<ConcreteEnvironment, EnvironmentSelectError> {
         match self {
-            EnvironmentSelect::Dir(path) => open_path(flox, path),
+            EnvironmentSelect::Dir(path) => Ok(open_path(flox, path)?),
             EnvironmentSelect::Unspecified => {
                 let current_dir = env::current_dir().context("could not get current directory")?;
                 let maybe_found_environment = find_dot_flox(&current_dir)?;
                 match maybe_found_environment {
                     Some(found) => {
-                        UninitializedEnvironment::DotFlox(found).into_concrete_environment(flox)
+                        Ok(UninitializedEnvironment::DotFlox(found)
+                            .into_concrete_environment(flox)?)
                     },
-                    None => Err(anyhow!(format!("No environment found in {current_dir:?}"))),
+                    None => Err(EnvironmentError2::DotFloxNotFound)?,
                 }
             },
             EnvironmentSelect::Remote(env_ref) => {
@@ -552,7 +566,7 @@ impl EnvironmentSelect {
                     &flox.floxhub,
                 );
 
-                let env = RemoteEnvironment::new(flox, pointer)?;
+                let env = RemoteEnvironment::new(flox, pointer).map_err(anyhow::Error::new)?;
                 Ok(ConcreteEnvironment::Remote(env))
             },
         }
@@ -568,20 +582,15 @@ impl EnvironmentSelect {
         &self,
         flox: &Flox,
         message: &str,
-    ) -> Result<ConcreteEnvironment> {
+    ) -> Result<ConcreteEnvironment, EnvironmentSelectError> {
         match self {
-            EnvironmentSelect::Dir(path) => open_path(flox, path),
+            EnvironmentSelect::Dir(path) => Ok(open_path(flox, path)?),
             // If the user doesn't specify an environment, check if there's an
             // already activated environment or an environment in the current
             // directory.
             EnvironmentSelect::Unspecified => match detect_environment(message)? {
-                Some(env) => env.into_concrete_environment(flox),
-                // todo: remove: `detect_environment` already checked current dir
-                None => {
-                    let current_dir =
-                        env::current_dir().context("could not get current directory")?;
-                    Err(anyhow!(format!("No environment found in {current_dir:?}")))
-                },
+                Some(env) => Ok(env.into_concrete_environment(flox)?),
+                None => Err(EnvironmentError2::DotFloxNotFound)?,
             },
             EnvironmentSelect::Remote(env_ref) => {
                 let pointer = ManagedPointer::new(
@@ -590,7 +599,7 @@ impl EnvironmentSelect {
                     &flox.floxhub,
                 );
 
-                let env = RemoteEnvironment::new(flox, pointer)?;
+                let env = RemoteEnvironment::new(flox, pointer).map_err(anyhow::Error::new)?;
                 Ok(ConcreteEnvironment::Remote(env))
             },
         }
@@ -603,7 +612,9 @@ impl EnvironmentSelect {
 ///   inside a git repo.
 /// - Check if there's an already activated environment.
 /// - Prompt if both are true.
-pub fn detect_environment(message: &str) -> Result<Option<UninitializedEnvironment>> {
+pub fn detect_environment(
+    message: &str,
+) -> Result<Option<UninitializedEnvironment>, EnvironmentSelectError> {
     let current_dir = env::current_dir().context("could not get current directory")?;
     let maybe_activated = last_activated_environment();
     let maybe_found_environment = find_dot_flox(&current_dir)?;
@@ -639,7 +650,7 @@ pub fn detect_environment(message: &str) -> Result<Option<UninitializedEnvironme
                     ],
                 },
             };
-            let (index, _) = dialog.raw_prompt()?;
+            let (index, _) = dialog.raw_prompt().map_err(anyhow::Error::new)?;
             match index {
                 0 => Some(found),
                 1 => Some(activated_env),
@@ -654,9 +665,8 @@ pub fn detect_environment(message: &str) -> Result<Option<UninitializedEnvironme
 }
 
 /// Open an environment defined in `{path}/.flox`
-fn open_path(flox: &Flox, path: &PathBuf) -> Result<ConcreteEnvironment> {
+fn open_path(flox: &Flox, path: &PathBuf) -> Result<ConcreteEnvironment, EnvironmentError2> {
     DotFlox::open(path)
-        .with_context(|| format!("No environment found in {path:?}"))
         .map(UninitializedEnvironment::DotFlox)?
         .into_concrete_environment(flox)
 }
@@ -738,7 +748,10 @@ impl UninitializedEnvironment {
     /// Open the contained environment and return a [ConcreteEnvironment]
     ///
     /// This function will fail if the contained environment is not available or invalid
-    pub fn into_concrete_environment(self, flox: &Flox) -> Result<ConcreteEnvironment> {
+    pub fn into_concrete_environment(
+        self,
+        flox: &Flox,
+    ) -> Result<ConcreteEnvironment, EnvironmentError2> {
         match self {
             UninitializedEnvironment::DotFlox(dot_flox) => {
                 let dot_flox_path = dot_flox.path.join(DOT_FLOX);

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -530,6 +530,8 @@ pub enum EnvironmentSelect {
 pub enum EnvironmentSelectError {
     #[error(transparent)]
     Environment(#[from] EnvironmentError2),
+    #[error("Did not find an environment in the current directory.")]
+    EnvNotFoundInCurrentDirectory,
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
 }
@@ -556,7 +558,7 @@ impl EnvironmentSelect {
                         Ok(UninitializedEnvironment::DotFlox(found)
                             .into_concrete_environment(flox)?)
                     },
-                    None => Err(EnvironmentError2::DotFloxNotFound)?,
+                    None => Err(EnvironmentSelectError::EnvNotFoundInCurrentDirectory)?,
                 }
             },
             EnvironmentSelect::Remote(env_ref) => {
@@ -590,7 +592,7 @@ impl EnvironmentSelect {
             // directory.
             EnvironmentSelect::Unspecified => match detect_environment(message)? {
                 Some(env) => Ok(env.into_concrete_environment(flox)?),
-                None => Err(EnvironmentError2::DotFloxNotFound)?,
+                None => Err(EnvironmentSelectError::EnvNotFoundInCurrentDirectory)?,
             },
             EnvironmentSelect::Remote(env_ref) => {
                 let pointer = ManagedPointer::new(

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -18,7 +18,7 @@ pub fn format_error(err: &EnvironmentError2) -> String {
     trace!("formatting environment_error: {err:?}");
 
     match err {
-        EnvironmentError2::DotFloxNotFound => display_chain(err),
+        EnvironmentError2::DotFloxNotFound(_) => display_chain(err),
 
         // todo: enrich with a path?
         EnvironmentError2::EnvDirNotFound => formatdoc! {"

--- a/cli/tests/environment-delete.bats
+++ b/cli/tests/environment-delete.bats
@@ -64,5 +64,5 @@ dot_flox_exists() {
   assert_failure
   run "$FLOX_BIN" delete
   assert_failure
-  assert_output --partial "No environment found in \"$(pwd -P)\""
+  assert_output --partial "Did not find an environment in the current directory."
 }


### PR DESCRIPTION
For `flox install pkg1 pkg2` in a directory without an environment, print:
```
❌ ERROR: Did not find an environment in the current directory.

Create an environment with 'flox init' or install to an environment found elsewhere with 'flox install pkg1 pkg2 --dir <PATH>'
```
For `flox install pkg1 pkg2 -d /tmp` when there's no environment in `/tmp`, print:
```
❌ ERROR: Did not find an environment in '/tmp'

Create an environment with 'flox init --dir /tmp'
```

For `flox uninstall pkg1 pkg2` in a directory without an environment, print:
```
❌ ERROR: Did not find an environment in the current directory.

Create an environment with 'flox init' or uninstall packages from an environment found elsewhere with 'flox uninstall pkg1 pkg2 --dir <path>'
```

For `flox uninstall pkg1 pkg2 -d /tmp` when there's no environment in `/tmp`, print:
```
❌ ERROR: Did not find an environment in '/tmp'

Create an environment with 'flox init --dir /tmp'
```