### PR TITLE
chore(pkgdb): Tighten gitignore for *.d

### DIFF
--- a/pkgdb/.gitignore
+++ b/pkgdb/.gitignore
@@ -1,5 +1,5 @@
 # Prerequisites
-*.d
+/bear.d/
 
 # Compiled Object files
 *.slo


### PR DESCRIPTION
## Proposed Changes

To match the one directory that generate, so that it doesn't ignore new files in:

    % git check-ignore -v pkgdb/src/buildenv/assets/activate.d/newfile pkgdb/src/buildenv/assets/etc/profile.d/newfile
    pkgdb/.gitignore:2:*.d	pkgdb/src/buildenv/assets/activate.d/newfile
    pkgdb/.gitignore:2:*.d	pkgdb/src/buildenv/assets/etc/profile.d/newfile

I noticed this while looking at the CUDA script and my editor failed to find it because many tools like `fd` and `rg` automatically exclude ignored files even if they are tracked.

## Release Notes

N/A