### PR TITLE
fix: skip_serializing_none for manifest and lock

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -3,6 +3,7 @@ use indent::{indent_all_by, indent_by};
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use serde_with::skip_serializing_none;
 
 pub type FlakeRef = Value;
 
@@ -159,6 +160,7 @@ pub struct LockedManifestCatalog {
     pub packages: Vec<LockedPackageCatalog>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct LockedPackageCatalog {

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -6,6 +6,7 @@ use indoc::{formatdoc, indoc};
 use log::debug;
 use serde::de::Error;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use toml_edit::{self, Array, DocumentMut, Formatted, InlineTable, Item, Key, Table, Value};
 
 use super::environment::path_environment::InitCustomization;
@@ -483,6 +484,7 @@ fn pkg_belongs_to_non_empty_toplevel_group(
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ManifestInstall(BTreeMap<String, ManifestPackageDescriptor>);
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
@@ -521,6 +523,7 @@ impl ManifestPackageDescriptor {
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ManifestVariables(BTreeMap<String, String>);
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
@@ -531,6 +534,7 @@ pub struct ManifestHook {
     on_activate: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(deny_unknown_fields)]
@@ -547,6 +551,7 @@ pub struct ManifestProfile {
     tcsh: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
@@ -563,6 +568,7 @@ pub struct ManifestOptions {
     pub cuda_detection: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(deny_unknown_fields)]
@@ -576,6 +582,7 @@ pub struct Allows {
     pub licenses: Vec<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]


### PR DESCRIPTION
Add `skip_serializing_none` to types for the manifest and lock.

Currently, if a newer version of flox has an optional field, if an environment is locked, the field is put as null in the lockfile. If an older version of flox without that field attempts to edit the environment, it will throw an error, e.g:
```
❌ ERROR: unrecognized manifest field 'options.cuda-detection'
```

Since serializing null doesn't gain us anything, we might as well skip it. It will also make lockfiles slightly smaller.