### PR TITLE
feat: add nodejs init hooks

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -562,6 +562,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1897,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,5 +50,6 @@ oauth2 = "4.4"
 jsonwebtoken = "9.2"
 textwrap = "0.16.0"
 indent = { version = "0.1.1" }
+semver = "1.0.22"
 
 [patch.crates-io]

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -45,6 +45,7 @@ chrono.workspace = true
 oauth2.workspace = true
 textwrap = {workspace = true, features = ["terminal_size"]}
 indent.workspace = true
+semver.workspace = true
 
 [dev-dependencies]
 temp-env = "0.3.2"

--- a/cli/flox/src/commands/init.rs
+++ b/cli/flox/src/commands/init.rs
@@ -485,6 +485,12 @@ impl Node {
         Ok(results.results.swap_remove(0))
     }
 
+    /// Return whether to skip the nodejs hook entirely, install a requested
+    /// version of nodejs, or offer to install the Flox default version of
+    /// nodejs.
+    ///
+    /// This is decided based on whether .nvmrc and package.json are present,
+    /// and whether Flox can provide versions they request.
     fn get_action(&self) -> NodeAction {
         match (&self.nvmrc_version, self.package_json_version.as_ref()) {
             (NVMRCVersion::Some(result), _) => NodeAction::Install(result.clone()),

--- a/cli/flox/src/commands/init.rs
+++ b/cli/flox/src/commands/init.rs
@@ -203,7 +203,7 @@ impl InitHook for Requirements {
             * A Python virtual environment to install dependencies into
 
             Would you like Flox to set up a standard Python environment?
-            You can always revisit the environment's declaration with 'flox edit'
+            You can always change the environment's manifest with 'flox edit'
         "};
 
         let dialog = Dialog {
@@ -221,7 +221,7 @@ impl InitHook for Requirements {
 
                 {}
                 Would you like Flox to apply these modifications?
-                You can always revisit the environment's declaration with 'flox edit'
+                You can always change the environment's manifest with 'flox edit'
             ", format_customization(&self.get_init_customization())?};
 
             let dialog = Dialog {
@@ -602,7 +602,7 @@ impl Node {
         message.push_str(&formatdoc! {"
 
             Would you like Flox to apply this suggestion?
-            You can always revisit the environment's declaration with 'flox edit'
+            You can always change the environment's manifest with 'flox edit'
             "});
 
         let dialog = Dialog {
@@ -619,7 +619,7 @@ impl Node {
 
                 {}
                 Would you like Flox to apply these modifications?
-                You can always revisit the environment's declaration with 'flox edit'
+                You can always change the environment's manifest with 'flox edit'
             ", format_customization(&self.get_init_customization())?};
 
             let dialog = Dialog {
@@ -646,7 +646,7 @@ impl Node {
             * Either an npm or yarn installation hook
 
             Would you like Flox to apply one of these modifications?
-            You can always revisit the environment's declaration with 'flox edit'", nodejs_version.map(|version| format!(" {version}")).unwrap_or("".to_string())};
+            You can always change the environment's manifest with 'flox edit'", nodejs_version.map(|version| format!(" {version}")).unwrap_or("".to_string())};
         let options = [
             "Yes - with npm hook",
             "Yes - with yarn hook",
@@ -678,7 +678,7 @@ impl Node {
 
                 {}
                 Would you like Flox to apply one of these modifications?
-                You can always revisit the environment's declaration with 'flox edit'
+                You can always change the environment's manifest with 'flox edit'
             ", format_customization(&self.get_init_customization())?};
 
             let dialog = Dialog {

--- a/pkgdb/tests/search.bats
+++ b/pkgdb/tests/search.bats
@@ -118,6 +118,24 @@ genParamsNixpkgsFlox() {
 
 # bats test_tags=search:semver, search:pname
 
+@test "'pkgdb search' with partial semvers (such as those in an .nvmrc)" {
+  params="$(genParams ".query.pname|=\"nodejs\"|.query.semver=\"18\"")"
+  $PKGDB_BIN search "$params"
+  run sh -c "$PKGDB_BIN search '$params' | wc -l"
+  assert_success
+  assert_output 4
+
+  params="$(genParams ".query.pname|=\"nodejs\"|.query.semver=\"18.18\"")"
+  $PKGDB_BIN search "$params"
+  run sh -c "$PKGDB_BIN search '$params' | wc -l"
+  assert_success
+  assert_output 4
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:semver, search:pname
+
 # Test `semver' by filtering to 18.*
 @test "'pkgdb search' 'pname=nodejs & semver=18.*'" {
   params="$(genParams '.query.pname|="nodejs"|.query.semver="18.*"')"


### PR DESCRIPTION
Implement nodejs init hooks, but only run them if _FLOX_NODE_HOOK is set, since the npm and yarn hooks are not yet implemented.

- Look for nodejs version in .nvmrc
- Look for nodejs version in the engines.node field of packages.json

Depending on whether a version is found and whether Flox can provide it, offer to install nodejs.

If offering to install nodejs, look for package-lock.json and yarn.lock, and depending on which are present, offer to add a hook.