### PR TITLE
fix: ensure _flox_activate_tracelevel not unset by "inner" activations

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2096,6 +2096,11 @@ EOF
   # environment to confirm that _flox_activate_tracelevel is set
   # for the outer activation.
 
+  # Each of the shell-specific dotfiles has also been updated to emit a
+  # warning if sourced without _flox_activate_tracelevel set in the
+  # environment, so we also assert that this warning is not present
+  # in any of the activation output.
+
   # Start by adding logic to create semaphore files for all shells.
   for i in "$HOME/.bashrc.extra" "$HOME/.config/fish/config.fish.extra" "$HOME/.tcshrc.extra" "$HOME/.zshrc.extra"; do
     cat > "$i" <<EOF
@@ -2119,6 +2124,7 @@ EOF
   echo "Testing bash"
   FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
   assert_success
+  refute_output --partial "_flox_activate_tracelevel not defined"
   run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
   assert_success
   run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
@@ -2128,6 +2134,7 @@ EOF
   echo "Testing fish"
   FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
   assert_success
+  refute_output --partial "_flox_activate_tracelevel not defined"
   run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
   assert_success
   run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
@@ -2137,6 +2144,7 @@ EOF
   echo "Testing tcsh"
   FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
   assert_success
+  refute_output --partial "_flox_activate_tracelevel not defined"
   cat "$HOME/.tcshrc.extra"
   run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
   assert_success
@@ -2147,6 +2155,7 @@ EOF
   echo "Testing zsh"
   FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
   assert_success
+  refute_output --partial "_flox_activate_tracelevel not defined"
   run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
   assert_success
   run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2008,8 +2008,8 @@ EOF
   project_setup
   FLOX_SHELL="bash" run $FLOX_BIN activate --dir "$PROJECT_DIR" -- env
   assert_success
-  refute_output "FLOX_SHELL="
-  refute_output "_flox_shell="
+  refute_output --partial "FLOX_SHELL="
+  refute_output --partial "_flox_shell="
 }
 
 # ---------------------------------------------------------------------------- #
@@ -2078,6 +2078,87 @@ EOF
   assert_equal "${lines[12]}" "Setting PATH from .zlogout"
   echo # leave a line between test outputs
 
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate,activate:nested_flox_activate_tracelevel
+@test "{bash,fish,tcsh,zsh}: confirm _flox_activate_tracelevel set in nested activation" {
+  project_setup
+
+  # The shell-specific flox init scripts finish by unsetting the
+  # _flox_activate_tracelevel environment variable, and this can
+  # cause problems for an "outer" interactive activation when there
+  # is an "inner" in-place activation happening by way of a "dotfile".
+
+  # Set up this test by creating dotfiles which perform an in-place
+  # activation, and then run an interactive activation of a second
+  # environment to confirm that _flox_activate_tracelevel is set
+  # for the outer activation.
+
+  # Start by adding logic to create semaphore files for all shells.
+  for i in "$HOME/.bashrc.extra" "$HOME/.config/fish/config.fish.extra" "$HOME/.tcshrc.extra" "$HOME/.zshrc.extra"; do
+    cat > "$i" <<EOF
+touch "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
+test -n "\$_flox_activate_tracelevel" || touch "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
+EOF
+  done
+
+  # Finish by appending shell-specific flox activation syntax.
+  for i in "$HOME/.bashrc.extra" "$HOME/.config/fish/config.fish.extra" "$HOME/.zshrc.extra"; do
+    echo "eval \"\$($FLOX_BIN activate --dir $PROJECT_DIR)\"" >> "$i"
+  done
+  echo "eval \"\`$FLOX_BIN activate --dir $PROJECT_DIR\`\"" >> "$HOME/.tcshrc.extra"
+
+  # Create a test environment.
+  _temp_env="$(mktemp -d)"
+  "$FLOX_BIN" init -d "$_temp_env"
+
+  # Activate the test environment from each shell, each of which will
+  # launch an interactive shell that sources the relevant dotfile.
+  echo "Testing bash"
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
+  assert_success
+  run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
+  assert_success
+  run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
+  assert_failure
+  echo # leave a line between test outputs
+
+  echo "Testing fish"
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
+  assert_success
+  run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
+  assert_success
+  run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
+  assert_failure
+  echo # leave a line between test outputs
+
+  echo "Testing tcsh"
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
+  assert_success
+  cat "$HOME/.tcshrc.extra"
+  run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
+  assert_success
+  run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
+  assert_failure
+  echo # leave a line between test outputs
+
+  echo "Testing zsh"
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
+  assert_success
+  run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
+  assert_success
+  run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
+  assert_failure
+  echo # leave a line between test outputs
+
+  rm -rf "$_temp_env"
+  rm \
+    "$HOME/.bashrc.extra" \
+    "$HOME/.tcshrc.extra" \
+    "$HOME/.config/fish/config.fish.extra" \
+    "$HOME/.zshrc.extra"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/pkgdb/src/buildenv/assets/activate
+++ b/pkgdb/src/buildenv/assets/activate
@@ -217,7 +217,7 @@ if [ $# -gt 0 ]; then
       if [ -n "$FLOX_NO_PROFILES" ]; then
         exec "$_flox_shell" "$@"
       else
-        exec "$_flox_shell" --init-command "source $FLOX_ENV/activate.d/fish" "$@"
+        exec "$_flox_shell" --init-command "set -gx _flox_activate_tracelevel $_flox_activate_tracelevel; source $FLOX_ENV/activate.d/fish" "$@"
       fi
       ;;
     *tcsh)
@@ -275,7 +275,7 @@ if [ -t 1 ] || [ -n "$_FLOX_FORCE_INTERACTIVE" ]; then
       if [ -n "$FLOX_NO_PROFILES" ]; then
         exec "$_flox_shell"
       else
-        exec "$_flox_shell" --init-command "source $FLOX_ENV/activate.d/fish"
+        exec "$_flox_shell" --init-command "set -gx _flox_activate_tracelevel $_flox_activate_tracelevel; source $FLOX_ENV/activate.d/fish"
       fi
       ;;
     *tcsh)

