### PR TITLE
feat: invalidate database when scraping rules change

### DIFF
--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -567,12 +567,13 @@ cc-check: $(TESTS:.cc=)
 
 #: Run all bats tests
 PKGDB_BATS_FILES ?= "$(PKGDB_ROOT)/tests"
+PKGDB_BATS_OPTS ?= ""
 bats-check: bin $(TEST_UTILS)
 	PKGDB_BIN="$(PKGDB_ROOT)/bin/pkgdb"                          \
 	PKGDB_IS_SQLITE3_BIN="$(PKGDB_ROOT)/tests/is_sqlite3"        \
 	PKGDB_SEARCH_PARAMS_BIN="$(PKGDB_ROOT)/tests/search-params"  \
 	  $(BATS) --print-output-on-failure --verbose-run --timing   \
-	          "$(PKGDB_BATS_FILES)";
+	          $(PKGDB_BATS_OPTS) "$(PKGDB_BATS_FILES)";
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -588,8 +588,9 @@ bats-check: bin $(TEST_UTILS)
 #       declarations of "headers" in the conventional sense.
 
 # SQL Schemas
-src/pkgdb/write.o: src/pkgdb/schemas.hh src/pkgdb/rules.json.hh
+src/pkgdb/write.o: src/pkgdb/schemas.hh
 
+src/pkgdb/scrape-rules.o: src/pkgdb/rules.json.hh
 
 # ---------------------------------------------------------------------------- #
 

--- a/pkgdb/include/flox/pkgdb/input.hh
+++ b/pkgdb/include/flox/pkgdb/input.hh
@@ -104,6 +104,8 @@ private:
    */
   void
   init();
+  bool
+  initDbRO();
 
 
 public:

--- a/pkgdb/include/flox/pkgdb/read.hh
+++ b/pkgdb/include/flox/pkgdb/read.hh
@@ -93,13 +93,25 @@ struct SqlVersions
 
 }; /* End struct `SqlVersions' */
 
+/** @brief SQLite3 schema fields for DbScrapeMeta table. */
+struct ScrapeMeta
+{
+  /**
+   * The hash representing the Scraping rules used to generate the database.
+   * This is checked upon opening and if they differ than the rules expected in
+   * the running version of pkgdb, the datbase is invalidated so it will be
+   * recreated on the *next* invocation.
+   */
+  std::string rulesHash;
+};
+
 /** @brief Emit version information to an output stream. */
 std::ostream &
 operator<<( std::ostream & oss, const SqlVersions & versions );
 
 
 /** The current SQLite3 schema versions. */
-constexpr SqlVersions sqlVersions = { .tables = 2, .views = 4 };
+constexpr SqlVersions sqlVersions = { .tables = 3, .views = 4 };
 
 
 /* -------------------------------------------------------------------------- */
@@ -264,6 +276,10 @@ public:
   /** @return The Package Database schema version. */
   SqlVersions
   getDbVersion();
+
+  /** @return The Package Database scrape meta fields. */
+  ScrapeMeta
+  getDbScrapeMeta();
 
   /**
    * @brief Get the `AttrSet.id` for a given path.

--- a/pkgdb/include/flox/pkgdb/read.hh
+++ b/pkgdb/include/flox/pkgdb/read.hh
@@ -99,8 +99,7 @@ struct ScrapeMeta
   /**
    * The hash representing the Scraping rules used to generate the database.
    * This is checked upon opening and if they differ than the rules expected in
-   * the running version of pkgdb, the datbase is invalidated so it will be
-   * recreated on the *next* invocation.
+   * the running version of pkgdb, the datbase is invalidated and recreated.
    */
   std::string rulesHash;
 };

