### PR TITLE
feat: support flake installables for list

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -691,7 +691,7 @@ impl ManifestPackageDescriptorCatalog {
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct ManifestPackageDescriptorFlake {
-    pub(crate) flake: String,
+    pub flake: String,
 }
 
 #[skip_serializing_none]

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -18,7 +18,7 @@ use crate::data::{System, Version};
 use crate::utils::proptest_btree_map_alphanum_keys;
 
 pub(super) const DEFAULT_GROUP_NAME: &str = "toplevel";
-pub(super) const DEFAULT_PRIORITY: usize = 5;
+pub const DEFAULT_PRIORITY: usize = 5;
 
 /// Represents the `[version]` number key in manifest.toml
 pub const MANIFEST_VERSION_KEY: &str = "version";

--- a/cli/flox-rust-sdk/src/providers/flox_cpp_utils.rs
+++ b/cli/flox-rust-sdk/src/providers/flox_cpp_utils.rs
@@ -38,31 +38,31 @@ pub enum FlakeInstallableError {
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct LockedInstallable {
     /// locked url of the flakeref component of the installable
-    pub(crate) locked_url: String,
-    pub(crate) flake_description: Option<String>,
-    pub(crate) locked_flake_attr_path: String,
-    pub(crate) derivation: String,
+    pub locked_url: String,
+    pub flake_description: Option<String>,
+    pub locked_flake_attr_path: String,
+    pub derivation: String,
     /// Map of output names to their paths
     /// The values are expected to be nix store paths
-    pub(crate) outputs: BTreeMap<String, String>,
+    pub outputs: BTreeMap<String, String>,
     /// List of output names in the original order
-    pub(crate) output_names: Vec<String>,
+    pub output_names: Vec<String>,
     /// List of output names to install as defined by the package
-    pub(crate) outputs_to_install: Option<Vec<String>>,
+    pub outputs_to_install: Option<Vec<String>>,
     /// List of output names to install as requested by the user
-    pub(crate) requested_outputs_to_install: Option<Vec<String>>,
+    pub requested_outputs_to_install: Option<Vec<String>>,
     /// System as defined by the package
-    pub(crate) package_system: String,
+    pub package_system: String,
     /// System as specified by the manifest and used to set default attribute
     /// paths when locking the installable
-    pub(crate) system: String,
-    pub(crate) name: String,
-    pub(crate) pname: Option<String>,
-    pub(crate) version: Option<String>,
-    pub(crate) description: Option<String>,
-    pub(crate) licenses: Option<Vec<String>>,
-    pub(crate) broken: Option<bool>,
-    pub(crate) unfree: Option<bool>,
+    pub system: String,
+    pub name: String,
+    pub pname: Option<String>,
+    pub version: Option<String>,
+    pub description: Option<String>,
+    pub licenses: Option<Vec<String>>,
+    pub broken: Option<bool>,
+    pub unfree: Option<bool>,
 }
 
 /// Required functionality to lock a flake installable

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -8,9 +8,13 @@ use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::models::lockfile::{
     InstalledPackage,
     LockedManifest,
+    LockedPackageFlake,
     PackageInfo,
+    PackageToList,
     TypedLockedManifestPkgdb,
 };
+use flox_rust_sdk::models::manifest::DEFAULT_PRIORITY;
+use flox_rust_sdk::providers::flox_cpp_utils::LockedInstallable;
 use indoc::formatdoc;
 use itertools::Itertools;
 use log::debug;
@@ -106,9 +110,13 @@ impl List {
     }
 
     /// print package ids only
-    fn print_name_only(mut out: impl Write, packages: &[InstalledPackage]) -> Result<()> {
+    fn print_name_only(mut out: impl Write, packages: &[PackageToList]) -> Result<()> {
         for p in packages {
-            writeln!(&mut out, "{}", p.install_id)?;
+            let install_id = match p {
+                PackageToList::CatalogOrPkgdb(p) => &p.install_id,
+                PackageToList::Flake(p) => &p.install_id,
+            };
+            writeln!(&mut out, "{install_id}")?;
         }
         Ok(())
     }
@@ -118,55 +126,126 @@ impl List {
     /// e.g. `pip: python3Packages.pip (20.3.4)`
     ///
     /// This is the default mode
-    fn print_extended(mut out: impl Write, packages: &[InstalledPackage]) -> Result<()> {
+    fn print_extended(mut out: impl Write, packages: &[PackageToList]) -> Result<()> {
         for p in packages {
-            writeln!(
-                &mut out,
-                "{id}: {path} ({version})",
-                id = p.install_id,
-                path = p.rel_path,
-                version = p.info.version.as_deref().unwrap_or("N/A")
-            )?;
+            match p {
+                PackageToList::CatalogOrPkgdb(p) => {
+                    writeln!(
+                        &mut out,
+                        "{id}: {path} ({version})",
+                        id = p.install_id,
+                        path = p.rel_path,
+                        version = p.info.version.as_deref().unwrap_or("N/A")
+                    )?;
+                },
+                PackageToList::Flake(p) => {
+                    writeln!(
+                        &mut out,
+                        "{id}: {locked_url}#{flake_attr_path}",
+                        id = p.install_id,
+                        locked_url = p.locked_installable.locked_url,
+                        flake_attr_path = p.locked_installable.locked_flake_attr_path
+                    )?;
+                },
+            }
         }
         Ok(())
     }
 
     /// print package ids, as well as extended detailed information
-    fn print_detail(mut out: impl Write, packages: &[InstalledPackage]) -> Result<()> {
-        for (idx, package) in packages.iter().sorted_by_key(|p| p.priority).enumerate() {
-            let InstalledPackage {
-                install_id: name,
-                rel_path,
-                info:
-                    PackageInfo {
-                        pname,
-                        version,
-                        description,
-                        license,
-                        unfree,
-                        broken,
-                    },
-                priority,
-            } = package;
+    fn print_detail(mut out: impl Write, packages: &[PackageToList]) -> Result<()> {
+        for (idx, package) in packages
+            .iter()
+            .sorted_by_key(|p| match p {
+                PackageToList::CatalogOrPkgdb(p) => p.priority.unwrap_or(DEFAULT_PRIORITY),
+                PackageToList::Flake(_) => DEFAULT_PRIORITY,
+            })
+            .enumerate()
+        {
+            let message = match package {
+                PackageToList::CatalogOrPkgdb(package) => {
+                    let InstalledPackage {
+                        install_id: name,
+                        rel_path,
+                        info:
+                            PackageInfo {
+                                pname,
+                                version,
+                                description,
+                                license,
+                                unfree,
+                                broken,
+                            },
+                        priority,
+                    } = package;
 
-            let message = formatdoc! {"
-                {name}: ({pname})
-                  Description: {description}
-                  Path:     {rel_path}
-                  Priority: {priority}
-                  Version:  {version}
-                  License:  {license}
-                  Unfree:   {unfree}
-                  Broken:   {broken}
-                ",
-                description = description.as_deref().unwrap_or("N/A"),
-                priority = priority.map(|p| p.to_string()).as_deref().unwrap_or("N/A"),
-                version = version.as_deref().unwrap_or("N/A"),
-                license = license.as_deref().unwrap_or("N/A"),
-                unfree = unfree.map(|u|u.to_string()).as_deref().unwrap_or("N/A"),
-                broken = broken.map(|b|b.to_string()).as_deref().unwrap_or("N/A"),
+                    formatdoc! {"
+                    {name}: ({pname})
+                      Description: {description}
+                      Path:     {rel_path}
+                      Priority: {priority}
+                      Version:  {version}
+                      License:  {license}
+                      Unfree:   {unfree}
+                      Broken:   {broken}
+                    ",
+                        description = description.as_deref().unwrap_or("N/A"),
+                        priority = priority.map(|p| p.to_string()).as_deref().unwrap_or("N/A"),
+                        version = version.as_deref().unwrap_or("N/A"),
+                        license = license.as_deref().unwrap_or("N/A"),
+                        unfree = unfree.map(|u|u.to_string()).as_deref().unwrap_or("N/A"),
+                        broken = broken.map(|b|b.to_string()).as_deref().unwrap_or("N/A"),
+                    }
+                },
+                PackageToList::Flake(package) => {
+                    let LockedPackageFlake {
+                        install_id,
+                        locked_installable:
+                            LockedInstallable {
+                                locked_url,
+                                locked_flake_attr_path,
+                                pname,
+                                version,
+                                description,
+                                licenses,
+                                broken,
+                                unfree,
+                                ..
+                            },
+                    } = package;
+
+                    let formatted_licenses = licenses.as_ref().map(|licenses| {
+                        if licenses.len() == 1 {
+                            format!("License:         {}", licenses[0])
+                        } else {
+                            format!("Licenses:        {}", licenses.join(", "))
+                        }
+                    });
+
+                    // Add parenthesis and a space to pname if it's not None
+                    let formatted_pname = pname.as_ref().map(|pname| format!(" ({})", pname));
+
+                    formatdoc! {"
+                    {install_id}:{formatted_pname}
+                      Locked URL:      {locked_url}
+                      Flake attribute: {locked_flake_attr_path}
+                      Description:     {description}
+                      Priority:        {priority}
+                      Version:         {version}
+                      {formatted_licenses}
+                      Unfree:          {unfree}
+                      Broken:          {broken}
+                    ",
+                        formatted_pname = formatted_pname.as_deref().unwrap_or(""),
+                        description = description.as_deref().unwrap_or("N/A"),
+                        priority = DEFAULT_PRIORITY,
+                        version = version.as_deref().unwrap_or("N/A"),
+                        formatted_licenses = formatted_licenses.as_deref().unwrap_or("License: N/A"),
+                        unfree = unfree.map(|u|u.to_string()).as_deref().unwrap_or("N/A"),
+                        broken = broken.map(|b|b.to_string()).as_deref().unwrap_or("N/A"),
+                    }
+                },
             };
-
             // add an empty line between packages
             if idx < packages.len() - 1 {
                 writeln!(&mut out, "{message}")?;
@@ -207,12 +286,13 @@ impl List {
 
 #[cfg(test)]
 mod tests {
+    use flox_rust_sdk::models::lockfile::test_helpers::LOCKED_NIX_EVAL_JOBS;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     use super::*;
 
-    fn test_packages() -> [InstalledPackage; 2] {
+    fn test_packages() -> [PackageToList; 2] {
         [
             InstalledPackage {
                 install_id: "pip-iid".to_string(),
@@ -226,7 +306,8 @@ mod tests {
                     broken: Some(false),
                 },
                 priority: Some(100),
-            },
+            }
+            .into(),
             InstalledPackage {
                 install_id: "python".to_string(),
                 rel_path: "python3Packages.python".to_string(),
@@ -239,11 +320,12 @@ mod tests {
                     broken: Some(false),
                 },
                 priority: Some(200),
-            },
+            }
+            .into(),
         ]
     }
 
-    fn uninformative_package() -> InstalledPackage {
+    fn uninformative_package() -> PackageToList {
         InstalledPackage {
             install_id: "pip-iid".to_string(),
             rel_path: "python3Packages.pip".to_string(),
@@ -257,6 +339,7 @@ mod tests {
             },
             priority: None,
         }
+        .into()
     }
 
     #[test]
@@ -270,6 +353,20 @@ mod tests {
         "});
     }
 
+    /// Test name only output for flake installables
+    #[test]
+    fn test_name_only_flake_output() {
+        let mut out = Vec::new();
+        List::print_name_only(&mut out, &[PackageToList::Flake(
+            LOCKED_NIX_EVAL_JOBS.clone(),
+        )])
+        .unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert_eq!(out, indoc! {"
+            nix-eval-jobs
+        "});
+    }
+
     #[test]
     fn test_print_extended_output() {
         let mut out = Vec::new();
@@ -278,6 +375,20 @@ mod tests {
         assert_eq!(out, indoc! {"
             pip-iid: python3Packages.pip (20.3.4)
             python: python3Packages.python (3.9.5)
+        "});
+    }
+
+    /// Test extended output for flake installables
+    #[test]
+    fn test_print_extended_flake_output() {
+        let mut out = Vec::new();
+        List::print_extended(&mut out, &[PackageToList::Flake(
+            LOCKED_NIX_EVAL_JOBS.clone(),
+        )])
+        .unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert_eq!(out, indoc! {"
+            nix-eval-jobs: github:nix-community/nix-eval-jobs/c132534bc68eb48479a59a3116ee7ce0f16ce12b#packages.aarch64-darwin.default
         "});
     }
 
@@ -318,10 +429,79 @@ mod tests {
         "})
     }
 
+    /// Test detailed output for flake installables
+    #[test]
+    fn test_print_detail_flake_output() {
+        let mut out = Vec::new();
+        List::print_detail(&mut out, &[PackageToList::Flake(
+            LOCKED_NIX_EVAL_JOBS.clone(),
+        )])
+        .unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert_eq!(out, indoc! {"
+            nix-eval-jobs: (nix-eval-jobs)
+              Locked URL:      github:nix-community/nix-eval-jobs/c132534bc68eb48479a59a3116ee7ce0f16ce12b
+              Flake attribute: packages.aarch64-darwin.default
+              Description:     Hydra's builtin hydra-eval-jobs as a standalone
+              Priority:        5
+              Version:         2.23.0
+              License:         GPL-3.0
+              Unfree:          false
+              Broken:          false
+        "});
+    }
+
+    /// Test detailed output for flake installables when pname is missing
+    #[test]
+    fn test_print_detail_flake_output_pname_missing() {
+        let mut out = Vec::new();
+        let mut package = LOCKED_NIX_EVAL_JOBS.clone();
+        package.locked_installable.pname = None;
+        List::print_detail(&mut out, &[PackageToList::Flake(package)]).unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert_eq!(out, indoc! {"
+            nix-eval-jobs:
+              Locked URL:      github:nix-community/nix-eval-jobs/c132534bc68eb48479a59a3116ee7ce0f16ce12b
+              Flake attribute: packages.aarch64-darwin.default
+              Description:     Hydra's builtin hydra-eval-jobs as a standalone
+              Priority:        5
+              Version:         2.23.0
+              License:         GPL-3.0
+              Unfree:          false
+              Broken:          false
+        "});
+    }
+
+    /// Test detailed output for flake installables with multiple licenses
+    #[test]
+    fn test_print_detail_flake_output_multiple_licenses() {
+        let mut out = Vec::new();
+        let mut package = LOCKED_NIX_EVAL_JOBS.clone();
+        if let Some(licenses) = package.locked_installable.licenses.as_mut() {
+            licenses.push("license 2".to_string());
+        }
+        List::print_detail(&mut out, &[PackageToList::Flake(package)]).unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert_eq!(out, indoc! {"
+            nix-eval-jobs: (nix-eval-jobs)
+              Locked URL:      github:nix-community/nix-eval-jobs/c132534bc68eb48479a59a3116ee7ce0f16ce12b
+              Flake attribute: packages.aarch64-darwin.default
+              Description:     Hydra's builtin hydra-eval-jobs as a standalone
+              Priority:        5
+              Version:         2.23.0
+              Licenses:        GPL-3.0, license 2
+              Unfree:          false
+              Broken:          false
+        "});
+    }
+
     #[test]
     fn test_print_detail_output_orders_by_priority_unknown_first() {
         let mut packages = test_packages();
-        packages[1].priority = None;
+        let PackageToList::CatalogOrPkgdb(ref mut package_2) = packages[1] else {
+            panic!();
+        };
+        package_2.priority = None;
 
         let mut out = Vec::new();
         List::print_detail(&mut out, &packages).unwrap();
@@ -350,7 +530,10 @@ mod tests {
     #[test]
     fn test_print_detail_output_orders_by_priority() {
         let mut packages = test_packages();
-        packages[1].priority = Some(10);
+        let PackageToList::CatalogOrPkgdb(ref mut package_2) = packages[1] else {
+            panic!();
+        };
+        package_2.priority = Some(10);
 
         let mut out = Vec::new();
         List::print_detail(&mut out, &packages).unwrap();

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -871,6 +871,7 @@ pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
         LockedManifestError::BrokenNotAllowed(_) => display_chain(err),
         // User facing
         LockedManifestError::UnfreeNotAllowed(_) => display_chain(err),
+        LockedManifestError::MissingPackageDescriptor(_) => display_chain(err),
     }
 }
 


### PR DESCRIPTION
Print out information about flake installables in flox list.

`list` with no flags and `list -e` print:
```
nix-eval-jobs: github:nix-community/nix-eval-jobs
```

`list -n` prints:
```
nix-eval-jobs
```

`list -a` prints:
```
nix-eval-jobs: (nix-eval-jobs)
  Locked URL:      github:nix-community/nix-eval-jobs/c132534bc68eb48479a59a3116ee7ce0f16ce12b
  Flake attribute: packages.aarch64-darwin.default
  Description:     Hydra's builtin hydra-eval-jobs as a standalone
  Priority:        5
  Version:         2.23.0
  License:         GPL-3.0
  Unfree:          false
  Broken:          false
```

Code notes:
A `PackageToList` enum was added to wrap either pkgdb/catalog packages or flake packages. A shared format makes sense for pkgdb and catalog packages since they share so much info in common, but flake packages are different enought that they should be handled explicitly by list's printing functions.