### PR TITLE
feat: use available memory to improve scrape perfomance

### DIFF
--- a/pkgdb/include/flox/core/util.hh
+++ b/pkgdb/include/flox/core/util.hh
@@ -444,6 +444,9 @@ merge_vectors( const std::vector<T> & lower, const std::vector<T> & higher )
 [[nodiscard]] std::string
 displayableGlobbedPath( const AttrPathGlob & attrs );
 
+/** @brief Get available system memory in kb */
+[[nodiscard]] long
+getAvailableSystemMemory( void );
 
 /* -------------------------------------------------------------------------- */
 
@@ -493,6 +496,11 @@ concatStringsSep( const std::string_view sep, const Container & strings )
  * @brief Prints a log message to `stderr` when called with `--debug` or `-vvv`.
  */
 #define debugLog( msg ) printLog( nix::Verbosity::lvlDebug, msg )
+
+/**
+ * @brief Prints a log message to `stderr` when called with `--verbose` or `-v`.
+ */
+#define verboseLog( msg ) printLog( nix::Verbosity::lvlTalkative, msg )
 
 /** @brief Prints a log message to `stderr` at default verbosity. */
 #define infoLog( msg ) printLog( nix::Verbosity::lvlInfo, msg )

--- a/pkgdb/include/flox/flox-flake.hh
+++ b/pkgdb/include/flox/flox-flake.hh
@@ -137,6 +137,10 @@ FLOX_DEFINE_EXCEPTION( LockFlakeException,
 
 /* -------------------------------------------------------------------------- */
 
+void
+callInChildProcess( std::function<void()>  lambda,
+                    const std::exception & thrownOnError );
+
 /**
  * @brief Thin wrapper around nix::lockFlake to ensure any downloads happen in
  *        a child process.

--- a/pkgdb/include/flox/pkgdb/input.hh
+++ b/pkgdb/include/flox/pkgdb/input.hh
@@ -89,7 +89,6 @@ private:
   /** The name of the input, used to emit output with shortnames. */
   std::optional<std::string> name;
 
-
   /**
    * @brief Prepare database handles for use.
    *
@@ -116,6 +115,11 @@ public:
   struct db_path_tag
   {};
 
+  /** Heuristically determined limits for page size for scraping.  This affects
+   * memory usage.  See @a getScrapingPageSize()
+   */
+  static const size_t maxPageSize = 100 * 1000;
+  static const size_t minPageSize = 1 * 1000;
 
   /**
    * @brief Construct a @a PkgDbInput from a @a RegistryInput and a path to
@@ -228,13 +232,6 @@ public:
                       const size_t     pageIdx,
                       const size_t     pageSize );
 
-  /**
-   * @brief Helper to identify the pageSize to use for scraping.
-   * @return pageSize in items
-   */
-  int
-  getScrapingPageSize();
-
   /** @brief Add/set a shortname for this input. */
   void
   setName( std::string_view name )
@@ -263,6 +260,14 @@ public:
   {
     return this->name;
   }
+
+  /**
+   * @brief Helper to identify the pageSize to use for scraping.
+   * @return pageSize in items
+   */
+  static int
+  getScrapingPageSize();
+
 }; /* End struct `PkgDbInput' */
 
 

--- a/pkgdb/include/flox/pkgdb/input.hh
+++ b/pkgdb/include/flox/pkgdb/input.hh
@@ -228,6 +228,13 @@ public:
                       const size_t     pageIdx,
                       const size_t     pageSize );
 
+  /**
+   * @brief Helper to identify the pageSize to use for scraping.
+   * @return pageSize in items
+   */
+  int
+  getScrapingPageSize();
+
   /** @brief Add/set a shortname for this input. */
   void
   setName( std::string_view name )

--- a/pkgdb/src/registry.cc
+++ b/pkgdb/src/registry.cc
@@ -317,9 +317,6 @@ FloxFlakeInput::getSubtrees()
 RegistryInput
 FloxFlakeInput::getLockedInput()
 {
-  // auto getFlake = [&]() { auto unusedFlake = this->getFlake(); };
-
-  // callInChildProcess( getFlake, LockFlakeException( "testing only" ) );
   return { this->getSubtrees(), this->getFlake()->lockedFlake.flake.lockedRef };
 }
 

--- a/pkgdb/src/registry.cc
+++ b/pkgdb/src/registry.cc
@@ -317,7 +317,12 @@ FloxFlakeInput::getSubtrees()
 RegistryInput
 FloxFlakeInput::getLockedInput()
 {
+  auto getFlake = [&]() { auto unusedFlake = this->getFlake(); };
+
+  callInChildProcess( getFlake, LockFlakeException( "testing only" ) );
   return { this->getSubtrees(), this->getFlake()->lockedFlake.flake.lockedRef };
+  // return { this->getSubtrees(), this->getFlake()->lockedFlake.flake.lockedRef
+  // };
 }
 
 

