### PR TITLE
chore: bump schema

### DIFF
--- a/cli/catalog-api-v1/openapi.json
+++ b/cli/catalog-api-v1/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Flox Catalog Service",
     "description": "\n# Flox Catalog Service API\n\nTBD\n\n*Markdown is available here*\n",
-    "version": "v0.1.dev129+g9e3c6c6.d19800101",
+    "version": "v0.1.dev134+gd1854a6.d19800101",
     "x-logo": {
       "url": "https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png"
     }
@@ -41,14 +41,10 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                }
-              ],
               "default": "nixpkgs",
               "title": "Catalogs",
-              "nullable": true
+              "nullable": true,
+              "type": "string"
             }
           },
           {
@@ -96,22 +92,22 @@
         }
       }
     },
-    "/api/v1/catalog/packages/{pkgPath}": {
+    "/api/v1/catalog/packages/{attr_path}": {
       "get": {
         "tags": [
           "catalog"
         ],
         "summary": "Shows avaliable packages of a specfic package",
-        "description": "Returns a list of versions for a given pkg-path\n\nRequired Query Parameters:\n- **pkgPath**: The pkg-path, must be valid.\n\nOptional Query Parameters:\n- **page**: Optional page number for pagination (def = 0)\n- **pageSize**: Optional page size for pagination (def = 10)\n\nReturns:\n- **PackageSearchResult**: A list of PackageInfo and the total result count",
-        "operationId": "packages_api_v1_catalog_packages__pkgPath__get",
+        "description": "Returns a list of versions for a given attr_path\n\nRequired Query Parameters:\n- **attr_path**: The attr_path, must be valid.\n\nOptional Query Parameters:\n- **page**: Optional page number for pagination (def = 0)\n- **pageSize**: Optional page size for pagination (def = 10)\n\nReturns:\n- **PackageSearchResult**: A list of PackageInfo and the total result count",
+        "operationId": "packages_api_v1_catalog_packages__attr_path__get",
         "parameters": [
           {
-            "name": "pkgPath",
+            "name": "attr_path",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Pkgpath"
+              "title": "Attr Path"
             }
           },
           {
@@ -137,7 +133,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A list of packages for pkgpath",
+            "description": "A list of packages attr_path",
             "content": {
               "application/json": {
                 "schema": {
@@ -147,7 +143,7 @@
             }
           },
           "404": {
-            "description": "pkgPath was not found.",
+            "description": "attr_path was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -175,7 +171,7 @@
           "catalog"
         ],
         "summary": "Resolve a list of Package Groups",
-        "description": "Resolves a list of package groups, each being a list of package descriptors.\n\nRequired Body:\n- **groups**: An object with an `items` array of PackageGroups to resolve.\n\nOptional Query Parameters:\n- **none**\n\nReturns:\n- **ResolvedPackageGroups**: A object with an `items` array of\n    `ResolvedPackageGroup` items.\n\nResolution Rules:\n- Each `PackageGroup` is resolved independently.\n- Each page that has a package that meets each of the descriptors in that group is returned in the results\n- The latest page will include details for each package in the group from that page\n- The remainder pages are returned without details (to get those details... TBD)\n\nA Package Descriptor match:\n- **name**: [required] - is not used in matching, only for reference (TBD is\n            there a uniqueness constraint?)\n- **pkgPath**: [required] - this must match the nix attribute path exactly and in full\n- **semver**: [optional] - This can be any valid semver range, and if given\n    will attempt to parse the nix `version` field.  If it can and it is\n    within the range, this check passes.  If it cannot parse `version` as a\n    valid semver, or it is not within the range, it is exluded.\n    - **allow-pre-release**: [optional] - Defaults to False.  Only applies\n        when a **semver** constraint is given.  If true, a `version` that can\n        be parsed as a valid semver, that includes a pre-release suffix will\n        be included as a candidate.  Otherwise, they will be excluded.\n- **version**: [optional] - If given, this must match the nix `version`\n    field precisely. This overrides **semver** matching if provided.",
+        "description": "Resolves a list of package groups, each being a list of package descriptors.\n\nRequired Body:\n- **groups**: An object with an `items` array of PackageGroups to resolve.\n\nOptional Query Parameters:\n- **none**\n\nReturns:\n- **ResolvedPackageGroups**: A object with an `items` array of\n    `ResolvedPackageGroup` items.\n\nResolution Rules:\n- Each `PackageGroup` is resolved independently.\n- Each page that has a package that meets each of the descriptors in that group is returned in the results\n- The latest page will include details for each package in the group from that page\n- The remainder pages are returned without details (to get those details... TBD)\n\nA Package Descriptor match:\n- **name**: [required] - is not used in matching, only for reference (TBD is\n            there a uniqueness constraint?)\n- **attr_path**: [required] - this must match the nix attribute path exactly and in full\n- **version**: [optional] - Either a literal version to match or a **semver** constraint.\n    This will be treated as a **semver** IFF TBD, otherwise it will be treated as\n    a literal string match to the nix `version` field.  If this is detected as a **semver**,\n    packages whose `version` field cannot be parsed as a **semver** will be excluded.\n    - **allow_pre_release**: [optional] - Defaults to False.  Only applies\n        when a **semver** constraint is given.  If true, a `version` that can\n        be parsed as a valid semver, that includes a pre-release suffix will\n        be included as a candidate.  Otherwise, they will be excluded.",
         "operationId": "resolve_api_v1_catalog_resolve_post",
         "requestBody": {
           "content": {
@@ -257,16 +253,12 @@
             "title": "Url"
           },
           "packages": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/PackageResolutionInfo"
-                },
-                "type": "array"
-              }
-            ],
             "title": "Packages",
-            "nullable": true
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ResolvedPackageDescriptor"
+            },
+            "type": "array"
           }
         },
         "type": "object",
@@ -276,13 +268,13 @@
         ],
         "title": "CatalogPage",
         "example": {
+          "attr_path": "foo.bar.curl",
           "description": "A very nice Item",
           "license": "foo",
           "locked_url": "git:git?rev=xyz",
           "name": "curl",
           "outputs": "{}",
           "outputs_to_install": "{}",
-          "pkg_path": "foo.bar.curl",
           "pname": "curl",
           "rev": "xyz",
           "rev_count": 4,
@@ -307,16 +299,12 @@
             "title": "Url"
           },
           "packages": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/PackageResolutionInfo"
-                },
-                "type": "array"
-              }
-            ],
             "title": "Packages",
-            "nullable": true
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ResolvedPackageDescriptor"
+            },
+            "type": "array"
           }
         },
         "type": "object",
