### PR TITLE
feat: add catalog compatible lockfile representation

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -209,7 +209,7 @@ pub mod test_helpers {
         global_manifest_path,
         init_global_manifest,
     };
-    use crate::models::lockfile::LockedManifest;
+    use crate::models::lockfile::LockedManifestPkgdb;
     use crate::providers::git::{GitCommandProvider, GitProvider};
 
     /// Get an instance of Flox that has both a locked global manifest and a git
@@ -239,11 +239,11 @@ pub mod test_helpers {
         owner: Option<&EnvironmentOwner>,
     ) -> (Flox, TempDir) {
         // Scrape nixpkgs once and then store the resulting global lockfile in memory
-        static GLOBAL_LOCKFILE: Lazy<LockedManifest> = Lazy::new(|| {
+        static GLOBAL_LOCKFILE: Lazy<LockedManifestPkgdb> = Lazy::new(|| {
             let (flox, _temp_dir_handle) = flox_instance();
             let pkgdb_nixpkgs_rev_new = "ab5fd150146dcfe41fda501134e6503932cc8dfd";
             std::env::set_var("_PKGDB_GA_REGISTRY_REF_OR_REV", pkgdb_nixpkgs_rev_new);
-            LockedManifest::update_global_manifest(&flox, vec![])
+            LockedManifestPkgdb::update_global_manifest(&flox, vec![])
                 .unwrap()
                 .new_lockfile
         });

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -19,7 +19,7 @@ use crate::data::CanonicalPath;
 use crate::flox::Flox;
 use crate::models::container_builder::ContainerBuilder;
 use crate::models::environment::{call_pkgdb, global_manifest_path};
-use crate::models::lockfile::{LockedManifest, LockedManifestError};
+use crate::models::lockfile::{LockedManifest, LockedManifestError, LockedManifestPkgdb};
 use crate::models::manifest::{
     insert_packages,
     remove_packages,
@@ -102,13 +102,13 @@ impl<State> CoreEnvironment<State> {
             debug!("no existing lockfile found, using the global lockfile as a base");
             // Use the global lock so we're less likely to kick off a pkgdb
             // scrape in e.g. an install.
-            LockedManifest::ensure_global_lockfile(flox)
+            LockedManifestPkgdb::ensure_global_lockfile(flox)
                 .map_err(CoreEnvironmentError::LockedManifest)?
         };
         let lockfile_path = CanonicalPath::new(existing_lockfile_path)
             .map_err(CoreEnvironmentError::BadLockfilePath)?;
 
-        let lockfile = LockedManifest::lock_manifest(
+        let lockfile = LockedManifestPkgdb::lock_manifest(
             Path::new(&*PKGDB_BIN),
             &manifest_path,
             &lockfile_path,
@@ -128,7 +128,7 @@ impl<State> CoreEnvironment<State> {
         )
         .map_err(CoreEnvironmentError::WriteLockfile)?;
 
-        Ok(lockfile)
+        Ok(LockedManifest::Pkgdb(lockfile))
     }
 
     /// Build the environment, [Self::lock] if necessary.
@@ -376,7 +376,7 @@ impl CoreEnvironment<ReadOnly> {
             new_lockfile,
             old_lockfile,
             ..
-        } = LockedManifest::update_manifest(
+        } = LockedManifestPkgdb::update_manifest(
             flox,
             Some(self.manifest_path()),
             self.lockfile_path(),

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -14,7 +14,7 @@ use self::remote_environment::RemoteEnvironmentError;
 use super::container_builder::ContainerBuilder;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
-use super::lockfile::LockedManifest;
+use super::lockfile::{LockedManifest, LockedManifestPkgdb};
 use super::manifest::PackageToInstall;
 use super::pkgdb::UpgradeResult;
 use crate::data::{CanonicalPath, CanonicalizeError, Version};
@@ -69,8 +69,8 @@ pub const N_HASH_CHARS: usize = 8;
 
 #[derive(Debug)]
 pub struct UpdateResult {
-    pub new_lockfile: LockedManifest,
-    pub old_lockfile: Option<LockedManifest>,
+    pub new_lockfile: LockedManifestPkgdb,
+    pub old_lockfile: Option<LockedManifestPkgdb>,
     pub store_path: Option<PathBuf>,
 }
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 
 use super::container_builder::ContainerBuilder;
 use super::environment::UpdateResult;
-use super::manifest::TypedManifestCatalog;
+use super::manifest::{TypedManifestCatalog, DEFAULT_GROUP_NAME};
 use super::pkgdb::CallPkgDbError;
 use crate::data::{CanonicalPath, CanonicalizeError, System, Version};
 use crate::flox::Flox;
@@ -170,7 +170,10 @@ impl LockedManifestCatalog {
                         .values()
                         .find(|install| {
                             install.pkg_path == package.attr_path
-                                && install.package_group.as_deref().unwrap_or("toplevel")
+                                && install
+                                    .package_group
+                                    .as_deref()
+                                    .unwrap_or(DEFAULT_GROUP_NAME)
                                     == group.name
                         })
                         .and_then(|install| install.priority);

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -122,24 +122,6 @@ impl LockedManifest {
         let contents = fs::read(path).map_err(LockedManifestError::ReadLockfile)?;
         serde_json::from_slice(&contents).map_err(LockedManifestError::ParseLockfile)
     }
-
-    pub fn check_lockfile(
-        path: &CanonicalPath,
-    ) -> Result<Vec<LockfileCheckWarning>, LockedManifestError> {
-        let mut pkgdb_cmd = Command::new(Path::new(&*PKGDB_BIN));
-        pkgdb_cmd
-            .args(["manifest", "check"])
-            .arg("--lockfile")
-            .arg(path.as_os_str());
-
-        debug!("checking lockfile with command: {}", pkgdb_cmd.display());
-
-        let value = call_pkgdb(pkgdb_cmd).map_err(LockedManifestError::CheckLockfile)?;
-        let warnings: Vec<LockfileCheckWarning> =
-            serde_json::from_value(value).map_err(LockedManifestError::ParseCheckWarnings)?;
-
-        Ok(warnings)
-    }
 }
 
 impl ToString for LockedManifest {
@@ -341,6 +323,25 @@ impl LockedManifestPkgdb {
             Self::update_global_manifest(flox, vec![])?;
         }
         Ok(global_lockfile_path)
+    }
+
+    /// Check the integrity of a lockfile using `pkgdb manifest check`
+    pub fn check_lockfile(
+        path: &CanonicalPath,
+    ) -> Result<Vec<LockfileCheckWarning>, LockedManifestError> {
+        let mut pkgdb_cmd = Command::new(Path::new(&*PKGDB_BIN));
+        pkgdb_cmd
+            .args(["manifest", "check"])
+            .arg("--lockfile")
+            .arg(path.as_os_str());
+
+        debug!("checking lockfile with command: {}", pkgdb_cmd.display());
+
+        let value = call_pkgdb(pkgdb_cmd).map_err(LockedManifestError::CheckLockfile)?;
+        let warnings: Vec<LockfileCheckWarning> =
+            serde_json::from_value(value).map_err(LockedManifestError::ParseCheckWarnings)?;
+
+        Ok(warnings)
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -191,8 +191,7 @@ impl LockedManifestCatalog {
                                 && install.package_group.as_deref().unwrap_or("toplevel")
                                     == group.name
                         })
-                        .and_then(|install| install.priority)
-                        .unwrap_or(5);
+                        .and_then(|install| install.priority);
 
                     InstalledPackage {
                         name: package.name,
@@ -435,7 +434,7 @@ impl TypedLockedManifestPkgdb {
                         name: name.clone(),
                         rel_path: locked_package.rel_path(),
                         info: locked_package.info.clone(),
-                        priority: locked_package.priority,
+                        priority: Some(locked_package.priority),
                     });
                 };
             }
@@ -448,7 +447,7 @@ pub struct InstalledPackage {
     pub name: String,
     pub rel_path: String,
     pub info: PackageInfo,
-    pub priority: usize,
+    pub priority: Option<usize>,
 }
 
 #[derive(Debug, Error)]

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -10,6 +10,8 @@ use toml_edit::{self, DocumentMut, Formatted, InlineTable, Item, Table, Value};
 use crate::data::{System, Version};
 use crate::models::pkgdb::PKGDB_BIN;
 
+pub(super) const DEFAULT_GROUP_NAME: &str = "toplevel";
+
 /// A wrapper around a [`toml_edit::DocumentMut`]
 /// that allows modifications of the raw manifest document,
 /// while preserving comments and user formatting.

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -87,7 +87,7 @@ pub(super) struct TypedManifestCatalog {
     /// The packages to install in the form of a map from package name
     /// to package descriptor.
     #[serde(default)]
-    install: ManifestInstall,
+    pub(super) install: ManifestInstall,
     /// Variables that are exported to the shell environment upon activation.
     #[serde(default)]
     vars: ManifestVariables,
@@ -103,19 +103,19 @@ pub(super) struct TypedManifestCatalog {
     options: ManifestOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, derive_more::Deref)]
 pub(super) struct ManifestInstall(BTreeMap<String, ManifestPackageDescriptor>);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub(super) struct ManifestPackageDescriptor {
-    pkg_path: String,
-    package_group: Option<String>,
-    priority: Option<usize>,
-    version: Option<String>,
-    systems: Option<Vec<System>>,
+    pub(super) pkg_path: String,
+    pub(super) package_group: Option<String>,
+    pub(super) priority: Option<usize>,
+    pub(super) version: Option<String>,
+    pub(super) systems: Option<Vec<System>>,
     #[serde(default)]
-    optional: bool,
+    pub(super) optional: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -70,7 +70,7 @@ impl FromStr for RawManifest {
 /// Writing a [`TypedManifest`] will drop comments and formatting.
 /// Hence, this should only be used in cases where these can safely be severed.
 /// Edits to the user facing manifest.toml file should be made using [`RawManifest`] instead.
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(untagged)]
 enum TypedManifest {
     /// v2 manifest, processed by flox and resolved using the catalog service
@@ -81,8 +81,8 @@ enum TypedManifest {
 
 /// Not meant for writing manifest files, only for reading them.
 /// Modifications should be made using the the raw functions in this module.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-struct TypedManifestCatalog {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(super) struct TypedManifestCatalog {
     version: Version<1>,
     /// The packages to install in the form of a map from package name
     /// to package descriptor.
@@ -103,12 +103,12 @@ struct TypedManifestCatalog {
     options: ManifestOptions,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
-struct ManifestInstall(BTreeMap<String, ManifestPackageDescriptor>);
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub(super) struct ManifestInstall(BTreeMap<String, ManifestPackageDescriptor>);
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
-struct ManifestPackageDescriptor {
+pub(super) struct ManifestPackageDescriptor {
     pkg_path: String,
     package_group: Option<String>,
     priority: Option<usize>,
@@ -118,19 +118,19 @@ struct ManifestPackageDescriptor {
     optional: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
-struct ManifestVariables(BTreeMap<String, String>);
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub(super) struct ManifestVariables(BTreeMap<String, String>);
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "kebab-case")]
-struct ManifestHook {
+pub(super) struct ManifestHook {
     /// A script that is run at activation time,
     /// in a flox provided bash shell
     on_activate: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
-struct ManifestProfile {
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub(super) struct ManifestProfile {
     /// When defined, this hook is run by _all_ shells upon activation
     common: Option<String>,
     /// When defined, this hook is run upon activation in a bash shell
@@ -141,9 +141,9 @@ struct ManifestProfile {
     fish: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "kebab-case")]
-struct ManifestOptions {
+pub(super) struct ManifestOptions {
     /// A list of systems that each package is resolved for.
     #[serde(default)]
     systems: Vec<System>,
@@ -155,8 +155,8 @@ struct ManifestOptions {
     semver: SemverOptions,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
-struct Allows {
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub(super) struct Allows {
     /// Whether to allow packages that are marked as `unfree`
     unfree: Option<bool>,
     /// Whether to allow packages that are marked as `broken`
@@ -166,8 +166,8 @@ struct Allows {
     licenses: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
-struct SemverOptions {
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub(super) struct SemverOptions {
     /// Whether to prefer pre-release versions when resolving
     #[serde(default)]
     prefer_pre_releases: Option<bool>,
@@ -206,7 +206,7 @@ pub enum ManifestError {
 ///
 /// The authoritative form of the manifest is in
 /// https://github.com/flox/pkgdb/blob/main/include/flox/resolver/manifest-raw.hh#L263
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct TypedManifestPkgdb {
     pub vars: Option<toml::Table>,
     pub hook: Option<toml::Table>,

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use catalog_api_v1::types::{self as api_types, error as api_error, PackageInfoApiInput};
 use catalog_api_v1::{Client as APIClient, Error as APIError};
 use enum_dispatch::enum_dispatch;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::data::System;
@@ -260,6 +261,7 @@ impl TryFrom<api_types::ResolvedPackageGroupInput> for ResolvedPackageGroup {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CatalogPage {
     pub packages: Vec<PackageResolutionInfo>,
     pub page: i64,

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -15,7 +15,6 @@ use flox_rust_sdk::models::environment::{
     PathPointer,
 };
 use flox_rust_sdk::models::lockfile::{
-    self,
     LockedManifest,
     LockedManifestPkgdb,
     TypedLockedManifestPkgdb,

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -14,7 +14,12 @@ use flox_rust_sdk::models::environment::{
     Environment,
     PathPointer,
 };
-use flox_rust_sdk::models::lockfile::{LockedManifest, TypedLockedManifest};
+use flox_rust_sdk::models::lockfile::{
+    self,
+    LockedManifest,
+    LockedManifestPkgdb,
+    TypedLockedManifestPkgdb,
+};
 use flox_rust_sdk::models::manifest::{insert_packages, PackageToInstall};
 use flox_rust_sdk::models::pkgdb::scrape_input;
 use flox_rust_sdk::models::search::{do_search, PathOrJson, Query, SearchParams, SearchResult};
@@ -89,10 +94,17 @@ impl Init {
                 typed: Spinner::new(|| {
                     // Some language hooks run searches,
                     // so run a scrape first
-                    let global_lockfile = LockedManifest::ensure_global_lockfile(&flox)?;
-                    let lockfile: TypedLockedManifest =
-                        LockedManifest::read_from_file(&CanonicalPath::new(global_lockfile)?)?
-                            .try_into()?;
+                    let global_lockfile = LockedManifestPkgdb::ensure_global_lockfile(&flox)?;
+
+                    let lockfile: LockedManifest =
+                        LockedManifest::read_from_file(&CanonicalPath::new(global_lockfile)?)?;
+
+                    let LockedManifest::Pkgdb(lockfile) = lockfile else {
+                        return Err(anyhow!("Expected a Pkgdb lockfile"));
+                    };
+
+                    let lockfile = TypedLockedManifestPkgdb::try_from(lockfile)?;
+
                     // --ga-registry forces a single input
                     if let Some((_, input)) = lockfile.registry().inputs.iter().next() {
                         scrape_input(&input.from)?;

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -5,7 +5,7 @@ use bpaf::Bpaf;
 use flox_rust_sdk::data::CanonicalPath;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{CoreEnvironmentError, Environment, EnvironmentError};
-use flox_rust_sdk::models::lockfile::{LockedManifest, LockedManifestError};
+use flox_rust_sdk::models::lockfile::{LockedManifestError, LockedManifestPkgdb};
 use flox_rust_sdk::models::manifest::PackageToInstall;
 use flox_rust_sdk::models::pkgdb::error_codes;
 use indoc::formatdoc;
@@ -127,7 +127,11 @@ impl Install {
 
         let lockfile_path = environment.lockfile_path(&flox)?;
         let lockfile_path = CanonicalPath::new(lockfile_path)?;
-        let warnings = LockedManifest::check_lockfile(&lockfile_path)?;
+
+        // Check for warnings in the lockfile using pkgdb
+        //
+        // TODO: handle catalog lockfiles
+        let warnings = LockedManifestPkgdb::check_lockfile(&lockfile_path)?;
 
         warnings
             .iter()

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -152,8 +152,9 @@ impl List {
                   Broken:   {broken}
                 ",
                 description = description.as_deref().unwrap_or("N/A"),
-                license = license.as_deref().unwrap_or("N/A"),
+                priority = priority.map(|p| p.to_string()).as_deref().unwrap_or("N/A"),
                 version = version.as_deref().unwrap_or("N/A"),
+                license = license.as_deref().unwrap_or("N/A"),
             };
 
             println!("{message}");

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -7,7 +7,7 @@ use flox_rust_sdk::models::lockfile::{
     InstalledPackage,
     LockedManifest,
     PackageInfo,
-    TypedLockedManifest,
+    TypedLockedManifestPkgdb,
 };
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -67,7 +67,12 @@ impl List {
 
         let system = &flox.system;
         let lockfile = Self::get_lockfile(&flox, &mut *env)?;
-        let packages = lockfile.list_packages(system);
+        let packages = match lockfile {
+            LockedManifest::Pkgdb(pkgdb_lockfile) => {
+                TypedLockedManifestPkgdb::try_from(pkgdb_lockfile)?.list_packages(system)
+            },
+            LockedManifest::Catalog(catalog_lockfile) => catalog_lockfile.list_packages(system),
+        };
 
         if packages.is_empty() {
             let message = formatdoc! {"
@@ -159,7 +164,7 @@ impl List {
     ///
     /// Does not write the lockfile,
     /// as that would require writing to the environment in case of remote environments)
-    fn get_lockfile(flox: &Flox, env: &mut dyn Environment) -> Result<TypedLockedManifest> {
+    fn get_lockfile(flox: &Flox, env: &mut dyn Environment) -> Result<LockedManifest> {
         let lockfile_path = env
             .lockfile_path(flox)
             .context("Could not get lockfile path")?;
@@ -179,7 +184,6 @@ impl List {
             LockedManifest::read_from_file(&path)?
         };
 
-        let lockfile: TypedLockedManifest = lockfile.try_into()?;
         Ok(lockfile)
     }
 }

--- a/cli/flox/src/commands/update.rs
+++ b/cli/flox/src/commands/update.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::UpdateResult;
-use flox_rust_sdk::models::lockfile::{Input, LockedManifest, TypedLockedManifest};
+use flox_rust_sdk::models::lockfile::{Input, LockedManifestPkgdb, TypedLockedManifestPkgdb};
 use flox_rust_sdk::models::pkgdb::{self, ScrapeError};
 use tracing::instrument;
 
@@ -63,9 +63,9 @@ impl Update {
 
                 (
                     old_lockfile
-                        .map(TypedLockedManifest::try_from)
+                        .map(TypedLockedManifestPkgdb::try_from)
                         .transpose()?,
-                    TypedLockedManifest::try_from(new_lockfile)?,
+                    TypedLockedManifestPkgdb::try_from(new_lockfile)?,
                     false,
                     description,
                 )
@@ -82,16 +82,16 @@ impl Update {
                     message: "Updating global-manifest...",
                     help_message: None,
                     typed: Spinner::new(|| {
-                        LockedManifest::update_global_manifest(&flox, self.inputs)
+                        LockedManifestPkgdb::update_global_manifest(&flox, self.inputs)
                     }),
                 }
                 .spin()?;
 
                 (
                     old_lockfile
-                        .map(TypedLockedManifest::try_from)
+                        .map(TypedLockedManifestPkgdb::try_from)
                         .transpose()?,
-                    TypedLockedManifest::try_from(new_lockfile)?,
+                    TypedLockedManifestPkgdb::try_from(new_lockfile)?,
                     true,
                     None,
                 )

--- a/cli/flox/src/utils/didyoumean.rs
+++ b/cli/flox/src/utils/didyoumean.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use anyhow::Result;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{global_manifest_path, Environment};
-use flox_rust_sdk::models::lockfile::LockedManifest;
+use flox_rust_sdk::models::lockfile::LockedManifestPkgdb;
 use flox_rust_sdk::models::search::{do_search, PathOrJson, SearchResults};
 use log::debug;
 
@@ -64,7 +64,7 @@ impl<'a> DidYouMean<'a, InstallSuggestion> {
         let lockfile = if lockfile_path.exists() {
             PathOrJson::Path(lockfile_path)
         } else {
-            PathOrJson::Path(LockedManifest::ensure_global_lockfile(flox)?)
+            PathOrJson::Path(LockedManifestPkgdb::ensure_global_lockfile(flox)?)
         };
 
         let search_params = construct_search_params(

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -697,6 +697,7 @@ pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
         "},
 
         LockedManifestError::ParseCheckWarnings(_) => display_chain(err),
+        LockedManifestError::UnsupportedLockfileForUpdate => display_chain(err),
     }
 }
 

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use crossterm::style::Stylize;
 use crossterm::tty::IsTty;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::lockfile::LockedManifest;
+use flox_rust_sdk::models::lockfile::LockedManifestPkgdb;
 use flox_rust_sdk::models::search::{PathOrJson, Query, SearchParams, SearchResult, SearchResults};
 use log::debug;
 
@@ -68,7 +68,7 @@ fn manifest_and_lockfile_from_detected_environment(
     // Use the global lock if we don't have a lock yet
     let lockfile_path = match lockfile_path {
         Some(lockfile_path) => lockfile_path,
-        None => LockedManifest::ensure_global_lockfile(flox)?,
+        None => LockedManifestPkgdb::ensure_global_lockfile(flox)?,
     };
     Ok((manifest_path, lockfile_path))
 }


### PR DESCRIPTION
* refactor: split `LockedManifest` into pkgdb and catalog variants
* implement `LockedManifestCatalog`
	+ include catalog compatible manifest
	+ include locked groups, with name, system and selected page 
	  (based on LockedGroups of the catalog service but with only one page)
* feat: impl `LockedManifestCatalog::list_packages`