### PR TITLE
docs: Fix release notes for 1.0.4 and subsequent

### DIFF
--- a/doc/release-notes/rl-1.0.4.md
+++ b/doc/release-notes/rl-1.0.4.md
@@ -25,8 +25,6 @@
 
 - `flox pull --force` now accepts `owner/name` as a parameter. Previously,
   force didn't allow for other parameters. (#1300)
-- Spinners are now displayed for `flox pull` in all cases. Previously this was
-  not consistent. (#1337)
 
 ### Packaging
 
@@ -46,5 +44,3 @@
   hook (#1227)
 * [Óscar Carrasco](https://github.com/oxcabe) - refactor: reimplement
   `InitHook` trait to avoid invalid states caused by `should_run` (#1313)
-* [Conor](https://github.com/crsche) - feat(PyProject::detect): detect
-  unconventional requirements.txt (#1323) (#1336)

--- a/doc/release-notes/rl-1.0.5.md
+++ b/doc/release-notes/rl-1.0.5.md
@@ -1,0 +1,11 @@
+## Release 1.0.5 (UNRELEASED)
+
+### Pull/Push Improvements
+
+- Spinners are now displayed for `flox pull` in all cases. Previously this was
+  not consistent. (#1337)
+
+### Thank you to our community contributions this release
+
+* [Conor](https://github.com/crsche) - feat(PyProject::detect): detect
+  unconventional requirements.txt (#1323) (#1336)


### PR DESCRIPTION
## Proposed Changes

Remove two fixes that didn't make it into the 1.0.4 release. Start a new release notes file for the next 1.0.5 (or could a minor instead of patch) release so that we don't forget to include them.

## Release Notes

Meta, this is the release notes 😁 