### PR TITLE
fix: handle project paths that contain spaces

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -475,3 +475,27 @@ env_is_activated() {
   # suffixed by '-zsh'
   [ -d "common-zsh" ]
 }
+
+# ---------------------------------------------------------------------------- #
+
+@test "bash: tolerates paths containing spaces" {
+  "$FLOX_BIN" delete -f
+  bad_dir="contains space/project"
+  mkdir -p "$PWD/$bad_dir"
+  cd "$PWD/$bad_dir"
+  "$FLOX_BIN" init
+  SHELL="bash" run bash -c '"$FLOX_BIN" activate -- true'
+  assert_success
+  refute_output --partial "no such file or directory"
+}
+
+@test "zsh: tolerates paths containing spaces" {
+  "$FLOX_BIN" delete -f
+  bad_dir="contains space/project"
+  mkdir -p "$PWD/$bad_dir"
+  cd "$PWD/$bad_dir"
+  "$FLOX_BIN" init
+  FLOX_SHELL="zsh" run zsh -c '"$FLOX_BIN" activate -- true'
+  assert_success
+  refute_output --partial "no such file or directory"
+}

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -102,7 +102,6 @@ if [ -d "$FLOX_ENV/etc/profile.d" ]; then
   declare -a _prof_scripts;
   _prof_scripts=( $(
     cd "$FLOX_ENV/etc/profile.d";
-    shopt -s nullglob;
     echo *.sh;
   ) );
   for p in "${_prof_scripts[@]}"; do . "$FLOX_ENV/etc/profile.d/$p"; done

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -80,13 +80,9 @@ then
 fi
 
 if [ -d "$FLOX_ENV/etc/profile.d" ]; then
-  declare -a _prof_scripts;
-  _prof_scripts=( $(
-    shopt -s nullglob;
-    echo "$FLOX_ENV/etc/profile.d"/*.sh;
-  ) );
-  for p in "${_prof_scripts[@]}"; do . "$p"; done
-  unset _prof_scripts;
+  while IFS= read -r -d '' profile_script; do
+    . "$profile_script"
+  done < <(find "$FLOX_ENV/etc/profile.d" -name '*.sh' -print0)
 fi
 
 # Disable command hashing to allow for newly installed flox packages to be found
@@ -98,12 +94,9 @@ set +h
 // unlike bash, zsh activation calls this script from the user's shell rcfile
 const char * const ZSH_ACTIVATE_SCRIPT = R"(
 if [ -d "$FLOX_ENV/etc/profile.d" ]; then
-  declare -a _prof_scripts;
-  _prof_scripts=( $(
-    echo "$FLOX_ENV/etc/profile.d"/*.sh;
-  ) );
-  for p in "${_prof_scripts[@]}"; do . "$p"; done
-  unset _prof_scripts;
+  while IFS= read -r -d '' profile_script; do
+    . "$profile_script"
+  done < <(find "$FLOX_ENV/etc/profile.d" -name '*.sh' -print0)
 fi
 
 # Disable command hashing to allow for newly installed flox packages to be found

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -80,9 +80,14 @@ then
 fi
 
 if [ -d "$FLOX_ENV/etc/profile.d" ]; then
-  while IFS= read -r -d '' profile_script; do
-    . "$profile_script"
-  done < <(find "$FLOX_ENV/etc/profile.d" -name '*.sh' -print0)
+  declare -a _prof_scripts;
+  _prof_scripts=( $(
+    cd "$FLOX_ENV/etc/profile.d";
+    shopt -s nullglob;
+    echo *.sh;
+  ) );
+  for p in "${_prof_scripts[@]}"; do . "$FLOX_ENV/etc/profile.d/$p"; done
+  unset _prof_scripts;
 fi
 
 # Disable command hashing to allow for newly installed flox packages to be found

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -99,9 +99,14 @@ set +h
 // unlike bash, zsh activation calls this script from the user's shell rcfile
 const char * const ZSH_ACTIVATE_SCRIPT = R"(
 if [ -d "$FLOX_ENV/etc/profile.d" ]; then
-  while IFS= read -r -d '' profile_script; do
-    . "$profile_script"
-  done < <(find "$FLOX_ENV/etc/profile.d" -name '*.sh' -print0)
+  declare -a _prof_scripts;
+  _prof_scripts=( $(
+    cd "$FLOX_ENV/etc/profile.d";
+    shopt -s nullglob;
+    echo *.sh;
+  ) );
+  for p in "${_prof_scripts[@]}"; do . "$FLOX_ENV/etc/profile.d/$p"; done
+  unset _prof_scripts;
 fi
 
 # Disable command hashing to allow for newly installed flox packages to be found


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This PR fixes a bug that causes activation failures when the path to a project contains spaces.

**Root cause**
Our activation script sources the scripts stored in `$FLOX_ENV/etc/profile.d`, and previously it did so like this:
```bash
declare -a _prof_scripts;
_prof_scripts=( $(
  echo "$FLOX_ENV/etc/profile.d"/*.sh;
) );
for p in "${_prof_scripts[@]}"; do . "$p"; done
unset _prof_scripts;
```
This creates an array, and then populates it with the output of a globbed `echo` command. The output of this echo command is a space-delimited string of paths. An array in both Bash and Zsh is constructed from a string containing space-delimited fields. This presents a problem when the paths themselves contain spaces, as those internal spaces appear the same as delimiters.

Thus, the path `foo bar` appears as two separate paths when printed by this command.

**Solution**
The solution for both shells is below:
```bash
while IFS= read -r -d '' profile_script; do
  . "$profile_script"
done < <(find "$FLOX_ENV/etc/profile.d" -name '*.sh' -print0)
```
Let's break down how this works:
- The `find` command uses process substitution to redirect its output to `stdin`, and prints file paths that are separated by the null character `\0`.
- `read` reads from `stdin` and stores the value in `profile_script`.
- The `-r` option turns on "raw mode", which doesn't interpret the `\` character as an escape.
- The `-d ''` option sets the delimiter to the null character, so `read` will stop reading when it hits the null character we set as the delimiter in the `find` command.
- The `while` loop will continue reading from `stdin` until `read` no longer finds any input.
- The `IFS=` statement sets the "internal field separator" to an empty string so that no characters are inadvertently used as internal delimiters within each null-character-delimited path.
- Now `profile_script` will contain the internal spaces in the path because no other characters are used as delimiters.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Fixes a bug that prevents users from completely activating their environments if the project path contains spaces.

<!-- Many thanks! -->
