### PR TITLE
ci: add pkgdb lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         ref: ${{ github.event.merge_group.head_ref || github.ref }}
         filters: |
           pkgdb:
-            - ".github/workflows/**"
+            - ".github/workflows/ci.yml"
             - "pkgdb/**"
             - "pkgs/**"
             - "Justfile"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     # For pull requests it's not necessary to checkout the code
     - uses: "actions/checkout@v4"
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.event.merge_group.base_ref || 'main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   merge_group:
 
 concurrency:
-  group: "ci-${{ github.event.pull_request.event.number || github.sha }}"
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -145,6 +145,22 @@ jobs:
           rm script.bash;
           exit "$TIDY_STATUS";
 
+      - name: 'Report'
+        if: always()
+        run: |
+          if [[ -s targets ]]; then
+            if [[ "${TIDY_STATUS?}" = 0 ]]; then
+              echo ":white_check_mark: PASS: linter has no recommendations"  \
+                >> "$GITHUB_STEP_SUMMARY";
+            else
+              echo ":x: FAIL: linter recommends changes"  \
+                >> "$GITHUB_STEP_SUMMARY";
+            fi
+          else
+            echo ":white_check_mark: PASS: no files were linted"  \
+              >> "$GITHUB_STEP_SUMMARY";
+          fi
+
 
 # ---------------------------------------------------------------------------- #
 #

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@
 #
 # ---------------------------------------------------------------------------- #
 
-name: 'Lint'
+name: 'Pkgdb Lint'
 on:
   # No need to run on `main` since we have `pull_request'.
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-      - uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v3'
 
       # Create a list of target files.
       # If the workflow was triggered by a PR, only check changed files.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ on:
         type: boolean
   pull_request:
     paths:
+      - '.github/workflows/lint.yml'
       - 'pkgdb/src/**'
       - 'pkgdb/include/**'
       - 'pkgdb/test/**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,137 @@
+# ============================================================================ #
+#
+# Run `clang-tidy' over the codebase and report warnings as annotations.
+#
+# ---------------------------------------------------------------------------- #
+
+name: 'Lint'
+on:
+  # No need to run on `main` since we have `pull_request'.
+  workflow_dispatch:
+    inputs:
+      all:
+        description: 'Check all files even if they are unchanged'
+        required: false
+        type: boolean
+  pull_request:
+    paths:
+      - 'pkgdb/src/**'
+      - 'pkgdb/include/**'
+      - 'pkgdb/test/**'
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
+jobs:
+  lint-clang-tidy:
+    name: 'Clang Tidy'
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: 'Checkout'
+      - uses: 'actions/checkout@v3'
+
+      # Create a list of target files.
+      # If the workflow was triggered by a PR, only check changed files.
+      # If the workflow was triggered explicitly then we _might_ be
+      # explicitly asked to check all files using an input param.
+      - name: 'Create Target List ( PR )'
+        if: ${{ github.event.pull_request }}
+        run: |
+          git fetch origin main;
+          echo "Checking changed sources" >&2;
+          ./pkgdb/build-aux/changed-sources > targets;
+
+      - name: 'Create Target List ( Dispatch )'
+        if: ${{ !github.event.pull_request }}
+        run: |
+          echo "all: ${{ inputs.all }}" >&2;
+          if [[ '${{ inputs.all }}' = true ]]; then
+            echo "Checking all sources" >&2;
+            # Keep this list aligned with `build-aux/changed-sources'
+            find pkgdb/include pkgdb/src pkgdb/test  \
+                 -name '*.cpp' -o                    \
+                 -name '*.hpp' -o                    \
+                 -name '*.hxx' -o                    \
+                 -name '*.cxx' -o                    \
+                 -name '*.cc'  -o                    \
+                 -name '*.hh'  -o                    \
+                 -name '*.c'   -o                    \
+                 -name '*.h'   -o                    \
+                 -name '*.ipp'                       \
+                 -print > targets;
+          else
+            git fetch origin main;
+            echo "Checking changed sources" >&2;
+            ./pkgdb/build-aux/changed-sources > targets;
+          fi
+
+      # TODO: If target list is empty, terminate workflow here
+      - name: 'Setup Nix'
+        uses: './.github/actions/common-setup'
+        with:
+          GITHUB_ACCESS_TOKEN:    "${{ secrets.NIX_GIT_TOKEN }}"
+          SUBSTITUTER:            "${{ vars.FLOX_CACHE_PUBLIC_BUCKET }}"
+          SUBSTITUTER_KEY:        "${{ secrets.FLOX_CACHE_PUBLIC_NIX_SECRET_KEY }}"
+          AWS_ACCESS_KEY_ID:      "${{ secrets.FLOX_CACHE_PUBLIC_AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY:  "${{ secrets.FLOX_CACHE_PUBLIC_AWS_SECRET_ACCESS_KEY }}"
+          SSH_KEY:                "${{ secrets.FLOXBOT_SSH_KEY }}"
+
+      - name: 'Create compile_commands.json'
+        run: |
+          nix develop -L --no-update-lock-file --command make -C pkgdb -j8 cdb;
+
+      - name: 'Create Tidy Log'
+        run: |
+          cat <<'EOF' > script.bash
+            status=0;
+
+            # Convert some characters to hex to escape them for annotations.
+            ghEscape() {
+              sed -e 's/%/%25/g' -e 's/:/%0A/g' -e 's/,/%2C/g' "${1:--}";
+            }
+
+            formatLint() {
+              local _file _kind _line _col _title _body;
+              _file="$( jq -r '.file' "$1"; )";
+              _kind="$( jq -r '.kind' "$1"; )";
+              _line="$( jq -r '.line' "$1"; )";
+              _col="$( jq -r '.column' "$1"; )";
+              _title="$( jq -r '.title' "$1"|ghEscape; )";
+              _body="$( jq -r '.body|join( "%0A" )' "$1"|ghEscape; )";
+              printf '::%s file=%s,line=%s,col=%s,title=%s::%s\n'     \
+                     "$_kind" "$_file" "$_line" "$_column" "$_title"  \
+                     "$_body";
+            }
+
+            while IFS='' read -r src; do
+              echo "clang-tidy is checking file \`$src'" >&2;
+              sh -c 'clang-tidy "$src"||printf ERROR;' > tidy.log;
+              if [[ "$( < tidy.log )" = ERROR ]]; then
+                status=1;
+                printf '::error file=%s,title=clang-tidy Error::%s\n'  \
+                       "$src" "Failed to process file \`$src'";
+              elif [[ "$( wc -l ./tidy.log|cut -d' ' -f1; )" -gt 0 ]]; then
+                while IFS='' read -r line; do
+                  formatLint "$line";
+                done < tidy.log
+              else
+                echo "clang-tidy generated no suggestions for file \`$src'" >&2;
+              fi
+              rm -f ./tidy.log;
+            done < ./targets
+            exit "$status";
+          EOF
+          nix develop -L --no-update-lock-file --command bash ./script.bash;
+          TIDY_STATUS="$?";
+          echo "TIDY_STATUS=$TIDY_STATUS" >> "$GITHUB_ENV";
+          rm script.bash;
+          exit "$TIDY_STATUS";
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - name: 'Create Target List ( PR )'
         if: ${{ github.event.pull_request }}
         run: |
