### PR TITLE
chore: debug symbols for nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,8 @@
 
     # Use nix@2.17
     overlays.nix = final: prev: {
+      # Uncomment to compile Nix with debug symbols on Linux
+      # nix = final.enableDebugging (final.callPackage ./pkgs/nix {});
       nix = final.callPackage ./pkgs/nix {};
     };
 

--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -10,8 +10,14 @@
 #
 #
 # ---------------------------------------------------------------------------- #
-{nixVersions}:
+{
+  nixVersions,
+  stdenv,
+}:
 nixVersions.nix_2_17.overrideAttrs (prev: {
+  # Necessary for compiling with debug symbols
+  inherit stdenv;
+
   # Apply patch files.
   patches =
     prev.patches


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Tweaks the flake to allow compiling debug symbols for Nix on Linux by uncommenting a line.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
