### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ of Nix.
 
 We are happy to welcome you to our [Discourse forum][discourse] and answer your
 questions! You can always reach out to us directly via the [Flox twitter
-account][twitter] or chat to us directly on [Matrix][matrix] or
+account][twitter] or chat to us directly on [Slack][slack] or
 [Discord][discord].
 
 ## 🤝 Found a bug? Missing a specific feature?
@@ -138,7 +138,7 @@ The Flox CLI is licensed under the GPLv2. See [LICENSE](./LICENSE).
 [images]: docs/tutorials/sharing-environments/#sharing-with-containers
 [docs]: https://flox.dev/docs
 [twitter]: https://twitter.com/floxdevelopment
-[matrix]: https://matrix.to/#/#flox:matrix.org
+[slack]: https://floxcommunitygroup.slack.com
 [discord]: https://discord.gg/5H7hN57eQR
 [new-issue]: https://github.com/flox/flox/issues/new/choose
 [post-nixpkgs]: https://flox.dev/blog/nixpkgs


### PR DESCRIPTION
to replace matrix link with new slack link