### PR TITLE
feat: use custom fetcher to wrap nixpkgs of locked packages

### DIFF
--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -106,13 +106,15 @@ createFloxEnv( nix::EvalState &     state,
 /* -------------------------------------------------------------------------- */
 
 /**
- * @brief Create a @a nix::StorePath containing a realised environment.
- * @param pkgs A list of packages to be added to the environment.
- * @param state A `nix` evaluator.
- * @param references A set of indirect dependencies to be added to
- *                   the environment.
- * @param originalPackage A map of packages to be added to the environment.
- * @return A @a nix::StorePath with a realised environment.
+ * @brief Merge all components of the environment into a single store path.
+ * @param state Nix state.
+ * @param pkgs List of packages to include in the environment.
+ *             - outputs of packages declared in the environment manifest
+ *             - flox specific packages (activation scripts, profile.d, etc.)
+ * @param references Set of store paths that the environment depends on.
+ * @param originalPackage Map of store paths to the locked package definition
+ *                        that provided them.
+ * @return The combined store path of the environment.
  */
 const nix::StorePath &
 createEnvironmentStorePath(

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -31,12 +31,12 @@
 namespace flox::buildenv {
 
 /**
- * @class flox::buildenv::SystenNotSupportedByLockfile
+ * @class flox::buildenv::SystemNotSupportedByLockfile
  * @brief An exception thrown when a lockfile is is missing a package.<system>
  * entry fro the requested system.
  * @{
  */
-FLOX_DEFINE_EXCEPTION( SystenNotSupportedByLockfile,
+FLOX_DEFINE_EXCEPTION( SystemNotSupportedByLockfile,
                        EC_LOCKFILE_INCOMPATIBLE_SYSTEM,
                        "unsupported system" )
 /** @} */

--- a/pkgdb/include/flox/fetchers/wrapped-nixpkgs-input.hh
+++ b/pkgdb/include/flox/fetchers/wrapped-nixpkgs-input.hh
@@ -1,0 +1,24 @@
+/* ========================================================================== *
+ *
+ * @file flox/fetchers/wrapped-nixpkgs-input.hh
+ *
+ * @brief Executable command helpers, argument parsers, etc.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+#include <nix/fetchers.hh>
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox {
+
+/**
+ * @brief Helper used to convert a `github` attribute set representation,
+ *        to a `flox-nixpkgs` attribute set representation.
+ */
+nix::fetchers::Attrs
+githubAttrsToFloxNixpkgsAttrs( const nix::fetchers::Attrs & attrs );
+
+}  // namespace flox

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -27,6 +27,7 @@
 #include <nlohmann/json.hpp>
 
 #include "flox/buildenv/realise.hh"
+#include "flox/fetchers/wrapped-nixpkgs-input.hh"
 #include "flox/resolver/lockfile.hh"
 
 
@@ -262,7 +263,15 @@ getRealisedPackages( nix::EvalState &                   state,
   std::vector<std::pair<buildenv::RealisedPackage, nix::StorePath>> realised;
 
 
-  auto packageInputRef = nix::FlakeRef( package.input );
+  /**
+   * Ensure the input is fetched with `flox-nixpkgs`.
+   * Currently, the 'flox-nixpkgs' fetcher requires the original input to be
+   * a rev or ref of `github:nixos/nixpkgs`.
+   */
+  auto floxNixpkgsAttrs
+    = flox::githubAttrsToFloxNixpkgsAttrs( package.input.attrs );
+  auto packageInputRef = nix::FlakeRef::fromAttrs( floxNixpkgsAttrs );
+
   auto packageFlake
     = flox::lockFlake( state, packageInputRef, nix::flake::LockFlags {} );
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -212,8 +212,8 @@ createFloxEnv( nix::EvalState &     state,
   auto packages = lockfile.getLockfileRaw().packages.find( system );
   if ( packages == lockfile.getLockfileRaw().packages.end() )
     {
-      // TODO: throw structured exception
-      throw SystenNotSupportedByLockfile(
+      // Custom exception for non supported system
+      throw SystemNotSupportedByLockfile(
         "'" + system + "' not supported by this environment" );
     }
 
@@ -230,7 +230,6 @@ createFloxEnv( nix::EvalState &     state,
 
   /* Extract derivations */
   nix::StorePathSet                      references;
-  std::vector<nix::StorePathWithOutputs> drvsToBuild;
   std::vector<RealisedPackage>           pkgs;
   std::map<nix::StorePath, std::pair<std::string, resolver::LockedPackageRaw>>
     originalPackage;

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -321,15 +321,16 @@ WrappedNixpkgsInputScheme::inputFromAttrs(
   nix::fetchers::maybeGetStrAttr( attrs, "narHash" );
   nix::fetchers::maybeGetIntAttr( attrs, "version" );
 
-  /*  */
-  if ( auto ref = nix::fetchers::maybeGetStrAttr( attrs, "rev" ) )
+  /* Check the rev field if present */
+  if ( auto rev = nix::fetchers::maybeGetStrAttr( attrs, "rev" ) )
     {
-      if ( std::regex_search( *ref, nix::revRegex ) )
+      if ( ! std::regex_match( *rev, nix::revRegex ) )
         {
-          throw nix::BadURL( "invalid Git commit hash '%s'", *ref );
+          throw nix::BadURL( "invalid Git commit hash '%s'", *rev );
         }
     }
 
+  /* Check the ref field if present */
   if ( auto ref = nix::fetchers::maybeGetStrAttr( attrs, "ref" ) )
     {
       if ( std::regex_search( *ref, nix::badGitRefRegex ) )

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -66,6 +66,13 @@ setup_file() {
 # bats test_tags=unfree,unfree:fail
 @test "Environment with unfree packages fails to build by default" {
   run "$PKGDB_BIN" buildenv "$LOCKFILES/unfree/manifest.lock"
+  assert_failure
+  assert_output --partial "'hello' is marked as unfree"
+}
+
+# bats test_tags=unfree,unfree:success
+@test "Environment with unfree packages succeeds if allwed in options" {
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/unfree-allowed/manifest.lock"
   assert_success
 }
 

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -61,6 +61,16 @@ setup_file() {
   assert_success
 }
 
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=unfree,unfree:fail
+@test "Environment with unfree packages fails to build by default" {
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/unfree/manifest.lock"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------- #
+
 # bats test_tags=single,binaries
 @test "Built environment contains binaries" {
   run "$PKGDB_BIN" buildenv \

--- a/pkgdb/tests/data/buildenv/lockfiles/unfree-allowed/manifest.toml
+++ b/pkgdb/tests/data/buildenv/lockfiles/unfree-allowed/manifest.toml
@@ -1,0 +1,7 @@
+# Expected to succeed because `hello-unfree` has an unfree license
+# but `options.allow.unfree` is set to `true`
+[install]
+hello.pkg-path = "hello-unfree"
+
+[options]
+allow.unfree = true

--- a/pkgdb/tests/data/buildenv/lockfiles/unfree/manifest.toml
+++ b/pkgdb/tests/data/buildenv/lockfiles/unfree/manifest.toml
@@ -1,0 +1,4 @@
+# Expected to fail because `hello-unfree` has an unfree license
+# and `options.allow.unfree` is not set to `true`
+[install]
+hello.pkg-path = "hello-unfree"


### PR DESCRIPTION
Convert `github:nixos/nixpkgs` references, locked in manifest lockfiles, to `flox-nixpkgs:v0` references.

NOTABLE BEHAVIOUR:
* registries can only be references to upstream nixpkgs using the `github:` scheme
* unfree (and broken) packages are denied by default and cause a `PackageEvalFailure` unless `options.allow.{unfree,broken}` is set to `true` in the manifest.