### PR TITLE
chore(cli): Omit the "Version: " prefix when printing the version

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -18,3 +18,4 @@ yes,Cadienvan,Michael Di Prisco,<cadienvan@gmail.com>
 yes,rchatrath7,Rakesh Chatrath,<rchatrath7@gmail.com>
 yes,lpmi-13,Adam Leskis,<leskis@gmail.com>
 yes,charmitro,Charalampos Mitrodimas,<charmitro@posteo.net>
+yes,sschuberth,Sebastian Schuberth,<sschuberth@gmail.com>

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> ExitCode {
 
     // Quit early if `--version` is present
     if Version::check() {
-        println!("Version: {}", *FLOX_VERSION);
+        println!("{}", *FLOX_VERSION);
         return ExitCode::from(0);
     }
 


### PR DESCRIPTION
Make it easier for third parties to parse the version output.

Resolves #1256.