### PR TITLE
refactor: remove dependency on `console` in favor of using `crossterm`

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -570,7 +570,6 @@ dependencies = [
  "bpaf",
  "chrono",
  "config",
- "console",
  "crossterm 0.26.1",
  "derive_more",
  "dirs",

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -49,7 +49,6 @@ indent.workspace = true
 semver.workspace = true
 sentry = { workspace = true, features = ["anyhow", "tracing", "debug-logs"] }
 serial_test.workspace = true
-console = "0.15.8"
 
 [dev-dependencies]
 temp-env = "0.3.2"

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -4,7 +4,7 @@ use std::io::stdout;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use console::style;
+use crossterm::style::Stylize;
 use crossterm::tty::IsTty;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::lockfile::LockedManifest;
@@ -233,7 +233,7 @@ impl Display for DisplaySearchResults {
             if self.use_bold {
                 name.replace(
                     &self.search_term,
-                    &format!("{}", style(&self.search_term).bold()),
+                    &format!("{}", self.search_term.clone().bold()),
                 )
             } else {
                 name.to_string()


### PR DESCRIPTION
#1250 added the `console` crate to bolden search terms.

Including `console` for styling is redundant considering that `crossterm::Stylize` supports the same features _and_ is used elsewhere in the code base already.