### PR TITLE
fix: code clean up and performance fixes

### DIFF
--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -254,6 +254,15 @@ public:
           std::size_t        pageSize,
           std::size_t        pageIdx );
 
+  void processAttrib ( nix::SymbolTable & syms,
+                              const flox::Cursor &      childCursor,
+                               const flox::AttrPath &    prefix,
+                               const flox::pkgdb::row_id parentId,
+                               const nix::Symbol &       aname,
+                               const bool inLegacyPackages,
+                               const bool tryRecur,
+                               Todos &                   todo);
+
 
 }; /* End class `PkgDb' */
 

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -258,11 +258,10 @@ public:
    * @brief Helper function for @a scrape to process a single attribute, adding
    * child attributes to the @a todo queue when appropriate to recurse.
    */
-  void processSingleAttrib ( const nix::SymbolTable & syms,
-                              const flox::Cursor &      parentCursor,
+  void processSingleAttrib ( const nix::SymbolStr & sym,
+                              const flox::Cursor &       cursor,
                                const flox::AttrPath &    prefix,
                                const flox::pkgdb::row_id parentId,
-                               const nix::Symbol &       aname,
                                const bool inLegacyPackages,
                                const bool tryRecur,
                                Todos &                   todo);

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -258,13 +258,13 @@ public:
    * @brief Helper function for @a scrape to process a single attribute, adding
    * child attributes to the @a todo queue when appropriate to recurse.
    */
-  void processSingleAttrib ( const nix::SymbolStr & sym,
-                              const flox::Cursor &       cursor,
-                               const flox::AttrPath &    prefix,
-                               const flox::pkgdb::row_id parentId,
-                               const bool inLegacyPackages,
-                               const bool tryRecur,
-                               Todos &                   todo);
+  void
+  processSingleAttrib( const nix::SymbolStr &    sym,
+                       const flox::Cursor &      cursor,
+                       const flox::AttrPath &    prefix,
+                       const flox::pkgdb::row_id parentId,
+                       const flox::subtree_type  subtree,
+                       Todos &                   todo );
 
 
 }; /* End class `PkgDb' */

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -254,8 +254,12 @@ public:
           std::size_t        pageSize,
           std::size_t        pageIdx );
 
-  void processAttrib ( nix::SymbolTable & syms,
-                              const flox::Cursor &      childCursor,
+  /**
+   * @brief Helper function for @a scrape to process a single attribute, adding
+   * child attributes to the @a todo queue when appropriate to recurse.
+   */
+  void processSingleAttrib ( const nix::SymbolTable & syms,
+                              const flox::Cursor &      parentCursor,
                                const flox::AttrPath &    prefix,
                                const flox::pkgdb::row_id parentId,
                                const nix::Symbol &       aname,

--- a/pkgdb/src/flox-flake.cc
+++ b/pkgdb/src/flox-flake.cc
@@ -45,7 +45,6 @@ callInChildProcess( std::function<void()>  lambda,
   pid_t pid = fork();
   if ( pid == -1 )
     {
-      // WML - TODO - better error handling here!
       errorLog( "callInChildProcess: failed to fork!" );
       exit( EXIT_FAILURE );
     }

--- a/pkgdb/src/pkgdb/write.cc
+++ b/pkgdb/src/pkgdb/write.cc
@@ -529,8 +529,7 @@ PkgDb::scrape( nix::SymbolTable & syms,
       if ( processAttrib( childCursor, prefix, parentId, aname, todo ) )
         {
           const auto [parentPrefix, _a, _b] = todo.top();
-          // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
-          do {
+          while ( ! todo.empty() ) {
               const auto [prefix, cursor, parentId] = todo.top();
               todo.pop();
 
@@ -541,7 +540,7 @@ PkgDb::scrape( nix::SymbolTable & syms,
                   processAttrib( childCursor, prefix, parentId, aname, todo );
                 }
             }
-          while ( ! todo.empty() );
+          
 
           this->setPrefixDone( parentPrefix, true );
         }


### PR DESCRIPTION
## Proposed Changes

- split apart the `scrape` function to address linting warnings
- parse the subtree type using the `subtree_type` enum and pass that around.  Since that is static for all children, it can be parsed once and the `enum` checked for various logic.  This also eliminates implied bools being passed around.
- general refactoring of code to limit passing complex values, and unnecessary code execution.

## Release Notes

N/A