### PR TITLE
feat(search): Strip version specifiers for catalog

### DIFF
--- a/cli/flox/doc-catalog/flox-search.md
+++ b/cli/flox/doc-catalog/flox-search.md
@@ -35,8 +35,8 @@ More specific information for a single package is available via the
 ```
 
 ## Fuzzy search
-`flox search` uses a fuzzy search mechanism that tries to match either the
-package name itself or some portion of the pkg-path.
+`flox search` uses a fuzzy search mechanism that tries to match either some
+portion of the pkg-path or description.
 
 # OPTIONS
 

--- a/cli/flox/doc-catalog/flox-search.md
+++ b/cli/flox/doc-catalog/flox-search.md
@@ -42,22 +42,8 @@ More specific information for a single package is available via the
 ```
 
 ## Fuzzy search
-When only given a package name,
 `flox search` uses a fuzzy search mechanism that tries to match either the
 package name itself or some portion of the pkg-path.
-
-The search query can also include a version filter following the
-familiar semver syntax (`@` between the package and version).
-```text
-$ flox search 'python@>2'
-```
-
-For packages that have a version that doesn't comform to semantic versioning
-you can use the `=` operator in the version filter
-and the search will perform an exact match on the version supplied.
-```text
-$ flox search foo@=2023-11
-```
 
 # OPTIONS
 

--- a/cli/flox/doc-catalog/flox-search.md
+++ b/cli/flox/doc-catalog/flox-search.md
@@ -22,13 +22,6 @@ flox [<general options>] search
 
 Search for available packages.
 
-Searches are performed in the context of the environment if one exists,
-making use of the environment's lock file and the locked base catalog within it
-if either one exists.
-Searches performed outside of an environment query a global base catalog.
-Both the global and environment's base catalogs can be updated with
-[`flox-update(1)`](./flox-update.md).
-
 A limited number of search results are reported by default for brevity.
 The full result set can be returned via the `-a` flag.
 

--- a/cli/flox/doc-catalog/flox-search.md
+++ b/cli/flox/doc-catalog/flox-search.md
@@ -1,0 +1,81 @@
+---
+title: FLOX-SEARCH
+section: 1
+header: "Flox User Manuals"
+...
+
+
+# NAME
+
+flox-search - search for packages
+
+# SYNOPSIS
+
+```
+flox [<general options>] search
+     [--json]
+     [-a]
+     <search-term>
+```
+
+# DESCRIPTION
+
+Search for available packages.
+
+Searches are performed in the context of the environment if one exists,
+making use of the environment's lock file and the locked base catalog within it
+if either one exists.
+Searches performed outside of an environment query a global base catalog.
+Both the global and environment's base catalogs can be updated with
+[`flox-update(1)`](./flox-update.md).
+
+A limited number of search results are reported by default for brevity.
+The full result set can be returned via the `-a` flag.
+
+Only the package name and description are shown by default.
+Structured search results can be returned via the `--json` flag.
+More specific information for a single package is available via the
+[`flox-show(1)`](./flox-show.md) command.
+
+```{.include}
+./include/package-names.md
+```
+
+## Fuzzy search
+When only given a package name,
+`flox search` uses a fuzzy search mechanism that tries to match either the
+package name itself or some portion of the pkg-path.
+
+The search query can also include a version filter following the
+familiar semver syntax (`@` between the package and version).
+```text
+$ flox search 'python@>2'
+```
+
+For packages that have a version that doesn't comform to semantic versioning
+you can use the `=` operator in the version filter
+and the search will perform an exact match on the version supplied.
+```text
+$ flox search foo@=2023-11
+```
+
+# OPTIONS
+
+## Search Options
+
+`<search-term>`
+:   The package name to search for.
+
+`--json`
+:   Display the search results in JSON format.
+
+`-a`, `--all`
+:   Display all search results (default: at most 10).
+
+```{.include}
+./include/general-options.md
+```
+
+# SEE ALSO
+[`flox-show(1)`](./flox-show.md),
+[`flox-update(1)`](./flox-update.md)

