### PR TITLE
docs(CONTRIBUTING): add note about CI, reorganize

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ to help enforcing those rules.
 
 -----
 
-For starters: commit messages shold have to follow the pattern:
+For starters: commit messages should follow the pattern:
 
 ```
 <type>[optional scope]: <description>
@@ -58,9 +58,9 @@ For starters: commit messages shold have to follow the pattern:
 ```
 
 The commit contains the following structural elements,
-to communicate intent to the consumers of your library:
+to communicate the intent of the change:
 
-1. **fix**: a commit of the type `fix` patches a bug in your codebase
+1. **fix**: a commit of the type `fix` patches a bug in the codebase
    (this correlates with PATCH in Semantic Versioning).
 2. **feat**: a commit of the type feat introduces a new feature to the codebase
    (this correlates with MINOR in Semantic Versioning).
@@ -365,4 +365,4 @@ updated by rebasing and resolving conflicts regularly to avoid messy merges.
 Merges to `main` should be squashed and *ff-only* back to `main` using GitHub
 PRs.  Or, if they represent multiple bigger changes, squashed into multiple
 distinct change sets.  Also be sure to run all tests before creating a mergable
-PR (See [below](#testing)).
+PR (See [above](#testing)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,95 @@ $ ./cli/target/debug/flox --help;
 $ just test-all;
 ```
 
+## PR Guidelines
+
+### CLA
+
+- [ ] All commits in a Pull Request are
+      [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+      and Verified by Github or via GPG.
+- [ ] As an outside contributor you need to accept the flox
+      [Contributor License Agreement](.github/CLA.md) by adding your Git/Github
+      details in a row at the end of the
+      [`CONTRIBUTORS.csv`](.github/CONTRIBUTORS.csv) file by way of the same
+      pull request or one done previously.
+
+### CI
+
+CI can only be run against the flox/flox repository - it can't be run on forks.
+To run CI on external contributions, a maintainer will have to fetch the branch
+for a PR and push it to a branch in the flox/flox repo.
+The maintainer reviewing a PR will run CI after approving the PR.
+If you ever need a run triggered, feel free to ping your reviewer!
+
+### Commits
+
+This project follows (tries to),
+[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+We employ [commitizen](https://commitizen-tools.github.io/commitizen/)
+to help enforcing those rules.
+
+**Commit messages that explain the content of the commit are appreciated**
+
+-----
+
+For starters: commit messages shold have to follow the pattern:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The commit contains the following structural elements,
+to communicate intent to the consumers of your library:
+
+1. **fix**: a commit of the type `fix` patches a bug in your codebase
+   (this correlates with PATCH in Semantic Versioning).
+2. **feat**: a commit of the type feat introduces a new feature to the codebase
+   (this correlates with MINOR in Semantic Versioning).
+3. **BREAKING CHANGE**: a commit that has a footer BREAKING CHANGE:,
+   or appends a ! after the type/scope, introduces a breaking API change
+   (correlating with MAJOR in Semantic Versioning).
+   A BREAKING CHANGE can be part of commits of any type.
+4. types other than fix: and feat: are allowed,
+   for example @commitlint/config-conventional (based on the Angular convention)
+   recommends `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`,
+   `test`, and others.
+5. footers other than BREAKING CHANGE: <description> may be provided
+   and follow a convention similar to git trailer format.
+
+Additional types are not mandated by the Conventional Commits specification,
+and have no implicit effect in Semantic Versioning
+(unless they include a BREAKING CHANGE).
+
+A scope may be provided to a commit’s type,
+to provide additional contextual information
+and is contained within parenthesis, e.g., feat(parser): add ability to parse
+arrays.
+
+-----
+
+A pre-commit hook will ensure only correctly formatted commit messages are
+committed.
+
+You can also run
+
+```console
+$ cz c
+```
+
+or
+
+```console
+$ cz commit
+```
+
+to make conforming commits interactively.
+
 ## Contents of the Repo
 
 Currently this repo houses three rust crates:
@@ -133,105 +222,6 @@ section refers to settings from that plugin.
   ```
    "shellformat.useEditorConfig": true,
   ```
-
-## Git
-
-### CLA
-
-- [ ] All commits in a Pull Request are
-      [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
-      and Verified by Github or via GPG.
-- [ ] As an outside contributor you need to accept the flox
-      [Contributor License Agreement](.github/CLA.md) by adding your Git/Github
-      details in a row at the end of the
-      [`CONTRIBUTORS.csv`](.github/CONTRIBUTORS.csv) file by way of the same
-      pull request or one done previously.
-
-### Commits
-
-This project follows (tries to),
-[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
-
-We employ [commitizen](https://commitizen-tools.github.io/commitizen/)
-to help enforcing those rules.
-
-**Commit messages that explain the content of the commit are appreciated**
-
------
-
-For starters: commit messages shold have to follow the pattern:
-
-```
-<type>[optional scope]: <description>
-
-[optional body]
-
-[optional footer(s)]
-```
-
-The commit contains the following structural elements,
-to communicate intent to the consumers of your library:
-
-1. **fix**: a commit of the type `fix` patches a bug in your codebase
-   (this correlates with PATCH in Semantic Versioning).
-2. **feat**: a commit of the type feat introduces a new feature to the codebase
-   (this correlates with MINOR in Semantic Versioning).
-3. **BREAKING CHANGE**: a commit that has a footer BREAKING CHANGE:,
-   or appends a ! after the type/scope, introduces a breaking API change
-   (correlating with MAJOR in Semantic Versioning).
-   A BREAKING CHANGE can be part of commits of any type.
-4. types other than fix: and feat: are allowed,
-   for example @commitlint/config-conventional (based on the Angular convention)
-   recommends `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`,
-   `test`, and others.
-5. footers other than BREAKING CHANGE: <description> may be provided
-   and follow a convention similar to git trailer format.
-
-Additional types are not mandated by the Conventional Commits specification,
-and have no implicit effect in Semantic Versioning
-(unless they include a BREAKING CHANGE).
-
-A scope may be provided to a commit’s type,
-to provide additional contextual information
-and is contained within parenthesis, e.g., feat(parser): add ability to parse
-arrays.
-
------
-
-A pre-commit hook will ensure only correctly formatted commit messages are
-committed.
-
-You can also run
-
-```console
-$ cz c
-```
-
-or
-
-```console
-$ cz commit
-```
-
-to make conforming commits interactively.
-
-### Merges
-
-Changes should be **squashed and merged** into `main`.
-
-Development is done on branches and merged back to `main`.  Keep your branch
-updated by rebasing and resolving conflicts regularly to avoid messy merges.
-Merges to `main` should be squashed and *ff-only* back to `main` using GitHub
-PRs.  Or, if they represent multiple bigger changes, squashed into multiple
-distinct change sets.  Also be sure to run all tests before creating a mergable
-PR (See [below](#testing)).
-
-
-### Releases
-
-**TODO**
-
-
 
 ## Testing
 
@@ -365,3 +355,14 @@ You can use boolean logic and specify the flag multiple times to run specific
 subsets of tests.
 See the [bats usage documentation](https://bats-core.readthedocs.io/en/stable/usage.html)
 for details.
+
+## Merges
+
+Changes should be **squashed and merged** into `main`.
+
+Development is done on branches and merged back to `main`.  Keep your branch
+updated by rebasing and resolving conflicts regularly to avoid messy merges.
+Merges to `main` should be squashed and *ff-only* back to `main` using GitHub
+PRs.  Or, if they represent multiple bigger changes, squashed into multiple
+distinct change sets.  Also be sure to run all tests before creating a mergable
+PR (See [below](#testing)).


### PR DESCRIPTION
- Add a note about running CI on external forks
- Move information more relevant for first time contributions to the top
