### PR TITLE
fix: improve already exists error message suggestion

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1522,6 +1522,7 @@ impl Push {
 
                 To rename your environment: 'flox edit --name <new name>'
                 To pull and manually re-apply your changes: 'flox delete && flox pull -r {owner}/{name}'
+                To overwrite and force update: 'flox push --force'
             "}.into(),
             ManagedEnvironmentError::Build(ref err) => formatdoc! {"
                 {err}


### PR DESCRIPTION
## Proposed Changes

Small tweak to offer an additional suggestion when a user encounters 'environment exists' (in FloxHub) error. 


## Release Notes

N/A


<!-- Many thanks! -->
