### PR TITLE
fix: set default nix vars process wide

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "flox"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flox"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -77,7 +77,7 @@ use crate::utils::errors::{
     format_core_error,
     format_locked_manifest_error,
 };
-use crate::utils::message;
+use crate::utils::{default_nix_env_vars, message};
 use crate::{subcommand_metric, utils};
 
 // Edit declarative environment configuration
@@ -592,7 +592,7 @@ impl Activate {
             ("FLOX_PROMPT_COLOR_2", prompt_color_2),
         ]);
 
-        exports.extend(Self::default_subprocess_env_vars());
+        exports.extend(default_nix_env_vars());
 
         if let Some(fixed_up_original_path_joined) = fixed_up_original_path_joined {
             exports.insert(
@@ -871,55 +871,6 @@ impl Activate {
             .iter()
             .map(|arg| format!(r#""{}""#, arg.replace('"', r#"\""#)))
             .join(" ")
-    }
-
-    /// Explicitly set environment for nix calls
-    ///
-    /// Nixpkgs itself is broken in that the packages it creates depends
-    /// upon a variety of environment variables at runtime.  On NixOS
-    /// these are convenient to set on a system-wide basis but that
-    /// essentially masks the problem, and it's not uncommon to see Nix
-    /// packages trip over the absence of environment variables when
-    /// invoked on other Linux distributions.
-    ///
-    /// For flox specifically, set Nix-provided defaults for certain
-    /// environment variables that we know to be required on the various
-    /// operating systems.
-    /// Setting buildtime variants of these environment variables
-    /// will bundle them in flox' package closure
-    /// and ensure that subprocesses are run with valid known values.
-    fn default_subprocess_env_vars() -> HashMap<&'static str, String> {
-        let mut env_map: HashMap<&str, String> = HashMap::new();
-
-        // use buildtime NIXPKGS_CACERT_BUNDLE_CRT
-        let ssl_cert_file = match env::var("SSL_CERT_FILE") {
-            Ok(v) => v,
-            Err(_) => {
-                let nixpkgs_cacert_bundle_crt = env!("NIXPKGS_CACERT_BUNDLE_CRT");
-                env_map.insert("SSL_CERT_FILE", nixpkgs_cacert_bundle_crt.to_string());
-                nixpkgs_cacert_bundle_crt.to_string()
-            },
-        };
-
-        env_map.insert("NIX_SSL_CERT_FILE", ssl_cert_file);
-
-        // on macos use buildtime NIX_COREFOUNDATION_RPATH and PATH_LOCALE
-        #[cfg(target_os = "macos")]
-        {
-            env_map.insert(
-                "NIX_COREFOUNDATION_RPATH",
-                env!("NIX_COREFOUNDATION_RPATH").to_string(),
-            );
-            env_map.insert("PATH_LOCALE", env!("PATH_LOCALE").to_string());
-        }
-
-        // on linux use buildtime LOCALE_ARCHIVE
-        #[cfg(target_os = "linux")]
-        {
-            env_map.insert("LOCALE_ARCHIVE", env!("LOCALE_ARCHIVE").to_string());
-        }
-
-        env_map
     }
 }
 

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -11,7 +11,7 @@ use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentErr
 use flox_rust_sdk::models::environment::{init_global_manifest, EnvironmentError2};
 use log::{debug, warn};
 use utils::init::{init_logger, init_sentry};
-use utils::message;
+use utils::{message, populate_default_nix_env_vars};
 
 use crate::utils::errors::{format_error, format_managed_error, format_remote_error};
 
@@ -24,6 +24,7 @@ async fn run(args: FloxArgs) -> Result<()> {
     init_logger(Some(args.verbosity));
     set_user()?;
     set_parent_process_id();
+    populate_default_nix_env_vars();
     let config = config::Config::parse()?;
     init_global_manifest(&config.flox.config_dir.join("global-manifest.toml"))?;
     args.handle(config).await?;

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::env;
 use std::io::Stderr;
 use std::sync::Mutex;
 
@@ -15,3 +17,60 @@ pub mod openers;
 pub mod search;
 
 pub static TERMINAL_STDERR: Lazy<Mutex<Stderr>> = Lazy::new(|| Mutex::new(std::io::stderr()));
+
+/// Explicitly set environment for nix calls
+///
+/// Nixpkgs itself is broken in that the packages it creates depends
+/// upon a variety of environment variables at runtime.  On NixOS
+/// these are convenient to set on a system-wide basis but that
+/// essentially masks the problem, and it's not uncommon to see Nix
+/// packages trip over the absence of environment variables when
+/// invoked on other Linux distributions.
+///
+/// For flox specifically, set Nix-provided defaults for certain
+/// environment variables that we know to be required on the various
+/// operating systems.
+/// Setting buildtime variants of these environment variables
+/// will bundle them in flox' package closure
+/// and ensure that subprocesses are run with valid known values.
+pub fn default_nix_env_vars() -> std::collections::HashMap<&'static str, String> {
+    let mut env_map: HashMap<&str, String> = HashMap::new();
+
+    // use buildtime NIXPKGS_CACERT_BUNDLE_CRT
+    let ssl_cert_file = match env::var("SSL_CERT_FILE") {
+        Ok(v) => v,
+        Err(_) => {
+            let nixpkgs_cacert_bundle_crt = env!("NIXPKGS_CACERT_BUNDLE_CRT");
+            env_map.insert("SSL_CERT_FILE", nixpkgs_cacert_bundle_crt.to_string());
+            nixpkgs_cacert_bundle_crt.to_string()
+        },
+    };
+
+    env_map.insert("NIX_SSL_CERT_FILE", ssl_cert_file);
+
+    // on macos use buildtime NIX_COREFOUNDATION_RPATH and PATH_LOCALE
+    #[cfg(target_os = "macos")]
+    {
+        env_map.insert(
+            "NIX_COREFOUNDATION_RPATH",
+            env!("NIX_COREFOUNDATION_RPATH").to_string(),
+        );
+        env_map.insert("PATH_LOCALE", env!("PATH_LOCALE").to_string());
+    }
+
+    // on linux use buildtime LOCALE_ARCHIVE
+    #[cfg(target_os = "linux")]
+    {
+        env_map.insert("LOCALE_ARCHIVE", env!("LOCALE_ARCHIVE").to_string());
+    }
+
+    env_map
+}
+
+/// Set the default nix environment variables for the current process
+pub fn populate_default_nix_env_vars() {
+    let env_map = default_nix_env_vars();
+    for (key, value) in env_map {
+        env::set_var(key, value)
+    }
+}

--- a/doc/release-notes/rl-1.0.1.md
+++ b/doc/release-notes/rl-1.0.1.md
@@ -1,0 +1,3 @@
+## Release 1.0.1 (2024-03-13)
+
+This release fixes SSL issues on MacOS when running remote commands such as e.g. `flox pull`, `flox push` or `flox activate -r`.


### PR DESCRIPTION
follow up on https://github.com/flox/flox/pull/1153, which mitigated this for pkgdb but not git

This PR is setting nix related env vars globally for the entire process at startup, as well explicitly for activated environments.

