### PR TITLE
feat: handle upgrade errors with catalog

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -62,7 +62,7 @@ build-cdb:
 # Build the binaries
 build: build-cli
 
-# Regenerate test data
+# Generate test data
 gen-data +mk_data_args="": build-data-gen
     mkdata="$PWD/cli/target/debug/mk_data"; pushd test_data; "$mkdata" {{mk_data_args}} config.toml; popd
 

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -540,10 +541,16 @@ impl CoreEnvironment<ReadOnly> {
                 let (lockfile, upgraded) =
                     self.upgrade_with_catalog_client(client, groups_or_iids, &catalog)?;
 
-                let upgraded = upgraded
-                    .into_iter()
-                    .map(|(_, pkg)| pkg.install_id.clone())
-                    .collect();
+                let upgraded = {
+                    let mut install_ids = upgraded
+                        .into_iter()
+                        .map(|(_, pkg)| pkg.install_id.clone())
+                        .collect::<HashSet<_>>()
+                        .into_iter()
+                        .collect::<Vec<_>>();
+                    install_ids.sort();
+                    install_ids
+                };
 
                 (LockedManifest::Catalog(lockfile), upgraded)
             },
@@ -633,10 +640,20 @@ impl CoreEnvironment<ReadOnly> {
             }
         };
 
-        let previous_packages = existing_lockfile
-            .as_ref()
-            .map(|lockfile| lockfile.packages.clone())
-            .unwrap_or_default();
+        // Record a nested map where you retrieve the locked package
+        // via pkgs[install_id][system]
+        let previous_packages = if let Some(ref lockfile) = existing_lockfile {
+            let mut pkgs_by_id = BTreeMap::new();
+            lockfile.packages.iter().for_each(|pkg| {
+                let by_system = pkgs_by_id
+                    .entry(pkg.install_id.clone())
+                    .or_insert(BTreeMap::new());
+                by_system.entry(pkg.system.clone()).or_insert(pkg.clone());
+            });
+            pkgs_by_id
+        } else {
+            BTreeMap::new()
+        };
 
         // Create a seed lockfile by "unlocking" (i.e. removing the locked entries of)
         // all packages matching the given groups or iids.
@@ -651,26 +668,40 @@ impl CoreEnvironment<ReadOnly> {
             })
         };
 
-        let upgraded =
+        let upgraded_lockfile =
             LockedManifestCatalog::lock_manifest(manifest, seed_lockfile.as_ref(), client)
                 .block_on()
                 .map_err(CoreEnvironmentError::LockedManifest)?;
 
-        // find all packages that after upgrading have a different derivation
-        let package_diff = upgraded
-            .packages
-            .iter()
-            .filter_map(move |pkg| {
-                previous_packages
-                    .iter()
-                    .find(|prev| {
-                        prev.install_id == pkg.install_id && prev.derivation != pkg.derivation
-                    })
-                    .map(|prev| (prev.clone(), pkg.clone()))
-            })
-            .collect();
+        let pkgs_after_upgrade = {
+            let mut pkgs_by_id = BTreeMap::new();
+            upgraded_lockfile.packages.iter().for_each(|pkg| {
+                let by_system = pkgs_by_id
+                    .entry(pkg.install_id.clone())
+                    .or_insert(BTreeMap::new());
+                by_system.entry(pkg.system.clone()).or_insert(pkg.clone());
+            });
+            pkgs_by_id
+        };
 
