### PR TITLE
feat: substantial speedup of all build operations

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -795,7 +795,7 @@ mod tests {
 
         env_view.build(&flox).expect("build should succeed");
         env_view
-            .link(&flox, env_path.path().with_extension("out-link"))
+            .link(&flox, env_path.path().with_extension("out-link"), &None)
             .expect("link should succeed");
 
         // very rudimentary check that the environment manifest built correctly

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -32,6 +32,7 @@ use super::{
     EnvironmentPointer,
     InstallationAttempt,
     PathPointer,
+    UninstallationAttempt,
     UpdateResult,
     CACHE_DIR_NAME,
     DOT_FLOX,
@@ -186,8 +187,8 @@ impl Environment for PathEnvironment {
     ///   any new packages.
     fn build(&mut self, flox: &Flox) -> Result<(), EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
-        env_view.build(flox)?;
-        env_view.link(flox, self.out_link(&flox.system)?)?;
+        let store_path = env_view.build(flox)?;
+        env_view.link(flox, self.out_link(&flox.system)?, &Some(store_path))?;
 
         Ok(())
     }
@@ -218,7 +219,7 @@ impl Environment for PathEnvironment {
     ) -> Result<InstallationAttempt, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.install(packages, flox)?;
-        env_view.link(flox, self.out_link(&flox.system)?)?;
+        env_view.link(flox, self.out_link(&flox.system)?, &result.store_path)?;
 
         Ok(result)
     }
@@ -232,10 +233,10 @@ impl Environment for PathEnvironment {
         &mut self,
         packages: Vec<String>,
         flox: &Flox,
-    ) -> Result<String, EnvironmentError2> {
+    ) -> Result<UninstallationAttempt, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.uninstall(packages, flox)?;
-        env_view.link(flox, self.out_link(&flox.system)?)?;
+        env_view.link(flox, self.out_link(&flox.system)?, &result.store_path)?;
 
         Ok(result)
     }
@@ -245,7 +246,7 @@ impl Environment for PathEnvironment {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.edit(flox, contents)?;
         if result != EditResult::Unchanged {
-            env_view.link(flox, self.out_link(&flox.system)?)?;
+            env_view.link(flox, self.out_link(&flox.system)?, &result.store_path())?;
         }
         Ok(result)
     }
@@ -258,7 +259,7 @@ impl Environment for PathEnvironment {
     ) -> Result<UpdateResult, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.update(flox, inputs)?;
-        env_view.link(flox, self.out_link(&flox.system)?)?;
+        env_view.link(flox, self.out_link(&flox.system)?, &result.store_path)?;
 
         Ok(result)
     }
@@ -271,7 +272,7 @@ impl Environment for PathEnvironment {
     ) -> Result<UpgradeResult, EnvironmentError2> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         let result = env_view.upgrade(flox, groups_or_iids)?;
