### PR TITLE
docs(pkgdb): Quote package group in upgrade error

### DIFF
--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -144,7 +144,7 @@ EOF
 
   run "$FLOX_BIN" upgrade hello
   assert_failure
-  assert_output --partial "package in a group with multiple packages"
+  assert_output --partial "package in the group 'toplevel' with multiple packages"
 }
 
 @test "check confirmation when all packages are up to date" {

--- a/pkgdb/src/resolver/command.cc
+++ b/pkgdb/src/resolver/command.cc
@@ -282,14 +282,16 @@ UpgradeCommand::run()
                 }
               else
                 {
-                  throw FloxException( nix::fmt(
-                    "'%s' is a package in a group with multiple packages.\n"
-                    "To upgrade the group, specify the group name:\n"
-                    "     $ flox upgrade %s\n"
-                    "To upgrade all packages, run:\n"
-                    "     $ flox upgrade",
-                    groupOrIID,
-                    groupName ) );
+                  throw FloxException(
+                    nix::fmt( "'%s' is a package in the group '%s' with "
+                              "multiple packages.\n"
+                              "To upgrade the group, specify the group name:\n"
+                              "     $ flox upgrade %s\n"
+                              "To upgrade all packages, run:\n"
+                              "     $ flox upgrade",
+                              groupOrIID,
+                              groupName,
+                              groupName ) );
                 }
             }
           else


### PR DESCRIPTION
## Proposed Changes

To make it clearer, in cases where the package doesn't belong to an explicit package group, that `toplevel` has a special meaning as the default group:

- https://flox.dev/docs/reference/command-reference/manifest.toml/#package-descriptors

My first interpretation of the error was that `toplevel` was an example rather than a reserved word.

Reformatting was applied automatically by `clang-format` to satisfy the pre-commit hook.

## Release Notes

N/A