### PR TITLE
build: use fenix provided rust-analyzer

### DIFF
--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -16,7 +16,6 @@
   openssl,
   pkg-config,
   pkgsFor,
-  rust-analyzer,
   rustfmt ? rust-toolchain.rustfmt,
   targetPlatform,
   zlib,
@@ -197,9 +196,6 @@ in
 
         devPackages = [
           rustfmt
-          rust-analyzer
-          rust-toolchain.rustc
-          rust-toolchain.clippy
         ];
 
         devEnvs =


### PR DESCRIPTION
Apparently using bundling rust-analyzer from nixpkgs ran into version incompatibilities with the rust toolchain provided by fenix: #1405.

This PR replaces the nixpkgs package with the one from the fenix toolchain.
