### PR TITLE
test: isolate flox config and caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,15 @@ jobs:
       - name: "Build"
         run: nix develop -L --no-update-lock-file --command just build-cli
 
-      - name: "CLI Tests"
+      - name: "CLI Unit Tests"
         env:
           RUST_BACKTRACE: 1
-        run: nix develop -L --no-update-lock-file --command just test-cli
+        run: nix develop -L --no-update-lock-file --command just impure-tests
+
+      - name: "CLI Integration Tests"
+        env:
+          RUST_BACKTRACE: 1
+        run: nix develop -L --no-update-lock-file --command just integ-tests -- -j 4
 
       - name: "Functional Tests"
         if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
@@ -360,4 +365,5 @@ jobs:
             nix run \
                 --accept-flake-config \
                 --extra-experimental-features '"nix-command flakes"' \
-                'github:flox/flox/${{ github.sha }}#packages.${{ matrix.system }}.flox-cli-tests'
+                'github:flox/flox/${{ github.sha }}#packages.${{ matrix.system }}.flox-cli-tests' \
+                -- -- -j 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: "CLI Integration Tests"
         env:
           RUST_BACKTRACE: 1
-        run: nix develop -L --no-update-lock-file --command just integ-tests -- -j 4
+        run: nix develop -L --no-update-lock-file --command just integ-tests
 
       - name: "Functional Tests"
         if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
@@ -365,5 +365,4 @@ jobs:
             nix run \
                 --accept-flake-config \
                 --extra-experimental-features '"nix-command flakes"' \
-                'github:flox/flox/${{ github.sha }}#packages.${{ matrix.system }}.flox-cli-tests' \
-                -- -- -j 4
+                'github:flox/flox/${{ github.sha }}#packages.${{ matrix.system }}.flox-cli-tests'

--- a/Justfile
+++ b/Justfile
@@ -73,8 +73,11 @@ build: build-cli
 
 # Run the CLI integration test suite
 @integ-tests +bats_args="": build
-    flox-cli-tests --pkgdb "{{PKGDB_BIN}}" \
-     --flox "{{FLOX_BIN}}" --ld-floxlib "{{LD_FLOXLIB}}" {{bats_args}}
+    flox-cli-tests \
+        --pkgdb "{{PKGDB_BIN}}" \
+        --flox "{{FLOX_BIN}}" \
+        --ld-floxlib "{{LD_FLOXLIB}}" \
+        {{bats_args}}
 
 # Run a specific CLI integration test file by name (not path)
 @integ-file +bats_args="": build

--- a/cli/tests/environment-activate.bats
+++ b/cli/tests/environment-activate.bats
@@ -74,6 +74,7 @@ activate_local_env() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox # concurrent pkgdb database creation
   project_setup
 }
 teardown() {
@@ -412,7 +413,6 @@ env_is_activated() {
   assert_line "emacs"
 }
 
-
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate:scripts:on-activate
@@ -427,7 +427,6 @@ env_is_activated() {
   # "$foo" environment variable.
   [ -d "$PROJECT_DIR/bar" ]
 }
-
 
 # ---------------------------------------------------------------------------- #
 

--- a/cli/tests/environment-containerize.bats
+++ b/cli/tests/environment-containerize.bats
@@ -46,6 +46,7 @@ podman_cache_reset() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
   env_setup
 

--- a/cli/tests/environment-delete.bats
+++ b/cli/tests/environment-delete.bats
@@ -30,6 +30,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
 }
 teardown() {

--- a/cli/tests/environment-edit.bats
+++ b/cli/tests/environment-edit.bats
@@ -47,6 +47,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
 }
 teardown() {

--- a/cli/tests/environment-init.bats
+++ b/cli/tests/environment-init.bats
@@ -18,11 +18,11 @@ project_setup() {
   export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
-  pushd "$PROJECT_DIR" >/dev/null || return
+  pushd "$PROJECT_DIR" > /dev/null || return
 }
 
 project_teardown() {
-  popd >/dev/null || return
+  popd > /dev/null || return
   rm -rf "${PROJECT_DIR?}"
   unset PROJECT_DIR
 }
@@ -31,6 +31,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
 }
 
@@ -152,7 +153,7 @@ function check_with_dir() {
   OWNER="owner"
   NAME="name"
 
-  echo "requests" >requirements.txt
+  echo "requests" > requirements.txt
 
   "$FLOX_BIN" init --auto-setup --name "$NAME"
 

--- a/cli/tests/environment-install.bats
+++ b/cli/tests/environment-install.bats
@@ -35,6 +35,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
 }
 teardown() {

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -38,6 +38,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
   floxhub_setup "$OWNER"
 }
