### PR TITLE
fix: tolerate missing version field in packages of locked manifest

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1012,7 +1012,7 @@ impl List {
                 "{id}: {path} ({version})",
                 id = p.name,
                 path = p.rel_path,
-                version = p.info.version
+                version = p.info.version.as_deref().unwrap_or("N/A")
             )
         });
     }
@@ -1046,6 +1046,7 @@ impl List {
                 ",
                 description = description.as_deref().unwrap_or("N/A"),
                 license = license.as_deref().unwrap_or("N/A"),
+                version = version.as_deref().unwrap_or("N/A"),
             };
 
             println!("{message}");

--- a/cli/tests/environment-list.bats
+++ b/cli/tests/environment-list.bats
@@ -122,3 +122,17 @@ EOF
   assert_success
   assert_output "hello"
 }
+
+# ---------------------------------------------------------------------------- #
+
+# https://github.com/flox/flox/issues/1039
+# bats test_tags=list,list:tolerates-missing-version
+@test "'flox list' tolerates missing version" {
+  "$FLOX_BIN" init
+  # `influxdb does not have a version attribute set in nixpkgs (2024-02-19)
+  # todo: replace with a more predicatable/smaller example
+  "$FLOX_BIN" install influxdb2
+  run "$FLOX_BIN" list
+  assert_success
+  assert_output "influxdb2: influxdb2 (N/A)"
+}


### PR DESCRIPTION
* Make `PackageInfo.version` an `Optional<String>`
* Write missing version as `N/A` in `flox list` impls
* Add a test to catch regressions

fixes #https://github.com/flox/flox/issues/1039