### PR TITLE
test(services): Test network services with Redis

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -91,6 +91,26 @@ EOF
   assert_output --partial "Services are not enabled in this environment"
 }
 
+@test "can start redis-server and access it using redis-cli" {
+  export FLOX_FEATURES_SERVICES=true
+
+  run "$FLOX_BIN" init
+  assert_success
+
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/redis.json" \
+    run "$FLOX_BIN" edit -f "${TESTS_DIR}/services/redis.toml"
+  assert_success
+
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
+    redis-cli ping
+EOF
+)
+  assert_success
+  assert_output --partial "PONG"
+}
+
+
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=services:stop

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -103,7 +103,7 @@ EOF
 
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/wait_and_cleanup.sh"
-    redis-cli ping
+    redis-cli -p "${REDIS_PORT}" ping
 EOF
 )
   assert_success

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -71,8 +71,8 @@ setup_sleeping_services() {
   "$FLOX_BIN" init
   run "$FLOX_BIN" edit -f "${TESTS_DIR}/services/touch_file.toml"
   assert_success
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
-    source "${TESTS_DIR}/services/start_and_cleanup.sh"
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
 EOF
 )
   assert_success
@@ -105,8 +105,8 @@ EOF
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
 
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
-    source "${TESTS_DIR}/services/start_and_cleanup.sh"
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
     "$FLOX_BIN" services stop invalid
 EOF
 )
@@ -119,9 +119,9 @@ EOF
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
 
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     exit_code=0
-    source "${TESTS_DIR}/services/start_and_cleanup.sh"
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
     "$FLOX_BIN" services stop one invalid || exit_code=$?
     "$PROCESS_COMPOSE_BIN" process list --output wide
     exit $exit_code
@@ -138,9 +138,9 @@ EOF
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
 
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     exit_code=0
-    source "${TESTS_DIR}/services/start_and_cleanup.sh"
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
     "$FLOX_BIN" services stop invalid one || exit_code=$?
     "$PROCESS_COMPOSE_BIN" process list --output wide
     exit $exit_code
@@ -171,8 +171,8 @@ EOF
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
 
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
-    source "${TESTS_DIR}/services/start_and_cleanup.sh"
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
     "$FLOX_BIN" services stop
     "$PROCESS_COMPOSE_BIN" process list --output wide
 EOF
@@ -189,8 +189,8 @@ EOF
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
 
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
-    source "${TESTS_DIR}/services/start_and_cleanup.sh"
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
     "$FLOX_BIN" services stop one
     "$PROCESS_COMPOSE_BIN" process list --output wide
 EOF
@@ -206,8 +206,8 @@ EOF
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
 
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
-    source "${TESTS_DIR}/services/start_and_cleanup.sh"
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
     "$FLOX_BIN" services stop one two
     "$PROCESS_COMPOSE_BIN" process list --output wide
 EOF
@@ -224,8 +224,8 @@ EOF
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
 
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
-    source "${TESTS_DIR}/services/start_and_cleanup.sh"
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/wait_and_cleanup.sh"
     "$FLOX_BIN" services stop one
     "$PROCESS_COMPOSE_BIN" process list --output wide
     "$FLOX_BIN" services stop one

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -103,7 +103,11 @@ EOF
 
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/wait_and_cleanup.sh"
-    redis-cli -p "${REDIS_PORT}" ping
+    timeout 2s bash -c '
+      while ! redis-cli -p "${REDIS_PORT}" ping; do
+        sleep 0.1
+      done
+    '
 EOF
 )
   assert_success

