### PR TITLE
fix(manifest): reject unknown fields in manifest.toml

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -325,6 +325,7 @@ pub enum TypedManifest {
 /// Modifications should be made using the the raw functions in this module.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+#[serde(deny_unknown_fields)]
 pub struct TypedManifestCatalog {
     pub(super) version: Version<1>,
     /// The packages to install in the form of a map from install_id
@@ -963,6 +964,19 @@ pub(super) mod test {
             profile: ManifestProfile::default(),
             options: ManifestOptions::default(),
         }
+    }
+
+    #[test]
+    fn catalog_manifest_rejects_unknown_fields() {
+        let manifest = formatdoc! {"
+            {CATALOG_MANIFEST}
+
+            unknown = 'field'
+        "};
+
+        let result = toml_edit::de::from_str::<TypedManifest>(&manifest);
+
+        assert!(result.is_err(), "{:?}", result);
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -974,9 +974,14 @@ pub(super) mod test {
             unknown = 'field'
         "};
 
-        let result = toml_edit::de::from_str::<TypedManifest>(&manifest);
+        let err = toml_edit::de::from_str::<TypedManifest>(&manifest)
+            .expect_err("manifest.toml should be invalid");
 
-        assert!(result.is_err(), "{:?}", result);
+        assert!(
+            err.message()
+                .starts_with("unknown field `unknown`, expected one of"),
+            "unexpected error message: {err}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Mark `TypedManifestCatalog` with `#[serde(deny_unknown_fields)]`.

Previously the handwritten json/toml parsing in pkgdb implemented this
but the behavior regressed when the manifest type was implemented in rust.