### PR TITLE
test(catalog-live): Fix and always run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,6 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           AUTH0_FLOX_DEV_CLIENT_SECRET: "${{ secrets.MANAGED_AUTH0_FLOX_DEV_CLIENT_SECRET }}"
-          TESTING_FLOX_CATALOG_URL: "${{ secrets.MANAGED_TESTING_FLOX_CATALOG_URL }}"
         run: nix develop -L --no-update-lock-file --command just integ-tests
 
   nix-build:

--- a/cli/tests/catalog-live.bats
+++ b/cli/tests/catalog-live.bats
@@ -14,10 +14,7 @@ load test_support.bash
 
 setup_file() {
   common_file_setup
-  if [ -z "${TESTING_FLOX_CATALOG_URL:-}" ]; then
-    skip "TESTING_FLOX_CATALOG_URL is not set"
-  fi
-  export FLOX_CATALOG_URL="$TESTING_FLOX_CATALOG_URL"
+  export FLOX_CATALOG_URL="https://flox-catalog.preview.flox.dev"
 }
 
 teardown_file() {

--- a/cli/tests/catalog-live.bats
+++ b/cli/tests/catalog-live.bats
@@ -29,7 +29,7 @@ teardown_file() {
   run "$FLOX_BIN" search hello -vvv
   assert_output --partial "using catalog client for search"
   assert_output --partial "hello"
-  assert_output --partial "A program that produces a familiar, friendly greeting"
+  assert_output --partial "a familiar, friendly greeting"
 }
 
 @test "'flox show' works with catalog server" {


### PR DESCRIPTION
## Proposed Changes

**test(catalog-live): Move env and always run**

Move the environment variable into the tests, rather than sourcing it
from GitHub, so that we always run the tests. This makes the behaviour
of the integration tests consistent across:

- local dev
- `cli-dev` job in CI
- `nix-build-bats-tests` in CI

Previously the latter was the only job to run these which makes it hard
to reason and work on failures.

You could still focus or skip these temporarily if you're working
somewhere without an internet connection.

**test(catalog-live): Relax package description**

The tests have failed in CI because the package description in the
latest catalog scrape has changed from:

    A program that produces a familiar, friendly greeting

To:

    Program that produces a familiar, friendly greeting

Relax the assertion so that we still find the right package but are more
lenient about the contents.

## Release Notes

N/A
