### PR TITLE
fix(pkgdb): Fix shell syntax in assertion

### DIFF
--- a/pkgdb/tests/migrate.bats
+++ b/pkgdb/tests/migrate.bats
@@ -96,7 +96,7 @@ genParamsNixpkgsFlox() {
 
   # Make sure we have > 0 packages, save the rules hash
   real_package_count=$(get_package_count $dbpath)
-  assert [ $real_package_count > 0 ]
+  assert [ $real_package_count -gt 0 ]
   old_rules_hash=$(get_scrape_meta $dbpath scrape_rules_hash)
   
   # Delete the packages, and assert it's empty


### PR DESCRIPTION
## Proposed Changes

Running the tests locally was producing an empty file in `pkgdb/0` which was untracked and unignored by git. It was caused by this test, which was redirecting empty output to a file, instead of comparing the integers.

## Release Notes

N/A