### PR TITLE
feat(search): Bold search term matches in interactive output

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -234,15 +234,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -570,6 +570,7 @@ dependencies = [
  "bpaf",
  "chrono",
  "config",
+ "console",
  "crossterm 0.26.1",
  "derive_more",
  "dirs",
@@ -3067,15 +3068,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3084,18 +3076,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.42.2"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3130,12 +3116,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3145,12 +3125,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3166,12 +3140,6 @@ checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -3181,12 +3149,6 @@ name = "windows_i686_gnu"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3202,12 +3164,6 @@ checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -3220,12 +3176,6 @@ checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3235,12 +3185,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -49,6 +49,7 @@ indent.workspace = true
 semver.workspace = true
 sentry = { workspace = true, features = ["anyhow", "tracing", "debug-logs"] }
 serial_test.workspace = true
+console = "0.15.8"
 
 [dev-dependencies]
 temp-env = "0.3.2"

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -1,8 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
+use std::io::stdout;
 use std::path::PathBuf;
 
 use anyhow::Result;
+use console::style;
+use crossterm::tty::IsTty;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::lockfile::LockedManifest;
 use flox_rust_sdk::models::search::{PathOrJson, Query, SearchParams, SearchResult, SearchResults};
@@ -190,6 +193,8 @@ pub struct DisplaySearchResults {
     count: Option<u64>,
     /// number of actual results (including duplicates)
     n_results: u64,
+    /// Whether to bold the search term matches in the output
+    use_bold: bool,
 }
 
 /// A struct that wraps the functionality needed to print [SearchResults] to a
@@ -210,21 +215,35 @@ impl DisplaySearchResults {
 
         let display_items: DisplayItems = search_results.results.into();
 
+        let use_bold = stdout().is_tty();
+
         Ok(DisplaySearchResults {
             search_term: search_term.to_string(),
             display_items,
             count: search_results.count,
             n_results: n_results as u64,
+            use_bold,
         })
     }
 }
 
 impl Display for DisplaySearchResults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let format_name = |name: &str| {
+            if self.use_bold {
+                name.replace(
+                    &self.search_term,
+                    &format!("{}", style(&self.search_term).bold()),
+                )
+            } else {
+                name.to_string()
+            }
+        };
+
         let column_width = self
             .display_items
             .iter()
-            .map(|d| d.to_string().len())
+            .map(|d| format_name(&d.to_string()).len())
             .max()
             .unwrap_or_default();
 
@@ -233,12 +252,16 @@ impl Display for DisplaySearchResults {
 
         while let Some(d) = items.next() {
             let desc = d.description.as_deref().unwrap_or(DEFAULT_DESCRIPTION);
-            write!(f, "{d:<column_width$}  {desc}", d = d.to_string())?;
+            let name = format_name(&d.to_string());
+
+            // The two spaces here provide visual breathing room.
+            write!(f, "{name:<column_width$}  {desc}", name = name)?;
             // Only print a newline if there are more items to print
             if items.peek().is_some() {
                 writeln!(f)?;
             }
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
This feature improves the user experience by making it easier to visually identify the search term matches in the search results when running `flox search` in an interactive terminal. The bolding is automatically disabled when the output is redirected to a file or piped to another command to ensure compatibility with non-interactive use cases.

Key changes:
    - Added the `atty` package to detect if the output is a
      terminal (TTY) and `console` for text styles
    - Updated the `DisplaySearchResults` struct to include a
      `use_bold` field to determine whether to bold the search
      term matches
    - Modified the `Display` trait implementation for
      `DisplaySearchResults` to conditionally bold the package names
      based on the `use_bold` field

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
