### PR TITLE
fix(activate): Verbose output from expect failures

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -207,7 +207,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:path,activate:path:bash
-@test "bash: activate puts package in path" {
+@test "bash: interactive activate puts package in path" {
   export FLOX_FEATURES_USE_CATALOG=false
   project_setup
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -219,7 +219,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:bash
-@test "catalog: bash: activate puts package in path" {
+@test "catalog: bash: interactive activate puts package in path" {
   project_setup
   export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -231,7 +231,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:fish
-@test "fish: activate puts package in path" {
+@test "fish: interactive activate puts package in path" {
   export FLOX_FEATURES_USE_CATALOG=false
   project_setup
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -243,7 +243,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:fish
-@test "catalog: fish: activate puts package in path" {
+@test "catalog: fish: interactive activate puts package in path" {
   project_setup
   export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -255,7 +255,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:tcsh
-@test "tcsh: activate puts package in path" {
+@test "tcsh: interactive activate puts package in path" {
   export FLOX_FEATURES_USE_CATALOG=false
   project_setup
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -267,7 +267,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:tcsh
-@test "catalog: tcsh: activate puts package in path" {
+@test "catalog: tcsh: interactive activate puts package in path" {
   project_setup
   export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -279,7 +279,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:zsh
-@test "zsh: activate puts package in path" {
+@test "zsh: interactive activate puts package in path" {
   export FLOX_FEATURES_USE_CATALOG=false
   project_setup
   export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
@@ -295,7 +295,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:zsh
-@test "catalog: zsh: activate puts package in path" {
+@test "catalog: zsh: interactive activate puts package in path" {
   project_setup
   export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -213,7 +213,7 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -225,7 +225,7 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -237,7 +237,7 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -249,7 +249,7 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -261,7 +261,7 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -273,7 +273,7 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -289,7 +289,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -304,7 +304,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }

--- a/cli/tests/activate/interactive-hello.exp
+++ b/cli/tests/activate/interactive-hello.exp
@@ -15,6 +15,7 @@ expect_after {
   "*\n" { exp_continue }
   "*\r" { exp_continue }
 }
+# this is only output for interactive activations
 expect "Preparing environment"
 
 # check for hello

--- a/cli/tests/activate/interactive-hello.exp
+++ b/cli/tests/activate/interactive-hello.exp
@@ -7,8 +7,9 @@ set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
 
 set timeout 20
+exp_internal 1
 
-spawn $flox -v activate --dir $dir
+spawn $flox activate --dir $dir
 expect_after {
   timeout { exit 1 }
   eof { exit 2 }

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -273,7 +273,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "$FLOX_CACHE_DIR/run/owner/.+\..+\..+/bin/hello"
   refute_output "not found"
 }

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -215,7 +215,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-interactive-hello.exp" "$OWNER/test"
+  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
   assert_output --partial "$FLOX_CACHE_DIR/remote/owner/test/.flox/run/bin/hello"
   refute_output "not found"
 }
@@ -229,7 +229,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-interactive-hello.exp" "$OWNER/test"
+  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
   assert_output --partial "$FLOX_CACHE_DIR/remote/owner/test/.flox/run/bin/hello"
   refute_output "not found"
 }

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -215,7 +215,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
+  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-interactive-hello.exp" "$OWNER/test"
   assert_output --partial "$FLOX_CACHE_DIR/remote/owner/test/.flox/run/bin/hello"
   refute_output "not found"
 }
@@ -229,7 +229,7 @@ EOF
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
-  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-hello.exp" "$OWNER/test"
+  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/remote-interactive-hello.exp" "$OWNER/test"
   assert_output --partial "$FLOX_CACHE_DIR/remote/owner/test/.flox/run/bin/hello"
   refute_output "not found"
 }


### PR DESCRIPTION
## Proposed Changes

This supersedes https://github.com/flox/flox/pull/1540

**refactor(activate): Rename interactive tests**

Make it clearer that these tests depend on the commands happening in an
interactive activation where we have a TTY. This means that they have to
use `expect` rather than `flox activate -- command`.

**fix(activate): Verbose output from expect failures**

Set `exp_internal` so that we get more feedback from flakey tests when
they fail. Like this one, which almost certainly hit the timeout, but we
can't tell where/why:

- https://github.com/flox/flox/actions/runs/9377878053/job/25820156213#step:6:84

This can also be enabled with `expect -d` but setting it within the
script makes it consistent for all tests that use it. Man page describes
the option as:

    exp_internal [-f file] value
                 causes further commands to send diagnostic information internal to Expect to stderr if value is non-zero.  This output is disabled if value is 0.  The diagnostic information includes every
                 character received, and every attempt made to match the current output against the patterns.

I've removed the `activate -v` option at the same time because the
combination output is very noisy.

## Release Notes

N/A