### PR TITLE
chore(pkgdb): realise.o depend on buildenv/assets

### DIFF
--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -182,6 +182,7 @@ HEADERS        = $(call rwildcard,include,*.hh)
 SRCS           = $(call rwildcard,src,*.cc)
 test_SRCS      = $(sort $(wildcard tests/*.cc))
 ALL_SRCS       = $(SRCS) $(test_SRCS)
+ASSETS         = $(shell find src/buildenv/assets -type f)
 BINS           = bin/pkgdb
 ifeq (Linux,$(OS))
 LIBS           = lib/ld-floxlib.so
@@ -618,6 +619,9 @@ src/pkgdb/scrape-rules.o: src/pkgdb/rules.json.hh
 
 # Make all `.o' files depend on all `include/**/*.hh' files.
 $(ALL_SRCS:.cc=.o): %.o: %.cc $(HEADERS)
+
+# Automatically pick up changes to embedded assets.
+src/buildenv/realise.o: $(ASSETS)
 
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

Ensure that any changes to the `buildenv/assets` directory trigger a rebuild of `realise.o`. This prevents some very confusing behaviour whereby the integration tests don't pick up changes to  the `profile.d` scripts.

The original problem is too laborious/tedious to reproduce but here's a demonstration that the rebuilding works correctly:

    (2) ~/projects/flox/flox on dcarley/pkgdb-rebuild-assets [$+]
    % just build-pkgdb
    make: Entering directory '/Users/dcarley/projects/flox/flox/pkgdb'
    mkdir -p tests;
    Generating tests/.gitignore
    make: Leaving directory '/Users/dcarley/projects/flox/flox/pkgdb'

    (2) ~/projects/flox/flox on dcarley/pkgdb-rebuild-assets [$+]
    % echo >> pkgdb/src/buildenv/assets/etc/profile.d/0800_cuda.sh

    (2) ~/projects/flox/flox on dcarley/pkgdb-rebuild-assets [$!+]
    % just build-pkgdb
    make: Entering directory '/Users/dcarley/projects/flox/flox/pkgdb'
    make: warning: undefined variable 'LOCALE_ARCHIVE'
    clang++  -Wall -Wextra -Wpedantic -Wno-gnu-zero-variadic-macro-arguments '-I/Users/dcarley/projects/flox/flox/pkgdb/include' '-DFLOX_PKGDB_VERSION=""' -isystem /nix/store/6qhw7sry9c5vq5h0qq5ywy3933zn8q9d-sqlite-3.43.2-dev/include -isystem /nix/store/iicn33f6ka01lhn85ny4kyl1g05km1l7-sqlite3pp-1.0.8/include -isystem /nix/store/q7h2n7f9bh4qiy98fld51cy6xmf2wn02-argparse-3.0/include -isystem /nix/store/1gxjmy1pifcmb7caf632gcl1fw3vf314-boost-1.81.0-dev/include -std=c++2a -isystem /nix/store/6djkkjsmyqblbwp8bfwn644b5mjd43ak-nix-2.17.1-dev/include -isystem /nix/store/5mk60n48w9g6jkx9lg6mb6bf9dbcy7c1-boehm-gc-8.2.2-dev/include -include /nix/store/6djkkjsmyqblbwp8bfwn644b5mjd43ak-nix-2.17.1-dev/include/nix/config.h -isystem /nix/store/0zajbyazps0zzwm3rifwx3nfa67dy2jb-nlohmann_json-3.11.2/include -isystem /nix/store/gpgw4xp5g6cycnixhjcq7prilajqq6cp-toml11-3.7.1/include -isystem /nix/store/d5clchfya9x4s72prkgi4wglaiwkkyf1-yaml-cpp-0.8.0/include -isystem /nix/store/nbdwcy5b2h5zyjlakrnmmp5f78nln2fn-cpp-semver-unstabble-2021-12-10/include '-DNIXPKGS_CACERT_BUNDLE_CRT="/nix/store/d9qdiyphispfjnyj9lb5kwrz144as3dm-nss-cacert-3.95/etc/ssl/certs/ca-bundle.crt"' '-DACTIVATE_PACKAGE_DIR="/nix/store/8dldls253avmhk85x8cmmv7k7ginwg5q-flox-activate"' '-DCONTAINER_BUILDER_PATH="/nix/store/mqlg8bq5j5731gsmw2v2mazsbxk6vgxd-mkContainer.nix"' '-DCOMMON_NIXPKGS_URL="github:NixOS/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd"' '-DFLOX_BASH_PKG="/nix/store/x1xxsh1gp6y389hyl40a0i74dkxiprl7-bash-5.2-p15"' '-DFLOX_CACERT_PKG="/nix/store/d9qdiyphispfjnyj9lb5kwrz144as3dm-nss-cacert-3.95"' '-DFLOX_LOCALE_ARCHIVE=""' '-DFLOX_PATH_LOCALE="/nix/store/3h3xsrfkadkm34f0316k18la5f1mchak-adv_cmds-119-locale/share/locale"' '-DFLOX_NIX_COREFOUNDATION_RPATH="/nix/store/7aiqcq3qjyy3cx3c2qafcv1q559hgbbc-apple-framework-CoreFoundation-11.0.0/Library/Frameworks"'   -c -o src/buildenv/realise.o src/buildenv/realise.cc
    mkdir -p tests;
    Generating tests/.gitignore
    mkdir -p bin;
    clang++ src/buildenv/buildenv.o src/buildenv/command.o src/buildenv/realise.o src/command.o src/eval.o src/exceptions.o src/expr.o src/fetchers/wrapped-nixpkgs-input.o src/flake-package.o src/flox-flake.o src/logger.o src/main.o src/metrics.o src/nix-state.o src/package.o src/parse/command.o src/pkgdb/command.o src/pkgdb/db-package.o src/pkgdb/gc.o src/pkgdb/get.o src/pkgdb/input.o src/pkgdb/list.o src/pkgdb/pkg-query.o src/pkgdb/primops.o src/pkgdb/read.o src/pkgdb/scrape-rules.o src/pkgdb/scrape.o src/pkgdb/write.o src/raw-package.o src/registry.o src/repl.o src/resolver/command.o src/resolver/descriptor.o src/resolver/environment.o src/resolver/lockfile.o src/resolver/manifest-raw.o src/resolver/manifest.o src/resolver/mixins.o src/resolver/primops.o src/search/command.o src/search/params.o src/tomlToJSON.o src/util.o src/versions.o src/yamlToJSON.o  -L/nix/store/wf28dxas0i3m27r4az6ppcs4z9syi2yv-nix-2.17.1/lib -L/nix/store/niqwvp0bvmqyxwk81lijvr3z0d35vhzv-boehm-gc-8.2.2/lib -lnixmain -lnixcmd -lnixexpr -lgc -lpthread -lnixstore -lnixutil -lnixfetchers -L/nix/store/kvblyyd48myv9gslk5w06w614flzx5kr-sqlite-3.43.2/lib -lsqlite3 -L/nix/store/d5clchfya9x4s72prkgi4wglaiwkkyf1-yaml-cpp-0.8.0/lib -lyaml-cpp -o bin/pkgdb;
    make: Leaving directory '/Users/dcarley/projects/flox/flox/pkgdb'
    
    (2) ~/projects/flox/flox on dcarley/pkgdb-rebuild-assets [$!+] took 5s
    % just build-pkgdb
    make: Entering directory '/Users/dcarley/projects/flox/flox/pkgdb'
    mkdir -p tests;
    Generating tests/.gitignore
    make: Leaving directory '/Users/dcarley/projects/flox/flox/pkgdb'

## Release Notes

N/A