### PR TITLE
feat: add `flox envs` command

### DIFF
--- a/cli/flox-rust-sdk/src/data/canonical_path.rs
+++ b/cli/flox-rust-sdk/src/data/canonical_path.rs
@@ -1,0 +1,39 @@
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use thiserror::Error;
+
+/// A path that is guaranteed to be canonicalized
+///
+/// [`ManagedEnvironment`] uses this to refer to the path of its `.flox` directory.
+/// [`ManagedEnvironment::encode`] is used to uniquely identify the environment
+/// by encoding the canonicalized path.
+/// This encoding is used to create a unique branch name in the floxmeta repository.
+/// Thus, rather than canonicalizing the path every time we need to encode it,
+/// we store the path as a [`CanonicalPath`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, derive_more::Deref, derive_more::AsRef)]
+#[deref(forward)]
+#[as_ref(forward)]
+pub struct CanonicalPath(PathBuf);
+
+#[derive(Debug, Error)]
+#[error("couldn't canonicalize path {path:?}: {err}")]
+pub struct CanonicalizeError {
+    pub path: PathBuf,
+    #[source]
+    pub err: std::io::Error,
+}
+
+impl CanonicalPath {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, CanonicalizeError> {
+        let canonicalized = std::fs::canonicalize(&path).map_err(|e| CanonicalizeError {
+            path: path.as_ref().to_path_buf(),
+            err: e,
+        })?;
+        Ok(Self(canonicalized))
+    }
+
+    pub fn into_path_buf(self) -> PathBuf {
+        self.0
+    }
+}

--- a/cli/flox-rust-sdk/src/data/mod.rs
+++ b/cli/flox-rust-sdk/src/data/mod.rs
@@ -1,4 +1,6 @@
+mod canonical_path;
 mod version;
 
+pub use canonical_path::{CanonicalPath, CanonicalizeError};
 pub use version::Version;
 pub type System = String;

--- a/cli/flox-rust-sdk/src/data/version.rs
+++ b/cli/flox-rust-sdk/src/data/version.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct Version<const V: u8>;
 

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -7,8 +7,8 @@ use fslock::LockFile;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
-use super::environment::{path_hash, CanonicalPath, EnvironmentPointer};
-use crate::data::Version;
+use super::environment::{path_hash, EnvironmentPointer};
+use crate::data::{CanonicalPath, Version};
 use crate::flox::Flox;
 use crate::utils::traceable_path;
 

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -15,9 +15,10 @@ use super::{
     LOCKFILE_FILENAME,
     MANIFEST_FILENAME,
 };
+use crate::data::CanonicalPath;
 use crate::flox::Flox;
 use crate::models::container_builder::ContainerBuilder;
-use crate::models::environment::{call_pkgdb, global_manifest_path, CanonicalPath};
+use crate::models::environment::{call_pkgdb, global_manifest_path};
 use crate::models::lockfile::{LockedManifest, LockedManifestError};
 use crate::models::manifest::{
     insert_packages,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -11,7 +11,6 @@ use super::path_environment::PathEnvironment;
 use super::{
     gcroots_dir,
     path_hash,
-    CanonicalPath,
     CanonicalizeError,
     CoreEnvironmentError,
     EditResult,
@@ -26,7 +25,7 @@ use super::{
     ENVIRONMENT_POINTER_FILENAME,
     N_HASH_CHARS,
 };
-use crate::data::Version;
+use crate::data::{CanonicalPath, Version};
 use crate::flox::{EnvironmentRef, Flox};
 use crate::models::container_builder::ContainerBuilder;
 use crate::models::env_registry::{
@@ -1875,7 +1874,7 @@ mod test {
             floxmeta,
             &flox,
             test_pointer,
-            CanonicalPath(dot_flox_path),
+            CanonicalPath::new(dot_flox_path).unwrap(),
             flox.temp_dir.join("out_link"),
         )
         .unwrap();
@@ -1915,7 +1914,7 @@ mod test {
             floxmeta,
             &flox,
             test_pointer,
-            CanonicalPath(dot_flox_path),
+            CanonicalPath::new(dot_flox_path).unwrap(),
             flox.temp_dir.join("out_link"),
         )
         .unwrap();

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -198,7 +198,9 @@ pub trait Environment: Send {
 /// A pointer to an environment, either managed or path.
 /// This is used to determine the type of an environment at a given path.
 /// See [EnvironmentPointer::open].
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, derive_more::From)]
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, derive_more::From,
+)]
 #[serde(untagged)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum EnvironmentPointer {
