### PR TITLE
fix(cli): make options.systems optional

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -112,7 +112,11 @@ impl<State> CoreEnvironment<State> {
                 let Some(ref client) = flox.catalog_client else {
                     return Err(CoreEnvironmentError::CatalogClientMissing);
                 };
-                LockedManifest::Catalog(self.lock_with_catalog_client(client, *manifest)?)
+                LockedManifest::Catalog(self.lock_with_catalog_client(
+                    client,
+                    *manifest,
+                    &flox.system,
+                )?)
             },
         };
 
@@ -179,6 +183,7 @@ impl<State> CoreEnvironment<State> {
         &self,
         client: &catalog::Client,
         manifest: TypedManifestCatalog,
+        default_system: &str,
     ) -> Result<LockedManifestCatalog, CoreEnvironmentError> {
         let existing_lockfile = 'lockfile: {
             let Ok(lockfile_path) = CanonicalPath::new(self.lockfile_path()) else {
@@ -197,9 +202,14 @@ impl<State> CoreEnvironment<State> {
             }
         };
 
-        LockedManifestCatalog::lock_manifest(&manifest, existing_lockfile.as_ref(), client)
-            .block_on()
-            .map_err(CoreEnvironmentError::LockedManifest)
+        LockedManifestCatalog::lock_manifest(
+            &manifest,
+            existing_lockfile.as_ref(),
+            client,
+            default_system,
+        )
+        .block_on()
+        .map_err(CoreEnvironmentError::LockedManifest)
     }
 
     /// Build the environment, [Self::lock] if necessary.

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -112,11 +112,7 @@ impl<State> CoreEnvironment<State> {
                 let Some(ref client) = flox.catalog_client else {
                     return Err(CoreEnvironmentError::CatalogClientMissing);
                 };
-                LockedManifest::Catalog(self.lock_with_catalog_client(
-                    client,
-                    *manifest,
-                    &flox.system,
-                )?)
+                LockedManifest::Catalog(self.lock_with_catalog_client(client, *manifest)?)
             },
         };
 
@@ -183,7 +179,6 @@ impl<State> CoreEnvironment<State> {
         &self,
         client: &catalog::Client,
         manifest: TypedManifestCatalog,
-        default_system: &str,
     ) -> Result<LockedManifestCatalog, CoreEnvironmentError> {
         let existing_lockfile = 'lockfile: {
             let Ok(lockfile_path) = CanonicalPath::new(self.lockfile_path()) else {
@@ -202,14 +197,9 @@ impl<State> CoreEnvironment<State> {
             }
         };
 
-        LockedManifestCatalog::lock_manifest(
-            &manifest,
-            existing_lockfile.as_ref(),
-            client,
-            default_system,
-        )
-        .block_on()
-        .map_err(CoreEnvironmentError::LockedManifest)
+        LockedManifestCatalog::lock_manifest(&manifest, existing_lockfile.as_ref(), client)
+            .block_on()
+            .map_err(CoreEnvironmentError::LockedManifest)
     }
 
     /// Build the environment, [Self::lock] if necessary.

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -164,7 +164,6 @@ pub struct ManifestProfile {
 #[serde(rename_all = "kebab-case")]
 pub struct ManifestOptions {
     /// A list of systems that each package is resolved for.
-    #[serde(default)]
     pub(super) systems: Option<Vec<System>>,
     /// Options that control what types of packages are allowed.
     #[serde(default)]

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -165,7 +165,7 @@ pub struct ManifestProfile {
 pub struct ManifestOptions {
     /// A list of systems that each package is resolved for.
     #[serde(default)]
-    pub(super) systems: Vec<System>,
+    pub(super) systems: Option<Vec<System>>,
     /// Options that control what types of packages are allowed.
     #[serde(default)]
     allow: Allows,


### PR DESCRIPTION
options.systems is optional for pkgdb, and if it's null, pkgdb defaults to the current system.

The CLI currently passes an empty list, which leads to pkgdb throwing SystemNotSupportedByLockfile.

Instead, make systems an Option in the CLI, and default to the current system for resolution if it is None.

Drop the use of lifetimes in collect_package_groups since that would require figuring out lifetimes for a second source of system strings which seems like too much effort when we could just copy a few strings instead.