### PR TITLE
test(services): Make file test more robust

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -73,12 +73,10 @@ setup_sleeping_services() {
   assert_success
   run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/start_and_cleanup.sh"
-    echo "looking for file"
-    [ -e hello.txt ]
-    echo "found it"
 EOF
 )
   assert_success
+  [ -e hello.txt ]
 }
 
 @test "'flox activate -s' error without feature flag" {


### PR DESCRIPTION
## Proposed Changes

This failed on a feature branch:

- https://github.com/flox/flox/actions/runs/9916449301/job/27399123582#step:6:381
- https://github.com/flox/flox/pull/1776

With the following output:

    -- command failed --
    status : 1
    output (4 lines):
      Starting process-compose
      Waiting for process-compose socket
      looking for file
      Shutting down process-compose
    --

I can't reproduce this locally but think it is a race condition whereby the service hasn't completed by the time we've confirmed the `process-compose` socket is created.

Prevent this from happening moving the file assertion outside of the activation after we've waited for `process-compose` to shutdown. It also gives us clearer output when it fails:

    not ok 1 process-compose can run generated config file in 1327ms
    # tags: bats:focus services
    # (in test file services.bats, line 80)
    #   `[ -e invalid.txt ]' failed


## Release Notes

N/A