### PR TITLE
fix: fix typo in flox push

### DIFF
--- a/cli/flox/doc/flox-push.md
+++ b/cli/flox/doc/flox-push.md
@@ -50,10 +50,10 @@ FloxHub with local changes to the environment.
 :   Directory to push the environment from (default: current directory).
 
 `-o`, `--owner`
-:   Owner to push push environment to (default: current user).
+:   FloxHub owner to push environment to (default: current user).
 
 `-f`, `--force`
-:   forceably overwrite the remote copy of the environment.
+:   Forceably overwrite the remote copy of the environment.
 
 ```{.include}
 ./include/general-options.md

--- a/cli/flox/doc/flox-push.md
+++ b/cli/flox/doc/flox-push.md
@@ -50,7 +50,7 @@ FloxHub with local changes to the environment.
 :   Directory to push the environment from (default: current directory).
 
 `-o`, `--owner`
-:   FloxHub owner to push environment to (default: current user).
+:   FloxHub owner to push environment to (default: current FloxHub user).
 
 `-f`, `--force`
 :   Forceably overwrite the remote copy of the environment.

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -33,7 +33,7 @@ pub struct Push {
     #[bpaf(long, short, argument("path"))]
     dir: Option<PathBuf>,
 
-    /// FloxHub owner to push environment to (default: current user)
+    /// FloxHub owner to push environment to (default: current FloxHub user)
     #[bpaf(long, short, argument("owner"))]
     owner: Option<EnvironmentOwner>,
 

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -33,7 +33,7 @@ pub struct Push {
     #[bpaf(long, short, argument("path"))]
     dir: Option<PathBuf>,
 
-    /// Owner to push environment to (default: current user)
+    /// FloxHub owner to push environment to (default: current user)
     #[bpaf(long, short, argument("owner"))]
     owner: Option<EnvironmentOwner>,
 

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -33,7 +33,7 @@ pub struct Push {
     #[bpaf(long, short, argument("path"))]
     dir: Option<PathBuf>,
 
-    /// Owner to push push environment to (default: current user)
+    /// Owner to push environment to (default: current user)
     #[bpaf(long, short, argument("owner"))]
     owner: Option<EnvironmentOwner>,
 


### PR DESCRIPTION
## Proposed Changes

fixes a duplicated word in the help for `flox push`

## Release Notes

N/A


<!-- Many thanks! -->