@@ -211,7 +213,7 @@ pub enum EnvironmentPointer {
 /// The identifier for a project environment.
 ///
 /// This is serialized to `env.json` inside the `.flox` directory
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct PathPointer {
     pub name: EnvironmentName,
@@ -232,7 +234,7 @@ impl PathPointer {
 /// points to an environment owner and the name of the environment.
 ///
 /// This is serialized to an `env.json` inside the `.flox` directory.
-#[derive(Debug, Serialize, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ManagedPointer {
     pub owner: EnvironmentOwner,
@@ -319,7 +321,7 @@ impl EnvironmentPointer {
 /// However, this type does not perform any validation of the referenced environment.
 /// Opening the environment with [ManagedEnvironment::open] or
 /// [PathEnvironment::open], could still fail.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 pub struct DotFlox {
     pub path: PathBuf,
     pub pointer: EnvironmentPointer,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -437,11 +437,8 @@ pub enum EnvironmentError {
     #[error("could not get current directory")]
     GetCurrentDir(#[source] std::io::Error),
 
-    #[error("failed to get canonical path for '.flox' directory: {path}")]
-    CanonicalDotFlox {
-        err: CanonicalizeError,
-        path: PathBuf,
-    },
+    #[error("failed to get canonical path for '.flox' directory")]
+    CanonicalDotFlox(#[source] CanonicalizeError),
 
     #[error("failed to access the environment registry")]
     Registry(#[from] EnvRegistryError),

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -23,7 +23,6 @@ use log::debug;
 
 use super::core_environment::CoreEnvironment;
 use super::{
-    CanonicalPath,
     CanonicalizeError,
     EditResult,
     Environment,
@@ -39,7 +38,7 @@ use super::{
     GCROOTS_DIR_NAME,
     LOCKFILE_FILENAME,
 };
-use crate::data::System;
+use crate::data::{CanonicalPath, System};
 use crate::flox::Flox;
 use crate::models::container_builder::ContainerBuilder;
 use crate::models::env_registry::{deregister, ensure_registered};

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -364,10 +364,8 @@ impl PathEnvironment {
         }
 
         let canonical_dot_flox =
-            CanonicalPath::new(&dot_flox_path).map_err(|e| EnvironmentError::CanonicalDotFlox {
-                err: e,
-                path: dot_flox_path.as_ref().to_path_buf(),
-            })?;
+            CanonicalPath::new(&dot_flox_path).map_err(EnvironmentError::CanonicalDotFlox)?;
+
         ensure_registered(
             flox,
             &canonical_dot_flox,

--- a/cli/flox-rust-sdk/src/models/environment_ref.rs
+++ b/cli/flox-rust-sdk/src/models/environment_ref.rs
@@ -11,7 +11,18 @@ pub static DEFAULT_NAME: &str = "default";
 pub static DEFAULT_OWNER: &str = "local";
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, AsRef, Deref, Display, DeserializeFromStr, SerializeDisplay,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    AsRef,
+    Deref,
+    Display,
+    DeserializeFromStr,
+    SerializeDisplay,
 )]
 pub struct EnvironmentOwner(String);
 
@@ -28,7 +39,17 @@ impl FromStr for EnvironmentOwner {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, AsRef, Display, DeserializeFromStr, SerializeDisplay,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    AsRef,
+    Display,
+    DeserializeFromStr,
+    SerializeDisplay,
 )]
 pub struct EnvironmentName(String);
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -12,15 +12,11 @@ use log::debug;
 use thiserror::Error;
 
 use super::container_builder::ContainerBuilder;
-use super::environment::{CanonicalizeError, UpdateResult};
+use super::environment::UpdateResult;
 use super::pkgdb::CallPkgDbError;
-use crate::data::{System, Version};
+use crate::data::{CanonicalPath, CanonicalizeError, System, Version};
 use crate::flox::Flox;
-use crate::models::environment::{
-    global_manifest_lockfile_path,
-    global_manifest_path,
-    CanonicalPath,
-};
+use crate::models::environment::{global_manifest_lockfile_path, global_manifest_path};
 use crate::models::pkgdb::{call_pkgdb, BuildEnvResult, PKGDB_BIN};
 use crate::utils::CommandExt;
 

--- a/cli/flox/doc/flox-envs.md
+++ b/cli/flox/doc/flox-envs.md
@@ -1,0 +1,51 @@
+---
+title: FLOX-ENVS
+section: 1
+header: "Flox User Manuals"
+...
+
+# NAME
+
+flox-envs - show active and available environments
+
+# SYNOPSIS
+
+```
+flox [<general options>] envs
+     [--active]
+     [--json]
+```
+
+# DESCRIPTION
+
+This command can be used to list available environments on the local machine.
+When one or more environments are active,
+the last activated environment will be listed first and printed in **bold**.
+
+Whenever an environment is used with any `flox` command
+it is registered to a user specific global registry.
+`flox envs` will list all environments known to it through the registry.
+Environments that are present on the local system may not show up
+until they are used the first time.
+Similarly, if an environment is changed
+(e.g. deleted and replaced by an environment with different metadata),
+the change may not show until the new environment is used.
+
+# OPTIONS
+
+## Edit Options
+
+`--active`
+:   Show only active environments
+
+`--json`
+:   Format the output as JSON
+
+```{.include}
+./include/general-options.md
+```
+
+# SEE ALSO
+[`flox-init(1)`](./flox-init.md),
+[`flox-pull(1)`](./flox-pull.md),
+[`flox-activate(1)`](./flox-activate.md)

--- a/cli/flox/src/commands/envs.rs
+++ b/cli/flox/src/commands/envs.rs
@@ -1,0 +1,210 @@
+use std::collections::BTreeSet;
+use std::fmt::Display;
+use std::path::Path;
+
+use anyhow::Result;
+use bpaf::Bpaf;
+use crossterm::style::Stylize;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::env_registry::{
+    env_registry_path,
+    read_environment_registry,
+    EnvRegistry,
+};
+use flox_rust_sdk::models::environment::DotFlox;
+use serde_json::json;
+use tracing::instrument;
+
+use super::{ActiveEnvironments, UninitializedEnvironment};
+use crate::commands::activated_environments;
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[derive(Bpaf, Debug, Clone)]
+#[bpaf(fallback(Mode::All))]
+enum Mode {
+    #[bpaf(long, hide)]
+    All,
+    #[bpaf(long)]
+    Active,
+}
+
+#[derive(Bpaf, Debug, Clone)]
+pub struct Envs {
+    #[bpaf(external(mode))]
+    mode: Mode,
+    #[bpaf(long)]
+    json: bool,
+}
+
+impl Envs {
+    /// List all environments
+    ///
+    /// If `--json` is passed, dispatch to [Self::handle_json]
+    ///
+    /// If `--active` is passed, print only the active environments
+    /// Always prints headers and formats the output.
+    #[instrument(name = "envs", skip_all)]
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("envs");
+
+        let active = activated_environments();
+
+        match self.mode {
+            Mode::Active => tracing::info_span!("active").in_scope(|| self.handle_active(active)),
+            Mode::All => tracing::info_span!("all").in_scope(|| {
+                let env_registry =
+                    read_environment_registry(env_registry_path(&flox))?.unwrap_or_default();
+                let registered = get_registered_environments(&env_registry);
+
+                self.handle_all(active, registered)
+            }),
+        }
+    }
+
+    /// Print active environments only
+    ///
+    /// If `--json` is passed, print a JSON list with objects for each active environment.
+    /// Otherwise, print a list of active environments.
+    /// If no environments are active, print an appropriate message.
+    fn handle_active(&self, active: ActiveEnvironments) -> Result<()> {
+        if self.json {
+            println!("{:#}", json!(active));
+            return Ok(());
+        }
+
+        if active.last_active().is_none() {
+            message::plain("No active environments");
+            return Ok(());
+        }
+
+        message::plain("Active environments:");
+        println!("{}", DisplayEnvironments::new(active.iter(), true));
+        Ok(())
+    }
+
+    /// Print all environments
+    ///
+    /// If `--json` is passed, print a JSON object with `active` and `inactive` keys.
+    /// If any environments are active, print them first.
+    /// Then print all inactive environments.
+    /// If no environments are known to Flox, print an appropriate message.
+    fn handle_all(
+        &self,
+        active: ActiveEnvironments,
+        registered: impl Iterator<Item = UninitializedEnvironment>,
+    ) -> Result<()> {
+        let inactive = get_inactive_environments(registered, active.iter())?;
+
+        if self.json {
+            println!(
+                "{:#}",
+                json!({
+                    "active": active,
+                    "inactive": inactive,
+                })
+            );
+            return Ok(());
+        }
+
+        if active.iter().next().is_none() && inactive.is_empty() {
+            message::plain("No environments known to Flox");
+        }
+
+        if active.iter().next().is_some() {
+            message::plain("Active environments:");
+            println!("{}", DisplayEnvironments::new(active.iter(), true));
+        }
+
+        if !inactive.is_empty() {
+            message::plain("Inactive environments:");
+            println!("{}", DisplayEnvironments::new(inactive.iter(), false));
+        }
+
+        Ok(())
+    }
+}
+
+struct DisplayEnvironments<'a> {
+    envs: Vec<&'a UninitializedEnvironment>,
+    format_active: bool,
+}
+
+impl<'a> DisplayEnvironments<'a> {
+    fn new(
+        envs: impl IntoIterator<Item = &'a UninitializedEnvironment>,
+        format_active: bool,
+    ) -> Self {
+        Self {
+            envs: envs.into_iter().collect(),
+            format_active,
+        }
+    }
+}
+
+impl<'a> Display for DisplayEnvironments<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let widest = self
+            .envs
+            .iter()
+            .map(|env| env.name().as_ref().len())
+            .max()
+            .unwrap_or(0);
+
+        let mut envs = self.envs.iter();
+
+        if self.format_active {
+            let Some(first) = envs.next() else {
+                return Ok(());
+            };
+            let first_formatted =
+                format!("{:<widest$}  {}", first.name(), format_path(first.path())).bold();
+            writeln!(f, "{first_formatted}")?;
+        }
+
+        for env in envs {
+            writeln!(f, "{:<widest$}  {}", env.name(), format_path(env.path()))?;
+        }
+
+        Ok(())
+    }
+}
+
+fn format_path(path: Option<&Path>) -> String {
+    path.map(|p| p.display().to_string())
+        .unwrap_or_else(|| "(remote)".to_string())
+}
+
+fn get_registered_environments(
+    registry: &EnvRegistry,
+) -> impl Iterator<Item = UninitializedEnvironment> + '_ {
+    registry.entries.iter().filter_map(|entry| {
+        let path = entry.path.parent()?.to_path_buf();
+        let pointer = entry.latest_env()?.pointer.clone();
+
+        // If we have a path registered that has since been deleted, skip it
+        if !entry.path.exists() {
+            return None;
+        }
+
+        Some(UninitializedEnvironment::DotFlox(DotFlox { path, pointer }))
+    })
+}
+
+/// Get the list of environments that are not active
+fn get_inactive_environments<'a>(
+    available: impl IntoIterator<Item = UninitializedEnvironment>,
+    active: impl IntoIterator<Item = &'a UninitializedEnvironment>,
+) -> Result<BTreeSet<UninitializedEnvironment>> {
+    // let active = activated_environments();
+
+    let inactive = {
+        let mut available = BTreeSet::from_iter(available);
+        for active in active {
+            available.remove(active);
+        }
+        available
+    };
+
+    Ok(inactive)
+}

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -5,12 +5,12 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Error, Result};
 use bpaf::Bpaf;
