### PR TITLE
[review] feat: add resolve shim and catalog feature flag

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -893,6 +893,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,10 +1068,12 @@ name = "flox-rust-sdk"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "blake3",
  "catalog-api-v1",
  "chrono",
  "derive_more",
+ "enum_dispatch",
  "fslock",
  "indent",
  "indoc",
@@ -1069,6 +1083,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "proptest-derive",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1"
+async-trait = "0.1.80"
 blake3 = "1.5.0"
 bpaf = { version = "0.9.8", features = ["derive", "autocomplete"] }
 catalog-api-v1 = { path = "catalog-api-v1" }
@@ -14,6 +15,7 @@ config = "0.14.0"
 crossterm = "0.27"
 derive_more = "0.99.17"
 dirs = "5.0.0"
+enum_dispatch = "0.3.13"
 flox-rust-sdk = { path = "flox-rust-sdk" }
 fslock = "0.2.1"
 futures = "0.3"

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -6,36 +6,39 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-log.workspace = true
+async-trait.workspace = true
+blake3.workspace = true
+catalog-api-v1.workspace = true
+chrono.workspace = true
 derive_more.workspace = true
-url.workspace = true
-serde_with.workspace = true
-thiserror.workspace = true
-tempfile.workspace = true
+enum_dispatch.workspace = true
+fslock.workspace = true
+indent.workspace = true
+indoc.workspace = true
+jsonwebtoken.workspace = true
+log.workspace = true
 once_cell.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+serde.workspace = true
+shell-escape.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml_edit.workspace = true
+toml.workspace = true
+tracing.workspace = true
+url.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
-indoc.workspace = true
-chrono.workspace = true
-blake3.workspace = true
-toml_edit.workspace = true
-tracing.workspace = true
-toml.workspace = true
-jsonwebtoken.workspace = true
-indent.workspace = true
-shell-escape.workspace = true
-fslock.workspace = true
-catalog-api-v1.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
 pretty_assertions.workspace = true