-        Ok((upgraded, package_diff))
+        // Iterate over the two sorted maps in lockstep
+        let package_diff = previous_packages
+            .iter()
+            .zip(pkgs_after_upgrade.iter())
+            .flat_map(|((_prev_id, prev_map), (_curr_id, curr_map))| {
+                let curr_iter = curr_map.iter().map(|(_sys, pkg)| pkg);
+                prev_map.iter().map(|(_sys, pkg)| pkg).zip(curr_iter)
+            })
+            .filter_map(|(prev_pkg, curr_pkg)| {
+                if prev_pkg.derivation != curr_pkg.derivation {
+                    Some((prev_pkg.clone(), curr_pkg.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        Ok((upgraded_lockfile, package_diff))
     }
 
     /// Makes a temporary copy of the environment so modifications to the manifest

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -15,7 +15,7 @@ use super::container_builder::ContainerBuilder;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
 use super::lockfile::{LockedManifest, LockedManifestPkgdb};
-use super::manifest::PackageToInstall;
+use super::manifest::{ManifestError, PackageToInstall};
 use super::pkgdb::UpgradeResult;
 use crate::data::{CanonicalPath, CanonicalizeError, Version};
 use crate::flox::{Flox, Floxhub};
@@ -464,6 +464,14 @@ pub enum EnvironmentError {
 
     #[error("failed to access the environment registry")]
     Registry(#[from] EnvRegistryError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UpgradeError {
+    #[error(transparent)]
+    PkgNotFound(#[from] ManifestError),
+    #[error("'{pkg}' is a package in the group '{group}' with multiple packages")]
+    NonEmptyNamedGroup { pkg: String, group: String },
 }
 
 /// Copy a whole directory recursively ignoring the original permissions

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -348,6 +348,119 @@ pub struct TypedManifestCatalog {
     pub(super) options: ManifestOptions,
 }
 
+impl TypedManifestCatalog {
+    pub fn pkg_descriptor_with_id(&self, id: impl AsRef<str>) -> Option<ManifestPackageDescriptor> {
+        pkg_descriptor_with_id(id, &self.install.0)
+    }
+
+    pub fn pkg_descriptors_in_toplevel_group(&self) -> Vec<(String, ManifestPackageDescriptor)> {
+        pkg_descriptors_in_toplevel_group(&self.install.0)
+    }
+
+    pub fn pkg_descriptors_in_named_group(
+        &self,
+        name: impl AsRef<str>,
+    ) -> Vec<(String, ManifestPackageDescriptor)> {
+        pkg_descriptors_in_named_group(name, &self.install.0)
+    }
+
+    pub fn pkg_or_group_found_in_manifest(&self, name: impl AsRef<str>) -> bool {
+        pkg_or_group_found_in_manifest(name.as_ref(), &self.install.0)
+    }
+
+    pub fn pkg_belongs_to_non_empty_named_group(
+        &self,
+        pkg: impl AsRef<str>,
+    ) -> Result<Option<String>, ManifestError> {
+        pkg_belongs_to_non_empty_named_group(pkg.as_ref(), &self.install.0)
+    }
+
+    pub fn pkg_belongs_to_non_empty_toplevel_group(
+        &self,
+        pkg: impl AsRef<str>,
+    ) -> Result<bool, ManifestError> {
+        pkg_belongs_to_non_empty_toplevel_group(pkg.as_ref(), &self.install.0)
+    }
+}
+
+pub(crate) fn pkg_descriptor_with_id(
+    id: impl AsRef<str>,
+    descriptors: &BTreeMap<String, ManifestPackageDescriptor>,
+) -> Option<ManifestPackageDescriptor> {
+    descriptors
+        .iter()
+        .find(|(install_id, _)| install_id.as_str() == id.as_ref())
+        .map(|(_, desc)| desc.clone())
+}
+
+pub(crate) fn pkg_descriptors_in_toplevel_group(
+    descriptors: &BTreeMap<String, ManifestPackageDescriptor>,
+) -> Vec<(String, ManifestPackageDescriptor)> {
+    descriptors
+        .iter()
+        .filter(|(_, desc)| desc.pkg_group.is_none())
+        .map(|(id, desc)| (id.clone(), desc.clone()))
+        .collect::<Vec<_>>()
+}
+
+pub(crate) fn pkg_descriptors_in_named_group(
+    name: impl AsRef<str>,
+    descriptors: &BTreeMap<String, ManifestPackageDescriptor>,
+) -> Vec<(String, ManifestPackageDescriptor)> {
+    descriptors
+        .iter()
+        .filter(|(_, desc)| {
+            desc.pkg_group
+                .as_ref()
+                .is_some_and(|n| n.as_str() == name.as_ref())
+        })
+        .map(|(id, desc)| (id.clone(), desc.clone()))
+        .collect::<Vec<_>>()
+}
+
+/// Scans the provided package descriptors to determine if the search term is a package or
+/// group in the manifest.
+fn pkg_or_group_found_in_manifest(
+    search_term: &str,
+    descriptors: &BTreeMap<String, ManifestPackageDescriptor>,
+) -> bool {
+    descriptors.iter().any(|(id, desc)| {
+        (search_term == id.as_str()) || (Some(search_term.to_string()) == desc.pkg_group)
+    })
+}
+
+/// Scans the provided package descriptors to determine if the specified package belongs to a
+/// named group in the manifest with other packages.
+fn pkg_belongs_to_non_empty_named_group(
+    pkg: &str,
+    descriptors: &BTreeMap<String, ManifestPackageDescriptor>,
+) -> Result<Option<String>, ManifestError> {
+    let descriptor =
+        pkg_descriptor_with_id(pkg, descriptors).ok_or(ManifestError::NotFound(pkg.to_string()))?;
+    let Some(group) = descriptor.pkg_group else {
+        return Ok(None);
+    };
+    let pkgs = pkg_descriptors_in_named_group(&group, descriptors);
+    let other_pkgs_in_group = pkgs.iter().any(|(id, _)| id != pkg);
+    if other_pkgs_in_group {
+        Ok(Some(group))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Scans the provided package descriptors to determine if the specified package belongs to
+/// the "toplevel" group with other packages.
+fn pkg_belongs_to_non_empty_toplevel_group(
+    pkg: &str,
+    descriptors: &BTreeMap<String, ManifestPackageDescriptor>,
+) -> Result<bool, ManifestError> {
+    pkg_descriptor_with_id(pkg, descriptors).ok_or(ManifestError::NotFound(pkg.to_string()))?;
+    let pkgs = pkg_descriptors_in_toplevel_group(descriptors);
+    let other_toplevel_packages_exist = pkgs.iter().any(|(id, _)| id != pkg);
+    Ok(other_toplevel_packages_exist)
+}
+
 #[derive(
     Debug,
     Clone,
@@ -489,6 +602,8 @@ pub enum ManifestError {
     /// FIXME: This is a temporary error variant until `flox` parses descriptors on its own
     #[error("failed while calling pkgdb")]
     PkgDbCall(#[source] std::io::Error),
+    #[error("no package or group named '{0}' in the manifest")]
+    NotFound(String),
 }
 
 /// A subset of the manifest used to check what type of edits users make. We

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -7,6 +7,7 @@ use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentErr
 use flox_rust_sdk::models::environment::{
     CoreEnvironmentError,
     EnvironmentError,
+    UpgradeError,
     ENVIRONMENT_POINTER_FILENAME,
 };
 use flox_rust_sdk::models::lockfile::LockedManifestError;
@@ -293,7 +294,7 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
         CoreEnvironmentError::BadLockfilePath(_) => display_chain(err),
 
         // todo: should be in LockedManifesterror
-        CoreEnvironmentError::UpgradeFailed(pkgdb_error) => {
+        CoreEnvironmentError::UpgradeFailedPkgDb(pkgdb_error) => {
             format_pkgdb_error(pkgdb_error, err, "Failed to upgrade environment.")
         },
         // other pkgdb call errors are unexpected
@@ -312,6 +313,16 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
 
             Please enable the catalog feature and try again.
         "},
+        CoreEnvironmentError::UpgradeFailedCatalog(err) => match err {
+            UpgradeError::PkgNotFound(err) => err.to_string(),
+            UpgradeError::NonEmptyNamedGroup { pkg, group } => formatdoc! {"
+                '{pkg}' is a package in the group '{group}' with multiple packages.
+                To upgrade the group, specify the group name:
+                    $ flox upgrade {group}
+                To upgrade all packages, run:
+                    $ flox upgrade
+            "},
+        },
     }
 }
 

--- a/cli/mk_data/README.md
+++ b/cli/mk_data/README.md
@@ -51,13 +51,20 @@ Each job is executed in a temporary directory inside the output directory.
 
 The config for a job is as follows:
 ```
-files    := [str] | null
-pre_cmd  := str | null
-cmd      := str | null
-post_cmd := str | null
+files                  := [str] | null
+pre_cmd                := str | null
+cmd                    := str | null
+post_cmd               := str | null
+ignore_pre_cmd_errors  := bool | null
+ignore_cmd_errors      := bool | null
+ignore_post_cmd_errors := bool | null
+skip_if_output_exists  := str | null
 ```
+where `*cmd`s are run by Bash.
 
 Semantics:
+- If `skip_if_output_exists` is `<path>`, then `$output_dir/<path>` is checked and if it exists the job is skipped.
+    - This is necessary if the job puts output in a place other than `<category>/<name>.json`.
 - `files` are relative paths specified relative to the input data directory.
 - `files` are copied from the input data directory into the working directory before anything else happens.
 - `pre_cmd` executes next, but no response file is generated during execution.
@@ -65,7 +72,8 @@ Semantics:
 - `post_cmd` is executed next, but no response file is generated.
 - `$RESPONSE_FILE` contains the path to the generated response file and is available inside `post_cmd` for post-processing of response files.
 
-Any error encountered while copying files or running commands will fail the job.
+Any error encountered while copying files or running commands will fail the job
+unless the appropriate `ignore_*_errors` field is set.
 If you expect a command to fail and still want to record the response, you should
 run the command as `cmd || true`.
 

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -255,7 +255,7 @@ EOF
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" "$FLOX_BIN" install curl hello
 
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/empty.json" \
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.json" \
     run "$FLOX_BIN" upgrade hello
   assert_output --partial "package in the group 'toplevel' with multiple packages"
 }

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -21,6 +21,8 @@ project_setup() {
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" > /dev/null || return
+  export FLOX_FEATURES_USE_CATALOG=true
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.json"
 }
 
 project_teardown() {
@@ -173,93 +175,83 @@ EOF
 # catalog tests
 
 @test "catalog: upgrade hello" {
-  skip "FIXME: upgrades package but reports that no packages were upgraded"
-
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" "$FLOX_BIN" install hello
 
-  old_hello_response_rev=$(jq -r '.[0].[0].pages.[0].page' "$GENERATED_DATA/resolve/old_hello.json")
-  old_hello_locked_rev=$(jq -r '.packages.[0].rev_count' "$LOCK_PATH")
-  assert_equal "$old_hello_locked_rev" "$old_hello_response_rev" 
+  old_hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/old_hello.json")
+  old_hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
+  assert_equal "$old_hello_locked_drv" "$old_hello_response_drv" 
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade
   assert_output --partial "Upgraded 'hello'"
-  hello_response_rev=$(jq -r '.[0].[0].pages.[0].page' "$GENERATED_DATA/resolve/hello.json")
-  hello_locked_rev=$(jq -r '.packages.[0].rev_count' "$LOCK_PATH")
-  assert_equal "$hello_locked_rev" "$hello_response_rev"
+  hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
+  hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
+  assert_equal "$hello_locked_drv" "$hello_response_drv"
   
-  assert_not_equal "$old_hello_locked_rev" "$hello_locked_rev"
+  assert_not_equal "$old_hello_locked_drv" "$hello_locked_drv"
 }
 
 @test "catalog: upgrade by group" {
-  skip "FIXME: upgrades package but reports that no packages were upgraded"
-
   "$FLOX_BIN" init
   cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
   tomlq -i -t '.install.hello."pkg-path" = "hello"' "$TMP_MANIFEST_PATH"
   tomlq -i -t '.install.hello."pkg-group" = "blue"' "$TMP_MANIFEST_PATH"
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
 
-  old_hello_response_rev=$(jq -r '.[0].[0].pages.[0].page' "$GENERATED_DATA/resolve/old_hello.json")
-  old_hello_locked_rev=$(jq -r '.packages.[0].rev_count' "$LOCK_PATH")
-  assert_equal "$old_hello_locked_rev" "$old_hello_response_rev"
+  old_hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/old_hello.json")
+  old_hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
+  assert_equal "$old_hello_locked_drv" "$old_hello_response_drv"
 
   # add the package group
 
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" \
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade blue
-  hello_response_rev=$(jq -r '.[0].[0].pages.[0].page' "$GENERATED_DATA/resolve/hello.json")
-  hello_locked_rev=$(jq -r '.packages.[0].rev_count' "$LOCK_PATH")
-  assert_equal "$hello_locked_rev" "$hello_response_rev"
+  hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
+  hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
+  assert_equal "$hello_locked_drv" "$hello_response_drv"
   assert_output --partial "Upgraded 'hello'"
   
-  assert_not_equal "$old_hello_locked_rev" "$hello_locked_rev"
+  assert_not_equal "$old_hello_locked_drv" "$hello_locked_drv"
 }
 
 @test "catalog: upgrade toplevel group" {
-  skip "FIXME: upgrades package but reports that no packages were upgraded"
-
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" "$FLOX_BIN" install hello
 
-  old_hello_response_rev=$(jq -r '.[0].[0].pages.[0].page' "$GENERATED_DATA/resolve/old_hello.json")
-  old_hello_locked_rev=$(jq -r '.packages.[0].rev_count' "$LOCK_PATH")
-  assert_equal "$old_hello_locked_rev" "$old_hello_response_rev"
+  old_hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/old_hello.json")
+  old_hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
+  assert_equal "$old_hello_locked_drv" "$old_hello_response_drv"
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade toplevel
   assert_output --partial "Upgraded 'hello'"
-  hello_response_rev=$(jq -r '.[0].[0].pages.[0].page' "$GENERATED_DATA/resolve/hello.json")
-  hello_locked_rev=$(jq -r '.packages.[0].rev_count' "$LOCK_PATH")
-  assert_equal "$hello_locked_rev" "$hello_response_rev"
+  hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
+  hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
+  assert_equal "$hello_locked_drv" "$hello_response_drv"
   
-  assert_not_equal "$old_hello_locked_rev" "$hello_locked_rev"
+  assert_not_equal "$old_hello_locked_drv" "$hello_locked_drv"
 }
 
 @test "catalog: upgrade by iid" {
-  skip "FIXME: upgrades package but reports that no packages were upgraded"
-
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" "$FLOX_BIN" install hello
 
-  old_hello_response_rev=$(jq -r '.[0].[0].pages.[0].page' "$GENERATED_DATA/resolve/old_hello.json")
-  old_hello_locked_rev=$(jq -r '.packages.[0].rev_count' "$LOCK_PATH")
-  assert_equal "$old_hello_locked_rev" "$old_hello_response_rev"
+  old_hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/old_hello.json")
+  old_hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
+  assert_equal "$old_hello_locked_drv" "$old_hello_response_drv"
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade hello
   assert_output --partial "Upgraded 'hello'"
-  hello_response_rev=$(jq -r '.[0].[0].pages.[0].page' "$GENERATED_DATA/resolve/hello.json")
-  hello_locked_rev=$(jq -r '.packages.[0].rev_count' "$LOCK_PATH")
-  assert_equal "$hello_locked_rev" "$hello_response_rev"
+  hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
+  hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
+  assert_equal "$hello_locked_drv" "$hello_response_drv"
   
-  assert_not_equal "$old_hello_locked_rev" "$hello_locked_rev"
+  assert_not_equal "$old_hello_locked_drv" "$hello_locked_drv"
 }
 
 @test "catalog: upgrade errors on iid in group with other packages" {
-  skip "FIXME: upgrades package but reports that no packages were upgraded"
-
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" "$FLOX_BIN" install curl hello
 
@@ -269,10 +261,6 @@ EOF
 }
 
 @test "catalog: check confirmation when all packages are up to date" {
-  # This will pass right now, but that's because _all_ of these tests get
-  # the "no packages need to be upgraded" message. Unskip once we get a real
-  # signal from these tests
-  skip "FIXME: upgrades package but reports that no packages were upgraded"
   export FLOX_FEATURES_USE_CATALOG=true
 
   "$FLOX_BIN" init

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -255,8 +255,8 @@ EOF
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" "$FLOX_BIN" install curl hello
 
-  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
-  run "$FLOX_BIN" upgrade hello
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
+    run "$FLOX_BIN" upgrade hello
   assert_output --partial "package in the group 'toplevel' with multiple packages"
 }
 

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -255,7 +255,7 @@ EOF
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" "$FLOX_BIN" install curl hello
 
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/empty.json" \
     run "$FLOX_BIN" upgrade hello
   assert_output --partial "package in the group 'toplevel' with multiple packages"
 }

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -51,7 +51,7 @@ cmd = "flox edit -f manifest.toml"
 pre_cmd = "flox init"
 cmd = "flox install hello"
 post_cmd = '''
-    cat "$RESPONSE_FILE" | jq | sed 's/"version": "2.12.1"/"version": "old_version"/g' > tmp.json
+    cat "$RESPONSE_FILE" | jq | sed 's/"derivation": .*$/"derivation": "\/nix\/store\/AAA-hello-2.12.1.drv",/g' > tmp.json
     mv tmp.json "$RESPONSE_FILE"
 '''
 

--- a/test_data/generated/resolve/old_hello.json
+++ b/test_data/generated/resolve/old_hello.json
@@ -8,7 +8,7 @@
           {
             "attr_path": "hello",
             "broken": false,
-            "derivation": "/nix/store/7db0fz4nh3bj3xcxmbyp9hajv2lkji2q-hello-2.12.1.drv",
+            "derivation": "/nix/store/AAA-hello-2.12.1.drv",
             "description": "A program that produces a familiar, friendly greeting",
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
@@ -28,15 +28,17 @@
             "rev_count": 633517,
             "rev_date": "2024-05-31T23:09:26Z",
             "scrape_date": "2024-06-04T09:46:16Z",
-            "stabilities": null,
+            "stabilities": [
+              "unstable"
+            ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "old_version"
+            "version": "2.12.1"
           },
           {
             "attr_path": "hello",
             "broken": false,
-            "derivation": "/nix/store/pb7w5qbpwyvy5979ps9qdpyjgfwhpvgn-hello-2.12.1.drv",
+            "derivation": "/nix/store/AAA-hello-2.12.1.drv",
             "description": "A program that produces a familiar, friendly greeting",
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
@@ -56,15 +58,17 @@
             "rev_count": 633517,
             "rev_date": "2024-05-31T23:09:26Z",
             "scrape_date": "2024-06-04T09:46:16Z",
-            "stabilities": null,
+            "stabilities": [
+              "unstable"
+            ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "old_version"
+            "version": "2.12.1"
           },
           {
             "attr_path": "hello",
             "broken": false,
-            "derivation": "/nix/store/vpw7qifbwiy18fj5qrppz91jlsskf1if-hello-2.12.1.drv",
+            "derivation": "/nix/store/AAA-hello-2.12.1.drv",
             "description": "A program that produces a familiar, friendly greeting",
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
@@ -84,15 +88,17 @@
             "rev_count": 633517,
             "rev_date": "2024-05-31T23:09:26Z",
             "scrape_date": "2024-06-04T09:46:16Z",
-            "stabilities": null,
+            "stabilities": [
+              "unstable"
+            ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "old_version"
+            "version": "2.12.1"
           },
           {
             "attr_path": "hello",
             "broken": false,
-            "derivation": "/nix/store/rn30zy2bj4zka8axq0ipknfp1pbgnnd1-hello-2.12.1.drv",
+            "derivation": "/nix/store/AAA-hello-2.12.1.drv",
             "description": "A program that produces a familiar, friendly greeting",
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
@@ -112,10 +118,12 @@
             "rev_count": 633517,
             "rev_date": "2024-05-31T23:09:26Z",
             "scrape_date": "2024-06-04T09:46:16Z",
-            "stabilities": null,
+            "stabilities": [
+              "unstable"
+            ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "old_version"
+            "version": "2.12.1"
           }
         ],
         "page": 633517,

--- a/tests/catalog.bats
+++ b/tests/catalog.bats
@@ -64,15 +64,16 @@ teardown_file() {
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" \
     "$FLOX_BIN" install hello
 
-  run "$FLOX_BIN" list
-  assert_success
-  assert_line "hello: hello (old_version)"
+  old_derivation=$(cat .flox/env/manifest.lock | jq -r -c '.packages[] | select(.system == "aarch64-darwin" and .install_id == "hello") | .derivation')
+  assert_equal "$old_derivation" "/nix/store/AAA-hello-2.12.1.drv"
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade -vvv
+  new_derivation=$(cat .flox/env/manifest.lock | jq -r -c '.packages[] | select(.system == "aarch64-darwin" and .install_id == "hello") | .derivation')
   assert_success
   assert_output --partial "using catalog client to upgrade"
   assert_output --partial "Upgraded 'hello'"
+  assert_not_equal "$old_derivation" "$new_derivation"
 
   run "$FLOX_BIN" list
   assert_success


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This unskips the catalog `flox upgrade` tests, which uncovered some cases that were not covered by existing catalog functionality. Specifically, catalog upgrade now matches `pkgdb` behavior when attempting to upgrade a package that belongs to a group with other packages.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