--- a/pkgdb/src/registry.cc
+++ b/pkgdb/src/registry.cc
@@ -317,12 +317,10 @@ FloxFlakeInput::getSubtrees()
 RegistryInput
 FloxFlakeInput::getLockedInput()
 {
-  auto getFlake = [&]() { auto unusedFlake = this->getFlake(); };
+  // auto getFlake = [&]() { auto unusedFlake = this->getFlake(); };
 
-  callInChildProcess( getFlake, LockFlakeException( "testing only" ) );
+  // callInChildProcess( getFlake, LockFlakeException( "testing only" ) );
   return { this->getSubtrees(), this->getFlake()->lockedFlake.flake.lockedRef };
-  // return { this->getSubtrees(), this->getFlake()->lockedFlake.flake.lockedRef
-  // };
 }
 
 

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -367,6 +367,19 @@ getAvailableSystemMemory()
 {
   long availableKb;
 
+  // Check and use environment override
+  const char * envVar   = "FLOX_AVAILABLE_MEMORY";
+  const char * envValue = std::getenv( envVar );
+  if ( envValue != nullptr && isUInt( envValue ) )
+    {
+      size_t envOverride = atoi( envValue );
+      verboseLog( nix::fmt(
+        "getAvailableSystemMemory: using environment override of '%d'",
+        envOverride ) );
+      return envOverride;
+    }
+
+
 #ifdef __APPLE__
   int freePages     = getSysCtlValue<int>( "vm.page_free_count" );
   int reusablePages = getSysCtlValue<int>( "vm.page_reusable_count" );

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -18,6 +18,8 @@
 #include <string_view>
 #include <vector>
 
+#include <sys/sysinfo.h>
+
 #include <nlohmann/json.hpp>
 #include <sqlite3pp.hh>
 
@@ -341,7 +343,23 @@ displayableGlobbedPath( const flox::AttrPathGlob & attrs )
   return s;
 }
 
+long
+getAvailableSystemMemory()
+{
+  struct sysinfo memInfo;
+  sysinfo( &memInfo );
 
+  long long totalPhysMem = memInfo.totalram;
+  long long freePhysMem  = memInfo.freeram;
+  long long bufMem       = memInfo.bufferram;
+  long long sharedMem    = memInfo.sharedram;
+  // Multiply in next statement to avoid int overflow on right hand side...
+  totalPhysMem *= memInfo.mem_unit;
+  freePhysMem *= memInfo.mem_unit;
+  bufMem *= memInfo.mem_unit;
+  sharedMem *= memInfo.mem_unit;
+  return ( freePhysMem + bufMem + sharedMem ) / 1024;
+}
 /* -------------------------------------------------------------------------- */
 
 }  // namespace flox

--- a/pkgdb/tests/util.cc
+++ b/pkgdb/tests/util.cc
@@ -9,6 +9,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
 
 #include "flox/core/types.hh"
 #include "flox/core/util.hh"
@@ -251,6 +252,30 @@ test_trim_copy0()
   return true;
 }
 
+bool
+test_getAvailableMemory()
+{
+  const char * envVar              = "FLOX_AVAILABLE_MEMORY";
+  const char * existingMemOverride = getenv( envVar );
+
+  // Ensure there is no override in the current environment
+  setenv( envVar, "", 1 );
+  // Result is in Kb, should reasonably expect this to be
+  // >= 500mb and <= 128gb(?)
+  EXPECT( flox::getAvailableSystemMemory() > 500 * 1024 );
+  EXPECT( flox::getAvailableSystemMemory() < 128 * 1024 * 0124 );
+
+  // Test available memory override
+  auto memory = flox::getAvailableSystemMemory() / 2;
+  setenv( envVar, std::to_string( memory ).c_str(), 1 );
+  EXPECT_EQ( flox::getAvailableSystemMemory(), memory );
+
+  // Clear this out for the remainder of the process
+  if ( existingMemOverride ) { setenv( envVar, existingMemOverride, 1 ); }
+  else { unsetenv( envVar ); }
+  return true;
+}
+
 
 /* -------------------------------------------------------------------------- */
 
@@ -278,6 +303,8 @@ main()
   RUN_TEST( trim_copy0 );
 
   RUN_TEST( hasPrefix0 );
+
+  RUN_TEST( getAvailableMemory );
 
   return ec;
 }

--- a/pkgdb/tests/util.cc
+++ b/pkgdb/tests/util.cc
@@ -263,7 +263,7 @@ test_getAvailableMemory()
   // Result is in Kb, should reasonably expect this to be
   // >= 500mb and <= 128gb(?)
   EXPECT( flox::getAvailableSystemMemory() > 500 * 1024 );
-  EXPECT( flox::getAvailableSystemMemory() < 128 * 1024 * 0124 );
+  EXPECT( flox::getAvailableSystemMemory() < 128 * 1024 * 1024 );
 
   // Test available memory override
   auto memory = flox::getAvailableSystemMemory() / 2;

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -14,15 +14,17 @@
   cargoTomlLatest = (lib.importTOML "${inputs.flox-latest}/cli/flox/Cargo.toml").package.version or "dirty";
   revCountDiff = self.revCount - inputs.flox-latest.revCount;
   version =
-    if !(self ? revCount || self ? shortRev) then # path://$PWD
+    if !(self ? revCount || self ? shortRev)
+    then # path://$PWD
       "${cargoToml}-dirty"
-    else if !(self ? revCount) then # github:flox/flox
+    else if !(self ? revCount)
+    then # github:flox/flox
       "${cargoToml}-g${self.shortRev}"
-    else if revCountDiff == 0 then # for release, only possible with overrides/follows
+    else if revCountDiff == 0
+    then # for release, only possible with overrides/follows
       "${cargoToml}"
     else # git+ssh://git@github.com/flox/flox
-      "${cargoTomlLatest}-${builtins.toString revCountDiff}-g${self.shortRev}"
-    ;
+      "${cargoTomlLatest}-${builtins.toString revCountDiff}-g${self.shortRev}";
 in
   symlinkJoin {
     name = "${flox-cli.pname}-${version}";


### PR DESCRIPTION
## Proposed Changes

Use available memory and observed heuristics to adjust the scraping page size.  This will allow scraping to work down to around 1.5G at the cost of 200% performance impact, but also reduce scrape time by ~15% if ~4G or more is available.

## Release Notes

Dynamically optimize memory / performance trade-off during scraping

<!-- Many thanks! -->
