### PR TITLE
fix(catalog): SSL_CERT_FILE for mitmproxy

### DIFF
--- a/cli/catalog-api-v1/README.md
+++ b/cli/catalog-api-v1/README.md
@@ -40,6 +40,6 @@ Mid-term updating the client library and proposing it as a PR will be done by au
 1. Install the Certificate Authority per [these instructions](https://docs.mitmproxy.org/stable/concepts-certificates/).
 1. Run a `flox` command, using the catalog and the proxy:
 
-        HTTPS_PROXY=http://localhost:8080 flox show bash
+        HTTPS_PROXY=http://localhost:8080 SSL_CERT_FILE=~/.mitmproxy/mitmproxy-ca-cert.pem flox show bash
 
 1. Explore the recorded flows in the `mitmproxy` interface.


### PR DESCRIPTION
## Proposed Changes

Small fix to 259cec4 because I found that `install` will fail if the package wasn't previously cached in the local store:

    ❌ ERROR: Failed to build environment.

    caught a nix exception: running pkgdb subcommand: error:
           … while fetching the input 'flox-nixpkgs:v0/flox/6c0b7a92c30122196a761b440ac0d46d3d9954f1'

           … while updating the lock file of flake 'path:/private/tmp/nix-2127-0?lastModified=1716376910&narHash=sha256-71E2zF7xAZivPCPeMiuZzTWk2DGN0Mi9N9aP53zoBro%3D'

           … while updating the flake input 'nixpkgs'

           … while fetching the input 'github:flox/nixpkgs/6c0b7a92c30122196a761b440ac0d46d3d9954f1'

           error: unable to download 'https://github.com/flox/nixpkgs/archive/6c0b7a92c30122196a761b440ac0d46d3d9954f1.tar.gz': SSL peer certificate or SSH remote key was not OK (60)

This didn't come up in my original testing because I was always using the same package.

Specifying these as inline environment variables because it could be confusing to export them and then find that other (e.g. non-flox) operations fail at a later point in time.

## Release Notes

N/A