### PR TITLE
fix: hide duplicate `upgrade` from help

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -398,7 +398,8 @@ enum AdditionalCommands {
     /// Update environment's base catalog or the global base catalog
     #[bpaf(command, hide, footer("Run 'man flox-update' for more details."))]
     Update(#[bpaf(external(environment::update))] environment::Update),
-    #[bpaf(command, hide, header(indoc! {"
+    /// Upgrade packages in an environment
+    #[bpaf(command, hide, footer("Run 'man flox-upgrade' for more details."), header(indoc! {"
         When no arguments are specified, all packages in the environment are upgraded.\n\n
 
         Packages to upgrade can be specified by either group name, or, if a package is
@@ -411,8 +412,6 @@ enum AdditionalCommands {
         The packages in that group can be upgraded without updating any other
         groups by passing 'toplevel' as the group name.
     "}))]
-    /// Upgrade packages in an environment
-    #[bpaf(command, footer("Run 'man flox-upgrade' for more details."))]
     Upgrade(#[bpaf(external(environment::upgrade))] environment::Upgrade),
     /// View and set configuration options
     #[bpaf(command, hide, footer("Run 'man flox-config' for more details."))]


### PR DESCRIPTION
Seems like we added two bpaf `command` annotations, the second of which overrode the first.
This PR merges both into one annotation, meaning we now have both footer and header, as well as hiding the command from `flox --help`.

closes #1010 