### PR TITLE
docs: fix header depth in manifest page

### DIFF
--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -59,8 +59,23 @@ pkg-path = "python310Packages.pip"
 Flox will use the first format by default when automatically editing
 the manifest.
 
-```{.include}
-./include/package-names.md
+### Package names
+
+<!-- Copied from package-names.md because it has the wrong header depth -->
+
+Packages are organized in a hierarchical structure such that certain packages
+are found at the top level (e.g. `ripgrep`),
+and other packages are found under package sets (e.g. `python310Packages.pip`).
+We call this location within the catalog the "pkg-path".
+
+The pkg-path is searched when you execute a `flox search` command.
+The pkg-path is what's shown by `flox show`.
+Finally, the pkg-path appears in your manifest after a `flox install`.
+
+```toml
+[install]
+ripgrep.pkg-path = "ripgrep"
+pip.pkg-path = "python310Packages.pip"
 ```
 
 ### Package descriptors


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Fixes the header depth for the "Package names" section of the `manifest.toml.md` man page. The include has a `##` header, which breaks the outline of this particular man page.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
