### PR TITLE
fix: require descriptor system enabled in options or default

### DIFF
--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -722,6 +722,9 @@ pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
 
             Supported systems are: aarch64-linux, x86_64-linux, aarch64-darwin, x86_64-darwin
         "},
+
+        LockedManifestError::SystemUnavailableInManifest { .. } => display_chain(err),
+
         LockedManifestError::ResolutionFailed(_) => display_chain(err),
         LockedManifestError::EmptyPage => display_chain(err),
     }


### PR DESCRIPTION
An error should be raised if a manifest descriptor tries to lock a system that is not specified in `options.systems` i.e. iff `install.*.systems ⊈ (options.systems ? {default systems..})`.

Fixes a logic regression wrt to pkgdb based locking which required this invariant but implemented it in pkgbd causing it to be overlooked while implementing the rust equivalent.
