### PR TITLE
feat: detect same commit on project and sync branch

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1592,7 +1592,7 @@ impl Pull {
 
                 Self::pull_new_environment(&flox, dir.join(DOT_FLOX), remote, self.force, &start)?;
 
-                message::updated(complete);
+                message::created(complete);
             },
             PullSelect::Existing {} => {
                 let dir = self.dir.unwrap_or_else(|| std::env::current_dir().unwrap());
@@ -1614,7 +1614,7 @@ impl Pull {
                     floxhub_host = flox.floxhub.base_url()
                 );
 
-                Dialog {
+                let result = Dialog {
                     message: &start_message,
                     help_message: None,
                     typed: Spinner::new(|| {
@@ -1628,17 +1628,24 @@ impl Pull {
                 }
                 .spin()?;
 
-                let complete_message = formatdoc! {"
-                    Pulled {owner}/{name} from {floxhub_host}{suffix}
+                match result {
+                    PullResult::Updated => {
+                        message::updated(formatdoc! {"
+                            Pulled {owner}/{name} from {floxhub_host}{suffix}
 
-                    You can activate this environment with 'flox activate'
-                    ",
-                    owner = pointer.owner, name = pointer.name,
-                    floxhub_host = flox.floxhub.base_url(),
-                    suffix = if self.force { " (forced)" } else { "" }
-                };
-
-                message::created(complete_message);
+                            You can activate this environment with 'flox activate'
+                            ",
+                            owner = pointer.owner, name = pointer.name,
+                            floxhub_host = flox.floxhub.base_url(),
+                            suffix = if self.force { " (forced)" } else { "" }
+                        });
+                    },
+                    PullResult::UpToDate => {
+                        message::warning(formatdoc! {"
+                            {owner}/{name} is already up to date.
+                        ", owner = pointer.owner, name = pointer.name});
+                    },
+                }
             },
         }
 
@@ -1654,13 +1661,14 @@ impl Pull {
         dot_flox_path: PathBuf,
         pointer: ManagedPointer,
         force: bool,
-    ) -> Result<()> {
-        let mut env = ManagedEnvironment::open(flox, pointer, dot_flox_path)
-            .context("Could not open environment")?;
-        env.pull(force)?; //.context("Could not pull environment")?;
-        env.build(flox)?; //.context("Could not build environment")?;
-
-        Ok(())
+    ) -> Result<PullResult, EnvironmentError2> {
+        let mut env = ManagedEnvironment::open(flox, pointer, dot_flox_path)?;
+        let state = env.pull(force)?;
+        // only build if the environment was updated
+        if let PullResult::Updated = state {
+            env.build(flox)?;
+        }
+        Ok(state)
     }
 
     /// Pull a new environment from floxhub into the given directory

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -17,6 +17,7 @@ use flox_rust_sdk::flox::{EnvironmentName, EnvironmentOwner, EnvironmentRef, Flo
 use flox_rust_sdk::models::environment::managed_environment::{
     ManagedEnvironment,
     ManagedEnvironmentError,
+    PullResult,
 };
 use flox_rust_sdk::models::environment::path_environment::{self, PathEnvironment};
 use flox_rust_sdk::models::environment::{

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -457,3 +457,17 @@ function add_insecure_package() {
   run "$FLOX_BIN" list
   assert_success
 }
+
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=pull:up-to-date
+# updating an up-to-date environment should return with an info message
+@test "pull up-to-date env returns info message" {
+  # pull a fresh environment
+  "$FLOX_BIN" pull --remote owner/name
+  # pull it again, and expect an info message
+  run "$FLOX_BIN" pull
+  assert_success
+  assert_line --partial "already up to date."
+}


### PR DESCRIPTION
`ManagedEnvironment::pull` will return `PullResult::UpToDate`
if both the project specific branch and it's upstream counterpart
are pointing at the same revision.