### PR TITLE
feat: use rules for scraping.

### DIFF
--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -588,7 +588,7 @@ bats-check: bin $(TEST_UTILS)
 #       declarations of "headers" in the conventional sense.
 
 # SQL Schemas
-src/pkgdb/write.o: src/pkgdb/schemas.hh
+src/pkgdb/write.o: src/pkgdb/schemas.hh src/pkgdb/rules.json.hh
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/include/flox/core/util.hh
+++ b/pkgdb/include/flox/core/util.hh
@@ -20,6 +20,7 @@
 #include <nix/attrs.hh>
 #include <nix/error.hh>
 #include <nix/flake/flakeref.hh>
+#include <nix/util.hh>
 #include <nlohmann/json.hpp>
 
 #include "flox/core/exceptions.hh"
@@ -221,6 +222,12 @@ struct adl_serializer<nix::FlakeRef>
 
 }  // namespace nlohmann
 
+/* -------------------------------------------------------------------------- */
+
+/** @brief Detect if two vectors of strings are equal. */
+[[nodiscard]] bool
+operator==( const std::vector<std::string> & lhs,
+            const std::vector<std::string> & rhs );
 
 /* -------------------------------------------------------------------------- */
 
@@ -344,13 +351,26 @@ isUInt( std::string_view str );
 /* -------------------------------------------------------------------------- */
 
 /**
- * @brief Does the string @str have the prefix @a prefix?
+ * @brief Does the string @a str have the prefix @a prefix?
  * @param prefix The prefix to check for.
  * @param str String to test.
  * @return `true` iff @a str has the prefix @a prefix.
  */
 [[nodiscard]] bool
 hasPrefix( std::string_view prefix, std::string_view str );
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Does the vector of strings @a lst begin with the elements
+ *        of @a prefix?
+ * @param prefix The prefix to check for.
+ * @param lst Vector of strings to test.
+ * @return `true` iff @a lst has the prefix @a prefix.
+ */
+[[nodiscard]] bool
+hasPrefix( const std::vector<std::string> & prefix,
+           const std::vector<std::string> & lst );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -43,7 +43,6 @@ struct ScrapeRulesRaw
   std::vector<AttrPathGlob> disallowPackage;
   std::vector<AttrPathGlob> allowRecursive;
   std::vector<AttrPathGlob> disallowRecursive;
-  // TODO: aliases
 }; /* End struct `ScrapeRulesRaw` */
 
 

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -9,9 +9,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <stack>
 #include <tuple>
 
+#include <nlohmann/json.hpp>
+
+#include "flox/core/types.hh"
 #include "flox/pkgdb/read.hh"
 
 
