### PR TITLE
feat: add initial support for resolution messages

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1395,10 +1395,12 @@ mod tests {
                     version: "1.0".to_string(),
                     system: SystemEnum::Aarch64Darwin,
                 }]),
+                msgs: vec![],
                 page: 1,
                 url: "url".to_string(),
                 complete: true,
             }),
+            msgs: vec![],
         }]);
 
         let (_, upgraded_packages) = env_view

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -587,9 +587,13 @@ impl LockedManifestCatalog {
                         Err(LockedManifestError::EmptyPage)
                     }
                 } else {
-                    Err(LockedManifestError::ResolutionFailed(
-                        "package group had no page".into(),
-                    ))
+                    // FIXME: this is temporary until #1482 (install resolution messages)
+                    let err_msg = group
+                        .msgs
+                        .first()
+                        .map(|rm| rm.msg())
+                        .unwrap_or("for no good reason".to_string());
+                    Err(LockedManifestError::ResolutionFailed(err_msg))
                 }
             })
             .collect::<Result<Vec<_>, _>>()?
@@ -1197,8 +1201,10 @@ pub(crate) mod tests {
                     unfree: Some(false),
                     version: "version".to_string(),
                 }]),
+                msgs: vec![],
             }),
             name: "group".to_string(),
+            msgs: vec![],
         }]
     });
 
@@ -1674,8 +1680,10 @@ pub(crate) mod tests {
                     version: "version".to_string(),
                     system: SystemEnum::Aarch64Darwin,
                 }]),
+                msgs: vec![],
             }),
             name: "group".to_string(),
+            msgs: vec![],
         }];
 
         let manifest = &*TEST_TYPED_MANIFEST;

--- a/cli/mk_data/src/generate.rs
+++ b/cli/mk_data/src/generate.rs
@@ -401,9 +401,6 @@ pub fn run_cmd(
         }
     }
 
-    // Don't want to accidentally merge response files
-    let _ = std::fs::remove_file(output_file);
-
     cmd.env("_FLOX_CATALOG_DUMP_RESPONSE_FILE", output_file);
     debug!("cmd: {:?}", cmd);
     let output = cmd.output().context("couldn't call command")?;

--- a/test_data/generated/envs/kitchen_sink/kitchen_sink.json
+++ b/test_data/generated/envs/kitchen_sink/kitchen_sink.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "hello",

--- a/test_data/generated/envs/krb5_prereqs/krb5_prereqs.json
+++ b/test_data/generated/envs/krb5_prereqs/krb5_prereqs.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "darwin.cctools",

--- a/test_data/generated/init/go.json
+++ b/test_data/generated/init/go.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "go",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "go",
@@ -41,9 +43,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "go",

--- a/test_data/generated/init/node_npm.json
+++ b/test_data/generated/init/node_npm.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "nodejs",

--- a/test_data/generated/init/node_yarn.json
+++ b/test_data/generated/init/node_yarn.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "default",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "nodejs",
@@ -45,9 +47,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "yarn",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "yarn",
@@ -85,9 +89,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "yarn",

--- a/test_data/generated/init/python_poetry.json
+++ b/test_data/generated/init/python_poetry.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "python3",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",
@@ -41,9 +43,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "default",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "poetry",
@@ -85,9 +89,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "default",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",
@@ -125,9 +131,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "poetry",

--- a/test_data/generated/init/python_poetry_zlib.json
+++ b/test_data/generated/init/python_poetry_zlib.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "poetry",

--- a/test_data/generated/init/python_pyproject_pip.json
+++ b/test_data/generated/init/python_pyproject_pip.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "default",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",
@@ -41,9 +43,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",

--- a/test_data/generated/init/python_pyproject_pip_zlib.json
+++ b/test_data/generated/init/python_pyproject_pip_zlib.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",

--- a/test_data/generated/init/python_requests.json
+++ b/test_data/generated/init/python_requests.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "default",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",
@@ -41,9 +43,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",

--- a/test_data/generated/init/python_requirements.json
+++ b/test_data/generated/init/python_requirements.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "default",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",
@@ -41,9 +43,11 @@
   ],
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",

--- a/test_data/generated/init/python_requirements_zlib.json
+++ b/test_data/generated/init/python_requirements_zlib.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",

--- a/test_data/generated/resolve/curl_hello.json
+++ b/test_data/generated/resolve/curl_hello.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "curl",

--- a/test_data/generated/resolve/emacs.json
+++ b/test_data/generated/resolve/emacs.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "emacs",

--- a/test_data/generated/resolve/emacs_vim.json
+++ b/test_data/generated/resolve/emacs_vim.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "emacs",

--- a/test_data/generated/resolve/gzip.json
+++ b/test_data/generated/resolve/gzip.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "gzip",

--- a/test_data/generated/resolve/hello-unfree.json
+++ b/test_data/generated/resolve/hello-unfree.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "hello-unfree",

--- a/test_data/generated/resolve/hello.json
+++ b/test_data/generated/resolve/hello.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "hello",

--- a/test_data/generated/resolve/krb5_after_prereqs_installed.json
+++ b/test_data/generated/resolve/krb5_after_prereqs_installed.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "darwin.cctools",

--- a/test_data/generated/resolve/ld_floxlib.json
+++ b/test_data/generated/resolve/ld_floxlib.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "boost",

--- a/test_data/generated/resolve/old_hello.json
+++ b/test_data/generated/resolve/old_hello.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "hello",

--- a/test_data/generated/resolve/python3.json
+++ b/test_data/generated/resolve/python3.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python3",

--- a/test_data/generated/resolve/python311Packages.pip.json
+++ b/test_data/generated/resolve/python311Packages.pip.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python311Packages.pip",

--- a/test_data/generated/resolve/python3_pip.json
+++ b/test_data/generated/resolve/python3_pip.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "python311Packages.pip",

--- a/test_data/generated/resolve/rubyPackages_3_2.rails.json
+++ b/test_data/generated/resolve/rubyPackages_3_2.rails.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "rubyPackages_3_2.rails",

--- a/test_data/generated/resolve/vim.json
+++ b/test_data/generated/resolve/vim.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "vim",

--- a/test_data/generated/resolve/webmention_ripgrep_rails.json
+++ b/test_data/generated/resolve/webmention_ripgrep_rails.json
@@ -1,9 +1,11 @@
 [
   [
     {
+      "msgs": [],
       "name": "toplevel",
       "page": {
         "complete": true,
+        "msgs": [],
         "packages": [
           {
             "attr_path": "rubyPackages_3_2.rails",


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This adds initial support for resolution messages returned by `catalog-server`.

We now display the fallback message returned by `catalog-server` whenever there is a resolution error rather than displaying `package group had no page`.
```text
❌ ERROR: resolution failed: AttrPath 'systemd' not found for some systems, valid systems are (['aarch64-linux', 'x86_64-linux']).
```

More user-friendly error messages and tests for certain messages will be delivered as part of https://github.com/flox/flox/issues/1482.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
