### PR TITLE
feat: add sentry user id to metrics

### DIFF
--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -27,6 +27,15 @@ async fn run(args: FloxArgs) -> Result<()> {
     set_parent_process_id();
     populate_default_nix_env_vars();
     let config = config::Config::parse()?;
+    let uuid = utils::metrics::read_metrics_uuid(&config)
+        .map(|u| Some(u.to_string()))
+        .unwrap_or(None);
+    sentry::configure_scope(|scope| {
+        scope.set_user(Some(sentry::User {
+            id: uuid,
+            ..Default::default()
+        }));
+    });
     init_global_manifest(&config.flox.config_dir.join("global-manifest.toml"))?;
     args.handle(config).await?;
     Ok(())

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -259,7 +259,7 @@ impl MetricsBuffer {
     }
 }
 
-fn read_metrics_uuid(config: &Config) -> Result<Uuid> {
+pub fn read_metrics_uuid(config: &Config) -> Result<Uuid> {
     let data_dir = &config.flox.data_dir;
     let uuid_path = data_dir.join(METRICS_UUID_FILE_NAME);
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Uses our metrics UUID as the Sentry user ID and attaches it to all metrics.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
