### PR TITLE
fix: error when using `pull --force` on non-existent environment

### DIFF
--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -188,34 +188,32 @@ impl Pull {
         force: bool,
         message: &str,
     ) -> Result<()> {
-        if dot_flox_path.exists() {
-            if force {
-                match open_path(flox, &dot_flox_path) {
-                    Ok(concrete_env) => match concrete_env {
-                        ConcreteEnvironment::Path(env) => {
-                            env.delete(flox)
-                                .context("Failed to delete existing environment")?;
-                        },
-                        ConcreteEnvironment::Managed(env) => {
-                            env.delete(flox)
-                                .context("Failed to delete existing environment")?;
-                        },
-                        ConcreteEnvironment::Remote(_) => {},
+	if force && dot_flox_path.is_dir() {
+            match open_path(flox, &dot_flox_path) {
+		Ok(concrete_env) => match concrete_env {
+                    ConcreteEnvironment::Path(env) => {
+			env.delete(flox)
+                            .context("Failed to delete existing environment")?;
                     },
-                    Err(_) => {
-                        fs::remove_dir_all(&dot_flox_path).context(format!(
-                            "Failed to remove existing .flox directory at {:?}",
-                            dot_flox_path
-                        ))?;
+                    ConcreteEnvironment::Managed(env) => {
+			env.delete(flox)
+                            .context("Failed to delete existing environment")?;
                     },
-                }
-            } else {
-                bail!(
-                    "An environment already exists at {:?}. Use --force to overwrite.",
-                    dot_flox_path
-                );
+                    ConcreteEnvironment::Remote(_) => {},
+		},
+		Err(_) => {
+                    fs::remove_dir_all(&dot_flox_path).context(format!(
+			"Failed to remove existing .flox directory at {:?}",
+			dot_flox_path
+                    ))?;
+		},
             }
-        }
+	} else if dot_flox_path.exists() {
+            bail!(
+                "An environment already exists at {:?}. Use --force to overwrite.",
+                dot_flox_path
+            );
+	}
 
         // region: write pointer
         let pointer = ManagedPointer::new(


### PR DESCRIPTION
This change allows `flox pull --force` to work correctly even when no previous environment exists, providing a more intuitive behavior.

Previously, when running `flox pull --force` in a directory without a previous environment (.flox directory), an error was thrown indicating that the .flox directory could not be removed. This was because the code checked for the existence of the directory before attempting to remove it.

This commit fixes the issue by only attempting to remove the .flox directory if it exists and is a directory. If the directory doesn't exist, the code now proceeds with creating a new environment as expected.
