### PR TITLE
fix: avoid infinitely sourcing bashrc

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -889,3 +889,23 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate,activate:infinite_source,activate:infinite_source:bash
+@test "bash: test for infinite source loop" {
+  "$FLOX_BIN" delete -f
+  "$FLOX_BIN" init
+  echo 'eval "$('"$FLOX_BIN"' activate -d '"$PWD"')"' >> "$HOME/.bashrc"
+  run timeout 1 bash -c 'eval "$("$FLOX_BIN" activate)"'
+  assert_success
+}
+
+# bats test_tags=activate,activate:infinite_source,activate:infinite_source:zsh
+@test "zsh: test for infinite source loop" {
+  "$FLOX_BIN" delete -f
+  "$FLOX_BIN" init
+  echo 'eval "$('"$FLOX_BIN"' activate -d '"$PWD"')"' >> "$HOME/.zshrc"
+  run timeout 1 zsh -c 'eval "$("$FLOX_BIN" activate)"'
+  assert_success
+}
+
+# ---------------------------------------------------------------------------- #

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -894,6 +894,8 @@ EOF
 @test "bash: test for infinite source loop" {
   "$FLOX_BIN" delete -f
   "$FLOX_BIN" init
+  # The bash -ic invocation sources .bashrc, and then the activate sources it a
+  # second time and disables further sourcing.
   cat << 'EOF' >> "$HOME/.bashrc"
 if [ -z "$ALREADY_SOURCED" ]; then
   export ALREADY_SOURCED=1

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -894,18 +894,31 @@ EOF
 @test "bash: test for infinite source loop" {
   "$FLOX_BIN" delete -f
   "$FLOX_BIN" init
-  echo 'eval "$('"$FLOX_BIN"' activate -d '"$PWD"')"' >> "$HOME/.bashrc"
-  run timeout 1 bash -c 'eval "$("$FLOX_BIN" activate)"'
-  assert_success
+  cat << 'EOF' >> "$HOME/.bashrc"
+if [ -z "$ALREADY_SOURCED" ]; then
+  export ALREADY_SOURCED=1
+elif [ "$ALREADY_SOURCED" == 1 ]; then
+  export ALREADY_SOURCED=2
+else
+  exit 2
+fi
+
+eval "$("$FLOX_BIN" activate -d "$PWD")"
+EOF
+  bash -ic true
 }
 
 # bats test_tags=activate,activate:infinite_source,activate:infinite_source:zsh
 @test "zsh: test for infinite source loop" {
   "$FLOX_BIN" delete -f
   "$FLOX_BIN" init
-  echo 'eval "$('"$FLOX_BIN"' activate -d '"$PWD"')"' >> "$HOME/.zshrc"
-  run timeout 1 zsh -c 'eval "$("$FLOX_BIN" activate)"'
-  assert_success
+  cat << 'EOF' >> "$HOME/.zshrc"
+[ "$ALREADY_SOURCED" == 1 ] && exit 2
+export ALREADY_SOURCED=1
+
+eval "$("$FLOX_BIN" activate -d "$PWD")"
+EOF
+  zsh -ic true
 }
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -391,10 +391,13 @@ const char * const BASH_ACTIVATE_SCRIPT_BEGIN = R"_(
 }
 
 # We use --rcfile to activate using bash which skips sourcing ~/.bashrc,
-# so source that here.
-if [ -f ~/.bashrc ]
+# so source that here, but not if we're already in the process of sourcing
+# bashrc in a parent process.
+if [ -f ~/.bashrc -a -z "$_flox_already_sourcing_bashrc" ]
 then
+    export _flox_already_sourcing_bashrc=1
     source ~/.bashrc
+    unset _flox_already_sourcing_bashrc
 fi
 
 # Restore environment variables set in the previous bash initialization.


### PR DESCRIPTION
## Proposed Changes

Check and set a guard prior to sourcing .bashrc to prevent in-place activations performed from within the .bashrc file from triggering an infinite loop.

## Release Notes

N/A