--- a/pkgdb/src/buildenv/assets/activate.d/bash
+++ b/pkgdb/src/buildenv/assets/activate.d/bash
@@ -18,9 +18,13 @@ fi
 # bashrc in a parent process.
 if [ -f ~/.bashrc ] && [ -z "$_flox_already_sourcing_bashrc" ]
 then
+  # Save and restore the current tracelevel in the event that sourcing
+  # bashrc launches an inner nested activation which unsets it.
+  _save_flox_activate_tracelevel="$_flox_activate_tracelevel"
   export _flox_already_sourcing_bashrc=1
   source ~/.bashrc
   unset _flox_already_sourcing_bashrc
+  export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 # Restore environment variables set in the previous bash initialization.

--- a/pkgdb/src/buildenv/assets/activate.d/bash
+++ b/pkgdb/src/buildenv/assets/activate.d/bash
@@ -27,6 +27,13 @@ then
   export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
+# The above .bashrc may have performed a nested activation, so confirm
+# _flox_activate_tracelevel is defined before proceeding.
+if [ -z "$_flox_activate_tracelevel" ]; then
+  echo 'WARNING (bash): _flox_activate_tracelevel not defined .. defaulting to 0' >&2
+  export _flox_activate_tracelevel=0
+fi
+
 # Restore environment variables set in the previous bash initialization.
 eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' "$_del_env")"
 eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' "$_add_env")"

--- a/pkgdb/src/buildenv/assets/activate.d/fish
+++ b/pkgdb/src/buildenv/assets/activate.d/fish
@@ -1,5 +1,11 @@
 set -gx _gnused "@gnused@"
 
+# Confirm _flox_activate_tracelevel is defined before proceeding.
+if not set -q _flox_activate_tracelevel
+  echo 'WARNING (fish): _flox_activate_tracelevel not defined .. defaulting to 0' >&2
+  set -gx _flox_activate_tracelevel 0
+end
+
 # Set verbosity level with a default of 0 if not already set
 if test $_flox_activate_tracelevel -ge 2
   set -gx fish_trace 1

--- a/pkgdb/src/buildenv/assets/activate.d/tcsh
+++ b/pkgdb/src/buildenv/assets/activate.d/tcsh
@@ -1,12 +1,18 @@
 setenv _gnused "@gnused@"
 
+# Confirm _flox_activate_tracelevel is defined before proceeding.
+if ( ! $?_flox_activate_tracelevel ) then
+  sh -c "echo 'WARNING (tcsh): _flox_activate_tracelevel not defined .. defaulting to 0' >&2"
+  setenv _flox_activate_tracelevel 0
+endif
+
 if ( $_flox_activate_tracelevel >= 2 ) then
   set verbose
 endif
 
 # Assert that the expected _{add,del}_env variables are present.
 if ( ! $?_add_env || ! $?_del_env ) then
-  echo 'ERROR (tcsh): $_add_env and $_del_env not found in environment' >&2
+  sh -c "echo 'ERROR (tcsh): _add_env and _del_env not found in environment' >&2"
   exit 1
 endif
 

--- a/pkgdb/src/buildenv/assets/activate.d/tcsh_home/.tcshrc
+++ b/pkgdb/src/buildenv/assets/activate.d/tcsh_home/.tcshrc
@@ -7,6 +7,10 @@
 # Start by reinstating the user's original $HOME.
 setenv HOME "$FLOX_ORIG_HOME"
 
+# Save the current tracelevel in the event that sourcing one of the user
+# dotfiles launches an inner nested activation which unsets it.
+set _save_flox_activate_tracelevel = "$_flox_activate_tracelevel"
+
 # We invoke tcsh with -f to prevent the user and system-wide
 # config files from coming back and overriding the environment
 # that we're trying to set up here, so we start by replicating
