### PR TITLE
fix: add helpers for lockFlake and getFlake

### DIFF
--- a/pkgdb/include/flox/flox-flake.hh
+++ b/pkgdb/include/flox/flox-flake.hh
@@ -138,26 +138,14 @@ FLOX_DEFINE_EXCEPTION( LockFlakeException,
 /* -------------------------------------------------------------------------- */
 
 /**
- * @brief Execute @param lambda in a child process setup for downloading
- *        files using `nix` fetchers.
+ * @brief Thin wrapper around nix::lockFlake to ensure any downloads happen in
+ *        a child process.
  *
- * Helper function to execute @param lambda in a child process in anticipation
- * of it triggering a download via nix.
- * If this occurs, the nix static global `nix::curlFileTransfer` object will
- * trigger a worker thread.
- * Later forks ( for scraping ) will then try to cleanup those threads but
- * will fail.
- * This keeps the thread creation and cleanup in the same child process.
- *
- * After calling this, the lambda should be called from the parent to actually
- * get the parent in the desired state, but the download will already be cached.
- *
- * There is room for optimization here for sure.
+ * When downloads occur, the nix static global `nix::curlFileTransfer` object
+ * will trigger a worker thread.  Later forks ( for scraping ) will then try to
+ * cleanup those threads but will fail.  Strictly using this wrapper for
+ * `lockFlake` keeps the thread creation and cleanup in the same child process.
  */
-// void
-// ensureFlakeIsDownloaded( std::function<void()> lambda );
-
-
 nix::flake::LockedFlake
 lockFlake( nix::EvalState &              state,
            const nix::FlakeRef &         flakeRef,

--- a/pkgdb/include/flox/flox-flake.hh
+++ b/pkgdb/include/flox/flox-flake.hh
@@ -13,6 +13,7 @@
 #include <memory>
 #include <nix/eval.hh>
 #include <nix/flake/flake.hh>
+#include <nix/flake/flakeref.hh>
 #include <sys/wait.h>
 #include <vector>
 
@@ -153,9 +154,14 @@ FLOX_DEFINE_EXCEPTION( LockFlakeException,
  *
  * There is room for optimization here for sure.
  */
-void
-ensureFlakeIsDownloaded( std::function<void()> lambda );
+// void
+// ensureFlakeIsDownloaded( std::function<void()> lambda );
 
+
+nix::flake::LockedFlake
+lockFlake( nix::EvalState &              state,
+           const nix::FlakeRef &         flakeRef,
+           const nix::flake::LockFlags & lockFlags );
 
 }  // namespace flox
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -449,14 +449,8 @@ createContainerBuilder( nix::EvalState &       state,
   static const nix::FlakeRef nixpkgsRef
     = nix::parseFlakeRef( COMMON_NIXPKGS_URL );
 
-  auto getFlake = [&]()
-  {
-    auto lockedNixpkgs
-      = nix::flake::lockFlake( state, nixpkgsRef, nix::flake::LockFlags() );
-  };
-  ensureFlakeIsDownloaded( getFlake );
   auto lockedNixpkgs
-    = nix::flake::lockFlake( state, nixpkgsRef, nix::flake::LockFlags() );
+    = flox::lockFlake( state, nixpkgsRef, nix::flake::LockFlags() );
 
   nix::Value vNixpkgsFlake {};
   nix::flake::callFlake( state, lockedNixpkgs, vNixpkgsFlake );

--- a/pkgdb/src/flox-flake.cc
+++ b/pkgdb/src/flox-flake.cc
@@ -97,7 +97,7 @@ lockFlake( nix::EvalState &              state,
 {
   auto nixLockFlake
     = [&]() { return nix::flake::lockFlake( state, flakeRef, lockFlags ); };
-  // Calling this in a child process will ensure and downloads are complete,
+  // Calling this in a child process will ensure downloads are complete,
   // keeping file transfers isolated to a child process.
   callInChildProcess( nixLockFlake,
                       LockFlakeException( "failed to lock flake" ) );

--- a/pkgdb/src/registry.cc
+++ b/pkgdb/src/registry.cc
@@ -317,17 +317,6 @@ FloxFlakeInput::getSubtrees()
 RegistryInput
 FloxFlakeInput::getLockedInput()
 {
-  /* `nix::getFlake` *may* result in a download internal to nix
-   * ( see `nix::curlFileTransfer` in nix code ) which is a static member
-   * function to enable connection sharing.
-   * Since we fork later in `scrape`, if we perform a download hear, when the
-   * child of the later fork exits, it tries to cleanup that file transfer
-   * object in the call to `exit()`.
-   * That dies exceptionally well since it's in a different process at
-   * that point.
-   * For now, we'll fork here to contain the downloads within a child, and
-   * hopefully avoid that situation. */
-
   return { this->getSubtrees(), this->getFlake()->lockedFlake.flake.lockedRef };
 }
 

--- a/pkgdb/src/registry.cc
+++ b/pkgdb/src/registry.cc
@@ -327,9 +327,7 @@ FloxFlakeInput::getLockedInput()
    * that point.
    * For now, we'll fork here to contain the downloads within a child, and
    * hopefully avoid that situation. */
-  auto getFlake = [&]() { auto unusedFlake = this->getFlake(); };
 
-  ensureFlakeIsDownloaded( getFlake );
   return { this->getSubtrees(), this->getFlake()->lockedFlake.flake.lockedRef };
 }
 


### PR DESCRIPTION
## Proposed Changes

Add wrappers around `lockFlake` and `getFlake` to ensure downloads of flakes occur in child processes.

## Release Notes

N/A