### PR TITLE
test(pull): test: copy over `pull` tests for catalog

### DIFF
--- a/cli/tests/catalog_responses/resolve/gzip.json
+++ b/cli/tests/catalog_responses/resolve/gzip.json
@@ -1,0 +1,170 @@
+[
+  [
+    {
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "packages": [
+          {
+            "attr_path": "gzip",
+            "broken": false,
+            "derivation": "/nix/store/zli2r0n81xjahwmgp7ib472yjv5s2v8h-gzip-1.13.drv",
+            "description": "GNU zip compression program",
+            "install_id": "gzip",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "name": "gzip-1.13",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/hmy1zsg68a2cgn687x7bl67dn6m7xrrv-gzip-1.13-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/g67jzdjwck8985nc6vwvd4nhyiayra6w-gzip-1.13"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/9mrmxl3h4vc4a05vffb127arr51zhbaw-gzip-1.13-info"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "gzip",
+            "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "rev_count": 633517,
+            "rev_date": "2024-05-31T23:09:26Z",
+            "scrape_date": "2024-06-04T19:02:00Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "1.13"
+          },
+          {
+            "attr_path": "gzip",
+            "broken": false,
+            "derivation": "/nix/store/rba5c5xri65rxgbqpny8vdw7i6v3siry-gzip-1.13.drv",
+            "description": "GNU zip compression program",
+            "install_id": "gzip",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "name": "gzip-1.13",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/p6nakv379irzabv50alajkkzbh4gkmhi-gzip-1.13-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/9xwv4djni67rnfxz9ml205djjshxfmhh-gzip-1.13"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/1zn8hvzb1v97icdq2fh5ck6ji6z8jhk0-gzip-1.13-info"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "gzip",
+            "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "rev_count": 633517,
+            "rev_date": "2024-05-31T23:09:26Z",
+            "scrape_date": "2024-06-04T19:02:00Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "1.13"
+          },
+          {
+            "attr_path": "gzip",
+            "broken": false,
+            "derivation": "/nix/store/1311fncd052qxgyh9vk8wpy9h8mm8skq-gzip-1.13.drv",
+            "description": "GNU zip compression program",
+            "install_id": "gzip",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "name": "gzip-1.13",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/b99abpifdq1yvrwlzdxiqg3sdkb90fn2-gzip-1.13-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/yrn2br8yajgg9vg3cnbxlzs2j924lyi1-gzip-1.13"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/0kwkxd6lqixmqnb7rl7g7b7jyq9clzl5-gzip-1.13-info"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "gzip",
+            "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "rev_count": 633517,
+            "rev_date": "2024-05-31T23:09:26Z",
+            "scrape_date": "2024-06-04T19:02:00Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "1.13"
+          },
+          {
+            "attr_path": "gzip",
+            "broken": false,
+            "derivation": "/nix/store/43raab2h8k63kmw356ks5d666s73c6wq-gzip-1.13.drv",
+            "description": "GNU zip compression program",
+            "install_id": "gzip",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "name": "gzip-1.13",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/8k07cnlcq91ycfhk0jkyk5idrpgpbf0p-gzip-1.13-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/j5chw7v1x3vlmf3wmdpdb5gwh9hl0b80-gzip-1.13"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/mqsnlc1llhyllm6pwl2ijpbnldqpga6i-gzip-1.13-info"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "gzip",
+            "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "rev_count": 633517,
+            "rev_date": "2024-05-31T23:09:26Z",
+            "scrape_date": "2024-06-04T19:02:00Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "1.13"
+          }
+        ],
+        "page": 633517,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/cli/tests/catalog_responses/resolve/responses_to_generate.json
+++ b/cli/tests/catalog_responses/resolve/responses_to_generate.json
@@ -1,6 +1,7 @@
 {
     "emacs": "emacs",
     "emacs_vim": "emacs vim",
+    "gzip": "gzip",
     "hello": "hello",
     "python311Packages.pip": "python311Packages.pip",
     "rubyPackages_3_2.rails": "rubyPackages_3_2.rails",

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -512,6 +512,32 @@ function add_insecure_package() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=pull:twice:no-force
+@test "catalog: pull environment inside the same environment without the '--force' flag" {
+  update_dummy_env "owner" "name"
+
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/gzip.json" \
+    run "$FLOX_BIN" pull --remote owner/name
+  assert_success
+
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/gzip.json" \
+    run "$FLOX_BIN" pull --remote owner/name
+  assert_failure
+}
+
+# bats test_tags=pull:twice:force
+@test "catalog: pull environment inside the same environment with '--force' flag" {
+  update_dummy_env "owner" "name"
+
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/gzip.json" \
+    run "$FLOX_BIN" pull --remote owner/name
+  assert_success
+
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/gzip.json" \
+    run "$FLOX_BIN" pull --remote owner/name --force
+  assert_success
+}
+
 # ---------------------------------------------------------------------------- #
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -428,6 +428,19 @@ function add_insecure_package() {
   assert_failure
 }
 
+# bats test_tags=pull:l2,pull:l2:c
+@test "catalog: l2.c: flox pull with --remote and --dir pulls into the specified directory" {
+  # dummy environment has no packages to resolve
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
+
+  run "$FLOX_BIN" pull --remote owner/name --dir ./inner
+  assert_success
+  assert [ -e "inner/.flox/env.json" ]
+  assert [ -e "inner/.flox/env.lock" ]
+  assert [ $(cat inner/.flox/env.json | jq -r '.name') == "name" ]
+  assert [ $(cat inner/.flox/env.json | jq -r '.owner') == "owner" ]
+}
+
 # ---------------------------------------------------------------------------- #
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -402,6 +402,21 @@ function add_insecure_package() {
 # ----------------------------- Catalog Tests -------------------------------- #
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=pull:l2,pull:l2:a,pull:l4
+@test "catalog: l2.a/l4: flox pull accepts a floxhub namespace/environment, creates .flox if it does not exist" {
+
+  # dummy environment has no packages to resolve
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
+
+  # dummy remote as we are not actually pulling anything
+  run "$FLOX_BIN" pull --remote owner/name
+  assert_success
+  assert [ -e ".flox/env.json" ]
+  assert [ -e ".flox/env.lock" ]
+  assert [ $(cat .flox/env.json | jq -r '.name') == "name" ]
+  assert [ $(cat .flox/env.json | jq -r '.owner') == "owner" ]
+}
+
 # ---------------------------------------------------------------------------- #
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -607,4 +607,30 @@ function add_insecure_package() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=pull:unsupported-package
+# pulling an environment with a package that is not available for the current platform
+# should fail with an error
+@test "catalog: pull environment with package not available for the current platform fails" {
+  update_dummy_env "owner" "name"
+  add_incompatible_package "owner" "name"
+
+  run "$FLOX_BIN" pull --remote owner/name
+
+  assert_failure
+  assert_line --partial "package 'extra' is not available for this system ('$NIX_SYSTEM')"
+}
+
+# bats test_tags=pull:eval-failure
+# pulling an environment with a package that fails to evaluate
+# should fail with an error
+@test "catalog: pull environment with insecure package fails to evaluate" {
+  update_dummy_env "owner" "name"
+  add_insecure_package "owner" "name"
+
+  run "$FLOX_BIN" pull --remote owner/name
+
+  assert_failure
+  assert_line --partial "package 'extra' failed to evaluate:"
+}
+
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -592,6 +592,19 @@ function add_insecure_package() {
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=activate:remote:incompatible
+# activating an incompatible environment should fail gracefully
+@test "catalog: activate incompatible environment fails gracefully" {
+
+  remove_extra_systems "owner" "name"
+  update_dummy_env "owner" "name"
+  make_incompatible "owner" "name"
+
+  run "$FLOX_BIN" activate --remote owner/name --trust
+  assert_failure
+  assert_output --partial "This environment is not yet compatible with your system ($NIX_SYSTEM)"
+}
+
 # ---------------------------------------------------------------------------- #
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -417,6 +417,17 @@ function add_insecure_package() {
   assert [ $(cat .flox/env.json | jq -r '.owner') == "owner" ]
 }
 
+# bats test_tags=pull:l2,pull:l2:b
+@test "catalog: l2.b: flox pull with --remote fails if an env is already present" {
+  # dummy environment has no packages to resolve
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
+
+  "$FLOX_BIN" pull --remote owner/name # dummy remote as we are not actually pulling anything
+
+  run "$FLOX_BIN" pull --remote owner/name # dummy remote as we are not actually pulling anything
+  assert_failure
+}
+
 # ---------------------------------------------------------------------------- #
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -441,6 +441,27 @@ function add_insecure_package() {
   assert [ $(cat inner/.flox/env.json | jq -r '.owner') == "owner" ]
 }
 
+# bats test_tags=pull:l3,pull:l3:a
+@test "catalog: l3.a: pulling without namespace/environment" {
+
+  # dummy environment has no packages to resolve
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
+
+  "$FLOX_BIN" pull --remote owner/name # dummy remote as we are not actually pulling anything
+  LOCKED_BEFORE=$(cat .flox/env.lock | jq -r '.rev')
+
+  update_dummy_env "owner" "name"
+
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/gzip.json" \
+    run "$FLOX_BIN" pull
+
+  assert_success
+
+  LOCKED_AFTER=$(cat .flox/env.lock | jq -r '.rev')
+
+  assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
+}
+
 # ---------------------------------------------------------------------------- #
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -462,6 +462,26 @@ function add_insecure_package() {
   assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
 }
 
+# bats test_tags=pull:l3,pull:l3:b
+@test "catalog: l3.b: pulling without namespace/environment respects --dir" {
+
+  # dummy environment has no packages to resolve
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
+
+  "$FLOX_BIN" pull --remote owner/name --dir ./inner # dummy remote as we are not actually pulling anything
+  LOCKED_BEFORE=$(cat ./inner/.flox/env.lock | jq -r '.rev')
+
+  update_dummy_env "owner" "name"
+
+  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/gzip.json" \
+    run "$FLOX_BIN" pull --dir ./inner
+  assert_success
+
+  LOCKED_AFTER=$(cat ./inner/.flox/env.lock | jq -r '.rev')
+
+  assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
+}
+
 # ---------------------------------------------------------------------------- #
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/push.bats
+++ b/cli/tests/push.bats
@@ -17,13 +17,13 @@ project_setup() {
   export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-push-${BATS_TEST_NUMBER?}"
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
-  pushd "$PROJECT_DIR" > /dev/null || return
+  pushd "$PROJECT_DIR" >/dev/null || return
   export FLOX_FEATURES_USE_CATALOG=true
-  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
 }
 
 project_teardown() {
-  popd > /dev/null || return
+  popd >/dev/null || return
   rm -rf "${PROJECT_DIR?}"
   unset PROJECT_DIR
 }
@@ -50,13 +50,13 @@ function update_dummy_env() {
 
   FLOXHUB_FLOXMETA_DIR="$BATS_TEST_TMPDIR/floxhub/$OWNER/floxmeta"
 
-  pushd "$FLOXHUB_FLOXMETA_DIR" > /dev/null || return
+  pushd "$FLOXHUB_FLOXMETA_DIR" >/dev/null || return
 
   touch new_file
   git add .
   git commit -m "update"
 
-  popd > /dev/null || return
+  popd >/dev/null || return
 }
 
 # ---------------------------------------------------------------------------- #
@@ -110,13 +110,13 @@ function update_dummy_env() {
   mkdir -p "machine_a"
   mkdir -p "machine_b"
 
-  pushd "machine_a" > /dev/null || return
+  pushd "machine_a" >/dev/null || return
   "$FLOX_BIN" init --name "test"
   "$FLOX_BIN" install hello
   "$FLOX_BIN" push --owner owner
-  popd > /dev/null || return
+  popd >/dev/null || return
 
-  pushd "machine_b" > /dev/null || return
+  pushd "machine_b" >/dev/null || return
   run "$FLOX_BIN" pull --remote owner/test
   assert_success
 
@@ -124,7 +124,7 @@ function update_dummy_env() {
   assert_success
   assert_line "hello"
 
-  popd > /dev/null || return
+  popd >/dev/null || return
 }
 
 # bats test_tags=push:h5
@@ -134,15 +134,15 @@ function update_dummy_env() {
   mkdir -p "machine_b"
 
   # Create an environment owner/test on machine_a and push it to floxhub
-  pushd "machine_a" > /dev/null || return
+  pushd "machine_a" >/dev/null || return
   "$FLOX_BIN" init --name "test"
   "$FLOX_BIN" install vim
   "$FLOX_BIN" push --owner owner
-  popd > /dev/null || return
+  popd >/dev/null || return
 
   # Create an environment owner/test on machine_b and try to push it to floxhub
   # this should fail as an envrioment with the same name but different provenance already exists on floxhub
-  pushd "machine_b" > /dev/null || return
+  pushd "machine_b" >/dev/null || return
   echo "trying to push to the same upstream env" >&3
 
   "$FLOX_BIN" init --name "test"
@@ -151,7 +151,7 @@ function update_dummy_env() {
   run "$FLOX_BIN" push --owner owner
   assert_failure
   assert_output --partial "An environment named owner/test already exists!"
-  popd > /dev/null || return
+  popd >/dev/null || return
 }
 
 # bats test_tags=push:h6
@@ -160,27 +160,27 @@ function update_dummy_env() {
   mkdir -p "machine_a" "machine_b" "machine_c"
 
   # Create an environment owner/test on machine_a and push it to floxhub
-  pushd "machine_a" > /dev/null || return
+  pushd "machine_a" >/dev/null || return
   "$FLOX_BIN" init --name "test"
   "$FLOX_BIN" install vim
   "$FLOX_BIN" push --owner owner
-  popd > /dev/null || return
+  popd >/dev/null || return
 
   # Create an environment owner/test on machine_b and force-push it to floxhub
-  pushd "machine_b" > /dev/null || return
+  pushd "machine_b" >/dev/null || return
   "$FLOX_BIN" init --name "test"
   "$FLOX_BIN" install emacs
   run "$FLOX_BIN" push --owner owner --force
   assert_success
-  popd > /dev/null || return
+  popd >/dev/null || return
 
   # Pull the environment owner/test on machine_c and check that it has the emacs package
-  pushd "machine_c" > /dev/null || return
+  pushd "machine_c" >/dev/null || return
   "$FLOX_BIN" pull --remote owner/test
   run "$FLOX_BIN" list --name
   assert_success
   assert_line "emacs"
-  popd > /dev/null || return
+  popd >/dev/null || return
 }
 
 # ---------------------------------------------------------------------------- #
@@ -188,17 +188,17 @@ function update_dummy_env() {
 
 # bats test_tags=push:h3
 @test "h2: push login: catalog: running flox push creates a remotely managed environment stored in the FloxHub" {
-  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json"
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/hello.json"
   mkdir -p "machine_a"
   mkdir -p "machine_b"
 
-  pushd "machine_a" > /dev/null || return
+  pushd "machine_a" >/dev/null || return
   "$FLOX_BIN" init --name "test"
   "$FLOX_BIN" install hello
   "$FLOX_BIN" push --owner owner
-  popd > /dev/null || return
+  popd >/dev/null || return
 
-  pushd "machine_b" > /dev/null || return
+  pushd "machine_b" >/dev/null || return
   run "$FLOX_BIN" pull --remote owner/test
   assert_success
 
@@ -206,7 +206,7 @@ function update_dummy_env() {
   assert_success
   assert_line "hello"
 
-  popd > /dev/null || return
+  popd >/dev/null || return
 }
 
 # bats test_tags=push:h5
@@ -215,22 +215,22 @@ function update_dummy_env() {
   mkdir -p "machine_b"
 
   # Create an environment owner/test on machine_a and push it to floxhub
-  pushd "machine_a" > /dev/null || return
+  pushd "machine_a" >/dev/null || return
   "$FLOX_BIN" init --name "test"
-  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/vim.json"
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/vim.json"
   "$FLOX_BIN" install vim
 
   # Also uses the `vim` resolution since it makes sure the manifest is locked before pushing
   "$FLOX_BIN" push --owner owner
-  popd > /dev/null || return
+  popd >/dev/null || return
 
   # Create an environment owner/test on machine_b and try to push it to floxhub
   # this should fail as an envrioment with the same name but different provenance already exists on floxhub
-  pushd "machine_b" > /dev/null || return
+  pushd "machine_b" >/dev/null || return
   echo "trying to push to the same upstream env" >&3
 
   "$FLOX_BIN" init --name "test"
-  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/emacs.json"
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/emacs.json"
   "$FLOX_BIN" install emacs
   # export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
 
@@ -238,7 +238,7 @@ function update_dummy_env() {
   run "$FLOX_BIN" push --owner owner
   assert_failure
   assert_output --partial "An environment named owner/test already exists!"
-  popd > /dev/null || return
+  popd >/dev/null || return
 }
 
 # bats test_tags=push:h6
@@ -246,31 +246,31 @@ function update_dummy_env() {
   mkdir -p "machine_a" "machine_b" "machine_c"
 
   # Create an environment owner/test on machine_a and push it to floxhub
-  pushd "machine_a" > /dev/null || return
+  pushd "machine_a" >/dev/null || return
   "$FLOX_BIN" init --name "test"
-  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/vim.json"
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/vim.json"
   "$FLOX_BIN" install vim
   # Also uses the `vim` resolution since it makes sure the manifest is locked before pushing
   "$FLOX_BIN" push --owner owner
-  popd > /dev/null || return
+  popd >/dev/null || return
 
   # Create an environment owner/test on machine_b and force-push it to floxhub
-  pushd "machine_b" > /dev/null || return
-  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
+  pushd "machine_b" >/dev/null || return
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
   "$FLOX_BIN" init --name "test"
-  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/emacs.json"
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/resolve/emacs.json"
   "$FLOX_BIN" install emacs
   # Also uses the `emacs` resolution since it makes sure the manifest is locked before pushing
   run "$FLOX_BIN" push --owner owner --force
   assert_success
-  popd > /dev/null || return
+  popd >/dev/null || return
 
   # Pull the environment owner/test on machine_c and check that it has the emacs package
-  pushd "machine_c" > /dev/null || return
-  export  _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
+  pushd "machine_c" >/dev/null || return
+  export _FLOX_USE_CATALOG_MOCK="$TESTS_DIR/catalog_responses/empty_responses.json"
   "$FLOX_BIN" pull --remote owner/test
   run "$FLOX_BIN" list --name
   assert_success
   assert_line "emacs"
-  popd > /dev/null || return
+  popd >/dev/null || return
 }


### PR DESCRIPTION
Copied all tests although less may suffice as well.

Added `remove_extra_systems` helper to simulate a manifest file that only supports a single system.

