### PR TITLE
chore(catalog): Add ability to trace HTTP requests

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -30,6 +30,7 @@ pub const DEFAULT_CATALOG_URL: &str = "https://flox-catalog.flox.dev";
 const NIXPKGS_CATALOG: &str = "nixpkgs";
 pub const FLOX_CATALOG_MOCK_DATA_VAR: &str = "_FLOX_USE_CATALOG_MOCK";
 pub const FLOX_CATALOG_DUMP_DATA_VAR: &str = "_FLOX_CATALOG_DUMP_RESPONSE_FILE";
+pub const FLOX_CATALOG_TRACE_HTTP_VAR: &str = "_FLOX_CATALOG_TRACE_HTTP";
 
 type ResolvedGroups = Vec<ResolvedPackageGroup>;
 
@@ -109,8 +110,16 @@ pub struct CatalogClient {
 
 impl CatalogClient {
     pub fn new(baseurl: &str) -> Self {
+        let verbose = std::env::var(FLOX_CATALOG_TRACE_HTTP_VAR).is_ok();
+        let timeout = std::time::Duration::from_secs(15);
+        let rclient = reqwest::ClientBuilder::new()
+            .connect_timeout(timeout)
+            .timeout(timeout)
+            .connection_verbose(verbose)
+            .build()
+            .unwrap();
         Self {
-            client: APIClient::new(baseurl),
+            client: APIClient::new_with_client(baseurl, rclient),
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

So that we can debug the requests and responses to the catalog server because `_FLOX_CATALOG_DUMP_RESPONSE_FILE` only gives us the translated response body. TBD whether we'd keep both.

It looks like this in use:

    % FLOX_FEATURES_USE_CATALOG=true _FLOX_CATALOG_TRACE_HTTP=true just flox show hello -vvvvv
    …
    2024-05-10T15:12:26.036380Z TRACE reqwest::connect::verbose: 4e6242c9 write: b"GET /api/v1/catalog/packages/hello?page=0&pageSize=10 HTTP/1.1\r\naccept: application/json\r\nhost: flox-catalog.flox.dev\r\n\r\n"
    2024-05-10T15:12:26.036445Z DEBUG hyper::proto::h1::io: flushed 121 bytes
    2024-05-10T15:12:26.036472Z TRACE hyper::proto::h1::conn: flushed({role=client}): State { reading: Init, writing: KeepAlive, keep_alive: Busy }
    2024-05-10T15:12:26.599513Z TRACE hyper::proto::h1::conn: Conn::read_head
    2024-05-10T15:12:26.599745Z TRACE reqwest::connect::verbose: 4e6242c9 read: b"HTTP/1.1 200 OK\r\nServer: nginx\r\nDate: Fri, 10 May 2024 15:12:26 GMT\r\nContent-Type: application/json\r\nContent-Length: 461\r\nConnection: keep-alive\r\nVary: Accept-Encoding\r\n\r\n{\"items\":[{\"attr_path\":\"hello\",\"name\":\"hello-2.12.1\",\"pname\":\"hello\",\"version\":\"2.12.1\",\"outputs\":[{\"name\":\"out\",\"store_path\":\"/nix/store/f96mbgrwdfx6116arpm2bzjak21wmmw6-hello-2.12.1\"}],\"outputs_to_install\":[\"out\"],\"description\":\"A program that produces a familiar, friendly greeting\",\"license\":\"GPL-3.0-or-later\",\"rev\":\"25865a40d14b3f9cf19f19b924e2ab4069b09588\",\"rev_count\":621993,\"rev_date\":\"2024-05-05T10:51:47Z\",\"system\":\"aarch64-darwin\"}],\"total_count\":1}"
    …

This is nice in the respect that it gives us the request too, there's minimal plumbing, and we don't have to figure out how to represent multiple request/response cycles.

However the output is pretty noisy and requires some additional un-escaping such as:

    pbpaste | sed 's/\\"/"/g' | jq .

## Release Notes

N/A