### PR TITLE
docs: manpage touch ups

### DIFF
--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -4,6 +4,9 @@ section: 1
 header: "Flox User Manuals"
 ...
 
+```{.include}
+./include/experimental-warning.md
+```
 
 # NAME
 

--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -11,16 +11,85 @@ flox-containerize - export an environment as a container image
 
 # SYNOPSIS
 
-flox [ `<general-options>` ] containerize [ `<options>` ]
+```
+flox [ `<general-options>` ] containerize
+     [-d=<path> | -r=<owner/name>]
+     [-o=<path>]
+```
 
 # DESCRIPTION
 
 Export a Flox environment as a container image.
-The image is dumped to stdout and should be piped to `docker load`.
+The image is written to `<path>`.
+Then use `docker load -i <path>` to load the image into docker.
+When `<path>` is `-`, the imag is written to `stdout`,
+and can be piped into `docker load` directly.
+
+Running the container will behave like running `flox activate`.
+Running the container interactively with `docker run -it <container id>`,
+will launch a bash subshell in the container
+with all your packages and variables set after running the activation hook.
+This is akin to `flox activate`
+
+Running the container non-interactively with `docker run <container id>`
+allows you to run a command within the container without launching a subshell,
+similar to `flox activate --`
+
+
+**Note**:
+The `containerize` command is currently **only available on Linux**.
+The produced container however can also run on macOS.
 
 # OPTIONS
+
+`-o`, `--output`
+:   Write the container to `<path>`
+    (default: `./<environment-name>-container.tar.gz`)
+    If `<path>` is `-`, writes to `stdout`.
 
 ```{.include}
 ./include/environment-options.md
 ./include/general-options.md
 ```
+
+# EXAMPLES
+
+Create a container image file and load it into Docker:
+
+```
+$ flox containerize -o ./mycontainer.tar.gz
+$ docker load -i ./mycontainer.tar.gz
+```
+
+Pipe the image into Docker directly:
+
+```
+$ flox containerize -o - | docker load
+```
+
+Run the container interactively:
+
+```
+$ flox init
+$ flox install hello
+$ flox containerize -o - | docker load
+$ docker run --rm -it <container id>
+[floxenv] $ hello
+Hello, world!
+```
+
+Run a specific command from within the container,
+but do not launch a subshell.
+
+```
+$ flox init
+$ flox install hello
+$ flox containerize -o - | docker load
+$ docker run <container id> hello
+Hello, world
+```
+
+# SEE ALSO
+
+[`flox-activate(1)`](./flox-activate.md)
+[`docker-load(1)`]

--- a/cli/flox/doc/flox-delete.md
+++ b/cli/flox/doc/flox-delete.md
@@ -14,7 +14,7 @@ flox-delete - delete an environment
 ```
 flox [<general options>] delete
      [-f]
-     [-d=<path> | -r=<owner/name>]
+     [-d=<path>]
 ```
 
 # DESCRIPTION
@@ -31,11 +31,24 @@ use.
 # OPTIONS
 
 ## Delete Options
+
 `-f`, `--force`
 :   Delete the environment without confirmation.
 
+<!-- Copied from ./include/environment-options.md
+     `flox delete` deos not currently handle remote environments
+     Replace with an include once support is added.
+ -->
+## Environment Options
+
+If no environment is specified for an environment command,
+the environment in the current directory
+or the active environment that was last activated is used.
+
+`-d`, `--dir`
+:   Path containing a .flox/ directory.
+
 ```{.include}
-./include/environment-options.md
 ./include/general-options.md
 ```
 

--- a/cli/flox/doc/flox-delete.md
+++ b/cli/flox/doc/flox-delete.md
@@ -53,5 +53,6 @@ or the active environment that was last activated is used.
 ```
 
 # See Also
+[`flox-init(1)`](./flox-init.md)
 [`flox-push(1)`](./flox-push.md),
 [`flox-pull(1)`](./flox-pull.md)

--- a/cli/flox/doc/flox-edit.md
+++ b/cli/flox/doc/flox-edit.md
@@ -53,10 +53,6 @@ which replaces the contents of the manifest with those of the provided file.
 :   Rename the environment to `<name>`.
     Only works for local environments.
 
-[ (\--file|-f) `<file>` ]
-:   Replace environment declaration with that in `<file>`.
-    If `<file>` is `-`, reads from stdin.
-
 ```{.include}
 ./include/environment-options.md
 ./include/general-options.md

--- a/cli/flox/doc/include/experimental-warning.md
+++ b/cli/flox/doc/include/experimental-warning.md
@@ -1,0 +1,2 @@
+> **Warning:**
+> This command is **experimental** and its behaviour is subject to change

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -375,7 +375,12 @@ enum SharingCommands {
     #[bpaf(command, footer("Run 'man flox-pull' for more details."))]
     Pull(#[bpaf(external(environment::pull))] environment::Pull),
     /// Containerize an environment
-    #[bpaf(command, hide, footer("Run 'man flox-containerize' for more details."))]
+    #[bpaf(
+        command,
+        hide,
+        footer("Run 'man flox-containerize' for more details."),
+        header("This command is experimental and its behaviour is subject to change")
+    )]
     Containerize(#[bpaf(external(environment::containerize))] environment::Containerize),
 }
 impl SharingCommands {


### PR DESCRIPTION
Small fixes to the manpages
* docs(containerize): fill out manpage sections
* docs(containerize): add experimental command warning
* docs(edit): remove duplicate `-f` option
* docs(delete): remove `-r` option
* docs(delete): add crossref to `flox-init(1)`