### PR TITLE
fix: don't notify of updates for dev builds

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -423,12 +423,18 @@ impl UpdateNotification {
         cache_dir: impl AsRef<Path>,
     ) -> Result<Option<Self>, UpdateNotificationError> {
         let notification_file = cache_dir.as_ref().join(UPDATE_NOTIFICATION_FILE_NAME);
-        Self::check_for_update_inner(
-            notification_file,
-            Self::get_latest_version(),
-            UPDATE_NOTIFICATION_EXPIRY,
-        )
-        .await
+        // FLOX_SENTRY_ENV won't be set for development builds.
+        // Skip printing an update notification.
+        if let Some(ref sentry_env) = *FLOX_SENTRY_ENV {
+            Self::check_for_update_inner(
+                notification_file,
+                Self::get_latest_version(sentry_env),
+                UPDATE_NOTIFICATION_EXPIRY,
+            )
+            .await
+        } else {
+            Ok(None)
+        }
     }
 
     /// If the user hasn't been notified of an update after `expiry` time has
@@ -522,13 +528,12 @@ impl UpdateNotification {
     /// Get latest version from downloads.flox.dev
     ///
     /// Timeout after TRAILING_NETWORK_CALL_TIMEOUT
-    async fn get_latest_version() -> Result<String, UpdateNotificationError> {
+    async fn get_latest_version(sentry_env: &str) -> Result<String, UpdateNotificationError> {
         let client = reqwest::Client::new();
 
         let request = client
             .get(format!(
-                "https://downloads.flox.dev/by-env/{}/LATEST_VERSION",
-                (*FLOX_SENTRY_ENV).as_ref().unwrap_or(&"stable".to_string())
+                "https://downloads.flox.dev/by-env/{sentry_env}/LATEST_VERSION",
             ))
             .timeout(TRAILING_NETWORK_CALL_TIMEOUT);
 


### PR DESCRIPTION
Currently if FLOX_SENTRY_ENV isn't set, we default to checking the stable channel for a version. This is then compared for equality with FLOX_VERSION. For dev builds, this will return false, so an update notification is printed.

Dev builds don't have semantic versions (e.g. 1.0.3-g294e510) so we can't use something other than equality to compare with latest.

Instead, just don't print the notification for dev builds.