### PR TITLE
fix(push): handle deleted environments on floxhub

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -4,7 +4,6 @@ use std::{fs, io};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::warn;
 
 use super::core_environment::CoreEnvironment;
 use super::generations::{Generations, GenerationsError};
@@ -1071,7 +1070,7 @@ impl ManagedEnvironment {
         {
             Ok(_) => {},
             Err(GitRemoteCommandError::RefNotFound(_)) => {
-                warn!("Upstream environment was deleted.")
+                debug!("Upstream environment was deleted.")
             },
             Err(e) => Err(ManagedEnvironmentError::FetchUpdates(e))?,
         };

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -4,6 +4,7 @@ use std::{fs, io};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::warn;
 
 use super::core_environment::CoreEnvironment;
 use super::generations::{Generations, GenerationsError};
@@ -1063,10 +1064,17 @@ impl ManagedEnvironment {
         }
 
         // Fetch the remote branch into sync branch
-        self.floxmeta
+        match self
+            .floxmeta
             .git
             .fetch_ref("dynamicorigin", &format!("+{sync_branch}:{sync_branch}",))
-            .map_err(ManagedEnvironmentError::FetchUpdates)?;
+        {
+            Ok(_) => {},
+            Err(GitRemoteCommandError::RefNotFound(_)) => {
+                warn!("Upstream environment was deleted.")
+            },
+            Err(e) => Err(ManagedEnvironmentError::FetchUpdates(e))?,
+        };
 
         // Check whether we can fast-forward merge the remote branch into the local branch
         // If "not" the environment has diverged.


### PR DESCRIPTION
`flox push` will fetch the latest changes from floxhub prior to pushing to detect diverged branches.
If the environment was removed upstream, the fetch failed. As a result, environments that were deleted before can not be pushed again. With this PR flox will ignore when git is unable to fetch the upstream branch due to it missing and will print a warning instead.

Since this routine is a an internal library detail, its in turn an internal non-user focused warning. Alternatively the warning could be silenced further or implemented as a "precheck" that is called from the frontend crate.
