### PR TITLE
feat(auth): Use the custom auth0 domain

### DIFF
--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -46,7 +46,7 @@
 
   # build time environment variables
   envs = let
-    auth0BaseUrl = "https://flox.us.auth0.com";
+    auth0BaseUrl = "https://auth.flox.dev";
   in
     {
       # 3rd party CLIs


### PR DESCRIPTION
Uses the new custom domain for auth0. 