### PR TITLE
refactor: reimplement `InitHook` trait to avoid invalid states caused by `should_run`

### DIFF
--- a/cli/flox/src/commands/init/go.rs
+++ b/cli/flox/src/commands/init/go.rs
@@ -48,7 +48,7 @@ pub(super) struct Go {
 
 impl Go {
     /// Creates and returns the Go hook with the detected module system.
-    pub fn new(path: &Path, flox: &Flox) -> Result<Self> {
+    pub fn new(flox: &Flox, path: &Path) -> Result<Self> {
         let module_system = Self::detect_module_system(flox, path)?;
 
         Ok(Self { module_system })
@@ -75,13 +75,15 @@ impl InitHook for Go {
     ///
     /// [Self::prompt_user] and [Self::get_init_customization]
     /// are expected to be called only if this method returns `true`!
+    /*
     fn should_run(&mut self, _path: &Path) -> Result<bool> {
         Ok(self.module_system.is_some())
     }
+    */
 
     /// Returns `true` if the user accepts the prompt. In that case,
     /// the hook customizes the manifest with the default Go environment.
-    fn prompt_user(&mut self, _path: &Path, _flox: &Flox) -> Result<bool> {
+    fn prompt_user(&mut self, _flox: &Flox, _path: &Path) -> Result<bool> {
         let module_system = &mut self
             .module_system
             .as_ref()
@@ -305,7 +307,7 @@ impl GoVersion {
         };
 
         let provided_go_version =
-            try_find_compatible_version("go", Some(&required_go_version), None::<Vec<&str>>, flox)?;
+            try_find_compatible_version(flox, "go", Some(&required_go_version), None::<Vec<&str>>)?;
 
         if let Some(found_go_version) = provided_go_version {
             let found_go_version = TryInto::<ProvidedPackage>::try_into(found_go_version)?;
@@ -351,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_should_run_returns_true_on_valid_module() {
-        let mut go = Go {
+        let mut _go = Go {
             module_system: Some(GoModuleSystemKind::Module(GoModSystem {
                 version: ProvidedVersion::Compatible {
                     requested: None,
@@ -359,12 +361,13 @@ mod tests {
                 },
             })),
         };
-        assert!(go.should_run(Path::new("")).unwrap());
+        // assert!(go.should_run(Path::new("")).unwrap());
+        todo!();
     }
 
     #[test]
     fn test_should_run_returns_true_on_valid_workspace() {
-        let mut go = Go {
+        let mut _go = Go {
             module_system: Some(GoModuleSystemKind::Workspace(GoWorkSystem {
                 version: ProvidedVersion::Compatible {
                     requested: None,
@@ -372,15 +375,17 @@ mod tests {
                 },
             })),
         };
-        assert!(go.should_run(Path::new("")).unwrap());
+        // assert!(go.should_run(Path::new("")).unwrap());
+        todo!();
     }
 
     #[test]
     fn test_should_run_returns_false_on_none_system() {
-        let mut go = Go {
+        let mut _go = Go {
             module_system: None,
         };
-        assert!(!go.should_run(Path::new("")).unwrap());
+        // assert!(!go.should_run(Path::new("")).unwrap());
+        todo!();
     }
 
     #[test]

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -223,7 +223,6 @@ impl Init {
 
 // TODO: clean up how we pass around path and flox
 trait InitHook {
-    // (flox: &Flox, path: &Path)
     fn prompt_user(&mut self, flox: &Flox, path: &Path) -> Result<bool>;
 
     fn get_init_customization(&self) -> InitCustomization;

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -164,29 +164,29 @@ impl Init {
     fn run_language_hooks(&self, flox: &Flox, path: &Path) -> Result<InitCustomization> {
         let mut hooks: Vec<Box<dyn InitHook>> = vec![];
 
-        let node = Node::new(flox, path)?;
-        hooks.push(Box::new(node));
-
-        let python = Python::new(flox, path);
-        hooks.push(Box::new(python));
-
-        let go = Go::new(flox, path)?;
-        hooks.push(Box::new(go));
-
-        let mut _customizations = vec![];
-
-        for mut _hook in hooks {
-            // Run hooks if we can't prompt
-            /*
-            if hook.should_run(path)?
-                && (self.auto_setup || (Dialog::can_prompt() && hook.prompt_user(path, flox)?))
-            {
-                customizations.push(hook.get_init_customization())
-            }
-            */
+        /*
+        if let Some(node) = Node::new(flox, path)? {
+            hooks.push(Box::new(node));
         }
 
-        Ok(Self::combine_customizations(_customizations))
+        if let Some(node) = Python::new(flox, path) {
+            hooks.push(Box::new(python));
+        }
+        */
+        if let Some(go) = Go::new(flox, path)? {
+            hooks.push(Box::new(go));
+        }
+
+        let mut customizations = vec![];
+
+        for mut hook in hooks {
+            // Run hooks if we can't prompt
+            if self.auto_setup || (Dialog::can_prompt() && hook.prompt_user(flox, path)?) {
+                customizations.push(hook.get_init_customization())
+            }
+        }
+
+        Ok(Self::combine_customizations(customizations))
     }
 
     /// Deduplicate packages and concatenate profiles into a single string

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -164,15 +164,14 @@ impl Init {
     fn run_language_hooks(&self, flox: &Flox, path: &Path) -> Result<InitCustomization> {
         let mut hooks: Vec<Box<dyn InitHook>> = vec![];
 
-        /*
         if let Some(node) = Node::new(flox, path)? {
             hooks.push(Box::new(node));
         }
 
-        if let Some(node) = Python::new(flox, path) {
+        if let Some(python) = Python::new(flox, path) {
             hooks.push(Box::new(python));
         }
-        */
+
         if let Some(go) = Go::new(flox, path)? {
             hooks.push(Box::new(go));
         }

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -8,7 +8,6 @@ use flox_rust_sdk::models::environment::{global_manifest_lockfile_path, global_m
 use flox_rust_sdk::models::manifest::PackageToInstall;
 use flox_rust_sdk::models::search::{do_search, PathOrJson, Query, SearchParams, SearchResult};
 use indoc::{formatdoc, indoc};
-use log::debug;
 use semver::VersionReq;
 
 use super::{format_customization, InitHook, AUTO_SETUP_HINT};
@@ -132,7 +131,7 @@ impl Node {
     /// - Returns [NodeAction::Nothing] if
     ///   - There's no package.json or .nvmrc
     ///   - We can't satisfy constraints in package.json
-    pub fn new(path: &Path, flox: &Flox) -> Result<Self> {
+    pub fn new(flox: &Flox, path: &Path) -> Result<Self> {
         // Check for a viable yarn
         // TODO: we should check for npm version as well,
         // but since npm comes bundled with nodejs, we'll probably cover the most
@@ -147,7 +146,7 @@ impl Node {
             None => None,
             Some(ref versions) => {
                 if yarn_lock_exists {
-                    Self::try_find_compatible_yarn(versions, flox)?
+                    Self::try_find_compatible_yarn(flox, versions)?
                 } else {
                     None
                 }
@@ -176,7 +175,7 @@ impl Node {
             Some(PackageJSONVersions {
                 node: Some(ref node_version),
                 ..
-            }) => match Self::try_find_compatible_version("nodejs", node_version, None, flox)? {
+            }) => match Self::try_find_compatible_version(flox, "nodejs", node_version, None)? {
                 None => Some(PackageJSONVersion::Unavailable),
                 Some(result) => Some(PackageJSONVersion::Found(Box::new(result))),
             },
@@ -191,7 +190,7 @@ impl Node {
             // so don't check .nvmrc if we know we'll use the version in
             // package.json or we know we can't provide it
             Some(PackageJSONVersion::Found(_)) | Some(PackageJSONVersion::Unavailable) => None,
-            _ => Self::get_nvmrc_version(path, flox)?,
+            _ => Self::get_nvmrc_version(flox, path)?,
         };
 
         let action = match yarn_install {
@@ -262,20 +261,20 @@ impl Node {
     /// Try to find node, npm, and yarn versions that satisfy constraints in
     /// package.json
     fn try_find_compatible_yarn(
-        versions: &PackageJSONVersions,
         flox: &Flox,
+        versions: &PackageJSONVersions,
     ) -> Result<Option<YarnInstall>> {
         let PackageJSONVersions { yarn, node, .. } = versions;
 
         let found_node = match node {
             Some(node_version) => {
-                match Self::get_default_node_if_compatible(Some(node_version.clone()), flox)? {
+                match Self::get_default_node_if_compatible(flox, Some(node_version.clone()))? {
                     // If the corresponding node isn't compatible, don't install yarn
                     None => return Ok(None),
                     Some(found_node) => found_node,
                 }
             },
-            None => Self::get_default_node_if_compatible(None, flox)?
+            None => Self::get_default_node_if_compatible(flox, None)?
                 .ok_or(anyhow!("Flox couldn't find nodejs in nixpkgs"))?,
         };
 
@@ -283,9 +282,9 @@ impl Node {
         // in nixpkgs
         let found_yarn = match yarn {
             Some(yarn_version) => {
-                Self::try_find_compatible_version("yarn", yarn_version, None, flox)?
+                Self::try_find_compatible_version(flox, "yarn", yarn_version, None)?
             },
-            _ => Some(Self::get_default_package("yarn", flox)?),
+            _ => Some(Self::get_default_package(flox, "yarn")?),
         };
 
         Ok(found_yarn.map(|found_yarn| YarnInstall {
@@ -299,7 +298,7 @@ impl Node {
     ///
     /// This will perform a search to determine if a requested version is
     /// available.
-    fn get_nvmrc_version(path: &Path, flox: &Flox) -> Result<Option<NVMRCVersion>> {
+    fn get_nvmrc_version(flox: &Flox, path: &Path) -> Result<Option<NVMRCVersion>> {
         let nvmrc = path.join(".nvmrc");
         if !nvmrc.exists() {
             return Ok(None);
@@ -310,7 +309,7 @@ impl Node {
             RequestedNVMRCVersion::None => None,
             RequestedNVMRCVersion::Unsure => Some(NVMRCVersion::Unsure),
             RequestedNVMRCVersion::Found(version) => {
-                match Self::try_find_compatible_version("nodejs", &version, None, flox)? {
+                match Self::try_find_compatible_version(flox, "nodejs", &version, None)? {
                     None => Some(NVMRCVersion::Unavailable),
                     Some(result) => Some(NVMRCVersion::Found(Box::new(result))),
                 }
@@ -358,10 +357,10 @@ impl Node {
 
     /// Searches for a given pname and version, optionally restricting rel_path
     fn try_find_compatible_version(
+        flox: &Flox,
         pname: &str,
         version: &str,
         rel_path: Option<Vec<String>>,
-        flox: &Flox,
     ) -> Result<Option<SearchResult>> {
         let query = Query {
             pname: Some(pname.to_string()),
@@ -389,8 +388,8 @@ impl Node {
     /// Get nixpkgs#nodejs,
     /// optionally verifying that it satisfies a version constraint.
     fn get_default_node_if_compatible(
-        version: Option<String>,
         flox: &Flox,
+        version: Option<String>,
     ) -> Result<Option<SearchResult>> {
         let query = Query {
             rel_path: Some(vec!["nodejs".to_string()]),
@@ -415,7 +414,7 @@ impl Node {
     }
 
     /// Get a package as if installed with `flox install {package}`
-    fn get_default_package(package: &str, flox: &Flox) -> Result<SearchResult> {
+    fn get_default_package(flox: &Flox, package: &str) -> Result<SearchResult> {
         let query = Query::new(package, Features::parse()?.search_strategy, Some(1), false)?;
         let params = SearchParams {
             manifest: None,
@@ -505,19 +504,19 @@ impl Node {
                 (message, result.version.clone())
             },
             (_, Some(NVMRCVersion::Unsure)) => {
-                let result = Self::get_default_package("nodejs", flox)?;
+                let result = Self::get_default_package(flox, "nodejs")?;
                 let message = format!("Flox detected an .nvmrc with a version specifier not understood by Flox, but Flox can provide {}",
                        result.version.as_ref().map(|version|format!("version {version}")).unwrap_or("another version".to_string()));
                 (message, result.version)
             },
             (_, Some(NVMRCVersion::Unavailable)) => {
-                let result = Self::get_default_package("nodejs", flox)?;
+                let result = Self::get_default_package(flox, "nodejs")?;
                 let message = format!("Flox detected an .nvmrc with a version of nodejs not provided by Flox, but Flox can provide {}",
                 result.version.as_ref().map(|version|format!("version {version}")).unwrap_or("another version".to_string()));
                 (message, result.version.clone())
             },
             (Some(PackageJSONVersion::Unspecified), None) => {
-                let result = Self::get_default_package("nodejs", flox)?;
+                let result = Self::get_default_package(flox, "nodejs")?;
                 mentions_package_json = true;
                 ("Flox detected a package.json".to_string(), result.version)
             },
@@ -552,7 +551,7 @@ impl Node {
     }
 
     /// Prompt whether to install nodejs (but not npm or yarn)
-    fn prompt_with_node(&self, node_install: &NodeInstall, flox: &Flox) -> Result<bool> {
+    fn prompt_with_node(&self, flox: &Flox, node_install: &NodeInstall) -> Result<bool> {
         let (nodejs_detected, nodejs_version, mentions_package_json) =
             self.nodejs_message_and_version(flox)?;
         let mut detected = format!("{nodejs_detected}\n");
@@ -602,16 +601,16 @@ impl Node {
     /// Prompt whether to install npm or yarn when either is viable
     fn prompt_for_package_manager(
         &mut self,
+        flox: &Flox,
         yarn_install: YarnInstall,
         node_install: NodeInstall,
-        flox: &Flox,
     ) -> Result<bool> {
         let yarn_version = Self::format_version_or_empty(yarn_install.yarn.version.as_ref());
         let yarn_node_version = Self::format_version_or_empty(yarn_install.node.version.as_ref());
         let node_version = Self::format_version_or_empty(
             match &node_install.node {
                 Some(found_node) => found_node.clone(),
-                None => Self::get_default_package("nodejs", flox)?,
+                None => Self::get_default_package(flox, "nodejs")?,
             }
             .version
             .as_ref(),
@@ -675,6 +674,7 @@ impl Node {
 }
 
 impl InitHook for Node {
+    /*
     fn should_run(&mut self, _path: &Path) -> Result<bool> {
         match self.action {
             NodeAction::InstallYarn(_) => {
@@ -695,14 +695,15 @@ impl InitHook for Node {
             },
         }
     }
+    */
 
-    fn prompt_user(&mut self, _path: &Path, flox: &Flox) -> Result<bool> {
+    fn prompt_user(&mut self, flox: &Flox, _path: &Path) -> Result<bool> {
         match &self.action {
             NodeAction::InstallYarn(yarn_install) => self.prompt_with_yarn(yarn_install),
             NodeAction::InstallYarnOrNode(yarn_install, node_install) => {
-                self.prompt_for_package_manager(*yarn_install.clone(), *node_install.clone(), flox)
+                self.prompt_for_package_manager(flox, *yarn_install.clone(), *node_install.clone())
             },
-            NodeAction::InstallNode(node_install) => self.prompt_with_node(node_install, flox),
+            NodeAction::InstallNode(node_install) => self.prompt_with_node(flox, node_install),
             NodeAction::Nothing => unreachable!(),
         }
     }
@@ -919,13 +920,10 @@ mod tests {
     #[serial]
     fn test_try_find_compatible_yarn_no_constraints() {
         let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
-        let yarn_install = Node::try_find_compatible_yarn(
-            &PackageJSONVersions {
-                yarn: None,
-                node: None,
-            },
-            &flox,
-        )
+        let yarn_install = Node::try_find_compatible_yarn(&flox, &PackageJSONVersions {
+            yarn: None,
+            node: None,
+        })
         .unwrap()
         .unwrap();
 
@@ -938,13 +936,10 @@ mod tests {
     #[serial]
     fn test_try_find_compatible_yarn_node_available() {
         let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
-        let yarn_install = Node::try_find_compatible_yarn(
-            &PackageJSONVersions {
-                yarn: None,
-                node: Some("18".to_string()),
-            },
-            &flox,
-        )
+        let yarn_install = Node::try_find_compatible_yarn(&flox, &PackageJSONVersions {
+            yarn: None,
+            node: Some("18".to_string()),
+        })
         .unwrap()
         .unwrap();
 
@@ -959,13 +954,10 @@ mod tests {
     #[serial]
     fn test_try_find_compatible_yarn_node_unavailable() {
         let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
-        let yarn_install = Node::try_find_compatible_yarn(
-            &PackageJSONVersions {
-                yarn: None,
-                node: Some("20".to_string()),
-            },
-            &flox,
-        )
+        let yarn_install = Node::try_find_compatible_yarn(&flox, &PackageJSONVersions {
+            yarn: None,
+            node: Some("20".to_string()),
+        })
         .unwrap();
 
         assert_eq!(yarn_install, None);
@@ -976,13 +968,10 @@ mod tests {
     #[serial]
     fn test_try_find_compatible_yarn_yarn_available() {
         let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
-        let yarn_install = Node::try_find_compatible_yarn(
-            &PackageJSONVersions {
-                yarn: Some("1".to_string()),
-                node: None,
-            },
-            &flox,
-        )
+        let yarn_install = Node::try_find_compatible_yarn(&flox, &PackageJSONVersions {
+            yarn: Some("1".to_string()),
+            node: None,
+        })
         .unwrap()
         .unwrap();
 
@@ -997,13 +986,10 @@ mod tests {
     #[serial]
     fn test_try_find_compatible_yarn_yarn_unavailable() {
         let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
-        let yarn_install = Node::try_find_compatible_yarn(
-            &PackageJSONVersions {
-                yarn: Some("2".to_string()),
-                node: None,
-            },
-            &flox,
-        )
+        let yarn_install = Node::try_find_compatible_yarn(&flox, &PackageJSONVersions {
+            yarn: Some("2".to_string()),
+            node: None,
+        })
         .unwrap();
 
         assert_eq!(yarn_install, None);
@@ -1015,13 +1001,10 @@ mod tests {
     #[serial]
     fn test_try_find_compatible_yarn_both_available() {
         let (flox, _temp_dir_handle) = flox_instance_with_global_lock();
-        let yarn_install = Node::try_find_compatible_yarn(
-            &PackageJSONVersions {
-                yarn: Some("1".to_string()),
-                node: Some("18".to_string()),
-            },
-            &flox,
-        )
+        let yarn_install = Node::try_find_compatible_yarn(&flox, &PackageJSONVersions {
+            yarn: Some("1".to_string()),
+            node: Some("18".to_string()),
+        })
         .unwrap()
         .unwrap();
 

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -226,15 +226,11 @@ impl Node {
             },
         };
 
-        if let Some(action) = action {
-            return Ok(Some(Self {
-                package_json_node_version,
-                nvmrc_version,
-                action,
-            }));
-        }
-
-        Ok(None)
+        Ok(action.map(|action| Self {
+            package_json_node_version,
+            nvmrc_version,
+            action,
+        }))
     }
 
     /// Look for nodejs, npm, and yarn versions in a (possibly non-existent)

--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -28,10 +28,9 @@ pub(super) struct Python {
 }
 
 impl Python {
-    /// Returns `true` if any valid provider was found
-    ///
-    /// [Self::prompt_user] and [Self::get_init_customization]
-    /// are expected to be called only if this method returns `true`!
+    /// Creates and returns the [Python] hook with any detected
+    /// [Provider] instances.
+    /// If no providers are detected, returns [None].
     pub fn new(flox: &Flox, path: &Path) -> Option<Self> {
         let providers = vec![
             PoetryPyProject::detect(flox, path).into(),


### PR DESCRIPTION
## Proposed Changes

This PR changes the `InitHook` trait by dropping `should_run` check and implementing a type-checker friendly design by allowing trait objects to be instantiated with `None` if they are not intended to run.  

The position of the `flox` argument in many methods is also corrected to be the first argument.
This change could be considered outside of the scope of this PR, and would drop it / move it to a different PR if requested.

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Fixes #1266.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