@@ -29,6 +33,105 @@ using Target = std::tuple<flox::AttrPath, flox::Cursor, row_id>;
  * A stack is used to promote depth-first processing.
  */
 using Todos = std::stack<Target, std::list<Target>>;
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Scraping rules to modify database creation process in _raw_ form. */
+struct ScrapeRulesRaw
+{
+  std::vector<AttrPathGlob> allowPackage;
+  std::vector<AttrPathGlob> disallowPackage;
+  std::vector<AttrPathGlob> allowRecursive;
+  std::vector<AttrPathGlob> disallowRecursive;
+  // TODO: aliases
+}; /* End struct `ScrapeRulesRaw` */
+
+
+/** @brief Convert a JSON object to a @a flox::pkgdb::ScrapeRulesRaw. */
+void
+from_json( const nlohmann::json & jfrom, ScrapeRulesRaw & rules );
+
+
+/* -------------------------------------------------------------------------- */
+
+enum ScrapeRule {
+  SR_NONE = 0,         /**< Empty state. */
+  SR_DEFAULT,          /**< Applies no special rules. */
+  SR_ALLOW_PACKAGE,    /**< Forces an package entry in DB. */
+  SR_ALLOW_RECURSIVE,  /**< Forces a sub-tree to be scraped. */
+  SR_DISALLOW_PACKAGE, /**< Do not add package entry to DB. */
+  /** Ignore sub-tree members unless otherwise specified. */
+  SR_DISALLOW_RECURSIVE
+}; /* End enum `ScrapeRule` */
+
+[[nodiscard]] std::string
+scrapeRuleToString( ScrapeRule rule );
+
+
+/* -------------------------------------------------------------------------- */
+struct RulesTreeNode
+{
+  using Children = std::unordered_map<std::string, RulesTreeNode>;
+
+  std::string attrName = "";
+  ScrapeRule  rule     = SR_DEFAULT;
+  Children    children = {};
+
+  RulesTreeNode() = default;
+
+  explicit RulesTreeNode( ScrapeRulesRaw rules );
+
+  explicit RulesTreeNode( const std::filesystem::path & path )
+    : RulesTreeNode( static_cast<ScrapeRulesRaw>( readAndCoerceJSON( path ) ) )
+  {}
+
+  explicit RulesTreeNode( std::string attrName,
+                          ScrapeRule  rule     = SR_DEFAULT,
+                          Children    children = {} )
+    : attrName( std::move( attrName ) )
+    , rule( std::move( rule ) )
+    , children( std::move( children ) )
+  {}
+
+  RulesTreeNode( std::string attrName, Children children )
+    : attrName( std::move( attrName ) ), children( std::move( children ) )
+  {}
+
+  void
+  addRule( AttrPathGlob & relPath, ScrapeRule rule );
+
+  /**
+   * @brief Get the rule at a path, or @a flox::pkgdb::SR_DEFAULT as a fallback.
+   *
+   * This *does NOT* apply parent rules to children.
+   *
+   * @see @a flox::pkgdb::RulesTreeNode::applyRules
+   */
+  [[nodiscard]] ScrapeRule
+  getRule( const AttrPath & path = {} ) const;
+
+  /**
+   * @brief Return true/false for explicit allow/disallow, or `std::nullopt`
+   *        if no rule is defined.
+   *        This is intended for use on _root_ nodes.
+   *
+   * Parent paths may _pass down_ rules to children unless otherwise defined
+   * at lower levels.
+   */
+  [[nodiscard]] std::optional<bool>
+  applyRules( const AttrPath & path ) const;
+
+
+}; /* End struct `RulesTreeNode' */
+
+
+/** @brief Convert a JSON object to a @a flox::pkgdb::RulesTreeNode. */
+void
+from_json( const nlohmann::json & jfrom, RulesTreeNode & rules );
+
+/** @brief Convert a @a flox::pkgdb::RulesTreeNode to a JSON object. */
+void
+to_json( nlohmann::json & jto, const RulesTreeNode & rules );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -68,6 +68,19 @@ scrapeRuleToString( ScrapeRule rule );
 
 
 /* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Node definition for a rules tree.
+ *
+ * The tree is built with a root node, where each node contains an attribute
+ * name, and the rule to be applied, along with a list of child nodes.
+ * This tree is built from reading the rules file, with paths through the tree
+ * constucted with SR_DEFAULT rules along the path until a leaf node with the
+ * appropriate rule can be added.  This allows hierarchical searching through
+ * the tree for attribute paths encountered during scraping and maintains the
+ * context for child inheritance of the rule defined for the deepest ancestral
+ * node.
+ */
 struct RulesTreeNode
 {
   using Children = std::unordered_map<std::string, RulesTreeNode>;

--- a/pkgdb/src/pkgdb/rules.json.hh
+++ b/pkgdb/src/pkgdb/rules.json.hh
@@ -1,8 +1,21 @@
+/*  Rules file for scraping.
+    Four entries are allowed, each containing an array of attribute paths, in
+   array form. `null` is allowed only in the `system` level of the attribute
+   path and will be replaced with four rules, one for each of the default
+   systems.
+
+    The entries are `allowRecursive`, `disallowRecursive`, `allowPackage`,
+   `diallowPackage`.
+*/
 R"_JSON(
 {
     "allowRecursive": [
+
+       // legacyPackages.*.darwin is not scraped using default logic
        ["legacyPackages", null, "darwin"],
-       ["legacyPackages", null, null, "darwin"]
+
+       // legacyPackages.*.swiftPackages.darwin is not scraped using default logic
+       ["legacyPackages", null, "swiftPackages", "darwin"]
     ]
 }
 )_JSON"

--- a/pkgdb/src/pkgdb/rules.json.hh
+++ b/pkgdb/src/pkgdb/rules.json.hh
@@ -6,15 +6,15 @@
 
     The entries are `allowRecursive`, `disallowRecursive`, `allowPackage`,
    `diallowPackage`.
+
+   Current rules explanation:
+    - legacyPackages.*.darwin is not scraped using default logic
+    - legacyPackages.*.swiftPackages.darwin is not scraped using default logic
 */
 R"_JSON(
 {
     "allowRecursive": [
-
-       // legacyPackages.*.darwin is not scraped using default logic
        ["legacyPackages", null, "darwin"],
-
-       // legacyPackages.*.swiftPackages.darwin is not scraped using default logic
        ["legacyPackages", null, "swiftPackages", "darwin"]
     ]
 }

--- a/pkgdb/src/pkgdb/rules.json.hh
+++ b/pkgdb/src/pkgdb/rules.json.hh
@@ -5,7 +5,9 @@
    systems.
 
     The entries are `allowRecursive`, `disallowRecursive`, `allowPackage`,
-   `diallowPackage`.
+   `diallowPackage`.  Note that currently a `disallowRecursive` will override
+   nested `allow*` rules.  This is not currently needed but could be allowed in
+   the future if needed.
 
    Current rules explanation:
     - legacyPackages.*.darwin is not scraped using default logic

