### PR TITLE
fix: Handle broken symlinks in run/ directory

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -381,7 +381,7 @@ impl Environment for ManagedEnvironment {
             out_link_modified_at: {out_link_modified_at:?}"
         );
 
-        if pointer_lock_modified_at >= out_link_modified_at {
+        if pointer_lock_modified_at >= out_link_modified_at || !self.out_link.exists() {
             self.build(flox)?;
         }
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -491,7 +491,7 @@ impl PathEnvironment {
              out_link_modified_at: {out_link_modified_at:?}"
         );
 
-        Ok(manifest_modified_at >= out_link_modified_at)
+        Ok(manifest_modified_at >= out_link_modified_at || !self.out_link(&flox.system)?.exists())
     }
 }
 


### PR DESCRIPTION
In the case where the user has uninstalled and reinstalled Flox, or if
the environment is somehow garbage collected, the symlink to the
environment in .flox/env/run will be broken. Previously, we got an error
in that case. We now treat it as invalidated the same as if the
environment needed a rebuild, and just try to build the environment
again.