--- a/pkgdb/include/flox/pkgdb/scrape-rules.hh
+++ b/pkgdb/include/flox/pkgdb/scrape-rules.hh
@@ -1,0 +1,229 @@
+/* ========================================================================== *
+ *
+ * @file flox/pkgdb/scrape-rules.hh
+ *
+ * @brief Interfaces for using rules during scraping.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <stack>
+
+#include <nlohmann/json.hpp>
+
+#include <nix/hash.hh>
+
+#include "flox/core/types.hh"
+#include "flox/core/util.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::pkgdb {
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Scraping rules to modify database creation process in _raw_ form. */
+struct ScrapeRulesRaw
+{
+  std::vector<AttrPathGlob> allowPackage;
+  std::vector<AttrPathGlob> disallowPackage;
+  std::vector<AttrPathGlob> allowRecursive;
+  std::vector<AttrPathGlob> disallowRecursive;
+}; /* End struct `ScrapeRulesRaw` */
+
+
+/** @brief Convert a JSON object to a @a flox::pkgdb::ScrapeRulesRaw. */
+void
+from_json( const nlohmann::json & jfrom, ScrapeRulesRaw & rules );
+
+
+/* -------------------------------------------------------------------------- */
+
+enum ScrapeRule {
+  SR_NONE = 0,         /**< Empty state. */
+  SR_DEFAULT,          /**< Applies no special rules. */
+  SR_ALLOW_PACKAGE,    /**< Forces an package entry in DB. */
+  SR_ALLOW_RECURSIVE,  /**< Forces a sub-tree to be scraped. */
+  SR_DISALLOW_PACKAGE, /**< Do not add package entry to DB. */
+  /** Ignore sub-tree members unless otherwise specified. */
+  SR_DISALLOW_RECURSIVE
+}; /* End enum `ScrapeRule` */
+
+[[nodiscard]] std::string
+scrapeRuleToString( ScrapeRule rule );
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Node definition for a rules tree.
+ *
+ * The tree is built with a root node, where each node contains an attribute
+ * name, and the rule to be applied, along with a list of child nodes.
+ * This tree is built from reading the rules file, with paths through the tree
+ * constructed with SR_DEFAULT rules along the path until a leaf node with the
+ * appropriate rule can be added.  This allows hierarchical searching through
+ * the tree for attribute paths encountered during scraping and maintains the
+ * context for child inheritance of the rule defined for the deepest ancestral
+ * node.  The rules tree is built as such entirely, once by reading the rules
+ * file. Attributes are checked node by node, until the full attribute lands on
+ * a node with a rule, or SR_DEFAULT is returned, instructing scrape to use the
+ * default decision making process.
+ *
+ * Example, the following 2 rules result in the following tree:
+ *
+ * allowRecursive foo.bar.bat
+ * allowRecursive foo.boo
+ *
+ * _root -> SR_DEFAULT
+ *   ^- foo -> SR_DEFAULT
+ *     ^- boo -> SR_ALLOW_RECURSIVE
+ *     ^- bar -> SR_DEFAULT
+ *       ^- bat -> SR_ALLOW_RECURSIVE
+ */
+struct RulesTreeNode
+{
+  using Children = std::unordered_map<std::string, RulesTreeNode>;
+
+  std::string attrName = "";
+  ScrapeRule  rule     = SR_DEFAULT;
+  Children    children = {};
+
+  RulesTreeNode() = default;
+
+  explicit RulesTreeNode( ScrapeRulesRaw rules );
+
+  explicit RulesTreeNode( const std::filesystem::path & path )
+    : RulesTreeNode( static_cast<ScrapeRulesRaw>( readAndCoerceJSON( path ) ) )
+  {}
+
+  explicit RulesTreeNode( std::string attrName,
+                          ScrapeRule  rule     = SR_DEFAULT,
+                          Children    children = {} )
+    : attrName( std::move( attrName ) )
+    , rule( std::move( rule ) )
+    , children( std::move( children ) )
+  {}
+
+  RulesTreeNode( std::string attrName, Children children )
+    : attrName( std::move( attrName ) ), children( std::move( children ) )
+  {}
+
+  /**
+   * @brief Adds a single rule to the RulesTree.
+   *
+   * This will add a node at @a relPath, relative to this node with the given
+   * rule, setting new descendant nodes to SR_DEFAULT along the way.  Trying to
+   * overwrite an existing rule that is not SR_DEFAULT will throw an exception.
+   *
+   * @see @a flox::pkgdb::RulesTreeNode::applyRules
+   */
+  void
+  addRule( AttrPathGlob & relPath, ScrapeRule rule );
+
+  /**
+   * @brief Get the rule at a path, or @a flox::pkgdb::SR_DEFAULT as a fallback.
+   *
+   * This *does NOT* apply parent rules to children.  The @a path is considered
+   * to be relative to this node.
+   *
+   * @see @a flox::pkgdb::RulesTreeNode::applyRules
+   */
+  [[nodiscard]] ScrapeRule
+  getRule( const AttrPath & path = {} ) const;
+
+  /**
+   * @brief Return true/false for explicit allow/disallow, or `std::nullopt`
+   *        if no rule is defined.
+   *        This is intended for use on _root_ nodes.
+   *
+   * Parent paths may _pass down_ rules to children unless otherwise defined
+   * at lower levels.
+   */
+  [[nodiscard]] std::optional<bool>
+  applyRules( const AttrPath & path ) const;
+
+
+}; /* End struct `RulesTreeNode' */
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Class to encapsulte a set of scraping rules
+ *
+ * This includes a root @a RulesTreeNode and a hash of the rules string that
+ * created it.
+ */
+class ScrapeRules
+{
+public:
+
+  /**
+   * @brief Creates a Rules tree and associated hash from a given string
+   * representaion of the rules JSON data.
+   *
+   */
+  explicit ScrapeRules( const std::string_view & rulesJSON );
+
+  /**
+   * @brief Applies the rules of the tree to the @a path provided.  See @a
+   * RulesTreeNode::applyRules() for further details.
+   *
+   */
+  [[nodiscard]] std::optional<bool>
+  applyRules( const AttrPath & path ) const
+  {
+    return rootNode.applyRules( path );
+  }
+
+  /**
+   * @brief Returns the root tree node of the rules tree.
+   *
+   */
+  const RulesTreeNode &
+  getRootNode()
+  {
+    return rootNode;
+  }
+
+  /**
+   * @brief Returns a hash in string format of the rules tree.
+   *
+   */
+  const std::string
+  hashString() const
+  {
+    return hash.to_string( nix::Base16, true );
+  }
+
+protected:
+
+  RulesTreeNode rootNode;
+  nix::Hash     hash;
+}; /* End clss `ScrapeRules' */
+
+/** @brief Convert a JSON object to a @a flox::pkgdb::RulesTreeNode. */
+void
+from_json( const nlohmann::json & jfrom, RulesTreeNode & rules );
+
+/** @brief Convert a @a flox::pkgdb::RulesTreeNode to a JSON object. */
+void
+to_json( nlohmann::json & jto, const RulesTreeNode & rules );
+
+const ScrapeRules &
+getDefaultRules();
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox::pkgdb
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/pkgdb/include/flox/pkgdb/write.hh
+++ b/pkgdb/include/flox/pkgdb/write.hh
@@ -15,6 +15,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <nix/hash.hh>
+
 #include "flox/core/types.hh"
 #include "flox/pkgdb/read.hh"
 
