### PR TITLE
test: don't include client by default

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -248,7 +248,7 @@ pub mod test_helpers {
                 .new_lockfile
         });
 
-        let (flox, tempdir_handle) = flox_instance_with_optional_floxhub(owner);
+        let (flox, tempdir_handle) = flox_instance_with_optional_floxhub_and_client(owner, false);
 
         // All Flox instances created by flox_instance() have the same global
         // manifest,
@@ -264,13 +264,16 @@ pub mod test_helpers {
     }
 
     pub fn flox_instance() -> (Flox, TempDir) {
-        flox_instance_with_optional_floxhub(None)
+        flox_instance_with_optional_floxhub_and_client(None, false)
     }
 
     /// If owner is None, no mock FloxHub is setup.
     /// If it is Some, a mock FloxHub with a repo for that owner will be setup,
     /// but no other owners will work.
-    fn flox_instance_with_optional_floxhub(owner: Option<&EnvironmentOwner>) -> (Flox, TempDir) {
+    pub fn flox_instance_with_optional_floxhub_and_client(
+        owner: Option<&EnvironmentOwner>,
+        use_client: bool,
+    ) -> (Flox, TempDir) {
         let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
 
         let cache_dir = tempdir_handle.path().join("caches");
@@ -306,7 +309,11 @@ pub mod test_helpers {
             )
             .unwrap(),
             floxhub_token: None,
-            catalog_client: Some(MockClient::default().into()),
+            catalog_client: if use_client {
+                Some(MockClient::default().into())
+            } else {
+                None
+            },
         };
 
         init_global_manifest(&global_manifest_path(&flox)).unwrap();

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -624,10 +624,6 @@ mod tests {
     use super::*;
     use crate::commands::ActiveEnvironments;
 
-    #[cfg(target_os = "macos")]
-    const PATH: &str =
-        "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/flox/env/bin:/nix/store/some/bin";
-
     static DEFAULT_ENV: Lazy<UninitializedEnvironment> = Lazy::new(|| {
         UninitializedEnvironment::DotFlox(DotFlox {
             path: PathBuf::from(""),

--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -176,14 +176,15 @@ fn render_show(search_results: &[SearchResult], all: bool) -> Result<()> {
 
 #[cfg(test)]
 mod test {
-    use flox_rust_sdk::flox::test_helpers::flox_instance;
+    use flox_rust_sdk::flox::test_helpers::flox_instance_with_optional_floxhub_and_client;
     use flox_rust_sdk::providers::catalog::{ApiErrorResponse, Client};
 
     use super::*;
 
     #[tokio::test]
     async fn show_handles_404() {
-        let (mut flox, _temp_dir_handle) = flox_instance();
+        let (mut flox, _temp_dir_handle) =
+            flox_instance_with_optional_floxhub_and_client(None, true);
         let Client::Mock(ref mut client) = flox.catalog_client.as_mut().unwrap() else {
             panic!()
         };


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Unit tests no longer include a client by default. Our logic for when to use the client often depends on the presence of the client on the `Flox` struct, so including the client by default could have unintended consequence in tests.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
