### PR TITLE
fix: only abort migration on local changes if migration was necessary

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -113,7 +113,7 @@ pub struct UninstallationAttempt {
 #[derive(Clone, Debug)]
 pub struct MigrationInfo {
     /// The manifest is v0 and needs to be migrated to v1
-    needs_manifest_migration: bool,
+    pub needs_manifest_migration: bool,
     /// The current lockfile is v0,
     /// or the manifest is v0 and the lockfile is v1.
     /// In either case, a migration requires changing the locked packages the

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1627,29 +1627,36 @@ async fn maybe_migrate_environment_to_v1(
 /// If confirm_upgrade_future is None, the user can't be prompted to confirm an upgrade.
 async fn maybe_migrate_environment_to_v1_inner(
     flox: &Flox,
-    environment: &mut ConcreteEnvironment,
+    concrete_environment: &mut ConcreteEnvironment,
     confirm_upgrade_future: Option<impl Future<Output = Result<bool>>>,
 ) -> Result<(), MigrationError> {
-    if let ConcreteEnvironment::Managed(ref environment) = environment {
-        if environment
-            .has_local_changes(flox)
-            .map_err(EnvironmentError::ManagedEnvironment)?
-        {
-            Err(EnvironmentError::ManagedEnvironment(
-                ManagedEnvironmentError::CheckoutOutOfSync,
-            ))?;
-        }
-    }
-
-    let description = environment_description(environment)?;
-    let environment = environment.dyn_environment_ref_mut();
+    let description = environment_description(concrete_environment)?;
 
     if flox.catalog_client.is_none() {
         return Ok(());
     }
     // The user answered the prompt to upgrade the environment
     let mut confirmed_upgrade = false;
-    if let Some(migration_info) = environment.needs_migration_to_v1(flox)? {
+    if let Some(migration_info) = concrete_environment
+        .dyn_environment_ref_mut()
+        .needs_migration_to_v1(flox)?
+    {
+        // If the migration requires changes to a manifest, check if the environment is in sync
+        // before asking whether to migrate
+        // (which would subsequently fail due to changes in the manifest).
+        if migration_info.needs_manifest_migration {
+            if let ConcreteEnvironment::Managed(ref environment) = concrete_environment {
+                if environment
+                    .has_local_changes(flox)
+                    .map_err(EnvironmentError::ManagedEnvironment)?
+                {
+                    Err(EnvironmentError::ManagedEnvironment(
+                        ManagedEnvironmentError::CheckoutOutOfSync,
+                    ))?;
+                }
+            }
+        }
+
         if migration_info.needs_upgrade {
             // We could be a bit more sophisticated and check if there are packages installed.
             // But we'll be re-writing the lock, so call it an upgrade.
@@ -1673,7 +1680,11 @@ async fn maybe_migrate_environment_to_v1_inner(
         let result = Dialog {
             message: "Migrating to version 1.",
             help_message: None,
-            typed: Spinner::new(|| environment.migrate_to_v1(flox, migration_info)),
+            typed: Spinner::new(|| {
+                concrete_environment
+                    .dyn_environment_ref_mut()
+                    .migrate_to_v1(flox, migration_info)
+            }),
         }
         .spin();
 
@@ -2238,7 +2249,7 @@ mod tests {
     async fn maybe_migrate_managed_environment_blocked() {
         let owner = "owner".parse().unwrap();
         let (flox, _temp_dir_handle) =
-            flox_instance_with_optional_floxhub_and_client(Some(&owner), false);
+            flox_instance_with_optional_floxhub_and_client(Some(&owner), true);
 
         let mut environment = ConcreteEnvironment::Managed(mock_managed_environment(
             &flox,


### PR DESCRIPTION
Initially, when calling `maybe_migrate_environment_to_v1_inner` in a managed environment with pending changes,
the migration dialog would show unconditionally.
After accepting the migration, `ManagedEnvironment::migrate_to_v1` would immediatly fail however due to the pending local changes.

To avoid this immediate failure after the dialog a check for local changes was added to `maybe_migrate_environment_to_v1_inner`.
However, since that ran before checking whether a migration was even necessary, it produced the wrong error when local changes were present.

That is it would print

```
 Cannot automatically migrate environment:
 The environment has changes that are not yet synced to a generation.

 Migrate the environment manually by setting 'version = 1'
 in the manifest file or reset the local manifest to the current generation using

    $ flox edit --reset
```

despite no migration was necessary in the first place.

The change proposed here is delaying the check for local changes until _after_ we checked whether a migration was necessary in the first place, so now e.g. `flox install` will correctly error with

```
Your environment has changes that are not yet synced to a generation.
Use 'flox edit --reset' or 'flox edit --sync' after modifying '.flox/env/manifest.toml'
```
