### PR TITLE
feat: build flox-activate package distinct from flox-pkgdb

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,7 @@
       GENERATED_DATA = ./test_data/generated;
 
       # Package activation scripts.
-      flox-activate = callPackage ./pkgs/flox-activate {};
+      flox-activation-scripts = callPackage ./pkgs/flox-activation-scripts {};
 
       # Customized `gh' executable used for auth.
       flox-gh = callPackage ./pkgs/flox-gh {};
@@ -233,7 +233,7 @@
     in {
       inherit
         (pkgs)
-        flox-activate
+        flox-activation-scripts
         flox-gh
         flox-pkgdb
         flox-cli

--- a/flake.nix
+++ b/flake.nix
@@ -175,6 +175,9 @@
 
       GENERATED_DATA = ./test_data/generated;
 
+      # Package activation scripts.
+      flox-activate = callPackage ./pkgs/flox-activate {};
+
       # Customized `gh' executable used for auth.
       flox-gh = callPackage ./pkgs/flox-gh {};
 
@@ -230,6 +233,7 @@
     in {
       inherit
         (pkgs)
+        flox-activate
         flox-gh
         flox-pkgdb
         flox-cli

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -153,8 +153,7 @@ VERSION := $(file < $(PKGDB_ROOT)/.version)
 # pkgs/flox-pkgdb/default.nix, but if working in a `nix develop' shell
 # then run `unset ACTIVATE_PACKAGE_DIR' to regenerate the package with
 # each build.
-ACTIVATE_PACKAGE_DIR ?= $(shell \
-  $(NIX) store add-path -n flox-activate src/buildenv/assets)
+ACTIVATE_PACKAGE_DIR ?= $(shell $(NIX) build --print-out-paths .#flox-activate)
 
 # The reference to CONTAINER_BUILDER_PATH in realise.cc requires that
 # libexec/mkContainer.nix be rendered as a single-file package in the

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -149,11 +149,12 @@ endif  # ifndef TOOLCHAIN
 VERSION := $(file < $(PKGDB_ROOT)/.version)
 
 # Files used by `pkgdb buildenv' need to be added to the `nix' store.
-# WARNING: the flox-activate package is normally created from within
-# pkgs/flox-pkgdb/default.nix, but if working in a `nix develop' shell
-# then run `unset ACTIVATE_PACKAGE_DIR' to regenerate the package with
-# each build.
-ACTIVATE_PACKAGE_DIR ?= $(shell $(NIX) build --print-out-paths .#flox-activate)
+# WARNING: the flox-activation-scripts package is normally created from
+# within pkgs/flox-pkgdb/default.nix, but if working in a `nix develop'
+# shell then run `unset ACTIVATION_SCRIPTS_PACKAGE_DIR' to regenerate
+# the package with each build.
+ACTIVATION_SCRIPTS_PACKAGE_DIR ?= \
+  $(shell $(NIX) build --print-out-paths .#flox-activation-scripts)
 
 # The reference to CONTAINER_BUILDER_PATH in realise.cc requires that
 # libexec/mkContainer.nix be rendered as a single-file package in the
@@ -364,7 +365,7 @@ endif # ifeq (Linux,$(OS))
 # ------------------------
 
 src/buildenv/realise.o: CXXFLAGS +=               \
-	'-DACTIVATE_PACKAGE_DIR="$(ACTIVATE_PACKAGE_DIR)"'
+	'-DACTIVATION_SCRIPTS_PACKAGE_DIR="$(ACTIVATION_SCRIPTS_PACKAGE_DIR)"'
 
 src/buildenv/realise.o: CXXFLAGS +=               \
 	'-DCONTAINER_BUILDER_PATH="$(CONTAINER_BUILDER_PATH)"'

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -39,8 +39,8 @@ namespace flox::buildenv {
 
 /* -------------------------------------------------------------------------- */
 
-#ifndef ACTIVATE_PACKAGE_DIR
-#  error "ACTIVATE_PACKAGE_DIR must be set to the path of `activate.d'"
+#ifndef ACTIVATION_SCRIPTS_PACKAGE_DIR
+#  error "ACTIVATION_SCRIPTS_PACKAGE_DIR must be set"
 #endif
 
 #ifndef CONTAINER_BUILDER_PATH
@@ -597,7 +597,7 @@ addScriptToScriptsDir( const std::string &           scriptContents,
                        const std::filesystem::path & scriptsDir,
                        const std::string &           scriptName )
 {
-  /* Ensure that the "activate.d" subdirectory exists. */
+  /* Ensure that the activation scripts "activate.d" subdirectory exists. */
   std::filesystem::create_directories( scriptsDir / ACTIVATION_SUBDIR_NAME );
 
   /* Write the script to a temporary file. */
@@ -753,7 +753,8 @@ makeActivationScripts( nix::EvalState &              state,
                             buildenv::Priority() );
   auto            references = nix::StorePathSet();
   references.insert( activationStorePath );
-  references.insert( state.store->parseStorePath( ACTIVATE_PACKAGE_DIR ) );
+  references.insert(
+    state.store->parseStorePath( ACTIVATION_SCRIPTS_PACKAGE_DIR ) );
   references.insert( state.store->parseStorePath( FLOX_BASH_PKG ) );
   references.insert( state.store->parseStorePath( FLOX_CACERT_PKG ) );
 
@@ -769,14 +770,15 @@ makeActivationScripts( nix::EvalState &              state,
  * package.
  */
 static std::pair<buildenv::RealisedPackage, nix::StorePath>
-makeActivatePackageDir( nix::EvalState & state )
+makeActivationScriptsPackageDir( nix::EvalState & state )
 {
-  /* Insert profile.d scripts.
+  /* Insert activation scripts.
    * The store path is provided at compile time via the
-   * `ACTIVATE_PACKAGE_DIR' environment variable. */
-  debugLog(
-    nix::fmt( "adding 'activate.d' to store, path=%s", ACTIVATE_PACKAGE_DIR ) );
-  auto profileScriptsPath = state.store->parseStorePath( ACTIVATE_PACKAGE_DIR );
+   * `ACTIVATION_SCRIPTS_PACKAGE_DIR' environment variable. */
+  debugLog( nix::fmt( "adding activation scripts to store, path=%s",
+                      ACTIVATION_SCRIPTS_PACKAGE_DIR ) );
+  auto profileScriptsPath
+    = state.store->parseStorePath( ACTIVATION_SCRIPTS_PACKAGE_DIR );
   state.store->ensurePath( profileScriptsPath );
   RealisedPackage realised( state.store->printStorePath( profileScriptsPath ),
                             true,
@@ -833,7 +835,7 @@ createFloxEnv( nix::ref<nix::EvalState> & state,
 
 
   auto [profileScriptsPath, profileScriptsReference]
-    = makeActivatePackageDir( *state );
+    = makeActivationScriptsPackageDir( *state );
 
   pkgs.push_back( profileScriptsPath );
   references.insert( profileScriptsReference );

--- a/pkgs/flox-activate/default.nix
+++ b/pkgs/flox-activate/default.nix
@@ -1,0 +1,40 @@
+{
+  bash,
+  coreutils,
+  findutils,
+  gnused,
+  runCommand,
+  shellcheck,
+}:
+runCommand "flox-activate" {
+  buildInputs = [bash coreutils gnused];
+} ''
+  cp -R ${../../pkgdb/src/buildenv/assets} $out
+
+  substituteInPlace $out/activate \
+    --replace "@coreutils@" "${coreutils}" \
+    --replace "@gnused@" "${gnused}" \
+    --replace "@out@" "$out" \
+    --replace "/usr/bin/env bash" "${bash}/bin/bash"
+
+  substituteInPlace $out/activate.d/bash \
+    --replace "@gnused@" "${gnused}"
+  substituteInPlace $out/activate.d/fish \
+    --replace "@gnused@" "${gnused}"
+  substituteInPlace $out/activate.d/tcsh \
+    --replace "@gnused@" "${gnused}"
+  substituteInPlace $out/activate.d/zsh \
+    --replace "@gnused@" "${gnused}"
+
+  for i in $out/etc/profile.d/*; do
+    substituteInPlace $i --replace "@coreutils@" "${coreutils}"
+    substituteInPlace $i --replace "@gnused@" "${gnused}"
+    substituteInPlace $i --replace "@findutils@" "${findutils}"
+  done
+
+  ${shellcheck}/bin/shellcheck \
+    $out/activate \
+    $out/activate.d/bash \
+    $out/activate.d/set-prompt.bash \
+    $out/etc/profile.d/*
+''

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -6,7 +6,7 @@
   runCommand,
   shellcheck,
 }:
-runCommand "flox-activate" {
+runCommand "flox-activation-scripts" {
   buildInputs = [bash coreutils gnused];
 } ''
   cp -R ${../../pkgdb/src/buildenv/assets} $out

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -2,7 +2,7 @@
   cacert,
   darwin,
   rust-toolchain,
-  flox-activate,
+  flox-activation-scripts,
   flox-pkgdb,
   gitMinimal,
   glibcLocalesUtf8,
@@ -63,7 +63,7 @@
         if flox-pkgdb == null
         then "ld-floxlib.so"
         else "${flox-pkgdb}/lib/ld-floxlib.so";
-      FLOX_ZDOTDIR = flox-activate + activate.d/zdotdir;
+      FLOX_ZDOTDIR = flox-activation-scripts + activate.d/zdotdir;
       PROCESS_COMPOSE_BIN = "${process-compose}/bin/process-compose";
 
       # bundling of internally used nix scripts

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -2,6 +2,7 @@
   cacert,
   darwin,
   rust-toolchain,
+  flox-activate,
   flox-pkgdb,
   gitMinimal,
   glibcLocalesUtf8,
@@ -62,7 +63,7 @@
         if flox-pkgdb == null
         then "ld-floxlib.so"
         else "${flox-pkgdb}/lib/ld-floxlib.so";
-      FLOX_ZDOTDIR = ../../pkgdb/src/buildenv/assets/activate.d/zdotdir;
+      FLOX_ZDOTDIR = flox-activate + activate.d/zdotdir;
       PROCESS_COMPOSE_BIN = "${process-compose}/bin/process-compose";
 
       # bundling of internally used nix scripts

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -10,6 +10,7 @@
   cacert,
   ccls,
   clang-tools_16,
+  flox-activate,
   include-what-you-use,
   lcov,
   nix,
@@ -63,39 +64,7 @@
       };
 
       # Used by `buildenv' to install the activation package.
-      ACTIVATE_PACKAGE_DIR =
-        runCommand "flox-activate" {
-          buildInputs = [bash coreutils gnused];
-        } ''
-          cp -R ${../../pkgdb/src/buildenv/assets} $out
-
-          substituteInPlace $out/activate \
-            --replace "@coreutils@" "${coreutils}" \
-            --replace "@gnused@" "${gnused}" \
-            --replace "@out@" "$out" \
-            --replace "/usr/bin/env bash" "${bash}/bin/bash"
-
-          substituteInPlace $out/activate.d/bash \
-            --replace "@gnused@" "${gnused}"
-          substituteInPlace $out/activate.d/fish \
-            --replace "@gnused@" "${gnused}"
-          substituteInPlace $out/activate.d/tcsh \
-            --replace "@gnused@" "${gnused}"
-          substituteInPlace $out/activate.d/zsh \
-            --replace "@gnused@" "${gnused}"
-
-          for i in $out/etc/profile.d/*; do
-            substituteInPlace $i --replace "@coreutils@" "${coreutils}"
-            substituteInPlace $i --replace "@gnused@" "${gnused}"
-            substituteInPlace $i --replace "@findutils@" "${findutils}"
-          done
-
-          ${shellcheck}/bin/shellcheck \
-            $out/activate \
-            $out/activate.d/bash \
-            $out/activate.d/set-prompt.bash \
-            $out/etc/profile.d/*
-        '';
+      ACTIVATE_PACKAGE_DIR = flox-activate;
 
       # Packages required for the (bash) activate script.
       FLOX_BASH_PKG = bash;

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -63,9 +63,6 @@
         path = ../../pkgdb/src/libexec/mkContainer.nix;
       };
 
-      # Used by `buildenv' to install the activation package.
-      ACTIVATE_PACKAGE_DIR = flox-activate;
-
       # Packages required for the (bash) activate script.
       FLOX_BASH_PKG = bash;
       FLOX_CACERT_PKG = cacert;
@@ -149,7 +146,7 @@ in
       configurePhase = ''
         runHook preConfigure;
         export PREFIX="$out";
-        echo "ACTIVATE_PACKAGE_DIR: $ACTIVATE_PACKAGE_DIR" >&2;
+        export ACTIVATE_PACKAGE_DIR="${flox-activate}";
         if [[ "''${enableParallelBuilding:-1}" = 1 ]]; then
           makeFlagsArray+=( "-j''${NIX_BUILD_CORES:?}" );
         fi

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -145,8 +145,8 @@ in
 
       configurePhase = ''
         runHook preConfigure;
-        export PREFIX="$out";
-        export ACTIVATE_PACKAGE_DIR="${flox-activate}";
+        makeFlagsArray+=( "PREFIX=$out" );
+        makeFlagsArray+=( "ACTIVATE_PACKAGE_DIR=${flox-activate}" );
         if [[ "''${enableParallelBuilding:-1}" = 1 ]]; then
           makeFlagsArray+=( "-j''${NIX_BUILD_CORES:?}" );
         fi

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -10,7 +10,7 @@
   cacert,
   ccls,
   clang-tools_16,
-  flox-activate,
+  flox-activation-scripts,
   include-what-you-use,
   lcov,
   nix,
@@ -146,7 +146,7 @@ in
       configurePhase = ''
         runHook preConfigure;
         makeFlagsArray+=( "PREFIX=$out" );
-        makeFlagsArray+=( "ACTIVATE_PACKAGE_DIR=${flox-activate}" );
+        makeFlagsArray+=( "ACTIVATION_SCRIPTS_PACKAGE_DIR=${flox-activation-scripts}" );
         if [[ "''${enableParallelBuilding:-1}" = 1 ]]; then
           makeFlagsArray+=( "-j''${NIX_BUILD_CORES:?}" );
         fi


### PR DESCRIPTION
## Proposed Changes

The activation package was previously assembled at build time from a set of static files (etc-profiles) and other scripts created by pkgdb, then it evolved into a set of static files with package path substitutions performed at Nix build time. This introduced the wrinkle that changes to the flox-activate package could not be picked up without having to exit and re-enter the `nix develop` shell.

This change splits out the flox-activate package as distinct from flox-pkgdb so that the package can be quickly re-rendered with an invocation of `nix build`. It then updates the Makefile, flox-pkgdb and flox-cli builds to use the files from this package.

## Release Notes

N/A