### PR TITLE
feat: install yarn in node `flox init` hook

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test 3.0.0",
  "shell-escape",
  "supports-color",
  "sys-info",
@@ -605,7 +606,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serial_test",
+ "serial_test 2.0.0",
  "shell-escape",
  "tempfile",
  "thiserror",
@@ -2160,7 +2161,21 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot",
- "serial_test_derive",
+ "serial_test_derive 2.0.0",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive 3.0.0",
 ]
 
 [[package]]
@@ -2168,6 +2183,17 @@ name = "serial_test_derive"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,5 +52,6 @@ jsonwebtoken = "9.2"
 textwrap = "0.16.0"
 indent = { version = "0.1.1" }
 semver = "1.0.22"
+serial_test = "3.0.0"
 
 [patch.crates-io]

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -165,11 +165,45 @@ pub enum FloxhubError {
     InvalidFloxhubBaseUrl(String, #[source] url::ParseError),
 }
 
+use tempfile::TempDir;
+/// Should only be used in the flox crate
+pub fn test_flox_instance() -> (Flox, TempDir) {
+    use std::str::FromStr;
+
+    use crate::models::environment::{global_manifest_path, init_global_manifest};
+
+    let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+
+    let cache_dir = tempdir_handle.path().join("caches");
+    let data_dir = tempdir_handle.path().join(".local/share/flox");
+    let temp_dir = tempdir_handle.path().join("temp");
+    let config_dir = tempdir_handle.path().join("config");
+
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::create_dir_all(&temp_dir).unwrap();
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    let flox = Flox {
+        system: env!("NIX_TARGET_SYSTEM").to_string(),
+        cache_dir,
+        data_dir,
+        temp_dir,
+        config_dir,
+        access_tokens: Default::default(),
+        netrc_file: Default::default(),
+        uuid: Default::default(),
+        floxhub: Floxhub::new(Url::from_str("https://hub.flox.dev").unwrap(), None).unwrap(),
+        floxhub_token: None,
+    };
+
+    init_global_manifest(&global_manifest_path(&flox)).unwrap();
+
+    (flox, tempdir_handle)
+}
+
 #[cfg(test)]
 pub mod tests {
     use std::str::FromStr;
-
-    use tempfile::TempDir;
 
     use super::*;
 
@@ -189,36 +223,8 @@ pub mod tests {
     const FAKE_TOKEN: &str= "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjk5OTk5OTk5OTl9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74";
 
     pub fn flox_instance() -> (Flox, TempDir) {
-        let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
-
-        let cache_dir = tempdir_handle.path().join("caches");
-        let data_dir = tempdir_handle.path().join(".local/share/flox");
-        let temp_dir = tempdir_handle.path().join("temp");
-        let config_dir = tempdir_handle.path().join("config");
-
-        std::fs::create_dir_all(&cache_dir).unwrap();
-        std::fs::create_dir_all(&temp_dir).unwrap();
-        std::fs::create_dir_all(&config_dir).unwrap();
-
-        let flox = Flox {
-            system: env!("NIX_TARGET_SYSTEM").to_string(),
-            cache_dir,
-            data_dir,
-            temp_dir,
-            config_dir,
-            access_tokens: Default::default(),
-            netrc_file: Default::default(),
-            uuid: Default::default(),
-            floxhub: Floxhub::new(Url::from_str("https://hub.flox.dev").unwrap(), None).unwrap(),
-            floxhub_token: None,
-        };
-
-        init_global_manifest(&global_manifest_path(&flox)).unwrap();
-
-        (flox, tempdir_handle)
+        test_flox_instance()
     }
-
-    use crate::models::environment::{global_manifest_path, init_global_manifest};
 
     #[tokio::test]
     async fn test_get_username() {

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -222,9 +222,7 @@ pub mod tests {
     /// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
     const FAKE_TOKEN: &str= "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjk5OTk5OTk5OTl9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74";
 
-    pub fn flox_instance() -> (Flox, TempDir) {
-        test_flox_instance()
-    }
+    pub use super::test_flox_instance as flox_instance;
 
     #[tokio::test]
     async fn test_get_username() {

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fmt::Display;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use log::debug;
@@ -9,6 +9,8 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
+
+use super::lockfile::FlakeRef;
 
 // This is the `PKGDB` path that we actually use.
 // This is set once and prefers the `PKGDB` env variable, but will use
@@ -223,3 +225,23 @@ impl Display for CaughtMsgError {
 }
 
 impl std::error::Error for CaughtMsgError {}
+
+#[derive(Debug, Error)]
+pub enum ScrapeError {
+    #[error(transparent)]
+    CallPkgDb(#[from] CallPkgDbError),
+    #[error("couldn't serialize FlakeRef")]
+    ParseJSON(#[source] serde_json::Error),
+}
+pub fn scrape_input(input: &FlakeRef) -> Result<(), ScrapeError> {
+    let mut pkgdb_cmd = Command::new(Path::new(&*PKGDB_BIN));
+    // TODO: this works for nixpkgs, but it won't work for anything else that is not exposing "legacyPackages"
+    pkgdb_cmd
+        .args(["scrape"])
+        .arg(serde_json::to_string(&input).map_err(ScrapeError::ParseJSON)?)
+        .arg("legacyPackages");
+
+    debug!("scraping input: {pkgdb_cmd:?}");
+    call_pkgdb(pkgdb_cmd)?;
+    Ok(())
+}

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -231,12 +231,13 @@ impl Query {
 /// Which subtree a package is under.
 ///
 /// This identifies which kind of package source a package came from (catalog, flake, or nixpkgs).
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Subtree {
     /// The package came from a catalog
     Catalog,
     /// The package came from a nixpkgs checkout
+    #[default]
     LegacyPackages,
     /// The package came from an arbitrary flake
     Packages,
@@ -422,7 +423,7 @@ pub fn do_search(search_params: &SearchParams) -> Result<(SearchResults, ExitSta
 }
 
 /// A package search result
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchResult {
     /// Which input the package came from

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -147,6 +147,8 @@ pub struct Query {
     pub name: Option<String>,
     /// Match against the `pname` of the package
     pub pname: Option<String>,
+    /// Match against the `relPath` of the package
+    pub rel_path: Option<Vec<String>>,
     /// Match against the explicit version number of the package
     pub version: Option<String>,
     /// Match against a semver specifier

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -47,6 +47,7 @@ textwrap = {workspace = true, features = ["terminal_size"]}
 indent.workspace = true
 semver.workspace = true
 sentry = {workspace = true, features = ["anyhow", "tracing", "debug-logs"]}
+serial_test.workspace = true
 
 [dev-dependencies]
 temp-env = "0.3.2"

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -66,7 +66,10 @@ impl Init {
 
         // Don't run hooks in home dir
         let customization = (dir != home_dir)
-            .then(|| self.run_hooks(&dir, &flox))
+            .then(|| {
+                // TODO: hooks may run a scrape, so we should scrape here with a spinner
+                self.run_hooks(&dir, &flox)
+            })
             .transpose()?
             .unwrap_or_default();
 
@@ -302,7 +305,6 @@ fn format_customization(customization: &InitCustomization) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use flox_rust_sdk::models::search::Subtree;
     use pretty_assertions::assert_eq;
 
     use super::*;

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -618,6 +618,12 @@ impl Node {
             .as_ref()
             .map(|version| format!(" {version}"))
             .unwrap_or("".to_string());
+        let yarn_node_version = yarn_install
+            .node
+            .version
+            .as_ref()
+            .map(|version| format!(" {version}"))
+            .unwrap_or("".to_string());
         let node_version = match &node_install.node {
             Some(found_node) => found_node.clone(),
             None => Self::get_default_package("nodejs", flox)?,
@@ -631,7 +637,7 @@ impl Node {
             Flox detected both a package-lock.json and a yarn.lock
 
             Flox can add the following to your environment:
-            * Either nodejs{node_version} with npm bundled, or yarn{yarn_version} with nodejs{node_version} bundled
+            * Either nodejs{node_version} with npm bundled, or yarn{yarn_version} with nodejs{yarn_node_version} bundled
             * Either an npm or yarn installation hook
 
             Would you like Flox to apply one of these modifications?

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -272,8 +272,8 @@ teardown() {
 }
 
 @test "'flox install' creates global lock" {
-  rm -f "$GLOBAL_MANIFEST_LOCK"
   "$FLOX_BIN" init
+  rm -f "$GLOBAL_MANIFEST_LOCK"
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
     run "$FLOX_BIN" install hello
   assert_success

--- a/cli/tests/package-show.bats
+++ b/cli/tests/package-show.bats
@@ -284,9 +284,9 @@ setup_file() {
 
   mkdir 1
   pushd 1
-  "$FLOX_BIN" init
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-    "$FLOX_BIN" --debug install nodejs
+    "$FLOX_BIN" init
+  "$FLOX_BIN" --debug install nodejs
 
   run --separate-stderr sh -c "$FLOX_BIN show nodejs|tail -n1"
   assert_success
@@ -295,11 +295,11 @@ setup_file() {
 
   mkdir 2
   pushd 2
-  "$FLOX_BIN" init
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
     "$FLOX_BIN" update --global
 
   # new environment uses the global lock
+  "$FLOX_BIN" init
   "$FLOX_BIN" install nodejs
 
   run --separate-stderr sh -c "$FLOX_BIN show nodejs|tail -n1"

--- a/cli/tests/update.bats
+++ b/cli/tests/update.bats
@@ -94,9 +94,9 @@ teardown() {
 @test "update bumps an input but not an already installed package" {
   rm -f "$GLOBAL_MANIFEST_LOCK"
 
-  "$FLOX_BIN" init
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-    "$FLOX_BIN" install hello
+    "$FLOX_BIN" init
+  "$FLOX_BIN" install hello
 
   # nixpkgs and hello are both locked to the old nixpkgs
   run jq -r '.registry.inputs.nixpkgs.from.narHash' .flox/env/manifest.lock

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -58,9 +58,9 @@ teardown() {
 @test "upgrade hello" {
   rm -f "$GLOBAL_MANIFEST_LOCK"
 
-  "$FLOX_BIN" init
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-    "$FLOX_BIN" install hello
+    "$FLOX_BIN" init
+  "$FLOX_BIN" install hello
 
   # nixpkgs and hello are both locked to the old nixpkgs
   run jq -r '.registry.inputs.nixpkgs.from.narHash' "$LOCK_PATH"
@@ -87,14 +87,14 @@ teardown() {
 @test "upgrade by group" {
   rm -f "$GLOBAL_MANIFEST_LOCK"
 
-  "$FLOX_BIN" init
+  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
+   "$FLOX_BIN" init
   cat << "EOF" > "$TMP_MANIFEST_PATH"
 [install]
 hello = { pkg-group = "blue" }
 EOF
 
-  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-    "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
+  "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
 
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
     "$FLOX_BIN" update
@@ -106,9 +106,9 @@ EOF
 }
 
 @test "upgrade toplevel group" {
-  "$FLOX_BIN" init
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-    "$FLOX_BIN" install hello
+    "$FLOX_BIN" init
+  "$FLOX_BIN" install hello
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
     "$FLOX_BIN" update
   assert_old_hello
@@ -121,9 +121,9 @@ EOF
 @test "upgrade by iid" {
   rm -f "$GLOBAL_MANIFEST_LOCK"
 
-  "$FLOX_BIN" init
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-    "$FLOX_BIN" install hello
+    "$FLOX_BIN" init
+  "$FLOX_BIN" install hello
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
     "$FLOX_BIN" update
   assert_old_hello

--- a/pkgdb/include/flox/search/params.hh
+++ b/pkgdb/include/flox/search/params.hh
@@ -44,6 +44,7 @@ struct SearchQuery
 
   std::optional<std::string> name;    /**< Filter results by exact `name`. */
   std::optional<std::string> pname;   /**< Filter results by exact `pname`. */
+  std::optional<flox::AttrPath> relPath; /**< Filter results by exact relPath. */
   std::optional<std::string> version; /**< Filter results by exact version. */
   std::optional<std::string> semver;  /**< Filter results by version range. */
   std::optional<uint8_t> limit; /**< Limit to a particular number of results. */

--- a/pkgdb/src/search/command.cc
+++ b/pkgdb/src/search/command.cc
@@ -74,6 +74,13 @@ SearchCommand::addSearchQueryOptions( argparse::ArgumentParser & parser )
     .action( [&]( const std::string & arg )
              { this->params.query.pname = arg; } );
 
+  parser.add_argument( "--rel-path" )
+    .help( "search for packages by exact 'relPath'." )
+    .metavar( "DOT.SEPARATED.REL.PATH" )
+    .nargs( 1 )
+    .action( [&]( const std::string & arg )
+             { this->params.query.relPath = splitAttrPath( arg ); } );
+
   parser.add_argument( "--version" )
     .help( "search for packages by exact 'version' match." )
     .metavar( "VERSION" )

--- a/pkgdb/src/search/params.cc
+++ b/pkgdb/src/search/params.cc
@@ -109,6 +109,7 @@ from_json( const nlohmann::json & jfrom, SearchQuery & qry )
     {
       if ( key == "name" ) { getOrFail( key, value, qry.name ); }
       else if ( key == "pname" ) { getOrFail( key, value, qry.pname ); }
+      else if ( key == "rel-path" ) { getOrFail( key, value, qry.relPath );}
       else if ( key == "version" ) { getOrFail( key, value, qry.version ); }
       else if ( key == "limit" ) { getOrFail( key, value, qry.limit ); }
       else if ( key == "semver" ) { getOrFail( key, value, qry.semver ); }
@@ -145,6 +146,7 @@ to_json( nlohmann::json & jto, const SearchQuery & qry )
 {
   jto["name"]                   = qry.name;
   jto["pname"]                  = qry.pname;
+  jto["rel-path"]              = qry.relPath;
   jto["version"]                = qry.version;
   jto["semver"]                 = qry.semver;
   jto["match"]                  = qry.partialMatch;
@@ -163,6 +165,7 @@ SearchQuery::fillPkgQueryArgs( pkgdb::PkgQueryArgs & pqa ) const
   /* XXX: DOES NOT CLEAR FIRST! We are called after global preferences. */
   pqa.name                      = this->name;
   pqa.pname                     = this->pname;
+  pqa.relPath                   = this->relPath;
   pqa.version                   = this->version;
   pqa.semver                    = this->semver;
   pqa.partialMatch              = this->partialMatch;

--- a/pkgdb/src/search/params.cc
+++ b/pkgdb/src/search/params.cc
@@ -109,7 +109,7 @@ from_json( const nlohmann::json & jfrom, SearchQuery & qry )
     {
       if ( key == "name" ) { getOrFail( key, value, qry.name ); }
       else if ( key == "pname" ) { getOrFail( key, value, qry.pname ); }
-      else if ( key == "rel-path" ) { getOrFail( key, value, qry.relPath );}
+      else if ( key == "rel-path" ) { getOrFail( key, value, qry.relPath ); }
       else if ( key == "version" ) { getOrFail( key, value, qry.version ); }
       else if ( key == "limit" ) { getOrFail( key, value, qry.limit ); }
       else if ( key == "semver" ) { getOrFail( key, value, qry.semver ); }
@@ -146,7 +146,7 @@ to_json( nlohmann::json & jto, const SearchQuery & qry )
 {
   jto["name"]                   = qry.name;
   jto["pname"]                  = qry.pname;
-  jto["rel-path"]              = qry.relPath;
+  jto["rel-path"]               = qry.relPath;
   jto["version"]                = qry.version;
   jto["semver"]                 = qry.semver;
   jto["match"]                  = qry.partialMatch;


### PR DESCRIPTION
Depending on which of package.json, package-lock.json, and yarn.lock are
present, check for a compatible version of yarn.

yarn hardcodes nixpkgs#nodejs as the node it uses, so make sure
nixpkgs#nodejs is compatible with engines.node before offering to
install yarn.

If constraints are not satisfied, fall back to just installing nodejs.

At this point, don't check engines.npm, because nixpkgs only contains
one version of npm, but it contains more versions of npm bundled in with
the several different versions of nodejs it contains.

The node init hook is left feature flagged with _FLOX_NODE_HOOK.