### PR TITLE
fix: multiple FLOX_ENV_LIB_DIRS support for ld-floxlib.so

### DIFF
--- a/pkgdb/src/ld-floxlib.c
+++ b/pkgdb/src/ld-floxlib.c
@@ -56,9 +56,22 @@ __asm__( ".symver strtok,strtok@GLIBC_2.2.5" );
 // Punt .. just go with default symbol bindings and hope for the best.
 #endif
 
-static int  audit_ld_floxlib = -1;
-static int  debug_ld_floxlib = -1;
-static char name_buf[PATH_MAX];
+// Define the maximum number of directories that can be specified in
+// the FLOX_ENV_LIB_DIRS environment variable. This is a somewhat
+// arbitrary limit, but it should be more than enough for most cases.
+#define FLOX_ENV_LIB_DIRS_MAXENTRIES 256
+
+// Define the maximum length of a directory path in the FLOX_ENV_LIB_DIRS
+// environment variable. This is also somewhat arbitrary, but it should
+// be more than enough for most cases.
+#define FLOX_ENV_LIB_DIRS_MAXLEN PATH_MAX
+
+static int    audit_ld_floxlib = -1;
+static int    debug_ld_floxlib = -1;
+static char   name_buf[PATH_MAX];
+static int    flox_env_lib_dirs_count = -1;
+static char   flox_env_lib_dirs_buf[FLOX_ENV_LIB_DIRS_MAXLEN];
+static char * flox_env_lib_dirs[FLOX_ENV_LIB_DIRS_MAXENTRIES];
 
 unsigned int
 la_version( unsigned int version )
@@ -97,53 +110,109 @@ la_objsearch( const char * name, uintptr_t * cookie, unsigned int flag )
       if ( fd != -1 ) { close( fd ); }
       else
         {
-          char * basename          = strrchr( name, '/' );
-          char * flox_env_lib_dirs = getenv( "FLOX_ENV_LIB_DIRS" );
-
+          char * basename = strrchr( name, '/' );
           if ( basename != NULL ) { basename++; }
           else { basename = (char *) name; }
 
-          if ( flox_env_lib_dirs != NULL )
+          if ( flox_env_lib_dirs_count == -1 )
             {
-              // Iterate over the colon-separated list of paths in
-              // FLOX_ENV_LIB_DIRS looking for the requested library.
-              // If found, return the full path to the library and
-              // otherwise return the original name.
-              char * flox_env_library_dir = NULL;
-              flox_env_library_dir        = strtok( flox_env_lib_dirs, ":" );
-              while ( flox_env_library_dir != NULL )
+              // Copy the contents of the FLOX_ENV_LIB_DIRS variable into
+              // flox_env_lib_dirs_buf and tokenize the buffer by replacing
+              // colons with NULLs as we count the entries, saving pointers
+              // to each of the paths in the flox_env_lib_dirs[] array.
+              flox_env_lib_dirs_count = 0;
+              const char * flox_env_lib_dirs_env
+                = getenv( "FLOX_ENV_LIB_DIRS" );
+              if ( flox_env_lib_dirs_env != NULL )
                 {
-                  (void) snprintf( name_buf,
-                                   sizeof( name_buf ),
-                                   "%s/%s",
-                                   flox_env_library_dir,
-                                   basename );
-                  if ( debug_ld_floxlib )
+                  if ( sizeof( flox_env_lib_dirs_env )
+                       > FLOX_ENV_LIB_DIRS_MAXLEN )
                     {
                       fprintf( stderr,
-                               "DEBUG: la_objsearch() checking: %s\n",
-                               name_buf );
+                               "ERROR: la_objsearch() "
+                               "FLOX_ENV_LIB_DIRS is too long, "
+                               "truncating to %d characters\n",
+                               FLOX_ENV_LIB_DIRS_MAXLEN );
                     }
-                  fd = open( name_buf, O_RDONLY );
-                  if ( fd != -1 )
+
+                  strncpy( flox_env_lib_dirs_buf,
+                           flox_env_lib_dirs_env,
+                           sizeof( flox_env_lib_dirs_buf ) );
+
+
+                  // Iterate over the colon-separated list of paths in the
+                  // flox_env_lib_dirs buffer, tokenizing as we go and
+                  // maintaining a count of the number of entries found.
+                  char * flox_env_library_dir = NULL;
+                  char * saveptr              = NULL;  // For strtok_r() context
+
+                  flox_env_library_dir
+                    = strtok_r( flox_env_lib_dirs_buf, ":", &saveptr );
+                  while ( flox_env_library_dir != NULL )
                     {
-                      close( fd );
-                      if ( audit_ld_floxlib < 0 )
-                        {
-                          audit_ld_floxlib
-                            = ( getenv( "LD_FLOXLIB_AUDIT" ) != NULL );
-                        }
-                      if ( audit_ld_floxlib || debug_ld_floxlib )
+                      if ( flox_env_lib_dirs_count
+                           >= FLOX_ENV_LIB_DIRS_MAXENTRIES )
                         {
                           fprintf( stderr,
-                                   "AUDIT: la_objsearch() resolved %s -> %s\n",
-                                   name,
-                                   name_buf );
+                                   "ERROR: la_objsearch() "
+                                   "FLOX_ENV_LIB_DIRS has too many entries, "
+                                   "truncating to the first %d\n",
+                                   FLOX_ENV_LIB_DIRS_MAXENTRIES );
+                          break;
                         }
-                      return name_buf;
+                      if ( debug_ld_floxlib )
+                        {
+                          fprintf( stderr,
+                                   "DEBUG: la_objsearch() "
+                                   "flox_env_lib_dirs[%d] = %s\n",
+                                   flox_env_lib_dirs_count,
+                                   flox_env_library_dir );
+                        }
+                      flox_env_lib_dirs[flox_env_lib_dirs_count]
+                        = flox_env_library_dir;
+                      flox_env_library_dir = strtok_r( NULL, ":", &saveptr );
+                      flox_env_lib_dirs_count++;
                     }
-                  flox_env_library_dir = strtok( NULL, ":" );
                 }
