### PR TITLE
build(flox-cli-tests): export absolute default path to pkgdb

### DIFF
--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -130,7 +130,7 @@ in
     }
     ${
       if PKGDB_BIN == null
-      then "export PKGDB_BIN='pkgdb';"
+      then ''export PKGDB_BIN="$(command -v pkgdb)";''
       else "export PKGDB_BIN='${PKGDB_BIN}';"
     }
     ${


### PR DESCRIPTION
`flox` was being called with PKGDB_PATH=pkgdb, but since #1299
 `pkgdb` is called with an cleared `PATH`.
Unless `flox-cli-tests` are being called with `--pkgdb <abs path to pkgdb>`,
executing pkgdb will fail with a No Such File exception.