-          git fetch origin main;
+          git fetch origin '${{ github.base_ref }}';
           echo "Checking changed sources" >&2;
           ./pkgdb/build-aux/changed-sources.sh > targets;
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,7 @@ jobs:
                  -name '*.ipp'                       \
                  -print > targets;
           else
-            git fetch origin main;
+            git fetch origin '${{ github.base_ref }}';
             echo "Checking changed sources" >&2;
             ./pkgdb/build-aux/changed-sources.sh > targets;
           fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,8 +68,18 @@ jobs:
             ./pkgdb/build-aux/changed-sources.sh > targets;
           fi
 
+      - name: 'Detect Empty Target List'
+        id: set-has-targets
+        run: |
+          if [[ -s targets ]]; then
+            echo 'HAS_TARGETS=' >> "$GITHUB_OUTPUT";
+          else
+            echo 'HAS_TARGETS=true' >> "$GITHUB_OUTPUT";
+          fi
+
       # TODO: If target list is empty, terminate workflow here
       - name: 'Setup Nix'
+        if: ${{ steps.set-has-targets.outputs.HAS_TARGETS }}
         uses: './.github/actions/common-setup'
         with:
           GITHUB_ACCESS_TOKEN:    "${{ secrets.NIX_GIT_TOKEN }}"
@@ -80,10 +90,12 @@ jobs:
           SSH_KEY:                "${{ secrets.FLOXBOT_SSH_KEY }}"
 
       - name: 'Create compile_commands.json'
+        if: ${{ steps.set-has-targets.outputs.HAS_TARGETS }}
         run: |
           nix develop -L --no-update-lock-file --command make -C pkgdb -j8 cdb;
 
       - name: 'Create Tidy Log'
+        if: ${{ steps.set-has-targets.outputs.HAS_TARGETS }}
         run: |
           cat <<'EOF' > script.bash
             status=0;

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git fetch origin main;
           echo "Checking changed sources" >&2;
-          ./pkgdb/build-aux/changed-sources > targets;
+          ./pkgdb/build-aux/changed-sources.sh > targets;
 
       - name: 'Create Target List ( Dispatch )'
         if: ${{ !github.event.pull_request }}
@@ -65,7 +65,7 @@ jobs:
           else
             git fetch origin main;
             echo "Checking changed sources" >&2;
-            ./pkgdb/build-aux/changed-sources > targets;
+            ./pkgdb/build-aux/changed-sources.sh > targets;
           fi
 
       # TODO: If target list is empty, terminate workflow here

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v4'
 
       # Create a list of target files.
       # If the workflow was triggered by a PR, only check changed files.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,9 +72,12 @@ jobs:
         id: set-has-targets
         run: |
           if [[ -s targets ]]; then
-            echo 'HAS_TARGETS=' >> "$GITHUB_OUTPUT";
-          else
             echo 'HAS_TARGETS=true' >> "$GITHUB_OUTPUT";
+            _changed="$( wc -l targets|cut -d' ' -f1; )";
+            echo "$_changed files require linting!" >> "$GITHUB_STEP_SUMMARY";
+          else
+            echo 'HAS_TARGETS=' >> "$GITHUB_OUTPUT";
+            echo "No files require linting!" >> "$GITHUB_STEP_SUMMARY";
           fi
 
       # TODO: If target list is empty, terminate workflow here


### PR DESCRIPTION
Restores GitHub Action from original `pkgdb` repository which runs
`clang-tidy` ( a lint checker ) and converts it output into GitHub suggestions.

This PR also causes existing CI workflows to cancel in progress runs if another
PR for the same _ref_ is pushed.
This should hopefully reduce CI spend.
