### PR TITLE
fix: a few lockfile discrepancies

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -157,8 +157,6 @@ pub struct ManifestProfile {
     bash: Option<String>,
     /// When defined, this hook is run upon activation in a zsh shell
     zsh: Option<String>,
-    /// When defined, this hook is run upon activation in a fish shell
-    fish: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
@@ -170,7 +168,7 @@ pub struct ManifestOptions {
     pub(super) systems: Vec<System>,
     /// Options that control what types of packages are allowed.
     #[serde(default)]
-    allows: Allows,
+    allow: Allows,
     /// Options that control how semver versions are resolved.
     #[serde(default)]
     semver: SemverOptions,
@@ -190,6 +188,7 @@ pub struct Allows {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+#[serde(rename_all = "kebab-case")]
 pub struct SemverOptions {
     /// Whether to prefer pre-release versions when resolving
     #[serde(default)]

--- a/pkgdb/include/flox/resolver/manifest-raw.hh
+++ b/pkgdb/include/flox/resolver/manifest-raw.hh
@@ -216,7 +216,20 @@ struct GlobalManifestRaw
 
   explicit operator GlobalManifestRawGA() const;
 
-
+  /**
+   * @brief Get the list of systems requested by the manifest.
+   *
+   * Default to the current system if systems is not specified.
+   */
+  [[nodiscard]] std::vector<System>
+  getSystems() const
+  {
+    if ( this->options.has_value() && this->options->systems.has_value() )
+      {
+        return *this->options->systems;
+      }
+    return std::vector<System> { nix::settings.thisSystem.get() };
+  }
 }; /* End struct `GlobalManifestRaw' */
 
 
@@ -488,6 +501,21 @@ struct GlobalManifestRawGA
     return ManifestRaw( static_cast<GlobalManifestRaw>( *this ) );
   }
 
+  /**
+   * @brief Get the list of systems requested by the manifest.
+   *
+   * Default to the current system if systems is not specified.
+   * TODO: deduplicate this with `GlobalManifestRaw::getSystems()` or drop.
+   */
+  [[nodiscard]] std::vector<System>
+  getSystems() const
+  {
+    if ( this->options.has_value() && this->options->systems.has_value() )
+      {
+        return *this->options->systems;
+      }
+    return std::vector<System> { nix::settings.thisSystem.get() };
+  }
 
 }; /* End struct `GlobalManifestRawGA' */
 

--- a/pkgdb/include/flox/resolver/manifest.hh
+++ b/pkgdb/include/flox/resolver/manifest.hh
@@ -174,12 +174,7 @@ public:
   [[nodiscard]] std::vector<System>
   getSystems() const
   {
-    const auto & manifest = this->getManifestRaw();
-    if ( manifest.options.has_value() && manifest.options->systems.has_value() )
-      {
-        return *manifest.options->systems;
-      }
-    return std::vector<System> { nix::settings.thisSystem.get() };
+    return this->getManifestRaw().getSystems();
   }
 
   [[nodiscard]] pkgdb::PkgQueryArgs

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -561,11 +561,9 @@ static std::vector<std::pair<std::string, resolver::LockedPackageRaw>>
 getLockedPackages( const resolver::LockfileRaw & lockfile,
                    const System &                system )
 {
-  traceLog( "getting locked packages" );
-  auto packages = lockfile.packages.find( system );
-  if ( packages == lockfile.packages.end() )
+  auto systems = lockfile.manifest.getSystems();
+  if ( std::find( systems.begin(), systems.end(), system ) == systems.end() )
     {
-      // Custom exception for non supported system
       throw SystemNotSupportedByLockfile(
         "'" + system + "' not supported by this environment" );
     }
@@ -573,6 +571,11 @@ getLockedPackages( const resolver::LockfileRaw & lockfile,
   /* Extract all packages */
   std::vector<std::pair<std::string, resolver::LockedPackageRaw>>
     locked_packages;
+
+  traceLog( "getting locked packages" );
+  auto packages = lockfile.packages.find( system );
+  /* The lockfile may not have any packages for this system */
+  if ( packages == lockfile.packages.end() ) { return locked_packages; }
 
   for ( auto const & package : packages->second )
     {

--- a/pkgdb/src/resolver/lockfile.cc
+++ b/pkgdb/src/resolver/lockfile.cc
@@ -560,6 +560,19 @@ LockfileRaw::from_v1_content( const nlohmann::json & jfrom )
         extract_json_errmsg( err ) );
     }
 
+  // load options
+  try
+    {
+      auto options = jfrom["manifest"]["options"];
+      options.get_to( this->manifest.options );
+    }
+  catch ( nlohmann::json::exception & err )
+    {
+      throw InvalidLockfileException(
+        "couldn't parse lockfile field 'manifest.options'",
+        extract_json_errmsg( err ) );
+    }
+
   debugLog( nix::fmt( "loaded lockfile v1" ) );
 }
 

--- a/pkgdb/tests/lockfile.cc
+++ b/pkgdb/tests/lockfile.cc
@@ -36,7 +36,7 @@ static const std::string lockfileContentV1 = R"( {
       }
     },
     "options": {
-      "allows": {
+      "allow": {
         "broken": null,
         "licenses": [],
         "unfree": null

--- a/pkgdb/tests/lockfile.cc
+++ b/pkgdb/tests/lockfile.cc
@@ -42,7 +42,7 @@ static const std::string lockfileContentV1 = R"( {
         "unfree": null
       },
       "semver": {
-        "prefer_pre_releases": null
+        "prefer-pre-releases": null
       },
       "systems": [
         "system"


### PR DESCRIPTION
The CLI and pkgdb have a few minor differences in how they treat lockfiles. Fix by:

- Using `allow` consistently (not `allows`)
- Dropping `profile.fish` since it's not present in pkgdb yet
- Using kebab-case
- Using `options.systems` to determine if a manifest.lock supports a system rather than packages. Current catalog locking code doesn't set empty packages for each system.
- Loading options when loading a LockfileRaw from v1 content