### PR TITLE
Update README.md to remove old discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ of Nix.
 
 We are happy to welcome you to our [Discourse forum][discourse] and answer your
 questions! You can always reach out to us directly via the [Flox twitter
-account][twitter] or chat to us directly on [Slack][slack] or
-[Discord][discord].
+account][twitter] or chat to us directly on [Slack][slack].
 
 ## 🤝 Found a bug? Missing a specific feature?
 
@@ -139,6 +138,5 @@ The Flox CLI is licensed under the GPLv2. See [LICENSE](./LICENSE).
 [docs]: https://flox.dev/docs
 [twitter]: https://twitter.com/floxdevelopment
 [slack]: https://go.flox.dev/slack
-[discord]: https://discord.gg/5H7hN57eQR
 [new-issue]: https://github.com/flox/flox/issues/new/choose
 [post-nixpkgs]: https://flox.dev/blog/nixpkgs

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ of Nix.
 
 We are happy to welcome you to our [Discourse forum][discourse] and answer your
 questions! You can always reach out to us directly via the [Flox twitter
-account][twitter] or chat to us directly on [Slack][slack].
+account][twitter] or chat with us directly on [Slack][slack].
 
 ## 🤝 Found a bug? Missing a specific feature?
 


### PR DESCRIPTION
as we are trying to move over to slack instead