### PR TITLE
fix(activate): Convert tests from expect

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -213,9 +213,8 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+  FLOX_SHELL="bash" USER="$REAL_USER" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- bash "$TESTS_DIR/hello-check.sh"
+  assert_success
 }
 
 # bats test_tags=activate,activate:path,activate:path:bash
@@ -225,9 +224,8 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+  FLOX_SHELL="bash" USER="$REAL_USER" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- bash "$TESTS_DIR/hello-check.sh"
+  assert_success
 }
 
 # bats test_tags=activate,activate:path,activate:path:fish
@@ -237,9 +235,8 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+  FLOX_SHELL="fish" USER="$REAL_USER" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- bash "$TESTS_DIR/hello-check.sh"
+  assert_success
 }
 
 # bats test_tags=activate,activate:path,activate:path:fish
@@ -249,9 +246,8 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+  FLOX_SHELL="fish" USER="$REAL_USER" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- bash "$TESTS_DIR/hello-check.sh"
+  assert_success
 }
 
 # bats test_tags=activate,activate:path,activate:path:tcsh
@@ -261,9 +257,8 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+  FLOX_SHELL="tcsh" USER="$REAL_USER" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- bash "$TESTS_DIR/hello-check.sh"
+  assert_success
 }
 
 # bats test_tags=activate,activate:path,activate:path:tcsh
@@ -273,9 +268,8 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+  FLOX_SHELL="tcsh" USER="$REAL_USER" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- bash "$TESTS_DIR/hello-check.sh"
+  assert_success
 }
 
 # bats test_tags=activate,activate:path,activate:path:zsh
@@ -289,9 +283,8 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+  FLOX_SHELL="zsh" USER="$REAL_USER" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- bash "$TESTS_DIR/hello-check.sh"
+  assert_success
 }
 
 # bats test_tags=activate,activate:path,activate:path:zsh
@@ -304,9 +297,8 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
-  assert_output --regexp "bin/hello"
-  refute_output "not found"
+  FLOX_SHELL="zsh" USER="$REAL_USER" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- bash "$TESTS_DIR/hello-check.sh"
+  assert_success
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/hello-check.sh
+++ b/cli/tests/hello-check.sh
@@ -1,0 +1,12 @@
+# When a project is activated with --dir check
+# - hello is installed
+# - prompt is set ### XXX how exactly? I don't see it doing this.
+# Assume throughout that the project is named project-\d+
+set -euxo pipefail
+
+# check for hello
+[[ "$({ command -v hello||which hello||type -P hello; } 2>&1)" =~ bin\/hello ]]
+
+# check for hello after changing directory
+cd ..
+[[ "$({ command -v hello||which hello||type -P hello; } 2>&1)" =~ bin\/hello ]]

--- a/cli/tests/hello-check.sh
+++ b/cli/tests/hello-check.sh
@@ -1,6 +1,6 @@
 # When a project is activated with --dir check
 # - hello is installed
-# - prompt is set ### XXX how exactly? I don't see it doing this.
+# - prompt is set
 # Assume throughout that the project is named project-\d+
 set -euxo pipefail
 
@@ -10,3 +10,6 @@ set -euxo pipefail
 # check for hello after changing directory
 cd ..
 [[ "$({ command -v hello||which hello||type -P hello; } 2>&1)" =~ bin\/hello ]]
+
+# closest we can get because PS1 isn't exported
+[[ "${FLOX_PROMPT_ENVIRONMENTS}" =~ project-[0-9]+ ]]


### PR DESCRIPTION
## Proposed Changes

We've had another flakey test:

- https://github.com/flox/flox/actions/runs/9377878053/job/25820156213#step:6:84

I don't think that `expect` is necessarily at fault here but the
timeouts and lack of feedback make it very hard to understand what's
happened. We could enable `exp_internal 1` to get more feedback but it's
very noisy, especially combined with `activate -v`.

Converting the assertions to a straight shell script that runs within
the activation is slightly faster but more importantly easier to reason
about and gives us clearer feedback. We took the same approach for
Python tests in the past.

I believe that these tests are functionally still the same. I've left
`hello.exp` in place because it's still used by one other test that has
a more specific assertion about the binary path.

## Release Notes

N/A