### PR TITLE
feat(catalog): support unfree, broken, licenses

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1020,6 +1020,7 @@ mod tests {
     use super::*;
     use crate::data::Version;
     use crate::flox::test_helpers::{flox_instance, flox_instance_with_global_lock};
+    use crate::models::lockfile::test_helpers::fake_package;
     use crate::models::manifest::DEFAULT_GROUP_NAME;
     use crate::models::{lockfile, manifest};
 
@@ -1248,7 +1249,7 @@ mod tests {
         let (mut env_view, _flox, _temp_dir_handle) = empty_core_environment();
 
         let mut manifest = manifest::test::empty_catalog_manifest();
-        let (foo_iid, foo_descriptor, foo_locked) = lockfile::tests::fake_package("foo", None);
+        let (foo_iid, foo_descriptor, foo_locked) = fake_package("foo", None);
         manifest.install.insert(foo_iid.clone(), foo_descriptor);
         let lockfile = lockfile::LockedManifestCatalog {
             version: Version,

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -16,6 +16,7 @@ use thiserror::Error;
 use super::container_builder::ContainerBuilder;
 use super::environment::UpdateResult;
 use super::manifest::{
+    Allows,
     ManifestPackageDescriptor,
     TypedManifestCatalog,
     DEFAULT_GROUP_NAME,
@@ -316,6 +317,10 @@ impl LockedManifestCatalog {
         let (already_locked_packages, groups_to_lock) =
             Self::split_fully_locked_groups(groups, seed_lockfile);
 
+        // The manifest could have been edited since locking packages,
+        // in which case there may be packages that aren't allowed.
+        Self::check_packages_are_allowed(&already_locked_packages, &manifest.options.allow)?;
+
         if groups_to_lock.is_empty() {
             debug!("All packages are already locked, skipping resolution");
             return Ok(LockedManifestCatalog {
@@ -332,7 +337,12 @@ impl LockedManifestCatalog {
             .map_err(LockedManifestError::CatalogResolve)?;
 
         // unpack locked packages from response
-        let locked_packages = Self::locked_packages_from_resolution(manifest, resolved)?.collect();
+        let locked_packages: Vec<LockedPackageCatalog> =
+            Self::locked_packages_from_resolution(manifest, resolved)?.collect();
+
+        // The server should be checking this,
+        // but double check
+        Self::check_packages_are_allowed(&locked_packages, &manifest.options.allow)?;
 
         let lockfile = LockedManifestCatalog {
             version: Version::<1>,
@@ -341,6 +351,51 @@ impl LockedManifestCatalog {
         };
 
         Ok(lockfile)
+    }
+
+    /// Given locked packages and manifest options allows, verify that the
+    /// locked packages are allowed.
+    fn check_packages_are_allowed(
+        locked_packages: &[LockedPackageCatalog],
+        allow: &Allows,
+    ) -> Result<(), LockedManifestError> {
+        if !allow.licenses.is_empty() {
+            for package in locked_packages {
+                if let Some(license) = &package.license {
+                    if !allow.licenses.contains(license) {
+                        return Err(LockedManifestError::LicenseNotAllowed(
+                            package.install_id.clone(),
+                            license.clone(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Don't allow broken by default
+        if !allow.broken.unwrap_or(false) {
+            for package in locked_packages {
+                // Assume a package isn't broken
+                if package.broken.unwrap_or(false) {
+                    return Err(LockedManifestError::BrokenNotAllowed(
+                        package.install_id.clone(),
+                    ));
+                }
+            }
+        }
+
+        // Allow unfree by default
+        if !allow.unfree.unwrap_or(true) {
+            for package in locked_packages {
+                // Assume a package isn't unfree
+                if package.unfree.unwrap_or(false) {
+                    return Err(LockedManifestError::UnfreeNotAllowed(
+                        package.install_id.clone(),
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Transform a lockfile into a mapping that is easier to query:
@@ -902,6 +957,13 @@ pub enum LockedManifestError {
 
     #[error("Catalog lockfile does not support update")]
     UnsupportedLockfileForUpdate,
+
+    #[error("The package '{0}' has license '{1}' which is not in the list of allowed licenses.\n\nAllow this license by adding it to 'options.allow.licenses' in manifest.toml")]
+    LicenseNotAllowed(String, String),
+    #[error("The package '{0}' is marked as broken.\n\nAllow broken packages by setting 'options.allow.broken = true' in manifest.toml")]
+    BrokenNotAllowed(String),
+    #[error("The package '{0}' has an unfree license.\n\nAllow unfree packages by setting 'options.allow.unfree = true' in manifest.toml")]
+    UnfreeNotAllowed(String),
 }
 
 /// A warning produced by `pkgdb manifest check`
@@ -966,6 +1028,7 @@ pub(crate) mod tests {
     use std::collections::HashMap;
     use std::vec;
 
+    use catalog::test_helpers::resolved_pkg_group_with_dummy_package;
     use catalog_api_v1::types::Output;
     use indoc::indoc;
     use once_cell::sync::Lazy;
@@ -974,6 +1037,7 @@ pub(crate) mod tests {
 
     use self::catalog::PackageResolutionInfo;
     use super::*;
+    use crate::models::manifest::test::empty_catalog_manifest;
     use crate::models::manifest::{self, RawManifest, TypedManifest};
 
     /// Validate that the parser for the locked manifest can handle null values
@@ -1934,5 +1998,211 @@ pub(crate) mod tests {
 
         assert_eq!(fully_locked, vec![]);
         assert_eq!(to_resolve.len(), 1);
+    }
+
+    /// [LockedManifestCatalog::lock_manifest] returns an error if an already
+    /// locked package is no longer allowed
+    #[tokio::test]
+    async fn lock_manifest_catches_not_allowed_package() {
+        // Create a manifest and lockfile with an unfree package foo.
+        // Don't set `options.allow.unfree`
+        let (foo_iid, foo_descriptor_one_system, mut foo_locked) = fake_package("foo", None);
+        foo_locked.unfree = Some(true);
+        let mut manifest = empty_catalog_manifest();
+        manifest
+            .install
+            .insert(foo_iid.clone(), foo_descriptor_one_system.clone());
+
+        let locked = LockedManifestCatalog {
+            version: Version::<1>,
+            manifest: manifest.clone(),
+            packages: vec![foo_locked.clone()],
+        };
+
+        // Set `options.allow.unfree = false` in the manifest, but not the lockfile
+        manifest.options.allow.unfree = Some(false);
+
+        let client = catalog::MockClient::new(None::<String>).unwrap();
+        assert!(matches!(
+            LockedManifestCatalog::lock_manifest(&manifest, Some(&locked), &client)
+                .await
+                .unwrap_err(),
+            LockedManifestError::UnfreeNotAllowed { .. }
+        ));
+    }
+
+    /// [LockedManifestCatalog::lock_manifest] returns an error if the server
+    /// returns a package that is not allowed.
+    #[tokio::test]
+    async fn lock_manifest_catches_not_allowed_package_from_server() {
+        // Create a manifest with a package foo and `options.allow.unfree = false`
+        let (foo_iid, foo_descriptor_one_system, _) = fake_package("foo", Some("toplevel"));
+        let mut manifest = empty_catalog_manifest();
+        manifest
+            .install
+            .insert(foo_iid.clone(), foo_descriptor_one_system.clone());
+        manifest.options.allow.unfree = Some(false);
+
+        // Return a response that says foo is unfree. If this happens, it's a bug in the server
+        let mut client = catalog::MockClient::new(None::<String>).unwrap();
+        let mut resolved_group = resolved_pkg_group_with_dummy_package(
+            "toplevel",
+            // TODO: this is hardcoded in fake_package
+            &System::from("aarch64-darwin"),
+            &foo_iid,
+            "foo",
+            "0",
+        );
+        resolved_group
+            .page
+            .as_mut()
+            .unwrap()
+            .packages
+            .as_mut()
+            .unwrap()[0]
+            .unfree = Some(true);
+        client.push_resolve_response(vec![resolved_group]);
+        assert!(matches!(
+            LockedManifestCatalog::lock_manifest(&manifest, None, &client)
+                .await
+                .unwrap_err(),
+            LockedManifestError::UnfreeNotAllowed { .. }
+        ));
+    }
+
+    /// [LockedManifestCatalog::check_packages_are_allowed] returns an error
+    /// when it finds a disallowed license
+    #[test]
+    fn check_packages_are_allowed_disallowed_license() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.license = Some("disallowed".to_string());
+
+        assert!(matches!(
+            LockedManifestCatalog::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: None,
+                broken: None,
+                licenses: vec!["allowed".to_string()]
+            }),
+            Err(LockedManifestError::LicenseNotAllowed { .. })
+        ));
+    }
+
+    /// [LockedManifestCatalog::check_packages_are_allowed] does not error when
+    /// a package's license is allowed
+    #[test]
+    fn check_packages_are_allowed_allowed_license() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.license = Some("allowed".to_string());
+
+        assert!(
+            LockedManifestCatalog::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: None,
+                broken: None,
+                licenses: vec!["allowed".to_string()]
+            })
+            .is_ok()
+        );
+    }
+
+    /// [LockedManifestCatalog::check_packages_are_allowed] returns an error
+    /// when a package is broken even if `allow.broken` is unset
+    #[test]
+    fn check_packages_are_allowed_broken_default() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.broken = Some(true);
+
+        assert!(matches!(
+            LockedManifestCatalog::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: None,
+                broken: None,
+                licenses: vec![]
+            }),
+            Err(LockedManifestError::BrokenNotAllowed { .. })
+        ));
+    }
+
+    /// [LockedManifestCatalog::check_packages_are_allowed] does not error for a
+    /// broken package when `allow.broken = true`
+    #[test]
+    fn check_packages_are_allowed_broken_true() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.broken = Some(true);
+
+        assert!(
+            LockedManifestCatalog::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: None,
+                broken: Some(true),
+                licenses: vec![]
+            })
+            .is_ok()
+        );
+    }
+
+    /// [LockedManifestCatalog::check_packages_are_allowed] returns an error
+    /// when a package is broken and `allow.broken = false`
+    #[test]
+    fn check_packages_are_allowed_broken_false() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.broken = Some(true);
+
+        assert!(matches!(
+            LockedManifestCatalog::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: None,
+                broken: Some(false),
+                licenses: vec![]
+            }),
+            Err(LockedManifestError::BrokenNotAllowed { .. })
+        ));
+    }
+
+    /// [LockedManifestCatalog::check_packages_are_allowed] does not error for
+    /// an unfree package when `allow.unfree` is unset
+    #[test]
+    fn check_packages_are_allowed_unfree_default() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.unfree = Some(true);
+
+        assert!(
+            LockedManifestCatalog::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: None,
+                broken: None,
+                licenses: vec![]
+            })
+            .is_ok()
+        );
+    }
+
+    /// [LockedManifestCatalog::check_packages_are_allowed] does not error for a
+    /// an unfree package when `allow.unfree = true`
+    #[test]
+    fn check_packages_are_allowed_unfree_true() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.unfree = Some(true);
+
+        assert!(
+            LockedManifestCatalog::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: Some(true),
+                broken: None,
+                licenses: vec![]
+            })
+            .is_ok()
+        );
+    }
+
+    /// [LockedManifestCatalog::check_packages_are_allowed] returns an error
+    /// when a package is unfree and `allow.unfree = false`
+    #[test]
+    fn check_packages_are_allowed_unfree_false() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.unfree = Some(true);
+
+        assert!(matches!(
+            LockedManifestCatalog::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: Some(false),
+                broken: None,
+                licenses: vec![]
+            }),
+            Err(LockedManifestError::UnfreeNotAllowed { .. })
+        ));
     }
 }

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -911,6 +911,56 @@ pub struct LockfileCheckWarning {
     pub message: String,
 }
 
