### PR TITLE
fix: do not copy user config into test suite

### DIFF
--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -304,17 +304,10 @@ xdg_tmp_setup() {
 
   mkdir -p "${XDG_CONFIG_HOME:?}"
   chmod u+w "$XDG_CONFIG_HOME"
-
-  if [[ -e "${REAL_XDG_CONFIG_HOME:?}/nix" && "$REAL_XDG_CONFIG_HOME" != "$XDG_CONFIG_HOME" ]]; then
-    rm -rf "$XDG_CONFIG_HOME/nix"
-    cp -Tr -- "$REAL_XDG_CONFIG_HOME/nix" "$XDG_CONFIG_HOME/nix"
-    chmod -R u+w "$XDG_CONFIG_HOME/nix"
-  fi
-  if [[ -e "${REAL_XDG_CONFIG_HOME}/flox" && "$REAL_XDG_CONFIG_HOME" != "$XDG_CONFIG_HOME" ]]; then
-    rm -rf "$XDG_CONFIG_HOME/flox"
-    cp -Tr -- "$REAL_XDG_CONFIG_HOME/flox" "$XDG_CONFIG_HOME/flox"
-    chmod -R u+w "$XDG_CONFIG_HOME/flox"
-  fi
+  mkdir -p "$XDG_DATA_HOME/nix"
+  chmod u+w "$XDG_DATA_HOME/nix"
+  mkdir -p "$XDG_DATA_HOME/flox"
+  chmod u+w "$XDG_DATA_HOME/flox"
 
   # Data Dirs
 


### PR DESCRIPTION
When setting up the test suite, we used to _copy_ the user's nix and flox config into the otherwise isolated managed test suite.
The commentary on the containing function suggests that _caches_ are copied for efficiency.
In the absence of compelling reason to impurely use user config files in the test suite, this removes the section that copies flox and nix config dirs and replaces it with `mkdir -p`.
