### PR TITLE
fix: repair setting of ZDOTDIR following 1299

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -390,10 +390,7 @@ impl Activate {
                     command.env("FLOX_ORIG_ZDOTDIR", zdotdir);
                 }
                 command
-                    .env(
-                        "ZDOTDIR",
-                        activation_path.join("activate.d").join("zdotdir"),
-                    )
+                    .env("ZDOTDIR", env!("FLOX_ZDOTDIR"))
                     .env(
                         "FLOX_ZSH_INIT_SCRIPT",
                         activation_path.join("activate").join("zsh"),

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -60,6 +60,7 @@
         if flox-pkgdb == null
         then "ld-floxlib.so"
         else "${flox-pkgdb}/lib/ld-floxlib.so";
+      FLOX_ZDOTDIR = ../../pkgdb/src/buildenv/assets/activate.d/zdotdir;
 
       # bundling of internally used nix scripts
       FLOX_RESOLVER_SRC = builtins.path {path = ../../resolver;};


### PR DESCRIPTION
PR1299 changed the top-level "activate" path from a directory containing scripts to a script to be invoked, and with that we changed the "zdotdir" from an entirely separate package to instead reside within the "activate.d" directory found in the environment itself.

This was fine for environments rendered with the new activation logic, but obviously broke for old environment renderings which lacked this directory.

## Proposed Changes

This patch updates the build and code to render and use a standalone zdotdir package just as it did previously.

## Release Notes

N/A