### PR TITLE
feat: detect [hook.script] and print deprecation warning

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "shell-escape",
+ "strip-ansi-escapes",
  "supports-color",
  "sys-info",
  "sysinfo",
@@ -736,6 +737,7 @@ dependencies = [
  "serde_with",
  "serial_test",
  "shell-escape",
+ "strip-ansi-escapes",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2857,6 +2859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,6 +3426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,6 +3458,26 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -35,6 +35,7 @@ tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
+strip-ansi-escapes = "0.2.0"
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -8,6 +8,7 @@ use log::debug;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::Value;
+use strip_ansi_escapes::strip;
 use thiserror::Error;
 
 use super::lockfile::{FlakeRef, LockedManifestPkgdb};
@@ -121,6 +122,11 @@ pub fn call_pkgdb(mut pkgdb_cmd: Command) -> Result<Value, CallPkgDbError> {
                 .lines()
                 .map_while(Result::ok)
                 .for_each(|line| {
+                    let stripped_line = strip(&line);
+                    let line_str = String::from_utf8_lossy(&stripped_line);
+                    if line_str.starts_with("warning:") {
+                        eprintln!("{}", std::format_args!("⚠️  {line}"));
+                    }
                     debug!(target: "pkgdb", "{line}");
                 });
         });

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -50,6 +50,7 @@ url.workspace = true
 uuid.workspace = true
 xdg.workspace = true
 path-dedot = "3.1.1"
+strip-ansi-escapes = "0.2.0"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -82,6 +82,15 @@ on-activate = """
 EOF
   )
 
+  export DEPRECATED_HOOK_SCRIPT=$(
+    cat <<- EOF
+[hook]
+script = """
+  echo "sourcing deprecated hook.script";
+"""
+EOF
+  )
+
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" > /dev/null || return
@@ -1004,6 +1013,17 @@ EOF
   assert_success
   refute_output "FLOX_SHELL="
   refute_output "_flox_shell="
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate,activate:deprecate_hook_script
+@test "use of [hook.script] prints deprecation warning" {
+  sed -i -e "s/^\[hook\]/${DEPRECATED_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+  FLOX_SHELL="bash" run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
+  assert_success
+  assert_output --partial "[hook.script] is deprecated and support for it will be removed in an upcoming release"
+  assert_output --partial "sourcing deprecated hook.script"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -724,7 +724,10 @@ makeActivationScripts( nix::EvalState &              state,
                    "\033[0m" /* ANSI_NORMAL */
                    " "
                    "[hook.script] is deprecated and support for "
-                   "it will be removed in an upcoming release\n" );
+                   "it will be removed in an upcoming release. "
+                   "Consider moving its contents to one of "
+                   "[hook.on-activate] or [profile.common]. "
+                   "See manifest.toml(5) for more information.\n" );
           debugLog( "adding 'hook.script' to activation scripts" );
           addScriptToScriptsDir( *hook->script, tempDir, "hook-script" );
         }

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -716,11 +716,15 @@ makeActivationScripts( nix::EvalState &              state,
   auto hook = manifest.hook;
   if ( hook.has_value() )
     {
-      // [hook.script] is deprecated, in favor of [profile.*].  For now we will
-      // allow it.
-      // TODO: print a warning??
       if ( hook->script.has_value() )
         {
+          fprintf( stderr,
+                   "\033[35;1m" /* ANSI_WARNING */
+                   "warning:"
+                   "\033[0m" /* ANSI_NORMAL */
+                   " "
+                   "[hook.script] is deprecated and support for "
+                   "it will be removed in an upcoming release\n" );
           debugLog( "adding 'hook.script' to activation scripts" );
           addScriptToScriptsDir( *hook->script, tempDir, "hook-script" );
         }


### PR DESCRIPTION
## Proposed Changes

Issue #1135 documents the request to print a deprecation warning with the use of `[hook.script]` in a flox manifest. This patch updates the rust `call_pkgdb()` function to pass stderr messages beginning with the string "warning:" directly to STDERR, and similarly updates the pkgdb `makeActivationScripts()` function to print a warning message to STDERR when rendering the `[hook.script]` manifest section to a file.

## Release Notes

* enabled deprecation warning when detecting use of the manifest `[hook.script]` section