### PR TITLE
refactor: testable metrics abstractions

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -55,7 +55,7 @@ use crate::utils::init::{
     telemetry_opt_out_needs_migration,
 };
 use crate::utils::message;
-use crate::utils::metrics::METRICS_UUID_FILE_NAME;
+use crate::utils::metrics::{AWSDatalakeConnection, Client, Hub, METRICS_UUID_FILE_NAME};
 
 static FLOX_DESCRIPTION: &'_ str = indoc! {"
     flox is a virtual environment and package manager all in one.\n\n
@@ -205,6 +205,9 @@ impl FloxArgs {
 
         if !config.flox.disable_metrics {
             init_telemetry(&config.flox.data_dir, &config.flox.cache_dir).await?;
+            let connection = AWSDatalakeConnection::default();
+            let client = Client::new_with_config(&config, connection)?;
+            Hub::global().set_client(client);
         } else {
             debug!("Metrics collection disabled");
             env::set_var("FLOX_DISABLE_METRICS", "true");

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -50,7 +50,7 @@ use crate::config::{Config, EnvironmentTrust, FLOX_CONFIG_FILE};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::init::{
     init_access_tokens,
-    init_telemetry,
+    init_telemetry_uuid,
     init_uuid,
     telemetry_opt_out_needs_migration,
 };
@@ -204,7 +204,10 @@ impl FloxArgs {
         }
 
         if !config.flox.disable_metrics {
-            init_telemetry(&config.flox.data_dir, &config.flox.cache_dir).await?;
+            debug!("Metrics collection enabled");
+
+            init_telemetry_uuid(&config.flox.data_dir, &config.flox.cache_dir)?;
+
             let connection = AWSDatalakeConnection::default();
             let client = Client::new_with_config(&config, connection)?;
             Hub::global().set_client(client);

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -14,6 +14,7 @@ use utils::init::{init_logger, init_sentry};
 use utils::{message, populate_default_nix_env_vars};
 
 use crate::utils::errors::{format_error, format_managed_error, format_remote_error};
+use crate::utils::metrics::Hub;
 
 mod build;
 mod commands;
@@ -62,6 +63,8 @@ fn main() -> ExitCode {
 
     init_logger(Some(verbosity));
     let _sentry_guard = init_sentry();
+
+    let _metrics_guard = Hub::global().try_guard().ok();
 
     // Pass down the verbosity level to all pkgdb calls
     std::env::set_var(

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -1,9 +1,13 @@
+use std::any::Any;
 use std::collections::{HashMap, VecDeque};
+use std::fmt::Debug;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration as TimeoutDuration;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use flox_rust_sdk::flox::FLOX_VERSION;
 use fslock::LockFile;
 use indoc::indoc;
@@ -20,7 +24,8 @@ use crate::config::Config;
 pub const METRICS_EVENTS_FILE_NAME: &str = "metrics-events-v2.json";
 pub const METRICS_UUID_FILE_NAME: &str = "metrics-uuid";
 pub const METRICS_LOCK_FILE_NAME: &str = "metrics-lock";
-const BUFFER_EXPIRY: Duration = Duration::hours(2);
+const DEFAULT_BUFFER_EXPIRY: Duration = Duration::hours(2);
+const DEFAULT_TIMEOUT: TimeoutDuration = TimeoutDuration::from_secs(2);
 
 pub static METRICS_EVENTS_URL: Lazy<String> = Lazy::new(|| {
     std::env::var("_FLOX_METRICS_URL_OVERRIDE").unwrap_or(env!("METRICS_EVENTS_URL").to_string())
@@ -59,6 +64,7 @@ impl<'a> tracing::field::Visit for MetricVisitor<'a> {
 /// with additional ad-hoc metadata
 ///
 /// Produced by [subcommand_metric!] and processed with [MetricsLayer].
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetricEvent {
     pub subcommand: Option<String>,
     pub extras: HashMap<String, String>,
@@ -97,7 +103,7 @@ where
         // Catch any errors that occurred while writing/pushing the metric.
         // We do want to _know_ about errors
         // but they should not block flox commands from running.
-        if let Err(err) = add_metric(MetricEvent { subcommand, extras }) {
+        if let Err(err) = Hub::global().record_metric(MetricEvent { subcommand, extras }) {
             debug!("Error adding metric: {err}");
         }
     }
@@ -105,12 +111,13 @@ where
 
 /// A single metric entry
 /// This is the a metric event with additional static metadata
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MetricEntry {
     subcommand: Option<String>,
     #[serde(flatten)]
     extras: HashMap<String, String>,
     timestamp: OffsetDateTime,
+    uuid: Uuid,
     flox_version: String,
     os_family: Option<String>,
     os_family_release: Option<String>,
@@ -122,14 +129,16 @@ pub struct MetricEntry {
 impl MetricEntry {
     pub fn new(
         MetricEvent { subcommand, extras }: MetricEvent,
-        now: OffsetDateTime,
+        timestamp: OffsetDateTime,
+        uuid: Uuid,
     ) -> MetricEntry {
         let linux_release = sys_info::linux_os_release().ok();
 
         MetricEntry {
             subcommand,
             extras,
-            timestamp: now,
+            uuid,
+            timestamp,
             flox_version: FLOX_VERSION.to_string(),
             os_family: sys_info::os_type()
                 .ok()
@@ -140,101 +149,6 @@ impl MetricEntry {
             empty_flags: vec![],
         }
     }
-}
-
-/// Push metrics to the telemetry backend
-///
-/// Any network errors will bubble up and be catched by the event handler.
-/// If the network request failed, the buffer file is _not_ cleared.
-fn push_metrics(mut metrics: MetricsBuffer, uuid: Uuid) -> Result<()> {
-    debug!("Pushing metrics to server");
-
-    let version = FLOX_VERSION.to_string();
-    let events = metrics
-        .iter()
-        .map(|entry| {
-            Ok(json!({
-                "event": "cli-invocation",
-                "properties": {
-                    "distinct_id": uuid,
-                    "subcommand": entry.subcommand,
-                    "extras": entry.extras,
-
-                    "$device_id": uuid,
-
-                    "$current_url": entry.subcommand.as_ref().map(|x| format!("flox://{x}")),
-                    "$pathname": entry.subcommand,
-
-                    "empty_flags": entry.empty_flags,
-
-                    "$lib": "flox-cli",
-
-                    "os": entry.os,
-                    "os_version": entry.os_version,
-                    "os_family": entry.os_family,
-                    "os_family_release": entry.os_family_release,
-
-                    // compat
-                    "$os": entry.os_family,
-                    "kernel_version": entry.os_family_release,
-
-                    "$set_once": {
-                        "initial_flox_version": version,
-
-                        "initial_os": entry.os,
-                        "initial_os_version": entry.os_version,
-                        "initial_os_family": entry.os_family,
-                        "initial_os_family_release": entry.os_family_release,
-
-                        // compat
-                        "$initial_os": entry.os_family,
-                        "initial_kernel_version": entry.os_family_release,
-                    },
-
-                    "$set": {
-                        "test": true,
-
-                        "used_rust_preview": true,
-                        "flox_cli_uuid": uuid,
-
-                        "flox_version": version,
-
-                        "os": entry.os,
-                        "os_version": entry.os_version,
-                        "os_family": entry.os_family,
-                        "os_family_release": entry.os_family_release,
-
-                        // compat
-                        "$os": entry.os_family,
-                        "kernel_version": entry.os_family_release,
-                    },
-                },
-
-                // Event ID used for deduplication
-                "uuid": Uuid::new_v4(),
-
-                "timestamp": entry.timestamp.format(&Iso8601::DEFAULT)?,
-            }))
-        })
-        .collect::<Result<Vec<serde_json::Value>>>()?;
-
-    debug!("Sending metrics to {}", &*METRICS_EVENTS_URL);
-    debug!("Metrics: {events:?}", events = events);
-
-    let req = reqwest::Client::new()
-        .put(&*METRICS_EVENTS_URL)
-        .header("content-type", "application/json")
-        .header("x-api-key", METRICS_EVENTS_API_KEY)
-        .header("user-agent", format!("flox-cli/{}", version))
-        .json(&events)
-        .send();
-
-    let handle = tokio::runtime::Handle::current();
-    let _guard = handle.enter();
-    futures::executor::block_on(req).context("could not send to telemetry backend")?;
-
-    metrics.clear()?;
-    Ok(())
 }
 
 /// A representation of the metrics buffer
@@ -298,11 +212,11 @@ impl MetricsBuffer {
     /// i.e. needs to be pushed to the server.
     ///
     /// The buffer is expired if it contains >= 1 entry
-    /// and the oldest entry is older than [BUFFER_EXPIRY].
-    fn is_expired(&self) -> bool {
+    /// and the oldest entry is older than `expiry`.
+    fn is_expired(&self, expiry: Duration) -> bool {
         let now = OffsetDateTime::now_utc();
         self.oldest_timestamp()
-            .map(|oldest| now - oldest > BUFFER_EXPIRY)
+            .map(|oldest| now - oldest > expiry)
             .unwrap_or(false)
     }
 
@@ -363,24 +277,668 @@ fn read_metrics_uuid(config: &Config) -> Result<Uuid> {
         })
 }
 
-fn add_metric(event: MetricEvent) -> Result<()> {
-    let config = Config::parse()?;
+static METRICS_HUB: Lazy<Hub> = Lazy::new(|| Hub {
+    client: Arc::new(Mutex::new(None)),
+});
 
-    if config.flox.disable_metrics {
-        return Ok(());
+/// A sharable wrapper around a metrics [Client],
+/// that allows for registering and flushing metric events.
+///
+/// A global [Hub] is used by the [MetricsLayer] to record metrics
+/// from tracing events emitted by [subcommand_metric!].
+#[derive(Debug)]
+pub struct Hub {
+    client: Arc<Mutex<Option<Client>>>,
+}
+
+impl Hub {
+    pub fn global() -> &'static Self {
+        &METRICS_HUB
     }
 
-    let uuid = read_metrics_uuid(&config)?;
-    let mut metrics_buffer = MetricsBuffer::read(&config.flox.cache_dir)?;
-
-    let new_entry = MetricEntry::new(event, OffsetDateTime::now_utc());
-    metrics_buffer.push(new_entry)?;
-
-    let force_flush_buffer = std::env::var("_FLOX_FORCE_FLUSH_METRICS").is_ok();
-
-    if metrics_buffer.is_expired() || force_flush_buffer {
-        push_metrics(metrics_buffer, uuid)?;
+    /// Set the client for the hub, replacing the existing one.
+    /// Returns the previous client, if any.
+    ///
+    ///
+    /// In practice this should only be called once,
+    /// when the metrics are setup.
+    pub fn set_client(&self, new_client: Client) -> Option<Client> {
+        self.with_client(|client| client.replace(new_client))
     }
 
-    Ok(())
+    /// Get a guard for the client, that will automatically flush the metrics on drop
+    ///
+    /// The guard will return an error if another guard is already active.
+    pub fn try_guard(&self) -> Result<MetricGuard> {
+        if Arc::strong_count(&self.client) > 1 {
+            bail!("A guard is already active, there can only be one guard at a time")
+        }
+
+        Ok(MetricGuard {
+            hub: Self {
+                client: self.client.clone(),
+            },
+        })
+    }
+
+    /// Run a function with the wrapped client, returning the result.
+    /// A mutex is locked for the duration of the function.
+    fn with_client<T>(&self, f: impl FnOnce(&mut Option<Client>) -> T) -> T {
+        let mut client = self
+            .client
+            .lock()
+            .expect("Metrics client mutex panicked on another thread");
+        f(&mut client)
+    }
+
+    /// Flush the metrics to the telemetry backend
+    ///
+    /// If `force` is true, the metrics are flushed even if the buffer is not expired.
+    /// This methods is jut a convience wrapper around [Client::flush],
+    /// that will do nothing if no client is setup.
+    fn flush_metrics(&self, force: bool) -> Result<()> {
+        self.with_client(|client| {
+            if let Some(client) = client {
+                client.flush(force)
+            } else {
+                debug!("No metrics client setup, skipping flush");
+                Ok(())
+            }
+        })
+    }
+
+    /// Record a metric event
+    ///
+    /// This is a convience wrapper around [Client::record_metric],
+    /// that will do nothing if no client is setup.
+    pub fn record_metric(&self, event: MetricEvent) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No metrics client setup, skipping record");
+                return Ok(());
+            };
+
+            client.record_metric(event)
+        })
+    }
+}
+
+/// A connection to a telemetry backend, i.e. a service that receives metrics
+pub trait Connection: Debug + Any + Send + Sync {
+    /// Send the metrics to the telemetry backend defined by the [Connection]
+    fn send(&mut self, data: Vec<&MetricEntry>) -> Result<()>;
+
+    /// A helper method to box a [Connection] trait object
+    fn boxed(self) -> Box<dyn Connection>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
+
+    /// A helper trampoline to downcast [Box<dyn Connection>] to a known type
+    ///
+    /// This is used in tests to retrieve [TestConnection] from a [Client]
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+/// Connection to the AWS Datalake backend
+#[derive(Debug)]
+pub struct AWSDatalakeConnection {
+    pub timeout: TimeoutDuration,
+    pub endpoint_url: String,
+    pub api_key: String,
+}
+
+impl Connection for AWSDatalakeConnection {
+    fn send(&mut self, entries: Vec<&MetricEntry>) -> Result<()> {
+        let events = entries
+            .iter()
+            .map(|entry| {
+                Ok(json!({
+                    "event": "cli-invocation",
+                    "properties": {
+                        "distinct_id": entry.uuid,
+                        "subcommand": entry.subcommand,
+                        "extras": entry.extras,
+
+                        "$device_id": entry.uuid,
+
+                        "$current_url": entry.subcommand.as_ref().map(|x| format!("flox://{x}")),
+                        "$pathname": entry.subcommand,
+
+                        "empty_flags": entry.empty_flags,
+
+                        "$lib": "flox-cli",
+
+                        "os": entry.os,
+                        "os_version": entry.os_version,
+                        "os_family": entry.os_family,
+                        "os_family_release": entry.os_family_release,
+
+                        // compat
+                        "$os": entry.os_family,
+                        "kernel_version": entry.os_family_release,
+
+                        "$set_once": {
+                            "initial_flox_version": entry.flox_version,
+
+                            "initial_os": entry.os,
+                            "initial_os_version": entry.os_version,
+                            "initial_os_family": entry.os_family,
+                            "initial_os_family_release": entry.os_family_release,
+
+                            // compat
+                            "$initial_os": entry.os_family,
+                            "initial_kernel_version": entry.os_family_release,
+                        },
+
+                        "$set": {
+                            "test": true,
+
+                            "used_rust_preview": true,
+                            "flox_cli_uuid": entry.uuid,
+
+                            "flox_version": entry.flox_version,
+
+                            "os": entry.os,
+                            "os_version": entry.os_version,
+                            "os_family": entry.os_family,
+                            "os_family_release": entry.os_family_release,
+
+                            // compat
+                            "$os": entry.os_family,
+                            "kernel_version": entry.os_family_release,
+                        },
+                    },
+
+                    // Event ID used for deduplication
+                    "uuid": Uuid::new_v4(),
+
+                    "timestamp": entry.timestamp.format(&Iso8601::DEFAULT)?,
+                }))
+            })
+            .collect::<Result<Vec<serde_json::Value>>>()?;
+
+        let events = json!(events);
+
+        debug!("Sending metrics to {}", &self.endpoint_url);
+        debug!("Metrics: {events:#}");
+
+        reqwest::blocking::Client::new()
+            .put(&self.endpoint_url)
+            .header("content-type", "application/json")
+            .header("x-api-key", &self.api_key)
+            .header("user-agent", format!("flox-cli/{}", &*FLOX_VERSION))
+            .json(&events)
+            .timeout(self.timeout)
+            .send()?;
+        Ok(())
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+impl Default for AWSDatalakeConnection {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_TIMEOUT,
+            endpoint_url: METRICS_EVENTS_URL.clone(),
+            api_key: METRICS_EVENTS_API_KEY.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct TestConnection {
+    pub sent: Vec<Vec<MetricEntry>>,
+}
+
+impl Connection for TestConnection {
+    fn send(&mut self, data: Vec<&MetricEntry>) -> Result<()> {
+        self.sent.push(data.into_iter().cloned().collect());
+        Ok(())
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct Client {
+    pub uuid: Uuid,
+    pub metrics_dir: PathBuf,
+    pub max_age: Duration,
+    pub connection: Box<dyn Connection>,
+}
+
+impl Client {
+    /// Create a new client with defaults read from the config
+    pub fn new_with_config(config: &Config, connection: impl Connection + 'static) -> Result<Self> {
+        let uuid = read_metrics_uuid(config)?;
+        let metrics_dir = config.flox.cache_dir.clone();
+        Ok(Client {
+            uuid,
+            metrics_dir,
+            max_age: DEFAULT_BUFFER_EXPIRY,
+            connection: connection.boxed(),
+        })
+    }
+
+    /// Send the metrics to the telemetry backend and clear the buffer file.
+    ///
+    /// Any connection errors will bubble up and be catched by the event handler.
+    /// If the network request failed, the buffer file is _not_ cleared.
+    fn flush(&mut self, force: bool) -> Result<()> {
+        let mut metrics = MetricsBuffer::read(&self.metrics_dir)?;
+        if metrics.is_expired(self.max_age) || force {
+            self.connection.send(metrics.iter().collect())?;
+            metrics.clear()?;
+        }
+        Ok(())
+    }
+
+    /// Record a metric event
+    ///
+    /// Takes a Metric event and adds additional shared metadata to it
+    /// before pushing it to the metrics buffer.
+    fn record_metric(&self, event: MetricEvent) -> Result<()> {
+        let entry = MetricEntry::new(event, OffsetDateTime::now_utc(), self.uuid);
+        let mut metrics_buffer = MetricsBuffer::read(&self.metrics_dir)?;
+        metrics_buffer.push(entry)?;
+        Ok(())
+    }
+}
+
+pub struct MetricGuard {
+    hub: Hub,
+}
+impl Drop for MetricGuard {
+    fn drop(&mut self) {
+        let force = std::env::var("_FLOX_FORCE_FLUSH_METRICS")
+            .unwrap_or_default()
+            .parse()
+            .unwrap_or(false);
+        if let Err(e) = self.hub.flush_metrics(force) {
+            debug!("Failed to flush metrics on guard drop: {e}")
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::*;
+    use crate::config::FloxConfig;
+    use crate::utils::init::{create_registry_and_filter_reload_handle, update_filters};
+
+    /// Create a new client with test defaults
+    fn create_client() -> (Client, TempDir) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache_dir = tempdir.path().join("cache");
+
+        fs::create_dir_all(&cache_dir).unwrap();
+
+        let client = Client {
+            uuid: Uuid::new_v4(),
+            metrics_dir: cache_dir,
+            max_age: Duration::hours(2),
+            connection: TestConnection::default().boxed(),
+        };
+
+        (client, tempdir)
+    }
+
+    /// Make a test entry with known values
+    fn make_entry(subcommand: &str) -> MetricEntry {
+        MetricEntry {
+            subcommand: Some(subcommand.to_string()),
+            extras: HashMap::new(),
+            timestamp: OffsetDateTime::now_utc(),
+            uuid: Uuid::new_v4(),
+            flox_version: "1.0.0".to_string(),
+            os_family: Some("Linux".to_string()),
+            os_family_release: Some("5.4.0-42-generic".to_string()),
+            os: Some("ubuntu".to_string()),
+            os_version: Some("20.04".to_string()),
+            empty_flags: vec![],
+        }
+    }
+
+    /// Make event with known values
+    fn make_event(subcommand: &str) -> MetricEvent {
+        MetricEvent {
+            subcommand: Some(subcommand.to_string()),
+            extras: HashMap::new(),
+        }
+    }
+
+    /// Test that the [MetricsBuffer] writes entries to disk when dropped
+    #[test]
+    fn test_metrics_buffer_write() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let mut buffer = MetricsBuffer::read(tempdir.as_ref()).unwrap();
+
+        let entry_foo = make_entry("foo");
+        let entry_bar = make_entry("bar");
+
+        buffer.push(entry_foo.clone()).unwrap();
+        buffer.push(entry_bar.clone()).unwrap();
+
+        // entries are writtent to disk immediately,
+        // but lets drop the buffer anyway to be closer to reality
+        drop(buffer);
+
+        let metrics_buffer_file =
+            fs::read_to_string(tempdir.path().join(METRICS_EVENTS_FILE_NAME)).unwrap();
+        assert_eq!(
+            metrics_buffer_file,
+            serde_json::to_string(&entry_foo).unwrap()
+                + "\n"
+                + &serde_json::to_string(&entry_bar).unwrap()
+                + "\n"
+        );
+    }
+
+    /// Test that the [MetricsBuffer] clears entries as expected
+    #[test]
+    fn test_metrics_buffer_clear() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let mut buffer = MetricsBuffer::read(tempdir.as_ref()).unwrap();
+
+        let entry_foo = make_entry("foo");
+        let entry_bar = make_entry("bar");
+
+        buffer.push(entry_foo.clone()).unwrap();
+        buffer.push(entry_bar.clone()).unwrap();
+
+        buffer.clear().unwrap();
+
+        assert_eq!(buffer.buffer.len(), 0);
+        assert_eq!(buffer.oldest_timestamp(), None);
+
+        // entries are writtent to disk immediately,
+        // but lets drop the buffer anyway to be closer to reality
+        drop(buffer);
+
+        let metrics_buffer_file =
+            fs::read_to_string(tempdir.path().join(METRICS_EVENTS_FILE_NAME)).unwrap();
+
+        assert_eq!(metrics_buffer_file, "");
+    }
+
+    /// Test that the [MetricsBuffer] reads entries as expected
+    #[test]
+    fn test_metrics_buffer_read() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let mut buffer = MetricsBuffer::read(tempdir.as_ref()).unwrap();
+
+        assert!(!buffer.is_expired(Duration::seconds(0)));
+        assert_eq!(buffer.oldest_timestamp(), None);
+        assert_eq!(buffer.buffer.len(), 0);
+
+        let mut entry_foo = make_entry("foo");
+        entry_foo.timestamp = OffsetDateTime::now_utc() - Duration::hours(3);
+
+        let entry_bar = make_entry("bar");
+
+        buffer.push(entry_foo.clone()).unwrap();
+        buffer.push(entry_bar.clone()).unwrap();
+
+        // Can't create another bufer object while one is currently locked
+        drop(buffer);
+
+        let buffer = MetricsBuffer::read(tempdir.as_ref()).unwrap();
+
+        assert_eq!(buffer.buffer.len(), 2);
+        assert_eq!(buffer.oldest_timestamp(), Some(entry_foo.timestamp));
+        assert!(!buffer.is_expired(Duration::hours(4)));
+        assert!(buffer.is_expired(Duration::hours(2)));
+
+        {
+            let mut iter = buffer.iter();
+            assert_eq!(iter.next(), Some(&entry_foo));
+            assert_eq!(iter.next(), Some(&entry_bar));
+        }
+    }
+
+    /// Test that the client is constructed correctly given a config
+    #[test]
+    fn test_client_construction() {
+        let uuid = Uuid::new_v4();
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let data_dir = tempdir.path().join("data");
+        let cache_dir = tempdir.path().join("cache");
+
+        fs::create_dir_all(&data_dir).unwrap();
+        fs::create_dir_all(&cache_dir).unwrap();
+
+        fs::write(data_dir.join(METRICS_UUID_FILE_NAME), format!("{uuid}")).unwrap();
+
+        let config = Config {
+            flox: FloxConfig {
+                data_dir,
+                cache_dir: cache_dir.clone(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let client = Client::new_with_config(&config, TestConnection::default()).unwrap();
+
+        assert_eq!(client.uuid, uuid);
+        assert_eq!(client.metrics_dir, cache_dir);
+    }
+
+    /// Test that [Client::record_metric] records metrics as expected
+    #[test]
+    fn test_client_record_metric() {
+        let (client, _tempdir) = create_client();
+
+        let event_foo = make_event("foo");
+        client.record_metric(event_foo.clone()).unwrap();
+        {
+            let buffer = MetricsBuffer::read(&client.metrics_dir).unwrap();
+            let entry_foo = buffer.iter().next().unwrap();
+            assert_eq!(entry_foo.subcommand, event_foo.subcommand);
+        }
+
+        let event_bar = make_event("bar");
+        client.record_metric(event_bar.clone()).unwrap();
+
+        {
+            let buffer = MetricsBuffer::read(&client.metrics_dir).unwrap();
+            let mut iter = buffer.iter();
+
+            let entry_foo = iter.next().unwrap();
+            let entry_bar = iter.next().unwrap();
+            assert_eq!(entry_foo.subcommand, event_foo.subcommand);
+            assert_eq!(entry_bar.subcommand, event_bar.subcommand);
+        }
+    }
+
+    /// Test that [Client::flush] sends metrics as expected and clears the buffer
+    #[test]
+    fn test_client_flush() {
+        let (mut client, _tempdir) = create_client();
+
+        let event_foo = make_event("foo");
+        let event_bar = make_event("bar");
+
+        client.record_metric(event_foo.clone()).unwrap();
+        client.record_metric(event_bar.clone()).unwrap();
+        client.flush(true).unwrap();
+
+        let buffer = MetricsBuffer::read(&client.metrics_dir).unwrap();
+        assert_eq!(buffer.buffer.len(), 0);
+
+        let x: Box<TestConnection> = client.connection.into_any().downcast().unwrap();
+
+        let mut sent = x.sent.iter();
+        let mut first_send = sent.next().unwrap().iter();
+        let entry_foo = first_send.next().unwrap();
+        let entry_bar = first_send.next().unwrap();
+
+        assert!(first_send.next().is_none());
+        assert!(sent.next().is_none());
+        assert_eq!(entry_foo.subcommand, event_foo.subcommand);
+        assert_eq!(entry_bar.subcommand, event_bar.subcommand);
+    }
+
+    /// Test that [Hub::try_guard] returns a guard as expected
+    /// And that the guard flushes the metrics on drop when the buffer is expired.
+    /// And that the guard does not flush the metrics when the buffer is not expired.
+    #[test]
+    fn test_hub_try_guard() {
+        let (client, _tempdir) = create_client();
+
+        let hub = Hub {
+            client: Arc::new(Mutex::new(None)),
+        };
+        hub.set_client(client);
+
+        let guard = hub.try_guard();
+
+        // only one guard at a time
+        assert!(hub.try_guard().is_err());
+
+        let event_foo = make_event("foo");
+        let event_bar = make_event("bar");
+
+        hub.record_metric(event_foo.clone()).unwrap();
+        hub.record_metric(event_bar.clone()).unwrap();
+
+        let metrics_dir = hub.with_client(|c| c.as_ref().unwrap().metrics_dir.clone());
+
+        // check that the events are in the buffer
+        // buffer needs to be dropped first to release the lock
+        {
+            let buffer = MetricsBuffer::read(&metrics_dir).unwrap();
+
+            let mut buffered_items = buffer.iter();
+            assert_eq!(
+                buffered_items.next().unwrap().subcommand,
+                event_foo.subcommand
+            );
+            assert_eq!(
+                buffered_items.next().unwrap().subcommand,
+                event_bar.subcommand
+            );
+        }
+
+        // dropping the guard should flush the metrics if expired
+        // nothing to be flushed now as the default max_age is 2 hours
+        drop(guard);
+
+        // force all events to be expired
+        hub.with_client(|c| c.as_mut().unwrap().max_age = Duration::seconds(0));
+
+        // create and drop the guard immediately
+        drop(hub.try_guard().unwrap());
+
+        // buffer should be empty now
+        let buffer = MetricsBuffer::read(&metrics_dir).unwrap();
+        assert_eq!(buffer.buffer.len(), 0);
+
+        // extract the client
+        let client = hub.with_client(|c| c.take().unwrap());
+
+        // check what has been sent
+        let x: Box<TestConnection> = client.connection.into_any().downcast().unwrap();
+
+        let mut sent = x.sent.iter();
+        let mut first_send = sent.next().unwrap().iter();
+        let entry_foo = first_send.next().unwrap();
+        let entry_bar = first_send.next().unwrap();
+
+        assert!(first_send.next().is_none());
+        assert!(sent.next().is_none());
+        assert_eq!(entry_foo.subcommand, event_foo.subcommand);
+        assert_eq!(entry_bar.subcommand, event_bar.subcommand);
+    }
+
+    /// Test that [MetricsLayer] records metrics as expected
+    ///
+    /// This test uses the global client to record metrics
+    /// and thus requires to run in serial with other tests that use the global client.
+    #[test]
+    #[serial_test::serial(global_metrics_client)]
+    fn test_metrics_layer() {
+        let (client, _tempdir) = create_client();
+
+        let backup_client = Hub::global().with_client(|c| c.replace(client));
+
+        let subscriber = tracing_subscriber::registry().with(MetricsLayer::new());
+
+        tracing::subscriber::with_default(subscriber, || {
+            subcommand_metric!("foo", bar = "baz");
+        });
+
+        let client = Hub::global().with_client(|c| {
+            let test_client = c.take().unwrap();
+            *c = backup_client;
+            test_client
+        });
+
+        let buffer = MetricsBuffer::read(&client.metrics_dir).unwrap();
+
+        let entry = buffer.iter().next().unwrap();
+        assert_eq!(entry.subcommand, Some("foo".to_string()));
+        assert_eq!(
+            entry.extras,
+            vec![("bar".to_string(), "baz".to_string())]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    /// Test that [MetricsLayer] records metrics as expected
+    /// even if a filter is applied
+    ///
+    /// This test uses the global client to record metrics
+    /// and thus requires to run in serial with other tests that use the global client.
+    #[test]
+    #[serial_test::serial(global_metrics_client)]
+    fn test_metrics_layer_with_filter() {
+        let (client, _tempdir) = create_client();
+
+        let backup_client = Hub::global().with_client(|c| c.replace(client));
+
+        let (subscriber, reload_handle) = create_registry_and_filter_reload_handle();
+
+        tracing::subscriber::with_default(subscriber, || {
+            subcommand_metric!("foo");
+            update_filters(&reload_handle, "debug");
+            subcommand_metric!("bar");
+            update_filters(&reload_handle, "off");
+            subcommand_metric!("baz");
+        });
+
+        let client = Hub::global().with_client(|c| {
+            let test_client = c.take().unwrap();
+            *c = backup_client;
+            test_client
+        });
+
+        let buffer = MetricsBuffer::read(&client.metrics_dir).unwrap();
+        let mut buffer_iter = buffer.iter();
+        let entry_foo = buffer_iter.next().unwrap();
+        let entry_bar = buffer_iter.next().unwrap();
+        let entry_baz = buffer_iter.next().unwrap();
+
+        assert_eq!(entry_foo.subcommand, Some("foo".to_string()));
+        assert_eq!(entry_bar.subcommand, Some("bar".to_string()));
+        assert_eq!(entry_baz.subcommand, Some("baz".to_string()));
+    }
 }

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -24,7 +24,7 @@ use crate::config::Config;
 pub const METRICS_EVENTS_FILE_NAME: &str = "metrics-events-v2.json";
 pub const METRICS_UUID_FILE_NAME: &str = "metrics-uuid";
 pub const METRICS_LOCK_FILE_NAME: &str = "metrics-lock";
-const DEFAULT_BUFFER_EXPIRY: Duration = Duration::hours(2);
+const DEFAULT_BUFFER_EXPIRY: Duration = Duration::minutes(2);
 const DEFAULT_TIMEOUT: TimeoutDuration = TimeoutDuration::from_secs(2);
 
 pub static METRICS_EVENTS_URL: Lazy<String> = Lazy::new(|| {

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -378,7 +378,7 @@ pub trait Connection: Debug + Any + Send + Sync {
 
     /// A helper trampoline to downcast [Box<dyn Connection>] to a known type
     ///
-    /// This is used in tests to retrieve [TestConnection] from a [Client]
+    /// This is used in tests to retrieve [tests::TestConnection] from a [Client]
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
@@ -491,22 +491,6 @@ impl Default for AWSDatalakeConnection {
     }
 }
 
-#[derive(Debug, Default)]
-struct TestConnection {
-    pub sent: Vec<Vec<MetricEntry>>,
-}
-
-impl Connection for TestConnection {
-    fn send(&mut self, data: Vec<&MetricEntry>) -> Result<()> {
-        self.sent.push(data.into_iter().cloned().collect());
-        Ok(())
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-}
-
 #[derive(Debug)]
 pub struct Client {
     pub uuid: Uuid,
@@ -578,6 +562,23 @@ mod tests {
     use super::*;
     use crate::config::FloxConfig;
     use crate::utils::init::{create_registry_and_filter_reload_handle, update_filters};
+
+    #[derive(Debug, Default)]
+    pub(super) struct TestConnection {
+        pub sent: Vec<Vec<MetricEntry>>,
+    }
+
+    impl Connection for TestConnection {
+        /// Store the sent metrics in memory
+        fn send(&mut self, data: Vec<&MetricEntry>) -> Result<()> {
+            self.sent.push(data.into_iter().cloned().collect());
+            Ok(())
+        }
+
+        fn into_any(self: Box<Self>) -> Box<dyn Any> {
+            self
+        }
+    }
 
     /// Create a new client with test defaults
     fn create_client() -> (Client, TempDir) {


### PR DESCRIPTION
For the most part wraps the existing metrics workflows
but allows for more granular tests of the individual components.
I.e.
* flushing can be tested without a connection to the datalake
* tracing behavior can be tested without setting up tracing globally
* Automatic flushing on drop can be tested as well without global setup.

This change _also_ include tests for the MetricsBuffer that buffers metrics on disk.

The design is heavily inspired by the sentry library.