@@ -273,7 +274,7 @@ EOF
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
   FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "$FLOX_CACHE_HOME/run/owner/.+\..+\..+/bin/hello"
+  assert_output --regexp "$FLOX_CACHE_DIR/run/owner/.+\..+\..+/bin/hello"
   refute_output "not found"
 }
 
@@ -297,7 +298,7 @@ EOF
   run dot_flox_exists
   assert_failure
 
-  run ls -lA "$FLOX_DATA_HOME/links"
+  run ls -lA "$FLOX_DATA_DIR/links"
   assert_output "total 0"
 }
 
@@ -326,7 +327,7 @@ EOF
 
 @test "sanity check upgrade works for managed environments" {
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-  make_empty_remote_env
+    make_empty_remote_env
 
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
     "$FLOX_BIN" install hello

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -30,6 +30,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
   floxhub_setup "owner"
   make_dummy_env "owner" "name"

--- a/cli/tests/environment-push.bats
+++ b/cli/tests/environment-push.bats
@@ -30,13 +30,11 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
   floxhub_setup "owner"
-
-  export _FLOX_FLOXHUB_GIT_URL="file://$BATS_TEST_TMPDIR/floxhub"
 }
 teardown() {
-  unset _FLOX_FLOXHUB_GIT_URL
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -40,6 +40,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
   floxhub_setup owner
 }
@@ -85,7 +86,7 @@ function make_empty_remote_env() {
   run --separate-stderr "$FLOX_BIN" install hello --remote "$OWNER/test"
   assert_success
 
-  assert [ -h "$FLOX_CACHE_HOME/run/$OWNER/test" ]
+  assert [ -h "$FLOX_CACHE_DIR/run/$OWNER/test" ]
 }
 
 # bats test_tags=install,remote,remote:install
@@ -147,7 +148,7 @@ EOF
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
   FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
-  assert_output --partial "$FLOX_CACHE_HOME/remote/owner/test/.flox/run/bin/hello"
+  assert_output --partial "$FLOX_CACHE_DIR/remote/owner/test/.flox/run/bin/hello"
   refute_output "not found"
 }
 

