### PR TITLE
feat: record which packages caused a failed install attempt

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1207,6 +1207,11 @@ impl Install {
     ) -> anyhow::Error {
         debug!("install error: {:?}", err);
 
+        subcommand_metric!(
+            "install",
+            "failed_packages" = packages.iter().map(|p| p.pkg_path.clone()).join(",")
+        );
+
         match err {
             // Try to make suggestions when a package isn't found
             EnvironmentError2::Core(CoreEnvironmentError::LockedManifest(

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -32,7 +32,7 @@ pub const METRICS_EVENTS_API_KEY: &str = env!("METRICS_EVENTS_API_KEY");
 /// We set the target to `flox_command` so that we can filter for these exact events.
 #[macro_export]
 macro_rules! subcommand_metric {
-    ($arg:tt $(, $key:ident = $value:expr)*) => {{
+    ($arg:tt $(, $key:tt = $value:expr)*) => {{
         tracing::trace!(target: "flox_command", subcommand = $arg $(, $key = $value)*);
     }};
 }


### PR DESCRIPTION
Records a telemetry message with the extra field `failed_packages`: "p1,...,pN"`, where `p1,...,pN` is a comma separated list of the packages supplied to the cli.

closes #950 
