### PR TITLE
Improve VISUAL and EDITOR arg splitting and fallback

### DIFF
--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -483,8 +483,8 @@ mod tests {
         let tmp2 = tempdir().expect("should create tempdir");
         let tmp3 = tempdir().expect("should create tempdir");
 
-        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
         let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path()))
+            .expect("should path-join tmpdirs")
             .into_string()
             .expect("should convert paths from OsString to String");
 
@@ -668,10 +668,7 @@ mod tests {
         );
     }
 
-    /// VISUAL whitespace only skips EDITOR, defaulting to PATH
-    /// This is a consequence of using is_empty to determine fallback logic
-    /// This test makes this behavior explicit, but whitespace only filenames
-    /// are already a strange variable value.
+    /// VISUAL whitespace only defaults to EDITOR before PATH
     #[test]
     fn test_determine_editor_from_vars_visual_whitespace() {
         let visual_var = "       ".to_owned();
@@ -694,7 +691,10 @@ mod tests {
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
                 .expect("should determine default editor"),
-            (nano, Vec::<String>::new())
+            (
+                PathBuf::from("code"),
+                vec!["-w"].into_iter().map(String::from).collect()
+            )
         );
 
         assert!(tmp1.path().is_dir());
@@ -725,7 +725,7 @@ mod tests {
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
                 .expect("should determine default editor"),
-            (nano, Vec::<String>::new())
+            (nano, Vec::new())
         );
 
         assert!(tmp1.path().is_dir());

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -316,6 +316,7 @@ impl Edit {
     }
 
     /// Determines the editor to use for interactive editing, based on the environment
+    /// Returns the editor and a list of args to pass to the editor
     ///
     /// If $VISUAL or $EDITOR is set, use that.
     /// The editor cannot be an empty string or one that consists of fully Unicode whitespace.
@@ -333,12 +334,13 @@ impl Edit {
     }
 
     /// Determines the editor to use for interactive editing, based on passed values
+    /// Returns the editor and a list of args to pass to the editor
     fn determine_editor_from_vars(
         visual_var: String,
         editor_var: String,
         path_var: String,
     ) -> Result<(PathBuf, Vec<String>)> {
-        let var = if !visual_var.is_empty() {
+        let var = if !visual_var.trim().is_empty() {
             visual_var
         } else {
             editor_var
@@ -482,7 +484,7 @@ mod tests {
         let tmp3 = tempdir().expect("should create tempdir");
 
         let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
-            .expect("should path-join tmpdirs")
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path()))
             .into_string()
             .expect("should convert paths from OsString to String");
 
@@ -513,10 +515,10 @@ mod tests {
         let vim = tmp2.path().join("vim");
         let vi = tmp2.path().join("vi");
         let emacs = tmp3.path().join("emacs");
-        File::create(nano.clone()).expect("should create file");
-        File::create(vim.clone()).expect("should create file");
-        File::create(vi.clone()).expect("should create file");
-        File::create(emacs.clone()).expect("should create file");
+        File::create(&nano).expect("should create file");
+        File::create(&vim).expect("should create file");
+        File::create(&vi).expect("should create file");
+        File::create(&emacs).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -549,11 +551,11 @@ mod tests {
         let vi = tmp2.path().join("vi");
         let emacs = tmp3.path().join("emacs");
 
-        fs::create_dir(nano.clone()).expect("should create directory");
+        fs::create_dir(&nano).expect("should create directory");
 
-        File::create(vim.clone()).expect("should create file");
-        File::create(vi.clone()).expect("should create file");
-        File::create(emacs.clone()).expect("should create file");
+        File::create(&vim).expect("should create file");
+        File::create(&vi).expect("should create file");
+        File::create(&emacs).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -585,10 +587,10 @@ mod tests {
         let vim = tmp2.path().join("vim");
         let vi = tmp2.path().join("vi");
         let emacs = tmp3.path().join("emacs");
-        File::create(nano.clone()).expect("should create file");
-        File::create(vim.clone()).expect("should create file");
-        File::create(vi.clone()).expect("should create file");
-        File::create(emacs.clone()).expect("should create file");
+        File::create(&nano).expect("should create file");
+        File::create(&vim).expect("should create file");
+        File::create(&vi).expect("should create file");
+        File::create(&emacs).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -686,8 +688,8 @@ mod tests {
 
         let nano = tmp1.path().join("nano");
         let vim = tmp2.path().join("vim");
-        File::create(nano.clone()).expect("should create file");
-        File::create(vim.clone()).expect("should create file");
+        File::create(&nano).expect("should create file");
+        File::create(&vim).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -717,8 +719,8 @@ mod tests {
 
         let nano = tmp1.path().join("nano");
         let vim = tmp2.path().join("vim");
-        File::create(nano.clone()).expect("should create file");
-        File::create(vim.clone()).expect("should create file");
+        File::create(&nano).expect("should create file");
+        File::create(&vim).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -748,8 +750,8 @@ mod tests {
 
         let nano = tmp1.path().join("nano");
         let vim = tmp2.path().join("vim");
-        File::create(nano.clone()).expect("should create file");
-        File::create(vim.clone()).expect("should create file");
+        File::create(&nano).expect("should create file");
+        File::create(&vim).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -355,7 +355,7 @@ impl Edit {
 
         let (path, editor) = env::split_paths(&path_var)
             .cartesian_product(["vim", "vi", "nano", "emacs"])
-            .find(|(path, editor)| path.join(editor).exists())
+            .find(|(path, editor)| path.join(editor).is_file())
             .context("no known editor found in $PATH")?;
 
         debug!("Using default editor {:?} from {:?}", editor, path);

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -529,6 +529,43 @@ mod tests {
         assert!(tmp3.path().is_dir());
     }
 
+    /// Do not default to directories
+    #[test]
+    fn test_determine_editor_from_vars_no_directory() {
+        let visual_var = "".to_owned();
+        let editor_var = "".to_owned();
+
+        let tmp1 = tempdir().expect("should create tempdir");
+        let tmp2 = tempdir().expect("should create tempdir");
+        let tmp3 = tempdir().expect("should create tempdir");
+
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
+            .expect("should path-join tmpdirs")
+            .into_string()
+            .expect("should convert paths from OsString to String");
+
+        let nano = tmp1.path().join("nano");
+        let vim = tmp2.path().join("vim");
+        let vi = tmp2.path().join("vi");
+        let emacs = tmp3.path().join("emacs");
+
+        fs::create_dir(nano.clone()).expect("should create directory");
+
+        File::create(vim.clone()).expect("should create file");
+        File::create(vi.clone()).expect("should create file");
+        File::create(emacs.clone()).expect("should create file");
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (vim, Vec::<String>::new())
+        );
+
+        assert!(tmp1.path().is_dir());
+        assert!(tmp2.path().is_dir());
+        assert!(tmp3.path().is_dir());
+    }
+
     /// Return VISUAL before EDITOR, do not default to PATH
     #[test]
     fn test_determine_editor_from_vars_visual() {

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -328,12 +328,16 @@ impl Edit {
         Self::determine_editor_from_vars(
             env::var("VISUAL").unwrap_or_default(),
             env::var("EDITOR").unwrap_or_default(),
-            env::var("PATH").context("$PATH not set")?
-        );
+            env::var("PATH").context("$PATH not set")?,
+        )
     }
 
     /// Determines the editor to use for interactive editing, based on passed values
-    fn determine_editor_from_vars(visual_var: String, editor_var: String, path_var: String) -> Result<(PathBuf, Vec<String>)> {
+    fn determine_editor_from_vars(
+        visual_var: String,
+        editor_var: String,
+        path_var: String,
+    ) -> Result<(PathBuf, Vec<String>)> {
         let var = if !visual_var.is_empty() {
             visual_var
         } else {
@@ -344,7 +348,7 @@ impl Edit {
         let editor = command.next().unwrap_or_default().to_owned();
         let args = command.map(|s| s.to_owned()).collect();
 
-        if editor != "" {
+        if !editor.is_empty() {
             debug!("Using configured editor {:?} with args {:?}", editor, args);
             return Ok((PathBuf::from(editor), args));
         }
@@ -356,7 +360,7 @@ impl Edit {
 
         debug!("Using default editor {:?} from {:?}", editor, path);
 
-        Ok((path.join(editor), (&[]).to_vec()))
+        Ok((path.join(editor), vec![]))
     }
 
     /// Retrieves the new manifest file contents if a new manifest file was provided
@@ -383,7 +387,7 @@ impl Edit {
         args: impl AsRef<Vec<String>>,
     ) -> Result<String> {
         let mut command = Command::new(editor.as_ref());
-        if args.as_ref().len() > 0 {
+        if !args.as_ref().is_empty() {
             command.args(args.as_ref());
         }
         command.arg(path.as_ref());
@@ -407,6 +411,7 @@ mod tests {
     use flox_rust_sdk::models::lockfile::LockedManifestError;
     use indoc::indoc;
     use serde::de::Error;
+    use tempfile::tempdir;
 
     use super::*;
 
@@ -464,6 +469,260 @@ mod tests {
         ));
 
         Edit::make_interactively_recoverable(result).expect_err("should return unhandled Err");
+    }
+
+    /// Error due to empty vars and no editor in PATH
+    #[test]
+    fn test_determine_editor_from_vars_not_found() {
+        let visual_var = "".to_owned();
+        let editor_var = "".to_owned();
+
+        let tmp1 = tempdir().expect("should create tempdir");
+        let tmp2 = tempdir().expect("should create tempdir");
+        let tmp3 = tempdir().expect("should create tempdir");
+
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
+            .expect("should path-join tmpdirs")
+            .into_string()
+            .expect("should convert paths from OsString to String");
+
+        Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+            .expect_err("should error with editor not found");
+
+        assert!(tmp1.path().is_dir());
+        assert!(tmp2.path().is_dir());
+        assert!(tmp3.path().is_dir());
+    }
+
+    /// Default to the first of any editor while traversing PATH
+    #[test]
+    fn test_determine_editor_from_vars_first_default_editor() {
+        let visual_var = "".to_owned();
+        let editor_var = "".to_owned();
+
+        let tmp1 = tempdir().expect("should create tempdir");
+        let tmp2 = tempdir().expect("should create tempdir");
+        let tmp3 = tempdir().expect("should create tempdir");
+
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
+            .expect("should path-join tmpdirs")
+            .into_string()
+            .expect("should convert paths from OsString to String");
+
+        let nano = tmp1.path().join("nano");
+        let vim = tmp2.path().join("vim");
+        let vi = tmp2.path().join("vi");
+        let emacs = tmp3.path().join("emacs");
+        File::create(nano.clone()).expect("should create file");
+        File::create(vim.clone()).expect("should create file");
+        File::create(vi.clone()).expect("should create file");
+        File::create(emacs.clone()).expect("should create file");
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (nano, Vec::<String>::new())
+        );
+
+        assert!(tmp1.path().is_dir());
+        assert!(tmp2.path().is_dir());
+        assert!(tmp3.path().is_dir());
+    }
+
+    /// Return VISUAL before EDITOR, do not default to PATH
+    #[test]
+    fn test_determine_editor_from_vars_visual() {
+        let visual_var = "micro".to_owned();
+        let editor_var = "hx".to_owned();
+
+        let tmp1 = tempdir().expect("should create tempdir");
+        let tmp2 = tempdir().expect("should create tempdir");
+        let tmp3 = tempdir().expect("should create tempdir");
+
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
+            .expect("should path-join tmpdirs")
+            .into_string()
+            .expect("should convert paths from OsString to String");
+
+        let nano = tmp1.path().join("nano");
+        let vim = tmp2.path().join("vim");
+        let vi = tmp2.path().join("vi");
+        let emacs = tmp3.path().join("emacs");
+        File::create(nano.clone()).expect("should create file");
+        File::create(vim.clone()).expect("should create file");
+        File::create(vi.clone()).expect("should create file");
+        File::create(emacs.clone()).expect("should create file");
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (PathBuf::from("micro"), Vec::<String>::new())
+        );
+
+        assert!(tmp1.path().is_dir());
+        assert!(tmp2.path().is_dir());
+        assert!(tmp3.path().is_dir());
+    }
+
+    /// Fallback to EDITOR, no default editor available in PATH
+    #[test]
+    fn test_determine_editor_from_vars_editor() {
+        let visual_var = "".to_owned();
+        let editor_var = "hx".to_owned();
+
+        let tmp1 = tempdir().expect("should create tempdir");
+        let tmp2 = tempdir().expect("should create tempdir");
+        let tmp3 = tempdir().expect("should create tempdir");
+
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
+            .expect("should path-join tmpdirs")
+            .into_string()
+            .expect("should convert paths from OsString to String");
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (PathBuf::from("hx"), Vec::<String>::new())
+        );
+
+        assert!(tmp1.path().is_dir());
+        assert!(tmp2.path().is_dir());
+        assert!(tmp3.path().is_dir());
+    }
+
+    /// Split VISUAL into editor and args
+    #[test]
+    fn test_determine_editor_from_vars_visual_with_args() {
+        let visual_var = "  code -w --reuse-window   --userdata-dir /home/user/code  ".to_owned();
+        let editor_var = "hx".to_owned();
+
+        let path_var = "".to_owned();
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (
+                PathBuf::from("code"),
+                vec!["-w", "--reuse-window", "--userdata-dir", "/home/user/code"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            )
+        );
+    }
+
+    /// Split EDITOR into editor and args
+    #[test]
+    fn test_determine_editor_from_vars_editor_with_args() {
+        let visual_var = "".to_owned();
+        let editor_var = "code -w".to_owned();
+
+        let path_var = "".to_owned();
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (
+                PathBuf::from("code"),
+                vec!["-w"].into_iter().map(String::from).collect()
+            )
+        );
+    }
+
+    /// VISUAL whitespace only skips EDITOR, defaulting to PATH
+    /// This is a consequence of using is_empty to determine fallback logic
+    /// This test makes this behavior explicit, but whitespace only filenames
+    /// are already a strange variable value.
+    #[test]
+    fn test_determine_editor_from_vars_visual_whitespace() {
+        let visual_var = "       ".to_owned();
+        let editor_var = "code -w".to_owned();
+
+        let tmp1 = tempdir().expect("should create tempdir");
+        let tmp2 = tempdir().expect("should create tempdir");
+        let tmp3 = tempdir().expect("should create tempdir");
+
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
+            .expect("should path-join tmpdirs")
+            .into_string()
+            .expect("should convert paths from OsString to String");
+
+        let nano = tmp1.path().join("nano");
+        let vim = tmp2.path().join("vim");
+        File::create(nano.clone()).expect("should create file");
+        File::create(vim.clone()).expect("should create file");
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (nano, Vec::<String>::new())
+        );
+
+        assert!(tmp1.path().is_dir());
+        assert!(tmp2.path().is_dir());
+        assert!(tmp3.path().is_dir());
+    }
+
+    /// EDITOR whitespace only defaults to editors on PATH
+    #[test]
+    fn test_determine_editor_from_vars_editor_whitespace() {
+        let visual_var = "".to_owned();
+        let editor_var = "       ".to_owned();
+
+        let tmp1 = tempdir().expect("should create tempdir");
+        let tmp2 = tempdir().expect("should create tempdir");
+        let tmp3 = tempdir().expect("should create tempdir");
+
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
+            .expect("should path-join tmpdirs")
+            .into_string()
+            .expect("should convert paths from OsString to String");
+
+        let nano = tmp1.path().join("nano");
+        let vim = tmp2.path().join("vim");
+        File::create(nano.clone()).expect("should create file");
+        File::create(vim.clone()).expect("should create file");
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (nano, Vec::<String>::new())
+        );
+
+        assert!(tmp1.path().is_dir());
+        assert!(tmp2.path().is_dir());
+        assert!(tmp3.path().is_dir());
+    }
+
+    /// VISUAL and EDITOR whitespace only defaults to editors on PATH
+    #[test]
+    fn test_determine_editor_from_vars_whitespace() {
+        let visual_var = "       ".to_owned();
+        let editor_var = "       ".to_owned();
+
+        let tmp1 = tempdir().expect("should create tempdir");
+        let tmp2 = tempdir().expect("should create tempdir");
+        let tmp3 = tempdir().expect("should create tempdir");
+
+        let path_var = std::env::join_paths([&tmp1, &tmp2, &tmp3].map(|d| d.path().to_owned()))
+            .expect("should path-join tmpdirs")
+            .into_string()
+            .expect("should convert paths from OsString to String");
+
+        let nano = tmp1.path().join("nano");
+        let vim = tmp2.path().join("vim");
+        File::create(nano.clone()).expect("should create file");
+        File::create(vim.clone()).expect("should create file");
+
+        assert_eq!(
+            Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
+                .expect("should determine default editor"),
+            (nano, Vec::<String>::new())
+        );
+
+        assert!(tmp1.path().is_dir());
+        assert!(tmp2.path().is_dir());
+        assert!(tmp3.path().is_dir());
     }
 
     /// Given a v0 manifest that can be migrated and v0 contents, the migration

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -249,7 +249,7 @@ impl Edit {
             bail!("Can't edit interactively in non-interactive context")
         }
 
-        let editor = Self::determine_editor()?;
+        let (editor, args) = Self::determine_editor()?;
 
         // Make a copy of the manifest for the user to edit so failed edits aren't left in
         // the original manifest. You can't put creation/cleanup inside the `edited_manifest_contents`
@@ -272,7 +272,7 @@ impl Edit {
         // Let the user keep editing the file until the build succeeds or the user
         // decides to stop.
         loop {
-            let new_manifest = Edit::edited_manifest_contents(&tmp_manifest, &editor)?;
+            let new_manifest = Edit::edited_manifest_contents(&tmp_manifest, &editor, &args)?;
 
             let result = Dialog {
                 message: "Building environment to validate edit...",
@@ -315,29 +315,48 @@ impl Edit {
         }
     }
 
-    /// Determines the editor to use for interactive editing
+    /// Determines the editor to use for interactive editing, based on the environment
     ///
-    /// If $EDITOR or $VISUAL is set, use that. Otherwise, try to find a known editor in $PATH.
+    /// If $VISUAL or $EDITOR is set, use that.
+    /// The editor cannot be an empty string or one that consists of fully Unicode whitespace.
+    /// Arguments can be passed and will be split on whitespace.
+    /// Otherwise, try to find a known editor in $PATH.
     /// The known editor selected is the first one found in $PATH from the following list:
     ///
     ///   vim, vi, nano, emacs.
-    fn determine_editor() -> Result<PathBuf> {
-        let editor = std::env::var("EDITOR").or(std::env::var("VISUAL")).ok();
+    fn determine_editor() -> Result<(PathBuf, Vec<String>)> {
+        Self::determine_editor_from_vars(
+            env::var("VISUAL").unwrap_or_default(),
+            env::var("EDITOR").unwrap_or_default(),
+            env::var("PATH").context("$PATH not set")?
+        );
+    }
 
-        if let Some(editor) = editor {
-            return Ok(PathBuf::from(editor));
+    /// Determines the editor to use for interactive editing, based on passed values
+    fn determine_editor_from_vars(visual_var: String, editor_var: String, path_var: String) -> Result<(PathBuf, Vec<String>)> {
+        let var = if !visual_var.is_empty() {
+            visual_var
+        } else {
+            editor_var
+        };
+        let mut command = var.split_whitespace();
+
+        let editor = command.next().unwrap_or_default().to_owned();
+        let args = command.map(|s| s.to_owned()).collect();
+
+        if editor != "" {
+            debug!("Using configured editor {:?} with args {:?}", editor, args);
+            return Ok((PathBuf::from(editor), args));
         }
-
-        let path_var = env::var("PATH").context("$PATH not set")?;
 
         let (path, editor) = env::split_paths(&path_var)
             .cartesian_product(["vim", "vi", "nano", "emacs"])
             .find(|(path, editor)| path.join(editor).exists())
             .context("no known editor found in $PATH")?;
 
-        debug!("Using editor {:?} from {:?}", editor, path);
+        debug!("Using default editor {:?} from {:?}", editor, path);
 
-        Ok(path.join(editor))
+        Ok((path.join(editor), (&[]).to_vec()))
     }
 
     /// Retrieves the new manifest file contents if a new manifest file was provided
@@ -361,8 +380,12 @@ impl Edit {
     fn edited_manifest_contents(
         path: impl AsRef<Path>,
         editor: impl AsRef<Path>,
+        args: impl AsRef<Vec<String>>,
     ) -> Result<String> {
         let mut command = Command::new(editor.as_ref());
+        if args.as_ref().len() > 0 {
+            command.args(args.as_ref());
+        }
         command.arg(path.as_ref());
 
         let child = command.spawn().context("editor command failed")?;

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -491,6 +491,7 @@ mod tests {
         Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
             .expect_err("should error with editor not found");
 
+        // ensure tempdir lifetimes do not drop -- require tempdir to exist on fs through the end of the test
         assert!(tmp1.path().is_dir());
         assert!(tmp2.path().is_dir());
         assert!(tmp3.path().is_dir());
@@ -516,9 +517,9 @@ mod tests {
         let vi = tmp2.path().join("vi");
         let emacs = tmp3.path().join("emacs");
         File::create(&nano).expect("should create file");
-        File::create(&vim).expect("should create file");
-        File::create(&vi).expect("should create file");
-        File::create(&emacs).expect("should create file");
+        File::create(vim).expect("should create file");
+        File::create(vi).expect("should create file");
+        File::create(emacs).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -526,6 +527,7 @@ mod tests {
             (nano, Vec::<String>::new())
         );
 
+        // ensure tempdir lifetimes do not drop -- require tempdir to exist on fs through the end of the test
         assert!(tmp1.path().is_dir());
         assert!(tmp2.path().is_dir());
         assert!(tmp3.path().is_dir());
@@ -551,11 +553,11 @@ mod tests {
         let vi = tmp2.path().join("vi");
         let emacs = tmp3.path().join("emacs");
 
-        fs::create_dir(&nano).expect("should create directory");
+        fs::create_dir(nano).expect("should create directory");
 
         File::create(&vim).expect("should create file");
-        File::create(&vi).expect("should create file");
-        File::create(&emacs).expect("should create file");
+        File::create(vi).expect("should create file");
+        File::create(emacs).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -563,6 +565,7 @@ mod tests {
             (vim, Vec::<String>::new())
         );
 
+        // ensure tempdir lifetimes do not drop -- require tempdir to exist on fs through the end of the test
         assert!(tmp1.path().is_dir());
         assert!(tmp2.path().is_dir());
         assert!(tmp3.path().is_dir());
@@ -587,10 +590,10 @@ mod tests {
         let vim = tmp2.path().join("vim");
         let vi = tmp2.path().join("vi");
         let emacs = tmp3.path().join("emacs");
-        File::create(&nano).expect("should create file");
-        File::create(&vim).expect("should create file");
-        File::create(&vi).expect("should create file");
-        File::create(&emacs).expect("should create file");
+        File::create(nano).expect("should create file");
+        File::create(vim).expect("should create file");
+        File::create(vi).expect("should create file");
+        File::create(emacs).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -598,6 +601,7 @@ mod tests {
             (PathBuf::from("micro"), Vec::<String>::new())
         );
 
+        // ensure tempdir lifetimes do not drop -- require tempdir to exist on fs through the end of the test
         assert!(tmp1.path().is_dir());
         assert!(tmp2.path().is_dir());
         assert!(tmp3.path().is_dir());
@@ -624,6 +628,7 @@ mod tests {
             (PathBuf::from("hx"), Vec::<String>::new())
         );
 
+        // ensure tempdir lifetimes do not drop -- require tempdir to exist on fs through the end of the test
         assert!(tmp1.path().is_dir());
         assert!(tmp2.path().is_dir());
         assert!(tmp3.path().is_dir());
@@ -685,8 +690,8 @@ mod tests {
 
         let nano = tmp1.path().join("nano");
         let vim = tmp2.path().join("vim");
-        File::create(&nano).expect("should create file");
-        File::create(&vim).expect("should create file");
+        File::create(nano).expect("should create file");
+        File::create(vim).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -697,6 +702,7 @@ mod tests {
             )
         );
 
+        // ensure tempdir lifetimes do not drop -- require tempdir to exist on fs through the end of the test
         assert!(tmp1.path().is_dir());
         assert!(tmp2.path().is_dir());
         assert!(tmp3.path().is_dir());
@@ -720,7 +726,7 @@ mod tests {
         let nano = tmp1.path().join("nano");
         let vim = tmp2.path().join("vim");
         File::create(&nano).expect("should create file");
-        File::create(&vim).expect("should create file");
+        File::create(vim).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -728,6 +734,7 @@ mod tests {
             (nano, Vec::new())
         );
 
+        // ensure tempdir lifetimes do not drop -- require tempdir to exist on fs through the end of the test
         assert!(tmp1.path().is_dir());
         assert!(tmp2.path().is_dir());
         assert!(tmp3.path().is_dir());
@@ -751,7 +758,7 @@ mod tests {
         let nano = tmp1.path().join("nano");
         let vim = tmp2.path().join("vim");
         File::create(&nano).expect("should create file");
-        File::create(&vim).expect("should create file");
+        File::create(vim).expect("should create file");
 
         assert_eq!(
             Edit::determine_editor_from_vars(visual_var, editor_var, path_var)
@@ -759,6 +766,7 @@ mod tests {
             (nano, Vec::<String>::new())
         );
 
+        // ensure tempdir lifetimes do not drop -- require tempdir to exist on fs through the end of the test
         assert!(tmp1.path().is_dir());
         assert!(tmp2.path().is_dir());
         assert!(tmp3.path().is_dir());


### PR DESCRIPTION
## Proposed Changes

Do we need to do something when the user tries to use single or double quotes?
@ysndr suggested using shlex.
If so -- that can be added in another commit
(kubectl handles this case by just looking for quotes and passing an escaped string to whatever the SHELL is)

I considered splitting the path search logic into a different function, so I could test it separately.
Do we think that would be better?

Fallback behavior is slightly weird/non-uniform when VISUAL is whitespace only -- do we care? If so, it will just require an additional whitespace parser for that case.

#1744 #1746

## Release Notes

`VISUAL` and `EDITOR` now support passing editor arguments split on whitespace
