### PR TITLE
fix: allow `flox pull` to overwrite environment with `--force` flag

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -16,3 +16,4 @@ yes,zmitchell,Zach Mitchell,<zach@floxdev.com>
 yes,jennymahmoudi,Jenny Mahmoudi,<jenny@floxdev.com>
 yes,Cadienvan,Michael Di Prisco,<cadienvan@gmail.com>
 yes,lpmi-13,Adam Leskis,<leskis@gmail.com>
+yes,charmitro,Charalampos Mitrodimas,<charmitro@posteo.net>

--- a/cli/tests/environment-pull.bats
+++ b/cli/tests/environment-pull.bats
@@ -297,6 +297,29 @@ function add_insecure_package() {
   assert_success
 }
 
+# bats test_tags=pull:add-system-flag
+# pulling an environment without packages for the current platform
+#should fail with an error
+@test "pull environment inside the same environment without the '--force' flag" {
+  update_dummy_env "owner" "name"
+
+  run "$FLOX_BIN" pull --remote owner/name
+  assert_success
+  run "$FLOX_BIN" pull --remote owner/name
+  assert_failure
+}
+
+# bats test_tags=pull:add-system-flag
+# pulling an environment without packages for the current platform
+@test "pull environment inside the same environment with '--force' flag" {
+  update_dummy_env "owner" "name"
+
+  run "$FLOX_BIN" pull --remote owner/name
+  assert_success
+  run "$FLOX_BIN" pull --remote owner/name --force
+  assert_success
+}
+
 # bats test_tags=pull:unsupported:prompt-fail
 # pulling an environment without packages for the current platform
 # should fail with an error


### PR DESCRIPTION
## Proposed Changes

When using `flox pull --force` while in an environment, it fails to overwrite the environment. This commit allows overwriting it by checking if the `force` flag is set.

Closes #1205 

## Release Notes

Allow overwriting the environment when pulling with `--force`, i.e. `flox pull --force`.