### PR TITLE
build: remove unneeded runtime buildInputs

### DIFF
--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -1,7 +1,6 @@
 {
   cacert,
   darwin,
-  rust-toolchain,
   flox-activation-scripts,
   flox-pkgdb,
   gitMinimal,
@@ -11,16 +10,14 @@
   inputs,
   installShellFiles,
   lib,
-  libgit2,
-  libssh2,
   nix,
   openssl,
   pkg-config,
   pkgsFor,
+  process-compose,
+  rust-toolchain,
   rustfmt ? rust-toolchain.rustfmt,
   targetPlatform,
-  zlib,
-  process-compose,
 }: let
   FLOX_VERSION = lib.fileContents ./../../VERSION;
 
@@ -120,18 +117,16 @@
     # runtime dependencies of the dependent crates
     buildInputs =
       [
-        openssl.dev # octokit -> hyper -> ssl
-        zlib # git2
-        libssh2 # git2
-        libgit2 # git2
+        # reqwest -> hyper -> openssl-sys
+        openssl.dev
       ]
       ++ lib.optional hostPlatform.isDarwin [
-        darwin.apple_sdk.frameworks.Security # git2 (and others)
+        darwin.libiconv
         darwin.apple_sdk.frameworks.SystemConfiguration
       ];
 
     nativeBuildInputs = [
-      pkg-config # for openssl
+      pkg-config
     ];
 
     inherit (envs) LIBSSH2_SYS_USE_PKG_CONFIG;


### PR DESCRIPTION
Removed runtime libraries no longer required by our rust build.

* `zlib, libssh2, libgit2, darwin.apple_sdk.frameworks.Security`: we no longer use the git2 crate
* add `libiconv` on macos which seems to have been provided by libgit2 before