### PR TITLE
feat: allow github:flox/nixpkgs urls in pkgdb

### DIFF
--- a/cli/tests/catalog_responses/hello_resolution.json
+++ b/cli/tests/catalog_responses/hello_resolution.json
@@ -11,7 +11,7 @@
               "derivation": "???",
               "description": "description",
               "license": "license",
-              "locked_url": "github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd",
+              "locked_url": "https://github.com/flox/nixpkgs?rev=ab5fd150146dcfe41fda501134e6503932cc8dfd",
               "install_id": "hello_install_id",
               "name": "hello",
               "outputs": [
@@ -48,7 +48,7 @@
               "derivation": "???",
               "description": "description",
               "license": "license",
-              "locked_url": "github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd",
+              "locked_url": "https://github.com/flox/nixpkgs?rev=ab5fd150146dcfe41fda501134e6503932cc8dfd",
               "install_id": "hello_install_id",
               "name": "hello",
               "outputs": [
@@ -85,7 +85,7 @@
               "derivation": "???",
               "description": "description",
               "license": "license",
-              "locked_url": "github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd",
+              "locked_url": "https://github.com/flox/nixpkgs?rev=ab5fd150146dcfe41fda501134e6503932cc8dfd",
               "install_id": "hello_install_id",
               "name": "hello",
               "outputs": [
@@ -122,7 +122,7 @@
               "derivation": "???",
               "description": "description",
               "license": "license",
-              "locked_url": "github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd",
+              "locked_url": "https://github.com/flox/nixpkgs?rev=ab5fd150146dcfe41fda501134e6503932cc8dfd",
               "install_id": "hello_install_id",
               "name": "hello",
               "outputs": [
@@ -162,7 +162,7 @@
               "derivation": "???",
               "description": "description",
               "license": "license",
-              "locked_url": "github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd",
+              "locked_url": "https://github.com/flox/nixpkgs?rev=ab5fd150146dcfe41fda501134e6503932cc8dfd",
               "install_id": "hello_install_id",
               "name": "hello",
               "outputs": [
@@ -199,7 +199,7 @@
               "derivation": "???",
               "description": "description",
               "license": "license",
-              "locked_url": "github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd",
+              "locked_url": "https://github.com/flox/nixpkgs?rev=ab5fd150146dcfe41fda501134e6503932cc8dfd",
               "install_id": "hello_install_id",
               "name": "hello",
               "outputs": [
@@ -236,7 +236,7 @@
               "derivation": "???",
               "description": "description",
               "license": "license",
-              "locked_url": "github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd",
+              "locked_url": "https://github.com/flox/nixpkgs?rev=ab5fd150146dcfe41fda501134e6503932cc8dfd",
               "install_id": "hello_install_id",
               "name": "hello",
               "outputs": [
@@ -273,7 +273,7 @@
               "derivation": "???",
               "description": "description",
               "license": "license",
-              "locked_url": "github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd",
+              "locked_url": "https://github.com/flox/nixpkgs?rev=ab5fd150146dcfe41fda501134e6503932cc8dfd",
               "install_id": "hello_install_id",
               "name": "hello",
               "outputs": [

--- a/pkgdb/include/flox/fetchers/wrapped-nixpkgs-input.hh
+++ b/pkgdb/include/flox/fetchers/wrapped-nixpkgs-input.hh
@@ -21,4 +21,65 @@ namespace flox {
 nix::fetchers::Attrs
 githubAttrsToFloxNixpkgsAttrs( const nix::fetchers::Attrs & attrs );
 
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Fetches a `nixpkgs` input and wraps it with a few modifications. */
+struct WrappedNixpkgsInputScheme : nix::fetchers::InputScheme
+{
+
+  [[nodiscard]] virtual std::string
+  type() const
+  {
+    return "flox-nixpkgs";
+  }
+
+  /** @brief Convert raw attributes into an input. */
+  [[nodiscard]] std::optional<nix::fetchers::Input>
+  inputFromAttrs( const nix::fetchers::Attrs & attrs ) const override;
+
+  /** @brief Convert a URL string into an input. */
+  [[nodiscard]] std::optional<nix::fetchers::Input>
+  inputFromURL( const nix::ParsedURL & url ) const override;
+
+  /** @brief Convert input to a URL representation. */
+  [[nodiscard]] nix::ParsedURL
+  toURL( const nix::fetchers::Input & input ) const override;
+
+  /**
+   * @brief Check to see if the input has all information necessary for use
+   *        with SQLite caches.
+   *
+   * We require `rev` and `version` fields to be present.
+   */
+  [[nodiscard]] bool
+  hasAllInfo( const nix::fetchers::Input & input ) const override;
+
+  /**
+   * @brief Override an input with a different `ref` or `rev`.
+   *
+   * This is unlikely to be used for our purposes; but because it's a part of
+   * the `nix` fetcher interface, we implement it.
+   */
+  [[nodiscard]] nix::fetchers::Input
+  applyOverrides( const nix::fetchers::Input & _input,
+                  std::optional<std::string>   ref,
+                  std::optional<nix::Hash>     rev ) const override;
+
+  /**
+   * @brief Clone the `nixpkgs` repository to prime the cache.
+   *
+   * This function is used by `nix flake archive` to pre-fetch sources.
+   */
+  void
+  clone( const nix::fetchers::Input & input,
+         const nix::Path &            destDir ) const override;
+
+  /** @brief Generate a flake with wraps `nixpkgs`. */
+  [[nodiscard]] std::pair<nix::StorePath, nix::fetchers::Input>
+  fetch( nix::ref<nix::Store>         store,
+         const nix::fetchers::Input & _input ) override;
+
+
+}; /* End class `WrappedNixpkgsInputScheme' */
 }  // namespace flox

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -812,7 +812,7 @@ evalCacheCursorForInput( nix::ref<nix::EvalState> &             state,
   /**
    * Ensure the input is fetched with `flox-nixpkgs`.
    * Currently, the 'flox-nixpkgs' fetcher requires the original input to be
-   * a rev or ref of `github:nixos/nixpkgs`.
+   * a rev or ref of `github:nixos/nixpkgs` or `github:flox/nixpkgs`.
    */
   auto floxNixpkgsAttrs = flox::githubAttrsToFloxNixpkgsAttrs( input.attrs );
   auto packageInputRef  = nix::FlakeRef::fromAttrs( floxNixpkgsAttrs );

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -209,11 +209,7 @@ floxNixpkgsAttrsToGithubAttrs( const nix::fetchers::Attrs & attrs )
   _attrs["repo"] = "nixpkgs";
 
   /* Inherit owner field (could be NixOS or flox) */
-  if ( auto owner = nix::fetchers::maybeGetStrAttr( attrs, "owner" ) )
-    {
-      _attrs["owner"] = *owner;
-    }
-  else { throw nix::Error( "missing 'owner' field in 'flox-nixpkgs' input" ); }
+  _attr["owner"] = nix::fetchers::getStrAttr( attrs, "type" );
 
   /* Inherit `rev' and `ref' fields */
   if ( auto rev = nix::fetchers::maybeGetStrAttr( attrs, "rev" ) )
@@ -278,6 +274,9 @@ githubAttrsToFloxNixpkgsAttrs( const nix::fetchers::Attrs & attrs )
   nix::fetchers::Attrs _attrs;
   _attrs["type"]    = "flox-nixpkgs";
   _attrs["version"] = latestWrapperVersion;
+
+  /* Inherit `owner' field */
+  _attrs["owner"] = owner;
 
   /* Inherit `rev' and `ref' fields */
   if ( auto rev = nix::fetchers::maybeGetStrAttr( attrs, "rev" ) )

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -205,9 +205,15 @@ static nix::fetchers::Attrs
 floxNixpkgsAttrsToGithubAttrs( const nix::fetchers::Attrs & attrs )
 {
   nix::fetchers::Attrs _attrs;
-  _attrs["type"]  = "github";
-  _attrs["owner"] = "NixOS";
-  _attrs["repo"]  = "nixpkgs";
+  _attrs["type"] = "github";
+  _attrs["repo"] = "nixpkgs";
+
+  /* Inherit owner field (could be NixOS or flox) */
+  if ( auto owner = nix::fetchers::maybeGetStrAttr( attrs, "owner" ) )
+    {
+      _attrs["owner"] = *owner;
+    }
+  else { throw nix::Error( "missing 'owner' field in 'flox-nixpkgs' input" ); }
 
   /* Inherit `rev' and `ref' fields */
   if ( auto rev = nix::fetchers::maybeGetStrAttr( attrs, "rev" ) )

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -209,7 +209,7 @@ floxNixpkgsAttrsToGithubAttrs( const nix::fetchers::Attrs & attrs )
   _attrs["repo"] = "nixpkgs";
 
   /* Inherit owner field (could be NixOS or flox) */
-  _attr["owner"] = nix::fetchers::getStrAttr( attrs, "type" );
+  _attrs["owner"] = nix::fetchers::getStrAttr( attrs, "owner" );
 
   /* Inherit `rev' and `ref' fields */
   if ( auto rev = nix::fetchers::maybeGetStrAttr( attrs, "rev" ) )
@@ -310,8 +310,9 @@ WrappedNixpkgsInputScheme::inputFromAttrs(
 
   for ( const auto & [name, value] : attrs )
     {
-      if ( ( name != "type" ) && ( name != "ref" ) && ( name != "rev" )
-           && ( name != "narHash" ) && ( name != "version" ) )
+      if ( ( name != "owner" ) && ( name != "type" ) && ( name != "ref" )
+           && ( name != "rev" ) && ( name != "narHash" )
+           && ( name != "version" ) )
         {
           throw nix::Error( "unsupported flox-nixpkgs input attribute '%s'",
                             name );

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -259,12 +259,13 @@ githubAttrsToFloxNixpkgsAttrs( const nix::fetchers::Attrs & attrs )
   auto owner = nix::fetchers::getStrAttr( attrs, "owner" );
   auto repo  = nix::fetchers::getStrAttr( attrs, "repo" );
 
-  if ( nix::toLower( owner ) != "nixos" || nix::toLower( repo ) != "nixpkgs" )
+  if ( ! ( nix::toLower( owner ) == "nixos" || nix::toLower( owner ) == "flox" )
+       || nix::toLower( repo ) != "nixpkgs" )
     {
-      throw nix::Error(
-        "unsupported input owner/repo '%s/%s' expected 'NixOS/nixpkgs'",
-        owner,
-        repo );
+      throw nix::Error( "unsupported input owner/repo '%s/%s' expected "
+                        "'NixOS/nixpkgs' or 'flox/nixpkgs'",
+                        owner,
+                        repo );
     }
 
 

--- a/pkgdb/src/resolver/lockfile.cc
+++ b/pkgdb/src/resolver/lockfile.cc
@@ -460,27 +460,20 @@ lockedPackageFromCatalogDescriptor( const nlohmann::json & jfrom,
   pkg.info     = jfrom;
   pkg.input    = LockedInputRaw();
 
-  pkg.input.url   = jfrom["locked_url"];
-  pkg.input.attrs = nix::fetchers::Attrs();
+  pkg.input.url = jfrom["locked_url"];
+
   // These attributes are needed by the current builder, and not included in the
   // descriptor. This will not always be true, but also may not be required to
   // build depending on the path taken for future environment builds.
-  if ( std::string supportedUrl = "github:NixOS/nixpkgs";
+  if ( std::string supportedUrl = "github:flox/nixpkgs";
        pkg.input.url.substr( 0, supportedUrl.size() ) != supportedUrl )
     {
       throw InvalidLockfileException(
         "unsupported lockfile URL for v1 lockfile",
         "must begin with " + supportedUrl );
     }
-  pkg.input.attrs["type"]  = "github";
-  pkg.input.attrs["owner"] = "NixOS";
-  pkg.input.attrs["repo"]  = "nixpkgs";
-
-  std::size_t found = pkg.input.url.rfind( "/" );
-  if ( found != std::string::npos )
-    {
-      pkg.input.attrs["rev"] = pkg.input.url.substr( found + 1 );
-    }
+  nix::FlakeRef parsed = nix::parseFlakeRef( pkg.input.url );
+  pkg.input.attrs      = parsed.toAttrs();
 }
 
 void

--- a/pkgdb/tests/.gitignore
+++ b/pkgdb/tests/.gitignore
@@ -1,5 +1,6 @@
 environment
 exceptions
+flox-nixpkgs
 gc
 is_sqlite3
 lockfile

--- a/pkgdb/tests/flox-nixpkgs.bats
+++ b/pkgdb/tests/flox-nixpkgs.bats
@@ -27,7 +27,7 @@ load setup_suite.bash
 @test "'flox-nixpkgs' fetcher sets 'allowUnfree' and 'allowBroken'" {
   run --separate-stderr "$PKGDB_BIN" eval "let
     nixpkgs = builtins.getFlake
-                \"flox-nixpkgs:v$FLOX_NIXPKGS_VERSION/$NIXPKGS_REV\";
+                \"flox-nixpkgs:v$FLOX_NIXPKGS_VERSION/flox/$NIXPKGS_REV\";
     inherit (nixpkgs.legacyPackages.x86_64-linux) config;
   in assert config.allowUnfree && config.allowBroken; true";
   assert_success;
@@ -40,7 +40,7 @@ load setup_suite.bash
 @test "'flox-nixpkgs' and 'github' fetchers fingerprints differ" {
   run --separate-stderr "$PKGDB_BIN" eval "let
     fp0 = builtins.getFingerprint
-            \"flox-nixpkgs\:v$FLOX_NIXPKGS_VERSION/$NIXPKGS_REV\";
+            \"flox-nixpkgs\:v$FLOX_NIXPKGS_VERSION/flox/$NIXPKGS_REV\";
     fp1 = builtins.getFingerprint \"github:NixOS/nixpkgs/$NIXPKGS_REV\";
   in assert fp0 != fp1; true";
   assert_success;
@@ -53,7 +53,7 @@ load setup_suite.bash
 @test "'flox-nixpkgs' and 'github' 'outPaths' match" {
   run --separate-stderr "$PKGDB_BIN" eval "let
     fp0 = builtins.getFlake
-            \"flox-nixpkgs\:v$FLOX_NIXPKGS_VERSION/$NIXPKGS_REV\";
+            \"flox-nixpkgs\:v$FLOX_NIXPKGS_VERSION/flox/$NIXPKGS_REV\";
     op0 = fp0.legacyPackages.x86_64-linux.hello.outPath;
 
     fp1 = builtins.getFlake \"github:NixOS/nixpkgs/$NIXPKGS_REV\";
@@ -68,7 +68,7 @@ load setup_suite.bash
 # ---------------------------------------------------------------------------- #
 
 @test "locked fields on 'flox-nixpkgs' scheme" {
-  URL="flox-nixpkgs:v$FLOX_NIXPKGS_VERSION/$NIXPKGS_REV";
+  URL="flox-nixpkgs:v$FLOX_NIXPKGS_VERSION/flox/$NIXPKGS_REV";
   run --separate-stderr "$PKGDB_BIN" get flake "$URL";
   assert_success;
   FLAKE_INFO="$output";
@@ -76,6 +76,10 @@ load setup_suite.bash
   run --separate-stderr sh -c "echo '$FLAKE_INFO'|jq -r '.attrs.type';";
   assert_success;
   assert_output 'flox-nixpkgs'
+
+  run --separate-stderr sh -c "echo '$FLAKE_INFO'|jq -r '.attrs.owner';";
+  assert_success;
+  assert_output 'flox'
 
   run --separate-stderr sh -c "echo '$FLAKE_INFO'|jq -r '.attrs.rev';";
   assert_success;

--- a/pkgdb/tests/flox-nixpkgs.cc
+++ b/pkgdb/tests/flox-nixpkgs.cc
@@ -1,0 +1,108 @@
+/* ========================================================================== *
+ *
+ *
+ *
+ * -------------------------------------------------------------------------- */
+
+#include <fstream>
+#include <iostream>
+
+#include <nlohmann/json.hpp>
+
+#include "flox/core/nix-state.hh"
+#include "flox/core/util.hh"
+#include "flox/fetchers/wrapped-nixpkgs-input.hh"
+#include "test.hh"
+
+
+/* -------------------------------------------------------------------------- */
+
+using namespace flox;
+
+
+/* -------------------------------------------------------------------------- */
+
+/** @brief Test a flox-nixpkgs URL can be parsed and then serialized. */
+bool
+test_URLRoundtrip()
+{
+  WrappedNixpkgsInputScheme inputScheme;
+  auto                      url = "flox-nixpkgs:v0/flox/" + nixpkgsRev;
+  auto input = inputScheme.inputFromURL( nix::parseURL( url ) );
+  EXPECT( input.has_value() );
+  EXPECT_EQ( inputScheme.toURL( *input ).to_string(), url );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Test a flox-nixpkgs input can be created from attrs and then has the
+ *        expected URL.
+ **/
+bool
+test_inputFromAttrs()
+{
+  nix::fetchers::Attrs      attrs = { { "version", (uint64_t) 0 },
+                                      { "type", "flox-nixpkgs" },
+                                      { "owner", "NixOS" },
+                                      { "rev", nixpkgsRev } };
+  WrappedNixpkgsInputScheme inputScheme;
+  auto                      url   = "flox-nixpkgs:v0/NixOS/" + nixpkgsRev;
+  auto                      input = inputScheme.inputFromAttrs( attrs );
+  EXPECT( input.has_value() );
+  EXPECT_EQ( inputScheme.toURL( *input ).to_string(), url );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Test a locked flox-nixpkgs input preserves all information in the
+ *        unlocked attrs.
+ **/
+bool
+test_lockedRepresentation( nix::ref<nix::EvalState> & state )
+{
+  nix::fetchers::Attrs      attrs = { { "version", (uint64_t) 0 },
+                                      { "type", "flox-nixpkgs" },
+                                      { "owner", "NixOS" },
+                                      { "rev", nixpkgsRev } };
+  WrappedNixpkgsInputScheme inputScheme;
+  auto                      url   = "flox-nixpkgs:v0/NixOS/" + nixpkgsRev;
+  auto                      input = inputScheme.inputFromAttrs( attrs );
+  EXPECT( input.has_value() );
+  auto locked = inputScheme.fetch( state->store, *input ).second;
+  EXPECT( locked.toAttrs() == attrs );
+  return true;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+int
+main()
+{
+  int exitCode = EXIT_SUCCESS;
+  // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define RUN_TEST( ... ) _RUN_TEST( exitCode, __VA_ARGS__ )
+
+  /* Initialize `nix' */
+  flox::NixState nstate;
+  auto           state = nstate.getState();
+
+  RUN_TEST( URLRoundtrip );
+  RUN_TEST( inputFromAttrs );
+  RUN_TEST( lockedRepresentation, state );
+
+  return exitCode;
+}
+
+
+/* -------------------------------------------------------------------------- *
+ *
+ *
+ *
+ * ========================================================================== */

--- a/pkgdb/tests/lockfile.cc
+++ b/pkgdb/tests/lockfile.cc
@@ -67,7 +67,7 @@ static const std::string lockfileContentV1 = R"( {
       "derivation": "derivation",
       "description": "description",
       "license": "license",
-      "locked_url": "github:NixOS/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3",
+      "locked_url": "github:flox/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3",
       "name": "hello",
       "outputs": {
         "name": "store_path"
@@ -160,11 +160,11 @@ test_LockfileFromV1()
   EXPECT( pkg.value().attrPath == attrPath );
 
   EXPECT_EQ( pkg.value().input.url,
-             "github:NixOS/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3" );
+             "github:flox/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3" );
   EXPECT_EQ( pkg.value().input.attrs["rev"],
              "9a333eaa80901efe01df07eade2c16d183761fa3" );
   // These are assumed from v1
-  EXPECT_EQ( pkg.value().input.attrs["owner"], "NixOS" );
+  EXPECT_EQ( pkg.value().input.attrs["owner"], "flox" );
   EXPECT_EQ( pkg.value().input.attrs["type"], "github" );
   EXPECT_EQ( pkg.value().input.attrs["repo"], "nixpkgs" );
   return true;

--- a/pkgdb/tests/lockfile.cc
+++ b/pkgdb/tests/lockfile.cc
@@ -67,7 +67,7 @@ static const std::string lockfileContentV1 = R"( {
       "derivation": "derivation",
       "description": "description",
       "license": "license",
-      "locked_url": "github:flox/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9a333eaa80901efe01df07eade2c16d183761fa3",
       "name": "hello",
       "outputs": {
         "name": "store_path"


### PR DESCRIPTION
We rely on a custom fetcher to allow us to build unfree packages in github:NixOS/nixpkgs. Catalog entries contain URLs of the form https://github.com/flox/nixpkgs, but they should be handled by our fetcher. To support this:
- in v1 lockfiles only, translate https://github.com/flox/nixpkgs into github:flox/nixpkgs
- permit flox as an owner in our fetcher