### PR TITLE
fix(upgrade): Keep lockfile if no pkgs change

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -720,7 +720,7 @@ impl CoreEnvironment<ReadOnly> {
             debug!("no groups or iids provided, unlocking all packages");
             None
         } else {
-            existing_lockfile.map(|mut lockfile| {
+            existing_lockfile.clone().map(|mut lockfile| {
                 lockfile.unlock_packages_by_group_or_iid(groups_or_iids);
                 lockfile
             })
@@ -759,7 +759,13 @@ impl CoreEnvironment<ReadOnly> {
             })
             .collect::<Vec<_>>();
 
-        Ok((upgraded_lockfile, package_diff))
+        let final_lockfile = if package_diff.is_empty() {
+            existing_lockfile.unwrap_or(upgraded_lockfile)
+        } else {
+            upgraded_lockfile
+        };
+
+        Ok((final_lockfile, package_diff))
     }
 
     /// Makes a temporary copy of the environment so modifications to the manifest

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -268,6 +268,35 @@ EOF
   assert_output --partial "No packages need to be upgraded"
 }
 
+@test "catalog: page changes should not be considered an upgrade" {
+  "$FLOX_BIN" init
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" \
+    "$FLOX_BIN" install curl hello
+  prev_lock_hash=$(jq --sort-keys --compact-output . "$LOCK_PATH" | sha256sum)
+
+  # Update the page and revision but keep the same derivations.
+  # This would fail to rebuild because the revs are faked.
+  BUMPED_REVS_RESPONE="curl_hello_bumped_revs.json"
+  jq '.[0][0].page |= (
+    (.page | .+ 123) as $newpage |
+    .page = $newpage |
+    .packages |= map(
+      (.rev | .[0:-8] + "deadbeef") as $newrev |
+      .rev_count = $newpage |
+      .rev = $newrev |
+      .locked_url |= sub("rev=.*"; "rev=" + $newrev)
+    ))' \
+    "$GENERATED_DATA/resolve/curl_hello.json" \
+    > "$BUMPED_REVS_RESPONE"
+  _FLOX_USE_CATALOG_MOCK="$BUMPED_REVS_RESPONE" \
+    run "$FLOX_BIN" upgrade
+  assert_success
+  assert_output --partial "No packages need to be upgraded"
+
+  curr_lock_hash=$(jq --sort-keys --compact-output . "$LOCK_PATH" | sha256sum)
+  assert_equal "$curr_lock_hash" "$prev_lock_hash"
+}
+
 @test "upgrade performs manifest migration" {
   NAME="name"
   FLOX_FEATURES_USE_CATALOG=false "$FLOX_BIN" init -n "$NAME"


### PR DESCRIPTION
## Proposed Changes

It's possible for the catalog server to resolve the same package version and derivation from a different page and revision of nixpkgs.

In these cases the packages haven't actually changed and we would tell the user that they haven't been upgraded, however we were still updating the lockfile with the new `page`, `rev`, `rev_count`, and `locked_url`.

Prevent this from happening by returning the existing lockfile. We currently still trigger a build on it though, in part because an existing test expects a noop upgrade to generate a lockfile and the outer function doesn't know whether the lockfile has changed.

A side-effect of this is that the test can't compare the raw lockfile contents because it appears to originally be written out in pretty-print format and then written in compact format, so we have to parse it with `jq` to do the comparison.

I did experiment with making this a unit test instead of an integration test, in part because the mock manipulation feels quite fragile, but the round-trip behaviour wasn't as clear and it likely wouldn't have highlighted the oddities above.

I also considered moving the mock manipulation into `test_data` but decided against it because it's clearer inline to understand the one test that uses it.

## Release Notes

N/A, part of catalog release.