### PR TITLE
feat: add `options.cuda-detection` to manifest

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -42,7 +42,7 @@ use crate::models::environment::copy_dir_recursive;
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner};
 use crate::models::floxmeta::{floxmeta_git_options, FloxMeta, FloxMetaError};
 use crate::models::lockfile::LockedManifest;
-use crate::models::manifest::PackageToInstall;
+use crate::models::manifest::{PackageToInstall, TypedManifest};
 use crate::models::pkgdb::UpgradeResult;
 use crate::providers::git::{
     GitCommandBranchHashError,
@@ -387,6 +387,12 @@ impl Environment for ManagedEnvironment {
             .current_gen_manifest()
             .map_err(ManagedEnvironmentError::ReadManifest)?;
         Ok(manifest)
+    }
+
+    /// Return the deserialized manifest
+    fn manifest(&self, flox: &Flox) -> Result<TypedManifest, EnvironmentError> {
+        Ok(toml::from_str(&self.manifest_content(flox)?)
+            .map_err(CoreEnvironmentError::DeserializeManifest)?)
     }
 
     fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -168,6 +168,9 @@ pub trait Environment: Send {
     /// to determine the current content of the manifest.
     fn manifest_content(&self, flox: &Flox) -> Result<String, EnvironmentError>;
 
+    /// Return the deserialized manifest
+    fn manifest(&self, flox: &Flox) -> Result<TypedManifest, EnvironmentError>;
+
     /// Return a path containing the built environment and its activation script.
     ///
     /// This should be a link to a store path so that it can be swapped
@@ -1014,7 +1017,7 @@ mod test {
         ));
         fs::write(environment.manifest_path(&flox).unwrap(), "").unwrap();
         assert!(matches!(
-            toml::from_str::<TypedManifest>(&environment.manifest_content(&flox).unwrap()).unwrap(),
+            environment.manifest(&flox).unwrap(),
             TypedManifest::Pkgdb(_),
         ));
         assert!(matches!(

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -47,7 +47,7 @@ use crate::models::env_registry::{deregister, ensure_registered};
 use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::lockfile::LockedManifest;
-use crate::models::manifest::{PackageToInstall, RawManifest};
+use crate::models::manifest::{PackageToInstall, RawManifest, TypedManifest};
 use crate::models::pkgdb::UpgradeResult;
 use crate::utils::mtime_of;
 
@@ -272,6 +272,12 @@ impl Environment for PathEnvironment {
     /// Read the environment definition file as a string
     fn manifest_content(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         fs::read_to_string(self.manifest_path(flox)?).map_err(EnvironmentError::ReadManifest)
+    }
+
+    /// Return the deserialized manifest
+    fn manifest(&self, _flox: &Flox) -> Result<TypedManifest, EnvironmentError> {
+        let env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
+        env_view.manifest().map_err(EnvironmentError::Core)
     }
 
     /// Returns the environment name

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -27,7 +27,7 @@ use crate::models::container_builder::ContainerBuilder;
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
 use crate::models::lockfile::LockedManifest;
-use crate::models::manifest::PackageToInstall;
+use crate::models::manifest::{PackageToInstall, TypedManifest};
 use crate::models::pkgdb::UpgradeResult;
 
 const REMOTE_ENVIRONMENT_BASE_DIR: &str = "remote";
@@ -263,6 +263,11 @@ impl Environment for RemoteEnvironment {
     /// Extract the current content of the manifest
     fn manifest_content(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         self.inner.manifest_content(flox)
+    }
+
+    /// Return the deserialized manifest
+    fn manifest(&self, flox: &Flox) -> Result<TypedManifest, EnvironmentError> {
+        self.inner.manifest(flox)
     }
 
     fn activation_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -217,6 +217,14 @@ impl RawManifest {
             toml_edit::value(Array::from_iter(systems.iter().copied())),
         );
 
+        let cuda_detection_key = Key::new("cuda-detection");
+        options_table.insert(&cuda_detection_key, toml_edit::value(false));
+        if let Some((mut key, _)) = options_table.get_key_value_mut(&cuda_detection_key) {
+            key.leaf_decor_mut().set_prefix(indoc! {r#"
+            # Uncomment to disable CUDA detection.
+            # "#});
+        }
+
         manifest.insert(MANIFEST_OPTIONS_KEY, Item::Table(options_table));
 
         // Insert heading comment
@@ -1063,6 +1071,8 @@ pub(super) mod test {
             # manifest.toml(5) for a list of available options.
             [options]
             systems = []
+            # Uncomment to disable CUDA detection.
+            # cuda-detection = false
         "#};
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization, false);
@@ -1132,6 +1142,8 @@ pub(super) mod test {
             # manifest.toml(5) for a list of available options.
             [options]
             systems = []
+            # Uncomment to disable CUDA detection.
+            # cuda-detection = false
         "#};
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization, true);
@@ -1203,6 +1215,8 @@ pub(super) mod test {
             # manifest.toml(5) for a list of available options.
             [options]
             systems = []
+            # Uncomment to disable CUDA detection.
+            # cuda-detection = false
         "#};
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization, false);
@@ -1279,6 +1293,8 @@ pub(super) mod test {
             # manifest.toml(5) for a list of available options.
             [options]
             systems = ["x86_64-linux"]
+            # Uncomment to disable CUDA detection.
+            # cuda-detection = false
         "#};
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization, false);
@@ -1352,6 +1368,8 @@ pub(super) mod test {
             # manifest.toml(5) for a list of available options.
             [options]
             systems = ["x86_64-linux"]
+            # Uncomment to disable CUDA detection.
+            # cuda-detection = false
         "#};
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization, false);

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -552,6 +552,7 @@ pub struct ManifestOptions {
     /// Options that control how semver versions are resolved.
     #[serde(default)]
     pub semver: SemverOptions,
+    pub cuda_detection: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -314,6 +314,7 @@ Options ::= {
   systems                   = null | [<STRING>, ...]
 , allow                     = null | Allows
 , semver                    = null | Semver
+, cuda-detection            = null | <BOOL>
 }
 
 Allows ::= {
@@ -358,6 +359,13 @@ Semver ::= {
     The default is `false`.
     Setting this value to `true` would allow a package version `4.2.0-pre`
     rather than `4.1.9`.
+
+`cuda-detection`
+:   Whether to detect CUDA libraries and provide them to the environment.
+    The default is `true`.
+    When enabled, Flox will detect if you have an Nvidia device and attempt to
+    locate `libcuda` in well-known paths. Then it will symlink the libraries
+    into `.flox/lib` and add that path to `FLOX_ENV_LIB_DIRS`.
 
 # SEE ALSO
 [`flox-init(1)`](./flox-init.md),

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -24,6 +24,7 @@ use flox_rust_sdk::models::environment::{
     FLOX_PROMPT_ENVIRONMENTS_VAR,
 };
 use flox_rust_sdk::models::lockfile::LockedManifestError;
+use flox_rust_sdk::models::manifest::TypedManifest;
 use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
 use indexmap::IndexSet;
 use indoc::formatdoc;
@@ -243,6 +244,13 @@ impl Activate {
                     .expect("`bare_description` is infallible"),
             ),
         ]);
+
+        if let TypedManifest::Catalog(manifest) = environment.manifest(&flox)? {
+            // default to enabling CUDA
+            if manifest.options.cuda_detection != Some(false) {
+                exports.insert("_FLOX_ENV_CUDA_DETECTION", "1".to_string());
+            }
+        }
 
         exports.extend(default_nix_env_vars());
 

--- a/cli/tests/cuda.bats
+++ b/cli/tests/cuda.bats
@@ -1,0 +1,135 @@
+
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test CUDA detection during `flox activate`.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=cuda
+
+# ---------------------------------------------------------------------------- #
+
+setup_file() {
+  common_file_setup
+}
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  export PROJECT_NAME="${PROJECT_DIR##*/}"
+
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" > /dev/null || return
+  "$FLOX_BIN" init -d "$PROJECT_DIR"
+
+  export FAKE_FHS_ROOT="${PROJECT_DIR}/fake_fhs_root"
+  mkdir "$FAKE_FHS_ROOT"
+  mkdir -p "${FAKE_FHS_ROOT}/dev"
+}
+
+project_teardown() {
+  popd > /dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+  unset PROJECT_NAME
+  unset FAKE_FHS_ROOT
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  project_setup
+}
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+#
+@test "cuda disabled when nvidia device absent" {
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash "$TESTS_DIR/cuda/cuda-disabled.sh" "${FAKE_FHS_ROOT}"
+  assert_success
+}
+
+@test "cuda disabled when nvidia0 device present but libcuba absent" {
+  touch "${FAKE_FHS_ROOT}/dev/nvidia0"
+
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash "$TESTS_DIR/cuda/cuda-disabled.sh" "${FAKE_FHS_ROOT}"
+  assert_success
+}
+
+@test "cuda disabled when nvidia0 device present and libcuda present but manifest opts-out" {
+  touch "${FAKE_FHS_ROOT}/dev/nvidia0"
+  mkdir -p "${FAKE_FHS_ROOT}/run/opengl-drivers"
+  touch "${FAKE_FHS_ROOT}/run/opengl-drivers/libcuda.so.1"
+  tomlq --in-place -t '.options."cuda-detection" = false' .flox/env/manifest.toml
+
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash "$TESTS_DIR/cuda/cuda-disabled.sh" "${FAKE_FHS_ROOT}"
+  assert_success
+}
+
+@test "cuda enabled when nvidia0 device present and libcuda present" {
+  touch "${FAKE_FHS_ROOT}/dev/nvidia0"
+  mkdir -p "${FAKE_FHS_ROOT}/run/opengl-drivers"
+  touch "${FAKE_FHS_ROOT}/run/opengl-drivers/libcuda.so.1"
+
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash "$TESTS_DIR/cuda/cuda-enabled.sh" "${FAKE_FHS_ROOT}"
+  assert_success
+  assert_output --partial "${PROJECT_DIR}/.flox/lib/libcuda.so.1"
+}
+
+@test "cuda enabled when nvidia1 device present and multiple libraries present in alternate directory" {
+  touch "${FAKE_FHS_ROOT}/dev/nvidia1"
+  mkdir -p "${FAKE_FHS_ROOT}/usr/local/lib"
+  touch "${FAKE_FHS_ROOT}/usr/local/lib/libcuda.so.1"
+  touch "${FAKE_FHS_ROOT}/usr/local/lib/libnvidia.so.1"
+  touch "${FAKE_FHS_ROOT}/usr/local/lib/libdxcore.so.1"
+
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash "$TESTS_DIR/cuda/cuda-enabled.sh" "${FAKE_FHS_ROOT}"
+  assert_success
+  assert_output --partial "${PROJECT_DIR}/.flox/lib/libcuda.so.1"
+  assert_output --partial "${PROJECT_DIR}/.flox/lib/libnvidia.so.1"
+  assert_output --partial "${PROJECT_DIR}/.flox/lib/libdxcore.so.1"
+}
+
+@test "cuda enabled when nested activation doesn't opt-out" {
+  touch "${FAKE_FHS_ROOT}/dev/nvidia0"
+  mkdir -p "${FAKE_FHS_ROOT}/run/opengl-drivers"
+  touch "${FAKE_FHS_ROOT}/run/opengl-drivers/libcuda.so.1"
+
+  tomlq --in-place -t '.options."cuda-detection" = false' .flox/env/manifest.toml
+
+  NESTED_PROJECT_DIR="${PROJECT_NAME}-nested"
+  "$FLOX_BIN" init -d "$NESTED_PROJECT_DIR"
+
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -- \
+    "$FLOX_BIN" activate -d "$NESTED_PROJECT_DIR" -- \
+    bash "$TESTS_DIR/cuda/cuda-enabled.sh" "${FAKE_FHS_ROOT}"
+  assert_success
+}
+
+# This is the current, rather than necessarily desired, behaviour.
+@test "cuda enabled when nested activation attempts to opt-out" {
+  touch "${FAKE_FHS_ROOT}/dev/nvidia0"
+  mkdir -p "${FAKE_FHS_ROOT}/run/opengl-drivers"
+  touch "${FAKE_FHS_ROOT}/run/opengl-drivers/libcuda.so.1"
+
+  NESTED_PROJECT_DIR="${PROJECT_NAME}-nested"
+  "$FLOX_BIN" init -d "$NESTED_PROJECT_DIR"
+  tomlq --in-place -t '.options."cuda-detection" = false' "${NESTED_PROJECT_DIR}/.flox/env/manifest.toml"
+
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -- \
+    "$FLOX_BIN" activate -d "$NESTED_PROJECT_DIR" -- \
+    bash "$TESTS_DIR/cuda/cuda-enabled.sh" "${FAKE_FHS_ROOT}"
+  assert_success
+}

--- a/cli/tests/cuda/cuda-disabled.sh
+++ b/cli/tests/cuda/cuda-disabled.sh
@@ -1,0 +1,11 @@
+set -euxo pipefail
+
+FHS_ROOT="${1}"
+
+# Get the function without loading support.
+_FLOX_ENV_CUDA_DETECTION=0 source "${FLOX_ENV}/etc/profile.d/0800_cuda.sh"
+
+LIBS_BEFORE="$FLOX_ENV_LIB_DIRS"
+activate_cuda "${FHS_ROOT}" || true
+LIBS_AFTER="$FLOX_ENV_LIB_DIRS"
+[[ "$LIBS_AFTER" == "$LIBS_BEFORE" ]]

--- a/cli/tests/cuda/cuda-enabled.sh
+++ b/cli/tests/cuda/cuda-enabled.sh
@@ -1,0 +1,18 @@
+
+set -euxo pipefail
+
+FHS_ROOT="${1}"
+
+# Get the function without executing it all.
+_FLOX_ENV_CUDA_DETECTION=0 source "${FLOX_ENV}/etc/profile.d/0800_cuda.sh"
+
+LIBS_BEFORE="$FLOX_ENV_LIB_DIRS"
+activate_cuda "${FHS_ROOT}"
+LIBS_AFTER="$FLOX_ENV_LIB_DIRS"
+[[ "$LIBS_AFTER" != "$LIBS_BEFORE" ]]
+
+IFS=':'
+for lib_dir in $LIBS_AFTER; do
+    find "$lib_dir" -type l || true
+done
+unset IFS

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
@@ -31,7 +31,7 @@ activate_cuda(){
     "${fhs_root_prefix}/usr/local/lib64" \
     "${fhs_root_prefix}/usr/local/lib" \
     -name libcuda.so.1 \
-    -execdir pwd \; -quit 2>/dev/null)
+    -execdir pwd \; -quit 2>/dev/null || true)
 
   if [ -z "$SYSTEM_LIB_DIR" ]; then
     return 0

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
@@ -10,19 +10,28 @@ export _findutils="@findutils@"
 
 # Only run if _FLOX_ENV_CUDA_DETECTION is set
 activate_cuda(){
+  # Strip any trailing slash so that we can construct it later.
+  local fhs_root_prefix="${1%/:-}"
+
   if [[ "$_FLOX_ENV_CUDA_DETECTION" != 1 ]]; then
     return 0
   fi
 
-  if ! ( "$_findutils/bin/find" /dev -maxdepth 1 -iname 'nvidia*' -o -iname dxg | read -r ;); then
+  if ! ( "$_findutils/bin/find" "${fhs_root_prefix}/dev" -maxdepth 1 -iname 'nvidia*' -o -iname dxg | read -r ;); then
     return 0
   fi
 
   LIB_DIR="$("$_coreutils/bin/realpath" --no-symlinks "$FLOX_ENV/../../lib")"
   SYSTEM_LIB_DIR=$("$_findutils/bin/find" \
-	  /run/opengl-drivers /lib64 /lib /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib \
-          -name libcuda.so.1 \
-	  -execdir pwd \; -quit 2>/dev/null )
+    "${fhs_root_prefix}/run/opengl-drivers" \
+    "${fhs_root_prefix}/lib64" \
+    "${fhs_root_prefix}/lib" \
+    "${fhs_root_prefix}/usr/lib64" \
+    "${fhs_root_prefix}/usr/lib" \
+    "${fhs_root_prefix}/usr/local/lib64" \
+    "${fhs_root_prefix}/usr/local/lib" \
+    -name libcuda.so.1 \
+    -execdir pwd \; -quit 2>/dev/null)
 
   if [ -z "$SYSTEM_LIB_DIR" ]; then
     return 0
@@ -39,7 +48,7 @@ activate_cuda(){
   export FLOX_ENV_LIB_DIRS="$FLOX_ENV_LIB_DIRS":"$LIB_DIR"
 }
 
-activate_cuda
+activate_cuda "/"
 
 # ---------------------------------------------------------------------------- #
 #

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
@@ -8,9 +8,9 @@ export _findutils="@findutils@"
 #
 # ---------------------------------------------------------------------------- #
 
-# Only run if FLOX_FEATURES_ENV_ENABLE_CUDA feature flag is set
+# Only run if _FLOX_ENV_CUDA_DETECTION is set
 activate_cuda(){
-  if [[ "$FLOX_FEATURES_ENV_ENABLE_CUDA" != 1 ]]; then
+  if [[ "$_FLOX_ENV_CUDA_DETECTION" != 1 ]]; then
     return 0
   fi
 

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
@@ -13,7 +13,7 @@ activate_cuda(){
   # Strip any trailing slash so that we can construct it later.
   local fhs_root_prefix="${1%/:-}"
 
-  if [[ "$_FLOX_ENV_CUDA_DETECTION" != 1 ]]; then
+  if [[ "${_FLOX_ENV_CUDA_DETECTION:-}" != 1 ]]; then
     return 0
   fi
 

--- a/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
+++ b/pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh
@@ -31,7 +31,7 @@ activate_cuda(){
     "${fhs_root_prefix}/usr/local/lib64" \
     "${fhs_root_prefix}/usr/local/lib" \
     -name libcuda.so.1 \
-    -execdir pwd \; -quit 2>/dev/null || true)
+    -printf '%h\n' -quit 2>/dev/null || true)
 
   if [ -z "$SYSTEM_LIB_DIR" ]; then
     return 0

--- a/pkgdb/src/resolver/manifest-raw.cc
+++ b/pkgdb/src/resolver/manifest-raw.cc
@@ -310,6 +310,8 @@ from_json( const nlohmann::json & jfrom, Options & opts )
                 + value.dump() );
             }
         }
+      /* Not used within pkgdb */
+      else if ( key == "cuda-detection" ) { ; }
       else
         {
           throw InvalidManifestFileException(


### PR DESCRIPTION
## Proposed Changes

**feat: add options.cuda-detection to manifest**

Instead of the secret feature flag FLOX_FEATURES_ENV_ENABLE_CUDA, add
`options.cuda-detection` to the manifest to control the CUDA activation
script. Default to enabling CUDA if the flag is not set, which is change
in behavior since we currently default to false.

Add a `manifest()` function to the `Environment` trait to simplify
getting a typed manifest for an environment.

**fix(cuda): Stub cuda-detection in pkgdb**

To prevent this error:

    -- command failed --
    status : 1
    output (3 lines):
      ❌ ERROR: Failed to build environment.

      invalid manifest file: unrecognized manifest field 'options.cuda-detection'.
    --

I've made it a noop since we're not actually doing anything with the
manifest option within `pkgdb`. The value is checked and an environment
variable set within the Rust CLI.

**test(cuda): Integration test CUDA detection**

Add new integration tests for the existing CUDA detection functionality.

In the long term it would be preferable to observe the end-to-end
behaviour of using PyTorch on an actual GPU instance but we don't
currently have the CI setup to do so and we need to be careful about
limiting costs.

This runs with Matthew's idea of passing in an FHS root that we can
treat as a "sandbox" to stub system paths inside. I considered using
`chroot` (or similar) to do the same but it requires root, some hoop
jumping to work on MacOS, and I suspect even more hoop jumping to work
with Flox/Nix.

**fix(cuda): Fix detection in other dirs**

This fixes the last test which was failing. Previously the script, when
run with `set -e` from the test, would exit on find's non-zero exit code
if any of the preceding directories didn't exist.

So if `/run/opengl-drivers` didn't exist then we wouldn't check any of
the other system dirs. I couldn't see a `find` argument to do this so
I've had to catch any non-zero exit from `find`.

**fix(cuda): Allow detection to be disabled**

The test was failing because disabling support in the manifest doesn't
set the environment variable and we run the test with `set -eu`:

    /private/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.2zW1hI/bats-run-DaoeO3/test/3/project-3/.flox/run/aarch64-darwin.project-3/etc/profile.d/0800_cuda.sh: line 16: _FLOX_ENV_CUDA_DETECTION: unbound variable

**chore(cuda): Add to manifest template**

Add a commented entry to the manifest template so that users can easily
find the option if they run into any problems with CUDA detection.

It's a little bit odd to add a key that then has a prefix to comment it
out. It's possible that `toml_edit` could change this behaviour in the
future but:

- we have unit tests around it
- we're serialising it straight away and the deserialised version of
  that will pass it as a comment

The only other options I could find were:

- add the suffix to the `options` table which puts it above `systems`
  and I think that should still be more prominent
- add the suffix to the `systems` key which feels even odder

**chore(cuda): Add to manifest man page**

Describe what the option does and some light information on how it's
implemented. I didn't want to provide too much in case we change it and
forget to update the docs, or expose an interface that we later break.

**fix(cuda): Use -printf instead of -execdir**

The previous command failed the "enabled" tests when running within
"Flox Bats Tests" (but not Flox CLI Tests) on CI. Temporarily removing
the `2>/dev/null` showed this:

    # ++ /nix/store/zr6klxfjzpdr2674ly1f4fix7ig57mjr-findutils-4.9.0/bin/find /tmp/bats-run-3fms49/test/120/project-5/fake_fhs_root/run/opengl-drivers /tmp/bats-run-3fms49/test/120/project-5/fake_fhs_root/lib64 /tmp/bats-run-3fms49/test/120/project-5/fake_fhs_root/lib /tmp/bats-run-3fms49/test/120/project-5/fake_fhs_root/usr/lib64 /tmp/bats-run-3fms49/test/120/project-5/fake_fhs_root/usr/lib /tmp/bats-run-3fms49/test/120/project-5/fake_fhs_root/usr/local/lib64 /tmp/bats-run-3fms49/test/120/project-5/fake_fhs_root/usr/local/lib -name libcuda.so.1 -execdir pwd ';' -quit
    # find: The current directory is included in the PATH environment variable, which is insecure in combination with the -execdir action of find.  Please remove the current directory from your $PATH (that is, remove ".", doubled colons, or leading or trailing colons)
    # ++ true
    # + SYSTEM_LIB_DIR=

The format string is described as:

    %h     Dirname; the Leading directories of the file's name (all but the last element).  If the file name contains no slashes (since it is in the current directory) the %h specifier expands to `.'.
           For files which are themselves directories and contain a slash (including /), %h expands to the empty string.  See the EXAMPLES section for an example.

## Release Notes

Enables CUDA library detection by default.
This can be disabled by with a new `options.cuda-detection` entry in the manifest.