### PR TITLE
chore(ci): Remove dupe integ-tests from job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,11 +149,6 @@ jobs:
           RUST_BACKTRACE: 1
         run: nix develop -L --no-update-lock-file --command just impure-tests
 
-      - name: "CLI Integration Tests"
-        env:
-          RUST_BACKTRACE: 1
-        run: nix develop -L --no-update-lock-file --command just integ-tests
-
       - name: "Functional Tests"
         if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
         env:
@@ -278,7 +273,7 @@ jobs:
       - "nix-build"
       - "pkgdb-dev"
       - "cli-dev"
-      # TODO: enable these when deemed reliable - "nix-build-bats-tests"
+      - "nix-build-bats-tests"
 
     steps:
       - name: "Slack Notification"


### PR DESCRIPTION
## Proposed Changes

The integration tests are being run twice:

- cli-dev: runs them "locally" on two different Runner systems
- nix-build-bats-tests: runs them "remotely" on four different builder systems

I noticed this while reviewing:

- https://github.com/flox/flox/actions/runs/9560120725?pr=1625

`cli-dev` is typically our longest running job in CI and running the integration tests there only gives us a subset of the coverage that we get from `nix-build-bats-tests`, so we can save time on the overall CI run and make failures easier to reason about by only running them in `nix-build-bats-tests`.

I've plumbed `nix-build-bats-tests` through to `report-failure` at the same time so that we get the same amount of reporting on `main`. They should be reliable enough now because we depend on them for PR merges.

[Before](https://github.com/flox/flox/actions/runs/9555067155):

![image](https://github.com/flox/flox/assets/260438/ce72438c-b563-4500-a6b9-e0fc0d231c86)

[After](https://github.com/flox/flox/actions/runs/9562997350?pr=1648):

![image](https://github.com/flox/flox/assets/260438/6ca4a34f-48a7-4ab6-be7c-47b78674c76e)

## Release Notes

N/A
