### PR TITLE
build: strip links from manpages

### DIFF
--- a/pkgs/flox-manpages/pandoc-filters/filter-links.lua
+++ b/pkgs/flox-manpages/pandoc-filters/filter-links.lua
@@ -1,0 +1,31 @@
+--- filter-links.lua – remove all links from a doc
+---
+--- This filter removes all href links from a document,
+--- and replaces them with strong/bold text.
+---
+--- Short term mitigation for https://github.com/jgm/pandoc/issues/9458
+
+-- Links have been included with pandoc lua filter sine pandoc 2.0.0
+PANDOC_VERSION:must_be_at_least '2.0'
+
+return {
+  { Link = function (elem)
+
+      local link = pandoc.Inlines({"<", pandoc.Underline(elem.target), ">"})
+
+      if elem.content ~= nil then
+        local elems = pandoc.Inlines({})
+        elems:extend({pandoc.Strong(elem.content)})
+        if elem.target:find("^%w+://") ~= nil then
+          elems:extend({" "})
+          elems:extend(link)
+        end
+
+        return elems
+      end
+
+      return link
+
+    end
+   }
+}


### PR DESCRIPTION
We experienced issues with pandoc's link handling [1]. For a short term mitigation this PR adds a small lua filter that strips all links from documents before they are compiled to roff and inserts them as plain underlined text.

In addition it refactors the compilation to be less inline'y.

[1]: https://github.com/jgm/pandoc/issues/9458


