### PR TITLE
Fix manual runs of pkgdb lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
               \)                                      \
               -print > targets;
           else
-            git fetch origin '${{ github.base_ref }}';
+            git fetch origin main;
             echo "Checking changed sources" >&2;
             ./pkgdb/build-aux/changed-sources.sh > targets;
           fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,16 +52,18 @@ jobs:
             echo "Checking all sources" >&2;
             # Keep this list aligned with `build-aux/changed-sources'
             find pkgdb/include pkgdb/src pkgdb/tests  \
-                 -name '*.cpp' -o                     \
-                 -name '*.hpp' -o                     \
-                 -name '*.hxx' -o                     \
-                 -name '*.cxx' -o                     \
-                 -name '*.cc'  -o                     \
-                 -name '*.hh'  -o                     \
-                 -name '*.c'   -o                     \
-                 -name '*.h'   -o                     \
-                 -name '*.ipp'                        \
-                 -print > targets;
+              \(                                      \
+                -name '*.cpp' -o                      \
+                -name '*.hpp' -o                      \
+                -name '*.hxx' -o                      \
+                -name '*.cxx' -o                      \
+                -name '*.cc'  -o                      \
+                -name '*.hh'  -o                      \
+                -name '*.c'   -o                      \
+                -name '*.h'   -o                      \
+                -name '*.ipp'                         \
+              \)                                      \
+              -print > targets;
           else
             git fetch origin '${{ github.base_ref }}';
             echo "Checking changed sources" >&2;


### PR DESCRIPTION
## Proposed Changes

Fix two issues that prevented the pkgdb lint workflow being run manually.

The individual commits contain more information about the issues and fixes.

## Release Notes

N/A