### PR TITLE
feat: trust official flox environments by default

### DIFF
--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -61,7 +61,7 @@ hook was defined.
     code.
     This presents a security risk,
     so you will be prompted whether to trust the environment.
-    Environments owned by the current user are always trusted.
+    Environments owned by the current user and Flox are always trusted.
     You may set certain environments to always be trusted using the config key
     `trusted_environments."<owner/name>" = (trust | deny)`,
     or via the following command:

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -982,6 +982,14 @@ pub(super) async fn ensure_environment_trust(
 
     let trust = config.flox.trusted_environments.get(&env_ref);
 
+    // Official Flox environments are trusted by default
+    // Only applies to the current flox owned FloxHub,
+    // so this rule might need to be revisited in the future.
+    if env_ref.owner().as_str() == "flox" {
+        debug!("Official Flox environment {env_ref} is trusted by default");
+        return Ok(());
+    }
+
     if let Some(ref token) = flox.floxhub_token {
         if token.handle()?.as_str() == env_ref.owner().as_str() {
             debug!("environment {env_ref} is trusted by token");

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -206,15 +206,28 @@ EOF
 # we trust it automatically.
 #
 # flox reads the user handle from the auth token.
-# Here we set a floxhub token with the user handle "test".
+# The default floxhub test token has the user handle "test".
 @test "m10.4: 'activate --remote' succeeds if owned by current user" {
   export OWNER="test"
   floxhub_setup "$OWNER"
   make_empty_remote_env
 
-  "$FLOX_BIN" install hello --remote "$OWNER/test"
-
   run "$FLOX_BIN" activate --remote "$OWNER/test" -- exit
+  assert_success
+}
+
+# bats test_tags=remote,activate,trust,remote:activate:trust-flox
+#
+# If the remotely accessed environment is owned by Flox,
+# we trust it automatically.
+#
+# flox reads the user handle from the auth token.
+# Here we set a floxhub token with the user handle "test".
+@test "m10.5: 'activate --remote' succeeds if owned by Flox" {
+  floxhub_setup "flox"
+  OWNER=flox make_empty_remote_env
+
+  run "$FLOX_BIN" activate --remote "flox/test" -- exit
   assert_success
 }
 
@@ -222,7 +235,7 @@ EOF
 
 @test "sanity check upgrade works for remote environments" {
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-  make_empty_remote_env
+    make_empty_remote_env
 
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
     "$FLOX_BIN" install hello --remote "$OWNER/test"


### PR DESCRIPTION
Automatically trust remote environments owned by "flox"