### PR TITLE
build(flox-tests): export absolute default path to pkgdb

### DIFF
--- a/pkgs/flox-tests/default.nix
+++ b/pkgs/flox-tests/default.nix
@@ -123,7 +123,7 @@ in
     }
     ${
       if PKGDB_BIN == null
-      then "export PKGDB_BIN='pkgdb';"
+      then ''export PKGDB_BIN="$(command -v pkgdb)";''
       else "export PKGDB_BIN='${PKGDB_BIN}';"
     }
     ${


### PR DESCRIPTION
This is 54d3ae9e4b1b988174f8710fbea5959628e5c978 but for flox-tests instead of just flox-cli-tests.

`flox-tests` was calling `flox` with `PKGDB_PATH=pkgdb` and expecting `flox` to find `pkgdb` in `PATH`, but since #1299 `pkgdb` is called with a cleared `PATH`.
Unless `flox-tests` are called with `--pkgdb <abs path to pkgdb>`, executing pkgdb will fail with a No Such File exception.