### PR TITLE
test: share common home (caches, etc) between tests

### DIFF
--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -2,7 +2,9 @@
 # -*- mode: bats; -*-
 # ============================================================================ #
 #
-# Test rust impl of `flox install`
+# Test the managed environment feature of flox.
+# * Tests whether flox commands work as expected in a managed environment
+# * Tests conversion of a local environments to managed environments
 #
 # ---------------------------------------------------------------------------- #
 
@@ -37,7 +39,6 @@ project_teardown() {
 setup() {
   common_test_setup
   project_setup
-  home_setup test
   floxhub_setup "$OWNER"
 }
 
@@ -280,6 +281,11 @@ EOF
 
 # bats test_tags=managed,delete,managed:delete
 @test "m10: deletes existing environment" {
+  # This test asserts before and after state of the home directory.
+  # Remaining state from other tests may cause this test misbehave.
+  # Hence, use a clean home directory, for this test rather than the shared one.
+  home_setup test
+
   make_empty_remote_env
 
   run dot_flox_exists

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -29,7 +29,6 @@ project_teardown() {
 # ---------------------------------------------------------------------------- #
 
 setup() {
-  home_setup test
   common_test_setup
   project_setup
   floxhub_setup "owner"

--- a/cli/tests/environment-push.bats
+++ b/cli/tests/environment-push.bats
@@ -29,7 +29,6 @@ project_teardown() {
 # ---------------------------------------------------------------------------- #
 
 setup() {
-  home_setup test
   common_test_setup
   project_setup
 

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -42,7 +42,6 @@ setup() {
   common_test_setup
   project_setup
   floxhub_setup owner
-  home_setup test
 }
 
 teardown() {


### PR DESCRIPTION
Diverse test files were setting up isolated home dirs for _all_ contained tests
using `home_setup test`.
While this provides better isolation between tests
it also increases the test runtime as caches have to be regenerated for every test.
By sharing a common home_dir between all (most) tests,
we can speed up the affected test files by approx. 25%.
In total that should accumulate to 1 tot 2  minutes total time saved per run of the test suite.