--- a/cli/tests/ld-floxlib.bats
+++ b/cli/tests/ld-floxlib.bats
@@ -50,13 +50,13 @@ project_setup() {
   # Create environment (verbosely for the logs), specifying a pinned
   # nixpkgs revision, although it has no effect (see below).
   sh -xc "_PKGDB_GA_REGISTRY_REF_OR_REV=${PKGDB_NIXPKGS_REV_OLDER?} \
-    $FLOX_BIN init";
+    $FLOX_BIN init"
 
   # "Update" lock for this one environment to use a pinned nixpkgs revision
   # containing old versions of nix (2.10.3) and glibc (2.34) for use in tests.
   # (Would be preferable if the previous init could honor the revision.)
   sh -xc "_PKGDB_GA_REGISTRY_REF_OR_REV=${PKGDB_NIXPKGS_REV_OLDER?} \
-    $FLOX_BIN update";
+    $FLOX_BIN update"
 
   # Install packages, including boost, curl and libarchive that are
   # compilation and runtime dependencies of libnixmain.so. Use `flox edit`

--- a/cli/tests/package-search.bats
+++ b/cli/tests/package-search.bats
@@ -37,6 +37,10 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
+
+  _PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_OLD" \
+    "$FLOX_BIN" update --global
 }
 
 teardown() {
@@ -54,10 +58,6 @@ setup_file() {
     echo "You must set \$PKGDB_BIN to run these tests" >&2
     exit 1
   fi
-
-  rm -f "$GLOBAL_MANIFEST_LOCK"
-  _PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_OLD" \
-    "$FLOX_BIN" update --global
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/package-show.bats
+++ b/cli/tests/package-show.bats
@@ -37,15 +37,18 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
+  rm -f "$GLOBAL_MANIFEST_LOCK"
+  _PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_OLD" \
+    "$FLOX_BIN" update --global
 }
+
 teardown() {
   common_test_teardown
 }
 
 setup_file() {
-  rm -f "$GLOBAL_MANIFEST_LOCK"
-  _PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_OLD" \
-    "$FLOX_BIN" update --global
+  :
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -452,7 +452,6 @@ common_suite_setup() {
   gitconfig_setup
   # setup pkgdb and populate cache
   pkgdb_vars_setup
-  populate_scrape_cache
   {
     print_var FLOX_TEST_HOME
     print_var HOME
@@ -478,11 +477,6 @@ common_suite_setup() {
     print_var PKGDB_NIXPKGS_REF_OLD
     print_var _PKGDB_GA_REGISTRY_REF_OR_REV
   } >&3
-}
-
-populate_scrape_cache() {
-  "$PKGDB_BIN" scrape "$PKGDB_NIXPKGS_REF_NEW" legacyPackages
-  "$PKGDB_BIN" scrape "$PKGDB_NIXPKGS_REF_OLD" legacyPackages
 }
 
 # Recognized by `bats'.

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -365,10 +365,14 @@ pkgdb_vars_setup() {
   # so that we get consistent packages and improved caching.
   _PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_NEW"
 
-  export PKGDB_NIXPKGS_REV_OLD PKGDB_NIXPKGS_REV_NEW \
+  export \
+    PKGDB_NIXPKGS_REV_OLD \
+    PKGDB_NIXPKGS_REV_NEW \
     PKGDB_NIXPKGS_REV_OLDER \
-    PKGDB_NIXPKGS_REF_OLD PKGDB_NIXPKGS_REF_NEW \
-    _PKGDB_GA_REGISTRY_REF_OR_REV PKGDB_NIXPKGS_NAR_HASH_OLD \
+    PKGDB_NIXPKGS_REF_OLD \
+    PKGDB_NIXPKGS_REF_NEW \
+    _PKGDB_GA_REGISTRY_REF_OR_REV \
+    PKGDB_NIXPKGS_NAR_HASH_OLD \
     PKGDB_NIXPKGS_NAR_HASH_NEW
 
   export __FT_RAN_PKGDB_VARS_SETUP=:
@@ -440,13 +444,15 @@ common_suite_setup() {
   nix_system_setup
   misc_vars_setup
   flox_cli_vars_setup
-  pkgdb_vars_setup
   # Generate configs and auth.
   ssh_key_setup
   floxtest_gitforge_setup
   # TODO: fix gpg setup and re-enable along with `gpgsign.bats' tests.
   #gpg_key_setup;
   gitconfig_setup
+  # setup pkgdb and populate cache
+  pkgdb_vars_setup
+  populate_scrape_cache
   {
     print_var FLOX_TEST_HOME
     print_var HOME
@@ -472,6 +478,11 @@ common_suite_setup() {
     print_var PKGDB_NIXPKGS_REF_OLD
     print_var _PKGDB_GA_REGISTRY_REF_OR_REV
   } >&3
+}
+
+populate_scrape_cache() {
+  "$PKGDB_BIN" scrape "$PKGDB_NIXPKGS_REF_NEW" legacyPackages
+  "$PKGDB_BIN" scrape "$PKGDB_NIXPKGS_REF_OLD" legacyPackages
 }
 
 # Recognized by `bats'.

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -127,11 +127,6 @@ setup_isolated_flox() {
   export FLOX_CONFIG_DIR="${BATS_TEST_TMPDIR?}/flox-config"
   export FLOX_DATA_DIR="${BATS_TEST_TMPDIR?}/flox-data"
   export FLOX_CACHE_DIR="${BATS_TEST_TMPDIR?}/flox-cache"
-  # pkgdb database creation is not concurrency safe:
-  #
-  #    ERROR: error running pkgdb: couldn't initialize read-only package database
-  export PKGDB_CACHEDIR="${BATS_TEST_TMPDIR?}/pkgdb-cache"
-
   export GLOBAL_MANIFEST_LOCK="$FLOX_CONFIG_DIR/global-manifest.lock"
 }
 

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -107,6 +107,35 @@ floxhub_setup() {
   export _FLOX_FLOXHUB_GIT_URL="file://$FLOX_FLOXHUB_PATH"
 }
 
+# Isolate flox config, data, and cache from the potentially shared
+# xdg directories.
+# This is necessary as other wisemultiple tests contest for the same
+# resources, e.g.:
+# * the global manifest and lockfile
+#   + created by multiple processes
+#   + deleted by some but assumed present by others
+#   + updated, upgraded, reset
+# * floxmeta clones for managed environments
+#   + same _owner_ and project name being reused
+#   + environments are created/deleted/edited concurrently
+#     -> git errors, and just plain data corruption
+# * local ephemeral environments by `--remote` commands.
+#   + git concurrency
+#
+# nix caches and pkgdb caches remain shared, since they are effectively read-only.
+setup_isolated_flox() {
+  export FLOX_CONFIG_DIR="${BATS_TEST_TMPDIR?}/flox-config"
+  export FLOX_DATA_DIR="${BATS_TEST_TMPDIR?}/flox-data"
+  export FLOX_CACHE_DIR="${BATS_TEST_TMPDIR?}/flox-cache"
+  # pkgdb database creation is not concurrency safe:
+  #
+  #    ERROR: error running pkgdb: couldn't initialize read-only package database
+  export PKGDB_CACHEDIR="${BATS_TEST_TMPDIR?}/pkgdb-cache"
+
+  export GLOBAL_MANIFEST_LOCK="$FLOX_CONFIG_DIR/global-manifest.lock"
+}
+
+
 # ---------------------------------------------------------------------------- #
 
 # common_file_setup [HOME_STYLE ::= (suite|file|test)]

--- a/cli/tests/update.bats
+++ b/cli/tests/update.bats
@@ -30,6 +30,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
 }
 teardown() {

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -48,6 +48,7 @@ assert_new_hello() {
 
 setup() {
   common_test_setup
+  setup_isolated_flox
   project_setup
 }
 teardown() {

--- a/pkgdb/src/pkgdb/input.cc
+++ b/pkgdb/src/pkgdb/input.cc
@@ -48,14 +48,52 @@ PkgDbInput::initDbRO()
 {
   bool isFresh = false;
 
-  /* Initialize DB if missing. */
+  /**
+   * Initialize DB if missing.
+   *
+   * Databases are initialized as a temporary file,
+   * then hard linked to the final location.
+   * The hard link is atomic, and the temporary file is removed.
+   *
+   * This way, we should be able to prevent other processes opening the
+   * partially initialized database.
+   */
   if ( ! std::filesystem::exists( this->dbPath ) )
     {
       std::filesystem::create_directories( this->dbPath.parent_path() );
       nix::logger->log(
         nix::lvlTalkative,
         nix::fmt( "Creating database '%s'", this->dbPath.string() ) );
-      PkgDb( this->getFlake()->lockedFlake, this->dbPath.string() );
+
+      // random 8 char suffix
+      std::string tempSuffix = "";
+      for ( int i = 0; i < 8; i++ ) { tempSuffix += 'a' + ( rand() % 25 ); }
+
+      auto tempDbPath = std::filesystem::path( this->dbPath )
+                          .replace_extension( this->dbPath.extension().string()
+                                              + "." + tempSuffix );
+
+      debugLog(
+        nix::fmt( "Creating temporary database '%s'", tempDbPath.string() ) );
+
+      PkgDb( this->getFlake()->lockedFlake, tempDbPath.string() );
+
+      try
+        {
+
+          debugLog( nix::fmt( "Moving intialized database '%s' -> %s",
+                              tempDbPath.string(),
+                              this->dbPath.string() ) );
+          std::filesystem::create_hard_link( tempDbPath, this->dbPath );
+        }
+      catch ( const std::exception & e )
+        {
+          debugLog(
+            "Failed to create link, db file created by other process?" );
+        }
+
+      std::filesystem::remove( tempDbPath );
+
       isFresh = true;
     }
 

--- a/pkgdb/src/pkgdb/input.cc
+++ b/pkgdb/src/pkgdb/input.cc
@@ -70,9 +70,10 @@ PkgDbInput::initDbRO()
         this->getFlake()->lockedFlake.getFingerprint(),
         this->dbPath.string() );
     }
-  catch ( ... )
+  catch ( const std::exception & e )
     {
-      throw PkgDbException( "couldn't initialize read-only package database" );
+      throw PkgDbException( "couldn't initialize read-only package database",
+                            e.what() );
     }
 
   return isFresh;

--- a/pkgdb/src/pkgdb/scrape.cc
+++ b/pkgdb/src/pkgdb/scrape.cc
@@ -78,7 +78,7 @@ ScrapeCommand::run()
   /* Print path to database. */
   std::cout << nlohmann::json(
                  { { "database-path",
-                     static_cast<std::string>( *this->dbPath ) } } )
+                     static_cast<std::string>( this->input->getDbPath() ) } } )
                  .dump()
             << std::endl;
   return EXIT_SUCCESS; /* GG, GG */

--- a/pkgdb/tests/scrape.bats
+++ b/pkgdb/tests/scrape.bats
@@ -163,31 +163,6 @@ setup_file() {
 }
 
 # ---------------------------------------------------------------------------- #
-
-# Parallel scrapes are likely to run into concurrency issues when
-# the required database does not yet exist.
-# Multiple processes may try to create the database "at the same time",
-# in the past leading to failures.
-# bats test_tags=scrape:parallel
-@test "'pkgdb scrape' doesn't crash when run in parallel" {
-  # We attempt an invocation of 8 parallel scrapes of the same package set
-  # for a total of 5 times.
-  # multiple runs increase the chance of concurrent events,
-  # the whole test is however a probabilistic measure.
-  for i in $(seq 5); do
-    # We don't want other tests polluting parallel test runs so we do this test
-    # with a unique cache directory.
-    run --separate-stderr sh -c '
-    PKGDB_CACHEDIR="$(mktemp -d)" parallel --halt-on-error 2 \
-      "echo {};
-       pkgdb scrape github:nixos/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd \
-          legacyPackages '$NIX_SYSTEM' 'akkoma-emoji'" \
-      ::: $(seq 8)'
-    assert_success
-  done
-}
-
-# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/pkgdb/tests/scrape.bats
+++ b/pkgdb/tests/scrape.bats
@@ -163,6 +163,31 @@ setup_file() {
 }
 
 # ---------------------------------------------------------------------------- #
+
+# Parallel scrapes are likely to run into concurrency issues when
+# the required database does not yet exist.
+# Multiple processes may try to create the database "at the same time",
+# in the past leading to failures.
+# bats test_tags=scrape:parallel
+@test "'pkgdb scrape' doesn't crash when run in parallel" {
+  # We attempt an invocation of 8 parallel scrapes of the same package set
+  # for a total of 5 times.
+  # multiple runs increase the chance of concurrent events,
+  # the whole test is however a probabilistic measure.
+  for i in $(seq 5); do
+    # We don't want other tests polluting parallel test runs so we do this test
+    # with a unique cache directory.
+    run --separate-stderr sh -c '
+    PKGDB_CACHEDIR="$(mktemp -d)" parallel --halt-on-error 2 \
+      "echo {};
+       pkgdb scrape github:nixos/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd \
+          legacyPackages '$NIX_SYSTEM' 'akkoma-emoji'" \
+      ::: $(seq 8)'
+    assert_success
+  done
+}
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/pkgdb/tests/search.bats
+++ b/pkgdb/tests/search.bats
@@ -484,6 +484,7 @@ genParamsNixpkgsFlox() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=search:parallel
 @test "'pkgdb search' doesn't crash when run in parallel" {
   # We don't want other tests polluting parallel test runs so we do this test
   # with a unique cache directory.


### PR DESCRIPTION
By default integration tests reuse the same home directory, including config, cache and data directories to improve test performance (mainly reusing nix and pkgdb caches).

However, when run in parallel multiple processes started at the same time contest:

* the global manifest and lockfile 
  + created by multiple processes
  + deleted by some but assumed present by others
  + updated, upgraded, reset
* pkgdb package databases
  + attempted to be created by multiple processes (possibly a bug related to db locking)
* floxmeta clones for managed environments
  + same _owner_ and project name being reused
  + environments are created/deleted/edited concurrently -> git errors, and just plain data corruption
* local ephemeral environments by `--remote` commands.
  + git concurrency

This PR introduces a new setup function `setup_isolated_flox`, which sets up test specific directories for flox, i.e. sets `FLOX_{DATA,CACHE,CONFIG}_DIR` to a subdir of `BATS_TEST_TMPDIR`, rather than the default `BATS_SUITE_TMPDIR`.

At this point, since i had to add this to basically every test (due to pkgdb database creation)
I figure this logic might be better located in the functions around `home_setup`, but I'm still hoping we can apply this in a less blanketed way eventually.

This PR implements multiple approaches to eliminate race conditions
between multiple processes initializing a pkgdb ... DB.
However opening initialized databases still causes occasional errors:

    couldn't initialize read-only package database: attempt to write a readonly database

Which is an exception raised _after_ the database is created.
It's puzzling to me, and given the limited lifetime pkgdb has left
-- I'd call further debugging of this to be of deminished returns at this point
and opt for disabling parallelism in CI instead.