@@ -326,13 +314,13 @@
         ],
         "title": "CatalogPage",
         "example": {
+          "attr_path": "foo.bar.curl",
           "description": "A very nice Item",
           "license": "foo",
           "locked_url": "git:git?rev=xyz",
           "name": "curl",
           "outputs": "{}",
           "outputs_to_install": "{}",
-          "pkg_path": "foo.bar.curl",
           "pname": "curl",
           "rev": "xyz",
           "rev_count": 4,
@@ -409,10 +397,6 @@
       },
       "ErrorResponse": {
         "properties": {
-          "status_code": {
-            "type": "integer",
-            "title": "Status Code"
-          },
           "detail": {
             "type": "string",
             "title": "Detail"
@@ -420,7 +404,6 @@
         },
         "type": "object",
         "required": [
-          "status_code",
           "detail"
         ],
         "title": "ErrorResponse"
@@ -445,51 +428,40 @@
       },
       "PackageDescriptor": {
         "properties": {
-          "name": {
+          "install_id": {
             "type": "string",
-            "title": "Name"
+            "title": "Install Id"
           },
-          "pkgPath": {
+          "attr_path": {
             "type": "string",
-            "title": "Pkgpath"
-          },
-          "semver": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
-            "title": "Semver",
-            "nullable": true
+            "title": "Attr Path"
           },
           "version": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
             "title": "Version",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
+          },
+          "allow_pre_releases": {
+            "title": "Allow Pre Releases",
+            "default": false,
+            "nullable": true,
+            "type": "boolean"
           },
           "derivation": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
             "title": "Derivation",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object",
         "required": [
-          "name",
-          "pkgPath"
+          "install_id",
+          "attr_path"
         ],
         "title": "PackageDescriptor",
         "example": {
-          "name": "curl",
-          "pkgPath": "curl"
+          "attr_path": "curl",
+          "install_id": "curl"
         }
       },
       "PackageGroup": {
@@ -502,13 +474,9 @@
             "$ref": "#/components/schemas/SystemEnum"
           },
           "stability": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
             "title": "Stability",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "descriptors": {
             "items": {
@@ -528,16 +496,16 @@
         "example": {
           "descriptors": [
             {
-              "name": "curl",
-              "pkgPath": "curl"
+              "attr_path": "curl",
+              "install_id": "curl"
             },
             {
-              "name": "slack",
-              "pkgPath": "slack"
+              "attr_path": "slack",
+              "install_id": "slack"
             },
             {
-              "name": "xeyes",
-              "pkgPath": "xorg.xeyes"
+              "attr_path": "xorg.xeyes",
+              "install_id": "xeyes"
             }
           ],
           "name": "test",
@@ -564,16 +532,16 @@
             {
               "descriptors": [
                 {
-                  "name": "curl",
-                  "pkgPath": "curl"
+                  "attr_path": "curl",
+                  "install_id": "curl"
                 },
                 {
-                  "name": "slack",
-                  "pkgPath": "slack"
+                  "attr_path": "slack",
+                  "install_id": "slack"
                 },
                 {
-                  "name": "xeyes",
-                  "pkgPath": "xorg.xeyes"
+                  "attr_path": "xorg.xeyes",
+                  "install_id": "xeyes"
                 }
               ],
               "name": "test",
@@ -601,46 +569,30 @@
             "title": "Version"
           },
           "outputs": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/Output"
-                },
-                "type": "array"
-              }
-            ],
             "title": "Outputs",
-            "nullable": true
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            },
+            "type": "array"
           },
           "outputs_to_install": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ],
             "title": "Outputs To Install",
-            "nullable": true
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
             "title": "Description",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "license": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
             "title": "License",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "rev": {
             "type": "string",
@@ -689,13 +641,13 @@
         ],
         "title": "PackageInfoAPI",
         "example": {
+          "attr_path": "foo.bar.curl",
           "description": "A very nice Item",
           "license": "foo",
           "locked_url": "git:git?rev=xyz",
           "name": "curl",
           "outputs": "{}",
           "outputs_to_install": "{}",
-          "pkg_path": "foo.bar.curl",
           "pname": "curl",
           "rev": "xyz",
           "rev_count": 4,
@@ -728,46 +680,30 @@
             "title": "Version"
           },
           "outputs": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/Output"
-                },
-                "type": "array"
-              }
-            ],
             "title": "Outputs",
-            "nullable": true
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            },
+            "type": "array"
           },
           "outputs_to_install": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ],
             "title": "Outputs To Install",
-            "nullable": true
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
             "title": "Description",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "license": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
             "title": "License",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "rev": {
             "type": "string",
@@ -803,140 +739,6 @@
         ],
         "title": "PackageInfoCommon"
       },
