### PR TITLE
feat: show source spans in manifest error messages

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "shell-escape",
+ "source-span",
  "supports-color",
  "sys-info",
  "sysinfo",
@@ -1838,6 +1839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "oauth2"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,7 +1985,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.1",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -2325,12 +2332,27 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
  "bitflags 2.5.0",
 ]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
@@ -3116,6 +3138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "source-span"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3afeb8b7a1ae2e8721f2193cc2291c9e00dd68511907fd8b807e2c8d42caa3c"
+dependencies = [
+ "termion",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,6 +3287,18 @@ checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix 0.37.27",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall 0.2.16",
+ "redox_termios",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,6 +45,7 @@ serde_json = "1"
 serde_with = "3.8.1"
 serde_yaml = "0.9"
 shell-escape = "0.1.5"
+source-span = "2.7.0"
 supports-color = "3.0.0"
 # provides process tools for shell detection
 sysinfo = "0.30.12"

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -36,6 +36,7 @@ use crate::models::manifest::{
     Manifest,
     ManifestError,
     PackageToInstall,
+    SpannedManifest,
     TomlEditError,
     TypedManifest,
     TypedManifestCatalog,
@@ -107,6 +108,10 @@ impl<State> CoreEnvironment<State> {
     ///
     /// todo: should we always write the lockfile to disk?
     pub fn lock(&mut self, flox: &Flox) -> Result<LockedManifest, CoreEnvironmentError> {
+        // Just need to know that it succeeds, don't need the actual value
+        let _: SpannedManifest = toml::from_str(&self.manifest_content()?)
+            .map_err(CoreEnvironmentError::DeserializeManifest)?;
+
         let manifest: TypedManifest = toml::from_str(&self.manifest_content()?)
             .map_err(CoreEnvironmentError::DeserializeManifest)?;
 

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -34,6 +34,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true
 shell-escape.workspace = true
+source-span.workspace = true
 supports-color.workspace = true
 sys-info.workspace = true
 sysinfo.workspace = true

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -124,9 +124,6 @@ fn main() -> ExitCode {
         Ok(()) => ExitCode::from(0),
 
         Err(e) => {
-            // todo: figure out how to deal with context, properly
-            debug!("{:#}", e);
-
             // Do not print any error if caused by wrapped flox (sh)
             if e.is::<FloxShellErrorCode>() {
                 return e.downcast_ref::<FloxShellErrorCode>().unwrap().0;


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Shows the source locations in the manifest when a user makes an edit that prevents the manifest from properly parsing.

![Screenshot 2024-06-13 at 7 04 28 PM](https://github.com/flox/flox/assets/10246891/2449a91f-d790-4b3a-a0e1-d0eb9fb436ae)

![Screenshot 2024-06-13 at 7 16 09 PM](https://github.com/flox/flox/assets/10246891/3177a29f-3b35-435f-a62f-71522aa63e0a)

Doing this requires creating duplicate data structures for the `TypedManifestCatalog` since the wrapper type that generates the source spans is incompatible with deriving `proptest::Arbitrary`. A papercut to be sure, but not a huge one.

This is in a WIP state as it doesn't show these errors for anything other than interactive editing and I haven't even run the test suite locally a single time.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