-serial_test.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
+serial_test.workspace = true
 
 [features]
 extra-tests = ["impure-unit-tests"]

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -202,6 +202,7 @@ pub mod test_helpers {
 
     use tempfile::{tempdir_in, TempDir};
 
+    use self::catalog::MockClient;
     use super::*;
     use crate::models::environment::{
         global_manifest_lockfile_path,
@@ -305,7 +306,7 @@ pub mod test_helpers {
             )
             .unwrap(),
             floxhub_token: None,
-            catalog_client: Some(catalog::Client::new(true)),
+            catalog_client: Some(MockClient.into()),
         };
 
         init_global_manifest(&global_manifest_path(&flox)).unwrap();

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -6,48 +6,48 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flox-rust-sdk.workspace = true
 anyhow.workspace = true
-tokio.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-serde_yaml.workspace = true
-log.workspace = true
 bpaf.workspace = true
-config.workspace = true
-dirs.workspace = true
-tempfile.workspace = true
-futures.workspace = true
-once_cell.workspace = true
-itertools.workspace = true
-toml_edit.workspace = true
-supports-color.workspace = true
-inquire.workspace = true
-indicatif.workspace = true
-crossterm.workspace = true
-shell-escape.workspace = true
-xdg.workspace = true
-nix.workspace = true
-indoc.workspace = true
-derive_more.workspace = true
-time.workspace = true
-uuid.workspace = true
-reqwest.workspace = true
-sysinfo.workspace = true
-sys-info.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
-tracing-log.workspace = true
-fslock.workspace = true
-indexmap.workspace = true
-url.workspace = true
 chrono.workspace = true
-oauth2.workspace = true
-textwrap = { workspace = true, features = ["terminal_size"] }
+config.workspace = true
+crossterm.workspace = true
+derive_more.workspace = true
+dirs.workspace = true
+flox-rust-sdk.workspace = true
+fslock.workspace = true
+futures.workspace = true
 indent.workspace = true
+indexmap.workspace = true
+indicatif.workspace = true
+indoc.workspace = true
+inquire.workspace = true
+itertools.workspace = true
+log.workspace = true
+nix.workspace = true
+oauth2.workspace = true
+once_cell.workspace = true
+reqwest.workspace = true
 semver.workspace = true
 sentry = { workspace = true, features = ["anyhow", "tracing", "debug-logs"] }
+serde_json.workspace = true
+serde_yaml.workspace = true
+serde.workspace = true
+shell-escape.workspace = true
+supports-color.workspace = true
+sys-info.workspace = true
+sysinfo.workspace = true
+tempfile.workspace = true
+textwrap = { workspace = true, features = ["terminal_size"] }
+thiserror.workspace = true
+time.workspace = true
+tokio.workspace = true
+toml_edit.workspace = true
+tracing-log.workspace = true
+tracing-subscriber.workspace = true
+tracing.workspace = true
+url.workspace = true
+uuid.workspace = true
+xdg.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -49,7 +49,7 @@ use flox_rust_sdk::models::environment::{
     FLOX_ACTIVE_ENVIRONMENTS_VAR,
 };
 use flox_rust_sdk::models::environment_ref;
-use flox_rust_sdk::providers::catalog;
+use flox_rust_sdk::providers::catalog::{self, CatalogClient, MockClient};
 use futures::Future;
 use indoc::{formatdoc, indoc};
 use log::{debug, info};
@@ -63,12 +63,13 @@ use toml_edit::Key;
 use url::Url;
 
 use crate::commands::general::update_config;
-use crate::config::features::Features;
+use crate::config::features::{self, Features};
 use crate::config::{Config, EnvironmentTrust, FLOX_CONFIG_FILE};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::display_chain;
 use crate::utils::init::{
     init_access_tokens,
+    init_catalog_client,
     init_telemetry_uuid,
     init_uuid,
     telemetry_opt_out_needs_migration,
@@ -315,8 +316,7 @@ impl FloxArgs {
             Ok(token) => token,
         };
 
-        let features = Features::parse()?;
-        let catalog_client = features.use_catalog.then(catalog::Client::default);
+        let catalog_client = init_catalog_client(&config);
 
         let flox = Flox {
             cache_dir: config.flox.cache_dir.clone(),

--- a/cli/flox/src/utils/completion.rs
+++ b/cli/flox/src/utils/completion.rs
@@ -1,11 +1,9 @@
 use anyhow::{bail, Result};
 use flox_rust_sdk::flox::{Flox, Floxhub, DEFAULT_FLOXHUB_URL};
-use flox_rust_sdk::providers::catalog;
 use log::debug;
 use tempfile::TempDir;
 
-use super::init::init_access_tokens;
-use crate::config::features::Features;
+use super::init::{init_access_tokens, init_catalog_client};
 use crate::config::Config;
 
 pub(crate) trait FloxCompletionExt
@@ -51,8 +49,7 @@ impl FloxCompletionExt for Flox {
             .expect("User must have a home directory")
             .join(".netrc");
 
-        let features = Features::parse()?;
-        let catalog_client = features.use_catalog.then(catalog::Client::default);
+        let catalog_client = init_catalog_client(&config);
 
         Ok(Flox {
             cache_dir: config.flox.cache_dir,

--- a/cli/flox/src/utils/init/catalog_client.rs
+++ b/cli/flox/src/utils/init/catalog_client.rs
@@ -1,0 +1,29 @@
+use flox_rust_sdk::providers::catalog::{CatalogClient, Client, MockClient};
+use tracing::debug;
+
+use crate::config::Config;
+
+/// Initialize the Catalog API client
+///
+/// - Return [None] if the Catalog API is disabled through the feature flag
+/// - Initialize a mock client if the `_FLOX_USE_CATALOG_MOCK` environment variable is set to `true`
+/// - Initialize a real client otherwise
+pub fn init_catalog_client(config: &Config) -> Option<Client> {
+    // Do not initialize a client if the Catalog API is disabled
+    if !config.features.clone().unwrap_or_default().use_catalog {
+        debug!("catalog feature is disabled, skipping client initialization");
+        return None;
+    }
+
+    // if $_FLOX_USE_CATALOG_MOCK is set to 'true', use the mock client
+    let use_mock = std::env::var("_FLOX_USE_CATALOG_MOCK").is_ok_and(|val| val == "true");
+    if use_mock {
+        debug!("Using mock catalog client");
+        // TODO: setup the "runtime" mock client, e.g. from a file
+        let mock = MockClient;
+        Some(Client::Mock(mock))
+    } else {
+        debug!("Using catalog client");
+        Some(Client::Catalog(CatalogClient::default()))
+    }
+}

--- a/cli/flox/src/utils/init/mod.rs
+++ b/cli/flox/src/utils/init/mod.rs
@@ -6,10 +6,12 @@ use indoc::indoc;
 use log::debug;
 use serde::Deserialize;
 
+mod catalog_client;
 mod logger;
 mod metrics;
 mod sentry;
 
+pub use catalog_client::*;
 pub use logger::*;
 pub use metrics::*;
 pub use sentry::*;


### PR DESCRIPTION
- Dispatching methods to clients manually tends to fragment the individual client implementations
between wrapping enum and client.
This refactor moves the client impls into a dedicated trait,
but exposes a unified interface through the `Client` enum.

- Move initialization logic up into `flox`
I think the constructors/types should be mostly pure when possible.
Selecting the right client based on an impure variable can be done by the caller instead.
Besides, the mock client likely needs additional initialization 
based on e.g. prepared responses,
that might look different in runtime/integration tests than it will in unit tests.