### PR TITLE
feat: add resolve shim and catalog feature flag

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -893,6 +893,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,10 +1068,12 @@ name = "flox-rust-sdk"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "blake3",
  "catalog-api-v1",
  "chrono",
  "derive_more",
+ "enum_dispatch",
  "fslock",
  "indent",
  "indoc",
@@ -1069,6 +1083,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "proptest-derive",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1057,6 +1057,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "blake3",
+ "catalog-api-v1",
  "chrono",
  "derive_more",
  "fslock",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1068,7 +1068,6 @@ name = "flox-rust-sdk"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "blake3",
  "catalog-api-v1",
  "chrono",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1068,6 +1068,7 @@ name = "flox-rust-sdk"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "blake3",
  "catalog-api-v1",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1"
+async-trait = "0.1.80"
 blake3 = "1.5.0"
 bpaf = { version = "0.9.8", features = ["derive", "autocomplete"] }
 catalog-api-v1 = { path = "catalog-api-v1" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,7 +6,6 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1"
-async-trait = "0.1.80"
 blake3 = "1.5.0"
 bpaf = { version = "0.9.8", features = ["derive", "autocomplete"] }
 catalog-api-v1 = { path = "catalog-api-v1" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1"
+async-trait = "0.1.80"
 blake3 = "1.5.0"
 bpaf = { version = "0.9.8", features = ["derive", "autocomplete"] }
 catalog-api-v1 = { path = "catalog-api-v1" }
@@ -14,6 +15,7 @@ config = "0.14.0"
 crossterm = "0.27"
 derive_more = "0.99.17"
 dirs = "5.0.0"
+enum_dispatch = "0.3.13"
 flox-rust-sdk = { path = "flox-rust-sdk" }
 fslock = "0.2.1"
 futures = "0.3"

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait.workspace = true
 blake3.workspace = true
 catalog-api-v1.workspace = true
 chrono.workspace = true

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -6,36 +6,39 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-log.workspace = true
+async-trait.workspace = true
+blake3.workspace = true
+catalog-api-v1.workspace = true
+chrono.workspace = true
 derive_more.workspace = true
-url.workspace = true
-serde_with.workspace = true
-thiserror.workspace = true
-tempfile.workspace = true
+enum_dispatch.workspace = true
+fslock.workspace = true
+indent.workspace = true
+indoc.workspace = true
+jsonwebtoken.workspace = true
+log.workspace = true
 once_cell.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+serde.workspace = true
+shell-escape.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml_edit.workspace = true
+toml.workspace = true
+tracing.workspace = true
+url.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
-indoc.workspace = true
-chrono.workspace = true
-blake3.workspace = true
-toml_edit.workspace = true
-tracing.workspace = true
-toml.workspace = true
-jsonwebtoken.workspace = true
-indent.workspace = true
-shell-escape.workspace = true
-fslock.workspace = true
-catalog-api-v1.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
 pretty_assertions.workspace = true
-serial_test.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
+serial_test.workspace = true
 
 [features]
 extra-tests = ["impure-unit-tests"]

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -28,6 +28,7 @@ jsonwebtoken.workspace = true
 indent.workspace = true
 shell-escape.workspace = true
 fslock.workspace = true
+catalog-api-v1.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait.workspace = true
 blake3.workspace = true
 catalog-api-v1.workspace = true
 chrono.workspace = true

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use url::Url;
 
 pub use crate::models::environment_ref::{self, *};
+use crate::providers::catalog;
 
 pub static FLOX_VERSION: Lazy<String> =
     Lazy::new(|| std::env::var("FLOX_VERSION").unwrap_or(env!("FLOX_VERSION").to_string()));
@@ -51,6 +52,8 @@ pub struct Flox {
     /// It's usually populated from the config during [Flox] initialization.
     /// Checking for [None] can be used to check if the use is logged in.
     pub floxhub_token: Option<FloxhubToken>,
+
+    pub catalog_client: Option<catalog::Client>,
 }
 
 impl Flox {}
@@ -302,6 +305,7 @@ pub mod test_helpers {
             )
             .unwrap(),
             floxhub_token: None,
+            catalog_client: Some(catalog::Client::new(true)),
         };
 
         init_global_manifest(&global_manifest_path(&flox)).unwrap();

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -202,6 +202,7 @@ pub mod test_helpers {
 
     use tempfile::{tempdir_in, TempDir};
 
+    use self::catalog::MockClient;
     use super::*;
     use crate::models::environment::{
         global_manifest_lockfile_path,
@@ -305,7 +306,7 @@ pub mod test_helpers {
             )
             .unwrap(),
             floxhub_token: None,
-            catalog_client: Some(catalog::Client::new(true)),
+            catalog_client: Some(MockClient.into()),
         };
 
         init_global_manifest(&global_manifest_path(&flox)).unwrap();

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -30,12 +30,6 @@ impl CatalogClient {
             client: APIClient::new(DEFAULT_CATALOG_URL),
         }
     }
-
-    pub fn new_with_reqwest_client(client: reqwest::Client) -> Self {
-        Self {
-            client: APIClient::new_with_client(DEFAULT_CATALOG_URL, client),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -71,11 +65,6 @@ impl ClientTrait for CatalogClient {
                 .collect::<Result<Vec<_>, _>>()?,
         };
 
-        let response = self
-            .client
-            .resolve_api_v1_catalog_resolve_post(&package_groups)
-            .await
-            .map_err(CatalogClientError::Resolution)?;
         let response = std::thread::scope(|s| {
             s.spawn(|| {
                 let rt = tokio::runtime::Runtime::new().unwrap();
@@ -88,6 +77,7 @@ impl ClientTrait for CatalogClient {
         })
         .unwrap()
         .map_err(CatalogClientError::Resolution)?;
+
         let resolved_package_groups = response.into_inner();
 
         resolved_package_groups

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use catalog_api_v1::types::{self as api_types, error as api_error};
 use catalog_api_v1::{Client as APIClient, Error as APIError};
 use enum_dispatch::enum_dispatch;
@@ -41,20 +40,18 @@ impl Default for CatalogClient {
     }
 }
 
-#[async_trait]
 #[enum_dispatch]
 pub trait ClientTrait {
     /// Resolve a list of [PackageGroup]s into a list of
     /// [ResolvedPackageGroup]s.
-    async fn resolve(
+    fn resolve(
         &self,
         package_groups: Vec<PackageGroup>,
     ) -> Result<Vec<ResolvedPackageGroup>, CatalogClientError>;
 }
 
-#[async_trait]
 impl ClientTrait for CatalogClient {
-    async fn resolve(
+    fn resolve(
         &self,
         package_groups: Vec<PackageGroup>,
     ) -> Result<Vec<ResolvedPackageGroup>, CatalogClientError> {
@@ -88,9 +85,8 @@ impl ClientTrait for CatalogClient {
     }
 }
 
-#[async_trait]
 impl ClientTrait for MockClient {
-    async fn resolve(
+    fn resolve(
         &self,
         _package_groups: Vec<PackageGroup>,
     ) -> Result<Vec<ResolvedPackageGroup>, CatalogClientError> {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use catalog_api_v1::types::{self as api_types, error as api_error};
 use catalog_api_v1::{Client as APIClient, Error as APIError};
 use enum_dispatch::enum_dispatch;
@@ -40,18 +41,20 @@ impl Default for CatalogClient {
     }
 }
 
+#[async_trait]
 #[enum_dispatch]
 pub trait ClientTrait {
     /// Resolve a list of [PackageGroup]s into a list of
     /// [ResolvedPackageGroup]s.
-    fn resolve(
+    async fn resolve(
         &self,
         package_groups: Vec<PackageGroup>,
     ) -> Result<Vec<ResolvedPackageGroup>, CatalogClientError>;
 }
 
+#[async_trait]
 impl ClientTrait for CatalogClient {
-    fn resolve(
+    async fn resolve(
         &self,
         package_groups: Vec<PackageGroup>,
     ) -> Result<Vec<ResolvedPackageGroup>, CatalogClientError> {
@@ -85,8 +88,9 @@ impl ClientTrait for CatalogClient {
     }
 }
 
+#[async_trait]
 impl ClientTrait for MockClient {
-    fn resolve(
+    async fn resolve(
         &self,
         _package_groups: Vec<PackageGroup>,
     ) -> Result<Vec<ResolvedPackageGroup>, CatalogClientError> {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -65,18 +65,11 @@ impl ClientTrait for CatalogClient {
                 .collect::<Result<Vec<_>, _>>()?,
         };
 
-        let response = std::thread::scope(|s| {
-            s.spawn(|| {
-                let rt = tokio::runtime::Runtime::new().unwrap();
-                rt.block_on(
-                    self.client
-                        .resolve_api_v1_catalog_resolve_post(&package_groups),
-                )
-            })
-            .join()
-        })
-        .unwrap()
-        .map_err(CatalogClientError::Resolution)?;
+        let response = self
+            .client
+            .resolve_api_v1_catalog_resolve_post(&package_groups)
+            .await
+            .map_err(CatalogClientError::Resolution)?;
 
         let resolved_package_groups = response.into_inner();
 

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1,0 +1,174 @@
+use std::env;
+
+use catalog_api_v1::types::{self as api_types, error as api_error};
+use catalog_api_v1::{Client as APIClient, Error as APIError};
+use once_cell::sync::Lazy;
+use thiserror::Error;
+
+use crate::data::System;
+
+const DEFAULT_CATALOG_URL: &str = "https://flox-catalog.flox.dev";
+/// Whether to use an actual catalog client or the mock client.
+///
+/// Don't use a feature flag since this shouldn't be exposed to users.
+static USE_CATALOG_MOCK: Lazy<bool> = Lazy::new(|| env::var("_FLOX_USE_CATALOG_MOCK").is_ok());
+
+/// Either a client for the actual catalog service,
+/// or a mock client for testing.
+#[derive(Debug)]
+pub enum Client {
+    Catalog(CatalogClient),
+    Mock(MockClient),
+}
+
+impl Client {
+    pub fn new(mock: bool) -> Self {
+        if mock {
+            Client::Mock(MockClient)
+        } else {
+            Client::Catalog(CatalogClient::default())
+        }
+    }
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new(*USE_CATALOG_MOCK)
+    }
+}
+
+/// A client for the catalog service.
+///
+/// This is a wrapper around the auto-generated APIClient.
+#[derive(Debug)]
+pub struct CatalogClient {
+    client: APIClient,
+}
+impl CatalogClient {
+    pub fn new() -> Self {
+        Self {
+            client: APIClient::new(DEFAULT_CATALOG_URL),
+        }
+    }
+}
+impl Default for CatalogClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub struct MockClient;
+
+impl Client {
+    /// Resolve a list of [PackageGroup]s into a list of
+    /// [ResolvedPackageGroup]s.
+    pub async fn resolve(
+        &self,
+        package_groups: Vec<PackageGroup>,
+    ) -> Result<Vec<ResolvedPackageGroup>, CatalogClientError> {
+        match self {
+            Client::Catalog(client) => {
+                let package_groups = api_types::PackageGroups {
+                    items: package_groups
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<Vec<_>, _>>()?,
+                };
+
+                let response = client
+                    .client
+                    .resolve_api_v1_catalog_resolve_post(&package_groups)
+                    .await
+                    .map_err(CatalogClientError::Resolution)?;
+
+                let resolved_package_groups = response.into_inner();
+
+                resolved_package_groups
+                    .items
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, _>>()
+            },
+            Client::Mock(_) => unimplemented!(),
+        }
+    }
+}
+
+/// Just an alias until the auto-generated PackageDescriptor diverges from what
+/// we need.
+pub type PackageDescriptor = api_types::PackageDescriptor;
+
+pub struct PackageGroup {
+    pub descriptors: Vec<PackageDescriptor>,
+    pub name: String,
+    pub system: System,
+}
+
+#[derive(Debug, Error)]
+pub enum CatalogClientError {
+    #[error("system not supported by catalog")]
+    UnsupportedSystem(#[source] api_error::ConversionError),
+    #[error("resolution failed")]
+    Resolution(#[source] APIError<api_types::ErrorResponse>),
+}
+
+impl TryFrom<PackageGroup> for api_types::PackageGroup {
+    type Error = CatalogClientError;
+
+    fn try_from(package_group: PackageGroup) -> Result<Self, CatalogClientError> {
+        Ok(Self {
+            descriptors: package_group.descriptors,
+            name: package_group.name,
+            system: package_group
+                .system
+                .try_into()
+                .map_err(CatalogClientError::UnsupportedSystem)?,
+            stability: None,
+        })
+    }
+}
+
+pub struct ResolvedPackageGroup {
+    pub name: String,
+    pub pages: Vec<CatalogPage>,
+    pub system: System,
+}
+
+impl TryFrom<api_types::ResolvedPackageGroupInput> for ResolvedPackageGroup {
+    type Error = CatalogClientError;
+
+    fn try_from(
+        resolved_package_group: api_types::ResolvedPackageGroupInput,
+    ) -> Result<Self, CatalogClientError> {
+        Ok(Self {
+            name: resolved_package_group.name,
+            pages: resolved_package_group
+                .pages
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>(),
+            system: resolved_package_group.system.to_string(),
+        })
+    }
+}
+
+pub struct CatalogPage {
+    pub packages: Vec<PackageResolutionInfo>,
+    pub page: i64,
+    pub url: String,
+}
+
+impl From<api_types::CatalogPage> for CatalogPage {
+    fn from(catalog_page: api_types::CatalogPage) -> Self {
+        Self {
+            packages: catalog_page.packages,
+            page: catalog_page.page,
+            url: catalog_page.url,
+        }
+    }
+}
+
+/// TODO: fix types for outputs and outputs_to_install,
+/// at which point this will probably no longer be an alias.
+type PackageResolutionInfo = api_types::PackageResolutionInfo;

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -1,1 +1,2 @@
+pub mod catalog;
 pub mod git;

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -6,48 +6,48 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flox-rust-sdk.workspace = true
 anyhow.workspace = true
-tokio.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-serde_yaml.workspace = true
-log.workspace = true
 bpaf.workspace = true
-config.workspace = true
-dirs.workspace = true
-tempfile.workspace = true
-futures.workspace = true
-once_cell.workspace = true
-itertools.workspace = true
-toml_edit.workspace = true
-supports-color.workspace = true
-inquire.workspace = true
-indicatif.workspace = true
-crossterm.workspace = true
-shell-escape.workspace = true
-xdg.workspace = true
-nix.workspace = true
-indoc.workspace = true
-derive_more.workspace = true
-time.workspace = true
-uuid.workspace = true
-reqwest.workspace = true
-sysinfo.workspace = true
-sys-info.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
-tracing-log.workspace = true
-fslock.workspace = true
-indexmap.workspace = true
-url.workspace = true
 chrono.workspace = true
-oauth2.workspace = true
-textwrap = { workspace = true, features = ["terminal_size"] }
+config.workspace = true
+crossterm.workspace = true
+derive_more.workspace = true
+dirs.workspace = true
+flox-rust-sdk.workspace = true
+fslock.workspace = true
+futures.workspace = true
 indent.workspace = true
+indexmap.workspace = true
+indicatif.workspace = true
+indoc.workspace = true
+inquire.workspace = true
+itertools.workspace = true
+log.workspace = true
+nix.workspace = true
+oauth2.workspace = true
+once_cell.workspace = true
+reqwest.workspace = true
 semver.workspace = true
 sentry = { workspace = true, features = ["anyhow", "tracing", "debug-logs"] }
+serde_json.workspace = true
+serde_yaml.workspace = true
+serde.workspace = true
+shell-escape.workspace = true
+supports-color.workspace = true
+sys-info.workspace = true
+sysinfo.workspace = true
+tempfile.workspace = true
+textwrap = { workspace = true, features = ["terminal_size"] }
+thiserror.workspace = true
+time.workspace = true
+tokio.workspace = true
+toml_edit.workspace = true
+tracing-log.workspace = true
+tracing-subscriber.workspace = true
+tracing.workspace = true
+url.workspace = true
+uuid.workspace = true
+xdg.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -49,7 +49,6 @@ use flox_rust_sdk::models::environment::{
     FLOX_ACTIVE_ENVIRONMENTS_VAR,
 };
 use flox_rust_sdk::models::environment_ref;
-use flox_rust_sdk::providers::catalog::{self, CatalogClient, MockClient};
 use futures::Future;
 use indoc::{formatdoc, indoc};
 use log::{debug, info};
@@ -63,7 +62,6 @@ use toml_edit::Key;
 use url::Url;
 
 use crate::commands::general::update_config;
-use crate::config::features::{self, Features};
 use crate::config::{Config, EnvironmentTrust, FLOX_CONFIG_FILE};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::display_chain;

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -49,7 +49,7 @@ use flox_rust_sdk::models::environment::{
     FLOX_ACTIVE_ENVIRONMENTS_VAR,
 };
 use flox_rust_sdk::models::environment_ref;
-use flox_rust_sdk::providers::catalog;
+use flox_rust_sdk::providers::catalog::{self, CatalogClient, MockClient};
 use futures::Future;
 use indoc::{formatdoc, indoc};
 use log::{debug, info};
@@ -63,12 +63,13 @@ use toml_edit::Key;
 use url::Url;
 
 use crate::commands::general::update_config;
-use crate::config::features::Features;
+use crate::config::features::{self, Features};
 use crate::config::{Config, EnvironmentTrust, FLOX_CONFIG_FILE};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::display_chain;
 use crate::utils::init::{
     init_access_tokens,
+    init_catalog_client,
     init_telemetry_uuid,
     init_uuid,
     telemetry_opt_out_needs_migration,
@@ -315,8 +316,7 @@ impl FloxArgs {
             Ok(token) => token,
         };
 
-        let features = Features::parse()?;
-        let catalog_client = features.use_catalog.then(catalog::Client::default);
+        let catalog_client = init_catalog_client(&config);
 
         let flox = Flox {
             cache_dir: config.flox.cache_dir.clone(),

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -49,6 +49,7 @@ use flox_rust_sdk::models::environment::{
     FLOX_ACTIVE_ENVIRONMENTS_VAR,
 };
 use flox_rust_sdk::models::environment_ref;
+use flox_rust_sdk::providers::catalog;
 use futures::Future;
 use indoc::{formatdoc, indoc};
 use log::{debug, info};
@@ -62,6 +63,7 @@ use toml_edit::Key;
 use url::Url;
 
 use crate::commands::general::update_config;
+use crate::config::features::Features;
 use crate::config::{Config, EnvironmentTrust, FLOX_CONFIG_FILE};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::display_chain;
@@ -313,6 +315,9 @@ impl FloxArgs {
             Ok(token) => token,
         };
 
+        let features = Features::parse()?;
+        let catalog_client = features.use_catalog.then(catalog::Client::default);
+
         let flox = Flox {
             cache_dir: config.flox.cache_dir.clone(),
             data_dir: config.flox.data_dir.clone(),
@@ -324,6 +329,7 @@ impl FloxArgs {
             uuid: init_uuid(&config.flox.data_dir).await?,
             floxhub_token,
             floxhub,
+            catalog_client,
         };
 
         // in debug mode keep the tempdir to reproduce nix commands

--- a/cli/flox/src/config/features.rs
+++ b/cli/flox/src/config/features.rs
@@ -9,6 +9,7 @@ pub struct Features {
     /// Which matching logic to use when searching for packages
     #[serde(default)]
     pub search_strategy: SearchStrategy,
+    pub use_catalog: bool,
 }
 
 impl Features {

--- a/cli/flox/src/config/features.rs
+++ b/cli/flox/src/config/features.rs
@@ -9,6 +9,7 @@ pub struct Features {
     /// Which matching logic to use when searching for packages
     #[serde(default)]
     pub search_strategy: SearchStrategy,
+    #[serde(default)]
     pub use_catalog: bool,
 }
 

--- a/cli/flox/src/utils/completion.rs
+++ b/cli/flox/src/utils/completion.rs
@@ -1,11 +1,9 @@
 use anyhow::{bail, Result};
 use flox_rust_sdk::flox::{Flox, Floxhub, DEFAULT_FLOXHUB_URL};
-use flox_rust_sdk::providers::catalog;
 use log::debug;
 use tempfile::TempDir;
 
-use super::init::init_access_tokens;
-use crate::config::features::Features;
+use super::init::{init_access_tokens, init_catalog_client};
 use crate::config::Config;
 
 pub(crate) trait FloxCompletionExt
@@ -51,8 +49,7 @@ impl FloxCompletionExt for Flox {
             .expect("User must have a home directory")
             .join(".netrc");
 
-        let features = Features::parse()?;
-        let catalog_client = features.use_catalog.then(catalog::Client::default);
+        let catalog_client = init_catalog_client(&config);
 
         Ok(Flox {
             cache_dir: config.flox.cache_dir,

--- a/cli/flox/src/utils/completion.rs
+++ b/cli/flox/src/utils/completion.rs
@@ -1,9 +1,11 @@
 use anyhow::{bail, Result};
 use flox_rust_sdk::flox::{Flox, Floxhub, DEFAULT_FLOXHUB_URL};
+use flox_rust_sdk::providers::catalog;
 use log::debug;
 use tempfile::TempDir;
 
 use super::init::init_access_tokens;
+use crate::config::features::Features;
 use crate::config::Config;
 
 pub(crate) trait FloxCompletionExt
@@ -49,6 +51,9 @@ impl FloxCompletionExt for Flox {
             .expect("User must have a home directory")
             .join(".netrc");
 
+        let features = Features::parse()?;
+        let catalog_client = features.use_catalog.then(catalog::Client::default);
+
         Ok(Flox {
             cache_dir: config.flox.cache_dir,
             data_dir: config.flox.data_dir,
@@ -60,6 +65,7 @@ impl FloxCompletionExt for Flox {
             uuid: uuid::Uuid::nil(),
             floxhub_token: None,
             floxhub: Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None)?,
+            catalog_client,
         })
     }
 }

--- a/cli/flox/src/utils/init/catalog_client.rs
+++ b/cli/flox/src/utils/init/catalog_client.rs
@@ -20,8 +20,7 @@ pub fn init_catalog_client(config: &Config) -> Option<Client> {
     if use_mock {
         debug!("Using mock catalog client");
         // TODO: setup the "runtime" mock client, e.g. from a file
-        let mock = MockClient;
-        Some(Client::Mock(mock))
+        Some(MockClient.into())
     } else {
         debug!("Using catalog client");
         Some(Client::Catalog(CatalogClient::default()))

--- a/cli/flox/src/utils/init/catalog_client.rs
+++ b/cli/flox/src/utils/init/catalog_client.rs
@@ -1,0 +1,29 @@
+use flox_rust_sdk::providers::catalog::{CatalogClient, Client, MockClient};
+use tracing::debug;
+
+use crate::config::Config;
+
+/// Initialize the Catalog API client
+///
+/// - Return [None] if the Catalog API is disabled through the feature flag
+/// - Initialize a mock client if the `_FLOX_USE_CATALOG_MOCK` environment variable is set to `true`
+/// - Initialize a real client otherwise
+pub fn init_catalog_client(config: &Config) -> Option<Client> {
+    // Do not initialize a client if the Catalog API is disabled
+    if !config.features.clone().unwrap_or_default().use_catalog {
+        debug!("catalog feature is disabled, skipping client initialization");
+        return None;
+    }
+
+    // if $_FLOX_USE_CATALOG_MOCK is set to 'true', use the mock client
+    let use_mock = std::env::var("_FLOX_USE_CATALOG_MOCK").is_ok_and(|val| val == "true");
+    if use_mock {
+        debug!("Using mock catalog client");
+        // TODO: setup the "runtime" mock client, e.g. from a file
+        let mock = MockClient;
+        Some(Client::Mock(mock))
+    } else {
+        debug!("Using catalog client");
+        Some(Client::Catalog(CatalogClient::default()))
+    }
+}

--- a/cli/flox/src/utils/init/mod.rs
+++ b/cli/flox/src/utils/init/mod.rs
@@ -6,10 +6,12 @@ use indoc::indoc;
 use log::debug;
 use serde::Deserialize;
 
+mod catalog_client;
 mod logger;
 mod metrics;
 mod sentry;
 
+pub use catalog_client::*;
 pub use logger::*;
 pub use metrics::*;
 pub use sentry::*;


### PR DESCRIPTION
- Add a wrapper client around the autogenerated client. This client can be used throughout flox-rust-sdk. It uses redefined types that are very similar to the autogenerated types, but there are some slight differences (currently just system and stability). These redefined types can be used throughout flox-rust-sdk, but they'll give us a single place to manage changes.
- Add a feature flag to use the catalog, and add an optional catalog_client to the Flox struct dependant on the feature flag
- Add an environment variable to control whether the actual catalog client is used or a mock client, which is left unimplemented!()