### PR TITLE
fix: add -V short for --version

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -146,7 +146,7 @@ pub struct FloxArgs {
 
     /// Print the version of the program
     #[allow(dead_code)] // fake arg, `--version` is checked for separately (see [Version])
-    #[bpaf(long)]
+    #[bpaf(long, short('V'))]
     version: bool,
 
     #[bpaf(external(commands), optional)]
@@ -543,7 +543,7 @@ impl Prefix {
 /// such as git always require correct arguments even in the presence of
 /// short circuiting flags such as `--version`
 #[derive(Bpaf, Default)]
-pub struct Version(#[bpaf(long("version"))] bool);
+pub struct Version(#[bpaf(short('V'), long("version"))] bool);
 
 impl Version {
     /// Parses to [Self] and extract the `--version` flag

--- a/pkgdb/build-aux/iwyu
+++ b/pkgdb/build-aux/iwyu
@@ -35,10 +35,10 @@ The default \`EXTRA-IWYU-ARGS' are:
 OPTIONS
   -t,--tool-opt OPT   Pass an option(s) to \`iwyu_tool.py'
   -f,--file PATH      Target specific file(s). May be used multiple times.
-  -V,--verbose        Run in verbose mode.
+  -v,--verbose        Run in verbose mode.
   -h,--help           Print help message to STDOUT.
   -u,--usage          Print usage message to STDOUT.
-  -v,--version        Print version information to STDOUT.
+  -V,--version        Print version information to STDOUT.
 
 ENVIRONMENT
   IWYU_TOOL           Command used as \`iwyu_tool.py' executable.
@@ -125,7 +125,7 @@ while [[ "$#" -gt 0 ]]; do
 		fi
 		_SOURCES+=("$1")
 		;;
-	-V | --verbose) _VERBOSE=: ;;
+	-v | --verbose) _VERBOSE=: ;;
 	-u | --usage)
 		usage
 		exit 0
@@ -134,7 +134,7 @@ while [[ "$#" -gt 0 ]]; do
 		usage -f
 		exit 0
 		;;
-	-v | --version)
+	-V | --version)
 		echo "$_version"
 		exit 0
 		;;


### PR DESCRIPTION
## Proposed Changes

- Add `-V` as short argument for `--version`

## Release Notes

- `-V` is short for `--version`
