### PR TITLE
chore: hide update command from `--help`

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -96,7 +96,7 @@ static FLOX_DESCRIPTION: &'_ str = indoc! {"
 
 /// Manually documented commands that are to keep the help text short
 const ADDITIONAL_COMMANDS: &str = indoc! {"
-    auth, config, envs, update, upgrade
+    auth, config, envs, upgrade
 "};
 
 fn vec_len<T>(x: Vec<T>) -> usize {

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -87,7 +87,7 @@ EOF
   run "$FLOX_BIN" --help
   assert_output --partial - << EOF
 Additional Commands. Use "flox COMMAND --help" for more info
-    auth, config, envs, update, upgrade
+    auth, config, envs, upgrade
 EOF
 }
 


### PR DESCRIPTION
#1508 marked the command as hidden but its usage entry was added manually, hence removed here.