### PR TITLE
chore(catalog): Add mitmproxy instructions

### DIFF
--- a/cli/catalog-api-v1/README.md
+++ b/cli/catalog-api-v1/README.md
@@ -35,7 +35,7 @@ Mid-term updating the client library and proposing it as a PR will be done by au
 
 1. Start the interface and leave it running in a separate terminal:
 
-        nix run 'nixpkgs/release-23.11#mitmproxy'
+        mitmproxy
 
 1. Install the Certificate Authority per [these instructions](https://docs.mitmproxy.org/stable/concepts-certificates/).
 1. Run a `flox` command, using the catalog and the proxy:

--- a/cli/catalog-api-v1/README.md
+++ b/cli/catalog-api-v1/README.md
@@ -28,3 +28,18 @@ $ cargo check -p catalog-api-v1
 
 Finally, remember to check-in the updated sources.
 Mid-term updating the client library and proposing it as a PR will be done by automation.
+
+## Debugging
+
+[mitmproxy](https://mitmproxy.org/) can be used to debug requests and responses from the Catalog API.
+
+1. Start the interface and leave it running in a separate terminal:
+
+        nix run 'nixpkgs/release-23.11#mitmproxy'
+
+1. Install the Certificate Authority per [these instructions](https://docs.mitmproxy.org/stable/concepts-certificates/).
+1. Run a `flox` command, using the catalog and the proxy:
+
+        HTTPS_PROXY=http://localhost:8080 flox show bash
+
+1. Explore the recorded flows in the `mitmproxy` interface.

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -7,6 +7,7 @@
   mkShell,
   pre-commit-check,
   shfmt,
+  mitmproxy,
   flox-cli,
   flox-cli-tests,
   flox-pkgdb,
@@ -42,6 +43,7 @@
       commitizen
       alejandra
       shfmt
+      mitmproxy
     ];
 in
   mkShell (


### PR DESCRIPTION
## Proposed Changes

So that we can easily debug interactions with the Catalog API.

This is the least intrusive solution which gives us pretty printed body
content and allows you to see multiple request/response cycles. The
following options were discounted because..

`progenitor` hooks aren't designed for inspecting response bodies:

- https://github.com/flox/flox/compare/main...dcarley/1434-catalog-debug-hooks

Verbose connection logging requires additional copy/paste and string
formatting to get a pretty printed body:

- https://github.com/flox/flox/compare/main...dcarley/1434-catalog-trace-http

TLS key logging to inspect in Wireshark requires messing with the TLS
implementation, including which root CAs are used, and Wireshark doesn't
make the body contents any easier to read anyway:

- https://github.com/flox/flox/compare/main...dcarley/1434-catalog-tls-keylog

The instructions use `mitmproxy` from 23.11 because there's a build
issue on unstable for MacOS:

- https://github.com/NixOS/nixpkgs/issues/291753

## Release Notes

N/A
