### PR TITLE
fix: implement parent shell detection by process id

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -283,6 +283,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +597,7 @@ dependencies = [
  "shell-escape",
  "supports-color",
  "sys-info",
+ "sysinfo",
  "temp-env",
  "tempfile",
  "textwrap",
@@ -936,7 +962,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -1127,9 +1153,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libredox"
@@ -1287,6 +1313,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1639,6 +1674,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2364,6 +2419,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,12 +3038,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3025,6 +3114,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,6 +3139,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3049,6 +3159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3175,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3073,6 +3195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,6 +3211,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3097,6 +3231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,6 +3247,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,10 @@ serde_with = "2.0.1"
 serde_yaml = "0.9"
 shell-escape = "0.1.5"
 supports-color = "2.0.0"
+# provides process tools for shell detection
+sysinfo = "0.30.7"
+# provide system version information for metric
+# TODO: review if we need this
 sys-info = "0.9"
 tempfile = "3.4.0"
 thiserror = "1"

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -33,6 +33,7 @@ derive_more.workspace = true
 time.workspace = true
 uuid.workspace = true
 reqwest.workspace = true
+sysinfo.workspace = true
 sys-info.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -29,7 +29,14 @@ interactive shell.
 Launches a subshell non-interactively when invoked with a command
 and arguments.
 May also be invoked as `$(flox activate)` to produce commands to be sourced
-by your current `$SHELL`.
+by the parent shell.
+The parent shell is detected automatically by inspecting the executable path
+of the parent process.
+If Flox can not interpret the path as a shell or a subshell is launched,
+Flox will fall back to `$SHELL`.
+To override the shell explicitly, `$FLOX_SHELL` can be set as an override.
+`flox activate` currently only supports `bash` and `zsh` shells
+for any of the detection mechanisms described above.
 
 When invoked interactively,
 the shell prompt will be modified to display the active environments,
@@ -112,10 +119,15 @@ hook was defined.
 `$FLOX_SHELL`
 :  When launching an interactive sub-shell, Flox launches the shell specified in
    `$FLOX_SHELL` if it is set.
+   When printing a shell for sourcing in the current shell,
+   Flox will produce a script suitable for `$FLOX_SHELL` if it is set.
 
 `$SHELL`
 :  When launching an interactive sub-shell, Flox launches the shell specified in
    `$SHELL` if it is set and `$FLOX_SHELL` is not set.
+   When printing a shell for sourcing in the current shell,
+   Flox will produce a script suitable for `$SHELL` if it is set
+   and `$FLOX_SHELL` is not set.
 
 `$FLOX_PROMPT_COLOR_{1,2}`
 :   Flox adds text to the beginning of the shell prompt to indicate which

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -20,21 +20,24 @@ flox [<general-options>] activate
 
 # DESCRIPTION
 
-Sets environment variables and aliases,
-runs hooks,
+Sets environment variables and aliases, runs hooks,
 and adds `bin` directories to your `$PATH`.
 
-Launches an interactive subshell when invoked as `flox activate` from an
-interactive shell.
-Launches a subshell non-interactively when invoked with a command
-and arguments.
-May also be invoked as `$(flox activate)` to produce commands to be sourced
-by the parent shell.
-The parent shell is detected automatically by inspecting the executable path
-of the parent process.
-If Flox can not interpret the path as a shell or a subshell is launched,
-Flox will fall back to `$SHELL`.
-To override the shell explicitly, `$FLOX_SHELL` can be set as an override.
+`flox activate` may run in one of three modes:
+
+* interactive: `flox activate` when invoked from an interactive shell
+  Launches an interactive sub-shell.
+  The shell to be launched is determined by `$FLOX_SHELL` or `$SHELL`.
+* command: `flox activate -- CMD`
+  Executes `CMD` in the same environment as if run inside an interactive shell
+  produced by an interactive `flox activate`
+  The shell `CMD` is run by is determined by `$FLOX_SHELL` or `$SHELL`.
+* in-place: `flox activate` when invoked from an non-interactive shell
+  with it's `stdout` redirected e.g. `eval "$(flox activate)"`
+  Produces commands to be sourced by the parent shell.
+  Flox will determine the parent shell from `$FLOX_SHELL` or otherwise
+  automatically determine the parent shell and fall back to `$SHELL`.
+
 `flox activate` currently only supports `bash` and `zsh` shells
 for any of the detection mechanisms described above.
 
@@ -127,7 +130,7 @@ hook was defined.
    `$SHELL` if it is set and `$FLOX_SHELL` is not set.
    When printing a shell for sourcing in the current shell,
    Flox will produce a script suitable for `$SHELL` if it is set
-   and `$FLOX_SHELL` is not set.
+   and `$FLOX_SHELL` is not set and Flox can't detect the parent shell.
 
 `$FLOX_PROMPT_COLOR_{1,2}`
 :   Flox adds text to the beginning of the shell prompt to indicate which

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -567,7 +567,7 @@ impl Activate {
 
         let shell = Self::detect_shell_for_subshell()?;
         let activate_error = if !self.run_args.is_empty() {
-            Self::activate_non_interactive(self.run_args, shell, exports, activation_path)
+            Self::activate_command(self.run_args, shell, exports, activation_path)
         } else {
             Self::activate_interactive(shell, exports, activation_path, now_active)
         };
@@ -576,7 +576,7 @@ impl Activate {
     }
 
     /// Used for `flox activate -- run_args`
-    fn activate_non_interactive(
+    fn activate_command(
         run_args: Vec<String>,
         shell: Shell,
         exports: HashMap<&str, String>,

--- a/cli/flox/src/utils/openers.rs
+++ b/cli/flox/src/utils/openers.rs
@@ -1,9 +1,12 @@
 use std::env;
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use anyhow::{anyhow, Context, Result};
 use itertools::Itertools;
-use log::debug;
+use log::{debug, warn};
+use sysinfo::{Pid, System};
 
 const OPENERS: &[&str] = &["xdg-open", "gnome-open", "kde-open"];
 
@@ -68,6 +71,100 @@ impl Browser {
 
     pub fn to_command(&self) -> Command {
         Command::new(&self.0)
+    }
+}
+
+#[derive(Debug)]
+pub enum Shell {
+    Bash(PathBuf),
+    Zsh(PathBuf),
+}
+
+impl TryFrom<&Path> for Shell {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &Path) -> std::prelude::v1::Result<Self, Self::Error> {
+        match value.file_name() {
+            Some(name) if name == "bash" => Ok(Shell::Bash(value.to_owned())),
+            Some(name) if name == "zsh" => Ok(Shell::Zsh(value.to_owned())),
+            _ => Err(anyhow!("Unsupported shell {value:?}")),
+        }
+    }
+}
+
+impl Display for Shell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Shell::Bash(_) => write!(f, "bash"),
+            Shell::Zsh(_) => write!(f, "zsh"),
+        }
+    }
+}
+
+impl Shell {
+    /// Detect the current shell from the parent process
+    ///
+    /// This function tries to detect the shell from the parent process.
+    /// If reading process information of the parent process fails,
+    /// or the exe path of the parent process can not be parsed to a known shell,
+    /// an error is returned.
+    fn detect_from_parent_process() -> Result<Self> {
+        // todo: we can narrow down the amount of data collected by sysinfo, for now collect everything
+        let system = System::new_all();
+
+        let parent_process = system
+            .process(Pid::from_u32(std::os::unix::process::parent_id()))
+            .context("Failed to get info about parent process")?;
+
+        // Investigate whether to use `parent_process.cmd()[0]` instead.
+        // Shells often have a compatibility mode with `sh` if invoked as `sh`.
+        // The current approach will only pick this mode up if the filename is sh e.g.
+        // symlinked to bash or zsh.
+        // Using `argv[0]` may still be unreliable as a path to a shell executable,
+        // if set manually by the calling process or the parent shell itself.
+        //
+        // However, all this is only relevant once we want to detect more shells
+        // -- including `sh` -- and not just `bash` and `zsh`.
+        let parent_exe: &Path = parent_process
+            .exe()
+            .context("Failed to get parent process exe")?;
+
+        Self::try_from(parent_exe)
+    }
+
+    /// Detect the current shell from the {var} environment variable
+    fn detect_from_env(var: &str) -> Result<Self> {
+        env::var(var)
+            .with_context(|| format!("{var} environment variable not set"))
+            .and_then(|shell| {
+                let path = PathBuf::from(shell);
+                Self::try_from(path.as_path())
+            })
+    }
+
+    /// Detect the executing shell
+    ///
+    /// This function first tries to detect the shell from the parent process,
+    /// and falls back to the SHELL environment variable if that fails.
+    /// If both fail, an error is returned.
+    ///
+    /// Both methods are overridable by setting the FLOX_SHELL environment variable.
+    pub fn detect() -> Result<Self> {
+        Self::detect_from_env("FLOX_SHELL")
+            .or_else(|_| Self::detect_from_parent_process())
+            .or_else(|err| {
+                warn!("Failed to detect shell from parent process: {err}");
+
+                Self::detect_from_env("SHELL")
+            })
+    }
+
+    /// Get the path to the shell executable
+    pub fn exe_path(&self) -> &Path {
+        match self {
+            Shell::Bash(path) => path,
+            Shell::Zsh(path) => path,
+        }
     }
 }
 

