### PR TITLE
feat: feature flag to point FLOX_ENV_LIB_DIRS as CUDA libraries

### DIFF
--- a/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+export _coreutils="@coreutils@"
+export _gnused="@gnused@"
+export _findutils="@findutils@"
+# ============================================================================ #
+#
+# Setup CUDA
+#
+# ---------------------------------------------------------------------------- #
+
+# Only run if FLOX_ENV_ENABLE_CUDA feature flag is set
+activate_cuda(){
+  if [[ "$FLOX_FEATURES_ENV_ENABLE_CUDA" != 1 ]]; then
+    return 0
+  fi
+
+  if ! ( "$_findutils/bin/find" /dev -maxdepth 1 -iname 'nvidia*' | read -r ;); then
+    return 0
+  fi
+
+  LIB_DIR="$("$_coreutils/bin/realpath" --no-symlinks "$FLOX_ENV/../../lib")"
+  "$_coreutils/bin/mkdir" -p "$LIB_DIR"
+  for target in libcuda.so.1 libcuda.so ; do
+      "$_findutils/bin/find" /run/opengl-drivers /lib /usr/lib /usr/local/lib \
+          -name "$target" \
+          -exec "$_coreutils/bin/ln" -sf "$LIB_DIR"/"$target" {} \; \
+          -quit
+  done
+  export FLOX_ENV_LIB_DIRS="$FLOX_ENV_LIB_DIRS":"$LIB_DIR"
+}
+
+activate_cuda
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -31,6 +31,7 @@
   git,
   coreutils,
   gnused,
+  findutils,
   procps,
   parallel,
   llvm, # for `llvm-symbolizer'
@@ -85,6 +86,8 @@
 
           for i in $out/etc/profile.d/*; do
             substituteInPlace $i --replace "@coreutils@" "${coreutils}"
+            substituteInPlace $i --replace "@gnused@" "${gnused}"
+            substituteInPlace $i --replace "@findutils@" "${findutils}"
           done
 
           ${shellcheck}/bin/shellcheck \


### PR DESCRIPTION
## Proposed Changes

add etc-profile for CUDA

## Release Notes
FLOX_ENV_ENABLE_CUDA=1 is now a feature flag to set FLOX_ENV_LIB_DIRS to the each directory in `ldconfig -p`.

TODO
- use host-provided ldconfig? or bring one in from glibc package?