### PR TITLE
refactor: spinners and messaging during `flox pull`

### DIFF
--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -310,7 +310,7 @@ function add_insecure_package() {
 
   run "$FLOX_BIN" pull --remote owner/name --force
   assert_success
-  assert_line --partial "Could not build modified environment, build errors need to be resolved manually."
+  assert_line --partial "Modified the manifest to include your system but could not build."
 
   run "$FLOX_BIN" list
   assert_success


### PR DESCRIPTION
* Add missing spinners when pulling new environments that require the current system to be added to the manifest (https://github.com/flox/flox/issue/1301) Rebuilding of the modified environment was not covered by any spinner.
* Change messages when pulling results in a broken environment. Previous messages always implied that the environment was ready to be activated even when we knew it was broken.
* Refactor pulling existing environments to match the structure of pulling new environments. Mainly moving messaging inwards.

Co-Authored-By: dan.carley@gmail.com