### PR TITLE
feat: mention env vars and hooks after init

### DIFF
--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -207,6 +207,7 @@ impl Init {
               $ flox search <package>    <- Search for a package
               $ flox install <package>   <- Install a package into an environment
               $ flox activate            <- Enter the environment
+              $ flox edit                <- Add environment variables and shell hooks
             "
         });
         Ok(())

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -89,6 +89,7 @@ Next:
   $ flox search <package>    <- Search for a package
   $ flox install <package>   <- Install a package into an environment
   $ flox activate            <- Enter the environment
+  $ flox edit                <- Add environment variables and shell hooks
 EOF
 
 }


### PR DESCRIPTION
After a flox init, include a mention of using flox edit to set env vars and shell hooks. Users have been surprised and excited when they discover this functionality exists, so give a hint about it so they find it.