+            }
+
+          // Iterate over the list of paths in flox_env_lib_dirs looking for
+          // the requested library. If found, return the full path to the
+          // library and otherwise return the original name.
+          static int i;
+          for ( i = 0; i < flox_env_lib_dirs_count; i++ )
+            {
+              {
+                (void) snprintf( name_buf,
+                                 sizeof( name_buf ),
+                                 "%s/%s",
+                                 flox_env_lib_dirs[i],
+                                 basename );
+                if ( debug_ld_floxlib )
+                  {
+                    fprintf( stderr,
+                             "DEBUG: la_objsearch() checking: %s\n",
+                             name_buf );
+                  }
+                fd = open( name_buf, O_RDONLY );
+                if ( fd != -1 )
+                  {
+                    close( fd );
+                    if ( audit_ld_floxlib < 0 )
+                      {
+                        audit_ld_floxlib
+                          = ( getenv( "LD_FLOXLIB_AUDIT" ) != NULL );
+                      }
+                    if ( audit_ld_floxlib || debug_ld_floxlib )
+                      {
+                        fprintf( stderr,
+                                 "AUDIT: la_objsearch() resolved %s -> %s\n",
+                                 name,
+                                 name_buf );
+                      }
+                    return name_buf;
+                  }
+              }
             }
         }
     }

--- a/pkgdb/src/ld-floxlib.c
+++ b/pkgdb/src/ld-floxlib.c
@@ -126,7 +126,7 @@ la_objsearch( const char * name, uintptr_t * cookie, unsigned int flag )
               if ( flox_env_lib_dirs_env != NULL )
                 {
                   if ( sizeof( flox_env_lib_dirs_env )
-                       > FLOX_ENV_LIB_DIRS_MAXLEN )
+                       >= FLOX_ENV_LIB_DIRS_MAXLEN )
                     {
                       fprintf( stderr,
                                "ERROR: la_objsearch() "


### PR DESCRIPTION
## Proposed Changes

The code to parse multiple FLOX_ENV lib directories was mutating the FLOX_ENV_LIB_DIRS environment and consequently breaking its ability to locate libraries in all but the first library on the list.

This patch updates the code to first make a copy of the environment variable, then split that new string into tokens as it populates a new array of pointers. To make the code as efficient as possible the string and array data are maintained in static fixed-length buffers, so we correspondingly make best efforts not to overflow those buffers in the process.

## Release Notes

- fixed bug affecting ability to load dynamic shared libraries from layered environment activations