### PR TITLE
feat(activate): allow activation without prompt

### DIFF
--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -96,6 +96,9 @@ See [`manifest.toml(1)`](./manifest.toml.md) for more details on shell hooks.
 `$FLOX_PROMPT_ENVIRONMENTS`
 :   Contains a space-delimited list of the active environments,
     e.g. `owner1/foo owner2/bar local_env`.
+    This is set to an _empty string_ if the config value for `shell_prompt`
+    is `hide-all` or `hide-default` and only environments named 'default'
+    are active.
 
 `$FLOX_ENV_CACHE`
 :   `activate` sets this variable to a directory that can be used by an

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -100,6 +100,14 @@ flox config --set 'trusted_environments."owner/name"' trust
 `search_limit`
 :   How many items `flox search` should show by default.
 
+`shell_prompt`
+:   Rule whether to change the shell prompt in activated environments
+    (default: "show-all").
+    Possible values are
+    * "show-all": shows all active anvironments
+    * "hide-all": disables the modification of the shell prompt
+    * "hide-default": filters out environments named 'default' from the shell prompt
+
 `trusted_environments`
 :   Remote environments that are trusted for activation.
     Contains keys of the form `"<owner>/<name>"` that map to either `"trust"` or

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1054,8 +1054,14 @@ impl ActiveEnvironments {
         self.0.push_front(env);
     }
 
+    /// Check if the given environment is active
     pub fn is_active(&self, env: &UninitializedEnvironment) -> bool {
         self.0.contains(env)
+    }
+
+    /// Iterate over the active environments
+    pub fn iter(&self) -> impl Iterator<Item = &UninitializedEnvironment> {
+        self.0.iter()
     }
 }
 

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -72,6 +72,9 @@ pub struct FloxConfig {
 
     /// The URL of the FloxHub instance to use
     pub floxhub_url: Option<Url>,
+
+    /// Rule whether to change the shell prompt in activated environments
+    pub shell_prompt: Option<EnvironmentPromptConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -79,6 +82,18 @@ pub struct FloxConfig {
 pub enum EnvironmentTrust {
     Trust,
     Deny,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EnvironmentPromptConfig {
+    /// Change the shell prompt to show all active environments
+    ShowAll,
+    /// Do not change the shell prompt
+    HideAll,
+    /// Change the shell prompt to show the active environments,
+    /// but omit 'default' environments
+    HideDefault,
 }
 
 // TODO: move to runix?

--- a/pkgdb/src/buildenv/assets/set-prompt.bash.sh
+++ b/pkgdb/src/buildenv/assets/set-prompt.bash.sh
@@ -21,7 +21,7 @@ fi
 
 unset _esc colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
 
-if [ -n "$_flox" ] && [ -n "${PS1:-}" ]; then
+if [ -n "$_flox" ] && [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
   # Start by saving the original value of PS1.
   if [ -z "$FLOX_SAVE_PS1" ]; then
     export FLOX_SAVE_PS1="$PS1"

--- a/pkgdb/src/buildenv/assets/set-prompt.zsh.sh
+++ b/pkgdb/src/buildenv/assets/set-prompt.zsh.sh
@@ -11,7 +11,7 @@ fi
 
 _flox="${_floxPrompt1} ${_floxPrompt2} "
 
-if [ -n "$_flox" -a -n "${PS1:-}" ]
+if [ -n "$_flox" -a -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]
 then
     # Start by saving the original value of PS1.
     if [ -z "$FLOX_SAVE_PS1" ]; then


### PR DESCRIPTION
Adds a new config option `shell_prompt` with the possible values `show-all`, `hide-all` and `hide-default`.

`flox activate` respects this config and will **disable** the prompt modifications if the value is `hide-all`.
With `hide-default` it filters out all `default` environments, entirely disabling the prompt if all active envs were filtered.