### PR TITLE
feat: support loading and buildenv for v1 lockfiles

### DIFF
--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -338,9 +338,9 @@ getRealisedPackages( nix::ref<nix::EvalState> &         state,
  * @return `StorePath` to the environment.
  */
 nix::StorePath
-createFloxEnv( nix::ref<nix::EvalState> &    state,
-               const resolver::LockfileRaw & lockfile,
-               const System &                system );
+createFloxEnv( nix::ref<nix::EvalState> & state,
+               const nlohmann::json &     lockfile,
+               const System &             system );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/resolver/lockfile.hh
+++ b/pkgdb/include/flox/resolver/lockfile.hh
@@ -211,12 +211,8 @@ struct LockfileRaw
   unsigned                                   lockfileVersion = 0;
 
 
-  ~LockfileRaw() = default;
-  LockfileRaw()  = default;
-  LockfileRaw( const nlohmann::json & jfrom )
-  {
-    this->load_from_content( jfrom );
-  }
+  ~LockfileRaw()                     = default;
+  LockfileRaw()                      = default;
   LockfileRaw( const LockfileRaw & ) = default;
   // NOLINTNEXTLINE(bugprone-exception-escape)
   LockfileRaw( LockfileRaw && ) = default;

--- a/pkgdb/include/flox/resolver/lockfile.hh
+++ b/pkgdb/include/flox/resolver/lockfile.hh
@@ -237,6 +237,9 @@ struct LockfileRaw
   void
   clear();
 
+  void
+  from_v1_content( const nlohmann::json & jfrom );
+
 
 }; /* End struct `LockfileRaw' */
 

--- a/pkgdb/include/flox/resolver/lockfile.hh
+++ b/pkgdb/include/flox/resolver/lockfile.hh
@@ -211,8 +211,8 @@ struct LockfileRaw
   unsigned                                   lockfileVersion = 0;
 
 
-  ~LockfileRaw()                     = default;
-  LockfileRaw()                      = default;
+  ~LockfileRaw() = default;
+  LockfileRaw()  = default;
   LockfileRaw( const LockfileRaw & ) = default;
   // NOLINTNEXTLINE(bugprone-exception-escape)
   LockfileRaw( LockfileRaw && ) = default;

--- a/pkgdb/include/flox/resolver/lockfile.hh
+++ b/pkgdb/include/flox/resolver/lockfile.hh
@@ -211,8 +211,12 @@ struct LockfileRaw
   unsigned                                   lockfileVersion = 0;
 
 
-  ~LockfileRaw()                     = default;
-  LockfileRaw()                      = default;
+  ~LockfileRaw() = default;
+  LockfileRaw()  = default;
+  LockfileRaw( const nlohmann::json & jfrom )
+  {
+    this->load_from_content( jfrom );
+  }
   LockfileRaw( const LockfileRaw & ) = default;
   // NOLINTNEXTLINE(bugprone-exception-escape)
   LockfileRaw( LockfileRaw && ) = default;
@@ -236,6 +240,9 @@ struct LockfileRaw
   /** @brief Reset to default/empty state. */
   void
   clear();
+
+  void
+  load_from_content( const nlohmann::json & jfrom );
 
   void
   from_v1_content( const nlohmann::json & jfrom );

--- a/pkgdb/include/flox/resolver/lockfile.hh
+++ b/pkgdb/include/flox/resolver/lockfile.hh
@@ -237,9 +237,23 @@ struct LockfileRaw
   void
   clear();
 
+  /** @brief Loads a JSON object to @a flox::resolver::LockfileRaw
+   * dispatching by the `lockfile-version` field.
+   *
+   * V0 lockfile schema was owned by `pkgdb` and thus had the entire schema
+   * implemented and strongly typed, allowing it to be fully loaded using
+   * `from_json` helpers.  V1 lockfile schema is owned by the Rust side as
+   * we transistion to the catalog service.  Therefore much less needs to be
+   * be known in `pkgdb` and for the transistion it was easiest to extract
+   * the parts needed and move them into the existing data structures, allowing
+   * everything else to remain the same.
+   * */
   void
   load_from_content( const nlohmann::json & jfrom );
 
