### PR TITLE
test: re-enable test for broken packages

### DIFF
--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -244,11 +244,28 @@ teardown() {
 }
 
 @test "'flox install' warns about broken packages" {
-  skip "waiting for broken packages to be added to catalog"
   "$FLOX_BIN" init
-  run "$FLOX_BIN" install TODO
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/tabula.json" \
+    run "$FLOX_BIN" install tabula
+  assert_failure
+  assert_line --partial "The package 'tabula' is marked as broken"
+}
+
+@test "'flox install' can build a broken package when allowed" {
+  "$FLOX_BIN" init
+  MANIFEST_CONTENT="$(cat << "EOF"
+    version = 1
+    [options]
+    allow.broken = true
+EOF
+  )"
+
+  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/tabula_allowed.json" \
+    run "$FLOX_BIN" install tabula
   assert_success
-  assert_line --partial "The package 'TODO' is marked as broken, it may not behave as expected during runtime"
+  assert_line --partial "The package 'tabula' is marked as broken, it may not behave as expected during runtime"
+  assert_line --partial "✅ 'tabula' installed to environment"
 }
 
 @test "resolution message: single package not found, without curation" {

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -163,7 +163,7 @@ cmd = "flox install rubyPackages_3_2.rails"
 [resolve.tabula]
 pre_cmd = "flox init"
 cmd = "flox install tabula"
-ignore_cmd_errors = true # tabula is unfree
+ignore_cmd_errors = true # tabula is broken
 
 # resolve.tabula_allowed is likely redundant and at least for the time being
 # generates the same JSON as resolve.tabula.

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -160,6 +160,22 @@ cmd = "flox install python311Packages.pip"
 pre_cmd = "flox init"
 cmd = "flox install rubyPackages_3_2.rails"
 
+[resolve.tabula]
+pre_cmd = "flox init"
+cmd = "flox install tabula"
+ignore_cmd_errors = true # tabula is unfree
+
+# resolve.tabula_allowed is likely redundant and at least for the time being
+# generates the same JSON as resolve.tabula.
+# But broken is included in the resolution request,
+# so include it here in case the server changes behavior.
+[resolve.tabula_allowed]
+pre_cmd = '''
+    flox init
+    tomlq --in-place --toml-output '.options.allow.broken = true' .flox/env/manifest.toml
+'''
+cmd = "flox install tabula"
+
 [resolve.webmention_ripgrep_rails]
 pre_cmd = "flox init"
 cmd = "flox install -i foo rubyPackages_3_2.webmention ripgrep -i bar rubyPackages_3_2.rails"

--- a/test_data/generated/resolve/tabula.json
+++ b/test_data/generated/resolve/tabula.json
@@ -1,0 +1,136 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "tabula",
+            "broken": true,
+            "derivation": "/nix/store/4kbcw3ifhzxlg0pqbbggqqvbh4jwl6wj-tabula-1.2.1.drv",
+            "description": "Tool for liberating data tables locked inside PDF files",
+            "install_id": "tabula",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "name": "tabula-1.2.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/gx0d5qdz8qqw76yiffkqaqw856ypafjk-tabula-1.2.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "tabula",
+            "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "rev_count": 645454,
+            "rev_date": "2024-06-29T19:44:37Z",
+            "scrape_date": "2024-07-02T05:57:57Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "1.2.1"
+          },
+          {
+            "attr_path": "tabula",
+            "broken": true,
+            "derivation": "/nix/store/vc64nqfxasqrfzccf9b8rbjijlnxv3c9-tabula-1.2.1.drv",
+            "description": "Tool for liberating data tables locked inside PDF files",
+            "install_id": "tabula",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "name": "tabula-1.2.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/0kz1zhbz4v9b59qpyx0dwvyiypiqbxas-tabula-1.2.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "tabula",
+            "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "rev_count": 645454,
+            "rev_date": "2024-06-29T19:44:37Z",
+            "scrape_date": "2024-07-02T05:57:57Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "1.2.1"
+          },
+          {
+            "attr_path": "tabula",
+            "broken": true,
+            "derivation": "/nix/store/mnzib5nl6kigngyvzgric7sk5y8sqsvh-tabula-1.2.1.drv",
+            "description": "Tool for liberating data tables locked inside PDF files",
+            "install_id": "tabula",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "name": "tabula-1.2.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/i6d1n6jmihy2kss843khf439jr09igyl-tabula-1.2.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "tabula",
+            "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "rev_count": 645454,
+            "rev_date": "2024-06-29T19:44:37Z",
+            "scrape_date": "2024-07-02T05:57:57Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "1.2.1"
+          },
+          {
+            "attr_path": "tabula",
+            "broken": true,
+            "derivation": "/nix/store/icqxqrlp4knhlgvksx2l0k4xm05jmx6y-tabula-1.2.1.drv",
+            "description": "Tool for liberating data tables locked inside PDF files",
+            "install_id": "tabula",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "name": "tabula-1.2.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/cgdzsim03yqdrmcf85bflyzi5yj5nn6l-tabula-1.2.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "tabula",
+            "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "rev_count": 645454,
+            "rev_date": "2024-06-29T19:44:37Z",
+            "scrape_date": "2024-07-02T05:57:57Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "1.2.1"
+          }
+        ],
+        "page": 645454,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/resolve/tabula_allowed.json
+++ b/test_data/generated/resolve/tabula_allowed.json
@@ -1,0 +1,136 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "tabula",
+            "broken": true,
+            "derivation": "/nix/store/4kbcw3ifhzxlg0pqbbggqqvbh4jwl6wj-tabula-1.2.1.drv",
+            "description": "Tool for liberating data tables locked inside PDF files",
+            "install_id": "tabula",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "name": "tabula-1.2.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/gx0d5qdz8qqw76yiffkqaqw856ypafjk-tabula-1.2.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "tabula",
+            "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "rev_count": 645454,
+            "rev_date": "2024-06-29T19:44:37Z",
+            "scrape_date": "2024-07-02T05:57:57Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "1.2.1"
+          },
+          {
+            "attr_path": "tabula",
+            "broken": true,
+            "derivation": "/nix/store/vc64nqfxasqrfzccf9b8rbjijlnxv3c9-tabula-1.2.1.drv",
+            "description": "Tool for liberating data tables locked inside PDF files",
+            "install_id": "tabula",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "name": "tabula-1.2.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/0kz1zhbz4v9b59qpyx0dwvyiypiqbxas-tabula-1.2.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "tabula",
+            "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "rev_count": 645454,
+            "rev_date": "2024-06-29T19:44:37Z",
+            "scrape_date": "2024-07-02T05:57:57Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "1.2.1"
+          },
+          {
+            "attr_path": "tabula",
+            "broken": true,
+            "derivation": "/nix/store/mnzib5nl6kigngyvzgric7sk5y8sqsvh-tabula-1.2.1.drv",
+            "description": "Tool for liberating data tables locked inside PDF files",
+            "install_id": "tabula",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "name": "tabula-1.2.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/i6d1n6jmihy2kss843khf439jr09igyl-tabula-1.2.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "tabula",
+            "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "rev_count": 645454,
+            "rev_date": "2024-06-29T19:44:37Z",
+            "scrape_date": "2024-07-02T05:57:57Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "1.2.1"
+          },
+          {
+            "attr_path": "tabula",
+            "broken": true,
+            "derivation": "/nix/store/icqxqrlp4knhlgvksx2l0k4xm05jmx6y-tabula-1.2.1.drv",
+            "description": "Tool for liberating data tables locked inside PDF files",
+            "install_id": "tabula",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "name": "tabula-1.2.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/cgdzsim03yqdrmcf85bflyzi5yj5nn6l-tabula-1.2.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "tabula",
+            "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+            "rev_count": 645454,
+            "rev_date": "2024-06-29T19:44:37Z",
+            "scrape_date": "2024-07-02T05:57:57Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "1.2.1"
+          }
+        ],
+        "page": 645454,
+        "url": ""
+      }
+    }
+  ]
+]


### PR DESCRIPTION
This test was skipped because broken packages were not yet available in the catalog. Now that broken packages are available, mock data can be generated and the test can be re-enabled.