### PR TITLE
feat: prepare manifest based builds

### DIFF
--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -44,6 +44,8 @@ namespace flox::buildenv {
 
 static constexpr std::string_view ACTIVATION_SCRIPT_NAME = "activate";
 static constexpr std::string_view ACTIVATION_SUBDIR_NAME = "activate.d";
+static constexpr std::string_view PACKAGE_BUILDS_SUBDIR_NAME
+  = "package-builds.d";
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/include/flox/resolver/manifest-raw.hh
+++ b/pkgdb/include/flox/resolver/manifest-raw.hh
@@ -333,6 +333,18 @@ from_json( const nlohmann::json & jfrom, ProfileScriptsRaw & profile );
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Declares scripts to be sourced by the user's interactive shell after
+ * activating the environment.*/
+struct BuildDescriptorRaw
+{
+  std::string command;
+};
+
+void
+from_json( const nlohmann::json & jfrom, BuildDescriptorRaw & profile );
+
+/* -------------------------------------------------------------------------- */
+
 /**
  * @brief A _raw_ description of an environment to be read from a file.
  *
@@ -357,6 +369,7 @@ struct ManifestRaw : public GlobalManifestRaw
 
   std::optional<HookRaw> hook;
 
+  std::optional<std::unordered_map<std::string, BuildDescriptorRaw>> build;
 
   ~ManifestRaw() override            = default;
   ManifestRaw()                      = default;
@@ -418,6 +431,7 @@ struct ManifestRaw : public GlobalManifestRaw
     this->vars    = std::nullopt;
     this->hook    = std::nullopt;
     this->profile = std::nullopt;
+    this->build   = std::nullopt;
   }
 
   /**

--- a/pkgdb/src/buildenv/buildenv-lockfile.cc
+++ b/pkgdb/src/buildenv/buildenv-lockfile.cc
@@ -191,7 +191,7 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load vars
   try
     {
-      auto value = jfrom["manifest"]["vars"];
+      auto value = jfrom.at( "manifest" ).value( "vars", nlohmann::json() );
       value.get_to( this->manifest.vars );
     }
   catch ( nlohmann::json::exception & err )
@@ -204,7 +204,7 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load hooks
   try
     {
-      auto hook = jfrom["manifest"]["hook"];
+      auto hook = jfrom.at( "manifest" ).value( "hook", nlohmann::json() );
       hook.get_to( this->manifest.hook );
     }
   catch ( nlohmann::json::exception & err )
@@ -217,8 +217,9 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load profile
   try
     {
-      auto hook = jfrom["manifest"]["profile"];
-      hook.get_to( this->manifest.profile );
+      auto profile
+        = jfrom.at( "manifest" ).value( "profile", nlohmann::json() );
+      profile.get_to( this->manifest.profile );
     }
   catch ( nlohmann::json::exception & err )
     {
@@ -239,7 +240,7 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
           std::string system;
           try
             {
-              installId = package["install_id"];
+              installId = package.at( "install_id" );
             }
           catch ( nlohmann::json::exception & err )
             {
@@ -251,7 +252,7 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
 
           try
             {
-              system = package["system"];
+              system = package.at( "system" );
             }
           catch ( nlohmann::json::exception & err )
             {
@@ -289,13 +290,27 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load options
   try
     {
-      auto options = jfrom["manifest"]["options"];
+      auto options
+        = jfrom.at( "manifest" ).value( "options", nlohmann::json() );
       options.get_to( this->manifest.options );
     }
   catch ( nlohmann::json::exception & err )
     {
       throw resolver::InvalidLockfileException(
         "couldn't parse lockfile field 'manifest.options'",
+        extract_json_errmsg( err ) );
+    }
+
+  // load build scripts
+  try
+    {
+      auto value = jfrom.at( "manifest" ).value( "build", nlohmann::json() );
+      value.get_to( this->manifest.build );
+    }
+  catch ( nlohmann::json::exception & err )
+    {
+      throw resolver::InvalidLockfileException(
+        "couldn't parse lockfile field 'manifest.build'",
         extract_json_errmsg( err ) );
     }
 

--- a/pkgdb/src/resolver/manifest-raw.cc
+++ b/pkgdb/src/resolver/manifest-raw.cc
@@ -646,6 +646,18 @@ HookRaw::check() const
     }
 }
 
+/* -------------------------------------------------------------------------- */
+
+void
+from_json( const nlohmann::json & jfrom, BuildDescriptorRaw & build )
+{
+  // for building we only need the command,
+  // other attribute are handled by `flox` and passed to the build script as
+  // applicable
+  auto value = jfrom.at( "command" );
+  value.get_to( build.command );
+}
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -171,6 +171,14 @@ setup_file() {
   assert_line "export singlequoteescaped='\'\''baz'"
 }
 
+# bats test_tags=buildenv:build-commands
+@test "Built environment contains build scripts" {
+  run "$PKGDB_BIN" buildenv "$GENERATED_DATA/envs/build-noop/manifest.lock"
+  assert_success
+  store_path=$(echo "$output" | jq -er '.store_path')
+  assert "$TEST" -f "${store_path}/package-builds.d/hello"
+}
+
 # ---------------------------------------------------------------------------- #
 
 # With '--container' produces a script that can be used to build a container.

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -321,15 +321,20 @@ post_cmd = '''
     mv "$RESPONSE_FILE" "$env_dir/$(basename $RESPONSE_FILE)"
 '''
 
-[envs.hello]
-skip_if_output_exists = "envs/hello"
+[envs.build-noop]
+skip_if_output_exists = "envs/build-noop"
 pre_cmd = "flox init"
-cmd = "flox install hello"
+cmd = '''
+echo '
+version = 1
+[build]
+hello.command = "echo hello"
+' | flox edit -f -
+'''
 post_cmd = '''
     envs_output_dir="$(dirname $RESPONSE_FILE)"
-    env_dir="$envs_output_dir/hello"
+    env_dir="$envs_output_dir/build-noop"
     mkdir -p "$env_dir"
     cp .flox/env/manifest.toml "$env_dir/manifest.toml"
     cp .flox/env/manifest.lock "$env_dir/manifest.lock"
-    rm "$RESPONSE_FILE"
 '''

--- a/test_data/generated/envs/build-noop/manifest.lock
+++ b/test_data/generated/envs/build-noop/manifest.lock
@@ -1,0 +1,25 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {},
+    "vars": {},
+    "hook": {},
+    "profile": {},
+    "options": {
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    },
+    "services": {},
+    "build": {
+      "hello": {
+        "command": "echo hello",
+        "files": null,
+        "systems": null
+      }
+    }
+  },
+  "packages": []
+}

