### PR TITLE
chore: checkout branch from fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: "Setup"
         uses: "./.github/actions/common-setup"
@@ -121,6 +122,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: "Setup"
         uses: "./.github/actions/common-setup"
@@ -181,6 +183,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: "Setup"
         uses: "./.github/actions/common-setup"
@@ -311,6 +314,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: "Setup"
         uses: "./.github/actions/common-setup"


### PR DESCRIPTION
Set repository to the fork when running the checkout step. This allows running CI against external forks.