### PR TITLE
fix: skip resolution of fully locked groups, invalidate locks

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -443,6 +443,10 @@ impl LockedManifestCatalog {
         map.into_values()
     }
 
+    /// Eliminate groups that are already fully locked
+    /// by extracting them into a separate list of locked packages.
+    ///
+    /// This is used to avoid re-resolving packages that are already locked.
     fn split_fully_locked_groups(
         groups: impl IntoIterator<Item = PackageGroup>,
         seed_lockfile: Option<&LockedManifestCatalog>,

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -135,6 +135,32 @@ pub struct ManifestPackageDescriptor {
     pub(crate) optional: bool,
 }
 
+impl ManifestPackageDescriptor {
+    /// Check if two package descriptors should have the same resolution.
+    /// This is used to determine if a package needs to be re-resolved
+    /// in the presence of an existing lock.
+    ///
+    /// * Descriptors are resolved per system,
+    ///   changing the supported systems does not invalidate _existing_ resolutions.
+    /// * Priority is not used in resolution, so it is ignored.
+    pub(super) fn invalidates_existing_resolution(&self, other: &Self) -> bool {
+        // unpack to avoid forgetting to update this method when new fields are added
+        let ManifestPackageDescriptor {
+            pkg_path,
+            pkg_group,
+            version,
+            optional,
+            systems: _,
+            priority: _,
+        } = self;
+
+        pkg_path != &other.pkg_path
+            || pkg_group != &other.pkg_group
+            || version != &other.version
+            || optional != &other.optional
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ManifestVariables(BTreeMap<String, String>);


### PR DESCRIPTION
* fix: unlock resolve descriptor if manifest was invalidated
Skip resolving with `derivation` if any significant attribute of the manifest descriptor changed (i.e. requested version, pkg-path, group, etc.)

* fix: skip resolution of fully locked groups
Add packages from fully locked groups to the lockfiel without re-resolution.