### PR TITLE
feat: support loading new lockfile schema

### DIFF
--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -315,9 +315,9 @@ getRealisedPackages( nix::ref<nix::EvalState> &         state,
  * @return `StorePath` to the environment.
  */
 nix::StorePath
-createFloxEnv( nix::ref<nix::EvalState> & state,
-               resolver::LockfileRaw &    lockfile,
-               const System &             system );
+createFloxEnv( nix::ref<nix::EvalState> &    state,
+               const resolver::LockfileRaw & lockfile,
+               const System &                system );
 
 
 /* -------------------------------------------------------------------------- */
@@ -369,7 +369,8 @@ createContainerBuilder( nix::EvalState &       state,
  * scripts.
  */
 std::pair<buildenv::RealisedPackage, nix::StorePathSet>
-makeActivationScripts( nix::EvalState & state, const resolver::LockfileRaw & lockfile );
+makeActivationScripts( nix::EvalState &              state,
+                       const resolver::LockfileRaw & lockfile );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -369,7 +369,7 @@ createContainerBuilder( nix::EvalState &       state,
  * scripts.
  */
 std::pair<buildenv::RealisedPackage, nix::StorePathSet>
-makeActivationScripts( nix::EvalState & state, resolver::Lockfile & lockfile );
+makeActivationScripts( nix::EvalState & state, const resolver::LockfileRaw & lockfile );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -316,7 +316,7 @@ getRealisedPackages( nix::ref<nix::EvalState> &         state,
  */
 nix::StorePath
 createFloxEnv( nix::ref<nix::EvalState> & state,
-               resolver::Lockfile &       lockfile,
+               resolver::LockfileRaw &    lockfile,
                const System &             system );
 
 

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -114,7 +114,7 @@ BuildEnvCommand::run()
 
   debugLog( "building environment" );
 
-  auto storePath = createFloxEnv( state, lockfile, system );
+  auto storePath = createFloxEnv( state, lockfileRaw, system );
 
   debugLog( "built environment: " + store->printStorePath( storePath ) );
 

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -114,7 +114,7 @@ BuildEnvCommand::run()
 
   debugLog( "building environment" );
 
-  auto storePath = createFloxEnv( state, lockfileRaw, system );
+  auto storePath = createFloxEnv( state, lockfile.getLockfileRaw(), system );
 
   debugLog( "built environment: " + store->printStorePath( storePath ) );
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -199,11 +199,11 @@ createEnvironmentStorePath(
  * @return List of locked packages for the given system paired with their id.
  */
 static std::vector<std::pair<std::string, resolver::LockedPackageRaw>>
-getLockedPackages( resolver::Lockfile & lockfile, const System & system )
+getLockedPackages( resolver::LockfileRaw & lockfile, const System & system )
 {
   traceLog( "creating FloxEnv" );
-  auto packages = lockfile.getLockfileRaw().packages.find( system );
-  if ( packages == lockfile.getLockfileRaw().packages.end() )
+  auto packages = lockfile.packages.find( system );
+  if ( packages == lockfile.packages.end() )
     {
       // Custom exception for non supported system
       throw SystemNotSupportedByLockfile(
@@ -691,7 +691,8 @@ appendBashCalledScript( const std::string & scriptName,
 /* -------------------------------------------------------------------------- */
 
 std::pair<buildenv::RealisedPackage, nix::StorePathSet>
-makeActivationScripts( nix::EvalState & state, resolver::Lockfile & lockfile )
+makeActivationScripts( nix::EvalState &        state,
+                       resolver::LockfileRaw & lockfile )
 {
   std::vector<nix::StorePath> activationScripts;
   auto tempDir = std::filesystem::path( nix::createTempDir() );
@@ -707,7 +708,7 @@ makeActivationScripts( nix::EvalState & state, resolver::Lockfile & lockfile )
   zshScript << ZSH_ACTIVATE_SCRIPT << "\n";
   zshScript << "source " << SET_PROMPT_ZSH_SH << "\n";
 
-  auto manifest = lockfile.getManifest().getManifestRaw();
+  auto manifest = lockfile.manifest;
 
   /* Add environment variables. */
   if ( auto vars = manifest.vars )
@@ -841,7 +842,7 @@ makeProfileDScripts( nix::EvalState & state )
  */
 nix::StorePath
 createFloxEnv( nix::ref<nix::EvalState> & state,
-               resolver::Lockfile &       lockfile,
+               resolver::LockfileRaw &    lockfile,
                const System &             system )
 {
   auto locked_packages = getLockedPackages( lockfile, system );

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -692,7 +692,7 @@ appendBashCalledScript( const std::string & scriptName,
 
 std::pair<buildenv::RealisedPackage, nix::StorePathSet>
 makeActivationScripts( nix::EvalState &        state,
-                       resolver::LockfileRaw & lockfile )
+                       const resolver::LockfileRaw & lockfile )
 {
   std::vector<nix::StorePath> activationScripts;
   auto tempDir = std::filesystem::path( nix::createTempDir() );

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -199,7 +199,8 @@ createEnvironmentStorePath(
  * @return List of locked packages for the given system paired with their id.
  */
 static std::vector<std::pair<std::string, resolver::LockedPackageRaw>>
-getLockedPackages( resolver::LockfileRaw & lockfile, const System & system )
+getLockedPackages( const resolver::LockfileRaw & lockfile,
+                   const System &                system )
 {
   traceLog( "creating FloxEnv" );
   auto packages = lockfile.packages.find( system );
@@ -691,7 +692,7 @@ appendBashCalledScript( const std::string & scriptName,
 /* -------------------------------------------------------------------------- */
 
 std::pair<buildenv::RealisedPackage, nix::StorePathSet>
-makeActivationScripts( nix::EvalState &        state,
+makeActivationScripts( nix::EvalState &              state,
                        const resolver::LockfileRaw & lockfile )
 {
   std::vector<nix::StorePath> activationScripts;
@@ -841,9 +842,9 @@ makeProfileDScripts( nix::EvalState & state )
  * @return The store path of the environment.
  */
 nix::StorePath
-createFloxEnv( nix::ref<nix::EvalState> & state,
-               resolver::LockfileRaw &    lockfile,
-               const System &             system )
+createFloxEnv( nix::ref<nix::EvalState> &    state,
+               const resolver::LockfileRaw & lockfile,
+               const System &                system )
 {
   auto locked_packages = getLockedPackages( lockfile, system );
 

--- a/pkgdb/tests/realise.cc
+++ b/pkgdb/tests/realise.cc
@@ -152,7 +152,9 @@ bool
 test_scriptsAreAddedToScriptsDir( nix::ref<nix::EvalState> & state,
                                   flox::resolver::Lockfile & lockfile )
 {
-  auto output     = flox::buildenv::makeActivationScripts( *state, lockfile.getLockfileRaw() );
+  auto output
+    = flox::buildenv::makeActivationScripts( *state,
+                                             lockfile.getLockfileRaw() );
   auto scriptsDir = std::filesystem::path( output.first.path )
                     / flox::buildenv::ACTIVATION_SUBDIR_NAME;
   std::vector<std::string> scripts
@@ -173,7 +175,9 @@ bool
 test_scriptsAreSourcedOrCalled( nix::ref<nix::EvalState> & state,
                                 flox::resolver::Lockfile & lockfile )
 {
-  auto output     = flox::buildenv::makeActivationScripts( *state, lockfile.getLockfileRaw() );
+  auto output
+    = flox::buildenv::makeActivationScripts( *state,
+                                             lockfile.getLockfileRaw() );
   auto scriptsDir = std::filesystem::path( output.first.path )
                     / flox::buildenv::ACTIVATION_SUBDIR_NAME;
   std::vector<std::string> shells         = { "bash", "zsh" };

--- a/pkgdb/tests/realise.cc
+++ b/pkgdb/tests/realise.cc
@@ -152,7 +152,7 @@ bool
 test_scriptsAreAddedToScriptsDir( nix::ref<nix::EvalState> & state,
                                   flox::resolver::Lockfile & lockfile )
 {
-  auto output     = flox::buildenv::makeActivationScripts( *state, lockfile );
+  auto output     = flox::buildenv::makeActivationScripts( *state, lockfile.getLockfileRaw() );
   auto scriptsDir = std::filesystem::path( output.first.path )
                     / flox::buildenv::ACTIVATION_SUBDIR_NAME;
   std::vector<std::string> scripts
@@ -173,7 +173,7 @@ bool
 test_scriptsAreSourcedOrCalled( nix::ref<nix::EvalState> & state,
                                 flox::resolver::Lockfile & lockfile )
 {
-  auto output     = flox::buildenv::makeActivationScripts( *state, lockfile );
+  auto output     = flox::buildenv::makeActivationScripts( *state, lockfile.getLockfileRaw() );
   auto scriptsDir = std::filesystem::path( output.first.path )
                     / flox::buildenv::ACTIVATION_SUBDIR_NAME;
   std::vector<std::string> shells         = { "bash", "zsh" };


### PR DESCRIPTION
Refactoring a few calls in buildenv to limit scope within that functionality.  This is in preparation for the new lockfile schema.  I'd like to get this in as a small PR first.