### PR TITLE
feat(edit, install): Impove error messages for remote commands.

### DIFF
--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -100,6 +100,7 @@ impl Install {
                 Create an environment with 'flox init' or install to an environment found elsewhere with 'flox install {} --dir <PATH>'",
                 self.packages.join(" ")})
             },
+            Err(EnvironmentSelectError::Anyhow(e)) => Err(e)?,
             Err(e) => Err(e)?,
         };
         let description = environment_description(&concrete_environment)?;

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -307,3 +307,18 @@ EOF
   assert_failure
   assert_output --partial "Environment not found in FloxHub."
 }
+
+# bats test_tags=remote,remote:not-found
+@test "edit --remote fails on a non existent environment" {
+  run "$FLOX_BIN" edit -r "$OWNER/i-dont-exist"
+  assert_failure
+  assert_output --partial "Environment not found in FloxHub."
+}
+
+
+# bats test_tags=remote,remote:not-found
+@test "install --remote fails on a non existent environment" {
+  run "$FLOX_BIN" install -r "$OWNER/i-dont-exist"
+  assert_failure
+  assert_output --partial "Environment not found in FloxHub."
+}


### PR DESCRIPTION
Improved error messages for remote environments, enhancing readability. This update affects the following commands:
* `flox edit --remote` for environments that were previously deleted or never existed
* `flox install --remote` for environments that were previously deleted or never existed

Users will now receive the error message "Environment not found in FloxHub" for all the cases listed above. 

This closes https://github.com/flox/product/issues/727
