### PR TITLE
chore(utils): Narrow down sysinfo data

### DIFF
--- a/cli/flox/src/utils/openers.rs
+++ b/cli/flox/src/utils/openers.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use anyhow::{anyhow, Context, Result};
 use itertools::Itertools;
 use log::debug;
-use sysinfo::{Pid, System};
+use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System, UpdateKind};
 
 const OPENERS: &[&str] = &["xdg-open", "gnome-open", "kde-open"];
 
@@ -140,8 +140,9 @@ impl Shell {
 }
 
 fn get_parent_process_exe() -> Result<PathBuf> {
-    // todo: we can narrow down the amount of data collected by sysinfo, for now collect everything
-    let system = System::new_all();
+    let refresh_exe = ProcessRefreshKind::new().with_exe(UpdateKind::Always);
+    let refresh_procs = RefreshKind::new().with_processes(refresh_exe);
+    let system = System::new_with_specifics(refresh_procs);
 
     let parent_process = system
         .process(Pid::from_u32(std::os::unix::process::parent_id()))


### PR DESCRIPTION
## Proposed Changes

Fix the TODO by only populating the process `exe` data that we need. The unit test would fail if the function is changed in the future to access other data that is no longer populated.

This work was prioritised because we had previously observed this test to be slow:

   > just unit-tests test_get_parent_process_exe
   ...
   running 1 test
   test utils::openers::tests::test_get_parent_process_exe ... ok

   test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 1.70s

However I haven't been able to reproduce it (on an M3 Mac) and this change doesn't appear to have made any appreciable difference to the runtime:

Before:

    (2) ~/projects/flox/flox/cli on HEAD (82e818fa) [$]
    % nix run 'nixpkgs#hyperfine' -- --runs=100 --warmup=2 'cargo test tests::test_get_parent_process_exe'
    Benchmark 1: cargo test tests::test_get_parent_process_exe
      Time (mean ± σ):     140.1 ms ±   3.4 ms    [User: 88.7 ms, System: 55.6 ms]
      Range (min … max):   133.1 ms … 158.4 ms    100 runs

      Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

After:

    (2) ~/projects/flox/flox/cli on dcarley/1410-get-parent-process-exe [$>]
    % nix run 'nixpkgs#hyperfine' -- --runs=100 --warmup=2 'cargo test tests::test_get_parent_process_exe'
    Benchmark 1: cargo test tests::test_get_parent_process_exe
      Time (mean ± σ):     136.8 ms ±   4.5 ms    [User: 80.9 ms, System: 54.4 ms]
      Range (min … max):   130.8 ms … 171.9 ms    100 runs

      Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Worth noting that in order to match the original reproduction:

- I'm measuring cargo test so that it's not sharing any state between runs
- I haven't switched to cargo-nextest as Matthew's run predated that
- I did add a two pre-runs to exclude any building in a reproducible way

## Release Notes

N/A, because we don't expect this to have a noticeable effect.