### PR TITLE
refactor: grammar - use contents instead of content

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -401,15 +401,15 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Extract the current content of the manifest
-    fn manifest_content(&self, flox: &Flox) -> Result<String, EnvironmentError> {
+    fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         let local_checkout = self.local_env_or_copy_current_generation(flox)?;
-        let manifest = local_checkout.manifest_content()?;
+        let manifest = local_checkout.manifest_contents()?;
         Ok(manifest)
     }
 
     /// Return the deserialized manifest
     fn manifest(&self, flox: &Flox) -> Result<TypedManifest, EnvironmentError> {
-        Ok(toml::from_str(&self.manifest_content(flox)?)
+        Ok(toml::from_str(&self.manifest_contents(flox)?)
             .map_err(CoreEnvironmentError::DeserializeManifest)?)
     }
 
@@ -1117,11 +1117,11 @@ impl ManagedEnvironment {
         }
 
         let local_manifest_bytes = local
-            .manifest_content()
+            .manifest_contents()
             .map_err(ManagedEnvironmentError::ReadLocalManifest)?;
 
         let remote_manifest_bytes = remote
-            .manifest_content()
+            .manifest_contents()
             .map_err(ManagedEnvironmentError::ReadGenerationManifest)?;
 
         Ok(local_manifest_bytes == remote_manifest_bytes)
@@ -2342,7 +2342,7 @@ mod test {
         let local_manifest = managed_env
             .local_env_or_copy_current_generation(&flox)
             .unwrap()
-            .manifest_content()
+            .manifest_contents()
             .unwrap();
         assert_eq!(local_manifest, locally_edited_content);
     }
@@ -2370,11 +2370,11 @@ mod test {
         let generation_manifest = managed_env
             .get_current_generation(&flox)
             .unwrap()
-            .manifest_content()
+            .manifest_contents()
             .unwrap();
 
         assert_eq!(
-            local_checkout.manifest_content().unwrap(),
+            local_checkout.manifest_contents().unwrap(),
             generation_manifest
         );
 
@@ -2387,7 +2387,7 @@ mod test {
 
         // sanity check that before synching, the manifest is now different
         assert_ne!(
-            local_checkout.manifest_content().unwrap(),
+            local_checkout.manifest_contents().unwrap(),
             generation_manifest
         );
 
@@ -2397,11 +2397,11 @@ mod test {
         let generation_manifest = managed_env
             .get_current_generation(&flox)
             .unwrap()
-            .manifest_content()
+            .manifest_contents()
             .unwrap();
 
         assert_eq!(
-            local_checkout.manifest_content().unwrap(),
+            local_checkout.manifest_contents().unwrap(),
             generation_manifest
         );
     }

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -166,7 +166,7 @@ pub trait Environment: Send {
     ///
     /// Implementations may use process context from [Flox]
     /// to determine the current content of the manifest.
-    fn manifest_content(&self, flox: &Flox) -> Result<String, EnvironmentError>;
+    fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError>;
 
     /// Return the deserialized manifest
     fn manifest(&self, flox: &Flox) -> Result<TypedManifest, EnvironmentError>;
@@ -240,7 +240,7 @@ pub trait Environment: Send {
         &self,
         flox: &Flox,
     ) -> Result<Option<MigrationInfo>, EnvironmentError> {
-        let raw_manifest = RawManifest::from_str(&self.manifest_content(flox)?).map_err(|e| {
+        let raw_manifest = RawManifest::from_str(&self.manifest_contents(flox)?).map_err(|e| {
             EnvironmentError::Core(CoreEnvironmentError::ModifyToml(
                 TomlEditError::ParseManifest(e),
             ))

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -279,7 +279,7 @@ impl Environment for PathEnvironment {
     }
 
     /// Read the environment definition file as a string
-    fn manifest_content(&self, flox: &Flox) -> Result<String, EnvironmentError> {
+    fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         fs::read_to_string(self.manifest_path(flox)?).map_err(EnvironmentError::ReadManifest)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -257,8 +257,8 @@ impl Environment for RemoteEnvironment {
     }
 
     /// Extract the current content of the manifest
-    fn manifest_content(&self, flox: &Flox) -> Result<String, EnvironmentError> {
-        self.inner.manifest_content(flox)
+    fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError> {
+        self.inner.manifest_contents(flox)
     }
 
     /// Return the deserialized manifest

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -264,7 +264,7 @@ impl Edit {
             .prefix("manifest.")
             .suffix(".toml")
             .tempfile_in(&flox.temp_dir)?;
-        std::fs::write(&tmp_manifest, environment.manifest_content(flox)?)?;
+        std::fs::write(&tmp_manifest, environment.manifest_contents(flox)?)?;
 
         let should_continue_dialog = Dialog {
             message: "Continue editing?",
@@ -477,7 +477,7 @@ mod tests {
 
         let actual_contents = concrete_environment
             .into_dyn_environment()
-            .manifest_content(&flox)
+            .manifest_contents(&flox)
             .unwrap();
         assert_eq!(actual_contents, "version = 1\n");
     }
@@ -514,7 +514,7 @@ mod tests {
 
         let actual_contents = concrete_environment
             .into_dyn_environment()
-            .manifest_content(&flox)
+            .manifest_contents(&flox)
             .unwrap();
         assert!(!actual_contents.contains("version = 1"));
     }
@@ -549,7 +549,7 @@ mod tests {
 
         let actual_contents = concrete_environment
             .dyn_environment_ref_mut()
-            .manifest_content(&flox)
+            .manifest_contents(&flox)
             .unwrap();
         assert!(actual_contents.contains("version = 1"));
     }
@@ -585,7 +585,7 @@ mod tests {
 
         let actual_contents = concrete_environment
             .into_dyn_environment()
-            .manifest_content(&flox)
+            .manifest_contents(&flox)
             .unwrap();
         assert!(actual_contents.contains("version = 1"));
     }

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -63,7 +63,7 @@ impl List {
             .detect_concrete_environment(&flox, "List using")?
             .into_dyn_environment();
 
-        let manifest_contents = env.manifest_content(&flox)?;
+        let manifest_contents = env.manifest_contents(&flox)?;
         if self.list_mode == ListMode::Config {
             tracing::Span::current().record("mode", "config");
             println!("{}", manifest_contents);

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1549,7 +1549,7 @@ pub(super) async fn ensure_environment_trust(
                 return Ok(());
             },
             Choices::Abort => bail!("Denied {env_ref} (temporary)"),
-            Choices::ShowConfig => eprintln!("{}", environment.manifest_content(flox)?),
+            Choices::ShowConfig => eprintln!("{}", environment.manifest_contents(flox)?),
         }
     }
 }
@@ -2008,7 +2008,7 @@ mod tests {
 
         assert!(environment
             .dyn_environment_ref_mut()
-            .manifest_content(&flox)
+            .manifest_contents(&flox)
             .unwrap()
             .contains("version = 1"));
     }
@@ -2079,7 +2079,7 @@ mod tests {
 
         assert!(!environment
             .dyn_environment_ref_mut()
-            .manifest_content(&flox)
+            .manifest_contents(&flox)
             .unwrap()
             .contains("version = 1"));
     }
@@ -2124,7 +2124,7 @@ mod tests {
 
         assert!(environment
             .dyn_environment_ref_mut()
-            .manifest_content(&flox)
+            .manifest_contents(&flox)
             .unwrap()
             .contains("version = 1"));
 

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -539,7 +539,7 @@ impl Pull {
         env: &ManagedEnvironment,
         flox: &Flox,
     ) -> Result<DocumentMut, anyhow::Error> {
-        manifest::add_system(&env.manifest_content(flox)?, &flox.system)
+        manifest::add_system(&env.manifest_contents(flox)?, &flox.system)
             .context("Could not add system to manifest")
     }
 
@@ -855,7 +855,7 @@ mod tests {
 
         assert!(dot_flox_path.exists());
 
-        let new_content = environment.manifest_content(&flox).unwrap();
+        let new_content = environment.manifest_contents(&flox).unwrap();
         assert!(environment.lockfile_path(&flox).unwrap().exists());
         assert!(new_content.contains("version = 1"));
         // The test might be run on aarch64 or x86_64
@@ -899,7 +899,7 @@ mod tests {
 
         assert!(dot_flox_path.exists());
 
-        let new_content = environment.manifest_content(&flox).unwrap();
+        let new_content = environment.manifest_contents(&flox).unwrap();
         assert!(!environment.lockfile_path(&flox).unwrap().exists());
         assert!(new_content.contains("version = 1"));
         // The test might be run on aarch64 or x86_64

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -531,7 +531,7 @@ EOF
 @test "bash: activate runs hook only once in nested activation" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [hook]
     on-activate = """
@@ -540,7 +540,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # Don't use run or assert_output because we can't use them for
   # shells other than bash.
@@ -556,7 +556,7 @@ EOF
 @test "fish: activate runs hook only once in nested activation" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [hook]
     on-activate = """
@@ -565,7 +565,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # Don't use run or assert_output because we can't use them for
   # shells other than bash.
@@ -583,7 +583,7 @@ EOF
 @test "tcsh: activate runs hook only once in nested activation" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [hook]
     on-activate = """
@@ -592,7 +592,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # Don't use run or assert_output because we can't use them for
   # shells other than bash.
@@ -610,7 +610,7 @@ EOF
 @test "zsh: activate runs hook only once in nested activations" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [hook]
     on-activate = """
@@ -619,7 +619,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # Don't use run or assert_output because we can't use them for
   # shells other than bash.
@@ -637,7 +637,7 @@ EOF
 @test "bash: activate runs profile twice in nested activation" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [profile]
     bash = """
@@ -646,7 +646,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # Don't use run or assert_output because we can't use them for
   # shells other than bash.
@@ -662,7 +662,7 @@ EOF
 @test "fish: activate runs profile twice in nested activation" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [profile]
     fish = """
@@ -671,7 +671,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # TODO: this gives unhelpful failures
   cat << 'EOF' | fish
@@ -686,7 +686,7 @@ EOF
 @test "tcsh: activate runs profile twice in nested activation" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [profile]
     tcsh = """
@@ -695,7 +695,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # Don't use run or assert_output because we can't use them for
   # shells other than bash.
@@ -709,7 +709,7 @@ EOF
 @test "zsh: activate runs profile twice in nested activation" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [profile]
     zsh = """
@@ -718,7 +718,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # TODO: this gives unhelpful failures
   cat << 'EOF' | zsh
@@ -1612,7 +1612,7 @@ EOF
 @test "'hook.on-activate' unsets environment variables in nested activation (bash)" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [hook]
     on-activate = """
@@ -1621,7 +1621,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   {
     export foo=baz
@@ -1637,7 +1637,7 @@ EOF
 @test "'hook.on-activate' unsets environment variables in nested activation (fish)" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [hook]
     on-activate = """
@@ -1646,7 +1646,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # TODO: this gives unhelpful failures
   cat << 'EOF' | fish
@@ -1667,7 +1667,7 @@ EOF
 @test "'hook.on-activate' unsets environment variables in nested activation (tcsh)" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [hook]
     on-activate = """
@@ -1676,7 +1676,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # TODO: this gives unhelpful failures
   cat << 'EOF' | tcsh
@@ -1697,7 +1697,7 @@ EOF
 @test "'hook.on-activate' unsets environment variables in nested activation (zsh)" {
   project_setup
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [hook]
     on-activate = """
@@ -1706,7 +1706,7 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   # TODO: this gives unhelpful failures
   cat << 'EOF' | zsh

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -274,7 +274,7 @@ teardown() {
 
 @test "'flox install' can build a broken package when allowed" {
   "$FLOX_BIN" init
-  MANIFEST_CONTENT="$(
+  MANIFEST_CONTENTS="$(
     cat << "EOF"
     version = 1
     [options]
@@ -282,7 +282,7 @@ teardown() {
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/tabula_allowed.json" \
     run "$FLOX_BIN" install tabula
   assert_success

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -95,7 +95,7 @@ EOF
   export FLOX_FEATURES_USE_CATALOG=false
 
   "$FLOX_BIN" init
-  MANIFEST_CONTENT="$(
+  MANIFEST_CONTENTS="$(
     cat <<-EOF
     [install]
 
@@ -105,11 +105,11 @@ EOF
 
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   run "$FLOX_BIN" list --config
   assert_success
-  assert_output "$MANIFEST_CONTENT"
+  assert_output "$MANIFEST_CONTENTS"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -119,7 +119,7 @@ EOF
   export FLOX_FEATURES_USE_CATALOG=false
 
   "$FLOX_BIN" init
-  MANIFEST_CONTENT="$(
+  MANIFEST_CONTENTS="$(
     cat <<-EOF
     [options]
     systems = [ "$NIX_SYSTEM" ]
@@ -130,7 +130,7 @@ EOF
 
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   run "$FLOX_BIN" list -n
   assert_success
@@ -170,7 +170,7 @@ EOF
 # bats test_tags=list,list:catalog,list:config
 @test "catalog: 'flox list --config' shows manifest content" {
   "$FLOX_BIN" init
-  MANIFEST_CONTENT="$(
+  MANIFEST_CONTENTS="$(
     cat <<-EOF
     version = 1
 
@@ -181,11 +181,11 @@ EOF
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   run "$FLOX_BIN" list --config
   assert_success
-  assert_output "$MANIFEST_CONTENT"
+  assert_output "$MANIFEST_CONTENTS"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -189,7 +189,7 @@ teardown() {
 @test "upgrade for flake installable" {
   "$FLOX_BIN" init
 
-  MANIFEST_CONTENT="$(cat << "EOF"
+  MANIFEST_CONTENTS="$(cat << "EOF"
   version = 1
 
   [install]
@@ -197,7 +197,7 @@ teardown() {
 EOF
   )"
 
-  echo "$MANIFEST_CONTENT" | "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   run "$FLOX_BIN" upgrade
   assert_success


### PR DESCRIPTION
We use both content and contents throughout the codebase to refer to
what's contained in the manifest. Use contents throughout as it's
consistent with file contents, which sounds more natural to most people.

Change:
manifest_content -> manifest_contents
MANIFEST_CONTENTS -> MANIFEST_CONTENT