+  /** @brief Helper to convert a JSON object to a @a flox::resolver::LockfileRaw
+   * assuming the content is a V1 lockfile, coercing fields as needed.
+   * */
   void
   from_v1_content( const nlohmann::json & jfrom );
 

--- a/pkgdb/include/flox/resolver/lockfile.hh
+++ b/pkgdb/include/flox/resolver/lockfile.hh
@@ -211,8 +211,8 @@ struct LockfileRaw
   unsigned                                   lockfileVersion = 0;
 
 
-  ~LockfileRaw() = default;
-  LockfileRaw()  = default;
+  ~LockfileRaw()                     = default;
+  LockfileRaw()                      = default;
   LockfileRaw( const LockfileRaw & ) = default;
   // NOLINTNEXTLINE(bugprone-exception-escape)
   LockfileRaw( LockfileRaw && ) = default;

--- a/pkgdb/include/flox/resolver/manifest-raw.hh
+++ b/pkgdb/include/flox/resolver/manifest-raw.hh
@@ -289,6 +289,8 @@ struct HookRaw
 
 }; /* End struct `HookRaw' */
 
+void
+from_json( const nlohmann::json & jfrom, HookRaw & hook );
 
 /* -------------------------------------------------------------------------- */
 
@@ -305,6 +307,9 @@ struct ProfileScriptsRaw
   /** @brief A script intended to be sourced only in Zsh shells. */
   std::optional<std::string> zsh;
 };
+
+void
+from_json( const nlohmann::json & jfrom, ProfileScriptsRaw & profile );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -84,8 +84,8 @@ BuildEnvCommand::run()
 
   debugLog( "lockfile: " + this->lockfileContent.dump( 2 ) );
 
-  resolver::LockfileRaw lockfile = this->lockfileContent;
-  auto system   = this->system.value_or( nix::settings.thisSystem.get() );
+
+  auto system = this->system.value_or( nix::settings.thisSystem.get() );
 
   auto store = this->getStore();
   auto state = this->getState();
@@ -113,7 +113,7 @@ BuildEnvCommand::run()
 
   debugLog( "building environment" );
 
-  auto storePath = createFloxEnv( state, lockfile, system );
+  auto storePath = createFloxEnv( state, this->lockfileContent, system );
 
   debugLog( "built environment: " + store->printStorePath( storePath ) );
 

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -84,8 +84,7 @@ BuildEnvCommand::run()
 
   debugLog( "lockfile: " + this->lockfileContent.dump( 2 ) );
 
-  resolver::LockfileRaw lockfileRaw = this->lockfileContent;
-  auto lockfile = resolver::Lockfile( std::move( lockfileRaw ) );
+  resolver::LockfileRaw lockfile = this->lockfileContent;
   auto system   = this->system.value_or( nix::settings.thisSystem.get() );
 
   auto store = this->getStore();
@@ -114,7 +113,7 @@ BuildEnvCommand::run()
 
   debugLog( "building environment" );
 
