### PR TITLE
fix: ignore lib directories in .flox

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -51,6 +51,7 @@ pub const MANIFEST_FILENAME: &str = "manifest.toml";
 pub const LOCKFILE_FILENAME: &str = "manifest.lock";
 pub const GCROOTS_DIR_NAME: &str = "run";
 pub const CACHE_DIR_NAME: &str = "cache";
+pub const LIB_DIR_NAME: &str = "lib";
 pub const ENV_DIR_NAME: &str = "env";
 pub const FLOX_ENV_VAR: &str = "FLOX_ENV";
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -36,6 +36,7 @@ use super::{
     DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
     GCROOTS_DIR_NAME,
+    LIB_DIR_NAME,
     LOCKFILE_FILENAME,
 };
 use crate::data::{CanonicalPath, System};
@@ -460,6 +461,7 @@ impl PathEnvironment {
         fs::write(dot_flox_path.join(".gitignore"), formatdoc! {"
             {GCROOTS_DIR_NAME}/
             {CACHE_DIR_NAME}/
+            {LIB_DIR_NAME}/
             "})
         .map_err(EnvironmentError::WriteGitignore)?;
 


### PR DESCRIPTION
## Proposed Changes
Filter lib dirs in .flox in gitignore. Useful when using flox/lib to have host-provided libs, eg CUDA. 

## Release Notes
N/A