### PR TITLE
chore(show): Remove deprecated --all argument

### DIFF
--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -20,16 +20,11 @@ use tracing::instrument;
 
 use crate::config::features::Features;
 use crate::subcommand_metric;
-use crate::utils::message;
 use crate::utils::search::{manifest_and_lockfile, DEFAULT_DESCRIPTION, SEARCH_INPUT_SEPARATOR};
 
 // Show detailed package information
 #[derive(Debug, Bpaf, Clone)]
 pub struct Show {
-    /// Whether to show all available package versions
-    #[bpaf(long, hide)]
-    pub all: bool, // TODO: Remove in future release.
-
     /// The package to show detailed information about. Must be an exact match
     /// for a pkg-path e.g. something copy-pasted from the output of `flox search`.
     #[bpaf(positional("pkg-path"))]
@@ -37,13 +32,9 @@ pub struct Show {
 }
 
 impl Show {
-    #[instrument(name = "show", fields(show_all = self.all, pkg_path = self.pkg_path), skip_all)]
+    #[instrument(name = "show", fields(pkg_path = self.pkg_path), skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("show");
-
-        if self.all {
-            message::warning("'--all' is now the default and the flag has been deprecated.");
-        }
 
         if let Some(client) = flox.catalog_client {
             tracing::debug!("using catalog client for show");
@@ -268,7 +259,6 @@ mod test {
         );
         let search_term = "search_term";
         let err = Show {
-            all: true, // unused
             pkg_path: search_term.to_string(),
         }
         .handle(flox)

--- a/cli/tests/show.bats
+++ b/cli/tests/show.bats
@@ -116,31 +116,6 @@ setup_file() {
 
 # ---------------------------------------------------------------------------- #
 
-@test "'flox show' - hello --all" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  _PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_OLD" \
-    "$FLOX_BIN" update --global
-
-  run --separate-stderr "$FLOX_BIN" show hello --all
-  assert_success
-  assert_equal "${lines[0]}" "hello - A program that produces a familiar, friendly greeting"
-  assert_equal "${lines[1]}" "    hello@2.12.1"
-  assert_regex "$stderr" "'--all' .* deprecated"
-}
-
-# ---------------------------------------------------------------------------- #
-
-@test "catalog: 'flox show' - hello --all" {
-  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/show/hello.json"
-  run --separate-stderr "$FLOX_BIN" show hello --all
-  assert_success
-  assert_equal "${lines[0]}" "hello - A program that produces a familiar, friendly greeting"
-  assert_equal "${lines[1]}" "    hello@2.12.1"
-  assert_regex "$stderr" "'--all' .* deprecated"
-}
-
-# ---------------------------------------------------------------------------- #
-
 # bats test_tags=python
 
 @test "'flox show' - python27Full" {
@@ -152,22 +127,6 @@ setup_file() {
   assert_success
   assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language"
   assert_equal "${lines[1]}" "    python27Full@2.7.18.6"
-}
-
-# ---------------------------------------------------------------------------- #
-
-# bats test_tags=python
-
-@test "'flox show' - python27Full --all" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  _PKGDB_GA_REGISTRY_REF_OR_REV="$PKGDB_NIXPKGS_REV_OLD" \
-    "$FLOX_BIN" update --global
-
-  run --separate-stderr "$FLOX_BIN" show python27Full --all
-  assert_success
-  assert_equal "${lines[0]}" "python27Full - A high-level dynamically-typed programming language"
-  assert_equal "${lines[1]}" "    python27Full@2.7.18.6"
-  assert_regex "$stderr" "'--all' .* deprecated"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

Remove the warning that was added in d27e0d00 so that it will now produce an error:

    % flox show --all
    ❌ ERROR: expected `<pkg-path>`, got `--all`. Pass `--help` for usage information

This has been in two releases (1.0.6 and 1.0.7) and the timing is good to remove it for 1.1.0 as a breaking change.

## Release Notes

Removed the deprecated `--all` flag from `flox show` now that it's the default.
