### PR TITLE
fix: Correct bold formatting in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -19,6 +19,6 @@ Expected:
 
 **Screenshots/terminal output (if relevant):**
 
-** flox Version (run `flox --version` if possible): **
+**flox Version (run `flox --version` if possible):**
 
-** `uname -a` output: **
+**`uname -a` output:**


### PR DESCRIPTION
## Proposed Changes

This avoids users that create bug reports to fixup the bold formatting each time themselves.

## Release Notes

N/A