--- a/test_data/generated/envs/build-noop/manifest.toml
+++ b/test_data/generated/envs/build-noop/manifest.toml
@@ -1,0 +1,5 @@
+
+version = 1
+[build]
+hello.command = "echo hello"
+


### PR DESCRIPTION
[feat: add package build section to manifest](https://github.com/flox/flox/pull/1802/commits/1a4c901d6a31d64a8dce3fc439c92d16c3b184a9) 

Add a new `build` section with the following format to the manifest:

```
build.<name> = {
  command    = <STRING>
, files      = null | [ “path1”, “path2”, … ] /* optional, build can write to $out */
, systems    = null | [ <STRING>, … ]
, sandbox    = null | "off" | "pure"
}
```

#1943 

[feat(buildenv): read build field](https://github.com/flox/flox/pull/1802/commits/8d69feb0bd0de97085a6c4ddd83446128c29a734) 
* feat(buildenv): add build scripts to environment

For every `build.<name>.command` in the manifest portion of the lockfile,
`pkgdb buildenv` should

- create an _executable_ file at `<env store-path>/package-builds.d/<build-id>`
- write the content of the command to that file.
- ignore other attributes in `build.<name>` unless we add additional attributes
  that influence the contents of the file in later Changes.

#1944

* test: check whether build commands are included in the env store path

* test: check whether build commands are executable

* fix: use `nlohmann::{at,value}` to access manifest fields

Direct accessors with `jfrom[...]` will _not_ throw an exception
but panic on asserting that the referenced value exists.