### PR TITLE
feat: managed environment local checkout

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -314,17 +314,7 @@ impl Environment for ManagedEnvironment {
             .writable(flox.temp_dir.clone())
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
-        let remote = generations
-            .get_current_generation()
-            .map_err(ManagedEnvironmentError::CreateGenerationFiles)?;
-
         let mut local_checkout = self.local_env_from_current_generation(flox)?;
-
-        if !Self::validate_checkout(&local_checkout, &remote)? {
-            Err(EnvironmentError::ManagedEnvironment(
-                ManagedEnvironmentError::CheckoutOutOfSync,
-            ))?
-        }
 
         let result = local_checkout.edit(flox, contents)?;
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1187,6 +1187,15 @@ pub enum PullResult {
 }
 
 impl ManagedEnvironment {
+    /// Create a new [ManagedEnvironment] from a [PathEnvironment]
+    /// by pushing the contents of the original environment as a generation to floxhub.
+    ///
+    /// The environment is pushed to the `owner` specified
+    /// and will retain the name of the original path environment.
+    ///
+    /// By default, if an environment with the same name already exists in the owner's repository,
+    /// the push will fail, unless `force` is set to `true`.
+    ///
     /// If access to a remote repository requires authentication,
     /// the FloxHub token must be set in the flox instance.
     /// The caller is responsible for ensuring that the token is present and valid.

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -328,8 +328,6 @@ impl Environment for ManagedEnvironment {
             local_checkout.link(flox, &self.out_link, store_path)?;
         }
 
-        self.reset_local_env_to_current_generation(flox)?;
-
         Ok(result)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -419,17 +419,19 @@ impl Environment for ManagedEnvironment {
     }
 
     fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
-        let pointer_lock_path = self.path.join(GENERATION_LOCK_FILENAME);
+        let local_manifest_path = self
+            .local_env_from_current_generation(flox)?
+            .manifest_path();
 
-        let pointer_lock_modified_at = mtime_of(pointer_lock_path);
+        let local_manifest = mtime_of(local_manifest_path);
         let out_link_modified_at = mtime_of(&self.out_link);
 
         debug!(
-            "pointer_lock_modified_at: {pointer_lock_modified_at:?}
+            "local_manifest: {local_manifest:?}
             out_link_modified_at: {out_link_modified_at:?}"
         );
 
-        if pointer_lock_modified_at >= out_link_modified_at || !self.out_link.exists() {
+        if local_manifest >= out_link_modified_at || !self.out_link.exists() {
             self.build(flox)?;
         }
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1021,7 +1021,8 @@ impl ManagedEnvironment {
         Ok(local_checkout)
     }
 
-    /// Create a local checkout of the current generation.
+    /// Return a [CoreEnvironment] for an existing local checkout
+    /// or create one from the current generation.
     ///
     /// Copies the `env/` directory from the current generation to the `.flox/` directory
     /// and returns a [CoreEnvironment] for the `.flox/env`.

--- a/cli/flox/doc/flox-edit.md
+++ b/cli/flox/doc/flox-edit.md
@@ -14,12 +14,13 @@ flox-edit - edit the declarative environment configuration
 ```
 flox [<general options>] edit
      [-d=<path> | -r=<owner/name>]
-     [[-f=<file>] | -n=<name>]
+     [[-f=<file>] | -n=<name> | --sync | --reset]
 ```
 
 # DESCRIPTION
 
-Transactionally edit the environment manifest.
+## Transactionally edit the environment manifest.
+
 By default invokes an editor with a copy of the local manifest for the user to
 interactively edit.
 The editor is found by querying `$EDITOR`, `$VISUAL`,
@@ -41,6 +42,19 @@ which renames a local environment but does not rebuild it.
 The environment can be edited non-interactively via the `-f` flag,
 which replaces the contents of the manifest with those of the provided file.
 
+## Sync the local manifest with the current generation.
+
+When unsing environments that were pushed or pulled from FloxHub,
+local changes to the manifest in `.flox/env/manifest.toml`
+will block the use of imperative environment commands
+`flox {install, uninstall, upgrade}`.
+In this case, a new generation has to be created from the local changes first
+or the local changes discarded.
+Run `flox edit --sync` to create a new generation,
+or `flox edit --reset` to discard local changes
+and reset to the current latest generation.
+
+
 # OPTIONS
 
 ## Edit Options
@@ -52,6 +66,14 @@ which replaces the contents of the manifest with those of the provided file.
 `-n`, `--name`
 :   Rename the environment to `<name>`.
     Only works for local environments.
+
+`-s`, `--sync`
+:   Create a new generation from the current local environment
+    (Only available for managed environments)
+
+`-r`, `--reset`
+:   Reset the environment to the current generation
+    (Only available for managed environments)
 
 ```{.include}
 ./include/environment-options.md

--- a/cli/flox/doc/flox-edit.md
+++ b/cli/flox/doc/flox-edit.md
@@ -44,15 +44,17 @@ which replaces the contents of the manifest with those of the provided file.
 
 ## Sync the local manifest with the current generation.
 
-When unsing environments that were pushed or pulled from FloxHub,
-local changes to the manifest in `.flox/env/manifest.toml`
+When using environments that were pushed to or pulled from FloxHub,
+changes to the local manifest in `.flox/env/manifest.toml`
 will block the use of imperative environment commands
 `flox {install, uninstall, upgrade}`.
-In this case, a new generation has to be created from the local changes first
-or the local changes discarded.
-Run `flox edit --sync` to create a new generation,
-or `flox edit --reset` to discard local changes
-and reset to the current latest generation.
+In this case, a new generation has to be created from the local manifest first
+or the changes discarded.
+Run `flox edit --reset` to discard local changes
+and reset to the current latest generation,
+or `flox edit --sync` to create a new generation.
+`flox edit` will always create a new generation including prior changes
+to the local manifest.
 
 
 # OPTIONS

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -152,11 +152,19 @@ impl Edit {
             EditAction::Reset { .. } => {
                 let span = tracing::info_span!("reset");
                 let _guard = span.enter();
-                let ConcreteEnvironment::Managed(environment) = detected_environment else {
-                    bail!("Cannot sync local or remote environments.");
+                let ConcreteEnvironment::Managed(mut environment) = detected_environment else {
+                    bail!("Cannot reset local or remote environments.");
                 };
 
                 environment.reset_local_env_to_current_generation(&flox)?;
+
+                Dialog {
+                    message: "Building environment",
+                    help_message: None,
+                    typed: Spinner::new(|| environment.build(&flox)),
+                }
+                .spin()?;
+
                 message::updated("Environment changes reset to current generation.");
             },
         }

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -208,7 +208,7 @@ impl Edit {
             // open too fast for the user to see it.
             Err(_) => (),
             // Note: ManagedEnvironmentError::CheckoutOutOfSync case is unreachable here,
-            // because its handled above for clarity.
+            // because it's handled above for clarity.
         };
 
         let active_environment = UninitializedEnvironment::from_concrete_environment(environment)?;

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -104,6 +104,12 @@ impl Edit {
 
                 let contents = Self::provided_manifest_contents(file)?;
 
+                if let ConcreteEnvironment::Managed(ref environment) = detected_environment {
+                    if environment.has_local_changes(&flox)? && contents.is_none() {
+                        bail!(ManagedEnvironmentError::CheckoutOutOfSync)
+                    }
+                };
+
                 // TODO: we have various functionality spread across
                 // UninitializedEnvironment, ConcreteEnvironment, and
                 // Environment.

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -204,9 +204,6 @@ impl Edit {
             Ok(_) => (),
             e @ Err(MigrationError::MigrationCancelled) => e?,
 
-            e @ Err(MigrationError::ConfirmedUpgradeFailed(
-                EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::CheckoutOutOfSync),
-            )) => e?,
             // If the user said they wanted an upgrade and it failed, print why but don't fail
             Err(e @ MigrationError::ConfirmedUpgradeFailed(_)) => {
                 message::warning(format_migration_error(&e));

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -115,7 +115,7 @@ impl Edit {
 
                 Self::edit_manifest(
                     &flox,
-                    &mut environment,
+                    &mut *environment,
                     active_environment,
                     description,
                     contents,
@@ -176,7 +176,7 @@ impl Edit {
     // instead of just environment is a pain
     async fn edit_manifest(
         flox: &Flox,
-        environment: &mut Box<dyn Environment>,
+        environment: &mut dyn Environment,
         active_environment: UninitializedEnvironment,
         description: String,
         contents: Option<String>,
@@ -203,7 +203,7 @@ impl Edit {
                 .map_err(apply_doc_link_for_unsupported_packages)?,
             // If not provided with new manifest contents, let the user edit the file directly
             // via $EDITOR or $VISUAL (as long as `flox edit` was invoked interactively).
-            None => Self::interactive_edit(flox, environment.as_mut()).await?,
+            None => Self::interactive_edit(flox, environment).await?,
         };
 
         // outside the match to avoid rustfmt falling on its face
@@ -449,7 +449,7 @@ mod tests {
 
         let err = Edit::edit_manifest(
             &flox,
-            &mut environment,
+            &mut *environment,
             active_environment,
             description,
             Some(new_contents.to_string()),
@@ -490,7 +490,7 @@ mod tests {
 
         let err = Edit::edit_manifest(
             &flox,
-            &mut environment,
+            &mut *environment,
             active_environment,
             description,
             Some(new_contents.to_string()),
@@ -533,7 +533,7 @@ mod tests {
 
         Edit::edit_manifest(
             &flox,
-            &mut environment,
+            &mut *environment,
             active_environment,
             description,
             Some(new_contents.to_string()),
@@ -576,7 +576,7 @@ mod tests {
 
         Edit::edit_manifest(
             &flox,
-            &mut environment,
+            &mut *environment,
             active_environment,
             description,
             Some(new_contents.to_string()),

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -142,7 +142,7 @@ impl Edit {
             EditAction::Sync { .. } => {
                 let span = tracing::info_span!("sync");
                 let _guard = span.enter();
-                let ConcreteEnvironment::Managed(environment) = detected_environment else {
+                let ConcreteEnvironment::Managed(mut environment) = detected_environment else {
                     bail!("Cannot sync local or remote environments.");
                 };
                 environment.create_generation_from_local_env(&flox)?;

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -111,7 +111,7 @@ impl Install {
         };
 
         let mut environment = concrete_environment.into_dyn_environment();
-        maybe_migrate_environment_to_v1(&flox, &mut environment, &description).await?;
+        maybe_migrate_environment_to_v1(&flox, &mut *environment, &description).await?;
 
         let mut packages_to_install = self
             .packages

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -5,7 +5,6 @@ use anyhow::{anyhow, bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::data::CanonicalPath;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironmentError;
 use flox_rust_sdk::models::environment::{CoreEnvironmentError, Environment, EnvironmentError};
 use flox_rust_sdk::models::lockfile::{
     LockedManifest,
@@ -109,12 +108,6 @@ impl Install {
         // Ensure the user is logged in for the following remote operations
         if let ConcreteEnvironment::Remote(_) = concrete_environment {
             ensure_floxhub_token(&mut flox).await?;
-        };
-
-        if let ConcreteEnvironment::Managed(ref environment) = concrete_environment {
-            if environment.has_local_changes(&flox)? {
-                bail!(ManagedEnvironmentError::CheckoutOutOfSync)
-            }
         };
 
         maybe_migrate_environment_to_v1(&flox, &mut concrete_environment).await?;

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1607,7 +1607,7 @@ pub enum MigrationError {
 /// If doing so requires an upgrade, prompt the user for whether to proceed.
 async fn maybe_migrate_environment_to_v1(
     flox: &Flox,
-    environment: &mut Box<dyn Environment>,
+    environment: &mut dyn Environment,
     description: &str,
 ) -> Result<(), MigrationError> {
     maybe_migrate_environment_to_v1_inner(
@@ -1624,7 +1624,7 @@ async fn maybe_migrate_environment_to_v1(
 /// If confirm_upgrade_future is None, the user can't be prompted to confirm an upgrade.
 async fn maybe_migrate_environment_to_v1_inner(
     flox: &Flox,
-    environment: &mut Box<dyn Environment>,
+    environment: &mut dyn Environment,
     description: &str,
     confirm_upgrade_future: Option<impl Future<Output = Result<bool>>>,
 ) -> Result<(), MigrationError> {
@@ -1977,7 +1977,7 @@ mod tests {
         // TODO: use None::<???> instead of false.then
         maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut environment,
+            &mut *environment,
             &description,
             false.then(|| confirm_migration_upgrade("")),
         )
@@ -2019,7 +2019,7 @@ mod tests {
 
         let err = maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut environment,
+            &mut *environment,
             &description,
             Some(async { Ok(false) }),
         )
@@ -2074,7 +2074,7 @@ mod tests {
 
         maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut environment,
+            &mut *environment,
             &description,
             Some(async { Ok(true) }),
         )
@@ -2124,7 +2124,7 @@ mod tests {
 
         let err = maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut environment,
+            &mut *environment,
             &description,
             Some(async { Ok(false) }),
         )
@@ -2167,7 +2167,7 @@ mod tests {
 
         let err = maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut environment,
+            &mut *environment,
             &description,
             Some(async { Ok(true) }),
         )

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -39,7 +39,10 @@ use flox_rust_sdk::flox::{
     FLOX_VERSION,
 };
 use flox_rust_sdk::models::env_registry::{EnvRegistry, ENV_REGISTRY_FILENAME};
-use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
+use flox_rust_sdk::models::environment::managed_environment::{
+    ManagedEnvironment,
+    ManagedEnvironmentError,
+};
 use flox_rust_sdk::models::environment::path_environment::PathEnvironment;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
 use flox_rust_sdk::models::environment::{
@@ -1607,14 +1610,14 @@ pub enum MigrationError {
 /// If doing so requires an upgrade, prompt the user for whether to proceed.
 async fn maybe_migrate_environment_to_v1(
     flox: &Flox,
-    environment: &mut dyn Environment,
-    description: &str,
+    environment: &mut ConcreteEnvironment,
 ) -> Result<(), MigrationError> {
     maybe_migrate_environment_to_v1_inner(
         flox,
         environment,
-        description,
-        Dialog::can_prompt().then_some(confirm_migration_upgrade(description)),
+        Dialog::can_prompt().then_some(confirm_migration_upgrade(&environment_description(
+            environment,
+        )?)),
     )
     .await
 }
@@ -1624,10 +1627,23 @@ async fn maybe_migrate_environment_to_v1(
 /// If confirm_upgrade_future is None, the user can't be prompted to confirm an upgrade.
 async fn maybe_migrate_environment_to_v1_inner(
     flox: &Flox,
-    environment: &mut dyn Environment,
-    description: &str,
+    environment: &mut ConcreteEnvironment,
     confirm_upgrade_future: Option<impl Future<Output = Result<bool>>>,
 ) -> Result<(), MigrationError> {
+    if let ConcreteEnvironment::Managed(ref environment) = environment {
+        if environment
+            .has_local_changes(flox)
+            .map_err(EnvironmentError::ManagedEnvironment)?
+        {
+            Err(EnvironmentError::ManagedEnvironment(
+                ManagedEnvironmentError::CheckoutOutOfSync,
+            ))?;
+        }
+    }
+
+    let description = environment_description(environment)?;
+    let environment = environment.dyn_environment_ref_mut();
+
     if flox.catalog_client.is_none() {
         return Ok(());
     }
@@ -1969,22 +1985,20 @@ mod tests {
         let (flox, _temp_dir_handle) =
             flox_instance_with_optional_floxhub_and_client(Some(&owner), true);
 
-        let concrete_environment =
+        let mut environment =
             ConcreteEnvironment::Managed(mock_managed_environment(&flox, "", owner));
-        // UninitializedEnvironment::from_concrete_environment(&ConcreteEnvironment::Managed(environment.clone())).
-        let description = environment_description(&concrete_environment).unwrap();
-        let mut environment = concrete_environment.into_dyn_environment();
+
         // TODO: use None::<???> instead of false.then
         maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut *environment,
-            &description,
+            &mut environment,
             false.then(|| confirm_migration_upgrade("")),
         )
         .await
         .unwrap();
 
         assert!(environment
+            .dyn_environment_ref_mut()
             .manifest_content(&flox)
             .unwrap()
             .contains("version = 1"));
@@ -2000,17 +2014,24 @@ mod tests {
         let (mut flox, _temp_dir_handle) =
             flox_instance_with_optional_floxhub_and_client(Some(&owner), false);
 
-        let concrete_environment =
+        let mut environment =
             ConcreteEnvironment::Managed(mock_managed_environment(&flox, "", owner));
-        let description = environment_description(&concrete_environment).unwrap();
-        let mut environment = concrete_environment.into_dyn_environment();
 
         // Lock in a transaction with a no-op upgrade without the catalog and
         // double check we got a pkgdb lockfile
-        environment.upgrade(&flox, &[]).unwrap();
+        environment
+            .dyn_environment_ref_mut()
+            .upgrade(&flox, &[])
+            .unwrap();
         assert!(matches!(
             LockedManifest::read_from_file(
-                &CanonicalPath::new(environment.lockfile_path(&flox).unwrap()).unwrap(),
+                &CanonicalPath::new(
+                    environment
+                        .dyn_environment_ref_mut()
+                        .lockfile_path(&flox)
+                        .unwrap()
+                )
+                .unwrap(),
             )
             .unwrap(),
             LockedManifest::Pkgdb(_)
@@ -2019,18 +2040,26 @@ mod tests {
 
         let err = maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut *environment,
-            &description,
+            &mut environment,
             Some(async { Ok(false) }),
         )
         .await
         .unwrap_err();
         // Lock in a transaction with a no-op upgrade without the catalog and
         // double check we got a pkgdb lockfile
-        environment.upgrade(&flox, &[]).unwrap();
+        environment
+            .dyn_environment_ref_mut()
+            .upgrade(&flox, &[])
+            .unwrap();
         assert!(matches!(
             LockedManifest::read_from_file(
-                &CanonicalPath::new(environment.lockfile_path(&flox).unwrap()).unwrap(),
+                &CanonicalPath::new(
+                    environment
+                        .dyn_environment_ref_mut()
+                        .lockfile_path(&flox)
+                        .unwrap()
+                )
+                .unwrap(),
             )
             .unwrap(),
             LockedManifest::Pkgdb(_)
@@ -2040,6 +2069,7 @@ mod tests {
         assert!(err.to_string().contains("Migration cancelled"));
 
         assert!(!environment
+            .dyn_environment_ref_mut()
             .manifest_content(&flox)
             .unwrap()
             .contains("version = 1"));
@@ -2055,40 +2085,49 @@ mod tests {
         let (mut flox, _temp_dir_handle) =
             flox_instance_with_optional_floxhub_and_client(Some(&owner), false);
 
-        let concrete_environment =
+        let mut environment =
             ConcreteEnvironment::Managed(mock_managed_environment(&flox, "", owner));
-        let description = environment_description(&concrete_environment).unwrap();
-        let mut environment = concrete_environment.into_dyn_environment();
 
         // Lock in a transaction with a no-op upgrade without the catalog and
         // double check we got a pkgdb lockfile
-        environment.upgrade(&flox, &[]).unwrap();
+        environment
+            .dyn_environment_ref_mut()
+            .upgrade(&flox, &[])
+            .unwrap();
         assert!(matches!(
             LockedManifest::read_from_file(
-                &CanonicalPath::new(environment.lockfile_path(&flox).unwrap()).unwrap(),
+                &CanonicalPath::new(
+                    environment
+                        .dyn_environment_ref_mut()
+                        .lockfile_path(&flox)
+                        .unwrap()
+                )
+                .unwrap(),
             )
             .unwrap(),
             LockedManifest::Pkgdb(_)
         ));
         flox.catalog_client = Some(MockClient::default().into());
 
-        maybe_migrate_environment_to_v1_inner(
-            &flox,
-            &mut *environment,
-            &description,
-            Some(async { Ok(true) }),
-        )
-        .await
-        .unwrap();
+        maybe_migrate_environment_to_v1_inner(&flox, &mut environment, Some(async { Ok(true) }))
+            .await
+            .unwrap();
 
         assert!(environment
+            .dyn_environment_ref_mut()
             .manifest_content(&flox)
             .unwrap()
             .contains("version = 1"));
 
         assert!(matches!(
             LockedManifest::read_from_file(
-                &CanonicalPath::new(environment.lockfile_path(&flox).unwrap()).unwrap(),
+                &CanonicalPath::new(
+                    environment
+                        .dyn_environment_ref_mut()
+                        .lockfile_path(&flox)
+                        .unwrap()
+                )
+                .unwrap(),
             )
             .unwrap(),
             LockedManifest::Catalog(_)
@@ -2105,17 +2144,24 @@ mod tests {
         let (mut flox, _temp_dir_handle) =
             flox_instance_with_optional_floxhub_and_client(Some(&owner), false);
 
-        let concrete_environment =
+        let mut environment =
             ConcreteEnvironment::Managed(mock_managed_environment(&flox, "", owner));
-        let description = environment_description(&concrete_environment).unwrap();
-        let mut environment = concrete_environment.into_dyn_environment();
 
         // Lock in a transaction with a no-op upgrade without the catalog and
         // double check we got a pkgdb lockfile
-        environment.upgrade(&flox, &[]).unwrap();
+        environment
+            .dyn_environment_ref_mut()
+            .upgrade(&flox, &[])
+            .unwrap();
         assert!(matches!(
             LockedManifest::read_from_file(
-                &CanonicalPath::new(environment.lockfile_path(&flox).unwrap()).unwrap(),
+                &CanonicalPath::new(
+                    environment
+                        .dyn_environment_ref_mut()
+                        .lockfile_path(&flox)
+                        .unwrap()
+                )
+                .unwrap(),
             )
             .unwrap(),
             LockedManifest::Pkgdb(_)
@@ -2124,8 +2170,7 @@ mod tests {
 
         let err = maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut *environment,
-            &description,
+            &mut environment,
             Some(async { Ok(false) }),
         )
         .await
@@ -2145,20 +2190,27 @@ mod tests {
         let (mut flox, _temp_dir_handle) =
             flox_instance_with_optional_floxhub_and_client(Some(&owner), false);
 
-        let concrete_environment = ConcreteEnvironment::Managed(mock_managed_environment(
+        let mut environment = ConcreteEnvironment::Managed(mock_managed_environment(
             &flox,
             MANIFEST_V0_FIELDS,
             owner,
         ));
-        let description = environment_description(&concrete_environment).unwrap();
-        let mut environment = concrete_environment.into_dyn_environment();
 
         // Lock in a transaction with a no-op upgrade without the catalog and
         // double check we got a pkgdb lockfile
-        environment.upgrade(&flox, &[]).unwrap();
+        environment
+            .dyn_environment_ref_mut()
+            .upgrade(&flox, &[])
+            .unwrap();
         assert!(matches!(
             LockedManifest::read_from_file(
-                &CanonicalPath::new(environment.lockfile_path(&flox).unwrap()).unwrap(),
+                &CanonicalPath::new(
+                    environment
+                        .dyn_environment_ref_mut()
+                        .lockfile_path(&flox)
+                        .unwrap()
+                )
+                .unwrap(),
             )
             .unwrap(),
             LockedManifest::Pkgdb(_)
@@ -2167,8 +2219,7 @@ mod tests {
 
         let err = maybe_migrate_environment_to_v1_inner(
             &flox,
-            &mut *environment,
-            &description,
+            &mut environment,
             Some(async { Ok(true) }),
         )
         .await
@@ -2178,6 +2229,52 @@ mod tests {
             err,
             MigrationError::ConfirmedUpgradeFailed(EnvironmentError::Core(
                 CoreEnvironmentError::MigrateManifest(_)
+            ))
+        ));
+    }
+
+    /// maybe_migrate_environment_to_v1 fails if a managed environment has local changes
+    #[tokio::test]
+    async fn maybe_migrate_managed_environment_blocked() {
+        let owner = "owner".parse().unwrap();
+        let (flox, _temp_dir_handle) =
+            flox_instance_with_optional_floxhub_and_client(Some(&owner), false);
+
+        let mut environment = ConcreteEnvironment::Managed(mock_managed_environment(
+            &flox,
+            &formatdoc! {"
+                # before
+                {MANIFEST_V0_FIELDS}
+            "},
+            owner,
+        ));
+
+        // modify the lockfile
+        {
+            let manifest_path = environment
+                .dyn_environment_ref_mut()
+                .manifest_path(&flox)
+                .unwrap();
+
+            fs::write(manifest_path, formatdoc! {"
+                # after
+                {MANIFEST_V0_FIELDS}
+            "})
+            .unwrap();
+        }
+
+        let err = maybe_migrate_environment_to_v1_inner(
+            &flox,
+            &mut environment,
+            Some(async { unreachable!() }),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            MigrationError::Environment(EnvironmentError::ManagedEnvironment(
+                ManagedEnvironmentError::CheckoutOutOfSync
             ))
         ));
     }

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -44,7 +44,7 @@ impl Uninstall {
             self.packages.as_slice().join(", "),
             self.environment
         );
-        let concrete_environment = match self
+        let mut concrete_environment = match self
             .environment
             .detect_concrete_environment(&flox, "Uninstall from")
         {
@@ -74,9 +74,10 @@ impl Uninstall {
             ensure_floxhub_token(&mut flox).await?;
         };
 
+        maybe_migrate_environment_to_v1(&flox, &mut concrete_environment).await?;
+
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
-        maybe_migrate_environment_to_v1(&flox, &mut *environment, &description).await?;
 
         let _ = Dialog {
             message: &format!("Uninstalling packages from environment {description}..."),

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -76,7 +76,7 @@ impl Uninstall {
 
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();
-        maybe_migrate_environment_to_v1(&flox, &mut environment, &description).await?;
+        maybe_migrate_environment_to_v1(&flox, &mut *environment, &description).await?;
 
         let _ = Dialog {
             message: &format!("Uninstalling packages from environment {description}..."),

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -640,7 +640,10 @@ pub fn format_migration_error(err: &MigrationError) -> String {
     trace!("formatting migration_error: {err:?}");
 
     match err {
-        MigrationError::ConfirmedUpgradeFailed(EnvironmentError::ManagedEnvironment(
+        MigrationError::Environment(EnvironmentError::ManagedEnvironment(
+            ManagedEnvironmentError::CheckoutOutOfSync,
+        ))
+        | MigrationError::ConfirmedUpgradeFailed(EnvironmentError::ManagedEnvironment(
             ManagedEnvironmentError::CheckoutOutOfSync,
         )) => formatdoc! {"
             Cannot automatically migrate environment:

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -549,6 +549,10 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
         ManagedEnvironmentError::Build(core_environment_error) => {
             format_core_error(core_environment_error)
         },
+        ManagedEnvironmentError::Link(core_environment_error) => {
+            format_core_error(core_environment_error)
+        },
+
         ManagedEnvironmentError::Registry(_) => display_chain(err),
     }
 }

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -640,8 +640,22 @@ pub fn format_migration_error(err: &MigrationError) -> String {
     trace!("formatting migration_error: {err:?}");
 
     match err {
+        MigrationError::ConfirmedUpgradeFailed(EnvironmentError::ManagedEnvironment(
+            ManagedEnvironmentError::CheckoutOutOfSync,
+        )) => formatdoc! {"
+            Cannot automatically migrate environment:
+            The environment has changes that are not yet synced to a generation.
+
+            Migrate the environment manually by setting 'version = 1'
+            in the manifest file or reset the local manifest to the current generation using
+
+                $ flox edit --reset
+        "},
         MigrationError::Environment(err) | MigrationError::ConfirmedUpgradeFailed(err) => {
-            format_error(err)
+            formatdoc! {"
+                Failed to migrate environment:
+                {err}
+            ", err = format_error(err).trim_end()}
         },
         _ => display_chain(err),
     }

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -14,7 +14,7 @@ use flox_rust_sdk::models::floxmeta::FloxMetaError;
 use flox_rust_sdk::models::lockfile::LockedManifestError;
 use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, ContextMsgError, PkgDbError};
 use flox_rust_sdk::providers::git::GitRemoteCommandError;
-use indoc::formatdoc;
+use indoc::{formatdoc, indoc};
 use log::{debug, trace};
 
 use crate::commands::{EnvironmentSelectError, MigrationError};
@@ -434,6 +434,12 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
             Please ensure that you have read and write permissions
             to the environment directory in '.flox/env'.
         "},
+
+        ManagedEnvironmentError::CheckoutOutOfSync => indoc! {"
+            Your environment has changes that are not yet synced to a generation.
+            Use 'flox edit --reset' or 'flox edit --sync' after modifying '.flox/env/manifest.toml'
+        "}
+        .to_string(),
 
         ManagedEnvironmentError::ReadLocalManifest(_) => display_chain(err),
         ManagedEnvironmentError::ReadGenerationManifest(_) => display_chain(err),

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -350,6 +350,7 @@ EOF
   refute_output "vim"
 }
 
+# bats test_tags=managed:xyz
 @test "sanity check upgrade works for managed environments" {
   # update shouldn't work for catalog: https://github.com/flox/flox/issues/1509
   export FLOX_FEATURES_USE_CATALOG=false
@@ -419,7 +420,8 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     "$FLOX_BIN" edit --sync
 
-  run "$FLOX_BIN" upgrade
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
+    run "$FLOX_BIN" upgrade
   assert_success
 }
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -426,18 +426,16 @@ EOF
 }
 
 # bats test_tags=managed,managed:local-edits-block:edit
-@test "changes to the local environment block 'flox edit'"  {
+@test "'flox edit' works despite local changes and commits them" {
   make_empty_remote_env
 
   tomlq -i -t '.install.hello."pkg-path" = "hello"' .flox/env/manifest.toml
 
-  run "$FLOX_BIN" edit -f .flox/env/manifest.toml
-  assert_failure
-
+  # simulate immediate save in a user editor
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
-    "$FLOX_BIN" edit --sync
+    run "$FLOX_BIN" edit -f  .flox/env/manifest.toml
 
-  run "$FLOX_BIN" edit -f .flox/env/manifest.toml
+
   assert_success
 }
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -433,7 +433,7 @@ EOF
 
   # simulate immediate save in a user editor
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
-    run "$FLOX_BIN" edit -f  .flox/env/manifest.toml
+    run "$FLOX_BIN" edit -f .flox/env/manifest.toml
 
 
   assert_success


### PR DESCRIPTION
Behavior changing integration of new local env checkout for managed environments


- [x] use local checkout by default in `ManagedEnvironment::{manifest,lockfile_path}`
- [x] validate the local checkout in command impls 
- [x] add `flox edit --{sync,reset}`
- [x] amend `sync` and `reset` to `flox-edit(1)` 