### PR TITLE
refactor: store full paths to .flox directories

### DIFF
--- a/cli/flox-rust-sdk/src/data/canonical_path.rs
+++ b/cli/flox-rust-sdk/src/data/canonical_path.rs
@@ -52,8 +52,4 @@ impl CanonicalPath {
     pub fn parent(inst: &CanonicalPath) -> Option<Self> {
         inst.0.parent().map(Self::new_unchecked)
     }
-
-    pub fn join(inst: &CanonicalPath, path: impl AsRef<Path>) -> Self {
-        Self::new_unchecked(inst.0.join(path))
-    }
 }

--- a/cli/flox-rust-sdk/src/data/canonical_path.rs
+++ b/cli/flox-rust-sdk/src/data/canonical_path.rs
@@ -33,7 +33,27 @@ impl CanonicalPath {
         Ok(Self(canonicalized))
     }
 
-    pub fn into_path_buf(self) -> PathBuf {
+    /// Create a [`CanonicalPath`] without checking if the path exists
+    /// or is canonical.
+    ///
+    /// This should only be used when the path is known to be canonical already.
+    pub fn new_unchecked(path: impl AsRef<Path>) -> Self {
+        Self(path.as_ref().to_path_buf())
+    }
+
+    /// Destruct the [`CanonicalPath`] and return the inner [`PathBuf`]
+    pub fn into_inner(self) -> PathBuf {
         self.0
+    }
+
+    /// Get the parent directory of the path as a [`CanonicalPath`]
+    ///
+    /// Returns [`None`] if the path has no parent.
+    pub fn parent(inst: &CanonicalPath) -> Option<Self> {
+        inst.0.parent().map(Self::new_unchecked)
+    }
+
+    pub fn join(inst: &CanonicalPath, path: impl AsRef<Path>) -> Self {
+        Self::new_unchecked(inst.0.join(path))
     }
 }

--- a/cli/flox-rust-sdk/src/data/canonical_path.rs
+++ b/cli/flox-rust-sdk/src/data/canonical_path.rs
@@ -33,23 +33,8 @@ impl CanonicalPath {
         Ok(Self(canonicalized))
     }
 
