### PR TITLE
feat: managed environment local checkout plumbing

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -91,7 +91,7 @@ impl<State> CoreEnvironment<State> {
     }
 
     /// Read the manifest file
-    fn manifest_content(&self) -> Result<String, CoreEnvironmentError> {
+    pub fn manifest_content(&self) -> Result<String, CoreEnvironmentError> {
         fs::read_to_string(self.manifest_path()).map_err(CoreEnvironmentError::OpenManifest)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -906,6 +906,17 @@ impl ManagedEnvironment {
         Ok(local)
     }
 
+    /// Validate that the local manifest checkout matches the one in the current generation.
+    ///
+    /// Returns true if they match, false otherwise.
+    /// Manifests are compared byte-for-byte, such semantically equivalent modifications
+    /// such as whitespace changes are still detected.
+    ///
+    /// Note:
+    /// This is not a method on CoreEnvironment because its currently only relevant
+    /// in the context of a ManagedEnvironment.
+    /// A potential future version could provide more detailed comaparison/diff information
+    /// that may be more generally useful and see this method changed or moved.
     fn validate_checkout(
         local: &CoreEnvironment,
         remote: &CoreEnvironment,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -883,7 +883,8 @@ impl ManagedEnvironment {
                 &mut local,
                 "Synchronized manual changes to generation".to_string(),
             )
-            .unwrap();
+            .map_err(ManagedEnvironmentError::CommitGeneration)?;
+
         self.lock_pointer()?;
         Ok(())
     }

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -889,7 +889,7 @@ impl ManagedEnvironment {
         Ok(())
     }
 
-    /// Create or reset a local checkout of the latet generation.
+    /// Create a local checkout of the latet generation.
     ///
     /// Copies the `env/` directory from the latest generation to the `.flox/` directory
     /// and returns a [CoreEnvironment] for the `.flox/env`.

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -892,7 +892,7 @@ impl ManagedEnvironment {
         Ok(())
     }
 
-    /// Create or reset a local checkout of the current generation.
+    /// Create a local checkout of the current generation.
     ///
     /// Copies the `env/` directory from the current generation to the `.flox/` directory
     /// and returns a [CoreEnvironment] for the `.flox/env`.

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -331,7 +331,7 @@ pub struct TypedManifestCatalog {
     /// The packages to install in the form of a map from install_id
     /// to package descriptor.
     #[serde(default)]
-    pub(super) install: ManifestInstall,
+    pub install: ManifestInstall,
     /// Variables that are exported to the shell environment upon activation.
     #[serde(default)]
     pub(super) vars: ManifestVariables,

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -435,6 +435,9 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
             to the environment directory in '.flox/env'.
         "},
 
+        ManagedEnvironmentError::ReadLocalManifest(_) => display_chain(err),
+        ManagedEnvironmentError::ReadGenerationManifest(_) => display_chain(err),
+
         ManagedEnvironmentError::BadBranchName(_) => display_chain(err),
 
         // currently unused

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -429,7 +429,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
         ManagedEnvironmentError::CreateLinksDir(_) => display_chain(err),
 
         ManagedEnvironmentError::CreateLocalEnvironmentView(err) => formatdoc! {"
-            Failed to create reset the local environment from the current generation: {err}
+            Failed to create the local environment from the current generation: {err}
 
             Please ensure that you have read and write permissions
             to the environment directory in '.flox/env'.

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -428,6 +428,13 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
         ManagedEnvironmentError::ReverseLink(_) => display_chain(err),
         ManagedEnvironmentError::CreateLinksDir(_) => display_chain(err),
 
+        ManagedEnvironmentError::CreateLocalEnvironmentView(err) => formatdoc! {"
+            Failed to create reset the local environment from the current generation: {err}
+
+            Please ensure that you have read and write permissions
+            to the environment directory in '.flox/env'.
+        "},
+
         ManagedEnvironmentError::BadBranchName(_) => display_chain(err),
 
         // currently unused


### PR DESCRIPTION
Adds plumbing commands to realize future behaviour changes of managed environments.
In particular this PR adds methods 

* to create a local copy of the environment stored in the current generation
* reset the local copy 
* and create a new generation from it.

While creation attempts to be as indestructive as possible, only writing files if the `.flox/env` directory does not yet exists, resetting the local copy currently discards any existing files in `.flox/env`.