### PR TITLE
docs: remove unreleased tag from 1.0.5 release notes

### DIFF
--- a/doc/release-notes/rl-1.0.5.md
+++ b/doc/release-notes/rl-1.0.5.md
@@ -1,4 +1,4 @@
-## Release 1.0.5 (UNRELEASED)
+## Release 1.0.5
 
 ### Pull/Push Improvements
 


### PR DESCRIPTION
## Proposed Changes

The notes from 1.0.5 say "UNRELEASED" but I believe the release has been completed.