-    /// Create a [`CanonicalPath`] without checking if the path exists
-    /// or is canonical.
-    ///
-    /// This should only be used when the path is known to be canonical already.
-    pub fn new_unchecked(path: impl AsRef<Path>) -> Self {
-        Self(path.as_ref().to_path_buf())
-    }
-
     /// Destruct the [`CanonicalPath`] and return the inner [`PathBuf`]
     pub fn into_inner(self) -> PathBuf {
         self.0
-    }
-
-    /// Get the parent directory of the path as a [`CanonicalPath`]
-    ///
-    /// Returns [`None`] if the path has no parent.
-    pub fn parent(inst: &CanonicalPath) -> Option<Self> {
-        inst.0.parent().map(Self::new_unchecked)
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -324,7 +324,7 @@ impl DotFlox {
     /// This method attempts to find a `.flox` directory in the specified parent path,
     /// and open it as a [DotFlox] directory.
     /// If the directory is not found, an [EnvironmentError::DotFloxNotFound] is returned.
-    pub fn open_default_in(parent_path: impl AsRef<Path>) -> Result<Self, EnvironmentError> {
+    pub fn open_in(parent_path: impl AsRef<Path>) -> Result<Self, EnvironmentError> {
         let dot_flox_path = parent_path.as_ref().join(DOT_FLOX);
         let dot_flox_path = CanonicalPath::new(&dot_flox_path)
             .map_err(|_| EnvironmentError::DotFloxNotFound(dot_flox_path))?;
@@ -543,11 +543,10 @@ pub fn find_dot_flox(initial_dir: &Path) -> Result<Option<DotFlox>, EnvironmentE
     );
     // Look for an immediate child named `.flox`
     if tentative_dot_flox.exists() {
-        let pointer =
-            DotFlox::open_default_in(&path).map_err(|err| EnvironmentError::InvalidDotFlox {
-                path: tentative_dot_flox.clone(),
-                source: Box::new(err),
-            })?;
+        let pointer = DotFlox::open_in(&path).map_err(|err| EnvironmentError::InvalidDotFlox {
+            path: tentative_dot_flox.clone(),
+            source: Box::new(err),
+        })?;
         debug!(".flox found: path={}", tentative_dot_flox.display());
         return Ok(Some(pointer));
     }
@@ -574,12 +573,11 @@ pub fn find_dot_flox(initial_dir: &Path) -> Result<Option<DotFlox>, EnvironmentE
         debug!("looking for .flox: path={}", tentative_dot_flox.display());
 
         if tentative_dot_flox.exists() {
-            let pointer = DotFlox::open_default_in(ancestor).map_err(|err| {
-                EnvironmentError::InvalidDotFlox {
+            let pointer =
+                DotFlox::open_in(ancestor).map_err(|err| EnvironmentError::InvalidDotFlox {
                     path: ancestor.to_path_buf(),
                     source: Box::new(err),
-                }
-            })?;
+                })?;
             debug!(".flox found: path={}", tentative_dot_flox.display());
             return Ok(Some(pointer));
         }

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -329,14 +329,8 @@ impl DotFlox {
         let dot_flox_path = CanonicalPath::new(&dot_flox_path)
             .map_err(|_| EnvironmentError::DotFloxNotFound(dot_flox_path))?;
 
-        Self::open(&dot_flox_path)
-    }
+        let pointer = EnvironmentPointer::open(&dot_flox_path)?;
 
-    /// Open the specified path as a [DotFlox] directory
-    ///
-    /// This method is used to open an existing [DotFlox] directory.
-    pub(crate) fn open(dot_flox_path: &CanonicalPath) -> Result<Self, EnvironmentError> {
-        let pointer = EnvironmentPointer::open(dot_flox_path)?;
         Ok(Self {
             path: dot_flox_path.to_path_buf(),
             pointer,

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -23,7 +23,6 @@ use log::debug;
 
 use super::core_environment::CoreEnvironment;
 use super::{
-    CanonicalizeError,
     DotFlox,
     EditResult,
     Environment,
@@ -369,7 +368,7 @@ impl PathEnvironment {
         let system: &str = system.as_ref();
 
         // Ensure that the .flox directory does not already exist
-        match DotFlox::open_default_in(dot_flox_parent_path.as_ref()) {
+        match DotFlox::open_in(dot_flox_parent_path.as_ref()) {
             // continue if the .flox directory does not exist, as it's being created by this method
             Err(EnvironmentError::DotFloxNotFound(_)) => {},
             // propagate any other error signalling a faulty .flox directory

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -24,6 +24,7 @@ use log::debug;
 use super::core_environment::CoreEnvironment;
 use super::{
     CanonicalizeError,
+    DotFlox,
     EditResult,
     Environment,
     EnvironmentError,
@@ -387,9 +388,14 @@ impl PathEnvironment {
         flox: &Flox,
     ) -> Result<Self, EnvironmentError> {
         let system: &str = system.as_ref();
-        match EnvironmentPointer::open(dot_flox_parent_path.as_ref()) {
+
+        // Ensure that the .flox directory does not already exist
+        match DotFlox::open_default_in(dot_flox_parent_path.as_ref()) {
+            // continue if the .flox directory does not exist, as it's being created by this method
             Err(EnvironmentError::DotFloxNotFound(_)) => {},
+            // propagate any other error signalling a faulty .flox directory
             Err(e) => Err(e)?,
+            // .flox directory exists, so we can't create a new environment here
             Ok(_) => Err(EnvironmentError::EnvironmentExists(
                 dot_flox_parent_path.as_ref().to_path_buf(),
             ))?,

--- a/cli/flox/src/commands/envs.rs
+++ b/cli/flox/src/commands/envs.rs
@@ -188,7 +188,7 @@ fn format_description(env: &UninitializedEnvironment) -> Cow<'_, str> {
 }
 
 fn format_path(path: Option<&Path>) -> Cow<'_, str> {
-    path.map(|p| p.to_string_lossy())
+    path.map(|p| p.parent().unwrap_or(p).to_string_lossy())
         .unwrap_or_else(|| "(remote)".into())
 }
 

--- a/cli/flox/src/commands/envs.rs
+++ b/cli/flox/src/commands/envs.rs
@@ -196,7 +196,7 @@ fn get_registered_environments(
     registry: &EnvRegistry,
 ) -> impl Iterator<Item = UninitializedEnvironment> + '_ {
     registry.entries.iter().filter_map(|entry| {
-        let path = entry.path.parent()?.to_path_buf();
+        let path = entry.path.clone();
         let pointer = entry.latest_env()?.pointer.clone();
 
         // If we have a path registered that has since been deleted, skip it

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -75,10 +75,11 @@ impl Install {
             Err(EnvironmentSelectError::Environment(
                 ref e @ EnvironmentError::DotFloxNotFound(ref dir),
             )) => {
+                let parent = dir.parent().unwrap_or(dir).display();
                 bail!(formatdoc! {"
                 {e}
 
-                Create an environment with 'flox init --dir {}'", dir.to_string_lossy()
+                Create an environment with 'flox init --dir {parent}'"
                 })
             },
             Err(e @ EnvironmentSelectError::EnvNotFoundInCurrentDirectory) => {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1047,7 +1047,7 @@ fn query_which_environment(
 
 /// Open an environment defined in `{path}/.flox`
 fn open_path(flox: &Flox, path: &PathBuf) -> Result<ConcreteEnvironment, EnvironmentError> {
-    DotFlox::open_default_in(path)
+    DotFlox::open_in(path)
         .map(UninitializedEnvironment::DotFlox)?
         .into_concrete_environment(flox)
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -24,6 +24,7 @@ use std::{env, fmt, fs, io, mem};
 
 use anyhow::{anyhow, bail, Context, Result};
 use bpaf::{Args, Bpaf, ParseFailure, Parser};
+use flox_rust_sdk::data::CanonicalPath;
 use flox_rust_sdk::flox::{
     EnvironmentName,
     EnvironmentOwner,
@@ -1134,7 +1135,9 @@ impl UninitializedEnvironment {
     ) -> Result<ConcreteEnvironment, EnvironmentError> {
         match self {
             UninitializedEnvironment::DotFlox(dot_flox) => {
-                let dot_flox_path = dot_flox.path;
+                let dot_flox_path = CanonicalPath::new(dot_flox.path)
+                    .map_err(|err| EnvironmentError::DotFloxNotFound(err.path))?;
+
                 let env = match dot_flox.pointer {
                     EnvironmentPointer::Path(path_pointer) => {
                         debug!("detected concrete environment type: path");

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -995,7 +995,7 @@ pub fn detect_environment(
         // If there's both an activated environment and an environment in the
         // current directory or git repo, prompt for which to use.
         (Some(activated_env), Some(found)) => {
-            let found_in_current_dir = found.path == current_dir;
+            let found_in_current_dir = found.path == current_dir.join(DOT_FLOX);
             Some(query_which_environment(
                 message,
                 activated_env,
@@ -1046,7 +1046,7 @@ fn query_which_environment(
 
 /// Open an environment defined in `{path}/.flox`
 fn open_path(flox: &Flox, path: &PathBuf) -> Result<ConcreteEnvironment, EnvironmentError> {
-    DotFlox::open(path)
+    DotFlox::open_default_in(path)
         .map(UninitializedEnvironment::DotFlox)?
         .into_concrete_environment(flox)
 }
@@ -1107,14 +1107,14 @@ impl UninitializedEnvironment {
             ConcreteEnvironment::Path(path_env) => {
                 let pointer = path_env.pointer.clone().into();
                 Ok(Self::DotFlox(DotFlox {
-                    path: path_env.parent_path().unwrap(),
+                    path: path_env.path.to_path_buf(),
                     pointer,
                 }))
             },
             ConcreteEnvironment::Managed(managed_env) => {
                 let pointer = managed_env.pointer().clone().into();
                 Ok(Self::DotFlox(DotFlox {
-                    path: managed_env.parent_path().unwrap(),
+                    path: managed_env.path.to_path_buf(),
                     pointer,
                 }))
             },
@@ -1134,7 +1134,7 @@ impl UninitializedEnvironment {
     ) -> Result<ConcreteEnvironment, EnvironmentError> {
         match self {
             UninitializedEnvironment::DotFlox(dot_flox) => {
-                let dot_flox_path = dot_flox.path.join(DOT_FLOX);
+                let dot_flox_path = dot_flox.path;
                 let env = match dot_flox.pointer {
                     EnvironmentPointer::Path(path_pointer) => {
                         debug!("detected concrete environment type: path");

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -109,7 +109,7 @@ impl Pull {
                 debug!("Resolved user intent: pull changes for environment found in {dir:?}");
 
                 let pointer = {
-                    let p = DotFlox::open_default_in(&dir)?.pointer;
+                    let p = DotFlox::open_in(&dir)?.pointer;
                     match p {
                         EnvironmentPointer::Managed(managed_pointer) => managed_pointer,
                         EnvironmentPointer::Path(_) => bail!("Cannot pull into a path environment"),

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -11,6 +11,7 @@ use flox_rust_sdk::models::environment::managed_environment::{
 };
 use flox_rust_sdk::models::environment::{
     CoreEnvironmentError,
+    DotFlox,
     Environment,
     EnvironmentError,
     EnvironmentPointer,
@@ -108,7 +109,7 @@ impl Pull {
                 debug!("Resolved user intent: pull changes for environment found in {dir:?}");
 
                 let pointer = {
-                    let p = EnvironmentPointer::open(&dir)?;
+                    let p = DotFlox::open_default_in(&dir)?.pointer;
                     match p {
                         EnvironmentPointer::Managed(managed_pointer) => managed_pointer,
                         EnvironmentPointer::Path(_) => bail!("Cannot pull into a path environment"),

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use bpaf::Bpaf;
+use flox_rust_sdk::data::CanonicalPath;
 use flox_rust_sdk::flox::{EnvironmentOwner, Flox};
 use flox_rust_sdk::models::environment::managed_environment::{
     ManagedEnvironment,
@@ -57,6 +58,8 @@ impl Push {
         let dir = self.dir.unwrap_or_else(|| std::env::current_dir().unwrap());
 
         let dot_flox = DotFlox::open_default_in(dir)?;
+        let canonical_dot_flox_path =
+            CanonicalPath::new(&dot_flox.path).expect("DotFlox path was just opened");
 
         match dot_flox.pointer {
             EnvironmentPointer::Managed(managed_pointer) => {
@@ -93,7 +96,7 @@ impl Push {
                         Self::push_make_managed(
                             &flox,
                             path_pointer,
-                            &dot_flox.path,
+                            canonical_dot_flox_path,
                             owner,
                             self.force,
                         )
@@ -124,7 +127,7 @@ impl Push {
     fn push_make_managed(
         flox: &Flox,
         path_pointer: PathPointer,
-        dot_flox_path: &Path,
+        dot_flox_path: CanonicalPath,
         owner: EnvironmentOwner,
         force: bool,
     ) -> Result<ManagedEnvironment> {

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -57,7 +57,7 @@ impl Push {
 
         let dir = self.dir.unwrap_or_else(|| std::env::current_dir().unwrap());
 
-        let dot_flox = DotFlox::open_default_in(dir)?;
+        let dot_flox = DotFlox::open_in(dir)?;
         let canonical_dot_flox_path =
             CanonicalPath::new(&dot_flox.path).expect("DotFlox path was just opened");
 

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -51,10 +51,11 @@ impl Uninstall {
             Err(EnvironmentSelectError::Environment(
                 ref e @ EnvironmentError::DotFloxNotFound(ref dir),
             )) => {
+                let parent = dir.parent().unwrap_or(dir).display();
                 bail!(formatdoc! {"
                 {e}
 
-                Create an environment with 'flox init --dir {}'", dir.to_string_lossy()
+                Create an environment with 'flox init --dir {parent}'"
                 })
             },
             Err(e @ EnvironmentSelectError::EnvNotFoundInCurrentDirectory) => {


### PR DESCRIPTION
Avoids managing both directories _containing_ a `.flox` and full paths to `.flox` directories.

Managed- and PathEnvironments, tracked full paths, while `DotFlox` ironically tracked only the parent directory.
This refactor changes `DotFlox::open` to require an existing, canonicalized `.flox` directory
and adds `DotFlox::open_in` which will eagerly assert the existence of a nested `.flox` diorectory.
`EnvironmentPointer:open` now similarly requires a guarantee that the `.flox` path exists.