### PR TITLE
fix: bump `unicode-width` crate

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3374,9 +3374,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unsafe-libyaml"


### PR DESCRIPTION
Fixes spinners broken in certain terminals such as iterm. and kitty when the spinner message contains multi codepoint/U+FE0F 2-char emojis.

The spinner library `indicatif` uses `unicode-width` to determine the size of its output. `unicode-width` was reporting an incorrect width for some emojis, causing the output of indicatif to overflow the terminal width.

Some "smarter" terminals seem to compute the length of the output internally masking that issue. Thus on e.g. iterm2, Terminal.app this issue did not appear.
