### PR TITLE
feat: stream pkgdb stdout/stderr in order

### DIFF
--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -1,7 +1,9 @@
 use std::env;
 use std::fmt::Display;
-use std::process::Command;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
 
+use log::debug;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::Value;
@@ -62,20 +64,44 @@ pub enum CallPkgDbError {
     ParseJSON(#[source] serde_json::Error),
     #[error("call to pkgdb failed")]
     PkgDbCall(#[source] std::io::Error),
+    #[error("couldn't get pkgdb stdout")]
+    PkgDbStdout,
+    #[error("couldn't get pkgdb stderr")]
+    PkgDbStderr,
 }
 
 /// Call pkgdb and try to parse JSON or error JSON.
 ///
 /// Error JSON is parsed into a [CallPkgDbError::PkgDbError].
 pub fn call_pkgdb(mut pkgdb_cmd: Command) -> Result<Value, CallPkgDbError> {
-    let output = pkgdb_cmd.output().map_err(CallPkgDbError::PkgDbCall)?;
+    let mut proc = pkgdb_cmd
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(CallPkgDbError::PkgDbCall)?;
+    let stderr = proc.stderr.take();
+    let Some(stderr) = stderr else {
+        proc.kill().map_err(CallPkgDbError::PkgDbCall)?;
+        return Err(CallPkgDbError::PkgDbStderr);
+    };
+    let mut stderr_reader = BufReader::new(stderr);
+    let mut buffer = String::new();
+    while let Ok(bytes_read) = stderr_reader.read_line(&mut buffer) {
+        // Zero bytes read -> the command is finished
+        if bytes_read == 0 {
+            break;
+        }
+        debug!(target: "pkgdb", "{}", buffer.trim_end());
+        buffer.clear();
+    }
+    let output = proc.wait_with_output().map_err(CallPkgDbError::PkgDbCall)?;
     // If command fails, try to parse stdout as a PkgDbError
     if !output.status.success() {
         match serde_json::from_slice::<PkgDbError>(&output.stdout) {
             Ok(pkgdb_err) => Err(pkgdb_err)?,
             Err(e) => Err(CallPkgDbError::ParsePkgDbError(e))?,
         }
-    // If command succeeds, try to parse stdout as JSON value
+    // If the command succeeds, try to parse stdout as a JSON value
     } else {
         let json = serde_json::from_slice(&output.stdout).map_err(CallPkgDbError::ParseJSON)?;
         Ok(json)

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -102,6 +102,15 @@ pub enum Verbosity {
     Quiet,
 }
 
+impl Verbosity {
+    pub fn to_pkgdb_verbosity_level(&self) -> usize {
+        match self {
+            Verbosity::Quiet => 0,
+            Verbosity::Verbose(n) => *n,
+        }
+    }
+}
+
 impl Default for Verbosity {
     fn default() -> Self {
         Verbosity::Verbose(0)

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -60,7 +60,16 @@ async fn main() -> ExitCode {
             .run_inner(Args::current_args())
             .unwrap_or_default()
     };
-    init_logger(Some(verbosity));
+    // Pass down the verbosity level to all pkgdb calls
+    std::env::set_var(
+        "_FLOX_PKGDB_VERBOSITY",
+        format!("{}", verbosity.to_pkgdb_verbosity_level()),
+    );
+    init_logger(Some(verbosity.clone()));
+    debug!(
+        "set _FLOX_PKGDB_VERBOSITY={}",
+        verbosity.to_pkgdb_verbosity_level()
+    );
 
     // Run the argument parser
     //

--- a/cli/flox/src/utils/logger.rs
+++ b/cli/flox/src/utils/logger.rs
@@ -111,7 +111,7 @@ where
 
         let head = format!("{level_prefix} {time_prefix} {origin_prefix}").bold();
 
-        let message = format!("{head}:\n{message}");
+        let message = format!("{head}: {message}");
 
         writeln!(f, "{}", message)?;
 

--- a/pkgdb/src/main.cc
+++ b/pkgdb/src/main.cc
@@ -67,6 +67,24 @@ FLOX_DEFINE_EXCEPTION( NixException, EC_NIX, "caught a nix exception" )
 
 /* -------------------------------------------------------------------------- */
 
+void
+setVerbosityFromEnv()
+{
+  auto valueChars = std::getenv( "_FLOX_PKGDB_VERBOSITY" );
+  if ( valueChars == nullptr ) { return; }
+  std::string value( valueChars );
+  if ( value == std::string( "0" ) ) { nix::verbosity = nix::lvlError; }
+  else if ( value == std::string( "1" ) ) { nix::verbosity = nix::lvlInfo; }
+  else if ( value == std::string( "2" ) ) { nix::verbosity = nix::lvlDebug; }
+  else if ( value == std::string( "3" ) ) { nix::verbosity = nix::lvlChatty; }
+  else if ( value == std::string( "4" ) ) { nix::verbosity = nix::lvlVomit; }
+  // Put this at the end so that if we *want* logging it will show up
+  traceLog( "found _FLOX_PKGDB_VERBOSITY=" + value );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
 int
 run( int argc, char * argv[] )
 {
@@ -115,6 +133,9 @@ run( int argc, char * argv[] )
     {
       throw flox::command::InvalidArgException( err.what() );
     }
+
+  /* Set the verbosity level requested by flox */
+  setVerbosityFromEnv();
 
   /* Run subcommand */
   if ( prog.is_subcommand_used( "scrape" ) ) { return cmdScrape.run(); }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Sets an environment variable in `flox` to indicate to `pkgdb` which verbosity level to use. Also redirects `pkgdb` stderr through the `flox` logging machinery.

For calls to `pkgdb search` the stdout and stderr output is streamed using background threads and a channel to preserve the order of stdout/stderr while `pkgdb` prints search results to stdout. Preserving this order is essential for debugging. For all other calls to `pkgdb` we can take a simpler approach: streaming stderr and then collecting the data on stdout.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users passing at least two `-v` flags will now see more output.

<!-- Many thanks! -->
