### PR TITLE
chore: less verbose output from expect

### DIFF
--- a/cli/tests/auth.bats
+++ b/cli/tests/auth.bats
@@ -70,7 +70,7 @@ teardown() {
   touch ./bin/xdg-open
   export PATH="$PWD/bin:$PATH"
 
-  run expect -d "$TESTS_DIR/auth/loginPrompt.exp"
+  run expect "$TESTS_DIR/auth/loginPrompt.exp"
   assert_success
   assert_line --partial "First copy your one-time code:"
   assert_line --regexp "Press enter to open .+ in your browser\.\.\."
@@ -91,7 +91,7 @@ teardown() {
   # emulate ssh environment
   export SSH_TTY="1"
 
-  run expect -d "$TESTS_DIR/auth/loginPrompt.exp"
+  run expect "$TESTS_DIR/auth/loginPrompt.exp"
   assert_success
   assert_line --regexp "Go to .+ in your browser"
   assert_line --partial "Then enter your one-time code: "

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -108,7 +108,7 @@ env_is_activated() {
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -122,7 +122,7 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -132,7 +132,7 @@ env_is_activated() {
 @test "bash: activate runs hook" {
   sed -i -e "s/\[hook\]/${HELLO_HOOK//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  SHELL=bash NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
   assert_output --partial "Welcome to your flox environment!"
 
   SHELL=bash USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
@@ -149,7 +149,7 @@ env_is_activated() {
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
   # SHELL=zsh USER="$REAL_USER" run -0 bash -c "echo exit | $FLOX_CLI activate --dir $PROJECT_DIR";
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
   assert_output --partial "Welcome to your flox environment!"
 
   SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
@@ -165,7 +165,7 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is aliased to \`echo testing'"
 }
 
@@ -176,7 +176,7 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is an alias for echo testing"
 }
 
@@ -185,7 +185,7 @@ env_is_activated() {
 @test "bash: activate sets env var" {
   sed -i -e "s/\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  SHELL=bash NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+  SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
   SHELL=bash NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
@@ -202,7 +202,7 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect -d "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
   SHELL=zsh NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -111,7 +111,7 @@ EOF
 
   sed "s/\[hook\]/${HOOK//$'\n'/\\n}/" "$MANIFEST_PATH" > "$TMP_MANIFEST_PATH"
 
-  SHELL=bash run expect -d "$TESTS_DIR/edit/re-activate.exp" "$TMP_MANIFEST_PATH"
+  SHELL=bash run expect "$TESTS_DIR/edit/re-activate.exp" "$TMP_MANIFEST_PATH"
   assert_success
 }
 

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -179,7 +179,7 @@ teardown() {
   mkdir 2
   "$FLOX_BIN" init --dir 2
 
-  SHELL=bash NO_COLOR=1 run expect -d "$TESTS_DIR/install/last-activated.exp"
+  SHELL=bash NO_COLOR=1 run expect "$TESTS_DIR/install/last-activated.exp"
   assert_success
 }
 
@@ -190,7 +190,7 @@ teardown() {
   mkdir 2
   "$FLOX_BIN" init --dir 2
 
-  SHELL=bash NO_COLOR=1 run -0 expect -d "$TESTS_DIR/install/prompt-which-environment.exp"
+  SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/install/prompt-which-environment.exp"
 }
 
 @test "'flox install' prompts when an environment is activated and there is an environment in the containing git repo" {
@@ -202,7 +202,7 @@ teardown() {
   git -C 2 init
   mkdir 2/subdirectory
 
-  SHELL=bash NO_COLOR=1 run -0 expect -d "$TESTS_DIR/install/prompt-which-environment-git.exp"
+  SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/install/prompt-which-environment-git.exp"
 }
 
 @test "i5: download package when install command runs" {

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -272,7 +272,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=bash USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
   assert_output --regexp "$FLOX_CACHE_HOME/run/owner/.+\..+\..+/bin/hello"
   refute_output "not found"
 }

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -308,7 +308,7 @@ function add_insecure_package() {
   update_dummy_env "owner" "name"
   make_incompatible "owner" "name"
 
-  run -0 expect -d "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_SYSTEM_PROMPT" no
+  run -0 expect "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_SYSTEM_PROMPT" no
   assert_success
   assert_output --partial "The environment you are trying to pull is not yet compatible with your system ($NIX_SYSTEM)"
   assert_line --partial "Did not pull the environment."
@@ -323,7 +323,7 @@ function add_insecure_package() {
   update_dummy_env "owner" "name"
   make_incompatible "owner" "name"
 
-  run -0 expect -d "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_SYSTEM_PROMPT" yes
+  run -0 expect "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_SYSTEM_PROMPT" yes
   assert_success
 
   run "$FLOX_BIN" list
@@ -385,7 +385,7 @@ function add_insecure_package() {
   update_dummy_env "owner" "name"
   add_incompatible_package "owner" "name"
 
-  run -0 expect -d "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_PACKAGE_PROMPT" no
+  run -0 expect "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_PACKAGE_PROMPT" no
   assert_success
   assert_line --partial "package 'extra' is not available for this system ('$NIX_SYSTEM')"
   assert_output --partial "$UNSUPPORTED_PACKAGE_PROMPT"
@@ -400,7 +400,7 @@ function add_insecure_package() {
   update_dummy_env "owner" "name"
   add_incompatible_package "owner" "name"
 
-  run -0 expect -d "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_PACKAGE_PROMPT" yes
+  run -0 expect "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_PACKAGE_PROMPT" yes
   assert_success
   assert_line --partial "package 'extra' is not available for this system ('$NIX_SYSTEM')"
   assert_output --partial "$UNSUPPORTED_PACKAGE_PROMPT"
@@ -433,7 +433,7 @@ function add_insecure_package() {
   update_dummy_env "owner" "name"
   add_insecure_package "owner" "name"
 
-  run -0 expect -d "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_PACKAGE_PROMPT" no
+  run -0 expect "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_PACKAGE_PROMPT" no
   assert_success
   assert_line --partial "package 'extra' failed to evaluate: "
   assert_output --partial "$UNSUPPORTED_PACKAGE_PROMPT"
@@ -448,7 +448,7 @@ function add_insecure_package() {
   update_dummy_env "owner" "name"
   add_insecure_package "owner" "name"
 
-  run -0 expect -d "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_PACKAGE_PROMPT" yes
+  run -0 expect "$TESTS_DIR/pull/answerPrompt.exp" owner/name "$UNSUPPORTED_PACKAGE_PROMPT" yes
   assert_success
   assert_line --partial "package 'extra' failed to evaluate: "
   assert_output --partial "$UNSUPPORTED_PACKAGE_PROMPT"

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -146,7 +146,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=bash USER="$REAL_USER" run -0 expect -d "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
+  SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
   assert_output --partial "$FLOX_CACHE_HOME/remote/owner/test/.flox/run/bin/hello"
   refute_output "not found"
 }

--- a/cli/tests/package-show.bats
+++ b/cli/tests/package-show.bats
@@ -307,7 +307,7 @@ setup_file() {
   assert_output "    nodejs - nodejs@$NODEJS_VERSION_NEW"
   popd
 
-  SHELL=bash run expect -d "$TESTS_DIR/show/prompt-which-environment.exp"
+  SHELL=bash run expect "$TESTS_DIR/show/prompt-which-environment.exp"
   assert_success
   assert_output --partial "nodejs - nodejs@$NODEJS_VERSION_NEW"
 }

--- a/tests/python.bats
+++ b/tests/python.bats
@@ -60,6 +60,6 @@ teardown() {
   assert_output --partial "✅ 'pip' installed to environment"
   assert_output --partial "✅ 'python3' installed to environment"
 
-  SHELL=bash run expect -d "$TESTS_DIR/python.exp" "$PROJECT_DIR"
+  SHELL=bash run expect "$TESTS_DIR/python.exp" "$PROJECT_DIR"
   assert_success
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Makes the output from failed `expect` tests less verbose so that it's easier to identify the cause of the test failure.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
