### PR TITLE
chore(manpages): Make available in devShell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,6 +358,12 @@ subsets of tests.
 See the [bats usage documentation](https://bats-core.readthedocs.io/en/stable/usage.html)
 for details.
 
+## Man Pages
+
+Unreleased changes to `man` pages are available from the `nix develop` shell but
+you will need to restart the shell or call `direnv reload` to pick up new
+changes.
+
 ## Rust Style Guidelines
 
 - In general, structs should derive `Clone` and `Debug`.

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -13,6 +13,7 @@
   flox-cli,
   flox-cli-tests,
   flox-pkgdb,
+  flox-manpages,
   ci ? false,
   GENERATED_DATA ? ./../../test_data/generated,
 }: let
@@ -60,7 +61,10 @@ in
       shellHook =
         flox-pkgdb.devShellHook
         + flox-cli.devShellHook
-        + pre-commit-check.shellHook;
+        + pre-commit-check.shellHook
+        + ''
+          export MANPATH=${flox-manpages}/share/man:$MANPATH
+        '';
 
       inherit GENERATED_DATA;
     }


### PR DESCRIPTION
## Proposed Changes

So that we can see rendered changes when not using an installer.

Before:

    (2) ~/projects/flox/flox on HEAD (353d4213) [$]
    % man -w manifest.toml
    /run/current-system/sw/share/man/man5/manifest.toml.5
    (2) ~/projects/flox/flox on HEAD (353d4213) [$]
    % man manifest.toml | tail -n16
                  installed and appear in search results.  The default is false.

          allow.licenses
                  A whitelist of software licenses to allow in search results in
                  installs.  Valid entries are SPDX Identifiers
                  <https://spdx.org/licenses>.

          semver.allow-pre-releases
                  Whether to allow pre-release software for package installations.
                  The default is false.  Setting this value to true would allow a
                  package version 4.2.0-pre rather than 4.1.9.

    SEE ALSO
          flox-init(1), flox-install(1), flox-edit(1)

                                                                  MANIFEST.TOML(5)

After:

    (2) ~/projects/flox/flox on dcarley/1631-manpages-in-devshell [$>]
    % man -w manifest.toml
    /nix/store/zla2ag33x482z8alpm9gsmb2dl8szdja-flox-manpages/share/man/man5/manifest.toml.5
    (2) ~/projects/flox/flox on dcarley/1631-manpages-in-devshell [$>]
    % man manifest.toml | tail -n16
           semver.allow-pre-releases
                  Whether to allow pre-release software for package installations.
                  The default is false.  Setting this value to true would allow a
                  package version 4.2.0-pre rather than 4.1.9.

           cuda-detection
                  Whether to detect CUDA libraries and provide them to the
                  environment.  The default is true.  When enabled, Flox will
                  detect if you have an Nvidia device and attempt to locate
                  libcuda in well-known paths.  Then it will symlink the libraries
                  into .flox/lib and add that path to FLOX_ENV_LIB_DIRS.

    SEE ALSO
           flox-init(1), flox-install(1), flox-edit(1)

                                                                  MANIFEST.TOML(5)

TIL: `man` also constructs its search paths based on `PATH` which is how the man pages for other Nix packages become available, at least on MacOS:

    % man -d manifest.toml
    -- Using pager: less -R
    --   Adding /Users/dcarley/.cache/flox/remote/dcarley/shell/.flox/run/share/man to manpath
    -- Searching PATH for man directories
    --   Adding /nix/store/2jwdy3fbd5qv3l6aq9pi92x9glk8ccsp-kitty-0.35.0/share/man to manpath
    --   Adding /nix/store/rwxlnia132w0g8qwss573r2fv7mnc0hi-imagemagick-7.1.1-32/share/man to manpath
    --   Adding /run/current-system/sw/share/man to manpath
    --   Adding /nix/var/nix/profiles/default/share/man to manpath
    --   Adding /usr/share/man to manpath
    --   Adding /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/share/man to manpath
    --   Adding /Library/Developer/CommandLineTools/usr/share/man to manpath
    -- Adding default manpath entries
    -- Parsing config file: /etc/man.conf
    -- Using manual path: /Users/dcarley/.cache/flox/remote/dcarley/shell/.flox/run/share/man:/nix/store/2jwdy3fbd5qv3l6aq9pi92x9glk8ccsp-kitty-0.35.0/share/man:/nix/store/rwxlnia132w0g8qwss573r2fv7mnc0hi-imagemagick-7.1.1-32/share/man:/run/current-system/sw/share/man:/nix/var/nix/profiles/default/share/man:/usr/share/man:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/share/man:/Library/Developer/CommandLineTools/usr/share/man
    -- Using manual sections: 1:1p:8:2:3:3p:4:5:6:7:9:0p:tcl:n:l:p:o
    -- Using locale paths: en_GB.UTF-8:en.UTF-8:.
    -- Using non-standard page width: 211
    -- Searching for manifest.toml
    --     Found manpage /run/current-system/sw/share/man/man5/manifest.toml.5
    --     Skipping catpage: non-standard page width
    -- Command: cd "/run/current-system/sw/share/man" && /usr/bin/zcat -f "/run/current-system/sw/share/man/man5/manifest.toml.5" | /usr/bin/mandoc -O width=211 | less -R

## Release Notes

N/A