### PR TITLE
feat: unknown service error types

### DIFF
--- a/cli/catalog-api-v1/build.rs
+++ b/cli/catalog-api-v1/build.rs
@@ -23,6 +23,11 @@ fn main() {
 fn generate_client(spec: &OpenAPI) -> String {
     let mut settings = progenitor::GenerationSettings::default();
     settings.with_derive("PartialEq");
+    settings.with_replacement(
+        "MessageType",
+        "crate::error::MessageType",
+        ["Default".parse().unwrap()].into_iter(),
+    );
     let mut generator = progenitor::Generator::new(&settings);
     let tokens = generator.generate_tokens(spec).unwrap();
     let ast = syn::parse2(tokens).unwrap();

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -418,90 +418,6 @@ pub mod types {
             value.parse()
         }
     }
-    ///MessageType
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "title": "MessageType",
-    ///  "type": "string",
-    ///  "enum": [
-    ///    "general",
-    ///    "resolution_trace",
-    ///    "attr_path_not_found",
-    ///    "constraints_too_tight"
-    ///  ]
-    ///}
-    /// ```
-    /// </details>
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        Deserialize,
-        Eq,
-        Hash,
-        Ord,
-        PartialEq,
-        PartialOrd,
-        Serialize
-    )]
-    pub enum MessageType {
-        #[serde(rename = "general")]
-        General,
-        #[serde(rename = "resolution_trace")]
-        ResolutionTrace,
-        #[serde(rename = "attr_path_not_found")]
-        AttrPathNotFound,
-        #[serde(rename = "constraints_too_tight")]
-        ConstraintsTooTight,
-    }
-    impl From<&MessageType> for MessageType {
-        fn from(value: &MessageType) -> Self {
-            value.clone()
-        }
-    }
-    impl ToString for MessageType {
-        fn to_string(&self) -> String {
-            match *self {
-                Self::General => "general".to_string(),
-                Self::ResolutionTrace => "resolution_trace".to_string(),
-                Self::AttrPathNotFound => "attr_path_not_found".to_string(),
-                Self::ConstraintsTooTight => "constraints_too_tight".to_string(),
-            }
-        }
-    }
-    impl std::str::FromStr for MessageType {
-        type Err = self::error::ConversionError;
-        fn from_str(value: &str) -> Result<Self, self::error::ConversionError> {
-            match value {
-                "general" => Ok(Self::General),
-                "resolution_trace" => Ok(Self::ResolutionTrace),
-                "attr_path_not_found" => Ok(Self::AttrPathNotFound),
-                "constraints_too_tight" => Ok(Self::ConstraintsTooTight),
-                _ => Err("invalid value".into()),
-            }
-        }
-    }
-    impl std::convert::TryFrom<&str> for MessageType {
-        type Error = self::error::ConversionError;
-        fn try_from(value: &str) -> Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl std::convert::TryFrom<&String> for MessageType {
-        type Error = self::error::ConversionError;
-        fn try_from(value: &String) -> Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl std::convert::TryFrom<String> for MessageType {
-        type Error = self::error::ConversionError;
-        fn try_from(value: String) -> Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
     ///Output
     ///
     /// <details><summary>JSON schema</summary>
@@ -1249,7 +1165,7 @@ pub mod types {
         pub level: MessageLevel,
         pub message: String,
         #[serde(rename = "type")]
-        pub type_: MessageType,
+        pub type_: crate::error::MessageType,
     }
     impl From<&ResolutionMessageGeneral> for ResolutionMessageGeneral {
         fn from(value: &ResolutionMessageGeneral) -> Self {

--- a/cli/catalog-api-v1/src/error.rs
+++ b/cli/catalog-api-v1/src/error.rs
@@ -1,0 +1,16 @@
+use std::hash::Hash;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MessageType {
+    #[serde(rename = "general")]
+    General,
+    #[serde(rename = "resolution_trace")]
+    ResolutionTrace,
+    #[serde(rename = "attr_path_not_found")]
+    AttrPathNotFound,
+    #[serde(rename = "constraints_too_tight")]
+    ConstraintsTooTight,
+    Unknown(String),
+}

--- a/cli/catalog-api-v1/src/error.rs
+++ b/cli/catalog-api-v1/src/error.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(untagged)]
 pub enum MessageType {
     #[serde(rename = "general")]
     General,
@@ -12,5 +13,6 @@ pub enum MessageType {
     AttrPathNotFound,
     #[serde(rename = "constraints_too_tight")]
     ConstraintsTooTight,
+
     Unknown(String),
 }

--- a/cli/catalog-api-v1/src/lib.rs
+++ b/cli/catalog-api-v1/src/lib.rs
@@ -4,4 +4,10 @@
 //! The spec is managed by the Catalog API team and is updated when the upstream API changes.
 
 mod client;
+mod error;
 pub use client::*;
+
+pub mod types {
+    pub use crate::error::MessageType;
+    pub use crate::client::types::*;
+}

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -721,16 +721,14 @@ impl LockedManifestCatalog {
                 match res_msg {
                     catalog::ResolutionMessage::General(inner) => {
                         tracing::debug!(kind = "general", "handling resolution message");
-                        // If we have a level and it's not an error, skip this message
-                        if let Some(level) = inner.level {
-                            if level != MessageLevel::Error {
-                                tracing::debug!(
-                                    level = level.to_string(),
-                                    msg = inner.msg,
-                                    "non-error resolution message"
-                                );
-                                continue;
-                            }
+                        // If it's not an error, skip this message
+                        if inner.level != MessageLevel::Error {
+                            tracing::debug!(
+                                level = inner.level.to_string(),
+                                msg = inner.msg,
+                                "non-error resolution message"
+                            );
+                            continue;
                         }
                         // If we don't have a level, I guess we have to treat it like an error
                         tracing::debug!("pushing fallback message");
@@ -760,18 +758,15 @@ impl LockedManifestCatalog {
                             kind = "constraints_too_tight",
                             "handling resolution message"
                         );
-                        // If we have a level and it's not an error, skip this message
-                        if let Some(level) = inner.level {
-                            if level != MessageLevel::Error {
-                                tracing::debug!(
-                                    level = level.to_string(),
-                                    msg = inner.msg,
-                                    "non-error resolution message"
-                                );
-                                continue;
-                            }
+                        // If it's not an error, skip this message
+                        if inner.level != MessageLevel::Error {
+                            tracing::debug!(
+                                level = inner.level.to_string(),
+                                msg = inner.msg,
+                                "non-error resolution message"
+                            );
+                            continue;
                         }
-                        // If we don't have a level, I guess we have to treat it like an error
                         tracing::debug!("pushing fallback message");
                         let failure = ResolutionFailure::ConstraintsTooTight {
                             fallback_msg: inner.msg.clone(),
@@ -780,22 +775,22 @@ impl LockedManifestCatalog {
                         failures.push(failure);
                     },
                     catalog::ResolutionMessage::Unknown(inner) => {
-                        tracing::debug!(kind = "unknown", "handling resolution message");
-                        // If we have a level and it's not an error, skip this message
-                        if let Some(level) = inner.level {
-                            if level != MessageLevel::Error {
-                                tracing::debug!(
-                                    level = level.to_string(),
-                                    msg = inner.msg,
-                                    "non-error resolution message"
-                                );
-                                continue;
-                            }
+                        tracing::debug!(
+                            kind = "unknown",
+                            level = inner.level.to_string(),
+                            msg = inner.msg,
+                            msg_type = inner.msg_type,
+                            context = serde_json::to_string(&inner.context).unwrap(),
+                            "handling unknown resolution message"
+                        );
+                        // If it's not an error, skip this message
+                        if inner.level != MessageLevel::Error {
+                            continue;
                         }
                         // If we don't have a level, I guess we have to treat it like an error
                         let failure = ResolutionFailure::UnknownServiceMessage {
                             msg: inner.msg.clone(),
-                            level: inner.level.unwrap_or(MessageLevel::Trace).to_string(),
+                            level: inner.level.to_string(),
                             context: inner.context.clone(),
                         };
                         failures.push(failure);
@@ -812,15 +807,13 @@ impl LockedManifestCatalog {
         manifest: &TypedManifestCatalog,
     ) -> Option<ResolutionFailure> {
         // If we have a level and it's not an error, skip this message
-        if let Some(level) = r_msg.level {
-            if level != MessageLevel::Error {
-                tracing::debug!(
-                    level = level.to_string(),
-                    msg = r_msg.msg,
-                    "non-error resolution message"
-                );
-                return None;
-            }
+        if r_msg.level != MessageLevel::Error {
+            tracing::debug!(
+                level = r_msg.level.to_string(),
+                msg = r_msg.msg,
+                "non-error resolution message"
+            );
+            return None;
         }
         if r_msg.valid_systems.is_empty() {
             tracing::debug!(

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -2080,23 +2080,20 @@ pub(crate) mod tests {
         client.push_resolve_response(response);
 
         let locked_manifest = LockedManifestCatalog::lock_manifest(manifest, None, &client).await;
-        match locked_manifest {
-            Ok(_) => panic!(),
-            Err(LockedManifestError::ResolutionFailed(res_failures)) => {
-                assert_eq!(res_failures.0.len(), 1);
-                match &res_failures.0[0] {
-                    ResolutionFailure::UnknownServiceMessage {
-                        level,
-                        msg,
-                        context: _,
-                    } => {
-                        assert_eq!(msg, &response_msg.msg());
-                        assert_eq!(level, "error");
-                    },
-                    _ => panic!(),
-                }
-            },
-            _ => panic!(),
+        if let Err(LockedManifestError::ResolutionFailed(res_failures)) = locked_manifest {
+            if let [ResolutionFailure::UnknownServiceMessage {
+                level,
+                msg,
+                context: _,
+            }] = res_failures.0.as_slice()
+            {
+                assert_eq!(msg, &response_msg.msg());
+                assert_eq!(level, "error");
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
         }
     }
 

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1031,7 +1031,6 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_response_with_new_message_type() {
-        // let expected_agent = format!("flox-cli/{}", &*FLOX_VERSION);
         let user_message = "User consumable Message";
         let user_message_type = "willnevereverexist_ihope";
         let json_response = json!(
@@ -1068,7 +1067,7 @@ mod tests {
                 assert!(msg_struct.msg_type == user_message_type);
             },
             _ => {
-                assert!(false)
+                panic!();
             },
         };
         mock.assert();

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -702,7 +702,7 @@ impl TryFrom<PackageGroup> for api_types::PackageGroup {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MsgGeneral {
     /// The log level of the message
-    pub level: Option<MessageLevel>,
+    pub level: MessageLevel,
     /// The actual message
     pub msg: String,
 }
@@ -711,7 +711,7 @@ pub struct MsgGeneral {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MsgAttrPathNotFound {
     /// The log level of the message
-    pub level: Option<MessageLevel>,
+    pub level: MessageLevel,
     /// The actual message
     pub msg: String,
     /// The requested attribute path
@@ -726,7 +726,7 @@ pub struct MsgAttrPathNotFound {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MsgConstraintsTooTight {
     /// The log level of the message
-    pub level: Option<MessageLevel>,
+    pub level: MessageLevel,
     /// The actual message
     pub msg: String,
 }
@@ -737,7 +737,7 @@ pub struct MsgUnknown {
     /// The original message type string
     pub msg_type: String,
     /// The log level of the message
-    pub level: Option<MessageLevel>,
+    pub level: MessageLevel,
     /// The actual message
     pub msg: String,
     /// The delivered `context`
@@ -756,7 +756,7 @@ pub enum ResolutionMessage {
     /// which could mean that all the version constraints can't be satisfied by
     /// a single page.
     ConstraintsTooTight(MsgConstraintsTooTight),
-    /// An unknown (likely new) message.
+    /// A (yet) unknown message type.
     Unknown(MsgUnknown),
 }
 
@@ -775,16 +775,14 @@ impl From<ResolutionMessageGeneral> for ResolutionMessage {
     fn from(r_msg: ResolutionMessageGeneral) -> Self {
         match r_msg.type_ {
             MessageType::General => ResolutionMessage::General(MsgGeneral {
-                level: Some(r_msg.level),
+                level: r_msg.level,
                 msg: r_msg.message,
             }),
             MessageType::ResolutionTrace => ResolutionMessage::General(MsgGeneral {
-                level: Some(MessageLevel::Trace),
+                level: MessageLevel::Trace,
                 msg: r_msg.message,
             }),
             MessageType::AttrPathNotFound => {
-                let level = r_msg.level;
-                let msg = r_msg.message;
                 // Should always be present for this type of message, but that's not enforced
                 // by the type system
                 let attr_path = r_msg
@@ -814,8 +812,8 @@ impl From<ResolutionMessageGeneral> for ResolutionMessage {
                     .map(|s| s.to_string())
                     .unwrap_or("default_install_id".to_string());
                 ResolutionMessage::AttrPathNotFound(MsgAttrPathNotFound {
-                    level: Some(level),
-                    msg,
+                    level: r_msg.level,
+                    msg: r_msg.message,
                     attr_path: attr_path.to_string(),
                     install_id,
                     valid_systems,
@@ -823,13 +821,13 @@ impl From<ResolutionMessageGeneral> for ResolutionMessage {
             },
             MessageType::ConstraintsTooTight => {
                 ResolutionMessage::ConstraintsTooTight(MsgConstraintsTooTight {
-                    level: Some(r_msg.level),
+                    level: r_msg.level,
                     msg: r_msg.message,
                 })
             },
             MessageType::Unknown(message_type) => ResolutionMessage::Unknown(MsgUnknown {
                 msg_type: message_type,
-                level: Some(r_msg.level),
+                level: r_msg.level,
                 msg: r_msg.message,
                 context: r_msg.context,
             }),


### PR DESCRIPTION
## Proposed Changes
- Replace the client generated `MessageType` with an `untagged` type with an `Unknown` variant.
- Add an `UnknownServiceMessage` to the `ResolutionFailure` enum
- Remove the `Option` on the `MessageLevel` field in related structs.  It's required in the API, so it should always be present.

As a follow up, I think the message handling shouldn't be tied explicitly to _failures_ since we can pass warnings and additional explanatory messages.  But that can be a follow up to refactor that when it's needed.

## Release Notes

- Improved resolution failure messaging.
