### PR TITLE
fix: invoke `tcsh -m` to source flox-provided $HOME/.tcshrc

### DIFF
--- a/pkgdb/src/buildenv/assets/activate
+++ b/pkgdb/src/buildenv/assets/activate
@@ -227,7 +227,7 @@ if [ $# -gt 0 ]; then
         export FLOX_ORIG_HOME="$HOME"
         export HOME="$_tcsh_home"
         export FLOX_TCSH_INIT_SCRIPT="$FLOX_ENV/activate.d/tcsh"
-        exec "$_flox_shell" "$@"
+        exec "$_flox_shell" -m "$@"
       fi
       ;;
     *zsh)
@@ -285,7 +285,9 @@ if [ -t 1 ] || [ -n "$_FLOX_FORCE_INTERACTIVE" ]; then
         export FLOX_ORIG_HOME="$HOME"
         export HOME="$_tcsh_home"
         export FLOX_TCSH_INIT_SCRIPT="$FLOX_ENV/activate.d/tcsh"
-        exec "$_flox_shell" -v
+        # The -m option is required for tcsh to source a .tcshrc file that
+        # the effective user does not own.
+        exec "$_flox_shell" -m
       fi
       ;;
     *zsh)


### PR DESCRIPTION
## Proposed Changes

By default tcsh silently refuses to source a .tcshrc file that the effective user does not own, but this behaviour can be overridden with the `-m` flag as described in tcsh(1):

  -m  The shell loads ˜/.tcshrc even if it does not belong to the effective user.

This patch adds this `-m` flag to the two tcsh invocations for which we are setting `$HOME`, and removes the `-v` flag that was accidentally left behind with a previous round of debugging.

## Release Notes

N/A