### PR TITLE
test: fix flaky podman test

### DIFF
--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -37,7 +37,7 @@ env_setup() {
 # However, that directory is not writable
 # and thus fails to be deleted by bats as part of the test teardown.
 podman_cache_reset() {
-  echo "Resetting podman cache" >&3
+  # echo "Resetting podman cache" >&3
   is_linux && podman system reset --force
   true
 }
@@ -150,9 +150,19 @@ function skip_if_linux() {
 
   assert_equal "${#lines[@]}" 1 # 1 result
   assert_equal "${lines[0]}" "bar"
-  assert_equal "${#stderr_lines[@]}" 2
-  assert_regex "${stderr_lines[0]}" "\/nix\/store\/.*\/bin\/hello"
-  assert_equal "${stderr_lines[1]}" "Hello, world!"
+
+  # Podman generates some errors/warnings about UIDs/GIDs due to how the rootless
+  # setup works: https://github.com/containers/podman/issues/15611
+  # Another error you may see is that the container file already exists, which is
+  # harmless and can be ignored.
+  # So, we can't rely on the *number* of stderr lines, but we know the lines we
+  # care about will be the last two lines.
+
+  n_stderr_lines="${#stderr_lines[@]}"
+  hello_line="$(($n_stderr_lines - 1))"
+  store_path_line="$(($n_stderr_lines - 2))"
+  assert_regex "${stderr_lines[$store_path_line]}" "\/nix\/store\/.*\/bin\/hello"
+  assert_equal "${stderr_lines[$hello_line]}" "Hello, world!"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This test failed due to an expected number of `stderr` lines containing errors and warnings
- `cannot find UID/GID for user flox-test`
    - This is related to how rootless mode works in Podman and it not being able to create additional users or allocate user ids in rootless mode: https://github.com/containers/podman/issues/15611
- `Using rootless single mapping into the namespace`
    - Same as above
- `acquiring lock 7 for container <hash>: file exists`
    - The podman cache already has this container, which makes sense if the other `podman` test creates the same container 
  
Ultimately this just skips counting `stderr` lines and instead checks that the last two lines are the ones we expect.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
