### PR TITLE
fix(activate): Improve user output when activating a remote env fails.

### DIFF
--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -427,6 +427,7 @@ impl GitCommandProvider {
 
         command
             .arg("clone")
+            .arg("--quiet")
             .arg("--single-branch")
             .arg("--no-tags")
             .arg("--branch")
@@ -616,6 +617,8 @@ pub enum GitRemoteCommandError {
 }
 
 const REF_NOT_FOUND_ERR_PREFIX: &str = "fatal: couldn't find remote ref ";
+const REMOTE_BRANCH_NOT_FOUND_ERR_PREFIX: &str = "warning: Could not find remote branch ";
+const REMOTE_BRANCH_NOT_FOUND_IN_UPSTREAM_ERR_PREFIX: &str = "fatal: Remote branch ";
 impl From<GitCommandError> for GitRemoteCommandError {
     fn from(err: GitCommandError) -> Self {
         match err {
@@ -637,6 +640,28 @@ impl From<GitCommandError> for GitRemoteCommandError {
                 let ref_name = stderr.strip_prefix(REF_NOT_FOUND_ERR_PREFIX).unwrap();
                 debug!("Ref not found: {ref_name}");
                 GitRemoteCommandError::RefNotFound(ref_name.to_string())
+            },
+            GitCommandError::BadExit(_, _, ref stderr)
+                if stderr.starts_with(REMOTE_BRANCH_NOT_FOUND_ERR_PREFIX) =>
+            {
+                let branch_name = stderr
+                    .strip_prefix(REMOTE_BRANCH_NOT_FOUND_ERR_PREFIX)
+                    .unwrap();
+                let branch_name = branch_name.strip_suffix(" to clone").unwrap_or(branch_name);
+                debug!("Could not find remote branch: {branch_name}");
+                GitRemoteCommandError::RefNotFound(branch_name.to_string())
+            },
+            GitCommandError::BadExit(_, _, ref stderr)
+                if stderr.starts_with(REMOTE_BRANCH_NOT_FOUND_IN_UPSTREAM_ERR_PREFIX) =>
+            {
+                let branch_name = stderr
+                    .strip_prefix(REMOTE_BRANCH_NOT_FOUND_IN_UPSTREAM_ERR_PREFIX)
+                    .unwrap();
+                let branch_name = branch_name
+                    .strip_suffix(" not found in upstream origin")
+                    .unwrap_or(branch_name);
+                debug!("Could not find remote branch in upstream: {branch_name}");
+                GitRemoteCommandError::RefNotFound(branch_name.to_string())
             },
             e => GitRemoteCommandError::Command(e),
         }
@@ -716,6 +741,7 @@ impl GitProvider for GitCommandProvider {
         if bare {
             command.arg("--bare");
         }
+        command.arg("--quiet");
 
         command.arg(origin.as_ref());
         command.arg("./");

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -616,8 +616,11 @@ pub enum GitRemoteCommandError {
     RefNotFound(String),
 }
 
+/// Failure message when _fetching_ a specific ref
 const REF_NOT_FOUND_ERR_PREFIX: &str = "fatal: couldn't find remote ref ";
+/// Message prefix when _fetching_ a missing branch
 const REMOTE_BRANCH_NOT_FOUND_ERR_PREFIX: &str = "warning: Could not find remote branch ";
+/// Message prefix when _cloning_ a missing branch of a repo
 const REMOTE_BRANCH_NOT_FOUND_IN_UPSTREAM_ERR_PREFIX: &str = "fatal: Remote branch ";
 impl From<GitCommandError> for GitRemoteCommandError {
     fn from(err: GitCommandError) -> Self {

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -77,6 +77,7 @@ impl Activate {
             Create an environment with 'flox init'"
                 })
             },
+            Err(EnvironmentSelectError::Anyhow(e)) => Err(e)?,
             Err(e) => Err(e)?,
         };
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -10,8 +10,10 @@ use flox_rust_sdk::models::environment::{
     UpgradeError,
     ENVIRONMENT_POINTER_FILENAME,
 };
+use flox_rust_sdk::models::floxmeta::FloxMetaError;
 use flox_rust_sdk::models::lockfile::LockedManifestError;
 use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, ContextMsgError, PkgDbError};
+use flox_rust_sdk::providers::git::GitRemoteCommandError;
 use indoc::formatdoc;
 use log::{debug, trace};
 
@@ -509,12 +511,23 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
             Please ensure that you have write permissions to FLOX_CACHE_DIR/remote.
         "},
 
+        RemoteEnvironmentError::ResetManagedEnvironment(ManagedEnvironmentError::FetchUpdates(
+            GitRemoteCommandError::RefNotFound(_),
+        ))
+        | RemoteEnvironmentError::GetLatestVersion(FloxMetaError::CloneBranch(
+            GitRemoteCommandError::AccessDenied,
+        ))
+        | RemoteEnvironmentError::GetLatestVersion(FloxMetaError::CloneBranch(
+            GitRemoteCommandError::RefNotFound(_),
+        )) => formatdoc! {"
+            Environment not found in FloxHub.
+            "},
+
         RemoteEnvironmentError::ResetManagedEnvironment(err) => formatdoc! {"
             Failed to reset remote environment to latest upstream version:
 
             {err}
             ", err = format_managed_error(err)},
-
         RemoteEnvironmentError::GetLatestVersion(err) => formatdoc! {"
             Failed to get latest version of remote environment: {err}
 

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -344,3 +344,10 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=remote,remote:not-found
+@test "activate --remote fails on a non existent environment" {
+  run "$FLOX_BIN" activate -r "$OWNER/i-dont-exist"
+  assert_failure
+  assert_output --partial "Environment not found in FloxHub."
+}


### PR DESCRIPTION
## Proposed Changes

This closes https://github.com/flox/product/issues/656.

## Release Notes

This changes the output to `Environment not found in FloxHub` when running `activate -r` on an environment fails in the following cases:
- activating a remote environment that does not exist, by a user that does not exist: foo/bar
- activating a remote environment that does not exist, of another user, the user is valid though
- activating your own environment, that has existed before, but then been deleted from FloxHub and does not exist anymore.