+pub mod test_helpers {
+    use super::*;
+
+    pub fn fake_package(
+        name: &str,
+        group: Option<&str>,
+    ) -> (String, ManifestPackageDescriptor, LockedPackageCatalog) {
+        let install_id = format!("{}_install_id", name);
+
+        let descriptor = ManifestPackageDescriptor {
+            pkg_path: name.to_string(),
+            pkg_group: group.map(|s| s.to_string()),
+            systems: Some(vec![SystemEnum::Aarch64Darwin.to_string()]),
+            version: None,
+            priority: None,
+            optional: false,
+        };
+
+        let locked = LockedPackageCatalog {
+            attr_path: name.to_string(),
+            broken: None,
+            derivation: "derivation".to_string(),
+            description: None,
+            install_id: install_id.clone(),
+            license: None,
+            locked_url: "".to_string(),
+            name: name.to_string(),
+            outputs: Default::default(),
+            outputs_to_install: None,
+            pname: name.to_string(),
+            rev: "".to_string(),
+            rev_count: 0,
+            rev_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::offset::Utc),
+            scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::offset::Utc),
+            stabilities: None,
+            unfree: None,
+            version: "".to_string(),
+            system: SystemEnum::Aarch64Darwin.to_string(),
+            group: group.unwrap_or(DEFAULT_GROUP_NAME).to_string(),
+            priority: 5,
+            optional: false,
+        };
+        (install_id, descriptor, locked)
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use std::collections::HashMap;
@@ -920,6 +970,7 @@ pub(crate) mod tests {
     use indoc::indoc;
     use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
+    use test_helpers::fake_package;
 
     use self::catalog::PackageResolutionInfo;
     use super::*;
@@ -1128,52 +1179,6 @@ pub(crate) mod tests {
             }],
         })
     });
