### PR TITLE
fix: enable nix-command experimental-feature for test

### DIFF
--- a/pkgdb/tests/setup_suite.bash
+++ b/pkgdb/tests/setup_suite.bash
@@ -70,7 +70,7 @@ reals_setup() {
 # Lookup system pair recognized by `nix' for this system.
 nix_system_setup() {
   if [[ -z "${NIX_SYSTEM:-}" ]]; then
-    NIX_SYSTEM="$(nix eval --impure --expr builtins.currentSystem --raw)"
+    NIX_SYSTEM="$(nix --experimental-features nix-command eval --impure --expr builtins.currentSystem --raw)"
   fi
   export NIX_SYSTEM
 }


### PR DESCRIPTION
## Proposed Changes

Without this patch tests fail as follows on systems where the 'nix-command' experimental feature has not been configured as a system-wide default:
```
✗ setup_suite []
TESTS_DIR: /Users/brantley/src/flox/pkgdb/tests
PKGDB_BIN: /Users/brantley/src/flox/pkgdb/bin/pkgdb
   (from function `nix_system_setup' in file tests/setup_suite.bash, line 73,
    from function `env_setup' in file tests/setup_suite.bash, line 127,
    from function `common_suite_setup' in file tests/setup_suite.bash, line 140,
    from function `setup_suite' in test file tests/setup_suite.bash, line 144)
     `setup_suite() { common_suite_setup; }' failed
   error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override
   bats warning: Executed 1 instead of expected 168 tests

168 tests, 1 failure, 167 not run in 1 seconds
```

This patch adds the necessary `--experimental-features` flag for the [1] failing `nix` invocation.

## Release Notes

N/A