@@ -33,142 +35,6 @@ using Target = std::tuple<flox::AttrPath, flox::Cursor, row_id>;
  * A stack is used to promote depth-first processing.
  */
 using Todos = std::stack<Target, std::list<Target>>;
-
-/* -------------------------------------------------------------------------- */
-
-/** @brief Scraping rules to modify database creation process in _raw_ form. */
-struct ScrapeRulesRaw
-{
-  std::vector<AttrPathGlob> allowPackage;
-  std::vector<AttrPathGlob> disallowPackage;
-  std::vector<AttrPathGlob> allowRecursive;
-  std::vector<AttrPathGlob> disallowRecursive;
-}; /* End struct `ScrapeRulesRaw` */
-
-
-/** @brief Convert a JSON object to a @a flox::pkgdb::ScrapeRulesRaw. */
-void
-from_json( const nlohmann::json & jfrom, ScrapeRulesRaw & rules );
-
-
-/* -------------------------------------------------------------------------- */
-
-enum ScrapeRule {
-  SR_DEFAULT,          /**< Applies no special rules. */
-  SR_ALLOW_PACKAGE,    /**< Forces an package entry in DB. */
-  SR_ALLOW_RECURSIVE,  /**< Forces a sub-tree to be scraped. */
-  SR_DISALLOW_PACKAGE, /**< Do not add package entry to DB. */
-  /** Ignore sub-tree members unless otherwise specified. */
-  SR_DISALLOW_RECURSIVE
-}; /* End enum `ScrapeRule` */
-
-[[nodiscard]] std::string
-scrapeRuleToString( ScrapeRule rule );
-
-
-/* -------------------------------------------------------------------------- */
-
-/**
- * @brief Node definition for a rules tree.
- *
- * The tree is built with a root node, where each node contains an attribute
- * name, and the rule to be applied, along with a list of child nodes.
- * This tree is built from reading the rules file, with paths through the tree
- * constructed with SR_DEFAULT rules along the path until a leaf node with the
- * appropriate rule can be added.  This allows hierarchical searching through
- * the tree for attribute paths encountered during scraping and maintains the
- * context for child inheritance of the rule defined for the deepest ancestral
- * node.  The rules tree is built as such entirely, once by reading the rules
- * file. Attributes are checked node by node, until the full attribute lands on
- * a node with a rule, or SR_DEFAULT is returned, instructing scrape to use the
- * default decision making process.
- *
- * Example, the following 2 rules result in the following tree:
- *
- * allowRecursive foo.bar.bat
- * allowRecursive foo.boo
- *
- * _root -> SR_DEFAULT
- *   ^- foo -> SR_DEFAULT
- *     ^- boo -> SR_ALLOW_RECURSIVE
- *     ^- bar -> SR_DEFAULT
- *       ^- bat -> SR_ALLOW_RECURSIVE
- */
-
-struct RulesTreeNode
-{
-  using Children = std::unordered_map<std::string, RulesTreeNode>;
-
-  std::string attrName = "";
-  ScrapeRule  rule     = SR_DEFAULT;
-  Children    children = {};
-
-  RulesTreeNode() = default;
-
-  explicit RulesTreeNode( ScrapeRulesRaw rules );
-
-  explicit RulesTreeNode( const std::filesystem::path & path )
-    : RulesTreeNode( static_cast<ScrapeRulesRaw>( readAndCoerceJSON( path ) ) )
-  {}
-
-  explicit RulesTreeNode( std::string attrName,
-                          ScrapeRule  rule     = SR_DEFAULT,
-                          Children    children = {} )
-    : attrName( std::move( attrName ) )
-    , rule( std::move( rule ) )
-    , children( std::move( children ) )
-  {}
-
-  RulesTreeNode( std::string attrName, Children children )
-    : attrName( std::move( attrName ) ), children( std::move( children ) )
-  {}
-
-  /**
-   * @brief Adds a single rule to the RulesTree.
-   *
-   * This will add a node at @a relPath, relative to this node with the given
-   * rule, setting new descendant nodes to SR_DEFAULT along the way.  Trying to
-   * overwrite an existing rule that is not SR_DEFAULT will throw an exception.
-   *
-   * @see @a flox::pkgdb::RulesTreeNode::applyRules
-   */
-  void
-  addRule( AttrPathGlob & relPath, ScrapeRule rule );
-
-  /**
-   * @brief Get the rule at a path, or @a flox::pkgdb::SR_DEFAULT as a fallback.
-   *
-   * This *does NOT* apply parent rules to children.  The @a path is considered
-   * to be relative to this node.
-   *
-   * @see @a flox::pkgdb::RulesTreeNode::applyRules
-   */
-  [[nodiscard]] ScrapeRule
-  getRule( const AttrPath & path = {} ) const;
-
-  /**
-   * @brief Return true/false for explicit allow/disallow, or `std::nullopt`
-   *        if no rule is defined.
-   *        This is intended for use on _root_ nodes.
-   *
-   * Parent paths may _pass down_ rules to children unless otherwise defined
-   * at lower levels.
-   */
-  [[nodiscard]] std::optional<bool>
-  applyRules( const AttrPath & path ) const;
-
-
-}; /* End struct `RulesTreeNode' */
-
-
-/** @brief Convert a JSON object to a @a flox::pkgdb::RulesTreeNode. */
-void
-from_json( const nlohmann::json & jfrom, RulesTreeNode & rules );
-
-/** @brief Convert a @a flox::pkgdb::RulesTreeNode to a JSON object. */
-void
-to_json( nlohmann::json & jto, const RulesTreeNode & rules );
-
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/src/pkgdb/read.cc
+++ b/pkgdb/src/pkgdb/read.cc
@@ -145,6 +145,18 @@ PkgDbReadOnly::getDbVersion()
   };
 }
 
