### PR TITLE
test: drop locked packages for dropped systems

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1811,7 +1811,7 @@ pub(crate) mod tests {
     }
 
     /// When packages are locked for multiple systems,
-    /// locking the same package for fewer packages should drop the extra systems
+    /// locking the same package for fewer systems should drop the extra systems
     #[test]
     fn drop_packages_for_removed_systems() {
         let (foo_iid, foo_descriptor_one_system, foo_locked) = fake_package("foo", Some("group1"));

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1816,7 +1816,11 @@ pub(crate) mod tests {
     fn drop_packages_for_removed_systems() {
         let (foo_iid, foo_descriptor_one_system, foo_locked) = fake_package("foo", Some("group1"));
 
-        // `fake_package` sets the system to [`Aarch64Darwin`]
+        assert_eq!(
+            foo_descriptor_one_system.systems,
+            Some(vec![SystemEnum::Aarch64Darwin.to_string()]),
+            "`fake_package` should set the system to [`Aarch64Darwin`]"
+        );
         let mut foo_descriptor_two_systems = foo_descriptor_one_system.clone();
         foo_descriptor_two_systems
             .systems

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1856,7 +1856,7 @@ pub(crate) mod tests {
         assert_eq!(
             groups[0].descriptors[0].systems,
             vec![SystemEnum::Aarch64Darwin,],
-            "Expected only the Darwin system to be present, second locked system dropped"
+            "Expected only the Darwin system to be present"
         );
 
         let (fully_locked, to_resolve): (Vec<_>, Vec<_>) =
@@ -1906,16 +1906,12 @@ pub(crate) mod tests {
             2,
             "Expected descriptors for two systems"
         );
-        assert_eq!(
-            groups[0].descriptors[0].systems,
-            vec![SystemEnum::Aarch64Darwin,],
-            "Expected only the Darwin system to be present, second locked system dropped"
-        );
-        assert_eq!(
-            groups[0].descriptors[1].systems,
-            vec![SystemEnum::Aarch64Linux,],
-            "Expected only the Darwin system to be present, second locked system dropped"
-        );
+        assert_eq!(groups[0].descriptors[0].systems, vec![
+            SystemEnum::Aarch64Darwin
+        ]);
+        assert_eq!(groups[0].descriptors[1].systems, vec![
+            SystemEnum::Aarch64Linux
+        ]);
 
         let (fully_locked, to_resolve): (Vec<_>, Vec<_>) =
             LockedManifestCatalog::split_fully_locked_groups(groups, Some(&locked));


### PR DESCRIPTION
Addresses the remaining test cases from #1529

* When packages are locked for multiple systems,
  locking the same package for fewer packages should drop the extra systems
* Adding another system to a package should invalidate the entire group
  such that new systems are resolved with the derivation constraints
  of already installed systems