### PR TITLE
fix: use native nix::flake::lockFlake in fetcher

### DIFF
--- a/pkgdb/include/flox/flox-flake.hh
+++ b/pkgdb/include/flox/flox-flake.hh
@@ -145,10 +145,18 @@ callInChildProcess( std::function<void()>  lambda,
  * @brief Thin wrapper around nix::lockFlake to ensure any downloads happen in
  *        a child process.
  *
- * When downloads occur, the nix static global `nix::curlFileTransfer` object
- * will trigger a worker thread.  Later forks ( for scraping ) will then try to
- * cleanup those threads but will fail.  Strictly using this wrapper for
- * `lockFlake` keeps the thread creation and cleanup in the same child process.
+ * When downloads occur, the nix `nix::curlFileTransfer` object
+ * will trigger a worker thread.  Later forks ( for scraping, or other ) will
+ * then try to cleanup those threads but will fail.  Strictly using this wrapper
+ * for `lockFlake` keeps the thread creation and cleanup in the same child
+ * process. There are other downloads that occur in Nix that foul this up such
+ * as `queryMissing`.  Since that can happen in the parent, and once it does,
+ * you do NOT want to fork, it's kind of an art to make the right call, this or
+ * the native one based on the context of where the call is being made.
+ *
+ * TODO: This mechanism should be revisited to see if it's actually needed, or
+ * if the download thread cleanup can be addressed differently, in a more
+ * consistent manner.
  */
 nix::flake::LockedFlake
 lockFlake( nix::EvalState &              state,

--- a/pkgdb/include/flox/flox-flake.hh
+++ b/pkgdb/include/flox/flox-flake.hh
@@ -137,32 +137,6 @@ FLOX_DEFINE_EXCEPTION( LockFlakeException,
 
 /* -------------------------------------------------------------------------- */
 
-void
-callInChildProcess( std::function<void()>  lambda,
-                    const std::exception & thrownOnError );
-
-/**
- * @brief Thin wrapper around nix::lockFlake to ensure any downloads happen in
- *        a child process.
- *
- * When downloads occur, the nix `nix::curlFileTransfer` object
- * will trigger a worker thread.  Later forks ( for scraping, or other ) will
- * then try to cleanup those threads but will fail.  Strictly using this wrapper
- * for `lockFlake` keeps the thread creation and cleanup in the same child
- * process. There are other downloads that occur in Nix that foul this up such
- * as `queryMissing`.  Since that can happen in the parent, and once it does,
- * you do NOT want to fork, it's kind of an art to make the right call, this or
- * the native one based on the context of where the call is being made.
- *
- * TODO: This mechanism should be revisited to see if it's actually needed, or
- * if the download thread cleanup can be addressed differently, in a more
- * consistent manner.
- */
-nix::flake::LockedFlake
-lockFlake( nix::EvalState &              state,
-           const nix::FlakeRef &         flakeRef,
-           const nix::flake::LockFlags & lockFlags );
-
 }  // namespace flox
 
 

--- a/pkgdb/include/flox/pkgdb/input.hh
+++ b/pkgdb/include/flox/pkgdb/input.hh
@@ -226,7 +226,7 @@ public:
    * @param pageIdx The page of attributes to process
    * @param pageSize The number of attributes per page.
    */
-  static void
+  static int
   scrapePrefixWorker( PkgDbInput *     input,
                       const AttrPath & prefix,
                       const size_t     pageIdx,

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -434,9 +434,9 @@ evalCacheCursorForInput( nix::ref<nix::EvalState> &             state,
   auto floxNixpkgsAttrs = flox::githubAttrsToFloxNixpkgsAttrs( input.attrs );
   auto packageInputRef  = nix::FlakeRef::fromAttrs( floxNixpkgsAttrs );
 
-  /* See note on `flox::lockFlake on whe we call the native version here. */
-  auto packageFlake
-    = flox::lockFlake( *state, packageInputRef, nix::flake::LockFlags {} );
+  auto packageFlake = nix::flake::lockFlake( *state,
+                                             packageInputRef,
+                                             nix::flake::LockFlags {} );
 
   auto cursor = getPackageCursor( state, packageFlake, attrPath );
   return cursor;
@@ -809,7 +809,7 @@ createContainerBuilder( nix::EvalState &       state,
     = nix::parseFlakeRef( COMMON_NIXPKGS_URL );
 
   auto lockedNixpkgs
-    = flox::lockFlake( state, nixpkgsRef, nix::flake::LockFlags() );
+    = nix::flake::lockFlake( state, nixpkgsRef, nix::flake::LockFlags() );
 
   nix::Value vNixpkgsFlake {};
   nix::flake::callFlake( state, lockedNixpkgs, vNixpkgsFlake );

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -434,8 +434,10 @@ evalCacheCursorForInput( nix::ref<nix::EvalState> &             state,
   auto floxNixpkgsAttrs = flox::githubAttrsToFloxNixpkgsAttrs( input.attrs );
   auto packageInputRef  = nix::FlakeRef::fromAttrs( floxNixpkgsAttrs );
 
-  auto packageFlake
-    = flox::lockFlake( *state, packageInputRef, nix::flake::LockFlags {} );
+  /* See note on `flox::lockFlake on whe we call the native version here. */
+  auto packageFlake = nix::flake::lockFlake( *state,
+                                             packageInputRef,
+                                             nix::flake::LockFlags {} );
 
   auto cursor = getPackageCursor( state, packageFlake, attrPath );
   return cursor;

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -435,9 +435,8 @@ evalCacheCursorForInput( nix::ref<nix::EvalState> &             state,
   auto packageInputRef  = nix::FlakeRef::fromAttrs( floxNixpkgsAttrs );
 
   /* See note on `flox::lockFlake on whe we call the native version here. */
-  auto packageFlake = nix::flake::lockFlake( *state,
-                                             packageInputRef,
-                                             nix::flake::LockFlags {} );
+  auto packageFlake
+    = flox::lockFlake( *state, packageInputRef, nix::flake::LockFlags {} );
 
   auto cursor = getPackageCursor( state, packageFlake, attrPath );
   return cursor;

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -100,7 +100,7 @@ createWrappedFlakeDirV0( const nix::FlakeRef & nixpkgsRef )
   /* Push verbosity level to suppress "warning: creating lock file ..." */
   auto oldVerbosity = nix::verbosity;
   nix::verbosity    = nix::lvlError;
-  auto _locked      = flox::lockFlake( *state, wrappedRef, {} );
+  auto _locked      = nix::flake::lockFlake( *state, wrappedRef, {} );
   /* Pop verbosity */
   nix::verbosity = oldVerbosity;
   debugLog( "locked flake template" );

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -97,7 +97,8 @@ createWrappedFlakeDirV0( const nix::FlakeRef & nixpkgsRef )
   flox::NixState           nixState;
   nix::ref<nix::EvalState> state = nixState.getState();
   nix::FlakeRef wrappedRef = nix::parseFlakeRef( "path:" + tmpDir.string() );
-  auto          _locked    = nix::flake::lockFlake( *state, wrappedRef, {} );
+  /* See note on `flox::lockFlake on whe we call the native version here. */
+  auto _locked = nix::flake::lockFlake( *state, wrappedRef, {} );
   debugLog( "locked flake template" );
 
   return tmpDir;

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -97,8 +97,7 @@ createWrappedFlakeDirV0( const nix::FlakeRef & nixpkgsRef )
   flox::NixState           nixState;
   nix::ref<nix::EvalState> state = nixState.getState();
   nix::FlakeRef wrappedRef = nix::parseFlakeRef( "path:" + tmpDir.string() );
-  /* See note on `flox::lockFlake on whe we call the native version here. */
-  auto _locked = flox::lockFlake( *state, wrappedRef, {} );
+  auto          _locked    = nix::flake::lockFlake( *state, wrappedRef, {} );
   debugLog( "locked flake template" );
 
   return tmpDir;

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -97,12 +97,7 @@ createWrappedFlakeDirV0( const nix::FlakeRef & nixpkgsRef )
   flox::NixState           nixState;
   nix::ref<nix::EvalState> state = nixState.getState();
   nix::FlakeRef wrappedRef = nix::parseFlakeRef( "path:" + tmpDir.string() );
-  /* Push verbosity level to suppress "warning: creating lock file ..." */
-  auto oldVerbosity = nix::verbosity;
-  nix::verbosity    = nix::lvlError;
-  auto _locked      = nix::flake::lockFlake( *state, wrappedRef, {} );
-  /* Pop verbosity */
-  nix::verbosity = oldVerbosity;
+  auto          _locked    = nix::flake::lockFlake( *state, wrappedRef, {} );
   debugLog( "locked flake template" );
 
   return tmpDir;

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -98,7 +98,7 @@ createWrappedFlakeDirV0( const nix::FlakeRef & nixpkgsRef )
   nix::ref<nix::EvalState> state = nixState.getState();
   nix::FlakeRef wrappedRef = nix::parseFlakeRef( "path:" + tmpDir.string() );
   /* See note on `flox::lockFlake on whe we call the native version here. */
-  auto _locked = nix::flake::lockFlake( *state, wrappedRef, {} );
+  auto _locked = flox::lockFlake( *state, wrappedRef, {} );
   debugLog( "locked flake template" );
 
   return tmpDir;

--- a/pkgdb/src/flox-flake.cc
+++ b/pkgdb/src/flox-flake.cc
@@ -67,7 +67,7 @@ callInChildProcess( std::function<void()>  lambda,
             }
           /* The error has already been reported via the child, just pass
            * along the exit code. */
-          exit( WEXITSTATUS( status ) );
+          _exit( WEXITSTATUS( status ) );
         }
       else { throw thrownOnError; }
     }
@@ -95,21 +95,22 @@ lockFlake( nix::EvalState &              state,
            const nix::flake::LockFlags & lockFlags )
 {
   /* We want to make sure we don't make nested calls to forks */
-  static std::atomic_flag inChildSentinel = ATOMIC_FLAG_INIT;
-  auto                    nixLockFlake
+  // static std::atomic_flag inChildSentinel = ATOMIC_FLAG_INIT;
+  auto nixLockFlake
     = [&]() { return nix::flake::lockFlake( state, flakeRef, lockFlags ); };
-  if ( ! inChildSentinel.test_and_set() )
-    {
-      // Calling this in a child process will ensure downloads are complete,
-      // keeping file transfers isolated to a child process.
-      callInChildProcess( nixLockFlake,
-                          LockFlakeException( "failed to lock flake" ) );
-      inChildSentinel.clear();
-    }
-  else
-    {
-      traceLog( "flox::lockFlake: already in child process, not re-forking." );
-    }
+  // if ( ! inChildSentinel.test_and_set() )
+  //   {
+  //     // Calling this in a child process will ensure downloads are complete,
+  //     // keeping file transfers isolated to a child process.
+  //     callInChildProcess( nixLockFlake,
+  //                         LockFlakeException( "failed to lock flake" ) );
+  //     inChildSentinel.clear();
+  //   }
+  // else
+  //   {
+  //     traceLog( "flox::lockFlake: already in child process, not re-forking."
+  //     );
+  //   }
 
   return ( nixLockFlake() );
 }

--- a/pkgdb/src/flox-flake.cc
+++ b/pkgdb/src/flox-flake.cc
@@ -38,88 +38,10 @@ namespace flox {
 
 /* -------------------------------------------------------------------------- */
 
-void
-callInChildProcess( std::function<void()>  lambda,
-                    const std::exception & thrownOnError )
-{
-  pid_t pid = fork();
-  if ( pid == -1 )
-    {
-      errorLog( "callInChildProcess: failed to fork!" );
-      exit( EXIT_FAILURE );
-    }
-  if ( 0 < pid )
-    {
-      debugLog( nix::fmt( "callInChildProcess: waiting for child: %d", pid ) );
-      int status = 0;
-      waitpid( pid, &status, 0 );
-      debugLog( nix::fmt(
-        "callInChildProcess: child is finished, exit code: %d, signal: %d",
-        WEXITSTATUS( status ),
-        WTERMSIG( status ) ) );
-
-      if ( WIFEXITED( status ) )
-        {
-          if ( WEXITSTATUS( status ) == EXIT_SUCCESS )
-            {
-              /* Success */
-              return;
-            }
-          /* The error has already been reported via the child, just pass
-           * along the exit code. */
-          _exit( WEXITSTATUS( status ) );
-        }
-      else { throw thrownOnError; }
-    }
-  else
-    {
-      lambda();
-      try
-        {
-          debugLog( "callInChildProcess(child): finished, exiting" );
-          exit( EXIT_SUCCESS );
-        }
-      catch ( const std::exception & err )
-        {
-          debugLog(
-            nix::fmt( "callInChildProcess(child): caught exception on exit: %s",
-                      err.what() ) );
-          exit( EXIT_SUCCESS );
-        }
-    }
-}
-
-nix::flake::LockedFlake
-lockFlake( nix::EvalState &              state,
-           const nix::FlakeRef &         flakeRef,
-           const nix::flake::LockFlags & lockFlags )
-{
-  /* We want to make sure we don't make nested calls to forks */
-  // static std::atomic_flag inChildSentinel = ATOMIC_FLAG_INIT;
-  auto nixLockFlake
-    = [&]() { return nix::flake::lockFlake( state, flakeRef, lockFlags ); };
-  // if ( ! inChildSentinel.test_and_set() )
-  //   {
-  //     // Calling this in a child process will ensure downloads are complete,
-  //     // keeping file transfers isolated to a child process.
-  //     callInChildProcess( nixLockFlake,
-  //                         LockFlakeException( "failed to lock flake" ) );
-  //     inChildSentinel.clear();
-  //   }
-  // else
-  //   {
-  //     traceLog( "flox::lockFlake: already in child process, not re-forking."
-  //     );
-  //   }
-
-  return ( nixLockFlake() );
-}
-
-
 FloxFlake::FloxFlake( const nix::ref<nix::EvalState> & state,
                       const nix::FlakeRef &            ref )
 try : state( state ),
-  lockedFlake( flox::lockFlake( *this->state, ref, defaultLockFlags ) )
+  lockedFlake( nix::flake::lockFlake( *this->state, ref, defaultLockFlags ) )
   {}
 catch ( const std::exception & err )
   {

--- a/pkgdb/src/pkgdb/input.cc
+++ b/pkgdb/src/pkgdb/input.cc
@@ -249,10 +249,14 @@ PkgDbInput::scrapePrefix( const flox::AttrPath & prefix )
         }
       else
         {
-          //
-          // This is the child process.  Do NOT run the exit handlers when
-          // exiting the child process It may have references to threads started
-          // in the parent that we do NOT want to get cleaned up.
+          /*
+           * It is critical for the forked child process to NOT run the exit
+           * handlers (as will be done in calling `exit()`).
+           * Doing so will cause the child to try and cleanup threads and such,
+           * that the parent is still using, specifically the nix download
+           * thread. Calling `_exit()` does not call the exit handlers and
+           * allows the child to exit cleanly without interrupting the parent.
+           */
           _exit( scrapePrefixWorker( this, prefix, pageIdx, pageSize ) );
         }
     }

--- a/pkgdb/tests/realise.cc
+++ b/pkgdb/tests/realise.cc
@@ -22,7 +22,7 @@ cursorForPackageName( nix::ref<nix::EvalState> & state,
 {
   auto flakeRef = nix::parseFlakeRef( nixpkgsRef );
   auto lockedRef
-    = flox::lockFlake( *state, flakeRef, nix::flake::LockFlags {} );
+    = nix::flake::lockFlake( *state, flakeRef, nix::flake::LockFlags {} );
   std::vector<std::string> attrPath = { "legacyPackages", system, name };
   auto cursor = flox::buildenv::getPackageCursor( state, lockedRef, attrPath );
   return cursor;


### PR DESCRIPTION
## Proposed Changes

- Fix forked child exits during scraping to use `_exit()`
- Remove `flox::lockFlake()` and wrapper to fork for downloads, no longer needed.

## Release Notes

N/A
