### PR TITLE
feat: wrap up `install` with catalog

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -107,11 +107,15 @@ impl<State> CoreEnvironment<State> {
             .map_err(CoreEnvironmentError::DeserializeManifest)?;
 
         let lockfile = match manifest {
-            TypedManifest::Pkgdb(_) => LockedManifest::Pkgdb(self.lock_with_pkgdb(flox)?),
+            TypedManifest::Pkgdb(_) => {
+                tracing::debug!("using pkgdb to lock");
+                LockedManifest::Pkgdb(self.lock_with_pkgdb(flox)?)
+            },
             TypedManifest::Catalog(manifest) => {
                 let Some(ref client) = flox.catalog_client else {
                     return Err(CoreEnvironmentError::CatalogClientMissing);
                 };
+                tracing::debug!("using catalog client to lock");
                 LockedManifest::Catalog(self.lock_with_catalog_client(client, *manifest)?)
             },
         };

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -593,8 +593,8 @@ mod tests {
 
     /// Pulling an environment without packages for the current platform should
     /// succeed if force is passed
-    #[test]
-    fn test_handle_pull_result_2() {
+    #[tokio::test]
+    async fn test_handle_pull_result_2() {
         let owner = "owner".parse().unwrap();
         let (flox, _temp_dir_handle) = flox_instance_with_global_lock_and_floxhub(&owner);
 
@@ -643,8 +643,8 @@ mod tests {
     /// Pulling an environment without packages for the current platform should
     /// prompt about adding system
     /// When the user confirms, the environment should not be removed
-    #[test]
-    fn test_handle_pull_result_4() {
+    #[tokio::test]
+    async fn test_handle_pull_result_4() {
         let owner = "owner".parse().unwrap();
         let (flox, _temp_dir_handle) = flox_instance_with_global_lock_and_floxhub(&owner);
 

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -593,6 +593,7 @@ mod tests {
 
     /// Pulling an environment without packages for the current platform should
     /// succeed if force is passed
+    // handle_pull_result() calls spin() which depends on tokio
     #[tokio::test]
     async fn test_handle_pull_result_2() {
         let owner = "owner".parse().unwrap();
@@ -643,6 +644,7 @@ mod tests {
     /// Pulling an environment without packages for the current platform should
     /// prompt about adding system
     /// When the user confirms, the environment should not be removed
+    // handle_pull_result() calls spin() which depends on tokio
     #[tokio::test]
     async fn test_handle_pull_result_4() {
         let owner = "owner".parse().unwrap();

--- a/tests/catalog.bats
+++ b/tests/catalog.bats
@@ -43,3 +43,15 @@ teardown_file() {
   assert_output --partial "using catalog client for show"
   assert_output --partial "hello - hello@2.12.1"
 }
+
+@test "'flox install' and 'flox activate' work with catalog server" {
+  "$FLOX_BIN" init
+  # TODO: drop this when flox init sets version = 1
+  echo 'version = 1' | "$FLOX_BIN" edit -f -
+  run "$FLOX_BIN" install hello -vvv
+  assert_success
+  assert_output --partial "using catalog client to lock"
+  run "$FLOX_BIN" activate -- hello
+  assert_success
+  assert_output --partial "Hello, world!"
+}


### PR DESCRIPTION
-  Provide tokio to functions called by `spin_with_delay`

    The catalog client uses `reqwest` which uses `tokio::time::sleep`. When
    the catalog is used in combination with our `spin_with_delay` function,
    this causes a panic:
    ```
    there is no reactor running, must be called from the context of a Tokio 1.x runtime
    ```

    Enter the tokio runtime context in the thread spawned by
    `spin_with_delay` to avoid the panic.

- Add functional test for catalog install. Note that this is still skipped since we're waiting for changes serverside