### PR TITLE
feat: allow flakes in install command

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -49,7 +49,7 @@ use crate::models::env_registry::{deregister, ensure_registered};
 use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::lockfile::LockedManifest;
-use crate::models::manifest::{PackageToInstall, RawManifest, TypedManifest};
+use crate::models::manifest::{CatalogPackage, PackageToInstall, RawManifest, TypedManifest};
 use crate::models::pkgdb::UpgradeResult;
 use crate::utils::mtime_of;
 
@@ -85,7 +85,7 @@ pub struct InitCustomization {
     pub profile_fish: Option<String>,
     pub profile_tcsh: Option<String>,
     pub profile_zsh: Option<String>,
-    pub packages: Option<Vec<PackageToInstall>>,
+    pub packages: Option<Vec<CatalogPackage>>,
 }
 
 impl PartialEq for PathEnvironment {

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -10,6 +10,7 @@ use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use toml_edit::{self, Array, DocumentMut, Formatted, InlineTable, Item, Key, Table, Value};
+use url::Url;
 
 use super::environment::path_environment::InitCustomization;
 use crate::data::{System, Version};
@@ -842,6 +843,10 @@ pub enum ManifestError {
     PkgDbCall(#[source] std::io::Error),
     #[error("no package or group named '{0}' in the manifest")]
     PkgOrGroupNotFound(String),
+    #[error("invalid flake ref: {0}")]
+    InvalidFlakeRef(String),
+    #[error("only remote flake refs are supported: {0}")]
+    LocalFlakeRef(String),
 }
 
 /// A subset of the manifest used to check what type of edits users make. We
@@ -890,20 +895,96 @@ pub struct PackageInsertion {
     pub already_installed: HashMap<String, bool>,
 }
 
-/// A package to install.
+/// Any kind of package that can be installed via `flox install`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PackageToInstall {
+    Catalog(CatalogPackage),
+    Flake(FlakePackage),
+}
+
+impl PackageToInstall {
+    pub fn id(&self) -> &str {
+        match self {
+            PackageToInstall::Catalog(pkg) => &pkg.id,
+            PackageToInstall::Flake(pkg) => &pkg.id,
+        }
+    }
+
+    pub fn set_id(&mut self, id: impl AsRef<str>) {
+        let id = String::from(id.as_ref());
+        match self {
+            PackageToInstall::Catalog(pkg) => pkg.id = id,
+            PackageToInstall::Flake(pkg) => pkg.id = id,
+        }
+    }
+}
+
+impl FromStr for PackageToInstall {
+    type Err = ManifestError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match Url::parse(s) {
+            Ok(url) => {
+                let id = infer_flake_install_id(&url)?;
+                Ok(PackageToInstall::Flake(FlakePackage { id, url }))
+            },
+            _ => Ok(PackageToInstall::Catalog(s.parse()?)),
+        }
+    }
+}
+
+/// Tries to infer an install id from the flake ref URL, or falls back to "flake".
+fn infer_flake_install_id(url: &Url) -> Result<String, ManifestError> {
+    if url.scheme() == "github" {
+        url.path()
+            .split('/')
+            .nth(1)
+            .map(|s| s.to_string())
+            .ok_or(ManifestError::InvalidFlakeRef(url.to_string()))
+    } else if url.scheme() == "https" && url.domain().is_some_and(|host| host == "github.com") {
+        let mut segments = url
+            .path_segments()
+            .ok_or(ManifestError::InvalidFlakeRef(url.to_string()))?;
+        segments
+            .nth(1)
+            .map(|s| s.to_string())
+            .ok_or(ManifestError::InvalidFlakeRef(url.to_string()))
+    } else {
+        Ok("flake".to_string())
+    }
+}
+
+/// Extracts only the catalog packages from a list of packages to install.
+pub fn catalog_packages_to_install(packages: &[PackageToInstall]) -> Vec<CatalogPackage> {
+    packages
+        .iter()
+        .filter_map(|pkg| match pkg {
+            PackageToInstall::Catalog(pkg) => Some((*pkg).clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A package to install from the catalog.
 ///
 /// Users may specify a different install ID than the package name,
 /// especially when the package is nested. This struct is the common
 /// denominator for packages with specified IDs and packages with
 /// default IDs.
-#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct PackageToInstall {
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CatalogPackage {
     pub id: String,
     pub pkg_path: String,
     pub version: Option<String>,
 }
 
-impl FromStr for PackageToInstall {
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct FlakePackage {
+    pub id: String,
+    pub url: Url,
+}
+
+impl FromStr for CatalogPackage {
     type Err = ManifestError;
 
     /// Parse a shorthand descriptor into `install_id`, `attribute_path` and `version`.
@@ -987,8 +1068,8 @@ impl FromStr for PackageToInstall {
     }
 }
 
-impl From<&PackageToInstall> for Vec<(&'static str, String)> {
-    fn from(val: &PackageToInstall) -> Self {
+impl From<&CatalogPackage> for Vec<(&'static str, String)> {
+    fn from(val: &CatalogPackage) -> Self {
         let mut vec = vec![("pkg-path", val.pkg_path.clone())];
         if let Some(version) = &val.version {
             vec.push(("version", version.clone()));
@@ -997,10 +1078,16 @@ impl From<&PackageToInstall> for Vec<(&'static str, String)> {
     }
 }
 
-impl From<&PackageToInstall> for InlineTable {
-    fn from(val: &PackageToInstall) -> Self {
+impl From<&CatalogPackage> for InlineTable {
+    fn from(val: &CatalogPackage) -> Self {
         InlineTable::from_iter(Vec::from(val))
     }
+}
+
+/// Reports whether a flake reference is a path on the local system.
+pub fn is_local_flake_ref(flakeref: impl AsRef<str>) -> bool {
+    let flakeref = flakeref.as_ref();
+    flakeref.starts_with('.') || flakeref.starts_with('/') || flakeref.starts_with("path:")
 }
 
 /// Insert package names into the `[install]` table of a manifest.
@@ -1033,25 +1120,40 @@ pub fn insert_packages(
     };
 
     for pkg in pkgs {
-        if !install_table.contains_key(&pkg.id) {
+        if !install_table.contains_key(pkg.id()) {
             let mut descriptor_table = InlineTable::new();
-            descriptor_table.insert(
-                "pkg-path",
-                Value::String(Formatted::new(pkg.pkg_path.clone())),
-            );
-            if let Some(ref version) = pkg.version {
-                descriptor_table.insert("version", Value::String(Formatted::new(version.clone())));
+            match pkg {
+                PackageToInstall::Catalog(pkg) => {
+                    descriptor_table.insert(
+                        "pkg-path",
+                        Value::String(Formatted::new(pkg.pkg_path.clone())),
+                    );
+                    if let Some(ref version) = pkg.version {
+                        descriptor_table
+                            .insert("version", Value::String(Formatted::new(version.clone())));
+                    }
+                    debug!(
+                        "package newly installed: id={}, pkg-path={}",
+                        pkg.id, pkg.pkg_path
+                    );
+                },
+                PackageToInstall::Flake(pkg) => {
+                    descriptor_table
+                        .insert("flake", Value::String(Formatted::new(pkg.url.to_string())));
+                    debug!(
+                        "package newly installed: id={}, flakeref={}",
+                        pkg.id,
+                        pkg.url.to_string()
+                    );
+                },
             }
+
             descriptor_table.set_dotted(true);
-            install_table.insert(&pkg.id, Item::Value(Value::InlineTable(descriptor_table)));
-            already_installed.insert(pkg.id.clone(), false);
-            debug!(
-                "package newly installed: id={}, pkg-path={}",
-                pkg.id, pkg.pkg_path
-            );
+            install_table.insert(pkg.id(), Item::Value(Value::InlineTable(descriptor_table)));
+            already_installed.insert(pkg.id().to_string(), false);
         } else {
-            already_installed.insert(pkg.id.clone(), true);
-            debug!("package already installed: id={}", pkg.id);
+            already_installed.insert(pkg.id().to_string(), true);
+            debug!("package already installed: id={}", pkg.id());
         }
     }
 
@@ -1390,7 +1492,7 @@ pub(super) mod test {
             profile_fish: None,
             profile_tcsh: None,
             profile_zsh: None,
-            packages: Some(vec![PackageToInstall {
+            packages: Some(vec![CatalogPackage {
                 id: "python3".to_string(),
                 pkg_path: "python3".to_string(),
                 version: Some("3.11.6".to_string()),
@@ -1628,23 +1730,27 @@ pub(super) mod test {
 
     #[test]
     fn insert_adds_new_package() {
-        let test_packages = vec![PackageToInstall::from_str("python").unwrap()];
+        let test_packages = vec![PackageToInstall::Catalog(
+            CatalogPackage::from_str("python").unwrap(),
+        )];
         let pre_addition_toml = DUMMY_MANIFEST.parse::<DocumentMut>().unwrap();
-        assert!(!contains_package(&pre_addition_toml, &test_packages[0].id).unwrap());
+        assert!(!contains_package(&pre_addition_toml, test_packages[0].id()).unwrap());
         let insertion =
             insert_packages(DUMMY_MANIFEST, &test_packages).expect("couldn't add package");
         assert!(
             insertion.new_toml.is_some(),
             "manifest was changed by install"
         );
-        assert!(contains_package(&insertion.new_toml.unwrap(), &test_packages[0].id).unwrap());
+        assert!(contains_package(&insertion.new_toml.unwrap(), test_packages[0].id()).unwrap());
     }
 
     #[test]
     fn no_change_adding_existing_package() {
-        let test_packages = vec![PackageToInstall::from_str("hello").unwrap()];
+        let test_packages = vec![PackageToInstall::Catalog(
+            CatalogPackage::from_str("hello").unwrap(),
+        )];
         let pre_addition_toml = DUMMY_MANIFEST.parse::<DocumentMut>().unwrap();
-        assert!(contains_package(&pre_addition_toml, &test_packages[0].id).unwrap());
+        assert!(contains_package(&pre_addition_toml, test_packages[0].id()).unwrap());
         let insertion = insert_packages(DUMMY_MANIFEST, &test_packages).unwrap();
         assert!(
             insertion.new_toml.is_none(),
@@ -1658,10 +1764,12 @@ pub(super) mod test {
 
     #[test]
     fn insert_adds_install_table_when_missing() {
-        let test_packages = vec![PackageToInstall::from_str("foo").unwrap()];
+        let test_packages = vec![PackageToInstall::Catalog(
+            CatalogPackage::from_str("foo").unwrap(),
+        )];
         let insertion = insert_packages("", &test_packages).unwrap();
         assert!(
-            contains_package(&insertion.new_toml.clone().unwrap(), &test_packages[0].id).unwrap()
+            contains_package(&insertion.new_toml.clone().unwrap(), test_packages[0].id()).unwrap()
         );
         assert!(
             insertion.new_toml.is_some(),
@@ -1675,7 +1783,9 @@ pub(super) mod test {
 
     #[test]
     fn insert_error_when_manifest_malformed() {
-        let test_packages = vec![PackageToInstall::from_str("foo").unwrap()];
+        let test_packages = vec![PackageToInstall::Catalog(
+            CatalogPackage::from_str("foo").unwrap(),
+        )];
         let attempted_insertion = insert_packages(BAD_MANIFEST, &test_packages);
         assert!(matches!(
             attempted_insertion,
@@ -1718,9 +1828,11 @@ pub(super) mod test {
     #[test]
     fn inserts_package_needing_quotes() {
         let attrs = r#"foo."bar.baz".qux"#;
-        let test_packages = vec![PackageToInstall::from_str(attrs).unwrap()];
+        let test_packages = vec![PackageToInstall::Catalog(
+            CatalogPackage::from_str(attrs).unwrap(),
+        )];
         let pre_addition_toml = DUMMY_MANIFEST.parse::<DocumentMut>().unwrap();
-        assert!(!contains_package(&pre_addition_toml, &test_packages[0].id).unwrap());
+        assert!(!contains_package(&pre_addition_toml, test_packages[0].id()).unwrap());
         let insertion =
             insert_packages(DUMMY_MANIFEST, &test_packages).expect("couldn't add package");
         assert!(
@@ -1728,7 +1840,7 @@ pub(super) mod test {
             "manifest was changed by install"
         );
         let new_toml = insertion.new_toml.unwrap();
-        assert!(contains_package(&new_toml, &test_packages[0].id).unwrap());
+        assert!(contains_package(&new_toml, test_packages[0].id()).unwrap());
         let inserted_path = new_toml
             .get("install")
             .and_then(|t| t.get("qux"))
@@ -1740,35 +1852,35 @@ pub(super) mod test {
 
     #[test]
     fn parses_string_descriptor() {
-        let parsed: PackageToInstall = "hello".parse().unwrap();
-        assert_eq!(parsed, PackageToInstall {
+        let parsed: CatalogPackage = "hello".parse().unwrap();
+        assert_eq!(parsed, CatalogPackage {
             id: "hello".to_string(),
             pkg_path: "hello".to_string(),
             version: None,
         });
-        let parsed: PackageToInstall = "foo.bar@=1.2.3".parse().unwrap();
-        assert_eq!(parsed, PackageToInstall {
+        let parsed: CatalogPackage = "foo.bar@=1.2.3".parse().unwrap();
+        assert_eq!(parsed, CatalogPackage {
             id: "bar".to_string(),
             pkg_path: "foo.bar".to_string(),
             version: Some("=1.2.3".to_string()),
         });
-        let parsed: PackageToInstall = "foo.bar@23.11".parse().unwrap();
-        assert_eq!(parsed, PackageToInstall {
+        let parsed: CatalogPackage = "foo.bar@23.11".parse().unwrap();
+        assert_eq!(parsed, CatalogPackage {
             id: "bar".to_string(),
             pkg_path: "foo.bar".to_string(),
             version: Some("23.11".to_string()),
         });
-        let parsed: PackageToInstall = "rubyPackages.\"http_parser.rb\"".parse().unwrap();
-        assert_eq!(parsed, PackageToInstall {
+        let parsed: CatalogPackage = "rubyPackages.\"http_parser.rb\"".parse().unwrap();
+        assert_eq!(parsed, CatalogPackage {
             id: "http_parser.rb".to_string(),
             pkg_path: "rubyPackages.\"http_parser.rb\"".to_string(),
             version: None,
         });
 
-        PackageToInstall::from_str("foo.\"bar.baz.qux@1.2.3")
+        CatalogPackage::from_str("foo.\"bar.baz.qux@1.2.3")
             .expect_err("missing closing quote should cause failure");
-        PackageToInstall::from_str("@1.2.3").expect_err("missing attrpath should cause failure");
-        PackageToInstall::from_str("foo@").expect_err("missing version should cause failure");
+        CatalogPackage::from_str("@1.2.3").expect_err("missing attrpath should cause failure");
+        CatalogPackage::from_str("foo@").expect_err("missing version should cause failure");
     }
 
     proptest! {
@@ -1778,5 +1890,45 @@ pub(super) mod test {
             let parsed = toml_edit::de::from_str::<TypedManifestCatalog>(&toml).unwrap();
             prop_assert_eq!(manifest, parsed);
         }
+    }
+
+    #[test]
+    fn infers_id_from_github_flake_ref() {
+        let url = Url::parse("github:foo/bar").unwrap();
+        eprintln!("{:?}", url);
+        let inferred = infer_flake_install_id(&url).unwrap();
+        assert_eq!(inferred.as_str(), "bar");
+    }
+
+    #[test]
+    fn infers_id_from_https_flake_ref() {
+        let url = Url::parse("https://github.com/foo/bar/archive/main.tar.gz").unwrap();
+        let inferred = infer_flake_install_id(&url).unwrap();
+        assert_eq!(inferred.as_str(), "bar");
+    }
+
+    #[test]
+    fn infers_fallback_id_for_https_flake_ref() {
+        let url = Url::parse("https://example.com/foo/bar/baz").unwrap();
+        let inferred = infer_flake_install_id(&url).unwrap();
+        assert_eq!(inferred.as_str(), "flake");
+    }
+
+    #[test]
+    fn inferring_id_fails_with_malformed_flakeref() {
+        let url = Url::parse("github:flox").unwrap();
+        let inferred = infer_flake_install_id(&url);
+        assert!(matches!(
+            inferred,
+            Err(ManifestError::InvalidFlakeRef { .. })
+        ));
+    }
+
+    #[test]
+    fn detects_local_flake_ref() {
+        assert!(is_local_flake_ref("./foo/bar"));
+        assert!(is_local_flake_ref("/some/absolute/path"));
+        assert!(is_local_flake_ref("path:foo/bar"));
+        assert!(!is_local_flake_ref("github:foo/bar"));
     }
 }

--- a/cli/flox/src/commands/init/go.rs
+++ b/cli/flox/src/commands/init/go.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::InitCustomization;
-use flox_rust_sdk::models::manifest::PackageToInstall;
+use flox_rust_sdk::models::manifest::CatalogPackage;
 use flox_rust_sdk::utils::traceable_path;
 use indoc::{formatdoc, indoc};
 use tracing::debug;
@@ -146,7 +146,7 @@ impl InitHook for Go {
             profile_fish: None,
             profile_tcsh: None,
             profile_zsh: None,
-            packages: Some(vec![PackageToInstall {
+            packages: Some(vec![CatalogPackage {
                 id: "go".to_string(),
                 pkg_path: "go".to_string(),
                 version: go_version,

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::InitCustomization;
-use flox_rust_sdk::models::manifest::PackageToInstall;
+use flox_rust_sdk::models::manifest::CatalogPackage;
 use flox_rust_sdk::utils::traceable_path;
 use indoc::{formatdoc, indoc};
 use semver::VersionReq;
@@ -646,7 +646,7 @@ impl InitHook for Node {
 
         let hook_on_activate = match &self.action {
             NodeInstallAction::Yarn(yarn_install) => {
-                packages.push(PackageToInstall {
+                packages.push(CatalogPackage {
                     id: "yarn".to_string(),
                     pkg_path: yarn_install.yarn.rel_path.clone().into(),
                     // TODO: we probably shouldn't pin this when we're just
@@ -660,12 +660,12 @@ impl InitHook for Node {
             NodeInstallAction::YarnOrNode(_, node_install)
             | NodeInstallAction::Node(node_install) => {
                 let nodejs_to_install = match &node_install.node {
-                    Some(result) => PackageToInstall {
+                    Some(result) => CatalogPackage {
                         id: "nodejs".to_string(),
                         pkg_path: result.rel_path.clone().into(),
                         version: result.version.clone(),
                     },
-                    None => PackageToInstall {
+                    None => CatalogPackage {
                         id: "nodejs".to_string(),
                         pkg_path: "nodejs".to_string(),
                         version: None,
@@ -780,7 +780,7 @@ mod tests {
             }
             .get_init_customization(),
             InitCustomization {
-                packages: Some(vec![PackageToInstall {
+                packages: Some(vec![CatalogPackage {
                     id: "yarn".to_string(),
                     pkg_path: "yarn.path".to_string(),
                     version: Some("1".to_string()),
@@ -831,7 +831,7 @@ mod tests {
             }
             .get_init_customization(),
             InitCustomization {
-                packages: Some(vec![PackageToInstall {
+                packages: Some(vec![CatalogPackage {
                     id: "nodejs".to_string(),
                     pkg_path: "nodejs.path".to_string(),
                     version: Some("1".to_string()),
@@ -864,7 +864,7 @@ mod tests {
             }
             .get_init_customization(),
             InitCustomization {
-                packages: Some(vec![PackageToInstall {
+                packages: Some(vec![CatalogPackage {
                     id: "nodejs".to_string(),
                     pkg_path: "nodejs.path".to_string(),
                     version: Some("1".to_string()),

--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Context, Error, Result};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::InitCustomization;
-use flox_rust_sdk::models::manifest::PackageToInstall;
+use flox_rust_sdk::models::manifest::CatalogPackage;
 use indoc::{formatdoc, indoc};
 use itertools::Itertools;
 use log::debug;
@@ -456,12 +456,12 @@ impl Provider for PoetryPyProject {
                 .to_string(),
             ),
             packages: Some(vec![
-                PackageToInstall {
+                CatalogPackage {
                     id: "python3".to_string(),
                     pkg_path: "python3".to_string(),
                     version: python_version,
                 },
-                PackageToInstall {
+                CatalogPackage {
                     id: "poetry".to_string(),
                     pkg_path: "poetry".to_string(),
                     version: None,
@@ -656,7 +656,7 @@ impl Provider for PyProject {
                 source "$PYTHON_DIR/bin/activate""#}
                 .to_string(),
             ),
-            packages: Some(vec![PackageToInstall {
+            packages: Some(vec![CatalogPackage {
                 id: "python3".to_string(),
                 pkg_path: "python3".to_string(),
                 version: python_version,
@@ -807,7 +807,7 @@ impl Provider for Requirements {
                 source "$PYTHON_DIR/bin/activate""#}
                 .to_string(),
             ),
-            packages: Some(vec![PackageToInstall {
+            packages: Some(vec![CatalogPackage {
                 id: "python3".to_string(),
                 pkg_path: "python3".to_string(),
                 version: None,

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -14,7 +14,12 @@ use flox_rust_sdk::models::lockfile::{
     ResolutionFailure,
     ResolutionFailures,
 };
-use flox_rust_sdk::models::manifest::PackageToInstall;
+use flox_rust_sdk::models::manifest::{
+    catalog_packages_to_install,
+    is_local_flake_ref,
+    CatalogPackage,
+    PackageToInstall,
+};
 use flox_rust_sdk::models::pkgdb::error_codes;
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -65,7 +70,7 @@ pub struct PkgWithIdOption {
     ///
     /// Append `@<version>` to specify a version requirement
     #[bpaf(positional("package"))]
-    pub path: String,
+    pub pkg: String,
 }
 
 impl Install {
@@ -118,13 +123,28 @@ impl Install {
             .iter()
             .map(|p| PackageToInstall::from_str(p))
             .collect::<Result<Vec<_>, _>>()?;
-        packages_to_install.extend(self.id.iter().map(|p| PackageToInstall {
-            id: p.id.clone(),
-            pkg_path: p.path.clone(),
-            version: None,
-        }));
+        let pkgs_with_ids = self
+            .id
+            .iter()
+            .map(|p| {
+                let mut pkg = PackageToInstall::from_str(&p.pkg);
+                if let Ok(ref mut pkg) = pkg {
+                    pkg.set_id(&p.id);
+                }
+                pkg
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        packages_to_install.extend(pkgs_with_ids.into_iter());
         if packages_to_install.is_empty() {
             bail!("Must specify at least one package");
+        }
+
+        for pkg in packages_to_install.iter() {
+            if let PackageToInstall::Flake(pkg) = pkg {
+                if is_local_flake_ref(pkg.url.as_str()) {
+                    bail!("Cannot install local flake references");
+                }
+            }
         }
 
         // We don't know the contents of the packages field when the span is created
@@ -152,9 +172,10 @@ impl Install {
             // TODO: move this behind the `installation.new_manifest.is_some()`
             // check below so we don't warn when we don't even install anything
             LockedManifest::Catalog(locked_manifest) => {
-                for warning in
-                    Self::generate_warnings(&locked_manifest.packages, &packages_to_install)
-                {
+                for warning in Self::generate_warnings(
+                    &locked_manifest.packages,
+                    &catalog_packages_to_install(&packages_to_install),
+                ) {
                     message::warning(warning);
                 }
             },
@@ -165,7 +186,7 @@ impl Install {
                     .iter()
                     .filter(|w| {
                         // Filter out warnings that are not related to the packages we just installed
-                        packages_to_install.iter().any(|p| w.package == p.id)
+                        packages_to_install.iter().any(|p| w.package == p.id())
                     })
                     .for_each(|w| message::warning(&w.message));
             },
@@ -174,12 +195,12 @@ impl Install {
         if installation.new_manifest.is_some() {
             // Print which new packages were installed
             for pkg in packages_to_install.iter() {
-                if let Some(false) = installation.already_installed.get(&pkg.id) {
+                if let Some(false) = installation.already_installed.get(pkg.id()) {
                     message::package_installed(pkg, &description);
                 } else {
                     message::warning(format!(
                         "Package with id '{}' already installed to environment {description}",
-                        pkg.id
+                        pkg.id()
                     ));
                 }
             }
@@ -187,7 +208,7 @@ impl Install {
             for pkg in packages_to_install.iter() {
                 message::warning(format!(
                     "Package with id '{}' already installed to environment {description}",
-                    pkg.id
+                    pkg.id()
                 ));
             }
         }
@@ -195,8 +216,13 @@ impl Install {
     }
 
     fn format_packages_for_tracing(packages: &[PackageToInstall]) -> String {
-        // TODO: settle on a real format for the contents of this string (JSON, etc)
-        packages.iter().map(|p| p.pkg_path.clone()).join(",")
+        packages
+            .iter()
+            .map(|p| match p {
+                PackageToInstall::Catalog(pkg) => pkg.pkg_path.clone(),
+                PackageToInstall::Flake(pkg) => pkg.url.to_string(),
+            })
+            .join(",")
     }
 
     fn handle_error(
@@ -209,7 +235,7 @@ impl Install {
 
         subcommand_metric!(
             "install",
-            "failed_packages" = packages.iter().map(|p| p.pkg_path.clone()).join(",")
+            "failed_packages" = Install::format_packages_for_tracing(packages)
         );
 
         match err {
@@ -219,6 +245,13 @@ impl Install {
                     flox_rust_sdk::models::pkgdb::CallPkgDbError::PkgDbError(pkgdberr),
                 ),
             )) if pkgdberr.exit_code == error_codes::RESOLUTION_FAILURE => 'error: {
+                let packages = packages
+                    .iter()
+                    .filter_map(|p| match p {
+                        PackageToInstall::Catalog(pkg) => Some(pkg),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
                 debug!("attempting to make install suggestion");
                 let paths = packages.iter().map(|p| p.pkg_path.clone()).join(", ");
 
@@ -284,7 +317,7 @@ impl Install {
     /// Generate warnings to print to the user about unfree and broken packages.
     fn generate_warnings(
         locked_packages: &[LockedPackageCatalog],
-        packages_to_install: &[PackageToInstall],
+        packages_to_install: &[CatalogPackage],
     ) -> Vec<String> {
         let mut warnings = vec![];
 
@@ -327,7 +360,7 @@ impl Install {
 mod tests {
     use flox_rust_sdk::models::lockfile::test_helpers::fake_package;
     use flox_rust_sdk::models::lockfile::LockedPackageCatalog;
-    use flox_rust_sdk::models::manifest::PackageToInstall;
+    use flox_rust_sdk::models::manifest::CatalogPackage;
     use flox_rust_sdk::providers::catalog::SystemEnum;
 
     use crate::commands::install::Install;
@@ -351,7 +384,7 @@ mod tests {
         let (foo_iid, _, mut foo_locked) = fake_package("foo", None);
         foo_locked.unfree = Some(true);
         let locked_packages = vec![foo_locked];
-        let packages_to_install = vec![PackageToInstall {
+        let packages_to_install = vec![CatalogPackage {
             id: foo_iid.clone(),
             pkg_path: "foo".to_string(),
             version: None,
@@ -379,7 +412,7 @@ mod tests {
         };
 
         let locked_packages = vec![foo_locked, foo_locked_second_system];
-        let packages_to_install = vec![PackageToInstall {
+        let packages_to_install = vec![CatalogPackage {
             id: foo_iid.clone(),
             pkg_path: "foo".to_string(),
             version: None,
@@ -399,7 +432,7 @@ mod tests {
         let (foo_iid, _, mut foo_locked) = fake_package("foo", None);
         foo_locked.broken = Some(true);
         let locked_packages = vec![foo_locked];
-        let packages_to_install = vec![PackageToInstall {
+        let packages_to_install = vec![CatalogPackage {
             id: foo_iid.clone(),
             pkg_path: "foo".to_string(),
             version: None,
@@ -427,7 +460,7 @@ mod tests {
         };
 
         let locked_packages = vec![foo_locked, foo_locked_second_system];
-        let packages_to_install = vec![PackageToInstall {
+        let packages_to_install = vec![CatalogPackage {
             id: foo_iid.clone(),
             pkg_path: "foo".to_string(),
             version: None,

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -34,6 +34,6 @@ pub(crate) fn warning(v: impl Display) {
 pub(crate) fn package_installed(pkg: &PackageToInstall, environment_description: &str) {
     updated(format!(
         "'{}' installed to environment {environment_description}",
-        pkg.id
+        pkg.id()
     ));
 }

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -383,3 +383,32 @@ EOF
 EOF
 )"
 }
+
+# ---------------------------------------------------------------------------- #
+
+@test "flake: github ref added to manifest" {
+  "$FLOX_BIN" init
+  input_flake="github:foo/bar"
+  run "$FLOX_BIN" install "$input_flake"
+  assert_success
+  installed_flake=$(tomlq -r -c -t ".install.bar" "$MANIFEST_PATH")
+  assert_equal "$installed_flake" "flake = \"$input_flake\""
+}
+
+@test "flake: https ref added to manifest" {
+  "$FLOX_BIN" init
+  input_flake="https://github.com/foo/bar/archive/main.tar.gz"
+  run "$FLOX_BIN" install "$input_flake"
+  assert_success
+  installed_flake=$(tomlq -r -c -t ".install.bar" "$MANIFEST_PATH")
+  assert_equal "$installed_flake" "flake = \"$input_flake\""
+}
+
+@test "flake: fallback id added to manifest" {
+  "$FLOX_BIN" init
+  input_flake="https://example.com/foo"
+  run "$FLOX_BIN" install "$input_flake"
+  assert_success
+  installed_flake=$(tomlq -r -c -t ".install.flake" "$MANIFEST_PATH")
+  assert_equal "$installed_flake" "flake = \"$input_flake\""
+}


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This allows a user to `flox install <flakeref>'.  The install ID is inferred in the following way:
- For `github` flake refs, the repository name is used.
- For `https` flake refs where the domain is `github.com`, the repository name is also used.
- For all other URLs the ID is set to `flake`.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users can now add Nix flakes to their manifest via the `flox install` command.

<!-- Many thanks! -->
