### PR TITLE
ci: rename TARGET -> FLOX_SRC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
           workflow_file_name: "ci.yml"
           ref:                "main"
           wait_interval:      10
-          client_payload:     '{"TARGET":"git+ssh://git@github.com/flox/flox?ref=${{ github.event.pull_request.head.ref || github.ref }}&rev=${{ github.event.pull_request.head.sha || github.sha }}"}'
+          client_payload:     '{"FLOX_SRC":"github:flox/flox/${{ github.event.pull_request.head.ref || github.ref }}&rev=${{ github.event.pull_request.head.sha || github.sha }}"}'
           propagate_failure:  true
           trigger_workflow:   true
           wait_workflow:      true


### PR DESCRIPTION
* `TARGET` property is now called `FLOX_SRC`
* `git+ssh://` is now needed for `FLOX_SRC` we can use `github:` type of flake input.