--- a/cli/tests/search.bats
+++ b/cli/tests/search.bats
@@ -97,11 +97,11 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
-@test "catalog: 'flox search' helpful error with unquoted redirect: hello@>1 -> hello@" {
-  skip "semver search not yet supported by catalog"
-  run "$FLOX_BIN" search hello@
-  assert_failure
-  assert_output --partial "try quoting"
+@test "catalog: 'flox search' warns about and strips version specifiers" {
+  export  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/search/hello.json"
+  run --separate-stderr "$FLOX_BIN" search hello@2.12.1
+  assert_success
+  assert_regex "$stderr" "'flox search' ignores version specifiers."
 }
 
 # ---------------------------------------------------------------------------- #
@@ -127,15 +127,6 @@ setup_file() {
 
 @test "'flox search' semver search: hello@2.12.1" {
   unset FLOX_FEATURES_USE_CATALOG
-  run --separate-stderr "$FLOX_BIN" search hello@2.12.1
-  assert_equal "${#lines[@]}" 1 # 1 result
-  assert_equal "${stderr_lines[0]}" "$SHOW_HINT"
-}
-
-# ---------------------------------------------------------------------------- #
-
-@test "catalog: 'flox search' semver search: hello@2.12.1" {
-  skip "semver search not yet supported by catalog"
   run --separate-stderr "$FLOX_BIN" search hello@2.12.1
   assert_equal "${#lines[@]}" 1 # 1 result
   assert_equal "${stderr_lines[0]}" "$SHOW_HINT"
@@ -177,33 +168,8 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
-@test "catalog: 'flox search' semver search: 'hello@>=1'" {
-  skip "semver search not yet supported by catalog"
-  run "$FLOX_BIN" search 'hello@>=1' --json
-  versions="$(echo "$output" | jq -c 'map(.version)')"
-  case "$THIS_SYSTEM" in
-    *-darwin)
-      assert_equal "$versions" '["2.12.1","2.12","2.10"]'
-      ;;
-    *-linux)
-      assert_equal "$versions" '[]'
-      ;;
-  esac
-}
-
-# ---------------------------------------------------------------------------- #
-
 @test "'flox search' semver search: hello@2.x" {
   unset FLOX_FEATURES_USE_CATALOG
-  run "$FLOX_BIN" search hello@2.x --json
-  versions="$(echo "$output" | jq -c 'map(.version)')"
-  assert_equal "$versions" '["2.12.1"]'
-}
-
-# ---------------------------------------------------------------------------- #
-
-@test "catalog: 'flox search' semver search: hello@2.x" {
-  skip "semver search not yet supported by catalog"
   run "$FLOX_BIN" search hello@2.x --json
   versions="$(echo "$output" | jq -c 'map(.version)')"
   assert_equal "$versions" '["2.12.1"]'
@@ -220,26 +186,8 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
-@test "catalog: 'flox search' semver search: hello@=2.10" {
-  skip "semver search not yet supported by catalog"
-  run --separate-stderr "$FLOX_BIN" search hello@=2.12 --all
-  assert_equal "${#lines[@]}" 1 # 1 result
-  assert_equal "${stderr_lines[0]}" "$SHOW_HINT"
-}
-
-# ---------------------------------------------------------------------------- #
-
 @test "'flox search' semver search: hello@v2" {
   unset FLOX_FEATURES_USE_CATALOG
-  run "$FLOX_BIN" search hello@v2 --json
-  versions="$(echo "$output" | jq -c 'map(.version)')"
-  assert_equal "$versions" '["2.12.1"]'
-}
-
-# ---------------------------------------------------------------------------- #
-
-@test "catalog: 'flox search' semver search: hello@v2" {
-  skip "semver search not yet supported by catalog"
   run "$FLOX_BIN" search hello@v2 --json
   versions="$(echo "$output" | jq -c 'map(.version)')"
   assert_equal "$versions" '["2.12.1"]'
@@ -256,26 +204,8 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
-@test "catalog: 'flox search' semver search: 'hello@>1 <3'" {
-  skip "semver search not yet supported by catalog"
-  run "$FLOX_BIN" search 'hello@>1 <3' --json
-  versions="$(echo "$output" | jq -c 'map(.version)')"
-  assert_equal "$versions" '["2.12.1"]'
-}
-
-# ---------------------------------------------------------------------------- #
-
 @test "'flox search' exact semver match listed first" {
   unset FLOX_FEATURES_USE_CATALOG
-  run "$FLOX_BIN" search hello@2.12.1 --json
-  first_line="$(echo "$output" | head -n 1 | grep 2.12.1)"
-  assert [ -n first_line ]
-}
-
-# ---------------------------------------------------------------------------- #
-
-@test "catalog: 'flox search' exact semver match listed first" {
-  skip "semver search not yet supported by catalog"
   run "$FLOX_BIN" search hello@2.12.1 --json
   first_line="$(echo "$output" | head -n 1 | grep 2.12.1)"
   assert [ -n first_line ]


### PR DESCRIPTION
## Proposed Changes

**feat(search): Strip version specifiers for catalog**

The catalog server won't support searching by version for now. You can
use `flox show` to find the versions for a given package:

- flox/catalog-server#60

The server has been stripping the version specifier server-side.
Implementing this client-side will allow us to remove that, which makes
it clearer, and easier to support versions as a separate parameter in
the future:

- flox/catalog-server#98

The note about version specifiers has been removed from the `--help`
message because we're not able to switch it based on the catalog feature
flag but the existing behaviour will continue to work for pkgdb.

It feels right to implement the logic in the `catalog`, but not as a
method on the client because it doesn't need any state, and then
generate the actual warning message in `search` where we're closer to
the user interface.

I've left one integration test to verify that the warning is generated.
The previous search term variations are now covered by a unit test. We
don't have a way to assert on the search term that is actually sent to
the catalog server but that feels OK.

**docs(search): Remove pkgdb and update for catalog**

These details aren't applicable when the catalog feature flag is used
and can be removed when we published the catalog version of these docs.

**docs(search): Catalog matches pkg-path or desc**

Bill described the catalog service doing the following:

> We do a fuzzy match against the last tuple of the `attr_path` the
> `description`, and the `name`.  Currently the `name` is transitively
> the same as the `attr_path` though, and I don't think I would document
> that as part of the search at this time.

## Release Notes

N/A until catalog release.