### PR TITLE
fix(managed): use local_checkout in `lock` and `build_container`

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -222,13 +222,7 @@ impl Environment for ManagedEnvironment {
     }
 
     fn build_container(&mut self, flox: &Flox) -> Result<ContainerBuilder, EnvironmentError> {
-        let generations = self
-            .generations()
-            .writable(flox.temp_dir.clone())
-            .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
-        let mut temporary = generations
-            .get_current_generation()
-            .map_err(ManagedEnvironmentError::CreateGenerationFiles)?;
+        let mut temporary = self.local_env_or_copy_current_generation(flox)?;
 
         let builder = temporary.build_container(flox)?;
         Ok(builder)

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -216,13 +216,7 @@ impl Environment for ManagedEnvironment {
     }
 
     fn lock(&mut self, flox: &Flox) -> Result<LockedManifest, EnvironmentError> {
-        let generations = self
-            .generations()
-            .writable(flox.temp_dir.clone())
-            .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
-        let mut temporary = generations
-            .get_current_generation()
-            .map_err(ManagedEnvironmentError::CreateGenerationFiles)?;
+        let mut temporary = self.local_env_or_copy_current_generation(flox)?;
 
         Ok(temporary.lock(flox)?)
     }


### PR DESCRIPTION
Uses the local checkout as source of truth for out-of-band locking and building of containers.

Does not validate the checkout as no modification to the manifest happens.
