### PR TITLE
fix: wrap the filter directly in the reload layer

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -78,8 +78,8 @@ use crate::utils::errors::{
     format_core_error,
     format_locked_manifest_error,
 };
-use crate::utils::{default_nix_env_vars, message};
 use crate::utils::openers::Shell;
+use crate::utils::{default_nix_env_vars, message};
 use crate::{subcommand_metric, utils};
 
 // Edit declarative environment configuration


### PR DESCRIPTION
Wrapping the `Filtered` layer in a `reload::Layer` caused the filter
to be applied globally.
The reload was exposing the filtering of the wrapped layer and applied it globally.
I am personally _not_ convinced this is _expected_ behaviour.
Making only the filter reloadable seems to both simplify the reload handle type
and fix the unwanted propagation of the filter to the global context.
Ordering of the log layer is still significant for unknown reasons:

Filtered layer must come first.
This appears to be the only way to avoid logs of the `flox_command` trace
which is processed by the `log_layer` irrepective of the filter applied to it.
My current understanding is, that it because the `metrics_layer` (at least) is
registering `Interest` for the event and that somehow bypasses the filter?!