@@ -38,6 +42,9 @@ if ( $?loginsh ) then
   endif
 endif
 # TODO: handle sourcing of $dirsfile (.cshdirs), as per tcsh(1).
+
+# Restore the current tracelevel.
+setenv _flox_activate_tracelevel "$_save_flox_activate_tracelevel"
 
 # Bring in the Nix and Flox environment customizations.
 if ( $?FLOX_TCSH_INIT_SCRIPT ) then

--- a/pkgdb/src/buildenv/assets/activate.d/zdotdir/.zlogin
+++ b/pkgdb/src/buildenv/assets/activate.d/zdotdir/.zlogin
@@ -3,6 +3,10 @@
 #
 # See README.md for more information on the initialization process.
 
+# Save and restore the current tracelevel in the event that sourcing
+# bashrc launches an inner nested activation which unsets it.
+_save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+
 if [ -f /etc/zlogin ]
 then
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
@@ -11,6 +15,7 @@ then
     else
         ZDOTDIR= source /etc/zlogin
     fi
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 zlogin="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zlogin"
@@ -22,6 +27,7 @@ then
     else
         ZDOTDIR= source "$zlogin"
     fi
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 # Bring in the Nix and Flox environment customizations.

--- a/pkgdb/src/buildenv/assets/activate.d/zdotdir/.zprofile
+++ b/pkgdb/src/buildenv/assets/activate.d/zdotdir/.zprofile
@@ -2,6 +2,10 @@
 #
 # See README.md for more information on the initialization process.
 
+# Save and restore the current tracelevel in the event that sourcing
+# bashrc launches an inner nested activation which unsets it.
+_save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+
 if [ -f /etc/zprofile ]
 then
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
@@ -10,6 +14,7 @@ then
     else
         ZDOTDIR= source /etc/zprofile
     fi
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 zprofile="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zprofile"
@@ -21,6 +26,7 @@ then
     else
         ZDOTDIR= source "$zprofile"
     fi
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 # Do not bring in the Nix and Flox environment customizations from this file

--- a/pkgdb/src/buildenv/assets/activate.d/zdotdir/.zshenv
+++ b/pkgdb/src/buildenv/assets/activate.d/zdotdir/.zshenv
@@ -3,6 +3,10 @@
 #
 # See README.md for more information on the initialization process.
 
+# Save and restore the current tracelevel in the event that sourcing
+# bashrc launches an inner nested activation which unsets it.
+_save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+
 if [ -f /etc/zshenv ]
 then
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
@@ -11,6 +15,7 @@ then
     else
         ZDOTDIR= source /etc/zshenv
     fi
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 zshenv="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zshenv"
@@ -22,6 +27,7 @@ then
     else
         ZDOTDIR= source "$zshenv"
     fi
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 # Bring in the Nix and Flox environment customizations, but _not_ if this is

--- a/pkgdb/src/buildenv/assets/activate.d/zdotdir/.zshrc
+++ b/pkgdb/src/buildenv/assets/activate.d/zdotdir/.zshrc
@@ -3,6 +3,10 @@
 #
 # See README.md for more information on the initialization process.
 
+# Save and restore the current tracelevel in the event that sourcing
+# bashrc launches an inner nested activation which unsets it.
+_save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+
 if [ -f /etc/zshrc ]
 then
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
@@ -11,6 +15,7 @@ then
     else
         ZDOTDIR= source /etc/zshrc
     fi
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 zshrc="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zshrc"
@@ -22,6 +27,7 @@ then
     else
         ZDOTDIR= source "$zshrc"
     fi
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
 fi
 
 # Bring in the Nix and Flox environment customizations, but _not_ if this is

--- a/pkgdb/src/buildenv/assets/activate.d/zsh
+++ b/pkgdb/src/buildenv/assets/activate.d/zsh
@@ -1,5 +1,11 @@
 export _gnused="@gnused@"
 
+# Confirm _flox_activate_tracelevel is defined before proceeding.
+if [ -z "$_flox_activate_tracelevel" ]; then
+  echo 'WARNING (zsh): _flox_activate_tracelevel not defined .. defaulting to 0' >&2
+  export _flox_activate_tracelevel=0
+fi
+
 # Enable shell-specific profile script startup with verbosity 2.
 if [ "$_flox_activate_tracelevel" -ge 2 ]; then
   set -x


### PR DESCRIPTION
## Proposed Changes

Running `eval "$(flox activate)"` from within a dotfile has the effect of sourcing the shell-specific flox init script which finishes by cleaning the `_flox_activate_tracelevel` variable from the environment. This is fine in an interactive setting, but when this is happening within an "inner" in-place activation launched from an "outer" interactive one, then this causes problems for the latter.
    
The fix is to expressly guard against the unsetting of this variable as can happen when sourcing any "dotfile" that may contain an invocation of `eval "$(flox activate)"` or equivalent.
    
The bug existed for each of the bash, fish, tcsh and zsh shells, and this patch includes fixes and tests for each of them.

## Release Notes

* fixed shell errors reported when performing nested activations