### PR TITLE
feat: allow versions newer than current stable to avoid update notification

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -465,7 +465,7 @@ impl UpdateNotification {
             )));
         }
 
-        if *FLOX_VERSION == new_version {
+        if *FLOX_VERSION >= new_version {
             return Ok(None);
         };
 


### PR DESCRIPTION
## Proposed Changes
Allow newer (eg: dev or qa) versions of flox to not cause a warning to update.

## Release Notes
N/A