### PR TITLE
chore: drop unused dependency nix-serve

### DIFF
--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -22,7 +22,6 @@
   jq,
   nix,
   yq,
-  nix-serve,
   openssh,
   parallel,
   podman,
@@ -59,7 +58,6 @@
       gnused
       gnutar
       jq
-      nix-serve
       openssh
       parallel
       unixtools.util-linux

--- a/pkgs/flox-tests/default.nix
+++ b/pkgs/flox-tests/default.nix
@@ -22,7 +22,6 @@
   gnutar,
   jq,
   nix,
-  nix-serve,
   openssh,
   parallel,
   unixtools,
@@ -59,7 +58,6 @@
       gnused
       gnutar
       jq
-      nix-serve
       openssh
       parallel
       unixtools.util-linux


### PR DESCRIPTION
nix-serve was used in publish tests which have been dropped