### PR TITLE
test: unit test incompatible environments

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -825,7 +825,7 @@ mod tests {
     #[test]
     #[serial]
     fn build_incompatible_package() {
-        #[cfg(target_os = "macos")]
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         let manifest_contents = formatdoc! {r#"
         [install]
         glibc.pkg-path = "glibc"
@@ -834,13 +834,31 @@ mod tests {
         systems = ["aarch64-darwin"]
         "#};
 
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+        let manifest_contents = formatdoc! {r#"
+        [install]
+        glibc.pkg-path = "glibc"
+
+        [options]
+        systems = ["x86_64-darwin"]
+        "#};
+
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
         let manifest_contents = formatdoc! {r#"
         [install]
         ps.pkg-path = "darwin.ps"
 
         [options]
         systems = ["x86_64-linux"]
+        "#};
+
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        let manifest_contents = formatdoc! {r#"
+        [install]
+        ps.pkg-path = "darwin.ps"
+
+        [options]
+        systems = ["aarch64-linux"]
         "#};
 
         let (mut env_view, flox, _temp_dir_handle) = empty_core_environment();

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -737,14 +737,11 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     use indoc::formatdoc;
-    #[cfg(feature = "impure-unit-tests")]
     use serial_test::serial;
     use tempfile::{tempdir_in, TempDir};
 
     use super::*;
     use crate::flox::test_helpers::{flox_instance, flox_instance_with_global_lock};
-    #[cfg(feature = "impure-unit-tests")]
-    use crate::models::environment::init_global_manifest;
 
     /// Create a CoreEnvironment with an empty manifest
     ///
@@ -764,8 +761,7 @@ mod tests {
     #[serial]
     #[cfg(feature = "impure-unit-tests")]
     fn edit_env_creates_manifest_and_lockfile() {
-        let (flox, tempdir) = flox_instance();
-        init_global_manifest(&global_manifest_path(&flox)).unwrap();
+        let (flox, tempdir) = flox_instance_with_global_lock();
 
         let env_path = tempfile::tempdir_in(&tempdir).unwrap();
         fs::write(env_path.path().join(MANIFEST_FILENAME), "").unwrap();
@@ -785,6 +781,7 @@ mod tests {
 
     /// A no-op with edit returns EditResult::Unchanged
     #[test]
+    #[serial]
     fn edit_no_op_returns_unchanged() {
         let (mut env_view, flox, _temp_dir_handle) = empty_core_environment();
 
@@ -796,6 +793,7 @@ mod tests {
     /// Trying to build a manifest with a system other than the current one
     /// results in an error that is_incompatible_system_error()
     #[test]
+    #[serial]
     fn build_incompatible_system() {
         #[cfg(target_os = "macos")]
         let manifest_contents = formatdoc! {r#"
@@ -825,6 +823,7 @@ mod tests {
     /// Trying to build a manifest with a package that is incompatible with the current system
     /// results in an error that is_incompatible_package_error()
     #[test]
+    #[serial]
     fn build_incompatible_package() {
         #[cfg(target_os = "macos")]
         let manifest_contents = formatdoc! {r#"
@@ -859,6 +858,7 @@ mod tests {
 
     /// Installing hello with edit returns EditResult::Success
     #[test]
+    #[serial]
     fn edit_adding_package_returns_success() {
         let (mut env_view, flox, _temp_dir_handle) = empty_core_environment();
 
@@ -874,6 +874,7 @@ mod tests {
 
     /// Adding a hook with edit returns EditResult::ReActivateRequired
     #[test]
+    #[serial]
     fn edit_adding_hook_returns_re_activate_required() {
         let (mut env_view, flox, _temp_dir_handle) = empty_core_environment();
 
@@ -942,8 +943,7 @@ mod tests {
     #[serial]
     #[cfg(feature = "impure-unit-tests")]
     fn build_flox_environment_and_links() {
-        let (flox, tempdir) = flox_instance();
-        init_global_manifest(&global_manifest_path(&flox)).unwrap();
+        let (flox, tempdir) = flox_instance_with_global_lock();
 
         let env_path = tempfile::tempdir_in(&tempdir).unwrap();
         fs::write(

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1154,7 +1154,7 @@ mod test {
     use url::Url;
 
     use super::*;
-    use crate::flox::tests::flox_instance;
+    use crate::flox::test_helpers::flox_instance;
     use crate::models::environment::{DOT_FLOX, ENVIRONMENT_POINTER_FILENAME};
     use crate::models::floxmetav2::floxmeta_dir;
     use crate::providers::git::tests::commit_file;

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -535,7 +535,7 @@ impl PathEnvironment {
 mod tests {
 
     use super::*;
-    use crate::flox::tests::flox_instance;
+    use crate::flox::test_helpers::flox_instance;
 
     #[test]
     fn create_env() {

--- a/cli/flox-rust-sdk/src/models/floxmetav2/mod.rs
+++ b/cli/flox-rust-sdk/src/models/floxmetav2/mod.rs
@@ -245,7 +245,7 @@ mod tests {
     use std::fs;
 
     use super::*;
-    use crate::flox::tests::flox_instance;
+    use crate::flox::test_helpers::flox_instance;
     use crate::flox::DEFAULT_FLOXHUB_URL;
     use crate::providers::git::GitProvider;
 

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -324,11 +324,8 @@ fn try_find_compatible_version(
 
 #[cfg(test)]
 mod tests {
-    use flox_rust_sdk::flox::test_flox_instance;
     use indoc::indoc;
-    use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
-    use tempfile::TempDir;
 
     use super::*;
 
@@ -409,12 +406,4 @@ mod tests {
             ]),
         });
     }
-
-    pub static FLOX_INSTANCE: Lazy<(Flox, TempDir)> = Lazy::new(|| {
-        let (flox, _temp_dir_handle) = test_flox_instance();
-        let pkgdb_nixpkgs_rev_new = "ab5fd150146dcfe41fda501134e6503932cc8dfd";
-        std::env::set_var("_PKGDB_GA_REGISTRY_REF_OR_REV", pkgdb_nixpkgs_rev_new);
-        LockedManifest::update_global_manifest(&flox, vec![]).unwrap();
-        (flox, _temp_dir_handle)
-    });
 }

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -760,11 +760,11 @@ impl InitHook for Node {
 
 #[cfg(test)]
 mod tests {
+    use flox_rust_sdk::flox::test_helpers::flox_instance_with_global_lock;
     use pretty_assertions::assert_eq;
     use serial_test::serial;
 
     use super::*;
-    use crate::commands::init::tests::FLOX_INSTANCE;
 
     #[test]
     fn test_parse_nvmrc_version_some() {
@@ -918,13 +918,13 @@ mod tests {
     #[test]
     #[serial]
     fn test_try_find_compatible_yarn_no_constraints() {
-        let flox = &FLOX_INSTANCE.0;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
         let yarn_install = Node::try_find_compatible_yarn(
             &PackageJSONVersions {
                 yarn: None,
                 node: None,
             },
-            flox,
+            &flox,
         )
         .unwrap()
         .unwrap();
@@ -937,13 +937,13 @@ mod tests {
     #[test]
     #[serial]
     fn test_try_find_compatible_yarn_node_available() {
-        let flox = &FLOX_INSTANCE.0;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
         let yarn_install = Node::try_find_compatible_yarn(
             &PackageJSONVersions {
                 yarn: None,
                 node: Some("18".to_string()),
             },
-            flox,
+            &flox,
         )
         .unwrap()
         .unwrap();
@@ -958,13 +958,13 @@ mod tests {
     #[test]
     #[serial]
     fn test_try_find_compatible_yarn_node_unavailable() {
-        let flox = &FLOX_INSTANCE.0;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
         let yarn_install = Node::try_find_compatible_yarn(
             &PackageJSONVersions {
                 yarn: None,
                 node: Some("20".to_string()),
             },
-            flox,
+            &flox,
         )
         .unwrap();
 
@@ -975,13 +975,13 @@ mod tests {
     #[test]
     #[serial]
     fn test_try_find_compatible_yarn_yarn_available() {
-        let flox = &FLOX_INSTANCE.0;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
         let yarn_install = Node::try_find_compatible_yarn(
             &PackageJSONVersions {
                 yarn: Some("1".to_string()),
                 node: None,
             },
-            flox,
+            &flox,
         )
         .unwrap()
         .unwrap();
@@ -996,13 +996,13 @@ mod tests {
     #[test]
     #[serial]
     fn test_try_find_compatible_yarn_yarn_unavailable() {
-        let flox = &FLOX_INSTANCE.0;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
         let yarn_install = Node::try_find_compatible_yarn(
             &PackageJSONVersions {
                 yarn: Some("2".to_string()),
                 node: None,
             },
-            flox,
+            &flox,
         )
         .unwrap();
 
@@ -1014,13 +1014,13 @@ mod tests {
     #[test]
     #[serial]
     fn test_try_find_compatible_yarn_both_available() {
-        let flox = &FLOX_INSTANCE.0;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
         let yarn_install = Node::try_find_compatible_yarn(
             &PackageJSONVersions {
                 yarn: Some("1".to_string()),
                 node: Some("18".to_string()),
             },
-            flox,
+            &flox,
         )
         .unwrap()
         .unwrap();

--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -711,11 +711,11 @@ mod tests {
         }
     }
 
+    use flox_rust_sdk::flox::test_helpers::flox_instance_with_global_lock;
     use pretty_assertions::assert_eq;
     use serial_test::serial;
 
     use super::*;
-    use crate::commands::init::tests::FLOX_INSTANCE;
 
     #[test]
     fn test_should_run_true() {
@@ -744,13 +744,13 @@ mod tests {
     /// An invalid pyproject.toml should return an error
     #[test]
     fn test_pyproject_invalid() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
         let content = indoc! {r#"
         ,
         "#};
 
-        let pyproject = PyProject::from_pyproject_content(content, flox);
+        let pyproject = PyProject::from_pyproject_content(content, &flox);
 
         assert!(pyproject.is_err());
     }
@@ -759,9 +759,9 @@ mod tests {
     #[test]
     #[serial]
     fn test_pyproject_empty() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
-        let pyproject = PyProject::from_pyproject_content("", flox).unwrap();
+        let pyproject = PyProject::from_pyproject_content("", &flox).unwrap();
 
         assert_eq!(pyproject.unwrap(), PyProject {
             provided_python_version: ProvidedVersion::Compatible {
@@ -775,14 +775,14 @@ mod tests {
     #[test]
     #[serial]
     fn test_pyproject_available_version() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
         let content = indoc! {r#"
         [project]
         requires-python = ">= 3.8"
         "#};
 
-        let pyproject = PyProject::from_pyproject_content(content, flox).unwrap();
+        let pyproject = PyProject::from_pyproject_content(content, &flox).unwrap();
 
         assert_eq!(pyproject.unwrap(), PyProject {
             provided_python_version: ProvidedVersion::Compatible {
@@ -796,14 +796,14 @@ mod tests {
     #[test]
     #[serial]
     fn test_pyproject_unavailable_version() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
         let content = indoc! {r#"
         [project]
         requires-python = "1"
         "#};
 
-        let pyproject = PyProject::from_pyproject_content(content, flox).unwrap();
+        let pyproject = PyProject::from_pyproject_content(content, &flox).unwrap();
 
         assert_eq!(pyproject.unwrap(), PyProject {
             provided_python_version: ProvidedVersion::Incompatible {
@@ -817,7 +817,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_pyproject_parse_version() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
         // python docs have a space in the version (>= 3.8):
         // https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires
@@ -827,7 +827,7 @@ mod tests {
         requires-python = ">= 3.8" # < with space
         "#};
 
-        let pyproject = PyProject::from_pyproject_content(content, flox).unwrap();
+        let pyproject = PyProject::from_pyproject_content(content, &flox).unwrap();
 
         assert_eq!(pyproject.unwrap(), PyProject {
             provided_python_version: ProvidedVersion::Compatible {
@@ -840,13 +840,13 @@ mod tests {
     /// An invalid pyproject.toml should return an error
     #[test]
     fn test_poetry_pyproject_invalid() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
         let content = indoc! {r#"
         ,
         "#};
 
-        let pyproject = PoetryPyProject::from_pyproject_content(content, flox);
+        let pyproject = PoetryPyProject::from_pyproject_content(content, &flox);
 
         assert!(pyproject.is_err());
     }
@@ -854,9 +854,9 @@ mod tests {
     /// None should be returned for an empty pyproject.toml
     #[test]
     fn test_poetry_pyproject_empty() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
-        let pyproject = PoetryPyProject::from_pyproject_content("", flox).unwrap();
+        let pyproject = PoetryPyProject::from_pyproject_content("", &flox).unwrap();
 
         assert_eq!(pyproject, None);
     }
@@ -865,13 +865,13 @@ mod tests {
     /// `tool.poetry.dependencies.python`
     #[test]
     fn test_poetry_pyproject_no_python() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
         let content = indoc! {r#"
         [tool.poetry]
         "#};
 
-        let pyproject = PoetryPyProject::from_pyproject_content(content, flox);
+        let pyproject = PoetryPyProject::from_pyproject_content(content, &flox);
 
         assert!(pyproject.is_err());
     }
@@ -880,14 +880,14 @@ mod tests {
     #[test]
     #[serial]
     fn test_poetry_pyproject_available_version() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
         let content = indoc! {r#"
         [tool.poetry.dependencies]
         python = "^3.7"
         "#};
 
-        let pyproject = PoetryPyProject::from_pyproject_content(content, flox).unwrap();
+        let pyproject = PoetryPyProject::from_pyproject_content(content, &flox).unwrap();
 
         assert_eq!(pyproject.unwrap(), PoetryPyProject {
             provided_python_version: ProvidedVersion::Compatible {
@@ -902,14 +902,14 @@ mod tests {
     #[test]
     #[serial]
     fn test_poetry_pyproject_unavailable_version() {
-        let (flox, _) = &*FLOX_INSTANCE;
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
 
         let content = indoc! {r#"
         [tool.poetry.dependencies]
         python = "1"
         "#};
 
-        let pyproject = PoetryPyProject::from_pyproject_content(content, flox).unwrap();
+        let pyproject = PoetryPyProject::from_pyproject_content(content, &flox).unwrap();
 
         assert_eq!(pyproject.unwrap(), PoetryPyProject {
             provided_python_version: ProvidedVersion::Incompatible {


### PR DESCRIPTION
Currently integration tests cover catching pkgdb build errors when a
manifest does not support the current system, or a package does not
support the current system. These cases will be faster and more targeted
if unit tested instead of integration tested.

Dropping integration tests will be done in a followup PR.

Writing these tests revealed there's currently no easy way to avoid a pkgdb scrape in a unit test and use an isolated flox instance, so the following changes were made as well:

- Add a test_helpers module with flox_instance_with_global_lock that
  ensures pkgdb scrape has been run and then adds a global lock to the
  flox instance being created.
- Move flox_instance to the test_helpers module
- Drop FLOX_INSTANCE in favor of flox_instance_with_global_lock. Using a
  single FLOX_INSTANCE is likely to cause problems when shared between
  multiple tests because it doesn't isolate tests.
  flox_instance_with_global_lock will be close to as performant with
  better isolation.