### PR TITLE
fix: use shorter path for sockets

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "catalog-api-v1",
  "chrono",
  "derive_more",
+ "dirs",
  "enum_dispatch",
  "fslock",
  "futures",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1096,7 +1096,6 @@ dependencies = [
  "catalog-api-v1",
  "chrono",
  "derive_more",
- "dirs",
  "enum_dispatch",
  "fslock",
  "futures",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "xdg",
 ]
 
 [[package]]

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -11,6 +11,7 @@ blake3.workspace = true
 catalog-api-v1.workspace = true
 chrono.workspace = true
 derive_more.workspace = true
+dirs.workspace = true
 enum_dispatch.workspace = true
 fslock.workspace = true
 futures.workspace = true

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -11,7 +11,6 @@ blake3.workspace = true
 catalog-api-v1.workspace = true
 chrono.workspace = true
 derive_more.workspace = true
-dirs.workspace = true
 enum_dispatch.workspace = true
 fslock.workspace = true
 futures.workspace = true

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -38,6 +38,7 @@ tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
+xdg.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -284,7 +284,9 @@ pub mod test_helpers {
         owner: Option<&EnvironmentOwner>,
         use_client: bool,
     ) -> (Flox, TempDir) {
-        let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        // Use /tmp instead of std::env::temp_dir since we store sockets in cache_dir,
+        // and std::env::temp_dir may return a path that is too long.
+        let tempdir_handle = tempfile::tempdir_in(PathBuf::from("/tmp")).unwrap();
 
         let cache_dir = tempdir_handle.path().join("caches");
         let data_dir = tempdir_handle.path().join(".local/share/flox");

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -554,8 +554,8 @@ impl Environment for ManagedEnvironment {
 
     /// Return the path where the process compose socket for an environment
     /// should be created
-    fn services_socket_path(&self) -> Result<PathBuf, EnvironmentError> {
-        services_socket_path(&self.path_hash())
+    fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
+        services_socket_path(&self.path_hash(), flox)
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -725,23 +725,24 @@ pub fn path_hash(p: &impl AsRef<Path>) -> String {
 /// - TMPDIR will often have a long path, e.g.
 ///   /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.vfDA8u
 /// - /var/run is not writeable
-/// So we use /tmp
+/// So we use `flox.cache_dir.join("run")` which is typically
+/// `~/.cache/flox/run`
 ///
 /// On Linux use XDG_RUNTIME_DIR per
 /// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-/// If unset, fallback to /tmp
+/// If unset, fallback to cache_dir like for macOS.
 fn services_socket_path(id: &str, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
     #[cfg(target_os = "macos")]
     let runtime_dir = None;
-    #[cfg(target_os = "macos")]
-    let max_length = 104;
-
     #[cfg(target_os = "linux")]
     let runtime_dir = {
         let base_directories =
             xdg::BaseDirectories::new().map_err(EnvironmentError::DetectRuntimeDir)?;
         base_directories.get_runtime_directory().ok().cloned()
     };
+
+    #[cfg(target_os = "macos")]
+    let max_length = 104;
     #[cfg(target_os = "linux")]
     // 108 minus a null character
     let max_length = 107;

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -361,8 +361,8 @@ impl Environment for PathEnvironment {
 
     /// Return the path where the process compose socket for an environment
     /// should be created
-    fn services_socket_path(&self) -> Result<PathBuf, EnvironmentError> {
-        services_socket_path(&self.path_hash())
+    fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
+        services_socket_path(&self.path_hash(), flox)
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -23,6 +23,8 @@ use log::debug;
 
 use super::core_environment::CoreEnvironment;
 use super::{
+    path_hash,
+    services_socket_path,
     DotFlox,
     EditResult,
     Environment,
@@ -39,7 +41,6 @@ use super::{
     GCROOTS_DIR_NAME,
     LIB_DIR_NAME,
     LOCKFILE_FILENAME,
-    SERVICES_SOCKET_NAME,
 };
 use crate::data::{CanonicalPath, System};
 use crate::flox::Flox;
@@ -167,6 +168,11 @@ impl PathEnvironment {
             .map_err(EnvironmentError::WriteEnvJson)?;
 
         Ok(())
+    }
+
+    /// Returns a unique identifier for the location of the environment.
+    fn path_hash(&self) -> String {
+        path_hash(&self.path)
     }
 }
 
@@ -356,7 +362,7 @@ impl Environment for PathEnvironment {
     /// Return the path where the process compose socket for an environment
     /// should be created
     fn services_socket_path(&self) -> Result<PathBuf, EnvironmentError> {
-        Ok(self.cache_path()?.join(SERVICES_SOCKET_NAME))
+        services_socket_path(&self.path_hash())
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -333,7 +333,7 @@ impl Environment for RemoteEnvironment {
         Ok(())
     }
 
-    fn services_socket_path(&self) -> Result<PathBuf, EnvironmentError> {
+    fn services_socket_path(&self, _flox: &Flox) -> Result<PathBuf, EnvironmentError> {
         Err(EnvironmentError::RemoteEnvironment(
             RemoteEnvironmentError::ServicesUnsupported,
         ))

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -263,7 +263,7 @@ impl Activate {
                 exports.insert(
                     FLOX_SERVICES_SOCKET_VAR,
                     environment
-                        .services_socket_path()?
+                        .services_socket_path(&flox)?
                         .to_string_lossy()
                         .to_string(),
                 );

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -151,7 +151,7 @@ impl Config {
             initialized = INSTANCE.get().is_some()
         );
 
-        fn read_raw_cofig() -> Result<HierarchicalConfig> {
+        fn read_raw_config() -> Result<HierarchicalConfig> {
             let flox_dirs = BaseDirectories::with_prefix(FLOX_DIR_NAME)?;
 
             let cache_dir = flox_dirs.get_cache_home();
@@ -228,14 +228,14 @@ impl Config {
             // If we are initializing the config for the first time,
             // we don't need to reload right after
             reload = false;
-            let config = read_raw_cofig()?;
+            let config = read_raw_config()?;
 
             Ok::<_, anyhow::Error>(Mutex::new(config))
         })?;
 
         let mut config_guard = instance.lock().expect("config mutex poisoned");
         if reload {
-            *config_guard = read_raw_cofig()?;
+            *config_guard = read_raw_config()?;
         }
 
         return Ok(config_guard.deref().clone());

--- a/cli/tests/services/touch_file/check.sh
+++ b/cli/tests/services/touch_file/check.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 echo "activating"
-eval $("$FLOX_BIN" activate)
+eval "$("$FLOX_BIN" activate)"
 CONFIG_FILE="$FLOX_ENV/service-config.yaml"
 SOCKET_FILE="${_FLOX_SERVICES_SOCKET}"
 

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -360,11 +360,14 @@ pkgdb_vars_setup() {
 # This helper should be run after setting `FLOX_TEST_HOME'.
 flox_vars_setup() {
   xdg_vars_setup
-  export FLOX_CACHE_HOME="$XDG_CACHE_HOME/flox"
+  # We store sockets in FLOX_CACHE_DIR,
+  # so create cache in /tmp since TMPDIR may result in too long of a path.
+  FLOX_CACHE_DIR="$(mktemp -d /tmp/flox.tests.XXXXXX)"
+  export FLOX_CACHE_DIR
   export FLOX_CONFIG_DIR="$XDG_CONFIG_HOME/flox"
   export FLOX_DATA_HOME="$XDG_DATA_HOME/flox"
   export FLOX_STATE_HOME="$XDG_STATE_HOME/flox"
-  export FLOX_META="$FLOX_CACHE_HOME/meta"
+  export FLOX_META="$FLOX_CACHE_DIR/meta"
   export FLOX_ENVIRONMENTS="$FLOX_DATA_HOME/environments"
   export USER="flox-test"
   export HOME="${FLOX_TEST_HOME:-$HOME}"
@@ -436,7 +439,7 @@ common_suite_setup() {
     print_var XDG_CONFIG_HOME
     print_var XDG_DATA_HOME
     print_var XDG_STATE_HOME
-    print_var FLOX_CACHE_HOME
+    print_var FLOX_CACHE_DIR
     print_var FLOX_CONFIG_DIR
     print_var FLOX_DATA_HOME
     print_var FLOX_STATE_HOME
@@ -467,6 +470,7 @@ common_suite_teardown() {
   if [[ -z ${FLOX_TEST_KEEP_TMP-} ]]; then
     rm -rf "$BATS_SUITE_TMPDIR"
   fi
+  rm -rf "$FLOX_CACHE_DIR"
   # Our agent was useful, but it's time for them to retire.
   # We force true in case we are tearing down when an agent never launched.
   eval "$(ssh-agent -k 2> /dev/null || echo ':')"

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -126,7 +126,12 @@ floxhub_setup() {
 setup_isolated_flox() {
   export FLOX_CONFIG_DIR="${BATS_TEST_TMPDIR?}/flox-config"
   export FLOX_DATA_DIR="${BATS_TEST_TMPDIR?}/flox-data"
-  export FLOX_CACHE_DIR="${BATS_TEST_TMPDIR?}/flox-cache"
+  # Don't use BATS_TEST_TMPDIR since we store sockets in FLOX_CACHE_DIR,
+  # and BATS_TEST_TMPDIR will likely be too long.
+  # Create within the existing FLOX_CACHE_DIR so this gets cleaned up by
+  # `common_suite_teardown`.
+  FLOX_CACHE_DIR="$(mktemp -d -p "$FLOX_CACHE_DIR")"
+  export FLOX_CACHE_DIR
   export GLOBAL_MANIFEST_LOCK="$FLOX_CONFIG_DIR/global-manifest.lock"
 }
 


### PR DESCRIPTION
The current path used may exceed the macOS limit of 104 characters, and it doesn't follow the XDG spec. Instead store the socket in `$XDG_RUNTIME_DIR/flox.path_hash.sock` or `~/.cache/flox/run/flox.path_hash.sock`.

Storing sockets in `flox.cache_dir` required moving the cache directory for tests to `/tmp` so that it wouldn't be too long.

`/tmp` was not used because it might get cleaned up before a long running `flox activate` exits.

ManagedEnvironment::encode was removed since `path_hash` can just be used directly before constructing an environment, and `self.path_hash` can now be used afterwards. Having both `path_hash` and `encode` is confusing.