### PR TITLE
test: use cargo-nextest for unit tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,7 +15,7 @@ nix_options := "--extra-experimental-features nix-command \
 PKGDB_BIN := "${PWD}/pkgdb/bin/pkgdb"
 FLOX_BIN := "${PWD}/cli/target/debug/flox"
 LD_FLOXLIB := "${PWD}/pkgdb/lib/ld-floxlib.so"
-cargo_test_invocation := "PKGDB_BIN=${PKGDB_BIN} cargo test --workspace"
+cargo_test_invocation := "PKGDB_BIN=${PKGDB_BIN} cargo nextest run --manifest-path ${PWD}/cli/Cargo.toml --workspace"
 
 
 # ---------------------------------------------------------------------------- #
@@ -93,12 +93,10 @@ gen-data +mk_data_args="": build-data-gen
 
 # Run the CLI unit tests
 @unit-tests regex="": build
-    pushd cli;                            \
      {{cargo_test_invocation}} {{regex}}
 
 # Run the CLI unit tests, including impure tests
 @impure-tests regex="": build
-    pushd cli;                                                     \
      {{cargo_test_invocation}} {{regex}} --features "extra-tests"
 
 # Run the entire CLI test suite

--- a/cli/flox/src/utils/openers.rs
+++ b/cli/flox/src/utils/openers.rs
@@ -252,7 +252,8 @@ mod tests {
     fn test_get_parent_process_exe() {
         let path = get_parent_process_exe().expect("should find parent process");
 
-        assert_eq!(path.file_name().unwrap(), "cargo");
+        let parent = path.file_name().unwrap();
+        assert!(parent == "cargo" || parent == "cargo-nextest");
     }
 
     /// Test the detection of the shell from environment variables

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -9,6 +9,7 @@
   pre-commit-check,
   shfmt,
   mitmproxy,
+  cargo-nextest,
   flox-cli,
   flox-cli-tests,
   flox-pkgdb,
@@ -47,6 +48,7 @@
       shfmt
       mitmproxy
       yq
+      cargo-nextest
     ];
 in
   mkShell (


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Replaces the default test runner with `cargo-nextest`, which runs tests in parallel and uses a different scheduling algorithm.

Locally the unit tests went from ~12s to ~4s.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
