### PR TITLE
Added FLOX_SHELL environment variable

### DIFF
--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -80,6 +80,14 @@ hook was defined.
 
 # ENVIRONMENT VARIABLES
 
+`$FLOX_SHELL`
+:  When launching an interactive sub-shell, Flox launches the shell specified in
+   `$FLOX_SHELL` if it is set.
+
+`$SHELL`
+:  When launching an interactive sub-shell, Flox launches the shell specified in
+   `$SHELL` if it is set and `$FLOX_SHELL` is not set.
+
 `$FLOX_PROMPT_ENVIRONMENTS`
 :   Contains a space-delimited list of the active environments,
     e.g. `owner1/foo owner2/bar local_env`.

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -414,7 +414,8 @@ impl ShellType {
     ///
     /// [1]: <https://github.com/flox/flox/blob/668a80a40ba19d50f8ca304ff351f4b27a886e21/flox-bash/lib/utils.sh#L1432>
     fn detect() -> Result<Self> {
-        let shell = env::var("FLOX_SHELL").unwrap_or(env::var("SHELL").context("SHELL must be set")?);
+        let shell =
+            env::var("FLOX_SHELL").unwrap_or(env::var("SHELL").context("SHELL must be set")?);
         let shell = Path::new(&shell);
         let shell = Self::try_from(shell)?;
         Ok(shell)

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -414,7 +414,7 @@ impl ShellType {
     ///
     /// [1]: <https://github.com/flox/flox/blob/668a80a40ba19d50f8ca304ff351f4b27a886e21/flox-bash/lib/utils.sh#L1432>
     fn detect() -> Result<Self> {
-        let shell = env::var("SHELL").context("SHELL must be set")?;
+        let shell = env::var("FLOX_SHELL").unwrap_or(env::var("SHELL").context("SHELL must be set")?);
         let shell = Path::new(&shell);
         let shell = Self::try_from(shell)?;
         Ok(shell)


### PR DESCRIPTION
* Added FLOX_SHELL so the end-user can control which shell `flox activate` launches. This allows end-users who don't use `zsh` or `bash` to call `flox activate` without having to first launch a supported shell.

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
I am a `nushell` user and I am trying out flox. This change allows me to set FLOX_SHELL to a `bash` or `zsh` binary so I can `activate` directly. The fall back is the original behavior of defaulting to the SHELL environment variable.

<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Support for end-users to set FLOX_SHELL to control which shell `flox activate` uses when setting up an environment.

<!-- Many thanks! -->
