### PR TITLE
feat: expose flox auth status

### DIFF
--- a/cli/flox/doc/flox-auth.md
+++ b/cli/flox/doc/flox-auth.md
@@ -13,7 +13,7 @@ flox-auth - FloxHub authentication commands
 
 ```
 flox [<general-options>] auth
-     (login | logout)
+     (login | logout | status)
 ```
 
 # DESCRIPTION
@@ -22,7 +22,7 @@ Authenticate with FloxHub so that you can push and pull environments.
 
 # OPTIONS
 
-## login
+## `login`
 Logs in to FloxHub.
 
 Required to interact with environments on FloxHub via `flox push`,
@@ -34,9 +34,13 @@ If called interactively it can open the browser for you if you press `<enter>`.
 
 See also:
 [`flox-push(1)`](./flox-push.md),
-[`flox-pull(1)`](./flox-pull.md), 
+[`flox-pull(1)`](./flox-pull.md),
 [`flox-activate(1)`](./flox-activate.md)
 
-## logout
+## `logout`
 
 Logs out from FloxHub.
+
+## `status`
+
+Print your current login status

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -178,7 +178,7 @@ pub enum Auth {
     #[bpaf(command)]
     Logout,
 
-    /// Get current username
+    /// Print your current login status
     #[bpaf(command)]
     Status,
 }
@@ -209,7 +209,7 @@ impl Auth {
             },
             Auth::Status => {
                 let Some(token) = flox.floxhub_token else {
-                    message::warning("You are not currently logged in to FloxHub");
+                    message::warning("You are not currently logged in to FloxHub.");
                     return Ok(());
                 };
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -179,8 +179,8 @@ pub enum Auth {
     Logout,
 
     /// Get current username
-    #[bpaf(command, hide)]
-    User,
+    #[bpaf(command)]
+    Status,
 }
 
 impl Auth {
@@ -207,10 +207,19 @@ impl Auth {
 
                 Ok(())
             },
-            Auth::User => {
-                let token = config.flox.floxhub_token.context("You are not logged in")?;
+            Auth::Status => {
+                let Some(token) = flox.floxhub_token else {
+                    message::warning("You are not currently logged in to FloxHub");
+                    return Ok(());
+                };
+
                 let handle = token.handle().context("Could not get user details")?;
-                println!("{handle}");
+
+                message::plain(format!(
+                    "You are logged in as {handle} on {}",
+                    flox.floxhub.base_url()
+                ));
+
                 Ok(())
             },
         }


### PR DESCRIPTION
Provides a `flox auth status` command that tells you whether you're logged in to FloxHub or not.
Largely based on the hidden `user` subcommand which got renamed and documented in this PR.