### PR TITLE
fix: move manifest.toml man page to section 5

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -187,7 +187,7 @@ impl RawManifest {
         options_table.decor_mut().set_prefix(indoc! {r#"
 
             # Additional options can be set in the `[options]` section. Refer to
-            # manifest.toml(1) for a list of available options.
+            # manifest.toml(5) for a list of available options.
         "#});
 
         // `systems` array
@@ -218,7 +218,7 @@ impl RawManifest {
                   #
                   # This is a Flox environment manifest.
                   # Visit flox.dev/docs/concepts/manifest/
-                  # or see flox-edit(1), manifest.toml(1) for more information.
+                  # or see flox-edit(1), manifest.toml(5) for more information.
                   #
                   {}"#,
                 decor.prefix().and_then(|raw_str| raw_str.as_str()).unwrap_or("")})
@@ -871,7 +871,7 @@ pub(super) mod test {
             #
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
-            # or see flox-edit(1), manifest.toml(1) for more information.
+            # or see flox-edit(1), manifest.toml(5) for more information.
             #
 
             # List packages you wish to install in your environment inside
@@ -913,7 +913,7 @@ pub(super) mod test {
             # """
 
             # Additional options can be set in the `[options]` section. Refer to
-            # manifest.toml(1) for a list of available options.
+            # manifest.toml(5) for a list of available options.
             [options]
             systems = []
         "#};
@@ -937,7 +937,7 @@ pub(super) mod test {
             #
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
-            # or see flox-edit(1), manifest.toml(1) for more information.
+            # or see flox-edit(1), manifest.toml(5) for more information.
             #
             version = 1
 
@@ -980,7 +980,7 @@ pub(super) mod test {
             # """
 
             # Additional options can be set in the `[options]` section. Refer to
-            # manifest.toml(1) for a list of available options.
+            # manifest.toml(5) for a list of available options.
             [options]
             systems = []
         "#};
@@ -1009,7 +1009,7 @@ pub(super) mod test {
             #
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
-            # or see flox-edit(1), manifest.toml(1) for more information.
+            # or see flox-edit(1), manifest.toml(5) for more information.
             #
 
             # List packages you wish to install in your environment inside
@@ -1050,7 +1050,7 @@ pub(super) mod test {
             # """
 
             # Additional options can be set in the `[options]` section. Refer to
-            # manifest.toml(1) for a list of available options.
+            # manifest.toml(5) for a list of available options.
             [options]
             systems = []
         "#};
@@ -1083,7 +1083,7 @@ pub(super) mod test {
             #
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
-            # or see flox-edit(1), manifest.toml(1) for more information.
+            # or see flox-edit(1), manifest.toml(5) for more information.
             #
 
             # List packages you wish to install in your environment inside
@@ -1124,7 +1124,7 @@ pub(super) mod test {
             # """
 
             # Additional options can be set in the `[options]` section. Refer to
-            # manifest.toml(1) for a list of available options.
+            # manifest.toml(5) for a list of available options.
             [options]
             systems = ["x86_64-linux"]
         "#};
@@ -1153,7 +1153,7 @@ pub(super) mod test {
             #
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
-            # or see flox-edit(1), manifest.toml(1) for more information.
+            # or see flox-edit(1), manifest.toml(5) for more information.
             #
 
             # List packages you wish to install in your environment inside
@@ -1195,7 +1195,7 @@ pub(super) mod test {
             """
 
             # Additional options can be set in the `[options]` section. Refer to
-            # manifest.toml(1) for a list of available options.
+            # manifest.toml(5) for a list of available options.
             [options]
             systems = ["x86_64-linux"]
         "#};

--- a/cli/flox/doc-catalog/flox-upgrade.md
+++ b/cli/flox/doc-catalog/flox-upgrade.md
@@ -33,7 +33,7 @@ pkg-group named 'toplevel'.
 The packages in that pkg-group can be upgraded without updating any other
 pkg-groups by passing 'toplevel' as the pkg-group name.
 
-See [`manifest.toml(1)`](./manifest.toml.md) for more on using pkg-groups.
+See [`manifest.toml(5)`](./manifest.toml.md) for more on using pkg-groups.
 
 # OPTIONS
 
@@ -50,4 +50,4 @@ See [`manifest.toml(1)`](./manifest.toml.md) for more on using pkg-groups.
 # SEE ALSO
 
 [`flox-update(1)`](./flox-update.md)
-[`manifest.toml(1)`](./manifest.toml.md),
+[`manifest.toml(5)`](./manifest.toml.md),

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -55,7 +55,7 @@ This means that for each shell hook various environment variables such as
 `PATH`, `MANPATH`, `PKG_CONFIG_PATH`, `PYTHONPATH`, etc,
 are set to the appropriate values for the environment in which the shell
 hook was defined.
-See [`manifest.toml(1)`](./manifest.toml.md) for more details on shell hooks.
+See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
 
 # OPTIONS
 

--- a/cli/flox/doc/flox-edit.md
+++ b/cli/flox/doc/flox-edit.md
@@ -26,7 +26,7 @@ The editor is found by querying `$EDITOR`, `$VISUAL`,
 and then by looking for common editors in `$PATH`.
 The manifest of an environment on FloxHub or in a different directory
 can be edited via the `-r` or `-d` flags respectively.
-See [`manifest.toml(1)`](./manifest.toml.md) for more details on the manifest
+See [`manifest.toml(5)`](./manifest.toml.md) for more details on the manifest
 format.
 
 Once the editor is closed the environment is built in order to validate the

--- a/cli/flox/doc/flox-install.md
+++ b/cli/flox/doc/flox-install.md
@@ -76,4 +76,4 @@ options.
 ## SEE ALSO
 [`flox-uninstall(1)`](./flox-uninstall.md),
 [`flox-edit(1)`](./flox-edit.md),
-[`manifest-toml(1)`](./manifest.toml.md)
+[`manifest.toml(5)`](./manifest.toml.md)

--- a/cli/flox/doc/flox-pull.md
+++ b/cli/flox/doc/flox-pull.md
@@ -46,7 +46,7 @@ environment's manifest.
 This may create a broken environment that cannot be pushed back to FloxHub until
 it is repaired with [`flox-edit(1)`](./flox-edit.md) or
 [`flox-remove(1)`](./flox-remove.md).
-See [`manifest.toml(1)`](./manifest.toml.md) for more on multi-system
+See [`manifest.toml(5)`](./manifest.toml.md) for more on multi-system
 environments.
 
 # OPTIONS
@@ -78,4 +78,4 @@ environments.
 [`flox-push(1)`](./flox-push.md)
 [`flox-edit(1)`](./flox-edit.md)
 [`flox-remove(1)`](./flox-remove.md)
-[`manifest.toml(1)`](./manifest.toml.md)
+[`manifest.toml(5)`](./manifest.toml.md)

--- a/cli/flox/doc/flox-upgrade.md
+++ b/cli/flox/doc/flox-upgrade.md
@@ -38,7 +38,7 @@ pkg-group named 'toplevel'.
 The packages in that pkg-group can be upgraded without updating any other
 pkg-groups by passing 'toplevel' as the pkg-group name.
 
-See [`manifest.toml(1)`](./manifest.toml.md) for more on using pkg-groups.
+See [`manifest.toml(5)`](./manifest.toml.md) for more on using pkg-groups.
 
 # OPTIONS
 
@@ -55,4 +55,4 @@ See [`manifest.toml(1)`](./manifest.toml.md) for more on using pkg-groups.
 # SEE ALSO
 
 [`flox-update(1)`](./flox-update.md)
-[`manifest.toml(1)`](./manifest.toml.md),
+[`manifest.toml(5)`](./manifest.toml.md),

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -1,6 +1,6 @@
 ---
 title: MANIFEST.TOML
-section: 1
+section: 5
 header: "Flox User Manuals"
 ...
 

--- a/pkgs/flox-manpages/default.nix
+++ b/pkgs/flox-manpages/default.nix
@@ -47,6 +47,8 @@ in
 
 
     fd ".*\.md" -d 1 ./ -x ${compileManPageBin} {} $buildDir/{/.}.1
+    rm -f $buildDir/manifest.toml.1
+    ${compileManPageBin} manifest.toml.md $buildDir/manifest.toml.5
 
     ls $buildDir
 

--- a/pkgs/flox-manpages/default.nix
+++ b/pkgs/flox-manpages/default.nix
@@ -47,8 +47,7 @@ in
 
 
     fd ".*\.md" -d 1 ./ -x ${compileManPageBin} {} $buildDir/{/.}.1
-    rm -f $buildDir/manifest.toml.1
-    ${compileManPageBin} manifest.toml.md $buildDir/manifest.toml.5
+    mv $buildDir/manifest.toml.1 $buildDir/manifest.toml.5
 
     ls $buildDir
 


### PR DESCRIPTION
## Proposed Changes

The manifest.toml file is currently being installed as section 1 when it should be installed for section 5 (File formats and conventions).

See `man(1)` for a description of the section numbers and their purpose.

## Release Notes

* moved the man page for `manifest.toml` from section 1 to section 5