### PR TITLE
feat: add helper-functions.bash collection w/ flox_portgrab()

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -21,6 +21,9 @@ export _flox_activate_tracelevel="${_FLOX_PKGDB_VERBOSITY:-0}"
 # --turbo: invoke commands directly without involving userShell
 # --noprofile: do not source `[profile]` scripts
 
+# Source helper functions
+. "@out@/activate.d/helper-functions.bash"
+
 # Set FLOX_ENV as the path by which all flox scripts can make reference to
 # the environment to which they belong. Use this to define the path to the
 # activation scripts directory.

--- a/assets/activation-scripts/activate.d/helper-functions.bash
+++ b/assets/activation-scripts/activate.d/helper-functions.bash
@@ -7,15 +7,16 @@ function flox_portgrab() {
   # Usage: port="$(portgrab)"
   #
   # - invokes nc as _server_ in background with args:
-  #   0.0.0.0: bind to all interfaces
-  #   -l 0: listen on ephemeral port
+  #   -l: listen, rather than connect, mode
   #   -n: do not perform name resolution
   #   -v: be verbose (so we can identify bound port number)
+  #   0.0.0.0: bind to all interfaces
+  #   0: get an ephemeral port
   # - parses port number from expected output to stderr, e.g.:
   #     Listening on 0.0.0.0 41669
   # - invokes nc as _client_ to connect to server, which shuts it down
   local -a words
-  ( $_netcat/bin/nc 0.0.0.0 -l 0 -n -v & ) 2>&1 | while read -r -a words; do
+  ( $_netcat/bin/nc -lnv 0.0.0.0 0 & ) 2>&1 | while read -r -a words; do
     if [ ${#words[@]} -eq 4 ] && \
        [ "${words[0]}" = "Listening" ] && \
        [ "${words[1]}" = "on" ] && \

--- a/assets/activation-scripts/activate.d/helper-functions.bash
+++ b/assets/activation-scripts/activate.d/helper-functions.bash
@@ -1,0 +1,36 @@
+export _netcat="@netcat@"
+
+function flox_portgrab() {
+  # Function which allocates and immediately releases ephemeral TCP port,
+  # used to identify available ports for use by services.
+  #
+  # Usage: port="$(portgrab)"
+  #
+  # - invokes nc as _server_ in background with args:
+  #   0.0.0.0: bind to all interfaces
+  #   -l 0: listen on ephemeral port
+  #   -n: do not perform name resolution
+  #   -v: be verbose (so we can identify bound port number)
+  # - parses port number from expected output to stderr, e.g.:
+  #     Listening on 0.0.0.0 41669
+  # - invokes nc as _client_ to connect to server, which shuts it down
+  local -a words
+  ( $_netcat/bin/nc 0.0.0.0 -l 0 -n -v & ) 2>&1 | while read -r -a words; do
+    if [ ${#words[@]} -eq 4 ] && \
+       [ "${words[0]}" = "Listening" ] && \
+       [ "${words[1]}" = "on" ] && \
+       [ "${words[2]}" = "0.0.0.0" ]; then
+      local _port="${words[3]}"
+      if $_netcat/bin/nc -N 0.0.0.0 "$_port" </dev/null >/dev/null 2>&1; then
+        # Success! Echo port and return.
+        echo "$_port"
+        return 0
+      else
+        # Not sure what would cause this, but return to avoid looping further.
+        return 1
+      fi
+    fi
+  done
+  # Return 1 to indicate failure.
+  return 1
+}

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -258,6 +258,21 @@ but this behavior may change.
 It is best to write hooks defensively, assuming the user is using the
 environment from any directory on their machine.
 
+**Helper Functions**
+
+The `on-activate` hook is pre-loaded with a growing number of functions
+to help with environment initialization:
+
+* `flox_portgrab()`
+
+    Usage:
+
+      SERVER_PORT=$(flox_portgrab)
+
+    Allocates and releases an ephemeral TCP port that is
+    guaranteed to be available for immediate reuse.
+
+
 ### `script` - DEPRECATED
 This field was deprecated in favor of the `profile` section.
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2182,3 +2182,24 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate:helpers,activate:helpers:flox_portgrab
+@test "helpers: flox_portgrab can be used in activate" {
+  project_setup
+
+  run "$FLOX_BIN" edit -f <(cat <<'EOF'
+    version = 1
+    [hook]
+    on-activate = """
+      export EPHEMERAL_PORT=$(flox_portgrab)
+    """
+EOF
+  )
+  assert_success
+
+  run "$FLOX_BIN" activate -- printenv EPHEMERAL_PORT
+  assert_success
+  assert_output --regexp '^[0-9]{5}$'
+}
+
+# ---------------------------------------------------------------------------- #

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -4,6 +4,7 @@
   findutils,
   gnused,
   ld-floxlib,
+  netcat,
   runCommand,
   shellcheck,
   stdenv,
@@ -35,6 +36,9 @@ in
     substituteInPlace $out/activate.d/zsh \
       --replace "@gnused@" "${gnused}"
 
+    substituteInPlace $out/activate.d/helper-functions.bash \
+      --replace "@netcat@" "${netcat}"
+
     for i in $out/etc/profile.d/*; do
       substituteInPlace $i --replace "@coreutils@" "${coreutils}"
       substituteInPlace $i --replace "@gnused@" "${gnused}"
@@ -45,6 +49,7 @@ in
     ${shellcheck}/bin/shellcheck \
       $out/activate \
       $out/activate.d/bash \
+      $out/activate.d/helper-functions.bash \
       $out/activate.d/set-prompt.bash \
       $out/etc/profile.d/*
   ''


### PR DESCRIPTION
## Proposed Changes

This patch adds a new place for adding bash helper functions to be used within the on-activate hook, and uses it to add a new flox_portgrab() function. This function is useful in the service management area for grabbing an ephemeral port that is guaranteed to be free and available for use.

Example usage:

export SERVER_PORT=$(flox_portgrab)

## Release Notes

* added new `flox_portgrab()` function for use within `hooks.on-activate` activation section of the manifest