--- a/pkgdb/src/pkgdb/rules.json.hh
+++ b/pkgdb/src/pkgdb/rules.json.hh
@@ -1,0 +1,8 @@
+R"_JSON(
+{
+    "allowRecursive": [
+       ["legacyPackages", null, "darwin"],
+       ["legacyPackages", null, null, "darwin"]
+    ]
+}
+)_JSON"

--- a/pkgdb/src/pkgdb/scrape.cc
+++ b/pkgdb/src/pkgdb/scrape.cc
@@ -18,6 +18,8 @@ namespace flox::pkgdb {
 
 /* -------------------------------------------------------------------------- */
 
+std::optional<std::string> rulesPath;
+
 /* Scrape Subcommand */
 
 ScrapeCommand::ScrapeCommand() : parser( "scrape" )
@@ -27,6 +29,18 @@ ScrapeCommand::ScrapeCommand() : parser( "scrape" )
     .help( "force re-evaluation of flake" )
     .nargs( 0 )
     .action( [&]( const auto & ) { this->force = true; } );
+  // TODO: don't assign to global.
+  //       Extend `PkgDbInput' and pass this through the registry as a member of
+  //       each individual flake input.
+  //       For now since we only have one input we'll use this forall.
+  //       This needs a rework later.
+  //
+  // TODO: Using this flag should invalidate the cache.
+  // TODO: We need to invalidate caches any time we change the rules file.
+  this->parser.add_argument( "-r", "--rules" )
+    .help( "the path to the rules.json file" )
+    .nargs( 1 )
+    .action( [&]( const std::string & str ) { rulesPath = str; } );
   this->addDatabasePathOption( this->parser );
   this->addFlakeRefArg( this->parser );
   this->addAttrPathArgs( this->parser );

--- a/pkgdb/src/pkgdb/scrape.cc
+++ b/pkgdb/src/pkgdb/scrape.cc
@@ -18,8 +18,6 @@ namespace flox::pkgdb {
 
 /* -------------------------------------------------------------------------- */
 
-std::optional<std::string> rulesPath;
-
 /* Scrape Subcommand */
 
 ScrapeCommand::ScrapeCommand() : parser( "scrape" )
@@ -29,18 +27,6 @@ ScrapeCommand::ScrapeCommand() : parser( "scrape" )
     .help( "force re-evaluation of flake" )
     .nargs( 0 )
     .action( [&]( const auto & ) { this->force = true; } );
-  // TODO: don't assign to global.
-  //       Extend `PkgDbInput' and pass this through the registry as a member of
-  //       each individual flake input.
-  //       For now since we only have one input we'll use this forall.
-  //       This needs a rework later.
-  //
-  // TODO: Using this flag should invalidate the cache.
-  // TODO: We need to invalidate caches any time we change the rules file.
-  this->parser.add_argument( "-r", "--rules" )
-    .help( "the path to the rules.json file" )
-    .nargs( 1 )
-    .action( [&]( const std::string & str ) { rulesPath = str; } );
   this->addDatabasePathOption( this->parser );
   this->addFlakeRefArg( this->parser );
   this->addAttrPathArgs( this->parser );

--- a/pkgdb/src/pkgdb/write.cc
+++ b/pkgdb/src/pkgdb/write.cc
@@ -55,10 +55,10 @@ RulesTreeNode::addRule( AttrPathGlob & relPath, ScrapeRule rule )
       if ( this->rule != SR_DEFAULT )
         {
           // TODO: Pass abs-path
-          throw FloxException(
-            "attempted to overwrite existing rule for `" + this->attrName
-            + "' with rule `" + scrapeRuleToString( this->rule )
-            + "' with new rule `" + scrapeRuleToString( rule ) + "'" );
+          throw FloxException( "attempted to overwrite existing rule '"
+                               + scrapeRuleToString( this->rule ) + "' for '"
+                               + this->attrName + "' with new rule '"
+                               + scrapeRuleToString( rule ) + "'" );
         }
       traceLog( "assigning rule to `" + scrapeRuleToString( rule ) + "' to `"
                 + this->attrName + '\'' );

--- a/pkgdb/src/pkgdb/write.cc
+++ b/pkgdb/src/pkgdb/write.cc
@@ -735,11 +735,11 @@ PkgDb::processSingleAttrib( const nix::SymbolStr &    sym,
       flox::AttrPath path = prefix;
       path.emplace_back( sym );
 
-      // FIXME: This breaks allows under recursiveDisallows!
       /* If the package or prefix is disallowed, bail. */
       const std::string   pathS = concatStringsSep( ".", prefix ) + "." + sym;
-      std::optional<bool> rulesAllowed = getDefaultRules().applyRules( path );
-      if ( rulesAllowed.has_value() && ( ! ( *rulesAllowed ) ) )
+      std::optional<bool> rulesBasedOverride
+        = getDefaultRules().applyRules( path );
+      if ( rulesBasedOverride.has_value() && ( ! ( *rulesBasedOverride ) ) )
         {
           traceLog( "scrapeRules: skipping disallowed attribute: " + pathS );
           return;
@@ -770,14 +770,13 @@ PkgDb::processSingleAttrib( const nix::SymbolStr &    sym,
       else
         {
           auto maybeRecurse = cursor->maybeGetAttr( "recurseForDerivations" );
-          bool allowed      = rulesAllowed.value_or( maybeRecurse != nullptr
-                                                && maybeRecurse->getBool() );
-
-          if ( rulesAllowed.has_value() )
+          bool allowed      = rulesBasedOverride.value_or(
+            maybeRecurse != nullptr && maybeRecurse->getBool() );
+          if ( rulesBasedOverride.has_value() )
             {
               traceLog(
                 nix::fmt( "scrapeRules: matching rule found (%s), for %s\n",
-                          rulesAllowed.value() ? "true" : "false",
+                          rulesBasedOverride.value() ? "true" : "false",
                           pathS ) );
             }
 

--- a/pkgdb/src/pkgdb/write.cc
+++ b/pkgdb/src/pkgdb/write.cc
@@ -28,10 +28,6 @@ namespace flox::pkgdb {
 
 /* -------------------------------------------------------------------------- */
 
-extern std::optional<std::string> rulesPath;
-
-/* -------------------------------------------------------------------------- */
-
 std::string
 scrapeRuleToString( ScrapeRule rule )
 {
@@ -704,20 +700,27 @@ PkgDb::setPrefixDone( const flox::AttrPath & prefix, bool done )
 
 /* -------------------------------------------------------------------------- */
 
+/* Current returns the one and only set of rules for scraping.
+ * These are hardcoded for now.
+ * TODO: make the rules file to use a command line argument or otherwise
+ * configurable.
+ */
 static const RulesTreeNode &
 getDefaultRules()
 {
   static std::optional<RulesTreeNode> rules;
   if ( ! rules.has_value() )
     {
-      ScrapeRulesRaw raw = nlohmann::json::parse(
+      /* These are just hardcoded for now.*/
+      std::string_view rulesJSON = (
 #include "./rules.json.hh"
       );
-      rules = RulesTreeNode( std::move( raw ) );
+
+      ScrapeRulesRaw raw = nlohmann::json::parse( rulesJSON );
+      rules              = RulesTreeNode( std::move( raw ) );
     }
   return *rules;
 }
-
 
 void
 PkgDb::processSingleAttrib( const nix::SymbolStr &    sym,

--- a/pkgdb/src/pkgdb/write.cc
+++ b/pkgdb/src/pkgdb/write.cc
@@ -7,19 +7,294 @@
  *
  * -------------------------------------------------------------------------- */
 
+#include <fstream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <ranges>
+#include <string>
 
+#include <nlohmann/json.hpp>
+
+#include "flox/core/util.hh"
 #include "flox/flake-package.hh"
 #include "flox/pkgdb/write.hh"
 
 #include "./schemas.hh"
 
-
 /* -------------------------------------------------------------------------- */
 
 namespace flox::pkgdb {
+
+/* -------------------------------------------------------------------------- */
+
+extern std::optional<std::string> rulesPath;
+
+/* -------------------------------------------------------------------------- */
+
+std::string
+scrapeRuleToString( ScrapeRule rule )
+{
+  switch ( rule )
+    {
+      case SR_NONE: return "UNSET";
+      case SR_DEFAULT: return "default";
+      case SR_ALLOW_PACKAGE: return "allowPackage";
+      case SR_DISALLOW_PACKAGE: return "disallowPackage";
+      case SR_ALLOW_RECURSIVE: return "allowRecursive";
+      case SR_DISALLOW_RECURSIVE: return "disallowRecursive";
+      default: return "UNKNOWN";
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+RulesTreeNode::addRule( AttrPathGlob & relPath, ScrapeRule rule )
+{
+  /* Modify our rule. */
+  if ( relPath.empty() )
+    {
+      if ( this->rule != SR_DEFAULT )
+        {
+          // TODO: Pass abs-path
+          throw FloxException(
+            "attempted to overwrite existing rule for `" + this->attrName
+            + "' with rule `" + scrapeRuleToString( this->rule )
+            + "' with new rule `" + scrapeRuleToString( rule ) + "'" );
+        }
+      traceLog( "assigning rule to `" + scrapeRuleToString( rule ) + "' to `"
+                + this->attrName + '\'' );
+      this->rule = rule;
+      return;
+    }
+  traceLog( "adding rule to `" + this->attrName + "': `"
+            + displayableGlobbedPath( relPath ) + " = "
+            + scrapeRuleToString( rule ) + '\'' );
+
+  /* Handle system glob by splitting into 4 recursive calls. */
+  if ( ! relPath.front().has_value() )
+    {
+      traceLog( "splitting system glob into real systems" );
+      for ( const auto & system : getDefaultSystems() )
+        {
+          AttrPathGlob relPathCopy = relPath;
+          relPathCopy.front()      = system;
+          this->addRule( relPathCopy, rule );
+        }
+      return;
+    }
+
+  std::string attrName = std::move( *relPath.front() );
+  // TODO: Use a `std::deque' instead of `std::vector' for efficiency.
+  //       This container is only used for `push_back' and `pop_front'.
+  //       Removing from the front is inefficient for `std::vector'.
+  relPath.erase( relPath.begin() );
+
+  if ( auto it = this->children.find( attrName ); it != this->children.end() )
+    {
+      traceLog( "found existing child `" + attrName + '\'' );
+      /* Add to existing child node. */
+      it->second.addRule( relPath, rule );
+    }
+  else if ( relPath.empty() )
+    {
+      /* Add leaf node. */
+      traceLog( "creating leaf `" + attrName + " = "
+                + scrapeRuleToString( rule ) + '\'' );
+      this->children.emplace( attrName, RulesTreeNode( attrName, rule ) );
+    }
+  else
+    {
+      traceLog( "creating child `" + attrName + '\'' );
+      /* Create a new child node. */
+      this->children.emplace( attrName, RulesTreeNode( attrName ) );
+      this->children.at( attrName ).addRule( relPath, rule );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+ScrapeRule
+RulesTreeNode::getRule( const AttrPath & path ) const
+{
+  const RulesTreeNode * node = this;
+  for ( const auto & attrName : path )
+    {
+      try
+        {
+          node = &node->children.at( attrName );
+        }
+      catch ( const std::out_of_range & err )
+        {
+          return SR_DEFAULT;
+        }
+    }
+  return node->rule;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::optional<bool>
+RulesTreeNode::applyRules( const AttrPath & path ) const
+{
+  auto rule = this->getRule( path );
+  /* Perform lookup in parents if necessary. */
+  if ( rule == SR_DEFAULT )
+    {
+      AttrPath pathCopy = path;
+      do {
+          pathCopy.pop_back();
+          rule = this->getRule( pathCopy );
+        }
+      while ( ( rule == SR_DEFAULT ) && ( ! pathCopy.empty() ) );
+    }
+
+  switch ( rule )
+    {
+      case SR_ALLOW_PACKAGE: return true;
+      case SR_DISALLOW_PACKAGE: return false;
+      case SR_ALLOW_RECURSIVE: return true;
+      case SR_DISALLOW_RECURSIVE: return false;
+      case SR_DEFAULT: return std::nullopt;
+      default:
+        throw PkgDbException( "encountered unexpected rule `"
+                              + scrapeRuleToString( rule ) + '\'' );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+from_json( const nlohmann::json & jfrom, RulesTreeNode & rules )
+{
+  ScrapeRulesRaw raw = jfrom;
+  rules              = static_cast<RulesTreeNode>( raw );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+to_json( nlohmann::json & jto, const RulesTreeNode & rules )
+{
+  jto           = nlohmann::json::object();
+  jto["__rule"] = scrapeRuleToString( rules.rule );
+  for ( const auto & [name, child] : rules.children )
+    {
+      nlohmann::json jchild;
+      to_json( jchild, child );
+      jto[name] = jchild;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+RulesTreeNode::RulesTreeNode( ScrapeRulesRaw raw )
+{
+  for ( const auto & path : raw.allowPackage )
+    {
+      AttrPathGlob pathCopy( std::move( path ) );
+      this->addRule( pathCopy, SR_ALLOW_PACKAGE );
+    }
+  for ( const auto & path : raw.disallowPackage )
+    {
+      AttrPathGlob pathCopy( std::move( path ) );
+      this->addRule( pathCopy, SR_DISALLOW_PACKAGE );
+    }
+  for ( const auto & path : raw.allowRecursive )
+    {
+      AttrPathGlob pathCopy( std::move( path ) );
+      this->addRule( pathCopy, SR_ALLOW_RECURSIVE );
+    }
+  for ( const auto & path : raw.disallowRecursive )
+    {
+      AttrPathGlob pathCopy( std::move( path ) );
+      this->addRule( pathCopy, SR_DISALLOW_RECURSIVE );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+from_json( const nlohmann::json & jfrom, ScrapeRulesRaw & rules )
+{
+  for ( const auto & [key, value] : jfrom.items() )
+    {
+      if ( key == "allowPackage" )
+        {
+          for ( const auto & path : value )
+            {
+              try
+                {
+                  rules.allowPackage.emplace_back( path );
+                }
+              catch ( nlohmann::json::exception & err )
+                {
+                  throw PkgDbException(
+                    "couldn't interpret field `allowPackage." + key + "': ",
+                    flox::extract_json_errmsg( err ) );
+                }
+            }
+        }
+      else if ( key == "disallowPackage" )
+        {
+          for ( const auto & path : value )
+            {
+              try
+                {
+                  rules.disallowPackage.emplace_back( path );
+                }
+              catch ( nlohmann::json::exception & err )
+                {
+                  throw PkgDbException(
+                    "couldn't interpret field `disallowPackage." + key + "': ",
+                    flox::extract_json_errmsg( err ) );
+                }
+            }
+        }
+      else if ( key == "allowRecursive" )
+        {
+          for ( const auto & path : value )
+            {
+              try
+                {
+                  rules.allowRecursive.emplace_back( path );
+                }
+              catch ( nlohmann::json::exception & err )
+                {
+                  throw PkgDbException(
+                    "couldn't interpret field `allowRecursive." + key + "': ",
+                    flox::extract_json_errmsg( err ) );
+                }
+            }
+        }
+      else if ( key == "disallowRecursive" )
+        {
+          for ( const auto & path : value )
+            {
+              try
+                {
+                  rules.disallowRecursive.emplace_back( path );
+                }
+              catch ( nlohmann::json::exception & err )
+                {
+                  throw PkgDbException(
+                    "couldn't interpret field `disallowRecursive." + key
+                      + "': ",
+                    flox::extract_json_errmsg( err ) );
+                }
+            }
+        }
+      else { throw FloxException( "unknown scrape rule: `" + key + "'" ); }
+    }
+}
 
 /* -------------------------------------------------------------------------- */
 
@@ -471,6 +746,22 @@ PkgDb::processSingleAttrib( const nix::SymbolStr &    sym,
         }
       throw;
     }
+}
+
+/* -------------------------------------------------------------------------- */
+
+static const RulesTreeNode &
+getDefaultRules()
+{
+  static std::optional<RulesTreeNode> rules;
+  if ( ! rules.has_value() )
+    {
+      ScrapeRulesRaw raw = nlohmann::json::parse(
+#include "./rules.json.hh"
+      );
+      rules = RulesTreeNode( std::move( raw ) );
+    }
+  return *rules;
 }
 
 

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -331,20 +331,15 @@ extract_json_errmsg( nlohmann::json::exception & err )
 std::string
 displayableGlobbedPath( const flox::AttrPathGlob & attrs )
 {
-  std::vector<std::string> globbed;
-  for ( const std::optional<std::string> & attr : attrs )
+  std::stringstream oss;
+  bool              first = true;
+  for ( const auto & attr : attrs )
     {
-      if ( attr.has_value() ) { globbed.emplace_back( *attr ); }
-      else { globbed.emplace_back( "*" ); }
+      if ( first ) { first = false; }
+      else { oss << '.'; }
+      oss << attr.value_or( "*" );
     }
-  auto fold
-    = []( std::string a, std::string b ) { return std::move( a ) + '.' + b; };
-
-  std::string s = std::accumulate( std::next( globbed.begin() ),
-                                   globbed.end(),
-                                   globbed[0],
-                                   fold );
-  return s;
+  return oss.str();
 }
 
 
@@ -414,6 +409,20 @@ getAvailableSystemMemory()
 /* -------------------------------------------------------------------------- */
 
 }  // namespace flox
+
+/* -------------------------------------------------------------------------- */
+
+bool
+operator==( const std::vector<std::string> & lhs,
+            const std::vector<std::string> & rhs )
+{
+  if ( lhs.size() != rhs.size() ) { return false; }
+  for ( size_t idx = 0; idx < lhs.size(); ++idx )
+    {
+      if ( lhs[idx] != rhs[idx] ) { return false; }
+    }
+  return true;
+}
 
 
 /* -------------------------------------------------------------------------- *

--- a/pkgdb/tests/pkgdb.cc
+++ b/pkgdb/tests/pkgdb.cc
@@ -55,6 +55,24 @@ static const nlohmann::json pkgDescriptorBaseRaw = R"( {
   "semver": "semver"
 } )"_json;
 
+/* -------------------------------------------------------------------------- */
+
+static const nlohmann::json rulesJSON = R"( {
+  "allowRecursive": [
+    ["legacyPackages", null, "darwin"]
+  ],
+  "disallowRecursive": [
+    ["legacyPackages", null, "emacsPackages"],
+    ["legacyPackages", null, "python310Packages"]
+  ],
+ "allowPackage": [
+   ["legacyPackages", null, "python310Packages", "pip"]
+ ],
+ "disallowPackage": [
+   ["legacyPackages", null, "gcc"]
+ ]
+} )"_json;
+
 
 /* -------------------------------------------------------------------------- */
 
@@ -943,6 +961,143 @@ test_getPackages_semver0( flox::pkgdb::PkgDb & db )
   return true;
 }
 
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Ensure parsing @a flox::pkgdb::RulesTreeNode from JSON doesn't throw.
+ */
+bool
+test_RulesTree_parse0()
+{
+  flox::pkgdb::RulesTreeNode rules(
+    rulesJSON.get<flox::pkgdb::ScrapeRulesRaw>() );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Ensure parsing @a flox::pkgdb::RulesTreeNode from JSON sets the
+ *        expected fields.
+ */
+bool
+test_RulesTree_parse1()
+{
+  flox::pkgdb::RulesTreeNode rules(
+    rulesJSON.get<flox::pkgdb::ScrapeRulesRaw>() );
+  flox::AttrPath path = { "legacyPackages", "x86_64-linux", "darwin" };
+  flox::pkgdb::RulesTreeNode * node = &rules;
+  for ( const std::string & attr : path )
+    {
+      if ( node->children.find( attr ) == node->children.end() )
+        {
+          EXPECT_FAIL( "RulesTreeNode missing child `" + attr + '\'' );
+        }
+      node = &node->children.at( attr );
+    }
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Ensure that a path without a rule uses the _default_ rule. */
+bool
+test_RulesTree_getRule_fallback0()
+{
+  flox::pkgdb::RulesTreeNode rules(
+    rulesJSON.get<flox::pkgdb::ScrapeRulesRaw>() );
+  flox::pkgdb::ScrapeRule rule = rules.getRule( flox::AttrPath { "phony" } );
+  EXPECT_EQ( rule, flox::pkgdb::SR_DEFAULT );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Ensure `null` glob works for all systems. */
+bool
+test_RulesTree_getRule0()
+{
+  flox::pkgdb::RulesTreeNode rules(
+    rulesJSON.get<flox::pkgdb::ScrapeRulesRaw>() );
+  flox::pkgdb::ScrapeRule rule = rules.getRule(
+    flox::AttrPath { "legacyPackages", "x86_64-linux", "darwin" } );
+  EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
+  rule = rules.getRule(
+    flox::AttrPath { "legacyPackages", "x86_64-darwin", "darwin" } );
+  EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
+  rule = rules.getRule(
+    flox::AttrPath { "legacyPackages", "aarch64-linux", "darwin" } );
+  EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
+  rule = rules.getRule(
+    flox::AttrPath { "legacyPackages", "aarch64-darwin", "darwin" } );
+  EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Ensure nested `allowPackage` under `disallowRecursive` is preserved.
+ */
+bool
+test_RulesTree_getRule1()
+{
+  flox::pkgdb::RulesTreeNode rules(
+    rulesJSON.get<flox::pkgdb::ScrapeRulesRaw>() );
+
+  flox::pkgdb::ScrapeRule rule = rules.children.at( "legacyPackages" )
+                                   .children.at( "x86_64-linux" )
+                                   .children.at( "python310Packages" )
+                                   .children.at( "pip" )
+                                   .rule;
+  EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_PACKAGE );
+
+  flox::pkgdb::ScrapeRule rule2
+    = rules.getRule( flox::AttrPath { "legacyPackages",
+                                      "x86_64-linux",
+                                      "python310Packages",
+                                      "pip" } );
+  EXPECT_EQ( rule2, flox::pkgdb::SR_ALLOW_PACKAGE );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ *  @brief Ensure @a flox::pkgdb::RulesTreeNode::getRule() does not _inherit_
+ *         parent rules.
+ *
+ * Inheritance is the responsibility of
+ * @a flox::pkgdb::RulesTreeNode::applyRules(), while `getRule()` should return
+ * the *exact* value of @a rule at an attribute path.
+ */
+bool
+test_RulesTree_getRule2()
+{
+  flox::pkgdb::RulesTreeNode rules(
+    rulesJSON.get<flox::pkgdb::ScrapeRulesRaw>() );
+
+  flox::pkgdb::ScrapeRule rule = rules.children.at( "legacyPackages" )
+                                   .children.at( "x86_64-linux" )
+                                   .children.at( "python310Packages" )
+                                   .children.at( "pip" )
+                                   .rule;
+  EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_PACKAGE );
+
+  flox::pkgdb::ScrapeRule rule2
+    = rules.getRule( flox::AttrPath { "legacyPackages",
+                                      "x86_64-linux",
+                                      "python310Packages",
+                                      "pip" } );
+  EXPECT_EQ( rule2, flox::pkgdb::SR_ALLOW_PACKAGE );
+  return true;
+}
+
 bool
 test_scrapeMemoryUse()
 {
@@ -983,7 +1138,10 @@ main( int argc, char * argv[] )
     {
       nix::verbosity = nix::lvlDebug;
     }
-
+  else if ( ( 1 < argc ) && ( std::string_view( argv[1] ) == "-vv" ) )
+    {
+      nix::verbosity = nix::lvlVomit;
+    }
   /* Initialize `nix' */
   flox::NixState nstate;
 
@@ -1027,6 +1185,13 @@ main( int argc, char * argv[] )
     RUN_TEST( getPackages_semver0, db );
 
     RUN_TEST( scrapeMemoryUse );
+
+    RUN_TEST( RulesTree_parse0 );
+    RUN_TEST( RulesTree_parse1 );
+    RUN_TEST( RulesTree_getRule_fallback0 );
+    RUN_TEST( RulesTree_getRule0 );
+    RUN_TEST( RulesTree_getRule1 );
+    RUN_TEST( RulesTree_getRule2 );
   }
 
   /* XXX: You may find it useful to preserve the file and print it for some

--- a/pkgdb/tests/pkgdb.cc
+++ b/pkgdb/tests/pkgdb.cc
@@ -59,7 +59,8 @@ static const nlohmann::json pkgDescriptorBaseRaw = R"( {
 
 static const nlohmann::json rulesJSON = R"( {
   "allowRecursive": [
-    ["legacyPackages", null, "darwin"]
+    ["legacyPackages", null, "darwin"],
+    ["legacyPackages", null, "swiftPackages", "darwin"]
   ],
   "disallowRecursive": [
     ["legacyPackages", null, "emacsPackages"],
@@ -1022,17 +1023,31 @@ test_RulesTree_getRule0()
 {
   flox::pkgdb::RulesTreeNode rules(
     rulesJSON.get<flox::pkgdb::ScrapeRulesRaw>() );
-  flox::pkgdb::ScrapeRule rule = rules.getRule(
+
+  flox::pkgdb::ScrapeRule rule
+    = rules.getRule( flox::AttrPath { "legacyPackages", "x86_64-linux" } );
+  EXPECT_EQ( rule, flox::pkgdb::SR_DEFAULT );
+
+  rule = rules.getRule(
     flox::AttrPath { "legacyPackages", "x86_64-linux", "darwin" } );
   EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
+
   rule = rules.getRule(
     flox::AttrPath { "legacyPackages", "x86_64-darwin", "darwin" } );
   EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
+
   rule = rules.getRule(
     flox::AttrPath { "legacyPackages", "aarch64-linux", "darwin" } );
   EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
+
   rule = rules.getRule(
     flox::AttrPath { "legacyPackages", "aarch64-darwin", "darwin" } );
+  EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
+
+  rule = rules.getRule( flox::AttrPath { "legacyPackages",
+                                         "aarch64-darwin",
+                                         "swiftPackages",
+                                         "darwin" } );
   EXPECT_EQ( rule, flox::pkgdb::SR_ALLOW_RECURSIVE );
   return true;
 }
@@ -1095,6 +1110,13 @@ test_RulesTree_getRule2()
                                       "python310Packages",
                                       "pip" } );
   EXPECT_EQ( rule2, flox::pkgdb::SR_ALLOW_PACKAGE );
+
+  flox::pkgdb::ScrapeRule rule3
+    = rules.getRule( flox::AttrPath { "legacyPackages",
+                                      "x86_64-linux",
+                                      "swiftPackages",
+                                      "darwin" } );
+  EXPECT_EQ( rule3, flox::pkgdb::SR_ALLOW_RECURSIVE );
   return true;
 }
 


### PR DESCRIPTION
## Proposed Changes

Add allow/disallow recurse/no-recurse rules for scraping.  This PR should not change the scope of what is scraped.  Those changes (additional rules) will be added as separate PRs.  Notes from the original PR have been carried over.

- Adds the ability to provide `pkgdb` scrape creation rules.
- Rules can be edited in a hard coded `pkgdb/src/pkgdb/rules.json.hh`.

Notable limitations:
- Cannot nest `allow*` under `disallowRecursive` ( docs in `rules.json.hh` reflect this limitation ).
  + `applyRules()` - supports nesting `allow*` under `disallowRecursive`.
  + `scrape()` - implementation may prevent this from working.
- Hard coded rules file - previous PR allowed for a command line argument to define the rules file, however, it's not clear when or if that will be needed and had several `FIXME`s in the implementation.  Removed on YAGNI principles.
- No database invalidation when rules change.
  + It is strongly recommended that some hash ( similar to fingerprint ) be added to a meta fields of DBs to invalidate them if and when a command line argument is provided for the rules to use.
  + For now, delete your caches during local dev between rule changes.

## Release Notes

N/A
