### PR TITLE
feat: locking using the catalog client

### DIFF
--- a/.github/workflows/nix-managed-lints.yml
+++ b/.github/workflows/nix-managed-lints.yml
@@ -37,9 +37,13 @@ jobs:
           git fetch origin '${{ github.base_ref }}';
 
       # avoid the next step being filled with nix substitution logs
-      - name: "Instantiate Development Shell"
+      # and ensure that `pre-commit` can run cargo with the `--offline` flag
+      - name: "Fetch rust dependencies"
         run: |
-          nix develop -L --no-update-lock-file --command true;
+          nix develop -L --no-update-lock-file --command \
+            cargo fetch \
+            --manifest-path ./cli/Cargo.toml \
+            --locked;
 
       - name: "Run Nix Git Hooks"
         run: |

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "fslock",
  "futures",
  "indent",
+ "indexmap 2.2.6",
  "indoc",
  "jsonwebtoken",
  "log",

--- a/cli/catalog-api-v1/build.rs
+++ b/cli/catalog-api-v1/build.rs
@@ -21,7 +21,9 @@ fn main() {
 }
 
 fn generate_client(spec: &OpenAPI) -> String {
-    let mut generator = progenitor::Generator::default();
+    let mut settings = progenitor::GenerationSettings::default();
+    settings.with_derive("PartialEq");
+    let mut generator = progenitor::Generator::new(&settings);
     let tokens = generator.generate_tokens(spec).unwrap();
     let ast = syn::parse2(tokens).unwrap();
     prettyplease::unparse(&ast)

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -100,7 +100,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct CatalogPageInput {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         pub packages: Vec<PackageResolutionInfo>,
@@ -170,7 +170,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct CatalogPageOutput {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         pub packages: Vec<PackageResolutionInfo>,
@@ -250,7 +250,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct CatalogStatus {
         pub attribute_path_ct: i64,
         pub catalogs: Vec<String>,
@@ -292,7 +292,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct ErrorResponse {
         pub detail: String,
         pub status_code: i64,
@@ -327,7 +327,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct Output {
         pub name: String,
         pub store_path: String,
@@ -392,7 +392,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageDescriptor {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub derivation: Option<String>,
@@ -469,7 +469,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageGroup {
         pub descriptors: Vec<PackageDescriptor>,
         pub name: String,
@@ -529,7 +529,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageGroups {
         pub items: Vec<PackageGroup>,
     }
@@ -670,7 +670,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageInfoApi {
         pub attr_path: String,
         pub description: String,
@@ -789,7 +789,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageInfoCommon {
         pub attr_path: String,
         pub description: String,
@@ -944,7 +944,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageResolutionInfo {
         pub attr_path: String,
         pub broken: bool,
@@ -1021,7 +1021,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageSearchResultInput {
         pub items: Vec<PackageInfoApi>,
         pub total_count: i64,
@@ -1083,7 +1083,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageSearchResultOutput {
         pub items: Vec<PackageInfoApi>,
         pub total_count: i64,
@@ -1121,7 +1121,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackagesResultInput {
         pub items: Vec<PackageInfoCommon>,
         pub total_count: i64,
@@ -1159,7 +1159,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackagesResultOutput {
         pub items: Vec<PackageInfoCommon>,
         pub total_count: i64,
@@ -1223,7 +1223,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct ResolvedPackageGroupInput {
         pub name: String,
         pub pages: Vec<CatalogPageInput>,
@@ -1288,7 +1288,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct ResolvedPackageGroupOutput {
         pub name: String,
         pub pages: Vec<CatalogPageOutput>,
@@ -1322,7 +1322,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct ResolvedPackageGroupsInput {
         pub items: Vec<ResolvedPackageGroupInput>,
     }
@@ -1354,7 +1354,7 @@ pub mod types {
     ///}
     /// ```
     /// </details>
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct ResolvedPackageGroupsOutput {
         pub items: Vec<ResolvedPackageGroupOutput>,
     }

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -16,6 +16,7 @@ enum_dispatch.workspace = true
 fslock.workspace = true
 futures.workspace = true
 indent.workspace = true
+indexmap.workspace = true
 indoc.workspace = true
 jsonwebtoken.workspace = true
 log.workspace = true

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -45,5 +45,7 @@ proptest-derive.workspace = true
 serial_test.workspace = true
 
 [features]
+# allow exporting test helpers in dev mode only
+tests = []
 extra-tests = ["impure-unit-tests"]
 impure-unit-tests = []

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -193,7 +193,7 @@ impl<State> CoreEnvironment<State> {
 
         LockedManifestCatalog::new(&manifest, existing_lockfile.as_ref(), client)
             .block_on()
-            .map_err(|_| todo!("add error"))
+            .map_err(CoreEnvironmentError::LockedManifest)
     }
 
     /// Build the environment, [Self::lock] if necessary.

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -191,7 +191,7 @@ impl<State> CoreEnvironment<State> {
             }
         };
 
-        LockedManifestCatalog::new(&manifest, existing_lockfile, client)
+        LockedManifestCatalog::new(&manifest, existing_lockfile.as_ref(), client)
             .block_on()
             .map_err(|_| todo!("add error"))
     }

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use log::debug;
 use pollster::FutureExt;
 use thiserror::Error;
+use tracing::warn;
 
 use super::{
     copy_dir_recursive,
@@ -187,7 +188,12 @@ impl<State> CoreEnvironment<State> {
                 .map_err(CoreEnvironmentError::LockedManifest)?;
             match lockfile {
                 LockedManifest::Catalog(lockfile) => Some(lockfile),
-                _ => None,
+                _ => {
+                    warn!(
+                        "Found version 1 manifest, but lockfile doesn't match: Ignoring lockfile."
+                    );
+                    None
+                },
             }
         };
 

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use log::debug;
+use pollster::FutureExt;
 use thiserror::Error;
 
 use super::{
@@ -19,13 +20,20 @@ use crate::data::CanonicalPath;
 use crate::flox::Flox;
 use crate::models::container_builder::ContainerBuilder;
 use crate::models::environment::{call_pkgdb, global_manifest_path};
-use crate::models::lockfile::{LockedManifest, LockedManifestError, LockedManifestPkgdb};
+use crate::models::lockfile::{
+    LockedManifest,
+    LockedManifestCatalog,
+    LockedManifestError,
+    LockedManifestPkgdb,
+};
 use crate::models::manifest::{
     insert_packages,
     remove_packages,
     Manifest,
     PackageToInstall,
     TomlEditError,
+    TypedManifest,
+    TypedManifestCatalog,
 };
 use crate::models::pkgdb::{
     error_codes,
@@ -35,6 +43,7 @@ use crate::models::pkgdb::{
     UpgradeResultJSON,
     PKGDB_BIN,
 };
+use crate::providers::catalog;
 use crate::utils::CommandExt;
 
 pub struct ReadOnly {}
@@ -80,9 +89,12 @@ impl<State> CoreEnvironment<State> {
 
     /// Lock the environment.
     ///
+    /// When a catalog client is provided, the catalog will be used to lock any
+    /// "V1" manifest.
+    /// Without a catalog client, only "V0" manifests can be locked using the pkgdb.
+    /// If a "V1" manifest is locked without a catalog client, an error will be returned.
+    ///
     /// This re-writes the lock if it exists.
-    /// If the lock doesn't exist, it uses the global lock, and then it writes
-    /// a new lock.
     ///
     /// Technically this does write to disk as a side effect for now.
     /// It's included in the [ReadOnly] struct for ergonomic reasons
@@ -90,6 +102,45 @@ impl<State> CoreEnvironment<State> {
     ///
     /// todo: should we always write the lockfile to disk?
     pub fn lock(&mut self, flox: &Flox) -> Result<LockedManifest, CoreEnvironmentError> {
+        let manifest: TypedManifest = toml::from_str(&self.manifest_content()?)
+            .map_err(CoreEnvironmentError::DeserializeManifest)?;
+
+        let lockfile = match manifest {
+            TypedManifest::Pkgdb(_) => LockedManifest::Pkgdb(self.lock_with_pkgdb(flox)?),
+            TypedManifest::Catalog(manifest) => {
+                let Some(ref client) = flox.catalog_client else {
+                    return Err(CoreEnvironmentError::CatalogClientMissing);
+                };
+                LockedManifest::Catalog(self.lock_with_catalog_client(client, *manifest)?)
+            },
+        };
+
+        let environment_lockfile_path = self.lockfile_path();
+
+        // Write the lockfile to disk
+        // todo: do we always want to do this?
+        debug!(
+            "generated lockfile, writing to {}",
+            environment_lockfile_path.display()
+        );
+        std::fs::write(
+            &environment_lockfile_path,
+            serde_json::to_string_pretty(&lockfile).unwrap(),
+        )
+        .map_err(CoreEnvironmentError::WriteLockfile)?;
+
+        Ok(lockfile)
+    }
+
+    /// Lock the environment with the pkgdb
+    ///
+    /// Passes the manifest and the existing lockfile to `pkgdb manifest lock`.
+    /// The lockfile is used to lock the underlying package registry.
+    /// If the environment has no lockfile, the global lockfile is used as a base instead.
+    fn lock_with_pkgdb(
+        &mut self,
+        flox: &Flox,
+    ) -> Result<LockedManifestPkgdb, CoreEnvironmentError> {
         let manifest_path = self.manifest_path();
         let environment_lockfile_path = self.lockfile_path();
         let existing_lockfile_path = if environment_lockfile_path.exists() {
@@ -115,20 +166,34 @@ impl<State> CoreEnvironment<State> {
             &global_manifest_path(flox),
         )
         .map_err(CoreEnvironmentError::LockedManifest)?;
+        Ok(lockfile)
+    }
 
-        // Write the lockfile to disk
-        // todo: do we always want to do this?
-        debug!(
-            "generated lockfile, writing to {}",
-            environment_lockfile_path.display()
-        );
-        std::fs::write(
-            &environment_lockfile_path,
-            serde_json::to_string_pretty(&lockfile).unwrap(),
-        )
-        .map_err(CoreEnvironmentError::WriteLockfile)?;
+    /// Lock the environment with the catalog client
+    ///
+    /// If a lockfile exists, it is used as a base.
+    /// If the manifest should be locked without a base,
+    /// remove the lockfile before calling this function or use [Self::upgrade] (todo - 2024-04-24).
+    fn lock_with_catalog_client(
+        &self,
+        client: &catalog::Client,
+        manifest: TypedManifestCatalog,
+    ) -> Result<LockedManifestCatalog, CoreEnvironmentError> {
+        let existing_lockfile = 'lockfile: {
+            let Ok(lockfile_path) = CanonicalPath::new(self.lockfile_path()) else {
+                break 'lockfile None;
+            };
+            let lockfile = LockedManifest::read_from_file(&lockfile_path)
+                .map_err(CoreEnvironmentError::LockedManifest)?;
+            match lockfile {
+                LockedManifest::Catalog(lockfile) => Some(lockfile),
+                _ => None,
+            }
+        };
 
-        Ok(LockedManifest::Pkgdb(lockfile))
+        LockedManifestCatalog::new(&manifest, existing_lockfile, client)
+            .block_on()
+            .map_err(|_| todo!("add error"))
     }
 
     /// Build the environment, [Self::lock] if necessary.
@@ -699,6 +764,9 @@ pub enum CoreEnvironmentError {
     // endregion
     #[error("unsupported system to build container: {0}")]
     ContainerizeUnsupportedSystem(String),
+
+    #[error("Could not process catalog manifest without a catalog client")]
+    CatalogClientMissing,
 }
 
 impl CoreEnvironmentError {

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -191,7 +191,7 @@ impl<State> CoreEnvironment<State> {
             }
         };
 
-        LockedManifestCatalog::new(&manifest, existing_lockfile.as_ref(), client)
+        LockedManifestCatalog::lock_manifest(&manifest, existing_lockfile.as_ref(), client)
             .block_on()
             .map_err(CoreEnvironmentError::LockedManifest)
     }

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -357,9 +357,11 @@ impl LockedManifestCatalog {
     /// A group is created for each unique combination of (descriptor.package_group ｘ descriptor.system).
     /// Each group contains a list of package descriptors that belong to that group.
     ///
-    /// `locked` is used to provide existing derivations for packages that are already locked,
+    /// `seed_lockfile` is used to provide existing derivations for packages that are already locked,
     /// e.g. by a previous lockfile.
     /// These packages are used to constrain the resolution.
+    /// If a package in `manifest` does not have a corresponding package in `seed_lockfile`,
+    /// that package will be unconstrained, allowing a first install.
     fn collect_package_groups<'manifest>(
         manifest: &'manifest TypedManifestCatalog,
         seed_lockfile: Option<&LockedManifestCatalog>,
@@ -411,7 +413,7 @@ impl LockedManifestCatalog {
         map.into_values()
     }
 
-    /// Convert a resolution results into a list of locked packages
+    /// Convert resolution results into a list of locked packages
     ///
     /// * Flattens `Group(Page(PackageResolutionInfo+)+)` into `LockedPackageCatalog+`
     /// * Adds a `system` field to each locked package.

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -399,6 +399,9 @@ impl LockedManifestCatalog {
                     system: system.clone(),
                 });
 
+                // If the package was just added to the manifest, it will be missing in the seed,
+                // which is derived from the _previous_ lockfile.
+                // In this case, the derivation will be None, and the package will be unconstrained.
                 let locked_derivation = seed_locked_packages
                     .get(&(manifest_descriptor, system))
                     .map(|p| p.derivation.clone());

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -42,7 +42,7 @@ pub struct Registry {
     _json: Value,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize /* , Deserialize implemented manually */)]
 #[serde(untagged)]
 pub enum LockedManifest {
     Catalog(LockedManifestCatalog),
@@ -136,7 +136,7 @@ impl ToString for LockedManifest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct LockedManifestCatalog {
     #[serde(rename = "lockfile-version")]
@@ -147,7 +147,7 @@ pub struct LockedManifestCatalog {
     pub packages: Vec<LockedPackageCatalog>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct LockedPackageCatalog {
     // region: original fields from the service

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1213,6 +1213,75 @@ mod tests {
         assert_eq!(actual_params, expected_params);
     }
 
+    #[test]
+    fn ungroup_response() {
+        let groups = vec![ResolvedPackageGroup {
+            system: "system".to_string(),
+            pages: vec![CatalogPage {
+                page: 1,
+                url: "url".to_string(),
+                packages: vec![PackageResolutionInfo {
+                    attr_path: "hello".to_string(),
+                    broken: false,
+                    derivation: "derivation".to_string(),
+                    description: "description".to_string(),
+                    license: "license".to_string(),
+                    locked_url: "locked_url".to_string(),
+                    name: "hello".to_string(),
+                    outputs: vec![Output {
+                        name: "name".to_string(),
+                        store_path: "store_path".to_string(),
+                    }],
+                    outputs_to_install: vec!["name".to_string()],
+                    pname: "pname".to_string(),
+                    rev: "rev".to_string(),
+                    rev_count: 1,
+                    rev_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
+                        .unwrap()
+                        .with_timezone(&chrono::offset::Utc),
+                    scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
+                        .unwrap()
+                        .with_timezone(&chrono::offset::Utc),
+                    stabilities: vec!["stability".to_string()],
+                    unfree: false,
+                    version: "version".to_string(),
+                }],
+            }],
+            name: "group".to_string(),
+        }];
+
+        let locked_packages =
+            LockedManifestCatalog::locked_packages_from_resolution(groups).collect::<Vec<_>>();
+
+        assert_eq!(locked_packages.len(), 1);
+        assert_eq!(&locked_packages[0], &LockedPackageCatalog {
+            attr_path: "hello".to_string(),
+            broken: false,
+            derivation: "derivation".to_string(),
+            description: "description".to_string(),
+            license: "license".to_string(),
+            locked_url: "locked_url".to_string(),
+            name: "hello".to_string(),
+            outputs: vec![("name".to_string(), "store_path".to_string())]
+                .into_iter()
+                .collect(),
+            outputs_to_install: vec!["name".to_string()],
+            pname: "pname".to_string(),
+            rev: "rev".to_string(),
+            rev_count: 1,
+            rev_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::offset::Utc),
+            scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::offset::Utc),
+            stabilities: vec!["stability".to_string()],
+            unfree: false,
+            version: "version".to_string(),
+            system: "system".to_string(),
+        });
+    }
+
     #[tokio::test]
     async fn test_locking_1() {
         let manifest = &*TEST_TYPED_MANIFEST;

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -137,17 +137,19 @@ impl ToString for LockedManifest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct LockedManifestCatalog {
     #[serde(rename = "lockfile-version")]
-    pub(crate) version: Version<1>,
+    pub version: Version<1>,
     /// original manifest that was locked
-    pub(crate) manifest: TypedManifestCatalog,
+    pub manifest: TypedManifestCatalog,
     /// locked pacakges
-    pub(crate) packages: Vec<LockedPackageCatalog>,
+    pub packages: Vec<LockedPackageCatalog>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct LockedPackageCatalog {
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub struct LockedPackageCatalog {
     // region: original fields from the service
     // These fields are copied from the generated struct.
     pub attr_path: String,
@@ -160,7 +162,9 @@ pub(crate) struct LockedPackageCatalog {
     pub pname: String,
     pub rev: String,
     pub rev_count: i64,
+    #[cfg_attr(test, proptest(strategy = "crate::utils::proptest_chrono_strategy()"))]
     pub rev_date: chrono::DateTime<chrono::offset::Utc>,
+    #[cfg_attr(test, proptest(strategy = "crate::utils::proptest_chrono_strategy()"))]
     pub scrape_date: chrono::DateTime<chrono::offset::Utc>,
     pub stabilities: Vec<String>,
     pub unfree: bool,

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -292,7 +292,7 @@ impl LockedManifestCatalog {
     ///
     /// If a seed lockfile is provided, packages that are already locked
     /// will constrain the resolution.
-    pub async fn new(
+    pub async fn lock_manifest(
         manifest: &TypedManifestCatalog,
         seed_lockfile: Option<&LockedManifestCatalog>,
         client: &impl catalog::ClientTrait,
@@ -1290,7 +1290,7 @@ mod tests {
         let mut client = catalog::MockClient::new(None::<String>).unwrap();
         client.push_resolve_response(TEST_RESOLUTION_RESPONSE.clone());
 
-        let locked_manifest = LockedManifestCatalog::new(manifest, None, &client)
+        let locked_manifest = LockedManifestCatalog::lock_manifest(manifest, None, &client)
             .await
             .unwrap();
         assert_eq!(

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -174,11 +174,11 @@ pub struct LockedPackageCatalog {
     pub stabilities: Vec<String>,
     pub unfree: bool,
     pub version: String,
+    pub outputs_to_install: Vec<String>,
     // endregion
 
     // region: converted fields
     pub outputs: BTreeMap<String, String>,
-    pub outputs_to_install: Vec<String>,
     // endregion
 
     // region: added fields

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -108,7 +108,16 @@ pub struct TypedManifestCatalog {
     pub(super) options: ManifestOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, derive_more::Deref)]
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Default,
+    PartialEq,
+    derive_more::Deref,
+    derive_more::DerefMut,
+)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ManifestInstall(BTreeMap<String, ManifestPackageDescriptor>);
 

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -11,6 +11,7 @@ use crate::data::{System, Version};
 use crate::models::pkgdb::PKGDB_BIN;
 
 pub(super) const DEFAULT_GROUP_NAME: &str = "toplevel";
+pub(super) const DEFAULT_PRIORITY: usize = 5;
 
 /// A wrapper around a [`toml_edit::DocumentMut`]
 /// that allows modifications of the raw manifest document,

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -16,7 +16,7 @@ pub(super) const DEFAULT_GROUP_NAME: &str = "toplevel";
 /// that allows modifications of the raw manifest document,
 /// while preserving comments and user formatting.
 #[derive(Debug)]
-struct RawManifest(toml_edit::DocumentMut);
+pub struct RawManifest(toml_edit::DocumentMut);
 impl RawManifest {
     /// Get the version of the manifest, if it's present or default to version 1.
     fn get_version(&self) -> Option<i64> {
@@ -75,7 +75,7 @@ impl FromStr for RawManifest {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(untagged)]
-enum TypedManifest {
+pub enum TypedManifest {
     /// v2 manifest, processed by flox and resolved using the catalog service
     Catalog(Box<TypedManifestCatalog>),
     /// deprecated v1 manifest, processed entirely by `pkgdb`
@@ -87,7 +87,7 @@ enum TypedManifest {
 /// Modifications should be made using the the raw functions in this module.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub(super) struct TypedManifestCatalog {
+pub struct TypedManifestCatalog {
     version: Version<1>,
     /// The packages to install in the form of a map from package name
     /// to package descriptor.
@@ -105,42 +105,42 @@ pub(super) struct TypedManifestCatalog {
     profile: ManifestProfile,
     /// Options that control the behavior of the manifest.
     #[serde(default)]
-    options: ManifestOptions,
+    pub(super) options: ManifestOptions,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, derive_more::Deref)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub(super) struct ManifestInstall(BTreeMap<String, ManifestPackageDescriptor>);
+pub struct ManifestInstall(BTreeMap<String, ManifestPackageDescriptor>);
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
-pub(super) struct ManifestPackageDescriptor {
-    pub(super) pkg_path: String,
-    pub(super) package_group: Option<String>,
-    pub(super) priority: Option<usize>,
-    pub(super) version: Option<String>,
-    pub(super) systems: Option<Vec<System>>,
+pub struct ManifestPackageDescriptor {
+    pub(crate) pkg_path: String,
+    pub(crate) package_group: Option<String>,
+    pub(crate) priority: Option<usize>,
+    pub(crate) version: Option<String>,
+    pub(crate) systems: Option<Vec<System>>,
     #[serde(default)]
-    pub(super) optional: bool,
+    pub(crate) optional: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub(super) struct ManifestVariables(BTreeMap<String, String>);
+pub struct ManifestVariables(BTreeMap<String, String>);
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
-pub(super) struct ManifestHook {
+pub struct ManifestHook {
     /// A script that is run at activation time,
     /// in a flox provided bash shell
     on_activate: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub(super) struct ManifestProfile {
+pub struct ManifestProfile {
     /// When defined, this hook is run by _all_ shells upon activation
     common: Option<String>,
     /// When defined, this hook is run upon activation in a bash shell
@@ -151,13 +151,13 @@ pub(super) struct ManifestProfile {
     fish: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
-pub(super) struct ManifestOptions {
+pub struct ManifestOptions {
     /// A list of systems that each package is resolved for.
     #[serde(default)]
-    systems: Vec<System>,
+    pub(super) systems: Vec<System>,
     /// Options that control what types of packages are allowed.
     #[serde(default)]
     allows: Allows,
@@ -166,9 +166,9 @@ pub(super) struct ManifestOptions {
     semver: SemverOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub(super) struct Allows {
+pub struct Allows {
     /// Whether to allow packages that are marked as `unfree`
     unfree: Option<bool>,
     /// Whether to allow packages that are marked as `broken`
@@ -178,9 +178,9 @@ pub(super) struct Allows {
     licenses: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub(super) struct SemverOptions {
+pub struct SemverOptions {
     /// Whether to prefer pre-release versions when resolving
     #[serde(default)]
     prefer_pre_releases: Option<bool>,

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -38,7 +38,7 @@ impl RawManifest {
     ///
     /// Discussion: using a string field as the version tag `version: "1"` vs `version: 1`
     /// could work today, but is still limited by the lack of an optional tag.
-    fn to_typed(&self) -> Result<TypedManifest, toml_edit::de::Error> {
+    pub fn to_typed(&self) -> Result<TypedManifest, toml_edit::de::Error> {
         match self.get_version() {
             Some(1) => Ok(TypedManifest::Catalog(toml_edit::de::from_document(
                 self.0.clone(),

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -579,7 +579,7 @@ impl From<api_types::CatalogPageInput> for CatalogPage {
 /// [lockfile::LockedPackageCatalog] adds (at least) a `system` field.
 /// We should consider whether adding a shim to [api_types::PackageResolutionInfo]
 /// is not adding unnecessary complexity.
-type PackageResolutionInfo = api_types::PackageResolutionInfo;
+pub type PackageResolutionInfo = api_types::PackageResolutionInfo;
 
 impl TryFrom<PackageInfoApi> for SearchResult {
     type Error = SearchError;

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -571,8 +571,14 @@ impl From<api_types::CatalogPageInput> for CatalogPage {
     }
 }
 
-/// Just an alias until the auto-generated PackageResolutionInfo diverges from
-/// what we need.
+/// TODO: Implement a shim for [api_types::PackageResolutionInfo] that
+/// converts `outputs` and `outputs_to_install` from
+/// [serde_json::Value] to [String] based types.
+///
+/// Since we plan to list resolved packages in a flat list within the lockfile,
+/// [lockfile::LockedPackageCatalog] adds (at least) a `system` field.
+/// We should consider whether adding a shim to [api_types::PackageResolutionInfo]
+/// is not adding unnecessary complexity.
 type PackageResolutionInfo = api_types::PackageResolutionInfo;
 
 impl TryFrom<PackageInfoApi> for SearchResult {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -571,10 +571,6 @@ impl From<api_types::CatalogPageInput> for CatalogPage {
     }
 }
 
-/// TODO: Implement a shim for [api_types::PackageResolutionInfo] that
-/// converts `outputs` and `outputs_to_install` from
-/// [serde_json::Value] to [String] based types.
-///
 /// Since we plan to list resolved packages in a flat list within the lockfile,
 /// [lockfile::LockedPackageCatalog] adds (at least) a `system` field.
 /// We should consider whether adding a shim to [api_types::PackageResolutionInfo]

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -452,7 +452,7 @@ impl ClientTrait for MockClient {
 /// we need.
 pub type PackageDescriptor = api_types::PackageDescriptor;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct PackageGroup {
     pub descriptors: Vec<PackageDescriptor>,
     pub name: String,
@@ -529,7 +529,7 @@ impl TryFrom<PackageGroup> for api_types::PackageGroup {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedPackageGroup {
     pub name: String,
     pub pages: Vec<CatalogPage>,

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -571,6 +571,8 @@ impl From<api_types::CatalogPageInput> for CatalogPage {
     }
 }
 
+/// TODO: Implement a shim for [api_types::PackageResolutionInfo]
+///
 /// Since we plan to list resolved packages in a flat list within the lockfile,
 /// [lockfile::LockedPackageCatalog] adds (at least) a `system` field.
 /// We should consider whether adding a shim to [api_types::PackageResolutionInfo]

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -162,3 +162,16 @@ pub fn traceable_path(p: &impl AsRef<Path>) -> impl tracing::Value {
     let path = p.as_ref();
     path.display().to_string()
 }
+
+#[cfg(any(test, feature = "test"))]
+pub fn proptest_chrono_strategy(
+) -> impl proptest::strategy::Strategy<Value = chrono::DateTime<chrono::Utc>> {
+    use chrono::TimeZone;
+    use proptest::prelude::*;
+
+    let start = chrono::Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
+    let end = chrono::Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap();
+
+    (start.timestamp()..end.timestamp())
+        .prop_map(|timestamp| chrono::Utc.timestamp_opt(timestamp, 0).unwrap())
+}

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -306,6 +306,12 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
         CoreEnvironmentError::ContainerizeUnsupportedSystem(system) => formatdoc! {"
             'containerize' is currently only supported on linux (found {system}).
         "},
+
+        CoreEnvironmentError::CatalogClientMissing => formatdoc! {"
+            The current manifest requires the (experimental) catalog feature.
+
+            Please enable the catalog feature and try again.
+        "},
     }
 }
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -560,6 +560,15 @@ pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
 
             Please ensure that the path exists and that you have read permissions.
         "},
+
+        // region: errors from the catalog locking
+        LockedManifestError::CatalogResolve(err) => formatdoc! {"
+            Failed to lock the manifest.
+
+            {err}
+        "},
+        // endregion
+
         // region: errors returned by pkgdb
         // we do minimal formatting here as the error message is supposed to be
         // already user friendly.


### PR DESCRIPTION
Implement locking of "v1" Manifests to "v1" lockfiles.

* construct arguments for `catalog::Client::resolve` from a manifest and optional "seed" lockfile
* (naively) implement deconstruction of {resolved groups ｘ pages ｘ packages} into a flat list of locked packages.
* Add logic in `CoreEnvironment` to dispatch locking to either pkgdb or the catalog based on the manifest found
* Handle error case where the catalog feature is disabled i.e. no client is set on `Flox`