### PR TITLE
Draft: test message output from pull

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -760,6 +760,42 @@ pub mod test_helpers {
         systems = ["aarch64-darwin"]
         "#};
 
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    pub const MANIFEST_INCOMPATIBLE_PACKAGE: &str = indoc! {r#"
+        [install]
+        glibc.pkg-path = "glibc"
+
+        [options]
+        systems = ["aarch64-darwin"]
+        "#};
+
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    pub const MANIFEST_INCOMPATIBLE_PACKAGE: &str = indoc! {r#"
+        [install]
+        glibc.pkg-path = "glibc"
+
+        [options]
+        systems = ["x86_64-darwin"]
+        "#};
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    pub const MANIFEST_INCOMPATIBLE_PACKAGE: &str = indoc! {r#"
+        [install]
+        ps.pkg-path = "darwin.ps"
+
+        [options]
+        systems = ["x86_64-linux"]
+        "#};
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    pub const MANIFEST_INCOMPATIBLE_PACKAGE: &str = indoc! {r#"
+        [install]
+        ps.pkg-path = "darwin.ps"
+
+        [options]
+        systems = ["aarch64-linux"]
+        "#};
+
     pub fn new_core_environment(flox: &Flox, contents: &str) -> CoreEnvironment {
         let env_path = tempfile::tempdir_in(&flox.temp_dir).unwrap().into_path();
         fs::write(env_path.join(MANIFEST_FILENAME), contents).unwrap();
@@ -772,10 +808,10 @@ pub mod test_helpers {
 mod tests {
     use std::os::unix::fs::PermissionsExt;
 
-    use indoc::{formatdoc, indoc};
+    use indoc::indoc;
     use serial_test::serial;
     use tempfile::{tempdir_in, TempDir};
-    use tests::test_helpers::MANIFEST_INCOMPATIBLE_SYSTEM;
+    use tests::test_helpers::{MANIFEST_INCOMPATIBLE_PACKAGE, MANIFEST_INCOMPATIBLE_SYSTEM};
 
     use self::test_helpers::new_core_environment;
     use super::*;
@@ -850,47 +886,13 @@ mod tests {
     #[test]
     #[serial]
     fn build_incompatible_package() {
-        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-        let manifest_contents = formatdoc! {r#"
-        [install]
-        glibc.pkg-path = "glibc"
-
-        [options]
-        systems = ["aarch64-darwin"]
-        "#};
-
-        #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-        let manifest_contents = formatdoc! {r#"
-        [install]
-        glibc.pkg-path = "glibc"
-
-        [options]
-        systems = ["x86_64-darwin"]
-        "#};
-
-        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-        let manifest_contents = formatdoc! {r#"
-        [install]
-        ps.pkg-path = "darwin.ps"
-
-        [options]
-        systems = ["x86_64-linux"]
-        "#};
-
-        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-        let manifest_contents = formatdoc! {r#"
-        [install]
-        ps.pkg-path = "darwin.ps"
-
-        [options]
-        systems = ["aarch64-linux"]
-        "#};
-
         let (mut env_view, flox, _temp_dir_handle) = empty_core_environment();
         let mut temp_env = env_view
             .writable(tempdir_in(&flox.temp_dir).unwrap().into_path())
             .unwrap();
-        temp_env.update_manifest(&manifest_contents).unwrap();
+        temp_env
+            .update_manifest(MANIFEST_INCOMPATIBLE_PACKAGE)
+            .unwrap();
         env_view.lock(&flox).unwrap();
         env_view.replace_with(temp_env).unwrap();
 

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -758,4 +758,37 @@ mod tests {
 
         assert!(dot_flox_path.exists());
     }
+
+    /// TODO: Invoke failure from edit_unsafe
+    #[test]
+    fn test_handle_pull_result_7() {
+        let owner = "owner".parse().unwrap();
+        let (flox, _temp_dir_handle) = flox_instance_with_global_lock_and_floxhub(&owner);
+
+        let dot_flox_path = tempdir_in(&flox.temp_dir).unwrap().into_path();
+
+        let result = Pull::handle_pull_result(
+            &flox,
+            incompatible_system_result(),
+            &dot_flox_path,
+            false,
+            mock_managed_environment(&flox, MANIFEST_INCOMPATIBLE_SYSTEM, owner),
+            Some(QueryFunctions {
+                query_add_system: |_| Ok(true),
+                query_ignore_build_errors: || panic!(),
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            message::Action::Warning(formatdoc!(
+                "
+            Pulled owner/test from https://hub.flox.dev/
+
+            Modified the manifest to include your system but could not build.
+            Use 'flox edit' to address issues before activating.
+            "
+            ))
+        );
+    }
 }

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -531,7 +531,10 @@ mod tests {
         mock_managed_environment,
         unusable_mock_managed_environment,
     };
-    use flox_rust_sdk::models::environment::test_helpers::MANIFEST_INCOMPATIBLE_SYSTEM;
+    use flox_rust_sdk::models::environment::test_helpers::{
+        MANIFEST_INCOMPATIBLE_PACKAGE,
+        MANIFEST_INCOMPATIBLE_SYSTEM,
+    };
     use flox_rust_sdk::models::pkgdb::error_codes::PACKAGE_BUILD_FAILURE;
     use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
     use tempfile::tempdir_in;
@@ -772,7 +775,7 @@ mod tests {
             incompatible_system_result(),
             &dot_flox_path,
             false,
-            mock_managed_environment(&flox, MANIFEST_INCOMPATIBLE_SYSTEM, owner),
+            mock_managed_environment(&flox, MANIFEST_INCOMPATIBLE_PACKAGE, owner),
             Some(QueryFunctions {
                 query_add_system: |_| Ok(true),
                 query_ignore_build_errors: || panic!(),

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -9,6 +9,30 @@ fn print_message(v: impl Display) {
     eprintln!("{v}");
 }
 
+#[allow(dead_code)]
+#[derive(Debug, PartialEq)]
+pub enum Action {
+    Plain(String),
+    Error(String),
+    Created(String),
+    Deleted(String),
+    Updated(String),
+    Warning(String),
+}
+
+impl Action {
+    pub fn print(self) {
+        match self {
+            Action::Plain(v) => plain(v),
+            Action::Error(v) => error(v),
+            Action::Created(v) => created(v),
+            Action::Deleted(v) => deleted(v),
+            Action::Updated(v) => updated(v),
+            Action::Warning(v) => warning(v),
+        }
+    }
+}
+
 /// alias for [print_message]
 pub(crate) fn plain(v: impl Display) {
     print_message(v);

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -310,7 +310,7 @@ function add_insecure_package() {
 
   run "$FLOX_BIN" pull --remote owner/name --force
   assert_success
-  assert_line --partial "Could not build modified environment, build errors need to be resolved manually."
+  assert_line --partial "Modified the manifest to include your system but could not build."
 
   run "$FLOX_BIN" list
   assert_success


### PR DESCRIPTION
## Proposed Changes

From https://github.com/flox/flox/pull/1337#pullrequestreview-2009466154

**refactor: wip Test handle_pull_result messages**

I've tried using an enum because we need to know the action and content
of the message. We don't have the emoji formatting though because that's
applied later.

Things I'm unsure about:

- using String when the existing methods use a trait?
- not able to do partial matches on the contents
- there are some intermediate warnings that aren't captured

An alternative could be to construct something like a logger that will
accept a different output buffer for the tests. It's a more invasive
change though.

NB: the existing methods would be removed and all callers updated but this just demonstrates the approach.

**chore: wip Additional test for pull errors**

I haven't figured out how to invoke the right branch of the code from
the tests yet.

## Release Notes

N/A