+ScrapeMeta
+PkgDbReadOnly::getDbScrapeMeta()
+{
+  sqlite3pp::query qry( this->db,
+                        "SELECT value FROM DbScrapeMeta "
+                        "WHERE key IN ( 'scrape_rules_hash' ) LIMIT 1" );
+  auto             itr       = qry.begin();
+  auto             rulesHash = ( *itr ).get<std::string>( 0 );
+
+  return ScrapeMeta { .rulesHash = rulesHash };
+}
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/src/pkgdb/schemas.hh
+++ b/pkgdb/src/pkgdb/schemas.hh
@@ -20,9 +20,13 @@ static const char * sql_versions = R"SQL(
 CREATE TABLE IF NOT EXISTS DbVersions (
   name     TEXT NOT NULL PRIMARY KEY
 , version  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS DbScrapeMeta (
+  key      TEXT NOT NULL PRIMARY KEY
+, value    TEXT NOT NULL
 )
 )SQL";
-
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/src/pkgdb/schemas.hh
+++ b/pkgdb/src/pkgdb/schemas.hh
@@ -15,7 +15,8 @@ namespace flox::pkgdb {
 
 /* -------------------------------------------------------------------------- */
 
-/* Holds metadata information about schema versions. */
+/* Holds various schema versions and metadata about the scraped packages held
+ * such as the rules hash used. */
 static const char * sql_versions = R"SQL(
 CREATE TABLE IF NOT EXISTS DbVersions (
   name     TEXT NOT NULL PRIMARY KEY

--- a/pkgdb/src/pkgdb/scrape-rules.cc
+++ b/pkgdb/src/pkgdb/scrape-rules.cc
@@ -1,0 +1,335 @@
+
+/* ========================================================================== *
+ *
+ * @file pkgdb/scrape-rules.cc
+ *
+ * @brief Implementation for rules used for scraping.
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#include <optional>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include "flox/pkgdb/scrape-rules.hh"
+#include "flox/pkgdb/write.hh"
+
+/* -------------------------------------------------------------------------- */
+
+namespace flox::pkgdb {
+
+/* -------------------------------------------------------------------------- */
+
+std::string
+scrapeRuleToString( ScrapeRule rule )
+{
+  switch ( rule )
+    {
+      case SR_NONE: return "UNSET";
+      case SR_DEFAULT: return "default";
+      case SR_ALLOW_PACKAGE: return "allowPackage";
+      case SR_DISALLOW_PACKAGE: return "disallowPackage";
+      case SR_ALLOW_RECURSIVE: return "allowRecursive";
+      case SR_DISALLOW_RECURSIVE: return "disallowRecursive";
+      default:
+        throw PkgDbException( "encountered unexpected rule '"
+                              + scrapeRuleToString( rule ) + '\'' );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+RulesTreeNode::addRule( AttrPathGlob & relPath, ScrapeRule rule )
+{
+  /* Modify our rule. */
+  if ( relPath.empty() )
+    {
+      if ( this->rule != SR_DEFAULT )
+        {
+          // TODO: Pass abs-path
+          throw FloxException( "attempted to overwrite existing rule '"
+                               + scrapeRuleToString( this->rule ) + "' for '"
+                               + this->attrName + "' with new rule '"
+                               + scrapeRuleToString( rule ) + "'" );
+        }
+      traceLog( "assigning rule to '" + scrapeRuleToString( rule ) + "' to `"
+                + this->attrName + '\'' );
+      this->rule = rule;
+      return;
+    }
+  traceLog( "adding rule to '" + this->attrName + "': '"
+            + displayableGlobbedPath( relPath )
+            + "' = " + scrapeRuleToString( rule ) + '\'' );
+
+  /* Handle system glob by splitting into 4 recursive calls. */
+  if ( ! relPath.front().has_value() )
+    {
+      if ( this->attrName != "legacyPackages" )
+        {
+          throw FloxException(
+            "glob in rules (null) only allowed as child of legacyPackages" );
+        }
+
+      traceLog( "splitting system glob into real systems" );
+      for ( const auto & system : getDefaultSystems() )
+        {
+          AttrPathGlob relPathCopy = relPath;
+          relPathCopy.front()      = system;
+          this->addRule( relPathCopy, rule );
+        }
+      return;
+    }
+
+  std::string attrName = std::move( *relPath.front() );
+  // TODO: Use a `std::deque' instead of `std::vector' for efficiency.
+  //       This container is only used for `push_back' and `pop_front'.
+  //       Removing from the front is inefficient for `std::vector'.
+  relPath.erase( relPath.begin() );
+
+  if ( auto it = this->children.find( attrName ); it != this->children.end() )
+    {
+      traceLog( "found existing child '" + attrName + '\'' );
+      /* Add to existing child node. */
+      it->second.addRule( relPath, rule );
+    }
+  else if ( relPath.empty() )
+    {
+      /* Add leaf node. */
+      traceLog( "creating leaf '" + attrName
+                + "' = " + scrapeRuleToString( rule ) + '\'' );
+      this->children.emplace( attrName, RulesTreeNode( attrName, rule ) );
+    }
+  else
+    {
+      traceLog( "creating child '" + attrName + '\'' );
+      /* Create a new child node. */
+      this->children.emplace( attrName, RulesTreeNode( attrName ) );
+      this->children.at( attrName ).addRule( relPath, rule );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+ScrapeRule
+RulesTreeNode::getRule( const AttrPath & path ) const
+{
+  const RulesTreeNode * node = this;
+  for ( const auto & attrName : path )
+    {
+      try
+        {
+          node = &node->children.at( attrName );
+        }
+      catch ( const std::out_of_range & err )
+        {
+          return SR_DEFAULT;
+        }
+    }
+  return node->rule;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+std::optional<bool>
+RulesTreeNode::applyRules( const AttrPath & path ) const
+{
+  auto rule = this->getRule( path );
+  /* Perform lookup in parents if necessary. */
+  if ( rule == SR_DEFAULT )
+    {
+      AttrPath pathCopy = path;
+      do {
+          pathCopy.pop_back();
+          rule = this->getRule( pathCopy );
+        }
+      while ( ( rule == SR_DEFAULT ) && ( ! pathCopy.empty() ) );
+    }
+
+  switch ( rule )
+    {
+      case SR_ALLOW_PACKAGE: return true;
+      case SR_DISALLOW_PACKAGE: return false;
+      case SR_ALLOW_RECURSIVE: return true;
+      case SR_DISALLOW_RECURSIVE: return false;
+      case SR_DEFAULT: return std::nullopt;
+      default:
+        throw PkgDbException( "encountered unexpected rule `"
+                              + scrapeRuleToString( rule ) + '\'' );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+from_json( const nlohmann::json & jfrom, RulesTreeNode & rules )
+{
+  ScrapeRulesRaw raw = jfrom;
+  rules              = static_cast<RulesTreeNode>( raw );
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+to_json( nlohmann::json & jto, const RulesTreeNode & rules )
+{
+  jto = { { "__rule", scrapeRuleToString( rules.rule ) } };
+  for ( const auto & [name, child] : rules.children )
+    {
+      nlohmann::json jchild;
+      to_json( jchild, child );
+      jto[name] = jchild;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+RulesTreeNode::RulesTreeNode( ScrapeRulesRaw raw )
+{
+  /* Add rules in order of precedence */
+  for ( const auto & path : raw.allowPackage )
+    {
+      AttrPathGlob pathCopy( std::move( path ) );
+      this->addRule( pathCopy, SR_ALLOW_PACKAGE );
+    }
+  for ( const auto & path : raw.disallowPackage )
+    {
+      AttrPathGlob pathCopy( std::move( path ) );
+      this->addRule( pathCopy, SR_DISALLOW_PACKAGE );
+    }
+  for ( const auto & path : raw.allowRecursive )
+    {
+      AttrPathGlob pathCopy( std::move( path ) );
+      this->addRule( pathCopy, SR_ALLOW_RECURSIVE );
+    }
+  for ( const auto & path : raw.disallowRecursive )
+    {
+      AttrPathGlob pathCopy( std::move( path ) );
+      this->addRule( pathCopy, SR_DISALLOW_RECURSIVE );
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+void
+from_json( const nlohmann::json & jfrom, ScrapeRulesRaw & rules )
+{
+  for ( const auto & [key, value] : jfrom.items() )
+    {
+      if ( key == "allowPackage" )
+        {
+          for ( const auto & path : value )
+            {
+              try
+                {
+                  rules.allowPackage.emplace_back( path );
+                }
+              catch ( nlohmann::json::exception & err )
+                {
+                  throw PkgDbException(
+                    "couldn't interpret field 'allowPackage." + key + "': ",
+                    flox::extract_json_errmsg( err ) );
+                }
+            }
+        }
+      else if ( key == "disallowPackage" )
+        {
+          for ( const auto & path : value )
+            {
+              try
+                {
+                  rules.disallowPackage.emplace_back( path );
+                }
+              catch ( nlohmann::json::exception & err )
+                {
+                  throw PkgDbException(
+                    "couldn't interpret field 'disallowPackage." + key + "': ",
+                    flox::extract_json_errmsg( err ) );
+                }
+            }
+        }
+      else if ( key == "allowRecursive" )
+        {
+          for ( const auto & path : value )
+            {
+              try
+                {
+                  rules.allowRecursive.emplace_back( path );
+                }
+              catch ( nlohmann::json::exception & err )
+                {
+                  throw PkgDbException(
+                    "couldn't interpret field 'allowRecursive." + key + "': ",
+                    flox::extract_json_errmsg( err ) );
+                }
+            }
+        }
+      else if ( key == "disallowRecursive" )
+        {
+          for ( const auto & path : value )
+            {
+              try
+                {
+                  rules.disallowRecursive.emplace_back( path );
+                }
+              catch ( nlohmann::json::exception & err )
+                {
+                  throw PkgDbException(
+                    "couldn't interpret field 'disallowRecursive'." + key
+                      + "': ",
+                    flox::extract_json_errmsg( err ) );
+                }
+            }
+        }
+      else { throw FloxException( "unknown scrape rule: '" + key + "'" ); }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+
+ScrapeRules::ScrapeRules( const std::string_view & rulesJSON )
+  : hash( nix::hashString( nix::htMD5, rulesJSON ) )
+{
+  ScrapeRulesRaw raw = nlohmann::json::parse( rulesJSON );
+  this->rootNode     = RulesTreeNode( std::move( raw ) );
+}
+
+/* Currently returns the one and only set of rules for scraping.
+ * These are hardcoded for now.
+ * TODO: make the rules file to use a command line argument or otherwise
+ * configurable.
+ */
+const ScrapeRules &
+getDefaultRules()
+{
+  static std::optional<ScrapeRules> rules;
+
+  /* These are just hardcoded for now.*/
+  std::string_view rulesJSON = (
+#include "./rules.json.hh"
+  );
+
+  if ( ! rules.has_value() ) { rules = ScrapeRules( rulesJSON ); }
+  return *rules;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+}  // namespace flox::pkgdb
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/pkgdb/src/pkgdb/write.cc
+++ b/pkgdb/src/pkgdb/write.cc
@@ -154,11 +154,10 @@ static void
 initScrapeMeta( PkgDb & pdb )
 {
   const ScrapeRules & scrapeRules = getDefaultRules();
-  traceLog( "WML: inserting into DbScrapeMeta table." )
-    sqlite3pp::command defineScrapeMeta(
-      pdb.db,
-      "INSERT OR IGNORE INTO DbScrapeMeta ( key, value ) VALUES"
-      " ( 'scrape_rules_hash', ? )" );
+  sqlite3pp::command  defineScrapeMeta(
+    pdb.db,
+    "INSERT OR IGNORE INTO DbScrapeMeta ( key, value ) VALUES"
+     " ( 'scrape_rules_hash', ? )" );
   defineScrapeMeta.bind( 1, scrapeRules.hashString().c_str(), sqlite3pp::copy );
   if ( sql_rc rcode = defineScrapeMeta.execute(); isSQLError( rcode ) )
     {

--- a/pkgdb/tests/data/search/params-local.json
+++ b/pkgdb/tests/data/search/params-local.json
@@ -1,0 +1,29 @@
+{
+  "manifest": {
+    "registry": {
+      "inputs": {
+        "nixpkgs": {
+          "from": "<testdir>/harnesses/proj0"
+        }
+      }
+    }
+  , "options": {
+      "systems": ["x86_64-linux"]
+    , "allow": {
+        "unfree": true
+      , "broken": false
+      , "licenses": null
+      }
+    , "semver": {
+        "prefer-pre-releases": false
+      }
+    }
+  }
+, "query": {
+    "match": "pkg1"
+  , "name": null
+  , "pname": null
+  , "version": null
+  , "semver": null
+  }
+}

--- a/pkgdb/tests/migrate.bats
+++ b/pkgdb/tests/migrate.bats
@@ -92,7 +92,7 @@ genParamsNixpkgsFlox() {
   assert_output --partial 'pkg1'
   
   # Find the db path this was scraped to
-  dbpath=$($PKGDB_BIN list | grep $TEST_HARNESS_FLAKE | awk '{ print $2 }' )
+  dbpath=$($PKGDB_BIN get db $TEST_HARNESS_FLAKE)
 
   # Make sure we have > 0 packages, save the rules hash
   real_package_count=$(get_package_count $dbpath)
@@ -117,12 +117,8 @@ genParamsNixpkgsFlox() {
   assert_success
   refute [ "$old_rules_hash" == "$(get_scrape_meta $dbpath scrape_rules_hash)" ]
 
-
-  # Run a search which should result in an invalidation *for the next run*
-  run sh -c "$PKGDB_BIN search '$search_params'"
-  assert_success
-  
-  # Run a second to actually re-create the Db, and check that we did
+  # Run a search which should result in an invalidation and re-creation of the
+  # database
   run sh -c "$PKGDB_BIN search '$search_params'"
   assert_output --partial 'pkg1'
   new_rules_hash=$(get_scrape_meta $dbpath scrape_rules_hash)

--- a/pkgdb/tests/pkgdb.cc
+++ b/pkgdb/tests/pkgdb.cc
@@ -975,7 +975,7 @@ test_RulesTree_parse0()
 }
 
 /**
- * @brief Ensure parsing @a flox::pkgdb::RulesTreeNode from JSON doesn't throw.
+ * @brief Ensure the hash is generated for the rules and is deterministic.
  */
 bool
 test_RulesTree_hash()


### PR DESCRIPTION
## Proposed Changes

- New Db schema to store scraping meta data
- Include a hash of the rules used to scrape in the Db
- When opening the Db, if the hash for the rules is different, invalidate the Db so it will be re-created

## Release Notes

- New schema for the package Db will cause existing databases to be re-created.