### PR TITLE
docs: add Rust style to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -394,6 +394,10 @@ subsets of tests.
 See the [bats usage documentation](https://bats-core.readthedocs.io/en/stable/usage.html)
 for details.
 
+## Rust Style Guidelines
+
+- In general, structs should derive `Clone` and `Debug`.
+
 ## Merges
 
 Changes should be **squashed and merged** into `main`.


### PR DESCRIPTION
Add Rust Style Guidelines section and add note about deriving `Clone` and `Debug` for structs. `Clone` and `Debug` are used so widely it's easier to add them up front and avoid times where you add it several layers deep only to find something can't derive `Clone`."