--- a/cli/tests/services/portgrab.sh
+++ b/cli/tests/services/portgrab.sh
@@ -1,0 +1,38 @@
+# This is an internal version of a helper that we may expose to `on-activate` in
+# the future: https://github.com/flox/flox/pull/1767
+
+function flox_portgrab() {
+  # Function which allocates and immediately releases ephemeral TCP port,
+  # used to identify available ports for use by services.
+  #
+  # Usage: port="$(portgrab)"
+  #
+  # - invokes nc as _server_ in background with args:
+  #   -l: listen, rather than connect, mode
+  #   -n: do not perform name resolution
+  #   -v: be verbose (so we can identify bound port number)
+  #   0.0.0.0: bind to all interfaces
+  #   0: get an ephemeral port
+  # - parses port number from expected output to stderr, e.g.:
+  #     Listening on 0.0.0.0 41669
+  # - invokes nc as _client_ to connect to server, which shuts it down
+  local -a words
+  ( nc -lnv 0.0.0.0 0 & ) 2>&1 | while read -r -a words; do
+    if [ ${#words[@]} -eq 4 ] && \
+       [ "${words[0]}" = "Listening" ] && \
+       [ "${words[1]}" = "on" ] && \
+       [ "${words[2]}" = "0.0.0.0" ]; then
+      local _port="${words[3]}"
+      if nc -N 0.0.0.0 "$_port" </dev/null >/dev/null 2>&1; then
+        # Success! Echo port and return.
+        echo "$_port"
+        return 0
+      else
+        # Not sure what would cause this, but return to avoid looping further.
+        return 1
+      fi
+    fi
+  done
+  # Return 1 to indicate failure.
+  return 1
+}

--- a/cli/tests/services/redis.toml
+++ b/cli/tests/services/redis.toml
@@ -1,5 +1,9 @@
 version = 1
 
+[vars]
+# https://github.com/flox/flox/issues/1341
+LD_AUDIT = ""
+
 [install]
 redis.pkg-path = "redis"
 netcat.pkg-path = "netcat"

--- a/cli/tests/services/redis.toml
+++ b/cli/tests/services/redis.toml
@@ -2,6 +2,14 @@ version = 1
 
 [install]
 redis.pkg-path = "redis"
+netcat.pkg-path = "netcat"
+
+[hook]
+on-activate = """
+source "${TESTS_DIR}/services/portgrab.sh"
+REDIS_PORT="$(flox_portgrab)"
+export REDIS_PORT
+"""
 
 [services.redis]
-command = "redis-server"
+command = 'redis-server --port "${REDIS_PORT}"'

--- a/cli/tests/services/redis.toml
+++ b/cli/tests/services/redis.toml
@@ -3,6 +3,8 @@ version = 1
 [vars]
 # https://github.com/flox/flox/issues/1341
 LD_AUDIT = ""
+# Redis requires this but it's unset on some of our runners/builders.
+LANG = "en_US.UTF-8"
 
 [install]
 redis.pkg-path = "redis"

--- a/cli/tests/services/redis.toml
+++ b/cli/tests/services/redis.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+redis.pkg-path = "redis"
+
+[services.redis]
+command = "redis-server"

--- a/cli/tests/services/wait_and_cleanup.sh
+++ b/cli/tests/services/wait_and_cleanup.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 export PC_SOCKET_PATH="${_FLOX_SERVICES_SOCKET}"
-SERVICE_CONFIG="${FLOX_ENV}/service-config.yaml"
 
 function cleanup() {
     echo "Shutting down process-compose"
@@ -11,11 +10,6 @@ function cleanup() {
     # https://github.com/F1bonacc1/process-compose/issues/197
     "$PROCESS_COMPOSE_BIN" down || true
 }
-
-# TODO: Replace when we have `flox activate --start-services`.
-echo "Starting process-compose"
-# https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
-"$PROCESS_COMPOSE_BIN" up --config "$SERVICE_CONFIG" --tui=false 3>&- &
 
 # TODO: Replace when exiting the activation stops `process-compose`.
 trap cleanup EXIT

--- a/cli/tests/services/wait_and_cleanup.sh
+++ b/cli/tests/services/wait_and_cleanup.sh
@@ -14,6 +14,10 @@ function cleanup() {
 # TODO: Replace when exiting the activation stops `process-compose`.
 trap cleanup EXIT
 
-# TODO: Replace when `flox activate --start-services` waits for socket.
-echo "Waiting for process-compose socket"
-timeout 2s bash -c "while [ ! -e \"$PC_SOCKET_PATH\" ]; do sleep 0.1; done"
+# TODO: Replace when `flox activate --start-services` waits.
+echo "Waiting for process-compose to start"
+timeout 2s bash -c '
+    while ! process-compose process list -o wide >/dev/null 2>&1; do
+        sleep 0.1
+    done
+'

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -158,7 +158,7 @@ cmd = "flox install python311Packages.pip"
 
 [resolve.redis]
 pre_cmd = "flox init"
-cmd = "flox install redis"
+cmd = "flox install redis netcat"
 
 [resolve."rubyPackages_3_2.rails"]
 pre_cmd = "flox init"

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -156,6 +156,10 @@ cmd = "flox install -i pip python311Packages.pip python3"
 pre_cmd = "flox init"
 cmd = "flox install python311Packages.pip"
 
+[resolve.redis]
+pre_cmd = "flox init"
+cmd = "flox install redis"
+
 [resolve."rubyPackages_3_2.rails"]
 pre_cmd = "flox init"
 cmd = "flox install rubyPackages_3_2.rails"

--- a/test_data/generated/resolve/redis.json
+++ b/test_data/generated/resolve/redis.json
@@ -1,0 +1,136 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "redis",
+            "broken": false,
+            "derivation": "/nix/store/d1z230q7h7d9097z75h4c7iyd2s84lrx-redis-7.2.5.drv",
+            "description": "Open source, advanced key-value store",
+            "install_id": "redis",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "name": "redis-7.2.5",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/r25wa9rba51wgaam4cpsfkrw7w04j06s-redis-7.2.5"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "redis",
+            "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "rev_count": 655136,
+            "rev_date": "2024-07-19T09:00:53Z",
+            "scrape_date": "2024-07-20T05:30:31Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "7.2.5"
+          },
+          {
+            "attr_path": "redis",
+            "broken": false,
+            "derivation": "/nix/store/n297lv0fh3b9bjmgxazlhnbjvrncf1y9-redis-7.2.5.drv",
+            "description": "Open source, advanced key-value store",
+            "install_id": "redis",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "name": "redis-7.2.5",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/dh8rdvd9r2az0hcl2iksz3nix7msq11b-redis-7.2.5"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "redis",
+            "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "rev_count": 655136,
+            "rev_date": "2024-07-19T09:00:53Z",
+            "scrape_date": "2024-07-20T05:30:31Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "7.2.5"
+          },
+          {
+            "attr_path": "redis",
+            "broken": false,
+            "derivation": "/nix/store/0s6a90i58bpamk2d0v21v47skhby0fkq-redis-7.2.5.drv",
+            "description": "Open source, advanced key-value store",
+            "install_id": "redis",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "name": "redis-7.2.5",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/l5z6yq56lc1rl5chbjxh4y3521qsby5x-redis-7.2.5"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "redis",
+            "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "rev_count": 655136,
+            "rev_date": "2024-07-19T09:00:53Z",
+            "scrape_date": "2024-07-20T05:30:31Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "7.2.5"
+          },
+          {
+            "attr_path": "redis",
+            "broken": false,
+            "derivation": "/nix/store/qhhxycr7gr9d74yri9242blqf9vay2wc-redis-7.2.5.drv",
+            "description": "Open source, advanced key-value store",
+            "install_id": "redis",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "name": "redis-7.2.5",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/n63288jr0baik4d379f44vcjlk4ng2w1-redis-7.2.5"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "redis",
+            "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "rev_count": 655136,
+            "rev_date": "2024-07-19T09:00:53Z",
+            "scrape_date": "2024-07-20T05:30:31Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "7.2.5"
+          }
+        ],
+        "page": 655136,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/resolve/redis.json
+++ b/test_data/generated/resolve/redis.json
@@ -8,6 +8,194 @@
         "msgs": [],
         "packages": [
           {
+            "attr_path": "netcat",
+            "broken": false,
+            "derivation": "/nix/store/6k76k3sispd3dy8gz43z0xnz0fync7cm-libressl-3.9.2.drv",
+            "description": "Free TLS/SSL implementation",
+            "install_id": "netcat",
+            "license": "[ Public Domain, BSD-4-Clause, 0BSD, BSD-3-Clause, GPL-3.0, ISC, OpenSSL ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "name": "libressl-3.9.2",
+            "outputs": [
+              {
+                "name": "nc",
+                "store_path": "/nix/store/vbxjcxfyjlg14kdp70lzsbnril02fy7g-libressl-3.9.2-nc"
+              },
+              {
+                "name": "bin",
+                "store_path": "/nix/store/8y6aisryapbcq41r0zkfx7yz931h5f1l-libressl-3.9.2-bin"
+              },
+              {
+                "name": "dev",
+                "store_path": "/nix/store/d86wzaammc97ayh8nmv9rx9w8fkdf0yj-libressl-3.9.2-dev"
+              },
+              {
+                "name": "man",
+                "store_path": "/nix/store/kwqs3d566pksx0z40kdmbrzmbyq0srkg-libressl-3.9.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/gvxdqj2x3gsaq760m8mva62rnlb59l9g-libressl-3.9.2"
+              }
+            ],
+            "outputs_to_install": [
+              "bin",
+              "man"
+            ],
+            "pname": "netcat",
+            "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "rev_count": 655136,
+            "rev_date": "2024-07-19T09:00:53Z",
+            "scrape_date": "2024-07-20T05:30:31Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "libressl-3.9.2"
+          },
+          {
+            "attr_path": "netcat",
+            "broken": false,
+            "derivation": "/nix/store/hqcnnllm4ciip798f3dzm1ns8bg7kl70-libressl-3.9.2.drv",
+            "description": "Free TLS/SSL implementation",
+            "install_id": "netcat",
+            "license": "[ Public Domain, BSD-4-Clause, 0BSD, BSD-3-Clause, GPL-3.0, ISC, OpenSSL ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "name": "libressl-3.9.2",
+            "outputs": [
+              {
+                "name": "nc",
+                "store_path": "/nix/store/rvj9zlhl6j26hm3s6kmixr423ha2621z-libressl-3.9.2-nc"
+              },
+              {
+                "name": "bin",
+                "store_path": "/nix/store/q51qw5f1n0zv5nn7kyrndhihhscy4h5p-libressl-3.9.2-bin"
+              },
+              {
+                "name": "dev",
+                "store_path": "/nix/store/1jb24na99wanl80lz59q1gykbgypbzrm-libressl-3.9.2-dev"
+              },
+              {
+                "name": "man",
+                "store_path": "/nix/store/xsikiangrcf153aka6vx4dcfbzihazhn-libressl-3.9.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/swnkadki3j0r6jw2zy7qc04894sck0p3-libressl-3.9.2"
+              }
+            ],
+            "outputs_to_install": [
+              "bin",
+              "man"
+            ],
+            "pname": "netcat",
+            "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "rev_count": 655136,
+            "rev_date": "2024-07-19T09:00:53Z",
+            "scrape_date": "2024-07-20T05:30:31Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "libressl-3.9.2"
+          },
+          {
+            "attr_path": "netcat",
+            "broken": false,
+            "derivation": "/nix/store/rx80h3kzrqj0whjsx56c8sdibh1dhb1z-libressl-3.9.2.drv",
+            "description": "Free TLS/SSL implementation",
+            "install_id": "netcat",
+            "license": "[ Public Domain, BSD-4-Clause, 0BSD, BSD-3-Clause, GPL-3.0, ISC, OpenSSL ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "name": "libressl-3.9.2",
+            "outputs": [
+              {
+                "name": "nc",
+                "store_path": "/nix/store/9swq4b0zixp9fzydiqlqy93ahp3bkbq3-libressl-3.9.2-nc"
+              },
+              {
+                "name": "bin",
+                "store_path": "/nix/store/a6yc689d9zrhxqs8mqsqxhk6l7rc00fg-libressl-3.9.2-bin"
+              },
+              {
+                "name": "dev",
+                "store_path": "/nix/store/gzhykfbsvjfhd6l0ff2qn43n9gkymsdw-libressl-3.9.2-dev"
+              },
+              {
+                "name": "man",
+                "store_path": "/nix/store/nhc2rr93sk2c9j6ndbkszz479gnpqza9-libressl-3.9.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/n4n0s9agd70gw6ccqv23lapkk2nk4n61-libressl-3.9.2"
+              }
+            ],
+            "outputs_to_install": [
+              "bin",
+              "man"
+            ],
+            "pname": "netcat",
+            "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "rev_count": 655136,
+            "rev_date": "2024-07-19T09:00:53Z",
+            "scrape_date": "2024-07-20T05:30:31Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "libressl-3.9.2"
+          },
+          {
+            "attr_path": "netcat",
+            "broken": false,
+            "derivation": "/nix/store/7vzj194v4s46lzw7kai7f10d17wcvqkx-libressl-3.9.2.drv",
+            "description": "Free TLS/SSL implementation",
+            "install_id": "netcat",
+            "license": "[ Public Domain, BSD-4-Clause, 0BSD, BSD-3-Clause, GPL-3.0, ISC, OpenSSL ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "name": "libressl-3.9.2",
+            "outputs": [
+              {
+                "name": "nc",
+                "store_path": "/nix/store/cdfkqcx3401l6cfxxs9c696id1bmvfsb-libressl-3.9.2-nc"
+              },
+              {
+                "name": "bin",
+                "store_path": "/nix/store/vp5gw3pb8s88fy4iycv25v7pdbiq9gpb-libressl-3.9.2-bin"
+              },
+              {
+                "name": "dev",
+                "store_path": "/nix/store/78pncc7pf6m3bax3n69v316bcr1lc932-libressl-3.9.2-dev"
+              },
+              {
+                "name": "man",
+                "store_path": "/nix/store/jgfzg4pcgik6mn7151mfrynwpxchr3qx-libressl-3.9.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/9c44d9g104ac36sz5zyg2yaj8my1vnaj-libressl-3.9.2"
+              }
+            ],
+            "outputs_to_install": [
+              "bin",
+              "man"
+            ],
+            "pname": "netcat",
+            "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+            "rev_count": 655136,
+            "rev_date": "2024-07-19T09:00:53Z",
+            "scrape_date": "2024-07-20T05:30:31Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "libressl-3.9.2"
+          },
+          {
             "attr_path": "redis",
             "broken": false,
             "derivation": "/nix/store/d1z230q7h7d9097z75h4c7iyd2s84lrx-redis-7.2.5.drv",


### PR DESCRIPTION
## Proposed Changes

**test(services): Use activate --start-services**

Replace the use of our custom start command now that the
`--start-services` argument has been added to `flox activate`.

This allows us to test our own code more thoroughly and removes the
manual setup that we had to do previously.

**test(services): Redis on standard port**

Test a networked service. We originally deferred this because of port
clashes when running on non-containerised CI systems (Nix builders) but:

a) it's important that we test this most common use case for services
b) workaround for ports will be added in a subsequent commit

I've chosen Redis because it's relatively small and fast to start,
unlike PostgreSQL for example. It currently creates a data dir within
the temporary project environment but that could be disabled with the
`--save "" --appendonly no` arguments.

I considered using `envs` instead of `resolve` to store the manifest
alongside the mocks but it required more setup and didn't make it much
clearer than co-locating the manifest with the tests.

**test(services): Redis on ephemeral port**

Prevent port clashes on non-containerised CI systems (Nix builders) by
using Michael's `flox_portgrab` function.

I'm not quite comfortable with exposing this to users yet because
subsequent activations will get a different port value for the client.

We could work around it by providing some sugar to store a named value
in `$FLOX_ENV_CACHE` but it locks us in to providing a specific
interface and it would be better to revise whether replaying activation
values is feasible first.

So for now I've copied the script internally to the tests and provided
`netcat` through the environment. The only differences from the draft PR
are the heading comment and using an unqualified `nc` path.

**test(services): Poll for process-compose list**

The new Redis test was hitting the same kind of race condition that we
saw in 1452e92 whereby the socket is created just shortly before the
service is actually started. So it was failing with the output:

    -- command failed --
    status : 1
    output (3 lines):
      Waiting for process-compose socket
      Could not connect to Redis at 127.0.0.1:52928: Connection refused
      Shutting down process-compose
    --

Prevent this from happening by polling `process-compose process list` as
we recently discussed doing when we get to #1640.

**test(services): LD_AUDIT workaround for Redis**

To prevent the following failure on Linux systems due to the issue
linked in the comment:

    # -- command failed --
    # status : 127
    # output (3 lines):
    #   Waiting for process-compose to start
    #   redis-cli: error while loading shared libraries: /nix/store/czhp4r5k06xgd449jxpnvghzj519pzl8-jemalloc-5.3.0/lib/libjemalloc.so.2: cannot allocate memory in static TLS block
    #   Shutting down process-compose
    # --

**test(services): LANG workaround for Redis**

This test was passing on the following jobs:

- Flox CLI Tests (macos-14-xlarge)
- Flox Bats Tests (x86_64-linux)
- Flox Bats Tests (aarch64-linux)

But failing on the following jobs:

- Flox CLI Tests (ubuntu-22.04-8core)
- Flox Bats Tests (x86_64-darwin)
- Flox Bats Tests (aarch64-darwin)

Dumping `process-compose process logs redis` from the test showed:

    # Could not connect to Redis at 127.0.0.1:50681: Connection refused
    # 44195:C 23 Jul 2024 03:58:02.100 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
    # 44195:C 23 Jul 2024 03:58:02.100 * Redis version=7.2.5, bits=64, commit=00000000, modified=0, pid=44195, just started
    # 44195:C 23 Jul 2024 03:58:02.100 * Configuration loaded
    # 44195:M 23 Jul 2024 03:58:02.100 # Failed to configure LOCALE for invalid locale name.

This feels like we're doing something wrong with the environment that we
run the tests in but I'm not sure where, so for expediency I'm just
going to fix it for Redis right now.

## Release Notes

N/A