### PR TITLE
chore(ci): Use ARM runner for MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-22.04-8core"
-          - "macos-latest-xl"
+          - "macos-14-xlarge"
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
@@ -113,7 +113,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-22.04-8core"
-          - "macos-latest-xl"
+          - "macos-14-xlarge"
 
     steps:
       - name: "Checkout"

--- a/cli/tests/floxhub-cross-systems.bats
+++ b/cli/tests/floxhub-cross-systems.bats
@@ -105,6 +105,9 @@ teardown() {
     x86_64-darwin)
       pull_system="x86_64-linux"
       ;;
+    aarch64-darwin)
+      pull_system="x86_64-linux"
+      ;;
     *)
       # we only run the above two systems consistently in CI
       skip "unsupported system: $NIX_SYSTEM"


### PR DESCRIPTION
## Proposed Changes

This is our slowest job in CI which has been using a MacOS 12 x86 runner. There are newer ARM64 runners available:

- https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

Changing this reduced the job time from 22m52s to 14m53s:

- https://github.com/flox/flox/actions/runs/9647806668/job/26607487916
- https://github.com/flox/flox/actions/runs/9648121868/job/26608534782

The difference in cost appears to be $0.14/min to $0.16/min which should also make it cheaper:

- https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-x64-powered-larger-runners
- https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-arm64-powered-larger-runners

## Release Notes

N/A