-      "PackageResolutionInfo": {
-        "properties": {
-          "attr_path": {
-            "type": "string",
-            "title": "Attr Path"
-          },
-          "derivation": {
-            "type": "string",
-            "title": "Derivation"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "pname": {
-            "type": "string",
-            "title": "Pname"
-          },
-          "version": {
-            "type": "string",
-            "title": "Version"
-          },
-          "outputs": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/Output"
-                },
-                "type": "array"
-              }
-            ],
-            "title": "Outputs",
-            "nullable": true
-          },
-          "outputs_to_install": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ],
-            "title": "Outputs To Install",
-            "nullable": true
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
-            "title": "Description",
-            "nullable": true
-          },
-          "license": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
-            "title": "License",
-            "nullable": true
-          },
-          "locked_url": {
-            "type": "string",
-            "title": "Locked Url"
-          },
-          "rev": {
-            "type": "string",
-            "title": "Rev"
-          },
-          "rev_count": {
-            "type": "integer",
-            "title": "Rev Count"
-          },
-          "rev_date": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Rev Date"
-          },
-          "broken": {
-            "type": "boolean",
-            "title": "Broken"
-          },
-          "unfree": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              }
-            ],
-            "title": "Unfree",
-            "nullable": true
-          },
-          "stabilities": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ],
-            "title": "Stabilities",
-            "nullable": true
-          },
-          "scrape_date": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Scrape Date"
-          }
-        },
-        "type": "object",
-        "required": [
-          "attr_path",
-          "derivation",
-          "name",
-          "pname",
-          "version",
-          "outputs",
-          "outputs_to_install",
-          "description",
-          "license",
-          "locked_url",
-          "rev",
-          "rev_count",
-          "rev_date",
-          "broken",
-          "unfree",
-          "stabilities",
-          "scrape_date"
-        ],
-        "title": "PackageResolutionInfo"
-      },
       "PackageSearchResult-Input": {
         "properties": {
           "items": {
@@ -959,13 +761,13 @@
         "title": "PackageSearchResult",
         "example": [
           {
+            "attr_path": "foo.bar.curl",
             "description": "A very nice Item",
             "license": "foo",
             "locked_url": "git:git?rev=xyz",
             "name": "curl",
             "outputs": "{}",
             "outputs_to_install": "{}",
-            "pkg_path": "foo.bar.curl",
             "pname": "curl",
             "rev": "xyz",
             "rev_count": 4,
@@ -1002,13 +804,13 @@
         "title": "PackageSearchResult",
         "example": [
           {
+            "attr_path": "foo.bar.curl",
             "description": "A very nice Item",
             "license": "foo",
             "locked_url": "git:git?rev=xyz",
             "name": "curl",
             "outputs": "{}",
             "outputs_to_install": "{}",
-            "pkg_path": "foo.bar.curl",
             "pname": "curl",
             "rev": "xyz",
             "rev_count": 4,
@@ -1065,6 +867,121 @@
         ],
         "title": "PackagesResult"
       },
+      "ResolvedPackageDescriptor": {
+        "properties": {
+          "attr_path": {
+            "type": "string",
+            "title": "Attr Path"
+          },
+          "derivation": {
+            "type": "string",
+            "title": "Derivation"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "pname": {
+            "type": "string",
+            "title": "Pname"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "outputs": {
+            "title": "Outputs",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            },
+            "type": "array"
+          },
+          "outputs_to_install": {
+            "title": "Outputs To Install",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": {
+            "title": "Description",
+            "nullable": true,
+            "type": "string"
+          },
+          "license": {
+            "title": "License",
+            "nullable": true,
+            "type": "string"
+          },
+          "locked_url": {
+            "type": "string",
+            "title": "Locked Url"
+          },
+          "rev": {
+            "type": "string",
+            "title": "Rev"
+          },
+          "rev_count": {
+            "type": "integer",
+            "title": "Rev Count"
+          },
+          "rev_date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Rev Date"
+          },
+          "broken": {
+            "type": "boolean",
+            "title": "Broken"
+          },
+          "unfree": {
+            "title": "Unfree",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "stabilities": {
+            "title": "Stabilities",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "scrape_date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Scrape Date"
+          },
+          "install_id": {
+            "type": "string",
+            "title": "Install Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "attr_path",
+          "derivation",
+          "name",
+          "pname",
+          "version",
+          "outputs",
+          "outputs_to_install",
+          "description",
+          "license",
+          "locked_url",
+          "rev",
+          "rev_count",
+          "rev_date",
+          "broken",
+          "unfree",
+          "stabilities",
+          "scrape_date",
+          "install_id"
+        ],
+        "title": "ResolvedPackageDescriptor"
+      },
       "ResolvedPackageGroup-Input": {
         "properties": {
           "name": {
@@ -1090,13 +1007,13 @@
         ],
         "title": "ResolvedPackageGroup",
         "example": {
+          "attr_path": "foo.bar.curl",
           "description": "A very nice Item",
           "license": "foo",
           "locked_url": "git:git?rev=xyz",
           "name": "curl",
           "outputs": "{}",
           "outputs_to_install": "{}",
-          "pkg_path": "foo.bar.curl",
           "pname": "curl",
           "rev": "xyz",
           "rev_count": 4,
@@ -1135,13 +1052,13 @@
         ],
         "title": "ResolvedPackageGroup",
         "example": {
+          "attr_path": "foo.bar.curl",
           "description": "A very nice Item",
           "license": "foo",
           "locked_url": "git:git?rev=xyz",
           "name": "curl",
           "outputs": "{}",
           "outputs_to_install": "{}",
-          "pkg_path": "foo.bar.curl",
           "pname": "curl",
           "rev": "xyz",
           "rev_count": 4,

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -51,13 +51,13 @@ pub mod types {
     ///  "title": "CatalogPage",
     ///  "examples": [
     ///    {
+    ///      "attr_path": "foo.bar.curl",
     ///      "description": "A very nice Item",
     ///      "license": "foo",
     ///      "locked_url": "git:git?rev=xyz",
     ///      "name": "curl",
     ///      "outputs": "{}",
     ///      "outputs_to_install": "{}",
-    ///      "pkg_path": "foo.bar.curl",
     ///      "pname": "curl",
     ///      "rev": "xyz",
     ///      "rev_count": 4,
@@ -79,14 +79,13 @@ pub mod types {
     ///  "properties": {
     ///    "packages": {
     ///      "title": "Packages",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "$ref": "#/components/schemas/PackageResolutionInfo"
-    ///          }
-    ///        }
-    ///      ]
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/ResolvedPackageDescriptor"
+    ///      }
     ///    },
     ///    "page": {
     ///      "title": "Page",
@@ -102,8 +101,8 @@ pub mod types {
     /// </details>
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct CatalogPageInput {
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub packages: Vec<PackageResolutionInfo>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub packages: Option<Vec<ResolvedPackageDescriptor>>,
         pub page: i64,
         pub url: String,
     }
@@ -121,13 +120,13 @@ pub mod types {
     ///  "title": "CatalogPage",
     ///  "examples": [
     ///    {
+    ///      "attr_path": "foo.bar.curl",
     ///      "description": "A very nice Item",
     ///      "license": "foo",
     ///      "locked_url": "git:git?rev=xyz",
     ///      "name": "curl",
     ///      "outputs": "{}",
     ///      "outputs_to_install": "{}",
-    ///      "pkg_path": "foo.bar.curl",
     ///      "pname": "curl",
     ///      "rev": "xyz",
     ///      "rev_count": 4,
@@ -149,14 +148,13 @@ pub mod types {
     ///  "properties": {
     ///    "packages": {
     ///      "title": "Packages",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "$ref": "#/components/schemas/PackageResolutionInfo"
-    ///          }
-    ///        }
-    ///      ]
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/ResolvedPackageDescriptor"
+    ///      }
     ///    },
     ///    "page": {
     ///      "title": "Page",
@@ -172,8 +170,8 @@ pub mod types {
     /// </details>
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct CatalogPageOutput {
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub packages: Vec<PackageResolutionInfo>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub packages: Option<Vec<ResolvedPackageDescriptor>>,
         pub page: i64,
         pub url: String,
     }
@@ -276,17 +274,12 @@ pub mod types {
     ///  "title": "ErrorResponse",
     ///  "type": "object",
     ///  "required": [
-    ///    "detail",
-    ///    "status_code"
+    ///    "detail"
     ///  ],
     ///  "properties": {
     ///    "detail": {
     ///      "title": "Detail",
     ///      "type": "string"
-    ///    },
-    ///    "status_code": {
-    ///      "title": "Status Code",
-    ///      "type": "integer"
     ///    }
     ///  }
     ///}
@@ -295,7 +288,6 @@ pub mod types {
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct ErrorResponse {
         pub detail: String,
-        pub status_code: i64,
     }
     impl From<&ErrorResponse> for ErrorResponse {
         fn from(value: &ErrorResponse) -> Self {
@@ -346,46 +338,44 @@ pub mod types {
     ///  "title": "PackageDescriptor",
     ///  "examples": [
     ///    {
-    ///      "name": "curl",
-    ///      "pkgPath": "curl"
+    ///      "attr_path": "curl",
+    ///      "install_id": "curl"
     ///    }
     ///  ],
     ///  "type": "object",
     ///  "required": [
-    ///    "name",
-    ///    "pkgPath"
+    ///    "attr_path",
+    ///    "install_id"
     ///  ],
     ///  "properties": {
+    ///    "allow_pre_releases": {
+    ///      "title": "Allow Pre Releases",
+    ///      "default": false,
+    ///      "type": [
+    ///        "boolean",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "attr_path": {
+    ///      "title": "Attr Path",
+    ///      "type": "string"
+    ///    },
     ///    "derivation": {
     ///      "title": "Derivation",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
+    ///      "type": [
+    ///        "string",
+    ///        "null"
     ///      ]
     ///    },
-    ///    "name": {
-    ///      "title": "Name",
+    ///    "install_id": {
+    ///      "title": "Install Id",
     ///      "type": "string"
-    ///    },
-    ///    "pkgPath": {
-    ///      "title": "Pkgpath",
-    ///      "type": "string"
-    ///    },
-    ///    "semver": {
-    ///      "title": "Semver",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
-    ///      ]
     ///    },
     ///    "version": {
     ///      "title": "Version",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
+    ///      "type": [
+    ///        "string",
+    ///        "null"
     ///      ]
     ///    }
     ///  }
@@ -394,13 +384,12 @@ pub mod types {
     /// </details>
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageDescriptor {
+        #[serde(default = "defaults::package_descriptor_allow_pre_releases")]
+        pub allow_pre_releases: Option<bool>,
+        pub attr_path: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub derivation: Option<String>,
-        pub name: String,
-        #[serde(rename = "pkgPath")]
-        pub pkg_path: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub semver: Option<String>,
+        pub install_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub version: Option<String>,
     }
@@ -420,16 +409,16 @@ pub mod types {
     ///    {
     ///      "descriptors": [
     ///        {
-    ///          "name": "curl",
-    ///          "pkgPath": "curl"
+    ///          "attr_path": "curl",
+    ///          "install_id": "curl"
     ///        },
     ///        {
-    ///          "name": "slack",
-    ///          "pkgPath": "slack"
+    ///          "attr_path": "slack",
+    ///          "install_id": "slack"
     ///        },
     ///        {
-    ///          "name": "xeyes",
-    ///          "pkgPath": "xorg.xeyes"
+    ///          "attr_path": "xorg.xeyes",
+    ///          "install_id": "xeyes"
     ///        }
     ///      ],
     ///      "name": "test",
@@ -456,10 +445,9 @@ pub mod types {
     ///    },
     ///    "stability": {
     ///      "title": "Stability",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
+    ///      "type": [
+    ///        "string",
+    ///        "null"
     ///      ]
     ///    },
     ///    "system": {
@@ -495,16 +483,16 @@ pub mod types {
     ///        {
     ///          "descriptors": [
     ///            {
-    ///              "name": "curl",
-    ///              "pkgPath": "curl"
+    ///              "attr_path": "curl",
+    ///              "install_id": "curl"
     ///            },
     ///            {
-    ///              "name": "slack",
-    ///              "pkgPath": "slack"
+    ///              "attr_path": "slack",
+    ///              "install_id": "slack"
     ///            },
     ///            {
-    ///              "name": "xeyes",
-    ///              "pkgPath": "xorg.xeyes"
+    ///              "attr_path": "xorg.xeyes",
+    ///              "install_id": "xeyes"
     ///            }
     ///          ],
     ///          "name": "test",
@@ -547,13 +535,13 @@ pub mod types {
     ///  "title": "PackageInfoAPI",
     ///  "examples": [
     ///    {
+    ///      "attr_path": "foo.bar.curl",
     ///      "description": "A very nice Item",
     ///      "license": "foo",
     ///      "locked_url": "git:git?rev=xyz",
     ///      "name": "curl",
     ///      "outputs": "{}",
     ///      "outputs_to_install": "{}",
-    ///      "pkg_path": "foo.bar.curl",
     ///      "pname": "curl",
     ///      "rev": "xyz",
     ///      "rev_count": 4,
@@ -591,18 +579,16 @@ pub mod types {
     ///    },
     ///    "description": {
     ///      "title": "Description",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
+    ///      "type": [
+    ///        "string",
+    ///        "null"
     ///      ]
     ///    },
     ///    "license": {
     ///      "title": "License",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
+    ///      "type": [
+    ///        "string",
+    ///        "null"
     ///      ]
     ///    },
     ///    "locked_url": {
@@ -615,25 +601,23 @@ pub mod types {
     ///    },
     ///    "outputs": {
     ///      "title": "Outputs",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "$ref": "#/components/schemas/Output"
-    ///          }
-    ///        }
-    ///      ]
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Output"
+    ///      }
     ///    },
     ///    "outputs_to_install": {
     ///      "title": "Outputs To Install",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "type": "string"
-    ///          }
-    ///        }
-    ///      ]
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
     ///    },
     ///    "pname": {
     ///      "title": "Pname",
@@ -673,12 +657,12 @@ pub mod types {
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageInfoApi {
         pub attr_path: String,
-        pub description: String,
-        pub license: String,
+        pub description: Option<String>,
+        pub license: Option<String>,
         pub locked_url: String,
         pub name: String,
-        pub outputs: Vec<Output>,
-        pub outputs_to_install: Vec<String>,
+        pub outputs: Option<Vec<Output>>,
+        pub outputs_to_install: Option<Vec<String>>,
         pub pname: String,
         pub rev: String,
         pub rev_count: i64,
@@ -721,18 +705,16 @@ pub mod types {
     ///    },
     ///    "description": {
     ///      "title": "Description",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
+    ///      "type": [
+    ///        "string",
+    ///        "null"
     ///      ]
     ///    },
     ///    "license": {
     ///      "title": "License",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
+    ///      "type": [
+    ///        "string",
+    ///        "null"
     ///      ]
     ///    },
     ///    "name": {
@@ -741,25 +723,23 @@ pub mod types {
     ///    },
     ///    "outputs": {
     ///      "title": "Outputs",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "$ref": "#/components/schemas/Output"
-    ///          }
-    ///        }
-    ///      ]
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Output"
+    ///      }
     ///    },
     ///    "outputs_to_install": {
     ///      "title": "Outputs To Install",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "type": "string"
-    ///          }
-    ///        }
-    ///      ]
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
     ///    },
     ///    "pname": {
     ///      "title": "Pname",
@@ -792,11 +772,11 @@ pub mod types {
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PackageInfoCommon {
         pub attr_path: String,
-        pub description: String,
-        pub license: String,
+        pub description: Option<String>,
+        pub license: Option<String>,
         pub name: String,
-        pub outputs: Vec<Output>,
-        pub outputs_to_install: Vec<String>,
+        pub outputs: Option<Vec<Output>>,
+        pub outputs_to_install: Option<Vec<String>>,
         pub pname: String,
         pub rev: String,
         pub rev_count: i64,
@@ -806,166 +786,6 @@ pub mod types {
     }
     impl From<&PackageInfoCommon> for PackageInfoCommon {
         fn from(value: &PackageInfoCommon) -> Self {
-            value.clone()
-        }
-    }
-    ///PackageResolutionInfo
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "title": "PackageResolutionInfo",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "attr_path",
-    ///    "broken",
-    ///    "derivation",
-    ///    "description",
-    ///    "license",
-    ///    "locked_url",
-    ///    "name",
-    ///    "outputs",
-    ///    "outputs_to_install",
-    ///    "pname",
-    ///    "rev",
-    ///    "rev_count",
-    ///    "rev_date",
-    ///    "scrape_date",
-    ///    "stabilities",
-    ///    "unfree",
-    ///    "version"
-    ///  ],
-    ///  "properties": {
-    ///    "attr_path": {
-    ///      "title": "Attr Path",
-    ///      "type": "string"
-    ///    },
-    ///    "broken": {
-    ///      "title": "Broken",
-    ///      "type": "boolean"
-    ///    },
-    ///    "derivation": {
-    ///      "title": "Derivation",
-    ///      "type": "string"
-    ///    },
-    ///    "description": {
-    ///      "title": "Description",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
-    ///      ]
-    ///    },
-    ///    "license": {
-    ///      "title": "License",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "string"
-    ///        }
-    ///      ]
-    ///    },
-    ///    "locked_url": {
-    ///      "title": "Locked Url",
-    ///      "type": "string"
-    ///    },
-    ///    "name": {
-    ///      "title": "Name",
-    ///      "type": "string"
-    ///    },
-    ///    "outputs": {
-    ///      "title": "Outputs",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "$ref": "#/components/schemas/Output"
-    ///          }
-    ///        }
-    ///      ]
-    ///    },
-    ///    "outputs_to_install": {
-    ///      "title": "Outputs To Install",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "type": "string"
-    ///          }
-    ///        }
-    ///      ]
-    ///    },
-    ///    "pname": {
-    ///      "title": "Pname",
-    ///      "type": "string"
-    ///    },
-    ///    "rev": {
-    ///      "title": "Rev",
-    ///      "type": "string"
-    ///    },
-    ///    "rev_count": {
-    ///      "title": "Rev Count",
-    ///      "type": "integer"
-    ///    },
-    ///    "rev_date": {
-    ///      "title": "Rev Date",
-    ///      "type": "string",
-    ///      "format": "date-time"
-    ///    },
-    ///    "scrape_date": {
-    ///      "title": "Scrape Date",
-    ///      "type": "string",
-    ///      "format": "date-time"
-    ///    },
-    ///    "stabilities": {
-    ///      "title": "Stabilities",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "array",
-    ///          "items": {
-    ///            "type": "string"
-    ///          }
-    ///        }
-    ///      ]
-    ///    },
-    ///    "unfree": {
-    ///      "title": "Unfree",
-    ///      "anyOf": [
-    ///        {
-    ///          "type": "boolean"
-    ///        }
-    ///      ]
-    ///    },
-    ///    "version": {
-    ///      "title": "Version",
-    ///      "type": "string"
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-    pub struct PackageResolutionInfo {
-        pub attr_path: String,
-        pub broken: bool,
-        pub derivation: String,
-        pub description: String,
-        pub license: String,
-        pub locked_url: String,
-        pub name: String,
-        pub outputs: Vec<Output>,
-        pub outputs_to_install: Vec<String>,
-        pub pname: String,
-        pub rev: String,
-        pub rev_count: i64,
-        pub rev_date: chrono::DateTime<chrono::offset::Utc>,
-        pub scrape_date: chrono::DateTime<chrono::offset::Utc>,
-        pub stabilities: Vec<String>,
-        pub unfree: bool,
-        pub version: String,
-    }
-    impl From<&PackageResolutionInfo> for PackageResolutionInfo {
-        fn from(value: &PackageResolutionInfo) -> Self {
             value.clone()
         }
     }
@@ -979,13 +799,13 @@ pub mod types {
     ///  "examples": [
     ///    [
     ///      {
+    ///        "attr_path": "foo.bar.curl",
     ///        "description": "A very nice Item",
     ///        "license": "foo",
     ///        "locked_url": "git:git?rev=xyz",
     ///        "name": "curl",
     ///        "outputs": "{}",
     ///        "outputs_to_install": "{}",
-    ///        "pkg_path": "foo.bar.curl",
     ///        "pname": "curl",
     ///        "rev": "xyz",
     ///        "rev_count": 4,
@@ -1041,13 +861,13 @@ pub mod types {
     ///  "examples": [
     ///    [
     ///      {
+    ///        "attr_path": "foo.bar.curl",
     ///        "description": "A very nice Item",
     ///        "license": "foo",
     ///        "locked_url": "git:git?rev=xyz",
     ///        "name": "curl",
     ///        "outputs": "{}",
     ///        "outputs_to_install": "{}",
-    ///        "pkg_path": "foo.bar.curl",
     ///        "pname": "curl",
     ///        "rev": "xyz",
     ///        "rev_count": 4,
@@ -1169,6 +989,166 @@ pub mod types {
             value.clone()
         }
     }
+    ///ResolvedPackageDescriptor
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "ResolvedPackageDescriptor",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "attr_path",
+    ///    "broken",
+    ///    "derivation",
+    ///    "description",
+    ///    "install_id",
+    ///    "license",
+    ///    "locked_url",
+    ///    "name",
+    ///    "outputs",
+    ///    "outputs_to_install",
+    ///    "pname",
+    ///    "rev",
+    ///    "rev_count",
+    ///    "rev_date",
+    ///    "scrape_date",
+    ///    "stabilities",
+    ///    "unfree",
+    ///    "version"
+    ///  ],
+    ///  "properties": {
+    ///    "attr_path": {
+    ///      "title": "Attr Path",
+    ///      "type": "string"
+    ///    },
+    ///    "broken": {
+    ///      "title": "Broken",
+    ///      "type": "boolean"
+    ///    },
+    ///    "derivation": {
+    ///      "title": "Derivation",
+    ///      "type": "string"
+    ///    },
+    ///    "description": {
+    ///      "title": "Description",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "install_id": {
+    ///      "title": "Install Id",
+    ///      "type": "string"
+    ///    },
+    ///    "license": {
+    ///      "title": "License",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "locked_url": {
+    ///      "title": "Locked Url",
+    ///      "type": "string"
+    ///    },
+    ///    "name": {
+    ///      "title": "Name",
+    ///      "type": "string"
+    ///    },
+    ///    "outputs": {
+    ///      "title": "Outputs",
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Output"
+    ///      }
+    ///    },
+    ///    "outputs_to_install": {
+    ///      "title": "Outputs To Install",
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    },
+    ///    "pname": {
+    ///      "title": "Pname",
+    ///      "type": "string"
+    ///    },
+    ///    "rev": {
+    ///      "title": "Rev",
+    ///      "type": "string"
+    ///    },
+    ///    "rev_count": {
+    ///      "title": "Rev Count",
+    ///      "type": "integer"
+    ///    },
+    ///    "rev_date": {
+    ///      "title": "Rev Date",
+    ///      "type": "string",
+    ///      "format": "date-time"
+    ///    },
+    ///    "scrape_date": {
+    ///      "title": "Scrape Date",
+    ///      "type": "string",
+    ///      "format": "date-time"
+    ///    },
+    ///    "stabilities": {
+    ///      "title": "Stabilities",
+    ///      "type": [
+    ///        "array",
+    ///        "null"
+    ///      ],
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    },
+    ///    "unfree": {
+    ///      "title": "Unfree",
+    ///      "type": [
+    ///        "boolean",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "version": {
+    ///      "title": "Version",
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    pub struct ResolvedPackageDescriptor {
+        pub attr_path: String,
+        pub broken: bool,
+        pub derivation: String,
+        pub description: Option<String>,
+        pub install_id: String,
+        pub license: Option<String>,
+        pub locked_url: String,
+        pub name: String,
+        pub outputs: Option<Vec<Output>>,
+        pub outputs_to_install: Option<Vec<String>>,
+        pub pname: String,
+        pub rev: String,
+        pub rev_count: i64,
+        pub rev_date: chrono::DateTime<chrono::offset::Utc>,
+        pub scrape_date: chrono::DateTime<chrono::offset::Utc>,
+        pub stabilities: Option<Vec<String>>,
+        pub unfree: Option<bool>,
+        pub version: String,
+    }
+    impl From<&ResolvedPackageDescriptor> for ResolvedPackageDescriptor {
+        fn from(value: &ResolvedPackageDescriptor) -> Self {
+            value.clone()
+        }
+    }
     ///ResolvedPackageGroupInput
     ///
     /// <details><summary>JSON schema</summary>
@@ -1178,13 +1158,13 @@ pub mod types {
     ///  "title": "ResolvedPackageGroup",
     ///  "examples": [
     ///    {
+    ///      "attr_path": "foo.bar.curl",
     ///      "description": "A very nice Item",
     ///      "license": "foo",
     ///      "locked_url": "git:git?rev=xyz",
     ///      "name": "curl",
     ///      "outputs": "{}",
     ///      "outputs_to_install": "{}",
-    ///      "pkg_path": "foo.bar.curl",
     ///      "pname": "curl",
     ///      "rev": "xyz",
     ///      "rev_count": 4,
@@ -1243,13 +1223,13 @@ pub mod types {
     ///  "title": "ResolvedPackageGroup",
     ///  "examples": [
     ///    {
+    ///      "attr_path": "foo.bar.curl",
     ///      "description": "A very nice Item",
     ///      "license": "foo",
     ///      "locked_url": "git:git?rev=xyz",
     ///      "name": "curl",
     ///      "outputs": "{}",
     ///      "outputs_to_install": "{}",
-    ///      "pkg_path": "foo.bar.curl",
     ///      "pname": "curl",
     ///      "rev": "xyz",
     ///      "rev_count": 4,
@@ -1522,6 +1502,12 @@ pub mod types {
             value.parse()
         }
     }
+    /// Generation of default values for serde.
+    pub mod defaults {
+        pub(super) fn package_descriptor_allow_pre_releases() -> Option<bool> {
+            Some(false)
+        }
+    }
 }
 #[derive(Clone, Debug)]
 /**Client for Flox Catalog Service
@@ -1534,7 +1520,7 @@ TBD
 *Markdown is available here*
 
 
-Version: v0.1.dev129+g9e3c6c6.d19800101*/
+Version: v0.1.dev134+gd1854a6.d19800101*/
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -1580,7 +1566,7 @@ impl Client {
     /// This string is pulled directly from the source OpenAPI
     /// document and may be in any format the API selects.
     pub fn api_version(&self) -> &'static str {
-        "v0.1.dev129+g9e3c6c6.d19800101"
+        "v0.1.dev134+gd1854a6.d19800101"
     }
 }
 #[allow(clippy::all)]
@@ -1650,10 +1636,10 @@ Sends a `GET` request to `/api/v1/catalog/search`
     }
     /**Shows avaliable packages of a specfic package
 
-Returns a list of versions for a given pkg-path
+Returns a list of versions for a given attr_path
 
 Required Query Parameters:
-- **pkgPath**: The pkg-path, must be valid.
+- **attr_path**: The attr_path, must be valid.
 
 Optional Query Parameters:
 - **page**: Optional page number for pagination (def = 0)
@@ -1662,17 +1648,17 @@ Optional Query Parameters:
 Returns:
 - **PackageSearchResult**: A list of PackageInfo and the total result count
 
-Sends a `GET` request to `/api/v1/catalog/packages/{pkgPath}`
+Sends a `GET` request to `/api/v1/catalog/packages/{attr_path}`
 
 */
-    pub async fn packages_api_v1_catalog_packages_pkg_path_get<'a>(
+    pub async fn packages_api_v1_catalog_packages_attr_path_get<'a>(
         &'a self,
-        pkg_path: &'a str,
+        attr_path: &'a str,
         page: Option<i64>,
         page_size: Option<i64>,
     ) -> Result<ResponseValue<types::PackagesResultInput>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/packages/{}", self.baseurl, encode_path(& pkg_path
+            "{}/api/v1/catalog/packages/{}", self.baseurl, encode_path(& attr_path
             .to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
@@ -1728,17 +1714,15 @@ Resolution Rules:
 A Package Descriptor match:
 - **name**: [required] - is not used in matching, only for reference (TBD is
             there a uniqueness constraint?)
-- **pkgPath**: [required] - this must match the nix attribute path exactly and in full
-- **semver**: [optional] - This can be any valid semver range, and if given
-    will attempt to parse the nix `version` field.  If it can and it is
-    within the range, this check passes.  If it cannot parse `version` as a
-    valid semver, or it is not within the range, it is exluded.
-    - **allow-pre-release**: [optional] - Defaults to False.  Only applies
+- **attr_path**: [required] - this must match the nix attribute path exactly and in full
+- **version**: [optional] - Either a literal version to match or a **semver** constraint.
+    This will be treated as a **semver** IFF TBD, otherwise it will be treated as
+    a literal string match to the nix `version` field.  If this is detected as a **semver**,
+    packages whose `version` field cannot be parsed as a **semver** will be excluded.
+    - **allow_pre_release**: [optional] - Defaults to False.  Only applies
         when a **semver** constraint is given.  If true, a `version` that can
         be parsed as a valid semver, that includes a pre-release suffix will
         be included as a candidate.  Otherwise, they will be excluded.
-- **version**: [optional] - If given, this must match the nix `version`
-    field precisely. This overrides **semver** matching if provided.
 
 Sends a `POST` request to `/api/v1/catalog/resolve`
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -29,6 +29,7 @@ use crate::providers::catalog::{
     CatalogPage,
     PackageDescriptor,
     PackageGroup,
+    PackageResolutionInfo,
     ResolvedPackageGroup,
 };
 use crate::utils::CommandExt;
@@ -160,8 +161,9 @@ pub struct LockedPackageCatalog {
     pub attr_path: String,
     pub broken: bool,
     pub derivation: String,
-    pub description: String,
-    pub license: String,
+    pub description: Option<String>,
+    pub install_id: String,
+    pub license: Option<String>,
     pub locked_url: String,
     pub name: String,
     pub pname: String,
@@ -171,14 +173,14 @@ pub struct LockedPackageCatalog {
     pub rev_date: chrono::DateTime<chrono::offset::Utc>,
     #[cfg_attr(test, proptest(strategy = "crate::utils::proptest_chrono_strategy()"))]
     pub scrape_date: chrono::DateTime<chrono::offset::Utc>,
-    pub stabilities: Vec<String>,
-    pub unfree: bool,
+    pub stabilities: Option<Vec<String>>,
+    pub unfree: Option<bool>,
     pub version: String,
-    pub outputs_to_install: Vec<String>,
+    pub outputs_to_install: Option<Vec<String>>,
     // endregion
 
     // region: converted fields
-    pub outputs: BTreeMap<String, String>,
+    pub outputs: Option<BTreeMap<String, String>>,
     // endregion
 
     // region: added fields
@@ -205,6 +207,7 @@ impl LockedPackageCatalog {
             broken,
             derivation,
             description,
+            install_id,
             license,
             locked_url,
             name,
@@ -220,10 +223,12 @@ impl LockedPackageCatalog {
             version,
         } = package;
 
-        let outputs = outputs
-            .into_iter()
-            .map(|output| (output.name, output.store_path))
-            .collect();
+        let outputs = outputs.map(|outputs| {
+            outputs
+                .into_iter()
+                .map(|output| (output.name, output.store_path))
+                .collect()
+        });
 
         let priority = descriptor.priority.unwrap_or(DEFAULT_PRIORITY);
         let group = descriptor
@@ -238,6 +243,7 @@ impl LockedPackageCatalog {
             broken,
             derivation,
             description,
+            install_id,
             license,
             locked_url,
             name,
@@ -286,18 +292,18 @@ impl LockedManifestCatalog {
                     .manifest
                     .install
                     .iter()
-                    .find(|(install_id, _)| install_id == &&package.name)
+                    .find(|(install_id, _)| install_id == &&package.install_id)
                     .and_then(|(_, descriptor)| descriptor.priority);
 
                 let package = package.clone();
 
                 InstalledPackage {
-                    name: package.name,
+                    install_id: package.install_id,
                     rel_path: package.attr_path,
                     info: PackageInfo {
-                        description: Some(package.description),
+                        description: package.description,
                         broken: package.broken,
-                        license: Some(package.license),
+                        license: package.license,
                         pname: package.pname,
                         unfree: package.unfree,
                         version: Some(package.version),
@@ -326,7 +332,7 @@ impl LockedManifestCatalog {
             .await
             .map_err(LockedManifestError::CatalogResolve)?;
 
-        let locked_packages = Self::locked_packages_from_resolution(manifest, resolved).collect();
+        let locked_packages = Self::locked_packages_from_resolution(manifest, resolved)?.collect();
 
         let lockfile = LockedManifestCatalog {
             version: Version::<1>,
@@ -346,7 +352,7 @@ impl LockedManifestCatalog {
             .iter()
             .filter_map(|package| {
                 let system = &package.system;
-                let manifest = seed.manifest.install.get(&package.name)?;
+                let manifest = seed.manifest.install.get(&package.install_id)?;
                 Some(((manifest, system), package))
             })
             .collect()
@@ -375,11 +381,11 @@ impl LockedManifestCatalog {
 
         for (install_id, manifest_descriptor) in manifest.install.iter() {
             let resolved_descriptor = PackageDescriptor {
-                name: install_id.clone(),
-                pkg_path: manifest_descriptor.pkg_path.clone(),
+                install_id: install_id.clone(),
+                attr_path: manifest_descriptor.pkg_path.clone(),
                 derivation: None,
-                semver: None,
                 version: manifest_descriptor.version.clone(),
+                allow_pre_releases: manifest.options.semver.prefer_pre_releases,
             };
 
             let group = manifest_descriptor
@@ -429,19 +435,39 @@ impl LockedManifestCatalog {
     fn locked_packages_from_resolution<'manifest>(
         manifest: &'manifest TypedManifestCatalog,
         groups: impl IntoIterator<Item = ResolvedPackageGroup> + 'manifest,
-    ) -> impl Iterator<Item = LockedPackageCatalog> + 'manifest {
-        let infos = groups.into_iter().flat_map(|group| {
-            group
-                .pages
+    ) -> Result<impl Iterator<Item = LockedPackageCatalog> + 'manifest, LockedManifestError> {
+        // For each group, extract the first page and its system.
+        // Error if the first page doesn't contain any packages.
+        let first_pages: Vec<(Vec<PackageResolutionInfo>, String)> = groups
+            .into_iter()
+            .map(|group| {
+                group
+                    .pages
+                    .into_iter()
+                    .take(1)
+                    .map(|page| {
+                        page.packages
+                            .map(|packages| (packages, group.system.clone()))
+                    })
+                    .next()
+                    .flatten()
+                    .ok_or(LockedManifestError::NoPackagesOnFirstPage)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Flatten packages from all the groups into a single iterator
+        let infos = first_pages.into_iter().flat_map(|(packages, system)| {
+            packages
                 .into_iter()
-                .take(1)
-                .flat_map(|page| page.packages.into_iter())
-                .map(move |package| (package, group.system.clone()))
+                .map(move |package| (package, system.clone()))
         });
 
-        infos.filter_map(|(package, system)| {
-            let Some(descriptor) = manifest.install.get(&package.name).cloned() else {
-                debug!("Package {} is not in the manifest, skipping", package.name);
+        Ok(infos.filter_map(|(package, system)| {
+            let Some(descriptor) = manifest.install.get(&package.install_id).cloned() else {
+                debug!(
+                    "Package {} is not in the manifest, skipping",
+                    package.install_id
+                );
                 return None;
             };
 
@@ -449,7 +475,7 @@ impl LockedManifestCatalog {
             Some(LockedPackageCatalog::from_parts(
                 package, descriptor, system,
             ))
-        })
+        }))
     }
 }
 
@@ -669,7 +695,7 @@ pub struct PackageInfo {
     pub broken: bool,
     pub license: Option<String>,
     pub pname: String,
-    pub unfree: bool,
+    pub unfree: Option<bool>,
     pub version: Option<String>,
 }
 
@@ -693,7 +719,7 @@ impl TypedLockedManifestPkgdb {
             for (name, locked_package) in system_packages {
                 if let Some(locked_package) = locked_package {
                     packages.push(InstalledPackage {
-                        name: name.clone(),
+                        install_id: name.clone(),
                         rel_path: locked_package.rel_path(),
                         info: locked_package.info.clone(),
                         priority: Some(locked_package.priority),
@@ -710,7 +736,7 @@ impl TypedLockedManifestPkgdb {
 // TODO: consider dropping this in favor of mapping to [LockedPackageCatalog]?
 /// A locked package with additionally derived attributes
 pub struct InstalledPackage {
-    pub name: String,
+    pub install_id: String,
     pub rel_path: String,
     pub info: PackageInfo,
     pub priority: Option<usize>,
@@ -720,7 +746,8 @@ pub struct InstalledPackage {
 pub enum LockedManifestError {
     #[error("failed to resolve packages")]
     CatalogResolve(#[from] catalog::ResolveError),
-
+    #[error("didn't find a first catalog page with packages")]
+    NoPackagesOnFirstPage,
     #[error("failed to lock manifest")]
     LockManifest(#[source] CallPkgDbError),
     #[error("failed to check lockfile")]
@@ -872,8 +899,8 @@ mod tests {
           version = 1
 
           [install]
-          hello.pkg-path = "hello"
-          hello.package-group = "group"
+          hello_install_id.pkg-path = "hello"
+          hello_install_id.package-group = "group"
 
           [options]
           systems = ["system"]
@@ -895,11 +922,11 @@ mod tests {
             name: "group".to_string(),
             system: "system".to_string(),
             descriptors: vec![PackageDescriptor {
-                name: "hello".to_string(),
-                pkg_path: "hello".to_string(),
+                install_id: "hello_install_id".to_string(),
+                attr_path: "hello".to_string(),
                 derivation: None,
-                semver: None,
                 version: None,
+                allow_pre_releases: None,
             }],
         }]
     });
@@ -910,19 +937,20 @@ mod tests {
             pages: vec![CatalogPage {
                 page: 1,
                 url: "url".to_string(),
-                packages: vec![PackageResolutionInfo {
+                packages: Some(vec![PackageResolutionInfo {
                     attr_path: "hello".to_string(),
                     broken: false,
                     derivation: "derivation".to_string(),
-                    description: "description".to_string(),
-                    license: "license".to_string(),
+                    description: Some("description".to_string()),
+                    install_id: "hello_install_id".to_string(),
+                    license: Some("license".to_string()),
                     locked_url: "locked_url".to_string(),
                     name: "hello".to_string(),
-                    outputs: vec![Output {
+                    outputs: Some(vec![Output {
                         name: "name".to_string(),
                         store_path: "store_path".to_string(),
-                    }],
-                    outputs_to_install: vec!["name".to_string()],
+                    }]),
+                    outputs_to_install: Some(vec!["name".to_string()]),
                     pname: "pname".to_string(),
                     rev: "rev".to_string(),
                     rev_count: 1,
@@ -932,10 +960,10 @@ mod tests {
                     scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
                         .unwrap()
                         .with_timezone(&chrono::offset::Utc),
-                    stabilities: vec!["stability".to_string()],
-                    unfree: false,
+                    stabilities: Some(vec!["stability".to_string()]),
+                    unfree: Some(false),
                     version: "version".to_string(),
-                }],
+                }]),
             }],
             name: "group".to_string(),
         }]
@@ -949,14 +977,17 @@ mod tests {
                 attr_path: "hello".to_string(),
                 broken: false,
                 derivation: "derivation".to_string(),
-                description: "description".to_string(),
-                license: "license".to_string(),
+                description: Some("description".to_string()),
+                install_id: "hello_install_id".to_string(),
+                license: Some("license".to_string()),
                 locked_url: "locked_url".to_string(),
                 name: "hello".to_string(),
-                outputs: vec![("name".to_string(), "store_path".to_string())]
-                    .into_iter()
-                    .collect(),
-                outputs_to_install: vec!["name".to_string()],
+                outputs: Some(
+                    vec![("name".to_string(), "store_path".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                outputs_to_install: Some(vec!["name".to_string()]),
                 pname: "pname".to_string(),
                 rev: "rev".to_string(),
                 rev_count: 1,
@@ -966,8 +997,8 @@ mod tests {
                 scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
                     .unwrap()
                     .with_timezone(&chrono::offset::Utc),
-                stabilities: vec!["stability".to_string()],
-                unfree: false,
+                stabilities: Some(vec!["stability".to_string()]),
+                unfree: Some(false),
                 version: "version".to_string(),
                 system: "system".to_string(),
                 group: "group".to_string(),
@@ -1008,17 +1039,17 @@ mod tests {
                 system: "system1".to_string(),
                 descriptors: vec![
                     PackageDescriptor {
-                        name: "emacs".to_string(),
-                        pkg_path: "emacs".to_string(),
+                        allow_pre_releases: None,
+                        attr_path: "emacs".to_string(),
                         derivation: None,
-                        semver: None,
+                        install_id: "emacs".to_string(),
                         version: None,
                     },
                     PackageDescriptor {
-                        name: "vim".to_string(),
-                        pkg_path: "vim".to_string(),
+                        allow_pre_releases: None,
+                        attr_path: "vim".to_string(),
                         derivation: None,
-                        semver: None,
+                        install_id: "vim".to_string(),
                         version: None,
                     },
                 ],
@@ -1028,17 +1059,17 @@ mod tests {
                 system: "system2".to_string(),
                 descriptors: vec![
                     PackageDescriptor {
-                        name: "emacs".to_string(),
-                        pkg_path: "emacs".to_string(),
+                        allow_pre_releases: None,
+                        attr_path: "emacs".to_string(),
                         derivation: None,
-                        semver: None,
+                        install_id: "emacs".to_string(),
                         version: None,
                     },
                     PackageDescriptor {
-                        name: "vim".to_string(),
-                        pkg_path: "vim".to_string(),
+                        allow_pre_releases: None,
+                        attr_path: "vim".to_string(),
                         derivation: None,
-                        semver: None,
+                        install_id: "vim".to_string(),
                         version: None,
                     },
                 ],
@@ -1075,17 +1106,17 @@ mod tests {
                 system: "system1".to_string(),
                 descriptors: vec![
                     PackageDescriptor {
-                        name: "emacs".to_string(),
-                        pkg_path: "emacs".to_string(),
+                        allow_pre_releases: None,
+                        attr_path: "emacs".to_string(),
+                        install_id: "emacs".to_string(),
                         derivation: None,
-                        semver: None,
                         version: None,
                     },
                     PackageDescriptor {
-                        name: "vim".to_string(),
-                        pkg_path: "vim".to_string(),
+                        allow_pre_releases: None,
+                        attr_path: "vim".to_string(),
                         derivation: None,
-                        semver: None,
+                        install_id: "vim".to_string(),
                         version: None,
                     },
                 ],
@@ -1094,10 +1125,10 @@ mod tests {
                 name: DEFAULT_GROUP_NAME.to_string(),
                 system: "system2".to_string(),
                 descriptors: vec![PackageDescriptor {
-                    name: "vim".to_string(),
-                    pkg_path: "vim".to_string(),
+                    allow_pre_releases: None,
+                    attr_path: "vim".to_string(),
                     derivation: None,
-                    semver: None,
+                    install_id: "vim".to_string(),
                     version: None,
                 }],
             },
@@ -1131,10 +1162,10 @@ mod tests {
                 name: DEFAULT_GROUP_NAME.to_string(),
                 system: "system1".to_string(),
                 descriptors: vec![PackageDescriptor {
-                    name: "vim".to_string(),
-                    pkg_path: "vim".to_string(),
+                    allow_pre_releases: None,
+                    attr_path: "vim".to_string(),
                     derivation: None,
-                    semver: None,
+                    install_id: "vim".to_string(),
                     version: None,
                 }],
             },
@@ -1142,10 +1173,10 @@ mod tests {
                 name: DEFAULT_GROUP_NAME.to_string(),
                 system: "system2".to_string(),
                 descriptors: vec![PackageDescriptor {
-                    name: "emacs".to_string(),
-                    pkg_path: "emacs".to_string(),
+                    allow_pre_releases: None,
+                    attr_path: "emacs".to_string(),
                     derivation: None,
-                    semver: None,
+                    install_id: "emacs".to_string(),
                     version: None,
                 }],
             },
@@ -1182,10 +1213,10 @@ mod tests {
                 name: "group1".to_string(),
                 system: "system".to_string(),
                 descriptors: vec![PackageDescriptor {
-                    name: "vim".to_string(),
-                    pkg_path: "vim".to_string(),
+                    allow_pre_releases: None,
+                    attr_path: "vim".to_string(),
                     derivation: None,
-                    semver: None,
+                    install_id: "vim".to_string(),
                     version: None,
                 }],
             },
@@ -1193,10 +1224,10 @@ mod tests {
                 name: "group2".to_string(),
                 system: "system".to_string(),
                 descriptors: vec![PackageDescriptor {
-                    name: "emacs".to_string(),
-                    pkg_path: "emacs".to_string(),
+                    allow_pre_releases: None,
+                    attr_path: "emacs".to_string(),
                     derivation: None,
-                    semver: None,
+                    install_id: "emacs".to_string(),
                     version: None,
                 }],
             },
@@ -1238,18 +1269,18 @@ mod tests {
             descriptors: vec![
                 // 'hello' was already locked, so it should have a derivation
                 PackageDescriptor {
-                    name: "hello".to_string(),
-                    pkg_path: "hello".to_string(),
+                    allow_pre_releases: None,
+                    attr_path: "hello".to_string(),
                     derivation: Some("derivation".to_string()),
-                    semver: None,
+                    install_id: "hello_install_id".to_string(),
                     version: None,
                 },
                 // The unlocked package should not have a derivation
                 PackageDescriptor {
-                    name: "unlocked".to_string(),
-                    pkg_path: "unlocked".to_string(),
+                    allow_pre_releases: None,
+                    attr_path: "unlocked".to_string(),
                     derivation: None,
-                    semver: None,
+                    install_id: "unlocked".to_string(),
                     version: None,
                 },
             ],
@@ -1265,19 +1296,20 @@ mod tests {
             pages: vec![CatalogPage {
                 page: 1,
                 url: "url".to_string(),
-                packages: vec![PackageResolutionInfo {
+                packages: Some(vec![PackageResolutionInfo {
                     attr_path: "hello".to_string(),
                     broken: false,
                     derivation: "derivation".to_string(),
-                    description: "description".to_string(),
-                    license: "license".to_string(),
+                    description: Some("description".to_string()),
+                    install_id: "hello_install_id".to_string(),
+                    license: Some("license".to_string()),
                     locked_url: "locked_url".to_string(),
                     name: "hello".to_string(),
-                    outputs: vec![Output {
+                    outputs: Some(vec![Output {
                         name: "name".to_string(),
                         store_path: "store_path".to_string(),
-                    }],
-                    outputs_to_install: vec!["name".to_string()],
+                    }]),
+                    outputs_to_install: Some(vec!["name".to_string()]),
                     pname: "pname".to_string(),
                     rev: "rev".to_string(),
                     rev_count: 1,
@@ -1287,10 +1319,10 @@ mod tests {
                     scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
                         .unwrap()
                         .with_timezone(&chrono::offset::Utc),
-                    stabilities: vec!["stability".to_string()],
-                    unfree: false,
+                    stabilities: Some(vec!["stability".to_string()]),
+                    unfree: Some(false),
                     version: "version".to_string(),
-                }],
+                }]),
             }],
             name: "group".to_string(),
         }];
@@ -1299,16 +1331,17 @@ mod tests {
 
         let locked_packages =
             LockedManifestCatalog::locked_packages_from_resolution(manifest, groups.clone())
+                .unwrap()
                 .collect::<Vec<_>>();
 
         assert_eq!(locked_packages.len(), 1);
         assert_eq!(
             &locked_packages[0],
             &LockedPackageCatalog::from_parts(
-                groups[0].pages[0].packages[0].clone(),
+                groups[0].pages[0].packages.as_ref().unwrap()[0].clone(),
                 manifest
                     .install
-                    .get(&groups[0].pages[0].packages[0].name)
+                    .get(&groups[0].pages[0].packages.as_ref().unwrap()[0].install_id)
                     .unwrap()
                     .clone(),
                 groups[0].system.clone()

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -90,7 +90,7 @@ pub enum TypedManifest {
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct TypedManifestCatalog {
     version: Version<1>,
-    /// The packages to install in the form of a map from package name
+    /// The packages to install in the form of a map from install_id
     /// to package descriptor.
     #[serde(default)]
     pub(super) install: ManifestInstall,
@@ -171,7 +171,7 @@ pub struct ManifestOptions {
     allow: Allows,
     /// Options that control how semver versions are resolved.
     #[serde(default)]
-    semver: SemverOptions,
+    pub semver: SemverOptions,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
@@ -192,7 +192,7 @@ pub struct Allows {
 pub struct SemverOptions {
     /// Whether to prefer pre-release versions when resolving
     #[serde(default)]
-    prefer_pre_releases: Option<bool>,
+    pub prefer_pre_releases: Option<bool>,
 }
 
 /// Deserialize the manifest as a [serde_json::Value],

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -281,7 +281,7 @@ impl ClientTrait for CatalogClient {
             |page_number, page_size| async move {
                 let response = self
                     .client
-                    .packages_api_v1_catalog_packages_pkg_path_get(
+                    .packages_api_v1_catalog_packages_attr_path_get(
                         attr_path,
                         Some(page_number),
                         Some(page_size),
@@ -548,7 +548,7 @@ impl TryFrom<api_types::ResolvedPackageGroupInput> for ResolvedPackageGroup {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CatalogPage {
-    pub packages: Vec<PackageResolutionInfo>,
+    pub packages: Option<Vec<PackageResolutionInfo>>,
     pub page: i64,
     pub url: String,
 }
@@ -569,7 +569,7 @@ impl From<api_types::CatalogPageInput> for CatalogPage {
 /// [lockfile::LockedPackageCatalog] adds (at least) a `system` field.
 /// We should consider whether adding a shim to [api_types::PackageResolutionInfo]
 /// is not adding unnecessary complexity.
-pub type PackageResolutionInfo = api_types::PackageResolutionInfo;
+pub type PackageResolutionInfo = api_types::ResolvedPackageDescriptor;
 
 impl TryFrom<PackageInfoApi> for SearchResult {
     type Error = SearchError;
@@ -586,8 +586,8 @@ impl TryFrom<PackageInfoApi> for SearchResult {
                 .collect(),
             pname: Some(package_info.pname),
             version: Some(package_info.version),
-            description: Some(package_info.description),
-            license: Some(package_info.license),
+            description: package_info.description,
+            license: package_info.license,
         })
     }
 }
@@ -607,8 +607,8 @@ impl TryFrom<PackageInfoCommon> for SearchResult {
                 .collect(),
             pname: Some(package_info.pname),
             version: Some(package_info.version),
-            description: Some(package_info.description),
-            license: Some(package_info.license),
+            description: package_info.description,
+            license: package_info.license,
         })
     }
 }

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -105,7 +105,7 @@ impl List {
 
     /// print package ids only
     fn print_name_only(packages: &[InstalledPackage]) {
-        packages.iter().for_each(|p| println!("{}", p.name));
+        packages.iter().for_each(|p| println!("{}", p.install_id));
     }
 
     /// print package ids, as well as path and version
@@ -117,7 +117,7 @@ impl List {
         packages.iter().for_each(|p| {
             println!(
                 "{id}: {path} ({version})",
-                id = p.name,
+                id = p.install_id,
                 path = p.rel_path,
                 version = p.info.version.as_deref().unwrap_or("N/A")
             )
@@ -127,7 +127,7 @@ impl List {
     /// print package ids, as well as extended detailed information
     fn print_detail(packages: &[InstalledPackage]) {
         for InstalledPackage {
-            name,
+            install_id: name,
             rel_path,
             info:
                 PackageInfo {
@@ -155,6 +155,7 @@ impl List {
                 priority = priority.map(|p| p.to_string()).as_deref().unwrap_or("N/A"),
                 version = version.as_deref().unwrap_or("N/A"),
                 license = license.as_deref().unwrap_or("N/A"),
+                unfree = unfree.map(|u|u.to_string()).as_deref().unwrap_or("N/A"),
             };
 
             println!("{message}");

--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -190,7 +190,6 @@ mod test {
         client.push_error_response(
             ApiErrorResponse {
                 detail: "detail".to_string(),
-                status_code: 404,
             },
             404,
         );

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -713,6 +713,7 @@ pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
 
         LockedManifestError::ParseCheckWarnings(_) => display_chain(err),
         LockedManifestError::UnsupportedLockfileForUpdate => display_chain(err),
+        LockedManifestError::NoPackagesOnFirstPage => display_chain(err),
     }
 }
 


### PR DESCRIPTION
This has a few non-trivial changes:
- CatalogPageInput::packages becomes an Option, which requires throwing an error during resolution if the first page doesn't have packages
- install_id is added in some places where name was incorrectly used, but name is still used in some places

Most changes were trivial:
- Lots of fields were made optional
- `status_code` was dropped from `ErrorResponse`