+use flox_rust_sdk::data::CanonicalPath;
 use flox_rust_sdk::flox::{EnvironmentName, Flox, DEFAULT_NAME};
 use flox_rust_sdk::models::environment::path_environment::{InitCustomization, PathEnvironment};
 use flox_rust_sdk::models::environment::{
     global_manifest_lockfile_path,
     global_manifest_path,
-    CanonicalPath,
     Environment,
     PathPointer,
 };

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -2,13 +2,9 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Result};
 use bpaf::Bpaf;
+use flox_rust_sdk::data::CanonicalPath;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::{
-    CanonicalPath,
-    CoreEnvironmentError,
-    Environment,
-    EnvironmentError,
-};
+use flox_rust_sdk::models::environment::{CoreEnvironmentError, Environment, EnvironmentError};
 use flox_rust_sdk::models::lockfile::{LockedManifest, LockedManifestError};
 use flox_rust_sdk::models::manifest::PackageToInstall;
 use flox_rust_sdk::models::pkgdb::error_codes;

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 use bpaf::Bpaf;
+use flox_rust_sdk::data::CanonicalPath;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::{CanonicalPath, Environment};
+use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::models::lockfile::{
     InstalledPackage,
     LockedManifest,

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -739,10 +739,11 @@ impl AdditionalCommands {
 
     async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
+            AdditionalCommands::Config(args) => args.handle(config, flox).await?,
             AdditionalCommands::Documentation(args) => args.handle(),
+            AdditionalCommands::Envs(args) => args.handle(flox)?,
             AdditionalCommands::Update(args) => args.handle(flox).await?,
             AdditionalCommands::Upgrade(args) => args.handle(flox).await?,
-            AdditionalCommands::Config(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }
@@ -1052,7 +1053,7 @@ impl ConcreteEnvironment {
 /// * for [RemoteEnvironment] that's the [ManagedPointer] to the remote environment
 ///
 /// Serialized as is into [FLOX_ACTIVE_ENVIRONMENTS_VAR] to be able to reopen environments.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(tag = "type")]
 #[serde(rename_all = "kebab-case")]
 pub enum UninitializedEnvironment {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod containerize;
 mod delete;
 mod edit;
+mod envs;
 mod general;
 mod init;
 mod install;
@@ -728,6 +729,9 @@ enum AdditionalCommands {
     /// View and set configuration options
     #[bpaf(command, hide, footer("Run 'man flox-config' for more details."))]
     Config(#[bpaf(external(general::config_args))] general::ConfigArgs),
+
+    #[bpaf(command, hide, footer("Run 'man flox-envs' for more details."))]
+    Envs(#[bpaf(external(envs::envs))] envs::Envs),
 }
 
 impl AdditionalCommands {

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -1,10 +1,10 @@
+use flox_rust_sdk::data::CanonicalizeError;
 use flox_rust_sdk::models::environment::managed_environment::{
     ManagedEnvironmentError,
     GENERATION_LOCK_FILENAME,
 };
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentError;
 use flox_rust_sdk::models::environment::{
-    CanonicalizeError,
     CoreEnvironmentError,
     EnvironmentError,
     ENVIRONMENT_POINTER_FILENAME,


### PR DESCRIPTION
This PR adds an environment registry and `flox envs` command.

Flox commands has so far been mostly stateless, i.e. the fact that an environment exists at a given path is "forgotten" as soon as the command completes.
`flox envs` is supposed to list both active and _available/inactive_ environments (that are represented by .flox directories).
To avoid _scanning_ for `.flox` directories, we use the env registry introduced in #1312.

In addition, the `flox envs` supports filtering the output to only active environments as well as formatting its output as JSON.
