### PR TITLE
fix: don't print success before error

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -446,11 +446,6 @@ impl Activate {
 
         debug!("running activation command: {:?}", command);
 
-        let message = formatdoc! {"
-                You are now using the environment {}.
-                To stop using this environment, type 'exit'\n", now_active.message_description()?};
-        message::updated(message);
-
         // exec should never return
         Err(command.exec().into())
     }

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -19,14 +19,14 @@ pub(crate) fn error(v: impl Display) {
 pub(crate) fn created(v: impl Display) {
     print_message(std::format_args!("✨ {v}"));
 }
-/// double width chracter, add an additional space for alignment
+/// double width character, add an additional space for alignment
 pub(crate) fn deleted(v: impl Display) {
     print_message(std::format_args!("🗑️  {v}"));
 }
 pub(crate) fn updated(v: impl Display) {
     print_message(std::format_args!("✅ {v}"));
 }
-/// double width chracter, add an additional space for alignment
+/// double width character, add an additional space for alignment
 pub(crate) fn warning(v: impl Display) {
     print_message(std::format_args!("⚠️  {v}"));
 }

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -143,6 +143,17 @@ for d in "${flox_env_dirs[@]}"; do
 done
 if [ $flox_env_found -eq 0 ]; then
 
+  # If interactive and a command has not been passed, this is an interactive
+  # activate,
+  # and we print a message to the user
+  # TODO: should this be printed after scripts?
+  # Should it be in Rust using message::updated?
+  if [ -t 1 ] && [ $# -eq 0 ]; then
+    echo "✅ You are now using the environment '$FLOX_ENV_DESCRIPTION'." >&2
+    echo "To stop using this environment, type 'exit'" >&2
+    echo >&2
+  fi
+
   # First activation of this environment. Snapshot environment to start.
   _start_env="$($_coreutils/bin/mktemp --suffix=.start-env)"
   export | $_coreutils/bin/sort > "$_start_env"
@@ -228,7 +239,8 @@ else
   # If we're attempting to launch an interactive shell then just print a
   # message to say that the environment has already been activated.
   if [ -t 1 ] && [ $# -eq 0 ]; then
-    echo "ERROR: Environment '$FLOX_ENV_DESCRIPTION' is already active." >&2
+    # TODO: should this be in Rust using message::error?
+    echo "❌ ERROR: Environment '$FLOX_ENV_DESCRIPTION' is already active." >&2
     exit 1
   fi
 


### PR DESCRIPTION
Running `flox activate` twice was printing:
```
✅ You are now using the environment 'name'.
To stop using this environment, type 'exit'

ERROR: Environment 'name' is already active.
```

Remove the success message from Rust, and only print it in Bash codepaths when the environment is not already active (and an interactive activation is being run).

Also add a ❌ to the error message.