### PR TITLE
refactor: don't default to search result type in node hook

### DIFF
--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -744,7 +744,7 @@ mod tests {
         assert_eq!(pyproject.unwrap(), PyProject {
             provided_python_version: ProvidedVersion::Compatible {
                 requested: None,
-                compatible: ProvidedPackage::new("python3", vec!["python3"], "3.11.6"),
+                compatible: ProvidedPackage::new("python3", vec!["python3"], "3.11.6",),
             },
         });
     }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
While working on the catalog init hook I discovered that we'll need a common-denominator type for handling information retrieved by either the catalog client or pkgdb. This introduces a new type to handle that, and it's presented as a separate PR to keep the catalog-init PR smaller.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