-  auto storePath = createFloxEnv( state, lockfile.getLockfileRaw(), system );
+  auto storePath = createFloxEnv( state, lockfile, system );
 
   debugLog( "built environment: " + store->printStorePath( storePath ) );
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -1270,7 +1270,8 @@ createFloxEnv( nix::ref<nix::EvalState> & state,
                const nlohmann::json &     lockfileContent,
                const System &             system )
 {
-  resolver::LockfileRaw lockfile( lockfileContent );
+  resolver::LockfileRaw lockfile;
+  lockfile.load_from_content( lockfileContent );
 
   auto locked_packages = getLockedPackages( lockfile, system );
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -899,10 +899,9 @@ getRealisedPackages( nix::ref<nix::EvalState> &         state,
                      const resolver::LockedPackageRaw & lockedPackage,
                      const System &                     system )
 {
-  debugLog( nix::fmt( "getting cursor for %s",
-                      lockedPackage.attrPath[0] ) ) auto timeEvalStart
-    = std::chrono::high_resolution_clock::now();
-  auto cursor = evalCacheCursorForInput( state,
+  debugLog( nix::fmt( "getting cursor for %s", lockedPackage.attrPath[0] ) );
+  auto timeEvalStart = std::chrono::high_resolution_clock::now();
+  auto cursor        = evalCacheCursorForInput( state,
                                          lockedPackage.input,
                                          lockedPackage.attrPath );
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -1264,10 +1264,18 @@ makeProfileDScripts( nix::EvalState & state )
  * @return The store path of the environment.
  */
 nix::StorePath
-createFloxEnv( nix::ref<nix::EvalState> &    state,
-               const resolver::LockfileRaw & lockfile,
-               const System &                system )
+createFloxEnv( nix::ref<nix::EvalState> & state,
+               const nlohmann::json &     lockfileContent,
+               const System &             system )
 {
+  int version = lockfileContent["lockfile-version"];
+  infoLog( nix::fmt( "lockfile version %d", version ) );
+
+  resolver::LockfileRaw lockfile;
+  if ( version == 0 ) { lockfile = lockfileContent; }
+  else { lockfile.from_v1_content( lockfileContent ); }
+
+
   auto locked_packages = getLockedPackages( lockfile, system );
 
   /* Extract derivations */

--- a/pkgdb/src/resolver/lockfile.cc
+++ b/pkgdb/src/resolver/lockfile.cc
@@ -435,7 +435,9 @@ LockfileRaw::load_from_content( const nlohmann::json & jfrom )
 
   switch ( version )
     {
-      case 0: *this = jfrom; break;
+      // v0 can be de-serialized _naturally_ using the from_json helpers
+      case 0: jfrom.get_to( *this ); break;
+      // v1 needs to be coerced into the LockfileRaw structure
       case 1: this->from_v1_content( jfrom ); break;
       default:
         throw InvalidLockfileException( "unsupported lockfile version",
@@ -553,8 +555,9 @@ LockfileRaw::from_v1_content( const nlohmann::json & jfrom )
     }
   catch ( nlohmann::json::exception & err )
     {
-      throw InvalidLockfileException( "couldn't parse lockfile field 'packages'",
-                                      extract_json_errmsg( err ) );
+      throw InvalidLockfileException(
+        "couldn't parse lockfile field 'packages'",
+        extract_json_errmsg( err ) );
     }
 
   debugLog( nix::fmt( "loaded lockfile v1" ) );

--- a/pkgdb/src/resolver/lockfile.cc
+++ b/pkgdb/src/resolver/lockfile.cc
@@ -489,9 +489,12 @@ LockfileRaw::from_v1_content( const nlohmann::json & jfrom )
   debugLog( nix::fmt( "loading v1 lockfile content" ) );
 
   unsigned version = jfrom["lockfile-version"];
-  if (version != 1)
+  if ( version != 1 )
+    {
       throw InvalidLockfileException(
-        nix::fmt("trying to parse v%d lockfile as v1", version), "");
+        nix::fmt( "trying to parse v%d lockfile", version ),
+        "expected v1" );
+    }
 
   // Set the version
   this->lockfileVersion = version;
@@ -513,7 +516,7 @@ LockfileRaw::from_v1_content( const nlohmann::json & jfrom )
   try
     {
       auto hook = jfrom["manifest"]["hook"];
-      hook.get_to(this->manifest.hook);
+      hook.get_to( this->manifest.hook );
     }
   catch ( nlohmann::json::exception & err )
     {
@@ -526,7 +529,7 @@ LockfileRaw::from_v1_content( const nlohmann::json & jfrom )
   try
     {
       auto hook = jfrom["manifest"]["profile"];
-      hook.get_to(this->manifest.profile);
+      hook.get_to( this->manifest.profile );
     }
   catch ( nlohmann::json::exception & err )
     {

--- a/pkgdb/src/resolver/lockfile.cc
+++ b/pkgdb/src/resolver/lockfile.cc
@@ -461,7 +461,7 @@ lockedPackageFromCatalogDescriptor( const nlohmann::json & jfrom,
   pkg.input.url   = jfrom["locked_url"];
   pkg.input.attrs = nix::fetchers::Attrs();
   // These attributes are needed by the current builder, and not included in the
-  // descriptor This will not always be true, but also may not be required to
+  // descriptor. This will not always be true, but also may not be required to
   // build depending on the path taken for future environment builds.
   if ( std::string supportedUrl = "github:NixOS/nixpkgs";
        pkg.input.url.substr( 0, supportedUrl.size() ) != supportedUrl )
@@ -480,8 +480,6 @@ lockedPackageFromCatalogDescriptor( const nlohmann::json & jfrom,
       pkg.input.attrs["rev"] = pkg.input.url.substr( found + 1 );
     }
 }
-
-// void load_optional_string
 
 void
 LockfileRaw::from_v1_content( const nlohmann::json & jfrom )
@@ -555,7 +553,7 @@ LockfileRaw::from_v1_content( const nlohmann::json & jfrom )
     }
   catch ( nlohmann::json::exception & err )
     {
-      throw InvalidLockfileException( "couldn't parse lockfile field 'groups'",
+      throw InvalidLockfileException( "couldn't parse lockfile field 'packages'",
                                       extract_json_errmsg( err ) );
     }
 

--- a/pkgdb/src/resolver/manifest-raw.cc
+++ b/pkgdb/src/resolver/manifest-raw.cc
@@ -464,7 +464,7 @@ to_json( nlohmann::json & jto, const EnvBaseRaw & env )
 
 /* -------------------------------------------------------------------------- */
 
-static void
+void
 from_json( const nlohmann::json & jfrom, ProfileScriptsRaw & profile )
 {
   assertIsJSONObject<InvalidManifestFileException>(
@@ -539,7 +539,7 @@ to_json( nlohmann::json & jto, const ProfileScriptsRaw & profile )
 
 /* -------------------------------------------------------------------------- */
 
-static void
+void
 from_json( const nlohmann::json & jfrom, HookRaw & hook )
 {
   assertIsJSONObject<InvalidManifestFileException>( jfrom,

--- a/pkgdb/tests/lockfile.cc
+++ b/pkgdb/tests/lockfile.cc
@@ -9,6 +9,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "flox/core/util.hh"
 #include "flox/resolver/lockfile.hh"
 #include "test.hh"
 
@@ -16,6 +17,79 @@
 /* -------------------------------------------------------------------------- */
 
 using namespace nlohmann::literals;
+
+
+static const std::string lockfileContentV1 = R"( {
+  "lockfile-version": 1,
+  "manifest": {
+    "hook": {
+      "on-activate": "my_onactivate"
+    },
+    "install": {
+      "hello": {
+        "optional": false,
+        "package-group": "group",
+        "pkg-path": "hello",
+        "priority": null,
+        "systems": null,
+        "version": null
+      }
+    },
+    "options": {
+      "allows": {
+        "broken": null,
+        "licenses": [],
+        "unfree": null
+      },
+      "semver": {
+        "prefer_pre_releases": null
+      },
+      "systems": [
+        "system"
+      ]
+    },
+    "profile": {
+      "bash": "profile.bash",
+      "common": "profile.common",
+      "zsh": "profile.zsh"
+    },
+    "vars": {"TEST": "VAR"},
+    "version": 1
+  },
+  "packages": [
+    {
+      "install_id": "mycowsay",
+      "group": "mygroupname",
+      "priority": 1,
+      "optional": false,
+      "attr_path": "cowsay",
+      "broken": false,
+      "derivation": "derivation",
+      "description": "description",
+      "license": "license",
+      "locked_url": "github:NixOS/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3",
+      "name": "hello",
+      "outputs": {
+        "name": "store_path"
+      },
+      "outputs_to_install": [
+        "name"
+      ],
+      "pname": "pname",
+      "rev": "rev",
+      "rev_count": 1,
+      "rev_date": "2021-08-31T00:00:00Z",
+      "scrape_date": "2021-08-31T00:00:00Z",
+      "stabilities": [
+        "stability"
+      ],
+      "system": "x86_64-linux",
+      "unfree": false,
+      "version": "version"
+    }
+  ]
+} )";
+
 
 
 /* -------------------------------------------------------------------------- */
@@ -56,6 +130,42 @@ test_LockedPackageRawFromJSON0()
   return true;
 }
 
+bool
+test_LockfileFromV1()
+{
+  using namespace flox::resolver;
+  nlohmann::json json = flox::parseOrReadJSONObject(lockfileContentV1);
+  LockfileRaw lockfile = LockfileRaw();
+  lockfile.load_from_content(json);
+  EXPECT(lockfile.lockfileVersion == 1);
+  EXPECT(lockfile.manifest.hook.has_value());
+  EXPECT_EQ(lockfile.manifest.hook.value().onActivate.value_or(""), "my_onactivate");
+
+  EXPECT(lockfile.manifest.profile.has_value());
+  EXPECT_EQ(lockfile.manifest.profile.value().common.value(), "profile.common");
+  EXPECT_EQ(lockfile.manifest.profile.value().bash.value(), "profile.bash");
+  EXPECT_EQ(lockfile.manifest.profile.value().zsh.value(), "profile.zsh");
+  
+  EXPECT(lockfile.manifest.vars.has_value());
+  EXPECT(lockfile.manifest.vars.value().size() == 1);
+  EXPECT_EQ(lockfile.manifest.vars.value()["TEST"], "VAR");
+
+  auto packages = lockfile.packages.at("x86_64-linux"); 
+  EXPECT(packages.size() == 1);
+
+  auto pkg = packages["mycowsay"];
+  // The attr path is pre-pended for compatibility reasons
+  flox::AttrPath attrPath = {"legacyPackages", "x86_64-linux", "cowsay"};
+  EXPECT( pkg.value().attrPath == attrPath );
+
+  EXPECT_EQ(pkg.value().input.url, "github:NixOS/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3");
+  EXPECT_EQ(pkg.value().input.attrs["rev"], "9a333eaa80901efe01df07eade2c16d183761fa3");
+  // These are assumed from v1
+  EXPECT_EQ(pkg.value().input.attrs["owner"], "NixOS");
+  EXPECT_EQ(pkg.value().input.attrs["type"], "github");
+  EXPECT_EQ(pkg.value().input.attrs["repo"], "nixpkgs");
+  return true;
+}
 
 /* -------------------------------------------------------------------------- */
 
@@ -69,6 +179,8 @@ main()
   RUN_TEST( LockedInputRawFromJSON0 );
 
   RUN_TEST( LockedPackageRawFromJSON0 );
+
+  RUN_TEST( LockfileFromV1 );
 
   return exitCode;
 }

--- a/pkgdb/tests/lockfile.cc
+++ b/pkgdb/tests/lockfile.cc
@@ -91,7 +91,6 @@ static const std::string lockfileContentV1 = R"( {
 } )";
 
 
-
 /* -------------------------------------------------------------------------- */
 
 bool
@@ -134,36 +133,40 @@ bool
 test_LockfileFromV1()
 {
   using namespace flox::resolver;
-  nlohmann::json json = flox::parseOrReadJSONObject(lockfileContentV1);
-  LockfileRaw lockfile = LockfileRaw();
-  lockfile.load_from_content(json);
-  EXPECT(lockfile.lockfileVersion == 1);
-  EXPECT(lockfile.manifest.hook.has_value());
-  EXPECT_EQ(lockfile.manifest.hook.value().onActivate.value_or(""), "my_onactivate");
+  nlohmann::json json     = flox::parseOrReadJSONObject( lockfileContentV1 );
+  LockfileRaw    lockfile = LockfileRaw();
+  lockfile.load_from_content( json );
+  EXPECT( lockfile.lockfileVersion == 1 );
+  EXPECT( lockfile.manifest.hook.has_value() );
+  EXPECT_EQ( lockfile.manifest.hook.value().onActivate.value_or( "" ),
+             "my_onactivate" );
 
-  EXPECT(lockfile.manifest.profile.has_value());
-  EXPECT_EQ(lockfile.manifest.profile.value().common.value(), "profile.common");
-  EXPECT_EQ(lockfile.manifest.profile.value().bash.value(), "profile.bash");
-  EXPECT_EQ(lockfile.manifest.profile.value().zsh.value(), "profile.zsh");
-  
-  EXPECT(lockfile.manifest.vars.has_value());
-  EXPECT(lockfile.manifest.vars.value().size() == 1);
-  EXPECT_EQ(lockfile.manifest.vars.value()["TEST"], "VAR");
+  EXPECT( lockfile.manifest.profile.has_value() );
+  EXPECT_EQ( lockfile.manifest.profile.value().common.value(),
+             "profile.common" );
+  EXPECT_EQ( lockfile.manifest.profile.value().bash.value(), "profile.bash" );
+  EXPECT_EQ( lockfile.manifest.profile.value().zsh.value(), "profile.zsh" );
 
-  auto packages = lockfile.packages.at("x86_64-linux"); 
-  EXPECT(packages.size() == 1);
+  EXPECT( lockfile.manifest.vars.has_value() );
+  EXPECT( lockfile.manifest.vars.value().size() == 1 );
+  EXPECT_EQ( lockfile.manifest.vars.value()["TEST"], "VAR" );
+
+  auto packages = lockfile.packages.at( "x86_64-linux" );
+  EXPECT( packages.size() == 1 );
 
   auto pkg = packages["mycowsay"];
   // The attr path is pre-pended for compatibility reasons
-  flox::AttrPath attrPath = {"legacyPackages", "x86_64-linux", "cowsay"};
+  flox::AttrPath attrPath = { "legacyPackages", "x86_64-linux", "cowsay" };
   EXPECT( pkg.value().attrPath == attrPath );
 
-  EXPECT_EQ(pkg.value().input.url, "github:NixOS/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3");
-  EXPECT_EQ(pkg.value().input.attrs["rev"], "9a333eaa80901efe01df07eade2c16d183761fa3");
+  EXPECT_EQ( pkg.value().input.url,
+             "github:NixOS/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3" );
+  EXPECT_EQ( pkg.value().input.attrs["rev"],
+             "9a333eaa80901efe01df07eade2c16d183761fa3" );
   // These are assumed from v1
-  EXPECT_EQ(pkg.value().input.attrs["owner"], "NixOS");
-  EXPECT_EQ(pkg.value().input.attrs["type"], "github");
-  EXPECT_EQ(pkg.value().input.attrs["repo"], "nixpkgs");
+  EXPECT_EQ( pkg.value().input.attrs["owner"], "NixOS" );
+  EXPECT_EQ( pkg.value().input.attrs["type"], "github" );
+  EXPECT_EQ( pkg.value().input.attrs["repo"], "nixpkgs" );
   return true;
 }
 


### PR DESCRIPTION
## Proposed Changes

- Added support for loading v1 lockfiles into the existing data structures without implementing a full schema de-serialization
- Made some assertions about the kind of inputs we'll allow in v1 lockfiles for the time being
- Added a basic unit test for correct parsing of v1 content into existing data structures

This is based on the assumption that `install_id`, `optional`, `priority`, and `system` are present in v1 lockfile schema as per our discussion.  Note that `optional` is not currently used it seems.

