### PR TITLE
feat: do not prompt if current active environment's name is `default`

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -290,6 +290,20 @@ impl EnvironmentPointer {
 
         serde_json::from_slice(&pointer_contents).map_err(EnvironmentError2::ParseEnvJson)
     }
+
+    pub fn name(&self) -> &EnvironmentName {
+        match self {
+            EnvironmentPointer::Managed(pointer) => &pointer.name,
+            EnvironmentPointer::Path(pointer) => &pointer.name,
+        }
+    }
+
+    pub fn owner(&self) -> Option<&EnvironmentOwner> {
+        match self {
+            EnvironmentPointer::Managed(pointer) => Some(&pointer.owner),
+            EnvironmentPointer::Path(_) => None,
+        }
+    }
 }
 
 /// Represents a `.flox` directory that contains an `env.json`.

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -13,7 +13,7 @@ use std::{env, vec};
 use anyhow::{anyhow, bail, Context, Result};
 use bpaf::Bpaf;
 use crossterm::tty::IsTty;
-use flox_rust_sdk::flox::{EnvironmentName, EnvironmentOwner, EnvironmentRef, Flox};
+use flox_rust_sdk::flox::{EnvironmentName, EnvironmentOwner, EnvironmentRef, Flox, DEFAULT_NAME};
 use flox_rust_sdk::models::environment::managed_environment::{
     ManagedEnvironment,
     ManagedEnvironmentError,
@@ -897,7 +897,7 @@ impl Init {
         let env_name = if let Some(name) = self.env_name {
             EnvironmentName::from_str(&name)?
         } else if dir == home_dir {
-            EnvironmentName::from_str("default")?
+            EnvironmentName::from_str(DEFAULT_NAME)?
         } else {
             let name = dir
                 .file_name()

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -656,6 +656,13 @@ pub fn detect_environment(
             Some(ref activated @ UninitializedEnvironment::DotFlox(DotFlox { ref path, .. })),
             Some(found),
         ) if path == &found.path => Some(activated.clone()),
+
+        // If both a 'default' environment is activated and an environment is
+        // found in the current directory or git repo, prefer the detected one.
+        (Some(activated), Some(detected)) if activated.pointer().name().as_ref() == "default" => {
+            Some(UninitializedEnvironment::DotFlox(detected))
+        },
+
         // If there's both an activated environment and an environment in the
         // current directory or git repo, prompt for which to use.
         (Some(activated_env), Some(found)) => {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -810,6 +810,15 @@ impl UninitializedEnvironment {
             },
         }
     }
+
+    fn pointer(&self) -> EnvironmentPointer {
+        match self {
+            UninitializedEnvironment::DotFlox(DotFlox { pointer, .. }) => pointer.clone(),
+            UninitializedEnvironment::Remote(pointer) => {
+                EnvironmentPointer::Managed(pointer.clone())
+            },
+        }
+    }
 }
 
 impl Display for UninitializedEnvironment {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -11,7 +11,14 @@ use std::{env, fmt, fs, mem};
 
 use anyhow::{bail, Context, Result};
 use bpaf::{Args, Bpaf, ParseFailure, Parser};
-use flox_rust_sdk::flox::{EnvironmentRef, Flox, Floxhub, DEFAULT_FLOXHUB_URL, FLOX_VERSION};
+use flox_rust_sdk::flox::{
+    EnvironmentRef,
+    Flox,
+    Floxhub,
+    DEFAULT_FLOXHUB_URL,
+    DEFAULT_NAME,
+    FLOX_VERSION,
+};
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
 use flox_rust_sdk::models::environment::path_environment::PathEnvironment;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
@@ -659,7 +666,9 @@ pub fn detect_environment(
 
         // If both a 'default' environment is activated and an environment is
         // found in the current directory or git repo, prefer the detected one.
-        (Some(activated), Some(detected)) if activated.pointer().name().as_ref() == "default" => {
+        (Some(activated), Some(detected))
+            if activated.pointer().name().as_ref() == DEFAULT_NAME =>
+        {
             Some(UninitializedEnvironment::DotFlox(detected))
         },
 

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -464,3 +464,30 @@ env_is_activated() {
   assert_success
   assert_line "PIP_CONFIG_FILE is /some/other/pip.ini"
 }
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate:flox-uses-default-env
+@test "'flox *' uses local environment over 'default' environment" {
+  $FLOX_BIN delete
+
+  mkdir default
+  pushd default > /dev/null || return
+  "$FLOX_BIN" init
+  "$FLOX_BIN" install vim
+  popd > /dev/null || return
+
+  "$FLOX_BIN" init
+  "$FLOX_BIN" install emacs
+
+  # sanity check that flox list lists the local environment
+  run -- "$FLOX_BIN" list -n
+  assert_success
+  assert_line "emacs"
+
+  # Run flox list within the default environment.
+  # Flox should choose the local environment over the default environment.
+  run -- "$FLOX_BIN" activate --dir default -- "$FLOX_BIN" list -n
+  assert_success
+  assert_line "emacs"
+}


### PR DESCRIPTION
When no explicit environment is provided using `-r` or `-d`
**and** the current the current active env is called `default`
**and** an environment is found in the parents of the current dir,

**then** perform flox operations _on the detected env_
**and** do not ask the user to chose.

In presence of another environment, a default environment can now only be modified by addressing it explicitly using `-d/-r`.

closes https://github.com/flox/flox/issues/833