### PR TITLE
fix: scrape performance on mac

### DIFF
--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -381,11 +381,20 @@ getAvailableSystemMemory()
 
 
 #ifdef __APPLE__
-  int freePages     = getSysCtlValue<int>( "vm.page_free_count" );
-  int reusablePages = getSysCtlValue<int>( "vm.page_reusable_count" );
-  int pageSize      = getSysCtlValue<int>( "vm.pagesize" );
-  availableKb       = ( freePages + reusablePages ) / 1024;
-  availableKb *= pageSize;
+  /* The following first attempt proved to be way too conservative
+   *
+   * int freePages     = getSysCtlValue<int>( "vm.page_free_count" );
+   * int reusablePages = getSysCtlValue<int>( "vm.page_reusable_count" );
+   * int pageSize      = getSysCtlValue<int>( "vm.pagesize" );
+   * availableKb       = ( freePages + reusablePages ) / 1024;
+   * availableKb *= pageSize;
+   */
+
+  long long physicalRAM = getSysCtlValue<int>( "hw.memsize" );
+  /* For now use 3/4ths of physical ram.
+   * Simplifed from ((physicalRAM / 1024) / 4) * 3
+   */
+  availableKb = ( physicalRAM / 4096 ) * 3;
 #else
   struct sysinfo memInfo;
   sysinfo( &memInfo );

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -390,7 +390,7 @@ getAvailableSystemMemory()
    * availableKb *= pageSize;
    */
 
-  long long physicalRAM = getSysCtlValue<int>( "hw.memsize" );
+  long long physicalRAM = getSysCtlValue<long long>( "hw.memsize" );
   /* For now use 3/4ths of physical ram.
    * Simplifed from ((physicalRAM / 1024) / 4) * 3
    */


### PR DESCRIPTION
## Proposed Changes

On mac, since we are unable to find a decent method of estimating _available_ memory, use 75% of physical RAM for now.  Currently on mac, it seems it's almost always using the bare minimum page size casing a 2x time penalty.

## Release Notes

- Addresses flake scraping performance on MacOS.
