### PR TITLE
fix(expect): wait for final activation output

### DIFF
--- a/cli/tests/install/prompt-which-environment-git.exp
+++ b/cli/tests/install/prompt-which-environment-git.exp
@@ -11,7 +11,9 @@ expect_after {
   "*\n" { exp_continue }
   "*\r" { exp_continue }
 }
-expect -ex "Getting ready to use environment" {}
+
+# wait until we see the environment "greeting" message
+expect -ex "To stop using this environment, type 'exit'" {}
 
 # cd to directory 2/subdirectory
 send "cd 2/subdirectory\n"

--- a/cli/tests/install/prompt-which-environment.exp
+++ b/cli/tests/install/prompt-which-environment.exp
@@ -12,7 +12,8 @@ expect_after {
   "*\r" { exp_continue }
 }
 
-expect -ex "Getting ready to use environment" {}
+# wait until we see the environment "greeting" message
+expect -ex "To stop using this environment, type 'exit'" {}
 
 # cd to directory 2
 send "cd 2\n"


### PR DESCRIPTION
The expect tests were only waiting until they _saw the spinner_ before issuing `cd 2` and expecting an echo of `cd 2` from the shell.
However, since the spinner continuously updates the terminal, the output got mangled: https://github.com/flox/flox/actions/runs/8193738916/job/22408165476?pr=1133#step:6:375

```
# expect: set expect_out(buffer) " 1 at /home/runner/work/_temp/nix-shell.c0NWi cd\r\u001b[2K\u2801 Getting ready to use environment 1 at /home/runner/work/_temp/nix-shell.c0NWi  2\r\n"

                                                                         cd here ^, the respective 2 is yonder to the right ------------------------------------------------------ ^
```