### PR TITLE
chore: simplify user facing error for manifest parsing issues

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -804,6 +804,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "toml",
  "toml_edit",
  "tracing",
  "tracing-log",

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -56,6 +56,7 @@ pretty_assertions.workspace = true
 serial_test.workspace = true
 temp-env.workspace = true
 tempfile.workspace = true
+toml.workspace = true
 
 
 [features]

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -26,7 +26,7 @@ use super::{
 use crate::commands::{ensure_floxhub_token, ConcreteEnvironment};
 use crate::subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog, Spinner};
-use crate::utils::errors::{apply_doc_link_for_unsupported_packages, format_locked_manifest_error};
+use crate::utils::errors::{apply_doc_link_for_unsupported_packages, format_core_error};
 use crate::utils::message;
 
 // Edit declarative environment configuration
@@ -180,8 +180,9 @@ impl Edit {
             .map_err(apply_doc_link_for_unsupported_packages);
 
             match result {
-                Err(EnvironmentError::Core(CoreEnvironmentError::LockedManifest(e))) => {
-                    message::error(format_locked_manifest_error(&e));
+                Err(EnvironmentError::Core(e @ CoreEnvironmentError::LockedManifest(_)))
+                | Err(EnvironmentError::Core(e @ CoreEnvironmentError::DeserializeManifest(_))) => {
+                    message::error(format_core_error(&e));
 
                     if !Dialog::can_prompt() {
                         bail!("Can't prompt to continue editing in non-interactive context");

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -158,7 +158,8 @@ impl Edit {
             .suffix(".toml")
             .tempfile_in(&flox.temp_dir)?;
         std::fs::write(&tmp_manifest, environment.manifest_content(flox)?)?;
-        let should_continue = Dialog {
+
+        let should_continue_dialog = Dialog {
             message: "Continue editing?",
             help_message: Default::default(),
             typed: Confirm {
@@ -179,25 +180,35 @@ impl Edit {
             .spin()
             .map_err(apply_doc_link_for_unsupported_packages);
 
-            match result {
-                Err(EnvironmentError::Core(e @ CoreEnvironmentError::LockedManifest(_)))
-                | Err(EnvironmentError::Core(e @ CoreEnvironmentError::DeserializeManifest(_))) => {
+            match Self::make_interactively_recoverable(result)? {
+                Ok(result) => return Ok(result),
+
+                // for recoverable errors, prompt the user to continue editing
+                Err(e) => {
                     message::error(format_core_error(&e));
 
                     if !Dialog::can_prompt() {
                         bail!("Can't prompt to continue editing in non-interactive context");
                     }
-                    if !should_continue.clone().prompt().await? {
+                    if !should_continue_dialog.clone().prompt().await? {
                         bail!("Environment editing cancelled");
                     }
                 },
-                Err(e) => {
-                    bail!(e)
-                },
-                Ok(result) => {
-                    return Ok(result);
-                },
             }
+        }
+    }
+
+    /// Returns `Ok` if the edit result is successful or recoverable, `Err` otherwise
+    fn make_interactively_recoverable(
+        result: Result<EditResult, EnvironmentError>,
+    ) -> Result<Result<EditResult, CoreEnvironmentError>, EnvironmentError> {
+        match result {
+            Err(EnvironmentError::Core(e @ CoreEnvironmentError::LockedManifest(_)))
+            | Err(EnvironmentError::Core(e @ CoreEnvironmentError::DeserializeManifest(_))) => {
+                Ok(Err(e))
+            },
+            Err(e) => Err(e),
+            Ok(result) => Ok(Ok(result)),
         }
     }
 
@@ -256,5 +267,57 @@ impl Edit {
 
         let contents = std::fs::read_to_string(path)?;
         Ok(contents)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flox_rust_sdk::models::lockfile::LockedManifestError;
+    use serde::de::Error;
+
+    use super::*;
+
+    /// successful edit returns value that will end the loop
+    #[test]
+    fn test_recover_edit_loop_result_success() {
+        let result = Ok(EditResult::Unchanged);
+
+        Edit::make_interactively_recoverable(result)
+            .expect("should return Ok")
+            .expect("should return Ok");
+    }
+
+    /// errors parsing the manifest are recoverable
+    #[test]
+    fn test_recover_edit_loop_result_bad_manifest() {
+        let result = Err(EnvironmentError::Core(
+            CoreEnvironmentError::DeserializeManifest(toml::de::Error::custom("msg")),
+        ));
+
+        Edit::make_interactively_recoverable(result)
+            .expect("should be recoverable")
+            .expect_err("should return recoverable Err");
+    }
+
+    /// errors parsing the manifest are recoverable
+    #[test]
+    fn test_recover_edit_loop_result_locking() {
+        let result = Err(EnvironmentError::Core(
+            CoreEnvironmentError::LockedManifest(LockedManifestError::EmptyPage),
+        ));
+
+        Edit::make_interactively_recoverable(result)
+            .expect("should be recoverable")
+            .expect_err("should return recoverable err");
+    }
+
+    /// other errors are not recoverable and should be returned as-is
+    #[test]
+    fn test_recover_edit_loop_result_other_error() {
+        let result = Err(EnvironmentError::Core(
+            CoreEnvironmentError::CatalogClientMissing,
+        ));
+
+        Edit::make_interactively_recoverable(result).expect_err("should return unhandled Err");
     }
 }

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -234,7 +234,7 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
         // todo: enrich with path
         // raised during edit
         CoreEnvironmentError::DeserializeManifest(err) => formatdoc! {
-            "Failed to parse manifest: {err:#?}
+            "Failed to parse manifest: {err}
         ",
             // The message adds a newline at the end,
             // trim to make the error look better

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -234,7 +234,9 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
         // todo: enrich with path
         // raised during edit
         CoreEnvironmentError::DeserializeManifest(err) => formatdoc! {
-            "Failed to parse manifest: {err}
+            "Failed to parse manifest:
+
+            {err}
         ",
             // The message adds a newline at the end,
             // trim to make the error look better

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -234,10 +234,12 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
         // todo: enrich with path
         // raised during edit
         CoreEnvironmentError::DeserializeManifest(err) => formatdoc! {
-            "Failed to parse manifest: {err}
-
-            Please ensure that '.flox/env/manifest.toml' is a valid TOML file.
-        "},
+            "Failed to parse manifest: {err:#?}
+        ",
+            // The message adds a newline at the end,
+            // trim to make the error look better
+            err = err.message().trim()
+        },
         CoreEnvironmentError::MakeSandbox(_) => display_chain(err),
         // witin transaction, user should not see this and likely can't do anything about it
         CoreEnvironmentError::WriteLockfile(_) => display_chain(err),


### PR DESCRIPTION
Shortens user facing message for manifest parsing errors and detects syntax issues in `flox edit`.