-        env_view.link(flox, self.out_link(&flox.system)?)?;
+        env_view.link(flox, self.out_link(&flox.system)?, &result.store_path)?;
 
         Ok(result)
     }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -15,6 +15,7 @@ use super::{
     EnvironmentError2,
     InstallationAttempt,
     ManagedPointer,
+    UninstallationAttempt,
     UpdateResult,
     DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
@@ -205,7 +206,7 @@ impl Environment for RemoteEnvironment {
         &mut self,
         packages: Vec<String>,
         flox: &Flox,
-    ) -> Result<String, EnvironmentError2> {
+    ) -> Result<UninstallationAttempt, EnvironmentError2> {
         let result = self.inner.uninstall(packages, flox)?;
         self.inner
             .push(flox, false)

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fmt::Display;
 use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use log::debug;
@@ -41,9 +42,12 @@ pub mod error_codes {
 /// The JSON output of a `pkgdb upgrade` call
 #[derive(Deserialize)]
 pub struct UpgradeResultJSON {
-    pub result: UpgradeResult,
+    pub result: UpgradeResultInner,
     pub lockfile: Value,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct UpgradeResultInner(pub Vec<String>);
 
 /// The JSON output of a `pkgdb buildenv` call
 #[derive(Deserialize)]
@@ -51,8 +55,11 @@ pub struct BuildEnvResult {
     pub store_path: String,
 }
 
-#[derive(Deserialize)]
-pub struct UpgradeResult(pub Vec<String>);
+#[derive(Debug)]
+pub struct UpgradeResult {
+    pub packages: Vec<String>,
+    pub store_path: Option<PathBuf>,
+}
 
 #[derive(Debug, Error)]
 pub enum CallPkgDbError {

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -250,9 +250,11 @@ impl GitCommandProvider {
         options: GitCommandOptions,
         path: P,
     ) -> Result<Self, GitCommandOpenError> {
+        debug!("attempting to open repo: path={}", path.as_ref().display());
         let bare = Self::is_bare_repo(&path)?;
 
         // resolved and canonicalized path to the git repo
+        debug!("determining path to git repo");
         let resolved_path = {
             let toplevel_or_git_dir = if bare {
                 let mut command = options.new_command();
@@ -280,6 +282,7 @@ impl GitCommandProvider {
                 .canonicalize()
                 .map_err(GitCommandOpenError::Canonicalize)?
         };
+        debug!("got non-canonical path: path={}", resolved_path.display());
 
         let path = path
             .as_ref()
@@ -289,6 +292,7 @@ impl GitCommandProvider {
         if resolved_path != path {
             return Err(GitCommandOpenError::Subdirectory);
         }
+        debug!("canonicalized path: path={}", path.display());
 
         Ok(GitCommandProvider {
             options,

--- a/pkgdb/include/flox/buildenv/command.hh
+++ b/pkgdb/include/flox/buildenv/command.hh
@@ -27,6 +27,19 @@ namespace flox::buildenv {
 
 /* -------------------------------------------------------------------------- */
 
+/**
+ * @class flox::buildenv::SystemNotSupportedByLockfile
+ * @brief An exception thrown when a lockfile is is missing a package.<system>
+ * entry fro the requested system.
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( BuildenvInvalidArguments,
+                       EC_BUILDENV_ARGUMENTS,
+                       "invalid arguments to buildenv" )
+/** @} */
+
+/* -------------------------------------------------------------------------- */
+
 /** @brief Evaluate and build a locked environment. */
 class BuildEnvCommand : NixState
 {
@@ -37,6 +50,7 @@ private:
   nlohmann::json             lockfileContent;
   std::optional<std::string> outLink;
   std::optional<System>      system;
+  std::optional<std::string> storePath;
   bool                       buildContainer;
 
 

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -91,6 +91,208 @@ FLOX_DEFINE_EXCEPTION( PackageBuildFailure,
 /* -------------------------------------------------------------------------- */
 
 /**
+ * @brief Get a cursor pointing at the new attribute or @a std::nullopt. This
+ *        is mostly a wrapper around
+ *        @a nix::eval_cache::AttrCursor::maybeGetAttr that can't return a
+ *        @a nullptr.
+ * @param cursor An existing cursor.
+ * @param attr The attribute to query under the cursor.
+ * @return Either a known non-null reference or @a std::nullopt.
+ */
+std::optional<nix::ref<nix::eval_cache::AttrCursor>>
+maybeGetCursor( nix::ref<nix::EvalState> &              state,
+                nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                const std::string &                     attr );
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Get a @a nix::eval_cache::AttrCursor pointing at the given attrpath.
+ * @param state A `nix` evaluator.
+ * @param flake A locked flake.
+ * @param attrpath The attrpath to get in the flake.
+ * @return An eval cache cursor pointing at the attrpath.
+ */
+nix::ref<nix::eval_cache::AttrCursor>
+getPackageCursor( nix::ref<nix::EvalState> &      state,
+                  const nix::flake::LockedFlake & flake,
+                  const flox::AttrPath &          attrpath );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Get a string attribute from an attrset using the eval cache.
+ * @param cursor A @a nix::eval_cache::AttrCursor.
+ * @param attr The name of the attribute to get.
+ * @return @a std::nullopt if the cursor doesn't point to an attrset, otherwise
+ * the @a std::string representing the attribute.
+ */
+std::optional<std::string>
+maybeGetStringAttr( nix::ref<nix::EvalState> &              state,
+                    nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                    const std::string &                     attr );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Get a list of strings from an attrset using the eval cache.
+ * @param cursor A @a nix::eval_cache::AttrCursor.
+ * @param attr The name of the attribute to get.
+ * @return The list of strings that were present under this attribute, @a
+ * std::nullopt if the cursor didn't point to an attrset.
+ */
+std::optional<std::vector<std::string>>
+maybeGetStringListAttr( nix::ref<nix::EvalState> &              state,
+                        nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                        const std::string &                     attr );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Get a boolean attribute from an attrset using the eval cache.
+ * @param cursor A @a nix::eval_cache::AttrCursor.
+ * @param attr The name of the attribute to get.
+ * @return @a std::nullopt if the cursor doesn't point to an attrset, otherwise
+ * the @a std::string representing the attribute.
+ */
+std::optional<bool>
+maybeGetBoolAttr( nix::ref<nix::EvalState> &              state,
+                  nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                  const std::string &                     attr );
+
+/* -------------------------------------------------------------------------- */
+
+using OutputsOrMissingOutput
+  = std::variant<std::unordered_map<std::string, std::string>, std::string>;
+
+/**
+ * @brief Uses the eval cache to query the store paths of this package's
+ * outputs.
+ * @param pkgCursor A @a nix::eval_cache::AttrCursor pointing at a package.
+ * @param names A @a std::vector<std::string> of the output names.
+ * @return A map of output names to store paths or the first missing output.
+ */
+OutputsOrMissingOutput
+getOutputsOutpaths( nix::ref<nix::EvalState> &              state,
+                    nix::ref<nix::eval_cache::AttrCursor> & pkgCursor,
+                    const std::vector<std::string> &        names );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Catch evaluation errors for `outPath` and `drvPath` due to unfree
+ * packages, etc.
+ * @param state A nix evaluator.
+ * @param packageName The name of the package being queried (for the error
+ * message).
+ * @param system The user's system type (for the error message).
+ * @param pkgCursor A @a nix::eval_cache::AttrCursor pointing at a package.
+ * @return The @a std::string of the requested store path
+ */
+std::string
+tryEvaluatePackageOutPath( nix::ref<nix::EvalState> &              state,
+                           const std::string &                     packageName,
+                           const std::string &                     system,
+                           nix::ref<nix::eval_cache::AttrCursor> & cursor );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Gets an @a nix::eval_cache::AttrCursor pointing at the final attribute
+ * of the provided attribute path in the provided input.
+ * @param state A nix evaluator.
+ * @param input The locked input to look inside.
+ * @param attrPath Where inside the locked input to acquire a cursor.
+ * @return The cursor.
+ */
+nix::ref<nix::eval_cache::AttrCursor>
+evalCacheCursorForInput( nix::ref<nix::EvalState> &             state,
+                         const flox::resolver::LockedInputRaw & input,
+                         const flox::AttrPath &                 attrPath );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Returns a map from output name to the corresponding outPath.
+ * @param state A nix evaluator.
+ * @param packageName The package whose outputs we're processing.
+ * @param pkgCursor A @a nix::eval_cache::AttrCursor pointing at the package
+ * (e.g. `legacyPackages.<system>.foo`).
+ * @return The output-to-storePath mapping.
+ */
+std::unordered_map<std::string, std::string>
+outpathsForPackageOutputs( nix::ref<nix::EvalState> &              state,
+                           const std::string &                     packageName,
+                           nix::ref<nix::eval_cache::AttrCursor> & pkgCursor );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Collects a list of packages that should be built for the environment.
+ * @param state A nix evaluator.
+ * @param packageName The name of the package whose outputs are being processed.
+ * @param lockedPackage The locked package from the lockfile.
+ * @param parentOutpath The outPath for the whole package itself (distinct from
+ * the outPath of its individual outputs).
+ * @param outputsToOutpaths A mapping from output name to outPath for that
+ * output.
+ * @return The list of packages generated from the locked package.
+ */
+std::vector<std::pair<buildenv::RealisedPackage, nix::StorePath>>
+collectRealisedPackages(
+  nix::ref<nix::EvalState> &                     state,
+  const std::string &                            packageName,
+  const flox::resolver::LockedPackageRaw &       lockedPackage,
+  const std::string &                            parentOutpath,
+  std::unordered_map<std::string, std::string> & outputsToOutpaths );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Throws an exception if the package doesn't adhere to the current allow
+ * rules.
+ * @param state A nix evaluator.
+ * @param packageName The name of the package being evaluated.
+ * @param allows The user-specific allow rules.
+ * @return Returns whether the package was unfree, as this has implications for
+ * whether the package is cached.
+ */
+bool
+ensurePackageIsAllowed( nix::ref<nix::EvalState> &              state,
+                        nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                        const std::string &                     packageName,
+                        const flox::resolver::Options::Allows & allows );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Collects and builds a list of packages from a locked package in the
+ * lockfile.
+ * @param state A nix evaluator.
+ * @param packageName The name of the package whose outputs are being processed.
+ * @param lockedPackage The locked package from the lockfile.
+ * @param system The current system.
+ * @return The list of packages generated from the locked package.
+ */
+std::vector<std::pair<buildenv::RealisedPackage, nix::StorePath>>
+getRealisedPackages( nix::ref<nix::EvalState> &         state,
+                     const std::string &                packageName,
+                     const resolver::LockedPackageRaw & lockedPackage,
+                     const System &                     system );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
  * Evaluate an environment definition and realise it.
  * @param state A `nix` evaluator.
  * @param lockfile a resolved and locked manifest.
@@ -98,9 +300,9 @@ FLOX_DEFINE_EXCEPTION( PackageBuildFailure,
  * @return `StorePath` to the environment.
  */
 nix::StorePath
-createFloxEnv( nix::EvalState &     state,
-               resolver::Lockfile & lockfile,
-               const System &       system );
+createFloxEnv( nix::ref<nix::EvalState> & state,
+               resolver::Lockfile &       lockfile,
+               const System &             system );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/core/exceptions.hh
+++ b/pkgdb/include/flox/core/exceptions.hh
@@ -95,6 +95,8 @@ enum error_category {
   EC_PACKAGE_EVAL_FAILURE,
   /** Package build failure. */
   EC_PACKAGE_BUILD_FAILURE,
+  /** `pkgdb buildenv` was called with invalid arguments */
+  EC_BUILDENV_ARGUMENTS,
 }; /* End enum `error_category' */
 
 

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -114,7 +114,7 @@ BuildEnvCommand::run()
 
   debugLog( "building environment" );
 
-  auto storePath = createFloxEnv( *state, lockfile, system );
+  auto storePath = createFloxEnv( state, lockfile, system );
 
   debugLog( "built environment: " + store->printStorePath( storePath ) );
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -13,11 +13,13 @@
 #include <nix/command.hh>
 #include <nix/derivations.hh>
 #include <nix/derived-path.hh>
+#include <nix/eval-cache.hh>
 #include <nix/eval-inline.hh>
 #include <nix/eval.hh>
 #include <nix/flake/flake.hh>
 #include <nix/get-drvs.hh>
 #include <nix/globals.hh>
+#include <nix/installable-flake.hh>
 #include <nix/local-fs-store.hh>
 #include <nix/path-with-outputs.hh>
 #include <nix/profiles.hh>
@@ -168,41 +170,6 @@ createEnvironmentStorePath(
 
 /* -------------------------------------------------------------------------- */
 
-static nix::Attr
-extractAttrPath( nix::EvalState &       state,
-                 nix::Value &           vFlake,
-                 const flox::AttrPath & attrPath )
-{
-  state.forceAttrs( vFlake, nix::noPos, "while parsing flake" );
-
-
-  auto * output = vFlake.attrs->get( state.symbols.create( "outputs" ) );
-
-  for ( auto attrName : attrPath )
-    {
-      state.forceAttrs( *output->value,
-                        output->pos,
-                        "while parsing cached flake data" );
-
-      auto * next
-        = output->value->attrs->get( state.symbols.create( attrName ) );
-
-      if ( next == nullptr )
-        {
-          std::ostringstream str;
-          output->value->print( state.symbols, str );
-          throw FloxException( "attribute '%s' not found in set '%s'",
-                               attrName,
-                               str.str() );
-        }
-      output = next;
-    }
-
-  return *output;
-}
-
-/* -------------------------------------------------------------------------- */
-
 /**
  * @brief Extract locked packages from the lockfile for the given system.
  * @throws @a SystemNotSupportedByLockfile exception if the lockfile does not
@@ -239,130 +206,403 @@ getLockedPackages( resolver::Lockfile & lockfile, const System & system )
 
 /* -------------------------------------------------------------------------- */
 
-/**
- * @brief Realise a locked package into a list of realised packages and store
- * paths.
- * Builds the derivation of the package and creates a @a RealisedPackage for
- * each output.
- * @param state Nix state.
- * @param pId Package id from the lockfile (used to inform build error message).
- * @param package Locked package to realise.
- * @param system System to realise the package for. (used to inform build error
- * message).
- * @return List of realised packages and their store paths for referencing.
- * @throws PackageEvalFailure if the package fails to evaluate.
- * @throws PackageEvalFailure if the package is marked as broken or unfree and
- * neither is allowed through the options.
- * @throws PackageBuildFailure if the package fails to build.
- * @throws PackageUnsupportedSystem if the package is not available for the
- given system.
- */
-static std::vector<std::pair<buildenv::RealisedPackage, nix::StorePath>>
-getRealisedPackages( nix::EvalState &                        state,
-                     const std::string &                     pId,
-                     const resolver::LockedPackageRaw &      package,
-                     const System &                          system,
-                     const flox::resolver::Options::Allows & allows )
+std::optional<nix::ref<nix::eval_cache::AttrCursor>>
+maybeGetCursor( nix::ref<nix::EvalState> &              state,
+                nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                const std::string &                     attr )
 {
-  std::vector<std::pair<buildenv::RealisedPackage, nix::StorePath>> realised;
+  debugLog(
+    nix::fmt( "getting attr cursor '%s.%s", cursor->getAttrPathStr(), attr ) );
+  auto symbol      = state->symbols.create( attr );
+  auto maybeCursor = cursor->maybeGetAttr( symbol, true );
+  if ( maybeCursor == nullptr ) { return std::nullopt; }
+  auto newCursor
+    = static_cast<nix::ref<nix::eval_cache::AttrCursor>>( maybeCursor );
+  return newCursor;
+}
 
+
+/* -------------------------------------------------------------------------- */
+
+nix::ref<nix::eval_cache::AttrCursor>
+getPackageCursor( nix::ref<nix::EvalState> &      state,
+                  const nix::flake::LockedFlake & flake,
+                  const flox::AttrPath &          attrpath )
+{
+  auto evalCache
+    = nix::openEvalCache( *state,
+                          std::make_shared<nix::flake::LockedFlake>( flake ) );
+  auto                     cursor = evalCache->getRoot();
+  std::vector<std::string> seen;
+  for ( auto attrName : attrpath )
+    {
+
+      if ( auto maybeCursor = maybeGetCursor( state, cursor, attrName );
+           maybeCursor.has_value() )
+        {
+          cursor = *maybeCursor;
+        }
+      else
+        {
+          debugLog( "failed to get package cursor" );
+          throw PackageEvalFailure(
+            nix::fmt( "failed to evaluate attribute '%s.%s'",
+                      cursor->getAttrPathStr(),
+                      attrName ) );
+        }
+    }
+  return cursor;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::optional<std::string>
+maybeGetStringAttr( nix::ref<nix::EvalState> &              state,
+                    nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                    const std::string &                     attr )
+{
+  debugLog(
+    nix::fmt( "getting string attr '%s.%s", cursor->getAttrPathStr(), attr ) );
+  auto maybeCursor = maybeGetCursor( state, cursor, attr );
+  if ( ! maybeCursor.has_value() ) { return std::nullopt; }
+  auto str = ( *maybeCursor )->getString();
+  return str;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::optional<std::vector<std::string>>
+maybeGetStringListAttr( nix::ref<nix::EvalState> &              state,
+                        nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                        const std::string &                     attr )
+{
+  debugLog( nix::fmt( "getting string list attr '%s.%s",
+                      cursor->getAttrPathStr(),
+                      attr ) );
+  auto maybeCursor = maybeGetCursor( state, cursor, attr );
+  if ( ! maybeCursor.has_value() ) { return std::nullopt; }
+  auto strs = ( *maybeCursor )->getListOfStrings();
+  return strs;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::optional<bool>
+maybeGetBoolAttr( nix::ref<nix::EvalState> &              state,
+                  nix::ref<nix::eval_cache::AttrCursor> & cursor,
+                  const std::string &                     attr )
+{
+  debugLog(
+    nix::fmt( "getting bool attr '%s.%s", cursor->getAttrPathStr(), attr ) );
+  auto maybeCursor = maybeGetCursor( state, cursor, attr );
+  if ( ! maybeCursor.has_value() ) { return std::nullopt; }
+  auto b = ( *maybeCursor )->getBool();
+  return b;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+OutputsOrMissingOutput
+getOutputsOutpaths( nix::ref<nix::EvalState> &              state,
+                    nix::ref<nix::eval_cache::AttrCursor> & pkgCursor,
+                    const std::vector<std::string> &        names )
+{
+  std::unordered_map<std::string, std::string> outpaths;
+  for ( const auto & outputName : names )
+    {
+      debugLog( nix::fmt( "getting output attr '%s.%s",
+                          pkgCursor->getAttrPathStr(),
+                          outputName ) );
+
+
+      // cursor to `<pkg>.${outputName}`
+      auto maybeCursor = maybeGetCursor( state, pkgCursor, outputName );
+      if ( ! maybeCursor.has_value() )
+        {
+          OutputsOrMissingOutput missing = outputName;
+          return missing;
+        }
+
+      // cursor to `<pkg>.${outputName}.outPath`
+      auto maybeStorePath
+        = maybeGetStringAttr( state, *maybeCursor, "outPath" );
+
+      if ( maybeStorePath == std::nullopt )
+        {
+          OutputsOrMissingOutput missing = outputName + ".outPath";
+          return missing;
+        }
+
+      outpaths[outputName] = *maybeStorePath;
+    }
+  return outpaths;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::string
+tryEvaluatePackageOutPath( nix::ref<nix::EvalState> &              state,
+                           const std::string &                     packageName,
+                           const std::string &                     system,
+                           nix::ref<nix::eval_cache::AttrCursor> & cursor )
+{
+  try
+    {
+      debugLog( nix::fmt( "trying to get outPath for '%s.outPath'",
+                          cursor->getAttrPathStr() ) );
+
+      auto result = maybeGetStringAttr( state, cursor, "outPath" );
+      if ( result.has_value() ) { return *result; }
+      throw PackageEvalFailure( "package '" + packageName
+                                + "' had no outPath" );
+    }
+  catch ( const nix::Error & e )
+    {
+      /**
+       * "not available on the requested hostPlatform"
+       *   -> package isn't supported on this system
+       */
+      debugLog( "failed to get outPath: " + std::string( e.what() ) );
+      if ( e.info().msg.str().find(
+             "is not available on the requested hostPlatform:" )
+           != std::string::npos )
+        {
+          debugLog( "'" + packageName + "' is not available on this system" );
+          throw PackageUnsupportedSystem(
+            nix::fmt( "package '%s' is not available for this system ('%s')",
+                      packageName,
+                      system ),
+
+            nix::filterANSIEscapes( e.what(), true ) );
+        }
+
+      /**
+       * eval errors are cached without the eror trace
+       * force an impure eval to get the full error message
+       */
+      try
+        {
+          debugLog(
+            "evaluating outPath uncached to get full error message" ) auto
+            vPackage
+            = cursor->forceValue();
+          state->forceAttrs( vPackage, nix::noPos, "while evaluating package" );
+          // expected to fail
+          auto aOutPath
+            = vPackage.attrs->get( state->symbols.create( "outPath" ) );
+          state->forceString( *aOutPath->value,
+                              aOutPath->pos,
+                              "while evaluating outPath" );
+          /**
+           * this should only be reachable if we have a cached eval failure,
+           * that evaluates successfully at a later time.
+           * Since eval checks for nixpkgs are disabled through the
+           * `flox-nixpkgs` fetcher which upon change will observe a different
+           * fingerprint, i.e. fresh cache, this is rather unlikely.
+           */
+          debugLog( "evaluation was expected to fail, but was successful" );
+          return aOutPath->value->string.s;
+        }
+      catch ( const nix::Error & e )
+        {
+          throw PackageEvalFailure(
+            nix::fmt( "package '%s' failed to evaluate", packageName ),
+            e.info().msg.str() );
+        }
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+nix::ref<nix::eval_cache::AttrCursor>
+evalCacheCursorForInput( nix::ref<nix::EvalState> &             state,
+                         const flox::resolver::LockedInputRaw & input,
+                         const flox::AttrPath &                 attrPath )
+{
 
   /**
    * Ensure the input is fetched with `flox-nixpkgs`.
    * Currently, the 'flox-nixpkgs' fetcher requires the original input to be
    * a rev or ref of `github:nixos/nixpkgs`.
    */
-  auto floxNixpkgsAttrs
-    = flox::githubAttrsToFloxNixpkgsAttrs( package.input.attrs );
-  auto packageInputRef = nix::FlakeRef::fromAttrs( floxNixpkgsAttrs );
+  auto floxNixpkgsAttrs = flox::githubAttrsToFloxNixpkgsAttrs( input.attrs );
+  auto packageInputRef  = nix::FlakeRef::fromAttrs( floxNixpkgsAttrs );
 
   auto packageFlake
-    = flox::lockFlake( state, packageInputRef, nix::flake::LockFlags {} );
+    = flox::lockFlake( *state, packageInputRef, nix::flake::LockFlags {} );
 
-  auto * vFlake = state.allocValue();
-  nix::flake::callFlake( state, packageFlake, *vFlake );
+  auto cursor = getPackageCursor( state, packageFlake, attrPath );
+  return cursor;
+}
 
-  /* Get referenced output. */
-  auto output = extractAttrPath( state, *vFlake, package.attrPath );
 
-  /* Interpret output as derivation. */
-  auto package_drv = getDerivation( state, *output.value, false );
+/* -------------------------------------------------------------------------- */
 
-  if ( ! package_drv.has_value() )
+std::unordered_map<std::string, std::string>
+outpathsForPackageOutputs( nix::ref<nix::EvalState> &              state,
+                           const std::string &                     packageName,
+                           nix::ref<nix::eval_cache::AttrCursor> & pkgCursor )
+{
+  debugLog( "getting outputs for " + packageName );
+
+  // get `<pkg>.outputs`
+  auto outputNames = maybeGetStringListAttr( state, pkgCursor, "outputs" );
+  if ( ! ( outputNames.has_value() ) )
     {
-      throw PackageEvalFailure( "Failed to get derivation for package '"
-                                + nlohmann::json( package ).dump() + "'" );
-    }
-
-  std::string packagePath;
-  try
-    {
-      packagePath = state.store->printStorePath( package_drv->queryOutPath() );
-    }
-  catch ( const nix::Error & e )
-    {
-
-      if ( e.info().msg.str().find(
-             "is not available on the requested hostPlatform:" )
-           != std::string::npos )
-        {
-          throw PackageUnsupportedSystem(
-            nix::fmt( "package '%s' is not available for this system ('%s')",
-                      pId,
-                      system ),
-
-            nix::filterANSIEscapes( e.what(), true ) );
-        }
-
-      // rethrow the original root cause without the nix trace
       throw PackageEvalFailure(
-        nix::fmt( "package '%s' failed to evaluate", pId ),
-        e.info().msg.str() );
-    };
-
-
-  /* Collect all outputs to include in the environment.
-   *
-   * Set the priority of the outputs to the priority of the package
-   * and the internal priority to the index of the output.
-   * This way `buildenv::buildEnvironment` can resolve conflicts between
-   * outputs of the same derivation. */
-  for ( auto [idx, output] : enumerate( package_drv->queryOutputs() ) )
-    {
-      /* Skip outputs without path */
-      if ( ! output.second.has_value() ) { continue; }
-      RealisedPackage realisedPackage(
-        state.store->printStorePath( output.second.value() ),
-        true,
-        buildenv::Priority( package.priority,
-                            packagePath,
-                            /* idx should always fit in uint its unlikely a
-                             * package has more than 4 billion outputs. */
-                            static_cast<unsigned>( idx ) ) );
-      realised.emplace_back( realisedPackage, output.second.value() );
+        nix::fmt( "package '%s' had no outputs", packageName ) );
     }
+  debugLog( nix::fmt( "found outputs [%s] for '%s'",
+                      flox::concatStringsSep( ",", *outputNames ),
+                      packageName ) );
 
-  /* Build the derivation */
-  if ( auto drvPath = package_drv->queryDrvPath() )
+  debugLog( "getting outPaths for outputs of " + packageName );
+
+  auto maybeOutputsToOutpaths
+    = getOutputsOutpaths( state, pkgCursor, *outputNames );
+
+  if ( std::holds_alternative<std::string>( maybeOutputsToOutpaths ) )
     {
-      /* Build derivation of pacakge in environment,
-       * rethrow errors as PackageBuildFailure. */
+      auto missingOutput = std::get<std::string>( maybeOutputsToOutpaths );
+      throw PackageEvalFailure( nix::fmt( "package '%s' had no output '%s'",
+                                          packageName,
+                                          missingOutput ) );
+    }
+  auto outputsToOutpaths
+    = std::get<std::unordered_map<std::string, std::string>>(
+      maybeOutputsToOutpaths );
+  return outputsToOutpaths;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::vector<std::pair<buildenv::RealisedPackage, nix::StorePath>>
+collectRealisedPackages(
+  nix::ref<nix::EvalState> &                     state,
+  const std::string &                            packageName,
+  const flox::resolver::LockedPackageRaw &       lockedPackage,
+  const std::string &                            parentOutpath,
+  std::unordered_map<std::string, std::string> & outputsToOutpaths )
+{
+  std::vector<std::pair<buildenv::RealisedPackage, nix::StorePath>> pkgs;
+  auto internalPriority = 0;
+  for ( const auto & [name, outpathStr] : outputsToOutpaths )
+    {
+      debugLog( "processing output '" + name + "' of '" + packageName + "'" );
+      auto outpathForOutput = state->store->parseStorePath( outpathStr );
+      buildenv::RealisedPackage pkg(
+        state->store->printStorePath( outpathForOutput ),
+        true,
+        buildenv::Priority( lockedPackage.priority,
+                            parentOutpath,
+                            internalPriority++ ) );
+      pkgs.emplace_back( pkg, outpathForOutput );
+    }
+  return pkgs;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::vector<std::pair<buildenv::RealisedPackage, nix::StorePath>>
+getRealisedPackages( nix::ref<nix::EvalState> &         state,
+                     const std::string &                packageName,
+                     const resolver::LockedPackageRaw & lockedPackage,
+                     const System &                     system )
+{
+  auto timeEvalStart = std::chrono::high_resolution_clock::now();
+  auto cursor        = evalCacheCursorForInput( state,
+                                         lockedPackage.input,
+                                         lockedPackage.attrPath );
+
+  /* Try to eval the outPath. Trying this eval tells us whether the package is
+   * unsupported. This eval will fail in a number of cases:
+   * - The package doesn't work on this system
+   * - The package is marked "insecure" i.e. it's old (e.g. Python 2)
+   * - Possibly other cases as well
+   * */
+
+  // uses the cached value
+  auto parentOutpath
+    = tryEvaluatePackageOutPath( state, packageName, system, cursor );
+
+  // auto parentOutpath
+  // = tryEvalPath( state, packageName, system, cursor, isUnfree, "outPath" );
+
+  /**
+   * Collect the store paths for each output of the package.
+   * Note that the "out" output is the same as the package's outPath.
+   */
+  auto outputsToOutpaths
+    = outpathsForPackageOutputs( state, packageName, cursor );
+
+
+  auto pkgs        = collectRealisedPackages( state,
+                                       packageName,
+                                       lockedPackage,
+                                       parentOutpath,
+                                       outputsToOutpaths );
+  auto timeEvalEnd = std::chrono::high_resolution_clock::now();
+
+  bool allValid = true;
+  for ( const auto & [pkg, outPath] : pkgs )
+    {
       try
         {
-          auto storePathWithOutputs
-            = nix::StorePathWithOutputs { *drvPath, {} };
-          state.store->buildPaths(
+          state->store->ensurePath( outPath );
+        }
+      catch ( const nix::Error & e )
+        {
+          debugLog( "failed to ensure path: " + std::string( e.what() ) );
+          allValid = false;
+          break;  // no need to check the rest if any output is not
+                  // substitutable
+        }
+    }
+
+  // one or more outputs are not substitutable
+  // we need to build the derivation to get all outputs
+  if ( ! allValid )
+    {
+      auto drvPath = cursor->forceDerivation();
+      try
+        {
+          auto storePathWithOutputs = nix::StorePathWithOutputs { drvPath, {} };
+          state->store->buildPaths(
             nix::toDerivedPaths( { storePathWithOutputs } ) );
         }
       catch ( const nix::Error & e )
         {
-          throw PackageBuildFailure( "Failed to build package '" + pId + "'",
+          throw PackageBuildFailure( "Failed to build package '" + packageName
+                                       + "'",
                                      nix::filterANSIEscapes( e.what(), true ) );
         }
     }
 
-  return realised;
+
+  auto timeBuildEnd = std::chrono::high_resolution_clock::now();
+
+  /* Report some timings for diagnostics */
+  auto timeEval = std::chrono::duration_cast<std::chrono::microseconds>(
+    timeEvalEnd - timeEvalStart );
+  auto timeBuild = std::chrono::duration_cast<std::chrono::microseconds>(
+    timeBuildEnd - timeEvalEnd );
+  auto timeTotal = timeEval + timeBuild;
+  debugLog( nix::fmt( "times for package %s: eval=%dus, build=%dus, total=%dus",
+                      packageName,
+                      timeEval.count(),
+                      timeBuild.count(),
+                      timeTotal.count() ) );
+  return pkgs;
 }
+
 
 /* -------------------------------------------------------------------------- */
 
@@ -514,16 +754,11 @@ makeProfileDScripts( nix::EvalState & state )
  * @return The store path of the environment.
  */
 nix::StorePath
-createFloxEnv( nix::EvalState &     state,
-               resolver::Lockfile & lockfile,
-               const System &       system )
+createFloxEnv( nix::ref<nix::EvalState> & state,
+               resolver::Lockfile &       lockfile,
+               const System &             system )
 {
   auto locked_packages = getLockedPackages( lockfile, system );
-
-  auto allows = lockfile.getManifestRaw()
-                  .options.value_or( flox::resolver::Options {} )
-                  .allow.value_or( flox::resolver::Options::Allows {} );
-
 
   /* Extract derivations */
   nix::StorePathSet            references;
@@ -533,8 +768,7 @@ createFloxEnv( nix::EvalState &     state,
 
   for ( auto const & [pId, package] : locked_packages )
     {
-      auto realised
-        = getRealisedPackages( state, pId, package, system, allows );
+      auto realised = getRealisedPackages( state, pId, package, system );
       for ( auto [realisedPackage, output] : realised )
         {
           pkgs.push_back( realisedPackage );
@@ -545,7 +779,7 @@ createFloxEnv( nix::EvalState &     state,
 
   // Add activation scripts to the environment
   auto [activationScriptPackage, activationScriptReferences]
-    = makeActivationScripts( state, lockfile );
+    = makeActivationScripts( *state, lockfile );
 
   pkgs.push_back( activationScriptPackage );
   references.insert( activationScriptReferences.begin(),
@@ -553,12 +787,15 @@ createFloxEnv( nix::EvalState &     state,
 
 
   auto [profileScriptsPath, profileScriptsReference]
-    = makeProfileDScripts( state );
+    = makeProfileDScripts( *state );
 
   pkgs.push_back( profileScriptsPath );
   references.insert( profileScriptsReference );
 
-  return createEnvironmentStorePath( state, pkgs, references, originalPackage );
+  return createEnvironmentStorePath( *state,
+                                     pkgs,
+                                     references,
+                                     originalPackage );
 }
 
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -214,6 +214,7 @@ extractAttrPath( nix::EvalState &       state,
 static std::vector<std::pair<std::string, resolver::LockedPackageRaw>>
 getLockedPackages( resolver::Lockfile & lockfile, const System & system )
 {
+  traceLog( "creating FloxEnv" );
   auto packages = lockfile.getLockfileRaw().packages.find( system );
   if ( packages == lockfile.getLockfileRaw().packages.end() )
     {
@@ -291,30 +292,6 @@ getRealisedPackages( nix::EvalState &                        state,
     {
       throw PackageEvalFailure( "Failed to get derivation for package '"
                                 + nlohmann::json( package ).dump() + "'" );
-    }
-
-  auto broken = package_drv->queryMetaBool( "broken", false );
-  if ( broken && ! allows.broken.value_or( false ) )
-    {
-      throw PackageEvalFailure(
-        nix::fmt( "Package '%s' is marked as broken.\n\n"
-                  "Allow building broken packages by setting "
-                  "'options.allow.broken = true' in manifest.toml",
-                  pId ) );
-    }
-
-  // if the package does not have an `unfree` attribute,
-  // assume it is unfree.
-  // Generally, nixpkgs packages _will_ have this attribute set.
-  // However, if it is missing it is safer to assume it is unfree.
-  auto unfree = package_drv->queryMetaBool( "unfree", true );
-  if ( unfree && ! allows.unfree.value_or( false ) )
-    {
-      throw PackageEvalFailure(
-        nix::fmt( "Package '%s' is marked as unfree.\n\n"
-                  "Allow building unfree packages by setting "
-                  "'options.allow.unfree = true' in manifest.toml",
-                  pId ) );
     }
 
   std::string packagePath;

--- a/pkgdb/tests/.gitignore
+++ b/pkgdb/tests/.gitignore
@@ -5,6 +5,7 @@ is_sqlite3
 lockfile
 manifest
 pkgdb
+realise
 registry
 search-params
 util

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -63,18 +63,6 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
-# bats test_tags=unfree,unfree:fail
-@test "Environment with unfree packages fails to build by default" {
-  run "$PKGDB_BIN" buildenv "$LOCKFILES/unfree/manifest.lock"
-  assert_failure
-  assert_output --partial "'hello' is marked as unfree"
-}
-
-# bats test_tags=unfree,unfree:success
-@test "Environment with unfree packages succeeds if allwed in options" {
-  run "$PKGDB_BIN" buildenv "$LOCKFILES/unfree-allowed/manifest.lock"
-  assert_success
-}
 
 # ---------------------------------------------------------------------------- #
 

--- a/pkgdb/tests/realise.cc
+++ b/pkgdb/tests/realise.cc
@@ -1,0 +1,155 @@
+/* ========================================================================== *
+ *
+ *  @file realise.cc
+ *
+ *  @brief Tests for `buildenv::realise` functionality.
+ *
+ * -------------------------------------------------------------------------- */
+
+#include "flox/buildenv/realise.hh"
+#include "flox/core/util.hh"
+#include "flox/resolver/manifest.hh"
+#include "test.hh"
+#include <nix/flake/flake.hh>
+
+/* -------------------------------------------------------------------------- */
+
+
+nix::ref<nix::eval_cache::AttrCursor>
+cursorForPackageName( nix::ref<nix::EvalState> & state,
+                      const std::string &        system,
+                      const std::string &        name )
+{
+  auto flakeRef = nix::parseFlakeRef( nixpkgsRef );
+  auto lockedRef
+    = flox::lockFlake( *state, flakeRef, nix::flake::LockFlags {} );
+  std::vector<std::string> attrPath = { "legacyPackages", system, name };
+  auto cursor = flox::buildenv::getPackageCursor( state, lockedRef, attrPath );
+  return cursor;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::string
+unsupportedPackage( const std::string & system )
+{
+  if ( system == "aarch64-darwin" ) { return "glibc"; }
+  else if ( system == "x86_64-darwin" ) { return "glibc"; }
+  else if ( system == "aarch64-linux" ) { return "spacebar"; }
+  else if ( system == "x86_64-linux" ) { return "spacebar"; }
+  else
+    {
+      // Should be unreachable
+      return "wat?";
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+bool
+test_tryEvaluatePackageOutPathReturnsValidOutpath(
+  nix::ref<nix::EvalState> & state,
+  const std::string &        system )
+{
+  auto pkg    = "ripgrep";
+  auto cursor = cursorForPackageName( state, system, pkg );
+  auto path
+    = flox::buildenv::tryEvaluatePackageOutPath( state, pkg, system, cursor
+
+    );
+  auto storePath = state->store->maybeParseStorePath( path );
+
+  return storePath.has_value();
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+bool
+test_evalFailureForInsecurePackage( nix::ref<nix::EvalState> & state,
+                                    const std::string &        system )
+{
+  auto pkg    = "python2";
+  auto cursor = cursorForPackageName( state, system, pkg );
+  try
+    {
+      auto path = flox::buildenv::tryEvaluatePackageOutPath( state,
+                                                             pkg,
+                                                             system,
+                                                             cursor );
+      return false;
+    }
+  catch ( const flox::buildenv::PackageEvalFailure & )
+    {
+      return true;
+    }
+  catch ( const std::exception & )
+    {
+      return false;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+bool
+test_unsupportedSystemExceptionForUnsupportedPackage(
+  nix::ref<nix::EvalState> & state,
+  const std::string &        system )
+{
+  auto pkg    = unsupportedPackage( system );
+  auto cursor = cursorForPackageName( state, system, pkg );
+  try
+    {
+      auto path = flox::buildenv::tryEvaluatePackageOutPath( state,
+                                                             pkg,
+                                                             system,
+                                                             cursor );
+      return false;
+    }
+  catch ( const flox::buildenv::PackageUnsupportedSystem & )
+    {
+      return true;
+    }
+  catch ( const std::exception & )
+    {
+      return false;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+int
+main( int argc, char * argv[] )
+{
+  int exitCode = EXIT_SUCCESS;
+#define RUN_TEST( ... ) _RUN_TEST( exitCode, __VA_ARGS__ )
+
+  nix::verbosity = nix::lvlWarn;
+  if ( ( 1 < argc ) && ( std::string_view( argv[1] ) == "-v" ) )  // NOLINT
+    {
+      nix::verbosity = nix::lvlDebug;
+    }
+
+  /* Initialize `nix' */
+  flox::NixState nstate;
+  auto           state = nstate.getState();
+
+  std::string system = nix::nativeSystem;
+
+  RUN_TEST( tryEvaluatePackageOutPathReturnsValidOutpath, state, system );
+  RUN_TEST( evalFailureForInsecurePackage, state, system );
+  RUN_TEST( unsupportedSystemExceptionForUnsupportedPackage, state, system );
+
+  return exitCode;
+}
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This PR is a dramatic speedup to all operations that build environments (install, pull, etc). This is accomplished via two major changes. It's recommended to review this by each commit since the two major changes are each isolated to their commits.

### Reusing temporary builds
The first major change is reusing temporary builds of environments. During transactions a copy of the environment is built in a temporary directory so as to not modify the existing environment until we know the new one builds successfully. The result of the build is a Nix store path for the newly built environment. Previously this store path was discarded. After building the temporary copy, the environment is built again from scratch so that it can create the GC root in the correct location. Now this store path is retained and passed to `pkgdb buildenv` so that it can skip the build and simply set the GC root.

Original build timing:
- First build (temporary copy): 8.3s
- Second build: 4.9s

Passing the store path:
- First build (temporary copy): 8.8s
- Second build (only creating the GC root): 0.05s

### Using the eval cache

The second major change is using the eval cache during `pkgdb buildenv`. Using the eval cache is an opt-in mechanism, and this was simply not implemented previously. The first time a flake attribute is evaluated _anywhere_ the result is cached and stored in a SQLite database in `~/.cache/nix/eval-cache-v5`. Nix evaluation is often the performance bottleneck, as is the case for scraping `nixpkgs` during `pkgdb scrape`. Using the cache in this way means that installing a package built for one environment is nearly instantaneous for a different environment.

```
chonker:pkgdb zmitchell$ time flox install ripgrep
✅ 'ripgrep' installed to environment pkgdb at /Users/zmitchell/code/floxdev/flox/flox-pull-extra-builds/pkgdb

real	0m0.448s
user	0m0.276s
sys	0m0.082s
```

Similarly, if you pull an environment, remove it, and pull it again, the second pull is very quick because the store path for the previous build already exists on the system (from the first build) and the evaluation of all the constituent packages has already been cached.

```
chonker:pkgdb zmitchell$ flox pull ghudgins/default
✨ Pulled ghudgins/default from https://hub.flox.dev/

You can activate this environment with 'flox activate'

chonker:pkgdb zmitchell$ rm -rf .flox
chonker:pkgdb zmitchell$ time flox pull ghudgins/default
✨ Pulled ghudgins/default from https://hub.flox.dev/

You can activate this environment with 'flox activate'


real	0m0.933s
user	0m0.242s
sys	0m0.162s
```

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Most operations will be substantially faster.

<!-- Many thanks! -->
