### PR TITLE
fix(search): Search suggestions for catalog

### DIFF
--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -71,7 +71,7 @@ impl Search {
             config.flox.search_limit.or(DEFAULT_SEARCH_LIMIT)
         };
 
-        let results = if let Some(client) = flox.catalog_client {
+        let results = if let Some(client) = &flox.catalog_client {
             tracing::debug!("using catalog client for search");
             let parsed_search = match SearchTerm::from_arg(&self.search_term) {
                 SearchTerm::Clean(term) => term,
@@ -128,6 +128,8 @@ impl Search {
 
             let suggestion = DidYouMean::<SearchSuggestion>::new(
                 &self.search_term,
+                flox.catalog_client,
+                flox.system,
                 manifest,
                 global_manifest,
                 lockfile,

--- a/cli/tests/search.bats
+++ b/cli/tests/search.bats
@@ -462,7 +462,7 @@ setup_file() {
 
 # bats test_tags=search:suggestions
 @test "'flox search' shows suggested results" {
-  unset FLOX_FEATURES_USE_CATALOG
+  export FLOX_FEATURES_USE_CATALOG=false
   run "$FLOX_BIN" search java
   assert_success
   assert_output --partial "Related search results for 'jdk'"

--- a/cli/tests/search.bats
+++ b/cli/tests/search.bats
@@ -459,6 +459,24 @@ setup_file() {
 }
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=search:suggestions
+@test "'flox search' shows suggested results" {
+  unset FLOX_FEATURES_USE_CATALOG
+  run "$FLOX_BIN" search java
+  assert_success
+  assert_output --partial "Related search results for 'jdk'"
+}
+
+# bats test_tags=search:suggestions
+@test "catalog: 'flox search' shows suggested results" {
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/search/java_suggestions.json" \
+    run "$FLOX_BIN" search java
+  assert_success
+  assert_output --partial "Related search results for 'jdk'"
+}
+
+# ---------------------------------------------------------------------------- #
 #
 #
 #

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -103,6 +103,9 @@ post_cmd = '''
     mv tmp.json "$RESPONSE_FILE"
 '''
 
+[search.java_suggestions]
+cmd = "flox search java"
+
 [show.hello]
 cmd = "flox show hello"
 

--- a/test_data/generated/search/java_suggestions.json
+++ b/test_data/generated/search/java_suggestions.json
@@ -1,0 +1,156 @@
+[
+  {
+    "count": 546,
+    "results": [
+      {
+        "description": "A parser generator for building parsers from grammars",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "javacc",
+        "relPath": [
+          "javacc"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "LALR parser generator for Java",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "javaCup",
+        "relPath": [
+          "javaCup"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "GeoIP Java API",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "geoipjava",
+        "relPath": [
+          "geoipjava"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "A library for extracting tables from PDF files.",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "tabula-java",
+        "relPath": [
+          "tabula-java"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "An interface compiler that connects C/C++ code to higher-level languages",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "swigWithJava",
+        "relPath": [
+          "swigWithJava"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "Programming language used for massively scalable soft real-time systems",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "erlang_javac",
+        "relPath": [
+          "erlang_javac"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "Cap'n Proto codegen plugin for Java",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "capnproto-java",
+        "relPath": [
+          "capnproto-java"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": null,
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "setJavaClassPath",
+        "relPath": [
+          "setJavaClassPath"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "Gauge plugin that lets you write tests in Java",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "java",
+        "relPath": [
+          "gaugePlugins",
+          "java"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "Programming language used for massively scalable soft real-time systems",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "erlang_odbc_javac",
+        "relPath": [
+          "erlang_odbc_javac"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      }
+    ]
+  },
+  {
+    "count": 72,
+    "results": [
+      {
+        "description": "The open-source Java Development Kit",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "jdk",
+        "relPath": [
+          "jdk"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "Certified builds of OpenJDK",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "jdk8",
+        "relPath": [
+          "jdk8"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
+        "description": "Certified builds of OpenJDK",
+        "input": "nixpkgs",
+        "license": null,
+        "pname": "jdk22",
+        "relPath": [
+          "jdk22"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Proposed Changes

Previously the suggestions were coming from `pkgdb` even when the catalog was enabled. They now use the same path as the original search. New integration tests have been added for both code paths.

We agreed in refinement that it was sufficient to plumb the catalog logic through to `DidYouMean` and refactor later when we removed `pkgdb`. We could group the catalog and pkgdb related arguments in separate types but it doesn't seem worth it if we've removing this code soon.

I considered moving the spinners up one or two levels but I think it makes sense to keep them close to the slow function based on the problems I ran into before with competing spinners at different levels of the codebase.

## Release Notes

N/A because it's fixing a bug in something that's not officially released yet.