### PR TITLE
feat: shorten environment descriptions

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -127,10 +127,10 @@ impl Edit {
                 if let ConcreteEnvironment::Path(mut environment) = detected_environment {
                     let old_name = environment.name();
                     if name == old_name {
-                        bail!("environment already named {name}");
+                        bail!("environment already named '{name}'");
                     }
                     environment.rename(name.clone())?;
-                    message::updated(format!("renamed environment {old_name} to {name}"));
+                    message::updated(format!("renamed environment '{old_name}' to '{name}'"));
                 } else {
                     // todo: handle remote environments in the future
                     bail!("Cannot rename environments on FloxHub");
@@ -163,7 +163,7 @@ impl Edit {
 
         // outside the match to avoid rustfmt falling on its face
         let reactivate_required_note = indoc! {"
-            Your manifest has changes that cannot be automatically applied to your current environment.
+            Your manifest has changes that cannot be automatically applied.
 
             Please 'exit' the environment and run 'flox activate' to see these changes.
        "};

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -135,7 +135,7 @@ impl Init {
         };
 
         message::created(format!(
-            "Created environment {name} ({system})",
+            "Created environment '{name}' ({system})",
             name = env.name(),
             system = flox.system
         ));

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -6,13 +6,15 @@ mod search;
 
 use std::collections::VecDeque;
 use std::fmt::Display;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{env, fmt, fs, mem};
 
 use anyhow::{bail, Context, Result};
 use bpaf::{Args, Bpaf, ParseFailure, Parser};
 use flox_rust_sdk::flox::{
+    EnvironmentName,
+    EnvironmentOwner,
     EnvironmentRef,
     Flox,
     Floxhub,
@@ -744,8 +746,11 @@ pub fn detect_environment(
                 help_message: None,
                 typed: Select {
                     options: vec![
-                        format!("{type_of_directory} [{found}]",),
-                        format!("current active flox environment [{activated_env}]",),
+                        format!("{type_of_directory} [{}]", found.prompt_description()?),
+                        format!(
+                            "current active flox environment [{}]",
+                            activated_env.prompt_description()?
+                        ),
                     ],
                 },
             };
@@ -886,33 +891,113 @@ impl UninitializedEnvironment {
             },
         }
     }
+
+    /// If the environment is remote or managed, the name of the owner
+    pub fn owner(&self) -> Option<&EnvironmentOwner> {
+        match self {
+            UninitializedEnvironment::DotFlox(DotFlox { pointer, .. }) => pointer.owner(),
+            UninitializedEnvironment::Remote(pointer) => Some(&pointer.owner),
+        }
+    }
+
+    /// The name of the environment
+    pub fn name(&self) -> &EnvironmentName {
+        match self {
+            UninitializedEnvironment::DotFlox(DotFlox { pointer, .. }) => pointer.name(),
+            UninitializedEnvironment::Remote(pointer) => &pointer.name,
+        }
+    }
+
+    /// Returns true if the environment is in the current directory
+    pub fn is_current_dir(&self) -> Result<bool> {
+        match self {
+            UninitializedEnvironment::DotFlox(DotFlox { path, .. }) => {
+                let current_dir = std::env::current_dir()?;
+                let is_current = current_dir.canonicalize()? == path.canonicalize()?;
+                Ok(is_current)
+            },
+            UninitializedEnvironment::Remote(_) => Ok(false),
+        }
+    }
+
+    /// Returns the path to the environment if it isn't remote
+    #[allow(dead_code)]
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            UninitializedEnvironment::DotFlox(DotFlox { path, .. }) => Some(path),
+            UninitializedEnvironment::Remote(_) => None,
+        }
+    }
+
+    /// Returns true if the environment is a managed environment
+    pub fn is_managed(&self) -> bool {
+        match self {
+            UninitializedEnvironment::DotFlox(DotFlox { pointer, .. }) => pointer.owner().is_some(),
+            UninitializedEnvironment::Remote(_) => false,
+        }
+    }
+
+    /// Returns true if the environment is a path environment
+    #[allow(dead_code)]
+    pub fn is_path_env(&self) -> bool {
+        match self {
+            UninitializedEnvironment::DotFlox(DotFlox { pointer, .. }) => pointer.owner().is_none(),
+            UninitializedEnvironment::Remote(_) => false,
+        }
+    }
+
+    /// Returns true if the environment is a remote environment
+    pub fn is_remote(&self) -> bool {
+        match self {
+            UninitializedEnvironment::DotFlox(_) => false,
+            UninitializedEnvironment::Remote(_) => true,
+        }
+    }
+
+    /// The environment description when displayed in a prompt
+    pub fn prompt_description(&self) -> Result<String> {
+        if self.is_remote() {
+            Ok(format!(
+                "{}/{} (remote)",
+                self.owner().unwrap(),
+                self.name()
+            ))
+        } else if self.is_managed() {
+            Ok(format!("{}/{}", self.owner().unwrap(), self.name()))
+        } else {
+            Ok(format!("{}", self.name()))
+        }
+    }
+
+    /// The environment description when displayed in messages
+    pub fn message_description(&self) -> Result<String> {
+        if self.is_remote() {
+            Ok(format!(
+                "'{}/{}' (remote)",
+                self.owner().unwrap(),
+                self.name()
+            ))
+        } else if self.is_managed() {
+            Ok(format!("'{}/{}'", self.owner().unwrap(), self.name()))
+        } else if self
+            .is_current_dir()
+            .expect("couldn't read current directory")
+        {
+            Ok(String::from("in current directory"))
+        } else {
+            Ok(format!("'{}'", self.name()))
+        }
+    }
 }
 
 impl Display for UninitializedEnvironment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            UninitializedEnvironment::DotFlox(DotFlox {
-                path,
-                pointer: EnvironmentPointer::Managed(managed_pointer),
-            }) => {
-                write!(
-                    f,
-                    "{}/{} at {}",
-                    managed_pointer.owner,
-                    managed_pointer.name,
-                    path.to_string_lossy(),
-                )
-            },
-            UninitializedEnvironment::DotFlox(DotFlox {
-                path,
-                pointer: EnvironmentPointer::Path(path_pointer),
-            }) => {
-                write!(f, "{} at {}", path_pointer.name, path.to_string_lossy())
-            },
-            UninitializedEnvironment::Remote(pointer) => {
-                write!(f, "{}/{} (remote)", pointer.owner, pointer.name,)
-            },
-        }
+        write!(
+            f,
+            "{}",
+            self.message_description()
+                .expect("couldn't get environment description")
+        )
     }
 }
 
