### PR TITLE
feat: bundle process-compose for services

### DIFF
--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -1,2 +1,3 @@
 pub mod catalog;
 pub mod git;
+pub mod services;

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -1,0 +1,7 @@
+use std::env;
+
+use once_cell::sync::Lazy;
+
+pub static PROCESS_COMPOSE_BIN: Lazy<String> = Lazy::new(|| {
+    env::var("PROCESS_COMPOSE_BIN").unwrap_or(env!("PROCESS_COMPOSE_BIN").to_string())
+});

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -51,3 +51,9 @@ teardown() {
   RUST_LOG=flox=debug FLOX_FEATURES_SERVICES=true run "$FLOX_BIN" init
   assert_output --partial "service management enabled"
 }
+
+@test "can call process-compose" {
+  run "$PROCESS_COMPOSE_BIN" version
+  assert_success
+  assert_output --partial "v1.6.1"
+}

--- a/flake.lock
+++ b/flake.lock
@@ -128,6 +128,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-process-compose": {
+      "locked": {
+        "lastModified": 1719406840,
+        "narHash": "sha256-f28HAjj6t6Uioe6KavnYvTC63VzO8+leRqRSIZM9qUU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a67ad0452b1ecd013ed3c0e2d4a50cabca396db7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1685801374,
@@ -174,6 +190,7 @@
         "fenix": "fenix",
         "nixpkgs": "nixpkgs",
         "nixpkgs-bear": "nixpkgs-bear",
+        "nixpkgs-process-compose": "nixpkgs-process-compose",
         "pre-commit-hooks": "pre-commit-hooks",
         "sqlite3pp": "sqlite3pp"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
   # drop once bear is no longer broken in a newer release
   inputs.nixpkgs-bear.url = "github:NixOS/nixpkgs/release-23.05";
 
+  inputs.nixpkgs-process-compose.url = "github:NixOS/nixpkgs/release-24.05";
+
   inputs.sqlite3pp.url = "github:aakropotkin/sqlite3pp";
   inputs.sqlite3pp.inputs.nixpkgs.follows = "nixpkgs";
 
@@ -90,6 +92,11 @@
       inherit (inputs.nixpkgs-bear.legacyPackages.${prev.system}) bear;
     };
 
+    # Use a more recent version of process-compose
+    overlays.process-compose = final: prev: {
+      inherit (inputs.nixpkgs-process-compose.legacyPackages.${prev.system}) process-compose;
+    };
+
     # Aggregates all external dependency overlays before adding any of the
     # packages defined by this flake.
     overlays.deps = nixpkgs.lib.composeManyExtensions [
@@ -97,6 +104,7 @@
       overlays.semver
       overlays.nix
       overlays.bear
+      overlays.process-compose
       sqlite3pp.overlays.default
       fenix.overlays.default
     ];

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -31,6 +31,7 @@
   unixtools,
   which,
   writeShellScriptBin,
+  process-compose,
   GENERATED_DATA ? ./../../test_data/generated,
   INPUT_DATA ? ./../../test_data/input_data,
   PROJECT_NAME ? "flox-cli-tests",
@@ -71,6 +72,7 @@
       unixtools.util-linux
       which
       yq
+      process-compose
     ]
     # TODO: this hack is not going to be needed once we test against sutff on system
     ++ lib.optional stdenv.isDarwin (
@@ -155,6 +157,7 @@ in
       then "export FLOX_BIN='flox';"
       else "export FLOX_BIN='${FLOX_BIN}';"
     }
+    export PROCESS_COMPOSE_BIN='${process-compose}/bin/process-compose';
 
     usage() {
           cat << EOF

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -19,6 +19,7 @@
   rustfmt ? rust-toolchain.rustfmt,
   targetPlatform,
   zlib,
+  process-compose,
 }: let
   FLOX_VERSION = lib.fileContents ./../../VERSION;
 
@@ -62,6 +63,7 @@
         then "ld-floxlib.so"
         else "${flox-pkgdb}/lib/ld-floxlib.so";
       FLOX_ZDOTDIR = ../../pkgdb/src/buildenv/assets/activate.d/zdotdir;
+      PROCESS_COMPOSE_BIN = "${process-compose}/bin/process-compose";
 
       # bundling of internally used nix scripts
       FLOX_RESOLVER_SRC = builtins.path {path = ../../resolver;};
@@ -195,7 +197,9 @@ in
           flox-pkgdb
           ;
 
-        ciPackages = [];
+        ciPackages = [
+          process-compose
+        ];
 
         devPackages = [
           rustfmt

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -7,6 +7,7 @@
   flox-pkgdb,
   flox-cli,
   flox-manpages,
+  process-compose,
   SENTRY_DSN ? null,
   SENTRY_ENV ? null,
   FLOX_VERSION ? null,
@@ -35,6 +36,7 @@ in
         --set PKGDB_BIN       "${flox-pkgdb}/bin/pkgdb" \
         --set LD_FLOXLIB      "${flox-pkgdb}/lib/ld-floxlib.so" \
         --set FLOX_BIN        "${flox-cli}/bin/flox" \
+        --set PROCESS_COMPOSE_BIN "${process-compose}/bin/process-compose" \
         --set FLOX_VERSION    "${version}"
     '';
   }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Adds process-compose to `flake.nix` and `flox` so that we can call it for service commands.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
