### PR TITLE
test(environment-managed): Copy cases for catalog

### DIFF
--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -160,7 +160,7 @@ EOF
 version = 1
 
 [install]
-hello = {}
+hello.pkg-path = "hello"
 EOF
 
   _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json" \

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -41,6 +41,8 @@ setup() {
   setup_isolated_flox
   project_setup
   floxhub_setup "$OWNER"
+  export FLOX_FEATURES_USE_CATALOG=true
+  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
 }
 
 teardown() {
@@ -69,6 +71,24 @@ dot_flox_exists() {
 
 # bats test_tags=install,managed
 @test "m1: install a package to a managed environment" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  make_empty_remote_env
+
+  run --separate-stderr "$FLOX_BIN" list --name
+  assert_success
+  assert_output ""
+
+  run "$FLOX_BIN" install hello
+  assert_success
+  assert_output --partial "environment '$OWNER/project-managed-${BATS_TEST_NUMBER}'" # managed env output
+
+  run --separate-stderr "$FLOX_BIN" list --name
+  assert_success
+  assert_output "hello"
+}
+
+# bats test_tags=install,managed
+@test "catalog: m1: install a package to a managed environment" {
   make_empty_remote_env
 
   run --separate-stderr "$FLOX_BIN" list --name
@@ -86,6 +106,20 @@ dot_flox_exists() {
 
 # bats test_tags=uninstall,managed
 @test "m2: uninstall a package from a managed environment" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  make_empty_remote_env
+  "$FLOX_BIN" install hello
+
+  run "$FLOX_BIN" uninstall hello
+  assert_success
+
+  run --separate-stderr "$FLOX_BIN" list --name
+  assert_success
+  assert_output ""
+}
+
+# bats test_tags=uninstall,managed
+@test "catalog: m2: uninstall a package from a managed environment" {
   make_empty_remote_env
   "$FLOX_BIN" install hello
 
@@ -99,6 +133,23 @@ dot_flox_exists() {
 
 # bats test_tags=edit,managed
 @test "m3: edit a package from a managed environment" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  make_empty_remote_env
+
+  TMP_MANIFEST_PATH="$BATS_TEST_TMPDIR/manifest.toml"
+
+  cat << "EOF" >> "$TMP_MANIFEST_PATH"
+[install]
+hello = {}
+EOF
+
+  run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
+  assert_success
+  assert_output --partial "✅ Environment successfully updated."
+}
+
+# bats test_tags=edit,managed
+@test "catalog: m3: edit a package from a managed environment" {
   make_empty_remote_env
 
   TMP_MANIFEST_PATH="$BATS_TEST_TMPDIR/manifest.toml"
@@ -117,7 +168,32 @@ EOF
 
 # bats test_tags=managed,pull,managed:pull
 @test "m4: pushed environment can be pulled" {
+  export FLOX_FEATURES_USE_CATALOG=false
 
+  mkdir a a_data
+  mkdir b b_data
+
+  # on machine a, create and push the environment
+  export FLOX_DATA_DIR="$(pwd)/a_data"
+  pushd a > /dev/null || return
+  "$FLOX_BIN" init
+  "$FLOX_BIN" install hello
+  "$FLOX_BIN" push --owner "$OWNER"
+  popd > /dev/null || return
+
+  # on another b machine, pull the environment
+  export FLOX_DATA_DIR="$(pwd)/b_data"
+  pushd b > /dev/null || return
+  "$FLOX_BIN" pull --remote "$OWNER/a"
+  run --separate-stderr "$FLOX_BIN" list --name
+
+  # assert that the environment contains the installed package
+  assert_output "hello"
+  popd > /dev/null || return
+}
+
+# bats test_tags=managed,pull,managed:pull
+@test "catalog: m4: pushed environment can be pulled" {
   mkdir a a_data
   mkdir b b_data
 
@@ -142,6 +218,44 @@ EOF
 
 # bats test_tags=managed,update,managed:update
 @test "m5: updated environment can be pulled" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  mkdir a a_data
+  mkdir b b_data
+
+  # on machine a, create and push the (empty) environment
+  export FLOX_DATA_DIR="$(pwd)/a_data"
+  pushd a > /dev/null || return
+  "$FLOX_BIN" init
+  "$FLOX_BIN" push --owner "$OWNER"
+  popd > /dev/null || return
+
+  # on another b machine,
+  #  - pull the environment
+  #  - install a package
+  #  - push the environment
+  export FLOX_DATA_DIR="$(pwd)/b_data"
+  pushd b > /dev/null || return
+  "$FLOX_BIN" pull --remote "$OWNER/a"
+  "$FLOX_BIN" install hello
+  "$FLOX_BIN" push --owner "$OWNER"
+  popd > /dev/null || return
+
+  # on machine a, pull the environment
+  # and check that the package is installed
+  export FLOX_DATA_DIR="$(pwd)/a_data"
+  pushd a > /dev/null || return
+  # assert that pulling succeeds
+  run "$FLOX_BIN" pull
+  assert_success
+
+  # assert that the environment contains the installed package
+  run --separate-stderr "$FLOX_BIN" list --name
+  assert_output "hello"
+  popd > /dev/null || return
+}
+
+# bats test_tags=managed,update,managed:update
+@test "catalog: m5: updated environment can be pulled" {
   mkdir a a_data
   mkdir b b_data
 
@@ -179,6 +293,48 @@ EOF
 
 # bats test_tags=managed,diverged,managed:diverged
 @test "m7: remote can not be pulled into diverged environment" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  mkdir a a_data
+  mkdir b b_data
+
+  # on machine a, create and push the (empty) environment
+  export FLOX_DATA_DIR="$(pwd)/a_data"
+  pushd a > /dev/null || return
+  "$FLOX_BIN" init
+  "$FLOX_BIN" push --owner "$OWNER"
+  popd > /dev/null || return
+
+  # on another b machine,
+  #  - pull the environment
+  #  - install a package
+  #  - push the environment
+  export FLOX_DATA_DIR="$(pwd)/b_data"
+  pushd b > /dev/null || return
+  "$FLOX_BIN" pull --remote "$OWNER/a"
+  "$FLOX_BIN" install vim
+  "$FLOX_BIN" push --owner "$OWNER"
+  popd > /dev/null || return
+
+  # on machine a, pull the environment
+  # and check that the package is installed
+  export FLOX_DATA_DIR="$(pwd)/a_data"
+  pushd a > /dev/null || return
+  run "$FLOX_BIN" install emacs
+  # assert that pulling fails
+  run "$FLOX_BIN" pull
+  assert_failure
+  # assert that the environment contains the installed package
+  assert_output --partial "diverged"
+
+  # assert that pulling with `--force` succeeds
+  run "$FLOX_BIN" pull --force
+  assert_success
+
+  popd > /dev/null || return
+}
+
+# bats test_tags=managed,diverged,managed:diverged
+@test "catalog: m7: remote can not be pulled into diverged environment" {
   mkdir a a_data
   mkdir b b_data
 
@@ -220,6 +376,40 @@ EOF
 
 # bats test_tags=managed,diverged,managed:diverged-upstream
 @test "m8: remote can be force pulled into diverged environment" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  mkdir a
+  mkdir b
+
+  # on machine a, create and push the (empty) environment
+  pushd a > /dev/null || return
+  "$FLOX_BIN" init
+  FLOX_DATA_DIR="$(pwd)/a_data" "$FLOX_BIN" push --owner "$OWNER"
+  popd > /dev/null || return
+
+  pushd b > /dev/null || return
+  FLOX_DATA_DIR="$(pwd)/b_data" "$FLOX_BIN" pull --remote "$OWNER/a"
+  FLOX_DATA_DIR="$(pwd)/b_data" "$FLOX_BIN" install vim
+  popd > /dev/null || return
+
+  pushd a > /dev/null || return
+  FLOX_DATA_DIR="$(pwd)/a_data" "$FLOX_BIN" install emacs
+  FLOX_DATA_DIR="$(pwd)/a_data" "$FLOX_BIN" push
+  popd > /dev/null || return
+
+  pushd b > /dev/null || return
+  FLOX_DATA_DIR="$(pwd)/b_data" "$FLOX_BIN" push --force
+  popd > /dev/null || return
+
+  pushd a > /dev/null || return
+  FLOX_DATA_DIR="$(pwd)/a_data" run "$FLOX_BIN" pull
+  assert_failure
+  FLOX_DATA_DIR="$(pwd)/a_data" run "$FLOX_BIN" pull --force
+  assert_success
+  popd > /dev/null || return
+}
+
+# bats test_tags=managed,diverged,managed:diverged-upstream
+@test "catalog: m8: remote can be force pulled into diverged environment" {
   mkdir a
   mkdir b
 
@@ -256,6 +446,15 @@ EOF
 # Make sure we haven't broken regular search
 # bats test_tags=managed,search,managed:search
 @test "m8: search works in managed environment" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  make_empty_remote_env
+
+  run "$FLOX_BIN" search hello
+  assert_success
+}
+
+# bats test_tags=managed,search,managed:search
+@test "catalog: m8: search works in managed environment" {
   make_empty_remote_env
 
   run "$FLOX_BIN" search hello
@@ -267,6 +466,20 @@ EOF
 # Make sure we haven't activate
 # bats test_tags=managed,activate,managed:activate
 @test "m9: activate works in managed environment" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  make_empty_remote_env
+  "$FLOX_BIN" install hello
+
+  # TODO: flox will set HOME if it doesn't match the home of the user with
+  # current euid. I'm not sure if we should change that, but for now just set
+  # USER to REAL_USER.
+  FLOX_SHELL=bash USER="$REAL_USER" run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
+  assert_output --regexp "$FLOX_CACHE_DIR/run/owner/.+\..+\..+/bin/hello"
+  refute_output "not found"
+}
+
+# bats test_tags=managed,activate,managed:activate
+@test "catalog: m9: activate works in managed environment" {
   make_empty_remote_env
   "$FLOX_BIN" install hello
 
@@ -311,6 +524,28 @@ EOF
 # and are recreated at the current pushed state.
 # bats test_tags=managed,delete,managed:fresh-deleted
 @test "m11: uses fresh branch after delete" {
+  export FLOX_FEATURES_USE_CATALOG=false
+  make_empty_remote_env
+  "$FLOX_BIN" install vim
+
+  run "$FLOX_BIN" delete
+  assert_success
+
+  run dot_flox_exists
+  assert_failure
+
+  # when recreating an environment, a new branch should be used
+  run "$FLOX_BIN" pull --remote "$OWNER/project-managed-${BATS_TEST_NUMBER}"
+  assert_success
+
+  "$FLOX_BIN" install emacs
+  run "$FLOX_BIN" list --name
+  assert_output --partial "emacs"
+  refute_output "vim"
+}
+
+# bats test_tags=managed,delete,managed:fresh-deleted
+@test "catalog: m11: uses fresh branch after delete" {
   make_empty_remote_env
   "$FLOX_BIN" install vim
 
@@ -331,6 +566,8 @@ EOF
 }
 
 @test "sanity check upgrade works for managed environments" {
+  # update shouldn't work for catalog: https://github.com/flox/flox/issues/1509
+  export FLOX_FEATURES_USE_CATALOG=false
   _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
     make_empty_remote_env
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -157,6 +157,8 @@ EOF
   TMP_MANIFEST_PATH="$BATS_TEST_TMPDIR/manifest.toml"
 
   cat << "EOF" >> "$TMP_MANIFEST_PATH"
+version = 1
+
 [install]
 hello = {}
 EOF

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -95,7 +95,8 @@ dot_flox_exists() {
   assert_success
   assert_output ""
 
-  run "$FLOX_BIN" install hello
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json" \
+    run "$FLOX_BIN" install hello
   assert_success
   assert_output --partial "environment '$OWNER/project-managed-${BATS_TEST_NUMBER}'" # managed env output
 
@@ -121,7 +122,8 @@ dot_flox_exists() {
 # bats test_tags=uninstall,managed
 @test "catalog: m2: uninstall a package from a managed environment" {
   make_empty_remote_env
-  "$FLOX_BIN" install hello
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json" \
+    "$FLOX_BIN" install hello
 
   run "$FLOX_BIN" uninstall hello
   assert_success
@@ -159,7 +161,8 @@ EOF
 hello = {}
 EOF
 
-  run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json" \
+    run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
   assert_success
   assert_output --partial "✅ Environment successfully updated."
 }
@@ -201,7 +204,8 @@ EOF
   export FLOX_DATA_DIR="$(pwd)/a_data"
   pushd a > /dev/null || return
   "$FLOX_BIN" init
-  "$FLOX_BIN" install hello
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json" \
+    "$FLOX_BIN" install hello
   "$FLOX_BIN" push --owner "$OWNER"
   popd > /dev/null || return
 
@@ -273,7 +277,8 @@ EOF
   export FLOX_DATA_DIR="$(pwd)/b_data"
   pushd b > /dev/null || return
   "$FLOX_BIN" pull --remote "$OWNER/a"
-  "$FLOX_BIN" install hello
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json" \
+    "$FLOX_BIN" install hello
   "$FLOX_BIN" push --owner "$OWNER"
   popd > /dev/null || return
 
@@ -352,7 +357,8 @@ EOF
   export FLOX_DATA_DIR="$(pwd)/b_data"
   pushd b > /dev/null || return
   "$FLOX_BIN" pull --remote "$OWNER/a"
-  "$FLOX_BIN" install vim
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/vim.json" \
+    "$FLOX_BIN" install vim
   "$FLOX_BIN" push --owner "$OWNER"
   popd > /dev/null || return
 
@@ -360,7 +366,8 @@ EOF
   # and check that the package is installed
   export FLOX_DATA_DIR="$(pwd)/a_data"
   pushd a > /dev/null || return
-  run "$FLOX_BIN" install emacs
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/emacs.json" \
+    run "$FLOX_BIN" install emacs
   # assert that pulling fails
   run "$FLOX_BIN" pull
   assert_failure
@@ -421,11 +428,13 @@ EOF
 
   pushd b > /dev/null || return
   FLOX_DATA_DIR="$(pwd)/b_data" "$FLOX_BIN" pull --remote "$OWNER/a"
-  FLOX_DATA_DIR="$(pwd)/b_data" "$FLOX_BIN" install vim
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/vim.json" \
+    FLOX_DATA_DIR="$(pwd)/b_data" "$FLOX_BIN" install vim
   popd > /dev/null || return
 
   pushd a > /dev/null || return
-  FLOX_DATA_DIR="$(pwd)/a_data" "$FLOX_BIN" install emacs
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/emacs.json" \
+    FLOX_DATA_DIR="$(pwd)/a_data" "$FLOX_BIN" install emacs
   FLOX_DATA_DIR="$(pwd)/a_data" "$FLOX_BIN" push
   popd > /dev/null || return
 
@@ -457,7 +466,8 @@ EOF
 @test "catalog: m8: search works in managed environment" {
   make_empty_remote_env
 
-  run "$FLOX_BIN" search hello
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/search/hello.json" \
+    run "$FLOX_BIN" search hello
   assert_success
 }
 
@@ -481,7 +491,8 @@ EOF
 # bats test_tags=managed,activate,managed:activate
 @test "catalog: m9: activate works in managed environment" {
   make_empty_remote_env
-  "$FLOX_BIN" install hello
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json" \
+    "$FLOX_BIN" install hello
 
   # TODO: flox will set HOME if it doesn't match the home of the user with
   # current euid. I'm not sure if we should change that, but for now just set
@@ -547,7 +558,8 @@ EOF
 # bats test_tags=managed,delete,managed:fresh-deleted
 @test "catalog: m11: uses fresh branch after delete" {
   make_empty_remote_env
-  "$FLOX_BIN" install vim
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/vim.json" \
+    "$FLOX_BIN" install vim
 
   run "$FLOX_BIN" delete
   assert_success
@@ -559,7 +571,8 @@ EOF
   run "$FLOX_BIN" pull --remote "$OWNER/project-managed-${BATS_TEST_NUMBER}"
   assert_success
 
-  "$FLOX_BIN" install emacs
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/emacs.json" \
+    "$FLOX_BIN" install emacs
   run "$FLOX_BIN" list --name
   assert_output --partial "emacs"
   refute_output "vim"


### PR DESCRIPTION
## Proposed Changes

**test(environment-managed): Copy cases for catalog**

Duplicate the tests that would touch the catalog to run in parallel with
pkgdb test cases. They are modified to pass in a subsequent commit to
make it easier to compare against the originals.

**test(environment-managed): Add catalog mock resps**

For all places where we install a package and expect to resolve from the
catalog server. These are specified inline so that all other commands
default to using the empty response and will blow up if we don't provide
the correct mocks.

**test(environment-managed): Fix manifest version**

Add a `version` when constructing a catalog compatible manifest to fix
this error:

    ❌ ERROR: unrecognized manifest field: 'version'.

**test(environment-managed): Fix manifest pkg-path**

Add a `pkg-path` when constructing a catalog compatible manifest to fix
this error:

    ❌ ERROR: Failed to parse manifest: missing field `pkg-path`
    in `install.hello`

---

I don't think it's worth attempting to de-duplicate the installs at the moment while we have parallel pkgdb and catalog tests. It'll be easier to do afterwards.

## Release Notes

N/A