### PR TITLE
fix: show a helpful error when a managed environment has been deleted

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -107,7 +107,7 @@ impl RemoteEnvironment {
         // (force) Pull latest changes of the environment from upstream.
         // remote environments stay in sync with upstream without providing a local staging state.
         inner
-            .pull(true)
+            .pull(flox, true)
             .map_err(RemoteEnvironmentError::ResetManagedEnvironment)?;
 
         let out_link = path.join(GCROOTS_DIR_NAME);

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -488,7 +488,11 @@ impl Pull {
                 let message = "The environment has diverged from the remote version";
                 anyhow::Error::msg(message)
             },
-            ManagedEnvironmentError::UpstreamNotFound(env_ref, _, user) => {
+            ManagedEnvironmentError::UpstreamNotFound {
+                env_ref,
+                upstream: _,
+                user,
+            } => {
                 let by_current_user = user
                     .map(|u| u == env_ref.owner().as_str())
                     .unwrap_or_default();

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -152,7 +152,7 @@ impl Pull {
         let state = Dialog {
             message: &pull_message,
             help_message: None,
-            typed: Spinner::new(|| env.pull(force)),
+            typed: Spinner::new(|| env.pull(flox, force)),
         }
         .spin()?;
 
@@ -253,7 +253,7 @@ impl Pull {
                 typed: Spinner::new(|| ManagedEnvironment::open(flox, pointer, &dot_flox_path)),
             }
             .spin()
-            .map_err(|err| Self::handle_error(flox, err));
+            .map_err(Self::handle_error);
 
             match result {
                 Err(err) => {
@@ -478,7 +478,7 @@ impl Pull {
         Ok(choice == 1)
     }
 
-    fn handle_error(flox: &Flox, err: ManagedEnvironmentError) -> anyhow::Error {
+    fn handle_error(err: ManagedEnvironmentError) -> anyhow::Error {
         match err {
             ManagedEnvironmentError::AccessDenied => {
                 let message = "You do not have permission to pull this environment";
@@ -488,11 +488,9 @@ impl Pull {
                 let message = "The environment has diverged from the remote version";
                 anyhow::Error::msg(message)
             },
-            ManagedEnvironmentError::UpstreamNotFound(env_ref, _) => {
-                let by_current_user = flox
-                    .floxhub_token
-                    .as_ref()
-                    .map(|token| token.handle() == env_ref.owner().as_str())
+            ManagedEnvironmentError::UpstreamNotFound(env_ref, _, user) => {
+                let by_current_user = user
+                    .map(|u| u == env_ref.owner().as_str())
                     .unwrap_or_default();
                 let message = format!("The environment {env_ref} does not exist.");
                 if by_current_user {

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -13,7 +13,12 @@ use log::{debug, warn};
 use utils::init::{init_logger, init_sentry};
 use utils::{message, populate_default_nix_env_vars};
 
-use crate::utils::errors::{format_error, format_managed_error, format_remote_error};
+use crate::utils::errors::{
+    format_environment_select_error,
+    format_error,
+    format_managed_error,
+    format_remote_error,
+};
 use crate::utils::metrics::Hub;
 
 mod build;
@@ -132,13 +137,6 @@ fn main() -> ExitCode {
                 return e.downcast_ref::<FloxShellErrorCode>().unwrap().0;
             }
 
-            if let Some(EnvironmentSelectError::Environment(e)) =
-                e.downcast_ref::<EnvironmentSelectError>()
-            {
-                message::error(format_error(e));
-                return ExitCode::from(1);
-            }
-
             if let Some(e) = e.downcast_ref::<EnvironmentError>() {
                 message::error(format_error(e));
                 return ExitCode::from(1);
@@ -151,6 +149,11 @@ fn main() -> ExitCode {
 
             if let Some(e) = e.downcast_ref::<RemoteEnvironmentError>() {
                 message::error(format_remote_error(e));
+                return ExitCode::from(1);
+            }
+
+            if let Some(e) = e.downcast_ref::<EnvironmentSelectError>() {
+                message::error(format_environment_select_error(e));
                 return ExitCode::from(1);
             }
 

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use bpaf::{Args, Parser};
-use commands::{FloxArgs, FloxCli, Prefix, Version};
+use commands::{EnvironmentSelectError, FloxArgs, FloxCli, Prefix, Version};
 use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironmentError;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentError;
@@ -130,6 +130,13 @@ fn main() -> ExitCode {
             // Do not print any error if caused by wrapped flox (sh)
             if e.is::<FloxShellErrorCode>() {
                 return e.downcast_ref::<FloxShellErrorCode>().unwrap().0;
+            }
+
+            if let Some(EnvironmentSelectError::Environment(e)) =
+                e.downcast_ref::<EnvironmentSelectError>()
+            {
+                message::error(format_error(e));
+                return ExitCode::from(1);
             }
 
             if let Some(e) = e.downcast_ref::<EnvironmentError>() {

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -440,11 +440,22 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
             Please check the spelling of the remote environment
             and make sure that you have access to it.
         "},
-        ManagedEnvironmentError::UpstreamNotFound(_, _) => formatdoc! {"
-            Environment not found in FloxHub.
+        ManagedEnvironmentError::UpstreamNotFound(env_ref, _, user) => {
+            let by_current_user = user
+                .as_ref()
+                .map(|u| u == env_ref.owner().as_str())
+                .unwrap_or_default();
+            let message = "Environment not found in FloxHub.";
+            if by_current_user {
+                formatdoc! {"
+                    {message}
 
-            You can run `flox push` to push the environment back to FloxHub.
-        "},
+                    You can run 'flox push' to push the environment back to FloxHub.
+                "}
+            } else {
+                message.to_string()
+            }
+        },
         // acces denied is catched early as ManagedEnvironmentError::AccessDenied
         ManagedEnvironmentError::Push(_) => display_chain(err),
         ManagedEnvironmentError::DeleteBranch(_) => display_chain(err),

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -440,8 +440,11 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
             Please check the spelling of the remote environment
             and make sure that you have access to it.
         "},
-        // todo: mark as bug?
-        ManagedEnvironmentError::UpstreamNotFound(_, _) => display_chain(err),
+        ManagedEnvironmentError::UpstreamNotFound(_, _) => formatdoc! {"
+            Environment not found in FloxHub.
+
+            You can run `flox push` to push the environment back to FloxHub.
+        "},
         // acces denied is catched early as ManagedEnvironmentError::AccessDenied
         ManagedEnvironmentError::Push(_) => display_chain(err),
         ManagedEnvironmentError::DeleteBranch(_) => display_chain(err),

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -442,7 +442,11 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
             Please check the spelling of the remote environment
             and make sure that you have access to it.
         "},
-        ManagedEnvironmentError::UpstreamNotFound(env_ref, _, user) => {
+        ManagedEnvironmentError::UpstreamNotFound {
+            env_ref,
+            upstream: _,
+            user,
+        } => {
             let by_current_user = user
                 .as_ref()
                 .map(|u| u == env_ref.owner().as_str())

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -15,6 +15,8 @@ use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, ContextMsgError,
 use indoc::formatdoc;
 use log::{debug, trace};
 
+use crate::commands::EnvironmentSelectError;
+
 /// Convert to an error variant that directs the user to the docs if the provided error is
 /// due to a package not being supported on the current system.
 pub fn apply_doc_link_for_unsupported_packages(err: EnvironmentError) -> EnvironmentError {
@@ -557,6 +559,21 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
         RemoteEnvironmentError::ReadInternalOutLink(_) => display_chain(err),
         RemoteEnvironmentError::DeleteOldOutLink(_) => display_chain(err),
         RemoteEnvironmentError::WriteNewOutlink(_) => display_chain(err),
+    }
+}
+
+pub fn format_environment_select_error(err: &EnvironmentSelectError) -> String {
+    trace!("formatting environment_select_error: {err:?}");
+
+    match err {
+        EnvironmentSelectError::Environment(err) => format_error(err),
+        EnvironmentSelectError::EnvNotFoundInCurrentDirectory => formatdoc! {"
+            Did not find an environment in the current directory.
+        "},
+        EnvironmentSelectError::Anyhow(err) => err
+            .chain()
+            .skip(1)
+            .fold(err.to_string(), |acc, cause| format!("{}: {}", acc, cause)),
     }
 }
 


### PR DESCRIPTION
Previously, we showed a generic failure message when the upstream 
environment was deleted. We now handle that case and show a message 
indicating what's happened and instructing the user how to restore the 
environment.

This also changes the way we handle EnvironmentSelectErrors. We now 
include a check for EnvironmentSelectError in main() alongside the other error
handler, and handle the EnvironmentSelectError::Environment variant the same as
ordinary EnvironmentErrors.