### PR TITLE
feat: mock search using client

### DIFF
--- a/cli/tests/catalog_responses/hello_search.json
+++ b/cli/tests/catalog_responses/hello_search.json
@@ -1,0 +1,100 @@
+[
+  {
+    "results": [
+      {
+        "input": "nixpkgs",
+        "system": "aarch64-darwin",
+        "relPath": [
+          "hello"
+        ],
+        "pname": "hello",
+        "version": "2.12.1",
+        "description": "A program that produces a familiar, friendly greeting",
+        "license": "GPL-3.0-or-later"
+      },
+      {
+        "input": "nixpkgs",
+        "system": "aarch64-darwin",
+        "relPath": [
+          "hello-wayland"
+        ],
+        "pname": "hello-wayland",
+        "version": "unstable-2023-10-26",
+        "description": "Hello world Wayland client",
+        "license": "MIT"
+      },
+      {
+        "input": "nixpkgs",
+        "system": "aarch64-darwin",
+        "relPath": [
+          "hello-unfree"
+        ],
+        "pname": "example-unfree-package",
+        "version": "1.0",
+        "description": "An example package with unfree license (for testing)",
+        "license": null
+      },
+      {
+        "input": "nixpkgs",
+        "system": "aarch64-darwin",
+        "relPath": [
+          "sbclPackages",
+          "cl-mw_dot_examples_dot_hello-world"
+        ],
+        "pname": "cl-mw.examples.hello-world",
+        "version": "20150407-git",
+        "description": null,
+        "license": null
+      },
+      {
+        "input": "nixpkgs",
+        "system": "aarch64-darwin",
+        "relPath": [
+          "sbclPackages",
+          "hello-builder"
+        ],
+        "pname": "hello-builder",
+        "version": "20230618-git",
+        "description": null,
+        "license": null
+      },
+      {
+        "input": "nixpkgs",
+        "system": "aarch64-darwin",
+        "relPath": [
+          "sbclPackages",
+          "hello-clog"
+        ],
+        "pname": "hello-clog",
+        "version": "20230618-git",
+        "description": null,
+        "license": null
+      },
+      {
+        "input": "nixpkgs",
+        "system": "aarch64-darwin",
+        "relPath": [
+          "sbclPackages",
+          "qtools-helloworld"
+        ],
+        "pname": "qtools-helloworld",
+        "version": "20230214-git",
+        "description": null,
+        "license": null
+      },
+      {
+        "input": "nixpkgs",
+        "system": "aarch64-darwin",
+        "relPath": [
+          "emacsPackages",
+          "sly-hello-world"
+        ],
+        "pname": "sly-hello-world",
+        "version": "20200225.1755",
+        "description": null,
+        "license": null
+      }
+    ],
+    "count": 8
+  }
+]

--- a/cli/tests/search.bats
+++ b/cli/tests/search.bats
@@ -334,6 +334,17 @@ setup_file() {
 }
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=catalog,catalog:search
+@test "mock client reads data from disk" {
+  FLOX_FEATURES_USE_CATALOG=true \
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/hello_search.json" \
+  run --separate-stderr "$FLOX_BIN" search hello -vvv
+  assert_equal "${#lines[@]}" 8 # 8 search results in this mock data
+  assert_regex "$stderr" "using catalog client for search"
+}
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Uses the mock client to supply search responses from data stored on disk when `FLOX_FEATURES_USE_CATALOG=true` and `_FLOX_USE_CATALOG_MOCK="<path to data>"`.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
