### PR TITLE
fix: print environment description in `delete`

### DIFF
--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -41,8 +41,14 @@ impl Delete {
             bail!("{message}")
         }
 
+        let message = if let EnvironmentSelect::Unspecified = self.environment {
+            format!("You are about to delete your environment {description}. Are you sure?")
+        } else {
+            "Are you sure?".to_string()
+        };
+
         let confirm = Dialog {
-            message: "Are you sure?",
+            message: &message,
             help_message: Some("Use `-f` to force deletion"),
             typed: Confirm {
                 default: Some(false),


### PR DESCRIPTION
55ff6afd2c87eb1c729ac06cfb67a995957b34ae shortened the prompt for `flox delete` from:
```
You are about to delete your environment {description}. Are you sure?
```
to
```
Are you sure?
```

This makes sense for cases where the environment is explicitly specified with `-d`, but because we have active environment detection, `flox delete` can delete an environment not in the current directory, and the prompt doesn't give you any signal that's happening:
```
> flox delete
! Are you sure? (y/N)
[Use `-f` to force deletion]
```

When `-d` is not passed, print out a message with the full description.