### PR TITLE
feat: handle expired tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
         env:
           RUST_BACKTRACE: 1
-          FLOXEM_FLOXTEST_TOKEN: "${{ secrets.FLOXEM_FLOXTEST_TOKEN }}"
+          AUTH0_FLOX_DEV_CLIENT_SECRET: "${{ secrets.AUTH0_FLOX_DEV_CLIENT_SECRET }}"
         run: nix develop -L --no-update-lock-file --command just functional-tests
 
   nix-build:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 anyhow = "1"
 blake3 = "1.5.0"
 bpaf = { version = "0.9.8", features = ["derive", "autocomplete"] }
-chrono = "0.4.24"
+chrono = { version = "0.4.24", features = ["serde"] }
 config = "0.13.1"
 crossterm = "0.26"
 derive_more = "0.99.17"
@@ -43,7 +43,7 @@ toml_edit = { version = "0.19", features = ["serde"] }
 tracing = "0.1"
 tracing-log = { version = "0.2", features = [] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = "2.4"
+url = { version = "2.4", features = ["serde"] }
 uuid = { version = "1.2", features = ["serde", "v4"] }
 walkdir = "2"
 xdg = "2.4"

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -193,8 +193,6 @@ impl Auth {
                 Ok(())
             },
             Auth::Logout => {
-                create_oauth_client()?;
-
                 if config.flox.floxhub_token.is_none() {
                     message::warning("You are not logged in");
                     return Ok(());

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -213,7 +213,7 @@ impl Auth {
                     return Ok(());
                 };
 
-                let handle = token.handle().context("Could not get user details")?;
+                let handle = token.handle();
 
                 message::plain(format!(
                     "You are logged in as {handle} on {}",
@@ -240,15 +240,15 @@ pub async fn login_flox(flox: &mut Flox) -> Result<()> {
     debug!("Writing token to config");
 
     // set the token in the runtime config
-    let token = flox.floxhub_token.insert(FloxhubToken::new(cred.token));
-    let handle = token.handle().context("Could not get user details")?;
+    let token = flox.floxhub_token.insert(FloxhubToken::new(cred.token)?);
+    let handle = token.handle();
 
     // write the token to the config file
     update_config(
         &flox.config_dir,
         &flox.temp_dir,
         "floxhub_token",
-        Some(token),
+        Some(token.clone()),
     )
     .context("Could not write token to config")?;
 

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1449,11 +1449,10 @@ impl Push {
                     owner
                 } else {
                     EnvironmentOwner::from_str(
-                        &flox
-                            .floxhub_token
+                        flox.floxhub_token
                             .as_ref()
                             .context("Need to be loggedin")?
-                            .handle()?,
+                            .handle(),
                     )?
                 };
 
@@ -1961,8 +1960,7 @@ impl Pull {
                 let by_current_user = flox
                     .floxhub_token
                     .as_ref()
-                    .and_then(|token| token.handle().ok())
-                    .map(|handle| handle == env_ref.owner().as_str())
+                    .map(|token| token.handle() == env_ref.owner().as_str())
                     .unwrap_or_default();
                 let message = format!("The environment {env_ref} does not exist.");
                 if by_current_user {

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -61,8 +61,8 @@ use url::Url;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{
     activated_environments,
-    auth,
     ensure_environment_trust,
+    ensure_floxhub_token,
     environment_description,
     ConcreteEnvironment,
     EnvironmentSelectError,
@@ -105,12 +105,17 @@ pub enum EditAction {
 }
 
 impl Edit {
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("edit");
 
         let detected_environment = self
             .environment
             .detect_concrete_environment(&flox, "edit")?;
+
+        // Ensure the user is logged in for the following remote operations
+        if let ConcreteEnvironment::Remote(_) = detected_environment {
+            ensure_floxhub_token(&mut flox).await?;
+        };
 
         match self.action {
             EditAction::EditManifest { file } => {
@@ -1130,7 +1135,7 @@ pub struct PkgWithIdOption {
 }
 
 impl Install {
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("install");
 
         debug!(
@@ -1162,6 +1167,12 @@ impl Install {
             Err(e) => Err(e)?,
         };
         let description = environment_description(&concrete_environment)?;
+
+        // Ensure the user is logged in for the following remote operations
+        if let ConcreteEnvironment::Remote(_) = concrete_environment {
+            ensure_floxhub_token(&mut flox).await?;
+        };
+
         let mut environment = concrete_environment.into_dyn_environment();
         let mut packages = self
             .packages
@@ -1281,7 +1292,7 @@ pub struct Uninstall {
 }
 
 impl Uninstall {
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("uninstall");
 
         debug!(
@@ -1312,6 +1323,12 @@ impl Uninstall {
             },
             Err(e) => Err(e)?,
         };
+
+        // Ensure the user is logged in for the following remote operations
+        if let ConcreteEnvironment::Remote(_) = concrete_environment {
+            ensure_floxhub_token(&mut flox).await?;
+        };
+
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
 
@@ -1406,25 +1423,8 @@ impl Push {
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("push");
 
-        if flox.floxhub_token.is_none() {
-            if !Dialog::can_prompt() {
-                let message = formatdoc! {"
-                    You are not logged in to FloxHub.
-
-                    Can not automatically login to FloxHub in non-interactive context.
-
-                    To login you can either
-                    * login to FloxHub with 'flox auth login',
-                    * set the 'floxhub_token' field to '<your token>' in your config
-                    * set the '$FLOX_FLOXHUB_TOKEN=<your_token>' environment variable."
-                };
-                bail!(message);
-            }
-
-            message::plain("You are not logged in to FloxHub. Logging in...");
-
-            auth::login_flox(&mut flox).await?;
-        }
+        // Ensure the user is logged in for the following remote operations
+        ensure_floxhub_token(&mut flox).await?;
 
         let dir = self.dir.unwrap_or_else(|| std::env::current_dir().unwrap());
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -16,6 +16,7 @@ use flox_rust_sdk::flox::{
     EnvironmentRef,
     Flox,
     Floxhub,
+    FloxhubToken,
     DEFAULT_FLOXHUB_URL,
     DEFAULT_NAME,
     FLOX_VERSION,
@@ -241,6 +242,13 @@ impl FloxArgs {
             git_url_override,
         )?;
 
+        let floxhub_token = config
+            .flox
+            .floxhub_token
+            .as_deref()
+            .map(FloxhubToken::from_str)
+            .transpose()?;
+
         let flox = Flox {
             cache_dir: config.flox.cache_dir.clone(),
             data_dir: config.flox.data_dir.clone(),
@@ -250,7 +258,7 @@ impl FloxArgs {
             temp_dir: temp_dir_path.clone(),
             system: env!("NIX_TARGET_SYSTEM").to_string(),
             uuid: init_uuid(&config.flox.data_dir).await?,
-            floxhub_token: config.flox.floxhub_token.clone(),
+            floxhub_token,
             floxhub,
         };
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1153,12 +1153,12 @@ pub(super) async fn ensure_floxhub_token(flox: &mut Flox) -> Result<()> {
         None if !Dialog::can_prompt() => {
             log::debug!("floxhub token is not present; can not prompt user");
             let message = formatdoc! {"
-                You are not logged in to floxhub.
+                You are not logged in to FloxHub.
 
-                Can not automatically login to floxhub in non-interactive context.
+                Can not automatically login to FloxHub in non-interactive context.
 
                 To login you can either
-                * login to floxhub with 'flox auth login',
+                * login to FloxHub with 'flox auth login',
                 * set the 'floxhub_token' field to '<your token>' in your config
                 * set the '$FLOX_FLOXHUB_TOKEN=<your_token>' environment variable."
             };

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -991,7 +991,7 @@ pub(super) async fn ensure_environment_trust(
     }
 
     if let Some(ref token) = flox.floxhub_token {
-        if token.handle()?.as_str() == env_ref.owner().as_str() {
+        if token.handle() == env_ref.owner().as_str() {
             debug!("environment {env_ref} is trusted by token");
             return Ok(());
         }

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -4,7 +4,7 @@ use std::{env, fs};
 
 use anyhow::{Context, Result};
 use config::{Config as HierarchicalConfig, Environment};
-use flox_rust_sdk::flox::{EnvironmentRef, FloxhubToken};
+use flox_rust_sdk::flox::EnvironmentRef;
 use itertools::{Either, Itertools};
 use log::{debug, trace};
 use once_cell::sync::OnceCell;
@@ -54,7 +54,12 @@ pub struct FloxConfig {
     pub config_dir: PathBuf,
 
     /// Token to authenticate on FloxHub
-    pub floxhub_token: Option<FloxhubToken>,
+    ///
+    /// Note: This does _not_ use [flox_rust_sdk::flox::FloxhubToken] because
+    /// parsing the token -- and thus parsing the config -- fails if the token is expired.
+    /// Instead parse as String (or some specialized enum to support keychains in the future)
+    /// and then validate the token as we build the [flox_rust_sdk::flox::Flox] instance.
+    pub floxhub_token: Option<String>,
 
     /// How many items `flox search` should show by default
     pub search_limit: Option<u8>,

--- a/cli/flox/src/utils/completion.rs
+++ b/cli/flox/src/utils/completion.rs
@@ -58,7 +58,7 @@ impl FloxCompletionExt for Flox {
             netrc_file,
             access_tokens,
             uuid: uuid::Uuid::nil(),
-            floxhub_token: config.flox.floxhub_token,
+            floxhub_token: None,
             floxhub: Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None)?,
         })
     }

--- a/cli/tests/environment-push.bats
+++ b/cli/tests/environment-push.bats
@@ -33,7 +33,6 @@ setup() {
   project_setup
   floxhub_setup "owner"
 
-  export FLOX_FLOXHUB_TOKEN=flox_testOAuthToken
   export _FLOX_FLOXHUB_GIT_URL="file://$BATS_TEST_TMPDIR/floxhub"
 }
 teardown() {
@@ -63,7 +62,7 @@ function update_dummy_env() {
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=push:h1
-@test "h1: push login: running flox push before user has login metadata prompts the user to login" {
+@test "h2: push login: running flox push before user has login metadata prompts the user to login" {
   unset FLOX_FLOXHUB_TOKEN # logout, effectively
 
   run "$FLOX_BIN" config
@@ -75,8 +74,21 @@ function update_dummy_env() {
   assert_output --partial 'You are not logged in to FloxHub.'
 }
 
-# bats test_tags=push:h2
-@test "h2: push login: running flox push before user has login metadata prompts the user to login" {
+# bats test_tags=push:h1:expired
+@test "h2: push login: running flox with an expired token prompts the user to login" {
+  # set an expired token
+  export FLOX_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY"
+
+  run "$FLOX_BIN" init
+  assert_output --partial 'Your FloxHub token has expired.'
+
+  run "$FLOX_BIN" push --owner owner # dummy owner
+  assert_failure
+  assert_output --partial 'You are not logged in to FloxHub.'
+}
+
+# bats test_tags=push:h3
+@test "h2: push login: running flox push creates a remotely managed environment stored in the FloxHub" {
   mkdir -p "machine_a"
   mkdir -p "machine_b"
 

--- a/pkgs/flox-tests/default.nix
+++ b/pkgs/flox-tests/default.nix
@@ -1,15 +1,14 @@
 {
-  self,
   gcc,
   runCommandCC,
   stdenv,
-  darwin,
   lib,
   bash,
   zsh,
   dash,
   bats,
   coreutils,
+  curl,
   entr,
   expect,
   findutils,
@@ -49,6 +48,7 @@
       dash
       batsWith
       coreutils
+      curl
       entr
       expect
       findutils

--- a/tests/cross-system.bats
+++ b/tests/cross-system.bats
@@ -1,4 +1,3 @@
-
 #! /usr/bin/env bats
 # -*- mode: bats; -*-
 # ============================================================================ #
@@ -24,10 +23,23 @@ load test_support.bash
 setup_file() {
   common_file_setup
   "$FLOX_BIN" config --set floxhub_url "https://hub.preview.flox.dev/"
-  if [ -z "${FLOXEM_FLOXTEST_TOKEN:-}" ]; then
-    skip "FLOXEM_FLOXTEST_TOKEN is not set"
+
+  if [ -z "${AUTH0_FLOX_DEV_CLIENT_SECRET:-}" ]; then
+    skip "AUTH0_FLOX_DEV_CLIENT_SECRET is not set"
   fi
-  export FLOX_FLOXHUB_TOKEN="$FLOXEM_FLOXTEST_TOKEN"
+
+  # Get a token for the `floxEM` user on the development FloxHub instance.
+  export FLOX_FLOXHUB_TOKEN="$(
+    curl --request POST \
+      --url https://flox-dev.us.auth0.com/oauth/token \
+      --header 'content-type: application/x-www-form-urlencoded' \
+      --data "client_id=A77LKKZbtUo7CbeKIeJs4SoqY1v4UZFh" \
+      --data "audience=https://hub.flox.dev/api" \
+      --data "grant_type=client_credentials" \
+      --data "client_secret=$AUTH0_FLOX_DEV_CLIENT_SECRET" \
+      | jq .access_token -r
+  )"
+
   export OWNER="floxEM"
 }
 

--- a/tests/cross-system.bats
+++ b/tests/cross-system.bats
@@ -28,7 +28,7 @@ setup_file() {
     skip "FLOXEM_FLOXTEST_TOKEN is not set"
   fi
   export FLOX_FLOXHUB_TOKEN="$FLOXEM_FLOXTEST_TOKEN"
-  export OWNER="floxtest"
+  export OWNER="floxEM"
 }
 
 teardown_file() {
@@ -93,8 +93,7 @@ teardown() {
       ;;
     *)
       # we only run the above two systems consistently in CI
-      echo "unsupported system: $NIX_SYSTEM"
-      return 1
+      skip "unsupported system: $NIX_SYSTEM"
       ;;
   esac
 


### PR DESCRIPTION
* Validate `floxhub_token` on startup

* Warn if token is expired, or otherwise invalid

* Try unset token from user conf file, if validation failed.

May fail if the token is set by a global conf file or env var. Failures to unset from the user conf are _ignored_, but trying to use the token later will trigger a login flow regardless.

* Ensure present token for all modifying remote commands
