### PR TITLE
fix(tests): Create new SSH_AUTH_SOCK in std path

### DIFF
--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -195,16 +195,12 @@ ssh_key_setup() {
       -C 'floxuser@example.invalid'
     chmod 600 "$FLOX_TEST_SSH_KEY"
   fi
-  export SSH_AUTH_SOCK="$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
-  if ! [[ -d ${SSH_AUTH_SOCK%/*} ]]; then mkdir -p "${SSH_AUTH_SOCK%/*}"; fi
-  # If our socket isn't open ( it probably ain't ) we open one.
-  if ! [[ -e $SSH_AUTH_SOCK ]]; then
-    # You can't find work in this town without a good agent. Lets get one.
-    eval "$(ssh-agent -s)"
-    ln -sf "$SSH_AUTH_SOCK" "$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
-    export SSH_AUTH_SOCK="$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
-    ssh-add "$FLOX_TEST_SSH_KEY"
-  fi
+  # Don't poison any existing agent and allow `ssh-add` to fail if we can't
+  # start a new one.
+  unset SSH_AUTH_SOCK SSH_AGENT_PID
+  # You can't find work in this town without a good agent. Lets get one.
+  eval "$(ssh-agent -s)"
+  ssh-add "$FLOX_TEST_SSH_KEY"
   unset SSH_ASKPASS
   export __FT_RAN_SSH_KEY_SETUP=:
 }

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -191,16 +191,12 @@ ssh_key_setup() {
       -C 'floxuser@example.invalid'
     chmod 600 "$FLOX_TEST_SSH_KEY"
   fi
-  export SSH_AUTH_SOCK="$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
-  if ! [[ -d "${SSH_AUTH_SOCK%/*}" ]]; then mkdir -p "${SSH_AUTH_SOCK%/*}"; fi
-  # If our socket isn't open ( it probably ain't ) we open one.
-  if ! [[ -e "$SSH_AUTH_SOCK" ]]; then
-    # You can't find work in this town without a good agent. Lets get one.
-    eval "$(ssh-agent -s)"
-    ln -sf "$SSH_AUTH_SOCK" "$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
-    export SSH_AUTH_SOCK="$BATS_SUITE_TMPDIR/ssh/ssh_agent.sock"
-    ssh-add "$FLOX_TEST_SSH_KEY"
-  fi
+  # Don't poison any existing agent and allow `ssh-add` to fail if we can't
+  # start a new one.
+  unset SSH_AUTH_SOCK SSH_AGENT_PID
+  # You can't find work in this town without a good agent. Lets get one.
+  eval "$(ssh-agent -s)"
+  ssh-add "$FLOX_TEST_SSH_KEY"
   unset SSH_ASKPASS
   export __FT_RAN_SSH_KEY_SETUP=:
 }


### PR DESCRIPTION
## Proposed Changes

I was unable to run the integration tests on MacOS because of this error:

    % just integ-tests
    make: Entering directory '/Users/dcarley/projects/flox/flox/pkgdb'
    mkdir -p tests;
    Generating tests/.gitignore
    make: Leaving directory '/Users/dcarley/projects/flox/flox/pkgdb'
    ~/projects/flox/flox/cli ~/projects/flox/flox
    flox-cli-tests: Running test suite with:
      FLOX_BIN:                 /Users/dcarley/projects/flox/flox/cli/target/debug/flox
      PKGDB_BIN:                /Users/dcarley/projects/flox/flox/pkgdb/bin/pkgdb
      NIX_BIN:                  /nix/store/wf28dxas0i3m27r4az6ppcs4z9syi2yv-nix-2.17.1/bin/nix
      LD_FLOXLIB:               /Users/dcarley/projects/flox/flox/pkgdb/lib/ld-floxlib.so
      PROJECT_TESTS_DIR:        /Users/dcarley/projects/flox/flox/cli/tests
      bats                      /nix/store/dhghqmkjk7fqpdbz71clvbh5zxp6p3lf-bats-with-libraries-1.10.0/bin/bats
      bats options              --print-output-on-failure --verbose-run --timing
      bats tests                /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.QlakKE/flox-cli-tests-0rwGJH
     ✗ setup_suite []
    NIX_BIN: /nix/store/wf28dxas0i3m27r4az6ppcs4z9syi2yv-nix-2.17.1/bin/nix
    NIX_STORE: /nix/store
    REAL_GIT_CONFIG_GLOBAL: /Users/dcarley/.gitconfig
    REAL_GIT_CONFIG_SYSTEM: /etc/gitconfig
    REAL_HOME: /Users/dcarley
    REAL_USER: dcarley
    REAL_XDG_CACHE_HOME: /Users/dcarley/.cache
    REAL_XDG_CONFIG_HOME: /Users/dcarley/.config
    REAL_XDG_DATA_HOME: /Users/dcarley/.local/share
    REAL_XDG_STATE_HOME: /Users/dcarley/.local/state
    TESTS_DIR: /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.QlakKE/flox-cli-tests-0rwGJH
       (from function `ssh_key_setup' in file setup_suite.bash, line 206,
        from function `common_suite_setup' in file setup_suite.bash, line 448,
        from function `setup_suite' in test file setup_suite.bash, line 483)
         `setup_suite() { common_suite_setup; }' failed with status 2
       Agent pid 66183
       Error connecting to agent: No such file or directory
       Agent pid 66183 killed
       bats warning: Executed 1 instead of expected 195 tests

    195 tests, 1 failure, 194 not run in 0 seconds

    error: Recipe `integ-tests` failed on line 80 with exit code 1

This appears to be caused by symlinking the agent socket to `BATS_SUITE_TMPDIR` which results in the new `SSH_AUTH_SOCK` value exceeding the allowed character limit for sockets on some platforms:

- https://unix.stackexchange.com/questions/367008/why-is-socket-path-length-limited-to-a-hundred-chars

On my machine the path resulted in 106 characters:

    % echo -n "/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.QlakKE/bats-run-1sBm1y/suite/ssh/ssh_agent.sock" | wc -c
    106

It can be reproduced more explicitly by passing a bind path argument:

    eval "$(ssh-agent -s -a "${BATS_SUITE_TMPDIR}/ssh/ssh_agent.sock")"

Which results in this error:

    (from function `ssh_key_setup' in file setup_suite.bash, line 206,
        from function `common_suite_setup' in file setup_suite.bash, line 448,
        from function `setup_suite' in test file setup_suite.bash, line 483)
         `setup_suite() { common_suite_setup; }' failed with status 2
       unix_listener: path "/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.QlakKE/bats-run-fIkyRS/suite/ssh/ssh_agent.sock" too long for Unix domain socket
       Error connecting to agent: No such file or directory
       bats warning: Executed 1 instead of expected 15 tests

Fix this by not symlinking the agent socket. We don't appear to depend on this in any way because there are no references to the path or environment variable, other than `ssh-add` implicitly using it.

The existing code would re-use the socket if it was already symlinked in place but I can't see how this would happen as it's run once during the suite setup and removed afterwards. This also had the side-effect of not using an existing `SSH_AUTH_SOCK` from the environment which I've carried over by unsetting the variables and always starting a new agent.

This could have alternatively been fixed by removing the `ssh_` prefix from the filename to bring it under the limit but it seems like a very brittle fix because we're so close to the limit.

I've updated both files that this function is defined.

## Release Notes

N/A