--- a/cli/flox/src/utils/openers.rs
+++ b/cli/flox/src/utils/openers.rs
@@ -74,7 +74,7 @@ impl Browser {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Shell {
     Bash(PathBuf),
     Zsh(PathBuf),
@@ -109,27 +109,9 @@ impl Shell {
     /// or the exe path of the parent process can not be parsed to a known shell,
     /// an error is returned.
     pub fn detect_from_parent_process() -> Result<Self> {
-        // todo: we can narrow down the amount of data collected by sysinfo, for now collect everything
-        let system = System::new_all();
+        let parent_process_exe = get_parent_process_exe()?;
 
-        let parent_process = system
-            .process(Pid::from_u32(std::os::unix::process::parent_id()))
-            .context("Failed to get info about parent process")?;
-
-        // Investigate whether to use `parent_process.cmd()[0]` instead.
-        // Shells often have a compatibility mode with `sh` if invoked as `sh`.
-        // The current approach will only pick this mode up if the filename is sh e.g.
-        // symlinked to bash or zsh.
-        // Using `argv[0]` may still be unreliable as a path to a shell executable,
-        // if set manually by the calling process or the parent shell itself.
-        //
-        // However, all this is only relevant once we want to detect more shells
-        // -- including `sh` -- and not just `bash` and `zsh`.
-        let parent_exe: &Path = parent_process
-            .exe()
-            .context("Failed to get parent process exe")?;
-
-        Self::try_from(parent_exe)
+        Self::try_from(parent_process_exe.as_path())
     }
 
     /// Detect the current shell from the {var} environment variable
@@ -151,6 +133,31 @@ impl Shell {
     }
 }
 
+fn get_parent_process_exe() -> Result<PathBuf> {
+    // todo: we can narrow down the amount of data collected by sysinfo, for now collect everything
+    let system = System::new_all();
+
+    let parent_process = system
+        .process(Pid::from_u32(std::os::unix::process::parent_id()))
+        .context("Failed to get info about parent process")?;
+
+    // Investigate whether to use `parent_process.cmd()[0]` instead.
+    // Shells often have a compatibility mode with `sh` if invoked as `sh`.
+    // The current approach will only pick this mode up if the filename is sh e.g.
+    // symlinked to bash or zsh.
+    // Using `argv[0]` may still be unreliable as a path to a shell executable,
+    // if set manually by the calling process or the parent shell itself.
+    //
+    // However, all this is only relevant once we want to detect more shells
+    // -- including `sh` -- and not just `bash` and `zsh`.
+    let parent_exe = parent_process
+        .exe()
+        .context("Failed to get parent process exe")?
+        .to_path_buf();
+
+    Ok(parent_exe)
+}
+
 fn first_in_path<'a, I>(
     candidates: I,
     path: impl IntoIterator<Item = PathBuf>,
@@ -162,4 +169,47 @@ where
     path.into_iter()
         .cartesian_product(candidates)
         .find(|(path, editor)| path.join(editor).exists())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test the parsing of the shell from a path
+    #[test]
+    fn parse_shell() {
+        let bash = PathBuf::from("/bin/bash");
+        let zsh = PathBuf::from("/bin/zsh");
+
+        assert_eq!(Shell::try_from(bash.as_path()).unwrap(), Shell::Bash(bash));
+        assert_eq!(Shell::try_from(zsh.as_path()).unwrap(), Shell::Zsh(zsh));
+        assert!(Shell::try_from(PathBuf::from("/bin/not_a_shell").as_path()).is_err())
+    }
+
+    /// Test the detection of the shell from the parent process
+    #[test]
+    fn test_get_parent_process_exe() {
+        let path = get_parent_process_exe().expect("should find parent process");
+
+        // The nix provided `cargo` binary wraps the real cargo binary
+        // `.cargo-wrapped`.
+        // This test assumes that the test environment of the test suite is
+        // provided by nix.
+        assert_eq!(path.file_name().unwrap(), ".cargo-wrapped");
+    }
+
+    /// Test the detection of the shell from environment variables
+    #[test]
+    fn test_detect_from_env_var() {
+        temp_env::with_var("MYSHELL", Some("/bin/bash"), || {
+            assert_eq!(
+                Shell::detect_from_env("MYSHELL").unwrap(),
+                Shell::Bash(PathBuf::from("/bin/bash"))
+            );
+        });
+
+        temp_env::with_var_unset("MYSHELL", || {
+            assert!(Shell::detect_from_env("MYSHELL").is_err());
+        });
+    }
 }

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -108,7 +108,7 @@ env_is_activated() {
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -122,7 +122,7 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -132,10 +132,10 @@ env_is_activated() {
 @test "bash: activate runs hook" {
   sed -i -e "s/\[hook\]/${HELLO_HOOK//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  FLOX_SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
   assert_output --partial "Welcome to your flox environment!"
 
-  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  FLOX_SHELL=bash USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
   assert_success
   assert_output --partial "Welcome to your flox environment!"
 }
@@ -148,11 +148,11 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  # SHELL=zsh USER="$REAL_USER" run -0 bash -c "echo exit | $FLOX_CLI activate --dir $PROJECT_DIR";
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  # FLOX_SHELL=zsh USER="$REAL_USER" run -0 bash -c "echo exit | $FLOX_CLI activate --dir $PROJECT_DIR";
+  FLOX_SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
   assert_output --partial "Welcome to your flox environment!"
 
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  FLOX_SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
   assert_success
   assert_output --partial "Welcome to your flox environment!"
 }
@@ -165,7 +165,7 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  FLOX_SHELL=bash USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is aliased to \`echo testing'"
 }
 
@@ -176,7 +176,7 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is an alias for echo testing"
 }
 
@@ -185,10 +185,10 @@ env_is_activated() {
 @test "bash: activate sets env var" {
   sed -i -e "s/\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+  FLOX_SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
-  SHELL=bash NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
+  FLOX_SHELL=bash NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
   assert_success
   assert_output --partial "baz"
 }
@@ -202,10 +202,10 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+  FLOX_SHELL=zsh USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
-  SHELL=zsh NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
+  FLOX_SHELL=zsh NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
   assert_success
   assert_output --partial "baz"
 }
@@ -220,10 +220,10 @@ env_is_activated() {
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=zsh NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- exit
+  FLOX_SHELL=zsh NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- exit
   assert_success
   assert_output --partial "baz"
-  SHELL=bash NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- exit
+  FLOX_SHELL=bash NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- exit
   assert_success
   assert_output --partial "baz"
 }
@@ -357,7 +357,7 @@ env_is_activated() {
   # TODO:
   # better with a flag like '--print-script'
   # this is confusing:
-  SHELL="bash" run "$FLOX_BIN" activate
+  FLOX_SHELL="bash" run "$FLOX_BIN" activate
   assert_success
   # check that env vars are set for compatibility with nix built software
   assert_line --partial "export NIX_SSL_CERT_FILE="
@@ -366,7 +366,7 @@ env_is_activated() {
 
 # bats test_tags=activate,activate:inplace-prints
 @test "'flox activate' prints script to modify current shell (zsh)" {
-  SHELL="zsh" run "$FLOX_BIN" activate
+  FLOX_SHELL="zsh" run "$FLOX_BIN" activate
   assert_success
   # check that env vars are set for compatibility with nix built software
   assert_line --partial "export NIX_SSL_CERT_FILE="

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -111,7 +111,7 @@ EOF
 
   sed "s/\[hook\]/${HOOK//$'\n'/\\n}/" "$MANIFEST_PATH" > "$TMP_MANIFEST_PATH"
 
-  SHELL=bash run expect "$TESTS_DIR/edit/re-activate.exp" "$TMP_MANIFEST_PATH"
+  FLOX_SHELL=bash run expect "$TESTS_DIR/edit/re-activate.exp" "$TMP_MANIFEST_PATH"
   assert_success
 }
 

--- a/cli/tests/environment-init.bats
+++ b/cli/tests/environment-init.bats
@@ -171,8 +171,8 @@ function check_with_dir() {
 
   "$FLOX_BIN" init --auto-setup --name "$NAME"
 
-  SHELL=bash "$FLOX_BIN" activate -- python -c "import requests"
-  SHELL=zsh "$FLOX_BIN" activate -- python -c "import requests"
+  FLOX_SHELL=bash "$FLOX_BIN" activate -- python -c "import requests"
+  FLOX_SHELL=zsh "$FLOX_BIN" activate -- python -c "import requests"
 
   floxhub_setup "$OWNER"
 
@@ -182,13 +182,13 @@ function check_with_dir() {
 
   "$FLOX_BIN" pull "$OWNER/$NAME"
 
-  SHELL=bash "$FLOX_BIN" activate -- python -c "import requests"
-  SHELL=zsh "$FLOX_BIN" activate -- python -c "import requests"
+  FLOX_SHELL=bash "$FLOX_BIN" activate -- python -c "import requests"
+  FLOX_SHELL=zsh "$FLOX_BIN" activate -- python -c "import requests"
 
   "$FLOX_BIN" delete -f
 
-  SHELL=bash "$FLOX_BIN" activate --trust -r "$OWNER/$NAME" -- python -c "import requests"
-  SHELL=zsh "$FLOX_BIN" activate --trust -r "$OWNER/$NAME" -- python -c "import requests"
+  FLOX_SHELL=bash "$FLOX_BIN" activate --trust -r "$OWNER/$NAME" -- python -c "import requests"
+  FLOX_SHELL=zsh "$FLOX_BIN" activate --trust -r "$OWNER/$NAME" -- python -c "import requests"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -179,7 +179,7 @@ teardown() {
   mkdir 2
   "$FLOX_BIN" init --dir 2
 
-  SHELL=bash NO_COLOR=1 run expect "$TESTS_DIR/install/last-activated.exp"
+  FLOX_SHELL=bash NO_COLOR=1 run expect "$TESTS_DIR/install/last-activated.exp"
   assert_success
 }
 
@@ -190,7 +190,7 @@ teardown() {
   mkdir 2
   "$FLOX_BIN" init --dir 2
 
-  SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/install/prompt-which-environment.exp"
+  FLOX_SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/install/prompt-which-environment.exp"
 }
 
 @test "'flox install' prompts when an environment is activated and there is an environment in the containing git repo" {
@@ -202,7 +202,7 @@ teardown() {
   git -C 2 init
   mkdir 2/subdirectory
 
-  SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/install/prompt-which-environment-git.exp"
+  FLOX_SHELL=bash NO_COLOR=1 run -0 expect "$TESTS_DIR/install/prompt-which-environment-git.exp"
 }
 
 @test "i5: download package when install command runs" {

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -272,7 +272,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
   assert_output --regexp "$FLOX_CACHE_HOME/run/owner/.+\..+\..+/bin/hello"
   refute_output "not found"
 }

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -146,7 +146,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
+  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
   assert_output --partial "$FLOX_CACHE_HOME/remote/owner/test/.flox/run/bin/hello"
   refute_output "not found"
 }

--- a/cli/tests/package-show.bats
+++ b/cli/tests/package-show.bats
@@ -307,7 +307,7 @@ setup_file() {
   assert_output "    nodejs - nodejs@$NODEJS_VERSION_NEW"
   popd
 
-  SHELL=bash run expect "$TESTS_DIR/show/prompt-which-environment.exp"
+  FLOX_SHELL=bash run expect "$TESTS_DIR/show/prompt-which-environment.exp"
   assert_success
   assert_output --partial "nodejs - nodejs@$NODEJS_VERSION_NEW"
 }

--- a/tests/python.bats
+++ b/tests/python.bats
@@ -61,7 +61,7 @@ teardown() {
   assert_output --partial "✅ 'pip' installed to environment"
   assert_output --partial "✅ 'python3' installed to environment"
 
-  SHELL=bash run expect "$TESTS_DIR/python.exp" "$PROJECT_DIR"
+  FLOX_SHELL=bash run expect "$TESTS_DIR/python.exp" "$PROJECT_DIR"
   assert_success
 }
 


### PR DESCRIPTION
We currently rely on `$SHELL` for our detection of the executing shell.
However, sub shells do not reliably reset this variable.
When `flox activate --print-script` is `eval`'ed in a sub shell
-- e.g. a direnv issued bash -- an incompatible script may produced.

    SHELL=zsh bash -c 'eval "$(flox activate --print-script)"'
    .../activate/zsh:13: setopt: command not found
    .../activate/zsh:14: setopt: command not found

This PR implements detection of the parent shell by determining
and inspecting the exe path of the parent process.
If determining the parent process fails,o r the process is an unsupported shell,
we fall back to the existing `$SHELL` detection.

Both methods are overridden by an explicit `FLOX_SHELL` variable.