### PR TITLE
style: use new brand colors for prompts and dialogs

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -561,9 +561,9 @@ impl Activate {
         let shell = ShellType::detect()?;
 
         let prompt_color_1 = env::var("FLOX_PROMPT_COLOR_1")
-            .unwrap_or(utils::colors::LIGHT_BLUE.to_ansi256().to_string());
+            .unwrap_or(utils::colors::INDIGO_400.to_ansi256().to_string());
         let prompt_color_2 = env::var("FLOX_PROMPT_COLOR_2")
-            .unwrap_or(utils::colors::DARK_PEACH.to_ansi256().to_string());
+            .unwrap_or(utils::colors::INDIGO_300.to_ansi256().to_string());
 
         let mut exports = HashMap::from([
             (FLOX_ENV_VAR, activation_path.to_string_lossy().to_string()),

--- a/cli/flox/src/utils/colors.rs
+++ b/cli/flox/src/utils/colors.rs
@@ -129,26 +129,14 @@ impl FloxColor {
     }
 }
 
-#[allow(unused)]
-pub const DARK_BLUE: FloxColor = FloxColor {
-    ansi256: 17,
-    rgb: (32, 20, 123),
-    basic: BasicColor::DarkBlue,
-};
-pub const LIGHT_BLUE: FloxColor = FloxColor {
-    ansi256: 61,
-    rgb: (88, 86, 156),
-    basic: BasicColor::Blue,
-};
-
-#[allow(unused)]
-pub const DARK_PEACH: FloxColor = FloxColor {
-    ansi256: 216,
-    rgb: (225, 185, 144),
+pub const INDIGO_300: FloxColor = FloxColor {
+    ansi256: 141,
+    rgb: (175, 135, 255),
     basic: BasicColor::DarkYellow,
 };
-pub const LIGHT_PEACH: FloxColor = FloxColor {
-    ansi256: 223,
-    rgb: (225, 206, 172),
-    basic: BasicColor::Yellow,
+
+pub const INDIGO_400: FloxColor = FloxColor {
+    ansi256: 99,
+    rgb: (135, 95, 255),
+    basic: BasicColor::Blue,
 };

--- a/cli/flox/src/utils/dialog.rs
+++ b/cli/flox/src/utils/dialog.rs
@@ -212,16 +212,16 @@ impl Dialog<'_, ()> {
 pub fn flox_theme() -> RenderConfig {
     let mut render_config = RenderConfig::default_colored();
 
-    if let (Some(light_peach), Some(light_blue)) = (
-        colors::LIGHT_PEACH.to_inquire(),
-        colors::LIGHT_BLUE.to_inquire(),
+    if let (Some(dark_peach), Some(light_blue)) = (
+        colors::INDIGO_300.to_inquire(),
+        colors::INDIGO_400.to_inquire(),
     ) {
-        render_config.answered_prompt_prefix = Styled::new(">").with_fg(light_peach);
-        render_config.highlighted_option_prefix = Styled::new(">").with_fg(light_peach);
-        render_config.prompt_prefix = Styled::new("!").with_fg(light_peach);
+        render_config.answered_prompt_prefix = Styled::new(">").with_fg(dark_peach);
+        render_config.highlighted_option_prefix = Styled::new(">").with_fg(dark_peach);
+        render_config.prompt_prefix = Styled::new("!").with_fg(dark_peach);
         render_config.prompt = StyleSheet::new().with_attr(Attributes::BOLD);
         render_config.help_message = Styled::new("").with_fg(light_blue).style;
-        render_config.answer = Styled::new("").with_fg(light_peach).style;
+        render_config.answer = Styled::new("").with_fg(dark_peach).style;
     } else {
         render_config.answered_prompt_prefix = Styled::new(">");
         render_config.highlighted_option_prefix = Styled::new(">");

--- a/pkgdb/src/buildenv/assets/mkContainer.nix
+++ b/pkgdb/src/buildenv/assets/mkContainer.nix
@@ -41,8 +41,8 @@
       Env = lib.mapAttrsToList (name: value: "${name}=${value}") {
         "FLOX_ENV" = environment;
         "FLOX_PROMPT_ENVIRONMENTS" = "floxenv";
-        "FLOX_PROMPT_COLOR_1" = "61";
-        "FLOX_PROMPT_COLOR_2" = "216";
+        "FLOX_PROMPT_COLOR_1" = "99";
+        "FLOX_PROMPT_COLOR_2" = "141";
         "_FLOX_ACTIVE_ENVIRONMENTS" = "[]";
         "FLOX_SOURCED_FROM_SHELL_RC" = "1"; # don't source from shell rc (again)
         "BASH_ENV" = "${environment}/activate/bash";

--- a/pkgdb/src/buildenv/assets/set-prompt.bash.sh
+++ b/pkgdb/src/buildenv/assets/set-prompt.bash.sh
@@ -13,7 +13,7 @@ _floxPrompt2="${colorPrompt2}[$FLOX_PROMPT_ENVIRONMENTS]"
 # https://git.savannah.gnu.org/cgit/bash.git/tree/bashline.c#n23
 # Note that we set colors even if support for progcomp is compiled in, but it is
 # turned off.
-if [[ $(shopt) =~ progcomp ]]; then
+if [[ $(shopt) =~ progcomp ]] && [[ "${NO_COLOR:-0}" != "0" ]]; then
   _flox=$(echo -e -n "${colorBold}${FLOX_PROMPT-$_floxPrompt1} ${_floxPrompt2}${colorReset} ")
 else
   _flox=$(echo -e -n "${FLOX_PROMPT-flox} [$FLOX_PROMPT_ENVIRONMENTS] ")

--- a/pkgdb/src/buildenv/assets/set-prompt.zsh.sh
+++ b/pkgdb/src/buildenv/assets/set-prompt.zsh.sh
@@ -1,9 +1,15 @@
 
 # Tweak the (already customized) prompt: add a flox indicator.
-_floxPrompt1="%F{${FLOX_PROMPT_COLOR_1}}flox"
-_floxPrompt2="%F{$FLOX_PROMPT_COLOR_2}[$FLOX_PROMPT_ENVIRONMENTS]"
-_flox="%B${FLOX_PROMPT-$_floxPrompt1} ${_floxPrompt2}%f%b "
 
+_floxPrompt1="${FLOX_PROMPT-flox}"
+_floxPrompt2="[$FLOX_PROMPT_ENVIRONMENTS]"
+
+if [[ "${NO_COLOR:-0}" == "0" ]]; then
+    _floxPrompt1="%B%F{${FLOX_PROMPT_COLOR_1}}${_floxPrompt1}%f%b"
+    _floxPrompt2="%F{${FLOX_PROMPT_COLOR_2}}${_floxPrompt2}%f"
+fi
+
+_flox="${_floxPrompt1} ${_floxPrompt2} "
 
 if [ -n "$_flox" -a -n "${PS1:-}" ]
 then


### PR DESCRIPTION
Uses new brand colors for the flox prompt and dialogs and explicitly support `NO_COLOR` for prompts

