### PR TITLE
chore(ci): Remove checkout ref and fetch-depth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,6 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: "Setup"
         uses: "./.github/actions/common-setup"
@@ -121,9 +118,6 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: "Setup"
         uses: "./.github/actions/common-setup"
@@ -188,9 +182,6 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: "Setup"
         uses: "./.github/actions/common-setup"
@@ -319,9 +310,6 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: "Setup"
         uses: "./.github/actions/common-setup"


### PR DESCRIPTION
## Proposed Changes

So that we checkout the same merge commit of a PR that we use to run the `flox-cli-tests` with, which is preferable because it will tell us about failures before we get to the merge queue:

- https://github.com/flox/flox/blob/3338caad08b554fb3757f90ebb1589b753fe12be/.github/workflows/ci.yml#L369

This would have helped me diagnose why the tests failed on my feature branch when mock changes were merged to `main`:

- https://github.com/flox/flox/actions/runs/9479547968/job/26118504738?pr=1560#step:6:367

Despite the checkout using the HEAD of the feature branch:

- https://github.com/flox/flox/actions/runs/9479547968/job/26118504738?pr=1560#step:2:215

This is a partial revert of a previous change but I can't see why those changes would be dependent on using the HEAD of the feature branch or having the full commit history:

- https://github.com/flox/flox/commit/31d1198de69797c1cf7bfdaccb3409e713cc9448
- https://github.com/flox/flox/pull/757

## Release Notes

N/A