@@ -1176,7 +1261,7 @@ pub(super) async fn ensure_floxhub_token(flox: &mut Flox) -> Result<()> {
 }
 
 pub fn environment_description(environment: &ConcreteEnvironment) -> Result<String> {
-    Ok(UninitializedEnvironment::from_concrete_environment(environment)?.to_string())
+    UninitializedEnvironment::from_concrete_environment(environment)?.message_description()
 }
 
 #[cfg(test)]

--- a/cli/tests/environment-init.bats
+++ b/cli/tests/environment-init.bats
@@ -82,7 +82,7 @@ teardown() {
   assert_success
 
   assert_output - <<EOF
-✨ Created environment test ($NIX_SYSTEM)
+✨ Created environment 'test' ($NIX_SYSTEM)
 
 Next:
   $ flox search <package>    <- Search for a package

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -76,7 +76,7 @@ dot_flox_exists() {
 
   run "$FLOX_BIN" install hello
   assert_success
-  assert_output --partial "environment $OWNER/project-managed-${BATS_TEST_NUMBER}" # managed env output
+  assert_output --partial "environment '$OWNER/project-managed-${BATS_TEST_NUMBER}'" # managed env output
 
   run --separate-stderr "$FLOX_BIN" list --name
   assert_success

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -94,7 +94,7 @@ function make_empty_remote_env() {
 
   run "$FLOX_BIN" install hello --remote "$OWNER/test"
   assert_success
-  assert_output --partial "environment $OWNER/test (remote)" # managed env output
+  assert_output --partial "environment '$OWNER/test' (remote)" # managed env output
 
   run --separate-stderr "$FLOX_BIN" list --name --remote "$OWNER/test"
   assert_success

--- a/cli/tests/install/last-activated.exp
+++ b/cli/tests/install/last-activated.exp
@@ -22,7 +22,7 @@ expect -ex "Getting ready to use environment" {}
 # install hello and check it's installed to environment 2
 set cmd "$flox install hello"
 send "$cmd\n"
-expect -re "✅ 'hello' installed to environment 2 at .*2" {}
+expect -re "✅ 'hello' installed to environment '2'" {}
 send "hello\n"
 expect -ex "Hello, world!" {}
 

--- a/cli/tests/install/prompt-which-environment-git.exp
+++ b/cli/tests/install/prompt-which-environment-git.exp
@@ -21,14 +21,14 @@ send "cd 2/subdirectory\n"
 # install hello and expect an interactive prompt
 send "$flox install hello\n"
 expect -ex "Do you want to install to the flox environment detected in git repo or the current active flox environment?" {}
-expect -re {flox environment detected in git repo \[2 at .*2\]} {}
-expect -re {current active flox environment \[1 at .*1\]} {}
+expect -re {flox environment detected in git repo \[2\]} {}
+expect -re {current active flox environment \[1\]} {}
 expect -re "type to filter.*\n"
 
 # choose the first option and expect the corresponding installation
 send "\r"
 # install hello and check it's installed to environment 2
-expect -re "✅ 'hello' installed to environment 2 at .*2" {}
+expect -re "✅ 'hello' installed to environment '2'" {}
 
 send "exit\n"
 expect eof

--- a/cli/tests/install/prompt-which-environment.exp
+++ b/cli/tests/install/prompt-which-environment.exp
@@ -22,14 +22,15 @@ expect "cd 2" {}
 # install hello and expect an interactive prompt
 send "$flox install hello\n"
 expect -ex "Do you want to install to the current directory's flox environment or the current active flox environment?" {}
-expect -re {current directory's flox environment \[2 at .*2\]} {}
-expect -re {current active flox environment \[1 at .*1\]} {}
+expect -re {current directory's flox environment \[2\]} {}
+expect -re {current active flox environment \[1\]} {}
 expect -re "type to filter.*\n"
 
 # choose the first option and expect the corresponding installation
 send "\r"
-# install hello and check it's installed to environment 2, but not into environment 1
-expect -re "✅ 'hello' installed to environment 2 at .*2" {}
+# install hello and check it's installed to environment 2,
+# which is in the current directory at this point
+expect -re "✅ 'hello' installed to environment in current directory" {}
 send "command -v hello\n"
 send "echo error code: $?\n"
 expect -re "error code: 1" {}


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Shortens environment descriptions so that they no longer include absolute paths. This also adds single quotes in specific places so that it's always clear when a word is the name of the environment.

**Previous output**
Install
<img width="1009" alt="Screenshot 2024-03-22 at 2 49 40 PM" src="https://github.com/flox/flox/assets/10246891/6825b687-cb44-4ab5-a039-f56b96eb04cc">

**New output**

Delete
<img width="1009" alt="Screenshot 2024-03-22 at 2 50 29 PM" src="https://github.com/flox/flox/assets/10246891/31977174-04b4-4880-8530-4791793e07ab">

Install
<img width="565" alt="Screenshot 2024-03-22 at 2 50 57 PM" src="https://github.com/flox/flox/assets/10246891/8aeb266d-cb56-4d12-a601-ec28cdc8b62f">

Init
<img width="634" alt="Screenshot 2024-03-22 at 2 51 37 PM" src="https://github.com/flox/flox/assets/10246891/0c1d4b5e-fe0f-4ab9-b721-3ce329c46715">


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Environment names will now always appear as `<owner>/<name>` or simply `<name>` instead of `<name> at <path>` so that CLI output is less verbose.

<!-- Many thanks! -->