-
-    pub(crate) fn fake_package(
-        name: &str,
-        group: Option<&str>,
-    ) -> (String, ManifestPackageDescriptor, LockedPackageCatalog) {
-        let install_id = format!("{}_install_id", name);
-
-        let descriptor = ManifestPackageDescriptor {
-            pkg_path: name.to_string(),
-            pkg_group: group.map(|s| s.to_string()),
-            systems: Some(vec![SystemEnum::Aarch64Darwin.to_string()]),
-            version: None,
-            priority: None,
-            optional: false,
-        };
-
-        let locked = LockedPackageCatalog {
-            attr_path: name.to_string(),
-            broken: None,
-            derivation: "derivation".to_string(),
-            description: None,
-            install_id: install_id.clone(),
-            license: None,
-            locked_url: "".to_string(),
-            name: name.to_string(),
-            outputs: Default::default(),
-            outputs_to_install: None,
-            pname: name.to_string(),
-            rev: "".to_string(),
-            rev_count: 0,
-            rev_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
-                .unwrap()
-                .with_timezone(&chrono::offset::Utc),
-            scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
-                .unwrap()
-                .with_timezone(&chrono::offset::Utc),
-            stabilities: None,
-            unfree: None,
-            version: "".to_string(),
-            system: SystemEnum::Aarch64Darwin.to_string(),
-            group: group.unwrap_or(DEFAULT_GROUP_NAME).to_string(),
-            priority: 5,
-            optional: false,
-        };
-        (install_id, descriptor, locked)
-    }
 
     #[test]
     fn make_params_smoke() {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -580,6 +580,9 @@ pub type PackageDescriptor = api_types::PackageDescriptor;
 pub type ApiErrorResponse = api_types::ErrorResponse;
 pub type ApiErrorResponseValue = ResponseValue<ApiErrorResponse>;
 
+/// An alias so the flox crate doesn't have to depend on the catalog-api crate
+pub type SystemEnum = api_types::SystemEnum;
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct PackageGroup {
     pub name: String,

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -811,6 +811,52 @@ impl TryFrom<PackageInfoCommon> for SearchResult {
     }
 }
 
+pub mod test_helpers {
+    use super::*;
+    use crate::data::System;
+
+    // This function should really be a #[cfg(test)] method on ResolvedPackageGroup,
+    // but you can't import test features across crates
+    pub fn resolved_pkg_group_with_dummy_package(
+        group_name: &str,
+        system: &System,
+        install_id: &str,
+        pkg_path: &str,
+        version: &str,
+    ) -> ResolvedPackageGroup {
+        let pkg = PackageResolutionInfo {
+            attr_path: pkg_path.to_string(),
+            broken: Some(false),
+            derivation: String::new(),
+            description: None,
+            install_id: install_id.to_string(),
+            license: None,
+            locked_url: String::new(),
+            name: String::new(),
+            outputs: vec![],
+            outputs_to_install: None,
+            pname: String::new(),
+            rev: String::new(),
+            rev_count: 0,
+            rev_date: chrono::offset::Utc::now(),
+            scrape_date: chrono::offset::Utc::now(),
+            stabilities: None,
+            unfree: None,
+            version: version.to_string(),
+            system: system.parse().unwrap(),
+        };
+        let page = CatalogPage {
+            packages: Some(vec![pkg]),
+            page: 0,
+            url: String::new(),
+            complete: true,
+        };
+        ResolvedPackageGroup {
+            name: group_name.to_string(),
+            page: Some(page),
+        }
+    }
+}
 #[cfg(test)]
 mod tests {
 

--- a/cli/flox/src/commands/init/go.rs
+++ b/cli/flox/src/commands/init/go.rs
@@ -341,10 +341,10 @@ mod tests {
         flox_instance_with_global_lock,
         flox_instance_with_optional_floxhub_and_client,
     };
+    use flox_rust_sdk::providers::catalog::test_helpers::resolved_pkg_group_with_dummy_package;
     use flox_rust_sdk::providers::catalog::Client;
 
     use super::*;
-    use crate::commands::init::tests::resolved_pkg_group_with_dummy_package;
     use crate::commands::init::ProvidedPackage;
 
     #[tokio::test]

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -763,8 +763,6 @@ async fn try_find_compatible_version(
 #[cfg(test)]
 mod tests {
 
-    use flox_rust_sdk::data::System;
-    use flox_rust_sdk::providers::catalog::{CatalogPage, ResolvedPackageGroup};
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -790,48 +788,6 @@ mod tests {
                     None
                 },
             }
-        }
-    }
-
-    // This function should really be a #[cfg(test)] method on ResolvedPackageGroup,
-    // but you can't import test features across crates
-    pub fn resolved_pkg_group_with_dummy_package(
-        group_name: &str,
-        system: &System,
-        install_id: &str,
-        pkg_path: &str,
-        version: &str,
-    ) -> ResolvedPackageGroup {
-        let pkg = PackageResolutionInfo {
-            attr_path: pkg_path.to_string(),
-            broken: Some(false),
-            derivation: String::new(),
-            description: None,
-            install_id: install_id.to_string(),
-            license: None,
-            locked_url: String::new(),
-            name: String::new(),
-            outputs: vec![],
-            outputs_to_install: None,
-            pname: String::new(),
-            rev: String::new(),
-            rev_count: 0,
-            rev_date: chrono::offset::Utc::now(),
-            scrape_date: chrono::offset::Utc::now(),
-            stabilities: None,
-            unfree: None,
-            version: version.to_string(),
-            system: system.parse().unwrap(),
-        };
-        let page = CatalogPage {
-            packages: Some(vec![pkg]),
-            page: 0,
-            url: String::new(),
-            complete: true,
-        };
-        ResolvedPackageGroup {
-            name: group_name.to_string(),
-            page: Some(page),
         }
     }
 

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -702,12 +702,12 @@ mod tests {
         flox_instance_with_global_lock,
         flox_instance_with_optional_floxhub_and_client,
     };
+    use flox_rust_sdk::providers::catalog::test_helpers::resolved_pkg_group_with_dummy_package;
     use flox_rust_sdk::providers::catalog::Client;
     use pretty_assertions::assert_eq;
     use serial_test::serial;
 
     use super::*;
-    use crate::commands::init::tests::resolved_pkg_group_with_dummy_package;
 
     #[test]
     fn parse_nvmrc_version_some() {

--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -829,12 +829,12 @@ mod tests {
         flox_instance_with_global_lock,
         flox_instance_with_optional_floxhub_and_client,
     };
+    use flox_rust_sdk::providers::catalog::test_helpers::resolved_pkg_group_with_dummy_package;
     use flox_rust_sdk::providers::catalog::Client;
     use pretty_assertions::assert_eq;
     use serial_test::serial;
 
     use super::*;
-    use crate::commands::init::tests::resolved_pkg_group_with_dummy_package;
     use crate::commands::init::ProvidedPackage;
 
     /// An invalid pyproject.toml should return an error

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Result};
@@ -5,7 +6,12 @@ use bpaf::Bpaf;
 use flox_rust_sdk::data::CanonicalPath;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{CoreEnvironmentError, Environment, EnvironmentError};
-use flox_rust_sdk::models::lockfile::{LockedManifest, LockedManifestError, LockedManifestPkgdb};
+use flox_rust_sdk::models::lockfile::{
+    LockedManifest,
+    LockedManifestError,
+    LockedManifestPkgdb,
+    LockedPackageCatalog,
+};
 use flox_rust_sdk::models::manifest::PackageToInstall;
 use flox_rust_sdk::models::pkgdb::error_codes;
 use indoc::formatdoc;
@@ -99,32 +105,34 @@ impl Install {
         };
 
         let mut environment = concrete_environment.into_dyn_environment();
-        let mut packages = self
+        let mut packages_to_install = self
             .packages
             .iter()
             .map(|p| PackageToInstall::from_str(p))
             .collect::<Result<Vec<_>, _>>()?;
-        packages.extend(self.id.iter().map(|p| PackageToInstall {
+        packages_to_install.extend(self.id.iter().map(|p| PackageToInstall {
             id: p.id.clone(),
             pkg_path: p.path.clone(),
             version: None,
             input: None,
         }));
-        if packages.is_empty() {
+        if packages_to_install.is_empty() {
             bail!("Must specify at least one package");
         }
 
         // We don't know the contents of the packages field when the span is created
-        tracing::Span::current()
-            .record("packages", Install::format_packages_for_tracing(&packages));
+        tracing::Span::current().record(
+            "packages",
+            Install::format_packages_for_tracing(&packages_to_install),
+        );
 
         let installation = Dialog {
             message: &format!("Installing packages to environment {description}..."),
             help_message: None,
-            typed: Spinner::new(|| environment.install(&packages, &flox)),
+            typed: Spinner::new(|| environment.install(&packages_to_install, &flox)),
         }
         .spin()
-        .map_err(|err| Self::handle_error(err, &flox, &*environment, &packages))?;
+        .map_err(|err| Self::handle_error(err, &flox, &*environment, &packages_to_install))?;
 
         let lockfile_path = environment.lockfile_path(&flox)?;
         let lockfile_path = CanonicalPath::new(lockfile_path)?;
@@ -133,28 +141,32 @@ impl Install {
         // Check for warnings in the lockfile
         let lockfile: LockedManifest = serde_json::from_str(&lockfile_content)?;
 
-        let warnings = match lockfile {
-            LockedManifest::Catalog(_) => {
-                // TODO: implement lockfile checking for catalog lockfiles
-                Vec::new()
+        match lockfile {
+            // TODO: move this behind the `installation.new_manifest.is_some()`
+            // check below so we don't warn when we don't even install anything
+            LockedManifest::Catalog(locked_manifest) => {
+                for warning in
+                    Self::generate_warnings(&locked_manifest.packages, &packages_to_install)
+                {
+                    message::warning(warning);
+                }
             },
             LockedManifest::Pkgdb(_) => {
                 // run `pkgdb manifest check`
-                LockedManifestPkgdb::check_lockfile(&lockfile_path)?
+                let warnings = LockedManifestPkgdb::check_lockfile(&lockfile_path)?;
+                warnings
+                    .iter()
+                    .filter(|w| {
+                        // Filter out warnings that are not related to the packages we just installed
+                        packages_to_install.iter().any(|p| w.package == p.id)
+                    })
+                    .for_each(|w| message::warning(&w.message));
             },
         };
 
-        warnings
-            .iter()
-            .filter(|w| {
-                // Filter out warnings that are not related to the packages we just installed
-                packages.iter().any(|p| w.package == p.id)
-            })
-            .for_each(|w| message::warning(&w.message));
-
         if installation.new_manifest.is_some() {
             // Print which new packages were installed
-            for pkg in packages.iter() {
+            for pkg in packages_to_install.iter() {
                 if let Some(false) = installation.already_installed.get(&pkg.id) {
                     message::package_installed(pkg, &description);
                 } else {
@@ -165,7 +177,7 @@ impl Install {
                 }
             }
         } else {
-            for pkg in packages.iter() {
+            for pkg in packages_to_install.iter() {
                 message::warning(format!(
                     "Package with id '{}' already installed to environment {description}",
                     pkg.id
@@ -225,5 +237,169 @@ impl Install {
             },
             err => apply_doc_link_for_unsupported_packages(err).into(),
         }
+    }
+
+    /// Generate warnings to print to the user about unfree and broken packages.
+    fn generate_warnings(
+        locked_packages: &[LockedPackageCatalog],
+        packages_to_install: &[PackageToInstall],
+    ) -> Vec<String> {
+        let mut warnings = vec![];
+
+        // There could be multiple packages with the same install_id but different systems.
+        // A package could be broken on one system but not another.
+        // So just keep track of which install_ids we've warned for.
+        // TODO: does the warning need to take system into account?
+        let mut warned_unfree = HashSet::new();
+        let mut warned_broken = HashSet::new();
+        for locked_package in locked_packages.iter() {
+            // If unfree && just installed && we haven't already warned for this install_id,
+            // warn that this package is unfree
+            if locked_package.unfree == Some(true)
+                && packages_to_install
+                    .iter()
+                    .any(|p| locked_package.install_id == p.id)
+                && !warned_unfree.contains(&locked_package.install_id)
+            {
+                warnings.push(format!("The package '{}' has an unfree license, please verify the licensing terms of use", locked_package.install_id));
+                warned_unfree.insert(&locked_package.install_id);
+            }
+
+            // If broken && just installed && we haven't already warned for this install_id,
+            // warn that this package is broken
+            if locked_package.broken == Some(true)
+                && packages_to_install
+                    .iter()
+                    .any(|p| locked_package.install_id == p.id)
+                && !warned_broken.contains(&locked_package.install_id)
+            {
+                warnings.push(format!("The package '{}' is marked as broken, it may not behave as expected during runtime.", locked_package.install_id));
+                warned_broken.insert(&locked_package.install_id);
+            }
+        }
+        warnings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flox_rust_sdk::models::lockfile::test_helpers::fake_package;
+    use flox_rust_sdk::models::lockfile::LockedPackageCatalog;
+    use flox_rust_sdk::models::manifest::PackageToInstall;
+    use flox_rust_sdk::providers::catalog::SystemEnum;
+
+    use crate::commands::install::Install;
+
+    /// [Install::generate_warnings] shouldn't warn for packages not in packages_to_install
+    #[test]
+    fn generate_warnings_empty() {
+        let (_, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.unfree = Some(true);
+        let locked_packages = vec![];
+        let packages_to_install = vec![];
+        assert_eq!(
+            Install::generate_warnings(&locked_packages, &packages_to_install),
+            Vec::<String>::new()
+        );
+    }
+
+    /// [Install::generate_warnings] should warn for an unfree package
+    #[test]
+    fn generate_warnings_unfree() {
+        let (foo_iid, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.unfree = Some(true);
+        let locked_packages = vec![foo_locked];
+        let packages_to_install = vec![PackageToInstall {
+            id: foo_iid.clone(),
+            pkg_path: "foo".to_string(),
+            version: None,
+            input: None,
+        }];
+        assert_eq!(
+            Install::generate_warnings(&locked_packages, &packages_to_install),
+            vec![format!(
+                "The package '{}' has an unfree license, please verify the licensing terms of use",
+                foo_iid
+            )]
+        );
+    }
+
+    /// [Install::generate_warnings] should only warn for an unfree package once
+    /// even if it's installed on multiple systems
+    #[test]
+    fn generate_warnings_unfree_multi_system() {
+        let (foo_iid, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.unfree = Some(true);
+
+        // TODO: fake_package shouldn't hardcode system?
+        let foo_locked_second_system = LockedPackageCatalog {
+            system: SystemEnum::Aarch64Linux.to_string(),
+            ..foo_locked.clone()
+        };
+
+        let locked_packages = vec![foo_locked, foo_locked_second_system];
+        let packages_to_install = vec![PackageToInstall {
+            id: foo_iid.clone(),
+            pkg_path: "foo".to_string(),
+            version: None,
+            input: None,
+        }];
+        assert_eq!(
+            Install::generate_warnings(&locked_packages, &packages_to_install),
+            vec![format!(
+                "The package '{}' has an unfree license, please verify the licensing terms of use",
+                foo_iid
+            )]
+        );
+    }
+
+    /// [Install::generate_warnings] should warn for a broken package
+    #[test]
+    fn generate_warnings_broken() {
+        let (foo_iid, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.broken = Some(true);
+        let locked_packages = vec![foo_locked];
+        let packages_to_install = vec![PackageToInstall {
+            id: foo_iid.clone(),
+            pkg_path: "foo".to_string(),
+            version: None,
+            input: None,
+        }];
+        assert_eq!(
+            Install::generate_warnings(&locked_packages, &packages_to_install),
+            vec![format!(
+                "The package '{}' is marked as broken, it may not behave as expected during runtime.",
+                foo_iid
+            )]
+        );
+    }
+
+    /// [Install::generate_warnings] should only warn for a broken package once
+    /// even if it's installed on multiple systems
+    #[test]
+    fn generate_warnings_broken_multi_system() {
+        let (foo_iid, _, mut foo_locked) = fake_package("foo", None);
+        foo_locked.broken = Some(true);
+
+        // TODO: fake_package shouldn't hardcode system?
+        let foo_locked_second_system = LockedPackageCatalog {
+            system: SystemEnum::Aarch64Linux.to_string(),
+            ..foo_locked.clone()
+        };
+
+        let locked_packages = vec![foo_locked, foo_locked_second_system];
+        let packages_to_install = vec![PackageToInstall {
+            id: foo_iid.clone(),
+            pkg_path: "foo".to_string(),
+            version: None,
+            input: None,
+        }];
+        assert_eq!(
+            Install::generate_warnings(&locked_packages, &packages_to_install),
+            vec![format!(
+                "The package '{}' is marked as broken, it may not behave as expected during runtime.",
+                foo_iid
+            )]
+        );
     }
 }

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -727,6 +727,12 @@ pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
 
         LockedManifestError::ResolutionFailed(_) => display_chain(err),
         LockedManifestError::EmptyPage => display_chain(err),
+        // User facing
+        LockedManifestError::LicenseNotAllowed(..) => display_chain(err),
+        // User facing
+        LockedManifestError::BrokenNotAllowed(_) => display_chain(err),
+        // User facing
+        LockedManifestError::UnfreeNotAllowed(_) => display_chain(err),
     }
 }
 

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -485,13 +485,23 @@ teardown() {
   assert_line --partial "The package 'hello-unfree' has an unfree license"
 }
 
+# This is also checking we can build an unfree package
 @test "catalog: 'flox install' warns about unfree packages" {
-  skip "will be fixed by https://github.com/flox/flox/issues/1507"
   "$FLOX_BIN" init
+  export  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello-unfree.json"
   run "$FLOX_BIN" install hello-unfree
   assert_success
   assert_line --partial "The package 'hello-unfree' has an unfree license"
 }
+
+@test "catalog: 'flox install' warns about broken packages" {
+  skip "waiting for broken packages to be added to catalog"
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install TODO
+  assert_success
+  assert_line --partial "The package 'TODO' is marked as broken, it may not behave as expected during runtime"
+}
+
 
 @test "'flox install' fails to install unfree packages if forbidden" {
   export FLOX_FEATURES_USE_CATALOG=false
@@ -504,29 +514,8 @@ teardown() {
   assert_output --partial "'options.allow.unfree = true'"
 }
 
-@test "catalog: 'flox install' fails to install unfree packages if forbidden" {
-  skip "will be fixed by https://github.com/flox/flox/issues/1507"
-  "$FLOX_BIN" init
-  tomlq --in-place -t '.options.allow.unfree = false' "$MANIFEST_PATH"
-
-  run "$FLOX_BIN" install hello-unfree
-  assert_failure
-  assert_line --partial "The package 'hello-unfree' has an unfree license."
-  assert_output --partial "'options.allow.unfree = true'"
-}
-
 @test "'flox install' fails to install broken packages" {
   export FLOX_FEATURES_USE_CATALOG=false
-  "$FLOX_BIN" init
-
-  run "$FLOX_BIN" install yi
-  assert_failure
-  assert_line --partial "The package 'yi' is marked as broken."
-  assert_output --partial "'options.allow.broken = true'"
-}
-
-@test "catalog: 'flox install' fails to install broken packages" {
-  skip "will be fixed by https://github.com/flox/flox/issues/1507"
   "$FLOX_BIN" init
 
   run "$FLOX_BIN" install yi

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -32,6 +32,10 @@ cmd = "flox install gzip"
 pre_cmd = "flox init"
 cmd = "flox install hello"
 
+[resolve.hello-unfree]
+pre_cmd = "flox init"
+cmd = "flox install hello-unfree"
+
 [resolve.krb5_after_prereqs_installed]
 files = ["envs/krb5_prereqs/manifest.toml"]
 pre_cmd = '''

--- a/test_data/generated/resolve/hello-unfree.json
+++ b/test_data/generated/resolve/hello-unfree.json
@@ -1,0 +1,134 @@
+[
+  [
+    {
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "packages": [
+          {
+            "attr_path": "hello-unfree",
+            "broken": false,
+            "derivation": "/nix/store/8zc74vxbw9jff5i3inikvbx03mz2bxs5-example-unfree-package-1.0.drv",
+            "description": "An example package with unfree license (for testing)",
+            "install_id": "hello-unfree",
+            "license": "Unfree",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "name": "example-unfree-package-1.0",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/xq3rlnp72jh4m8v3pab57k8w39b94kyh-example-unfree-package-1.0"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello-unfree",
+            "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "rev_count": 633517,
+            "rev_date": "2024-05-31T23:09:26Z",
+            "scrape_date": "2024-06-04T09:46:16Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": true,
+            "version": "example-unfree-package-1.0"
+          },
+          {
+            "attr_path": "hello-unfree",
+            "broken": false,
+            "derivation": "/nix/store/lr23l4cy1y9ibz2w4mihfmx87higjhmn-example-unfree-package-1.0.drv",
+            "description": "An example package with unfree license (for testing)",
+            "install_id": "hello-unfree",
+            "license": "Unfree",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "name": "example-unfree-package-1.0",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/w9yy0m1rryxxbsn9ilkcj92iih0d2il3-example-unfree-package-1.0"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello-unfree",
+            "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "rev_count": 633517,
+            "rev_date": "2024-05-31T23:09:26Z",
+            "scrape_date": "2024-06-04T09:46:16Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": true,
+            "version": "example-unfree-package-1.0"
+          },
+          {
+            "attr_path": "hello-unfree",
+            "broken": false,
+            "derivation": "/nix/store/7ky2wqdjwxs991jhksrfj8akpqkzfkjn-example-unfree-package-1.0.drv",
+            "description": "An example package with unfree license (for testing)",
+            "install_id": "hello-unfree",
+            "license": "Unfree",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "name": "example-unfree-package-1.0",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/lx86x4cvck8vpwnsbw4dk8aih7va0000-example-unfree-package-1.0"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello-unfree",
+            "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "rev_count": 633517,
+            "rev_date": "2024-05-31T23:09:26Z",
+            "scrape_date": "2024-06-04T09:46:16Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": true,
+            "version": "example-unfree-package-1.0"
+          },
+          {
+            "attr_path": "hello-unfree",
+            "broken": false,
+            "derivation": "/nix/store/j1xxad9pnvjrnasnmgblcadxs0d5vm29-example-unfree-package-1.0.drv",
+            "description": "An example package with unfree license (for testing)",
+            "install_id": "hello-unfree",
+            "license": "Unfree",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "name": "example-unfree-package-1.0",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/bl6ih61gz66l899npfsavxgvynx6jwa1-example-unfree-package-1.0"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello-unfree",
+            "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+            "rev_count": 633517,
+            "rev_date": "2024-05-31T23:09:26Z",
+            "scrape_date": "2024-06-04T09:46:16Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": true,
+            "version": "example-unfree-package-1.0"
+          }
+        ],
+        "page": 633517,
+        "url": ""
+      }
+    }
+  ]
+]


### PR DESCRIPTION
Unfree, broken, and licenses are already copied from the manifest into
catalog resolution requests. But pkgdb warnings and errors still needed
to be ported to catalog code paths.

- When `options.allow` are changed with a `flox edit`, an error should
  be thrown if already installed packages are no longer allowed
- When unfree or broken packages are installed, a warning should be
  printed to the user.

Note that with pkgdb, if a package failed to install because it was not
allowed, a helpful error was printed suggesting a modification to
`options.allow`. This is no longer possible since resolution failures do
not currently include enough information to determine if the failure was
due to an `options.allow` setting. The corresponding copied but skipped
integration tests were dropped instead of re-enabling.

`fake_package` was moved to a `test_helpers` module, and `resolved_pkg_group_with_dummy_package` was moved from the `flox` crate to the `flox-rust-sdk` crate so these helpers could be used in unit tests.