### PR TITLE
feat: add tracing instrumentation

### DIFF
--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -44,10 +44,10 @@ indexmap.workspace = true
 url.workspace = true
 chrono.workspace = true
 oauth2.workspace = true
-textwrap = {workspace = true, features = ["terminal_size"]}
+textwrap = { workspace = true, features = ["terminal_size"] }
 indent.workspace = true
 semver.workspace = true
-sentry = {workspace = true, features = ["anyhow", "tracing", "debug-logs"]}
+sentry = { workspace = true, features = ["anyhow", "tracing", "debug-logs"] }
 serial_test.workspace = true
 
 [dev-dependencies]

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -21,6 +21,7 @@ use oauth2::{
     TokenUrl,
 };
 use serde::Serialize;
+use tracing::instrument;
 use url::Url;
 
 use crate::commands::general::update_config;
@@ -184,15 +185,20 @@ pub enum Auth {
 }
 
 impl Auth {
+    #[instrument(name = "auth", skip_all)]
     pub async fn handle(self, config: Config, mut flox: Flox) -> Result<()> {
         subcommand_metric!("auth2");
 
         match self {
             Auth::Login => {
+                let span = tracing::info_span!("login");
+                let _guard = span.enter();
                 login_flox(&mut flox).await?;
                 Ok(())
             },
             Auth::Logout => {
+                let span = tracing::info_span!("logout");
+                let _guard = span.enter();
                 if config.flox.floxhub_token.is_none() {
                     message::warning("You are not logged in");
                     return Ok(());
@@ -206,6 +212,8 @@ impl Auth {
                 Ok(())
             },
             Auth::Status => {
+                let span = tracing::info_span!("status");
+                let _guard = span.enter();
                 let Some(token) = flox.floxhub_token else {
                     message::warning("You are not currently logged in to FloxHub.");
                     return Ok(());

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -124,7 +124,7 @@ impl Edit {
         match self.action {
             EditAction::EditManifest { file } => {
                 // TODO: differentiate between interactive edits and replacement
-                let span = tracing::info_span!("edit");
+                let span = tracing::info_span!("edit_file");
                 let _guard = span.enter();
                 Self::edit_manifest(&flox, detected_environment, file).await?
             },
@@ -497,7 +497,6 @@ impl Activate {
                 bail!("Environment '{now_active}' is already active.");
             }
             debug!("Environment is already active: environment={now_active}. Ignoring activation (may patch PATH)");
-            drop(_guard); // don't want to record the time inside the environment
             Self::reactivate_in_place(fixed_up_original_path_joined)?;
             return Ok(());
         }
@@ -2090,7 +2089,7 @@ impl Update {
 
         let (old_lockfile, new_lockfile, global, description) = match self.environment_or_global {
             EnvironmentOrGlobalSelect::Environment(ref environment_select) => {
-                let span = tracing::info_span!("environment");
+                let span = tracing::info_span!("update_local");
                 let _guard = span.enter();
 
                 let concrete_environment =
@@ -2118,7 +2117,7 @@ impl Update {
                 )
             },
             EnvironmentOrGlobalSelect::Global => {
-                let span = tracing::info_span!("global");
+                let span = tracing::info_span!("update_global");
                 let _guard = span.enter();
 
                 let UpdateResult {

--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -1309,7 +1309,8 @@ impl Uninstall {
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("uninstall");
 
-        // We don't know the contents of the packages field when the span is created
+        // Vec<T> doesn't implement tracing::Value, so you have to join the strings
+        // yourself.
         tracing::Span::current().record("packages", self.packages.iter().join(","));
 
         debug!(
@@ -2215,6 +2216,7 @@ impl Update {
             }),
         }
         .spin();
+        drop(_guard);
 
         for result in results {
             result?;

--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -9,6 +9,7 @@ use indoc::indoc;
 use serde::Serialize;
 use tokio::fs;
 use toml_edit::Key;
+use tracing::instrument;
 
 use crate::config::{Config, ReadWriteError, FLOX_CONFIG_FILE};
 use crate::subcommand_metric;
@@ -23,6 +24,7 @@ use crate::utils::metrics::{
 #[derive(Bpaf, Clone)]
 pub struct ResetMetrics {}
 impl ResetMetrics {
+    #[instrument(name = "reset-metrics", skip_all)]
     pub async fn handle(self, _config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("reset-metrics");
         let mut metrics_lock = LockFile::open(&flox.cache_dir.join(METRICS_LOCK_FILE_NAME))?;
@@ -82,6 +84,7 @@ pub enum ConfigArgs {
 
 impl ConfigArgs {
     /// handle config flags like commands
+    #[instrument(name = "config", skip_all)]
     pub async fn handle(&self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("config");
         match self {

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -21,6 +21,7 @@ use flox_rust_sdk::models::search::{do_search, PathOrJson, Query, SearchParams, 
 use indoc::formatdoc;
 use log::debug;
 use toml_edit::{Document, Formatted, Item, Table, Value};
+use tracing::instrument;
 
 use crate::commands::{environment_description, ConcreteEnvironment};
 use crate::subcommand_metric;
@@ -55,6 +56,7 @@ pub struct Init {
 }
 
 impl Init {
+    #[instrument(name = "init", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("init");
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -43,7 +43,6 @@ use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 use thiserror::Error;
 use toml_edit::Key;
-use tracing::instrument;
 use url::Url;
 
 use crate::commands::general::update_config;
@@ -164,7 +163,6 @@ impl fmt::Debug for Commands {
 
 impl FloxArgs {
     /// Initialize the command line by creating an initial FloxBuilder
-    #[instrument(name = "cli", skip_all)]
     pub async fn handle(self, mut config: crate::config::Config) -> Result<()> {
         // Given no command, skip initialization and print welcome message
         if self.command.is_none() {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -43,6 +43,7 @@ use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 use thiserror::Error;
 use toml_edit::Key;
+use tracing::instrument;
 use url::Url;
 
 use crate::commands::general::update_config;
@@ -163,6 +164,7 @@ impl fmt::Debug for Commands {
 
 impl FloxArgs {
     /// Initialize the command line by creating an initial FloxBuilder
+    #[instrument(name = "cli", skip_all)]
     pub async fn handle(self, mut config: crate::config::Config) -> Result<()> {
         // Given no command, skip initialization and print welcome message
         if self.command.is_none() {

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -68,7 +68,7 @@ pub struct Search {
 // which is TODO.
 // Luckily most flakes don't.
 impl Search {
-    #[instrument(name = "search")]
+    #[instrument(name = "search", fields(json = self.json, show_all = self.all, search_term = self.search_term), skip_all)]
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("search", search_term = &self.search_term);
 
@@ -180,7 +180,7 @@ pub struct Show {
 }
 
 impl Show {
-    #[instrument(name = "show")]
+    #[instrument(name = "show", fields(show_all = self.all, search_term = self.search_term), skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("show");
 

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -17,6 +17,7 @@ use flox_rust_sdk::models::search::{
 };
 use indoc::formatdoc;
 use log::debug;
+use tracing::instrument;
 
 use crate::config::features::Features;
 use crate::config::Config;
@@ -39,7 +40,7 @@ const FLOX_SHOW_HINT: &str = "Use 'flox show <package>' to see available version
 pub struct ChannelArgs {}
 
 // Search for packages to install
-#[derive(Bpaf, Clone)]
+#[derive(Debug, Bpaf, Clone)]
 pub struct Search {
     /// Display search results as a JSON array
     #[bpaf(long)]
@@ -67,6 +68,7 @@ pub struct Search {
 // which is TODO.
 // Luckily most flakes don't.
 impl Search {
+    #[instrument(name = "search")]
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("search", search_term = &self.search_term);
 
@@ -165,7 +167,7 @@ fn render_search_results_json(search_results: SearchResults) -> Result<()> {
 }
 
 // Show detailed package information
-#[derive(Bpaf, Clone)]
+#[derive(Debug, Bpaf, Clone)]
 pub struct Show {
     /// Whether to show all available package versions
     #[bpaf(long)]
@@ -178,6 +180,7 @@ pub struct Show {
 }
 
 impl Show {
+    #[instrument(name = "show")]
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("show");
 

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -60,8 +60,8 @@ fn main() -> ExitCode {
             .unwrap_or_default()
     };
 
-    init_logger(Some(verbosity));
     let _sentry_guard = init_sentry();
+    init_logger(Some(verbosity));
 
     // Pass down the verbosity level to all pkgdb calls
     std::env::set_var(

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -6,7 +6,6 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
 use crate::commands::Verbosity;
-use crate::utils::dialog::Dialog;
 use crate::utils::metrics::MetricsLayer;
 use crate::utils::TERMINAL_STDERR;
 
@@ -95,7 +94,7 @@ pub fn create_registry_and_filter_reload_handle() -> (
     // Logs are being passed through by the `log` crate and correctly filtered by `tracing`.
     let filter = tracing_subscriber::filter::EnvFilter::try_new("trace").unwrap();
     let (filter, filter_reload_handle) = tracing_subscriber::reload::Layer::new(filter);
-    let use_colors = Dialog::can_prompt();
+    let use_colors = supports_color::on(supports_color::Stream::Stderr).is_some();
     let log_layer = tracing_subscriber::fmt::layer()
         .with_writer(LockingTerminalStderr)
         .with_ansi(use_colors)

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
 use crate::commands::Verbosity;
+use crate::utils::dialog::Dialog;
 use crate::utils::metrics::MetricsLayer;
 use crate::utils::TERMINAL_STDERR;
 
@@ -94,8 +95,10 @@ pub fn create_registry_and_filter_reload_handle() -> (
     // Logs are being passed through by the `log` crate and correctly filtered by `tracing`.
     let filter = tracing_subscriber::filter::EnvFilter::try_new("trace").unwrap();
     let (filter, filter_reload_handle) = tracing_subscriber::reload::Layer::new(filter);
+    let use_colors = Dialog::can_prompt();
     let log_layer = tracing_subscriber::fmt::layer()
         .with_writer(LockingTerminalStderr)
+        .with_ansi(use_colors)
         .event_format(tracing_subscriber::fmt::format())
         .with_filter(filter);
     let metrics_layer = MetricsLayer::new();


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Adds tracing instrumentation to individual commands so that they can be picked up by Sentry. The only command not covered by instrumentation is `activate`, which needs special handling because we call `exec` in this command. That will come later once we have a solution.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
