### PR TITLE
fix: use longer hash for environment registry

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -65,7 +65,7 @@ pub const FLOX_PROFILE_PLACEHOLDER: &str = "_FLOX_INIT_PROFILE";
 pub const FLOX_HOOK_PLACEHOLDER: &str = "_FLOX_INIT_HOOK";
 pub const FLOX_INSTALL_PLACEHOLDER: &str = "_FLOX_INIT_INSTALL";
 
-pub const N_HASH_CHARS: usize = 5;
+pub const N_HASH_CHARS: usize = 8;
 
 #[derive(Debug)]
 pub struct UpdateResult {


### PR DESCRIPTION
Currently we would likely have a hash collision if someone had sqrt(2^(4 bits per hex character * 5 hex characters)) = 1024 environments.

Admittedly that's not super likely, but using 8 characters instead is still pretty legible, and it raises 1024 to 65536.