### PR TITLE
feat: migrate hook.script to hook.on-activate

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -918,15 +918,7 @@ impl CoreEnvironment<ReadOnly> {
         let mut temp_env = self.writable(&tempdir)?;
 
         if migration_info.needs_manifest_migration {
-            migration_info
-                .raw_manifest
-                .insert(MANIFEST_VERSION_KEY, toml_edit::value(1));
-
-            // Make sure it parses
-            migration_info
-                .raw_manifest
-                .to_typed()
-                .map_err(CoreEnvironmentError::MigrateManifest)?;
+            Self::migrate_manifest_contents_to_v1(&mut migration_info.raw_manifest)?;
 
             debug!("migration transaction: updating manifest");
             temp_env.update_manifest(migration_info.raw_manifest.to_string())?;
@@ -951,6 +943,50 @@ impl CoreEnvironment<ReadOnly> {
         Ok(store_path)
     }
 
+    /// Migrate a v0 [RawManifest] to a v1 [RawManifest] by inserting
+    /// `version = 1` and moving `hook.script` to `hook.on-activate` if
+    /// `hook.on-activate` doesn't already exist.
+    ///
+    /// `raw_manifest` is expected to be a v0 manifest.
+    /// Return an error if the resulting manifest is not a valid v1 manifest.
+    /// Note that the modifications are still made even if an error is returned to allow
+    /// [Self::migrate_and_edit_unsafe] to use the invalid manifest.
+    fn migrate_manifest_contents_to_v1(
+        raw_manifest: &mut RawManifest,
+    ) -> Result<(), CoreEnvironmentError> {
+        // // Insert `version = 1`
+        raw_manifest.insert(MANIFEST_VERSION_KEY, toml_edit::value(1));
+
+        // Migrate `hook.script` to `hook.on-activate`
+        let hook = raw_manifest.get_mut("hook").and_then(|s| s.as_table_mut());
+        if let Some(hook) = hook {
+            if hook.get("on-activate").is_none() {
+                // Rename `hook.script` to `hook.on-activate`, preserving
+                // comments and formatting
+                if let Some((script_key, script_item)) = hook.remove_entry("script") {
+                    // Unit tests cover this is safe to unwrap
+                    let mut on_activate = toml_edit::Key::from_str("on-activate").unwrap();
+                    let mut on_activate_key = on_activate.as_mut();
+                    let decor = on_activate_key.leaf_decor_mut();
+                    *decor = script_key.leaf_decor().clone();
+                    let dotted_decor = on_activate_key.dotted_decor_mut();
+                    *dotted_decor = script_key.dotted_decor().clone();
+                    // Does not preserve order of hooks,
+                    // but we only have one field in the hook section.
+                    hook.insert_formatted(&on_activate, script_item);
+                }
+            }
+        }
+
+        // Make sure it parses
+        raw_manifest
+            .to_typed()
+            .map_err(CoreEnvironmentError::MigrateManifest)?;
+        Ok(())
+    }
+
+    /// Replace manifest with provided `contents` and perform migration in a
+    /// single transaction
     pub fn migrate_and_edit_unsafe(
         &mut self,
         flox: &Flox,
@@ -969,17 +1005,14 @@ impl CoreEnvironment<ReadOnly> {
         let mut raw_manifest = RawManifest::from_str(&contents)
             .map_err(|e| CoreEnvironmentError::ModifyToml(TomlEditError::ParseManifest(e)))?;
 
-        raw_manifest.insert(MANIFEST_VERSION_KEY, toml_edit::value(1));
+        let migrate_result = Self::migrate_manifest_contents_to_v1(&mut raw_manifest);
 
         debug!("migration transaction: updating manifest");
         temp_env.update_manifest(raw_manifest.to_string())?;
 
         // Check if the manifest is valid after updating it, because we want to
         // update it no matter what.
-        if let Err(migrate_error) = raw_manifest
-            .to_typed()
-            .map_err(CoreEnvironmentError::MigrateManifest)
-        {
+        if let Err(migrate_error) = migrate_result {
             debug!(
                 "migration transaction: migration failed: {:?}",
                 migrate_error
@@ -1289,6 +1322,7 @@ mod tests {
     use catalog_api_v1::types::{ResolvedPackageDescriptor, SystemEnum};
     use chrono::{DateTime, Utc};
     use indoc::{formatdoc, indoc};
+    use pretty_assertions::assert_eq;
     use serial_test::serial;
     use tempfile::{tempdir_in, TempDir};
     use tests::test_helpers::MANIFEST_INCOMPATIBLE_SYSTEM;
@@ -1751,5 +1785,112 @@ mod tests {
         } else {
             panic!("expected LockForMigration error");
         }
+    }
+
+    /// [CoreEnvironment::migrate_manifest_contents_to_v1] migrates a manifest
+    /// with `script` in a `[hook]` table correctly, maintaining comments and
+    /// formatting.
+    #[test]
+    fn migrate_script_hook_table() {
+        let contents = formatdoc! {r#"
+            [vars]
+            foo = "bar"
+
+            # comment 1
+            [hook] # comment 2
+            # comment 3
+             script = "echo hello" # comment 4
+            # comment 5
+
+            [options]
+            "#};
+        let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
+        CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap();
+        assert_eq!(raw_manifest.to_string(), formatdoc! {r#"
+                version = 1
+                [vars]
+                foo = "bar"
+
+                # comment 1
+                [hook] # comment 2
+                # comment 3
+                 on-activate = "echo hello" # comment 4
+                # comment 5
+
+                [options]
+                "#
+        });
+    }
+
+    /// [CoreEnvironment::migrate_manifest_contents_to_v1] migrates a manifest
+    /// with hook.script as a dotted key correctly, maintaining comments and
+    /// formatting.
+    #[test]
+    fn migrate_script_hook_dotted_decor() {
+        let contents = formatdoc! {r#"
+            vars.foo = "bar"
+
+            # comment 1
+            hook . script = "echo hello" # comment 2
+            # comment 3
+
+            options.allow.unfree = false
+            "#};
+        let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
+        CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap();
+        assert_eq!(raw_manifest.to_string(), formatdoc! {r#"
+                vars.foo = "bar"
+
+                # comment 1
+                hook . on-activate = "echo hello" # comment 2
+                # comment 3
+
+                options.allow.unfree = false
+                version = 1
+                "#
+        });
+    }
+
+    /// If a manifest contains both `hook.script` and `hook.on-activate`,
+    /// [CoreEnvironment::migrate_manifest_contents_to_v1] returns an error.
+    #[test]
+    fn migrate_script_skip_for_on_activate() {
+        let contents = formatdoc! {r#"
+            [hook]
+            script = "echo hello"
+            on-activate = "echo hello"
+            "#};
+        let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
+        let err = CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap_err();
+        assert_eq!(raw_manifest.to_string(), formatdoc! {r#"
+                version = 1
+                [hook]
+                script = "echo hello"
+                on-activate = "echo hello"
+                "#
+        });
+        if let CoreEnvironmentError::MigrateManifest(e) = err {
+            assert!(e.message().contains("unknown field `script`"));
+        } else {
+            panic!("expected MigrateManifest error");
+        }
+    }
+
+    /// Even if a manifest fails validation, it is still modified by
+    /// [CoreEnvironment::migrate_manifest_contents_to_v1].
+    #[test]
+    fn migrate_script_modifies_on_error() {
+        let contents = formatdoc! {r#"
+            [hook]
+            script = "echo hello"
+            on-activate = "echo hello"
+            "#};
+        let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
+        assert!(raw_manifest.get("version").is_none());
+        CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap_err();
+        assert_eq!(
+            raw_manifest.get("version").unwrap().as_integer().unwrap(),
+            1
+        );
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1857,16 +1857,16 @@ mod tests {
     fn migrate_script_skip_for_on_activate() {
         let contents = formatdoc! {r#"
             [hook]
-            script = "echo hello"
-            on-activate = "echo hello"
+            script = "echo foo"
+            on-activate = "echo bar"
             "#};
         let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
         let err = CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap_err();
         assert_eq!(raw_manifest.to_string(), formatdoc! {r#"
                 version = 1
                 [hook]
-                script = "echo hello"
-                on-activate = "echo hello"
+                script = "echo foo"
+                on-activate = "echo bar"
                 "#
         });
         if let CoreEnvironmentError::MigrateManifest(e) = err {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1592,10 +1592,10 @@ pub fn environment_description(environment: &ConcreteEnvironment) -> Result<Stri
 }
 
 #[derive(Debug, Error)]
-enum MigrationError {
+pub enum MigrationError {
     #[error("Migration cancelled. Run 'flox upgrade' to migrate the environment.")]
     MigrationCancelled,
-    #[error("Upgrade failed.")]
+    #[error("upgrade failed")]
     ConfirmedUpgradeFailed(#[source] EnvironmentError),
     #[error(transparent)]
     Environment(#[from] EnvironmentError),

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use bpaf::{Args, Parser};
-use commands::{EnvironmentSelectError, FloxArgs, FloxCli, Prefix, Version};
+use commands::{EnvironmentSelectError, FloxArgs, FloxCli, MigrationError, Prefix, Version};
 use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironmentError;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentError;
@@ -17,6 +17,7 @@ use crate::utils::errors::{
     format_environment_select_error,
     format_error,
     format_managed_error,
+    format_migration_error,
     format_remote_error,
 };
 use crate::utils::metrics::Hub;
@@ -151,6 +152,11 @@ fn main() -> ExitCode {
 
             if let Some(e) = e.downcast_ref::<EnvironmentSelectError>() {
                 message::error(format_environment_select_error(e));
+                return ExitCode::from(1);
+            }
+
+            if let Some(e) = e.downcast_ref::<MigrationError>() {
+                message::error(format_migration_error(e));
                 return ExitCode::from(1);
             }
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -17,7 +17,7 @@ use flox_rust_sdk::providers::git::GitRemoteCommandError;
 use indoc::formatdoc;
 use log::{debug, trace};
 
-use crate::commands::EnvironmentSelectError;
+use crate::commands::{EnvironmentSelectError, MigrationError};
 
 /// Convert to an error variant that directs the user to the docs if the provided error is
 /// due to a package not being supported on the current system.
@@ -613,6 +613,17 @@ pub fn format_environment_select_error(err: &EnvironmentSelectError) -> String {
             .chain()
             .skip(1)
             .fold(err.to_string(), |acc, cause| format!("{}: {}", acc, cause)),
+    }
+}
+
+pub fn format_migration_error(err: &MigrationError) -> String {
+    trace!("formatting migration_error: {err:?}");
+
+    match err {
+        MigrationError::Environment(err) | MigrationError::ConfirmedUpgradeFailed(err) => {
+            format_error(err)
+        },
+        _ => display_chain(err),
     }
 }
 


### PR DESCRIPTION
When performing migration of manifest version 0 to version 1, rename
hook.script to hook.on-activate if hook.on-activate doesn't already
exist.

Also add formatter for MigrationError.

MigrationError wraps some errors that should be pretty printed, but the
wrapping causes the formatting function to not be printed. Fix this by
adding a formatting function that calls the formatters for the contained
errors.

Errors were being printed as:
```
❌ ERROR: Upgrade failed.: could not automatically migrate manifest to version 1: unknown field `prefer-pre-releases`, expected `allow-pre-releases`
in `options.semver`
```

But they should be printed as:
```
❌ ERROR: Could not automatically migrate manifest to version 1:

unknown field `prefer-pre-releases`, expected `allow-pre-releases`

Use 'flox edit' to resolve errors and then try again.
```