### PR TITLE
fix: allow usage of private flakes

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -272,9 +272,10 @@ impl<State> CoreEnvironment<State> {
             pkgdb_cmd.args(["--service-config", &service_config_path.to_string_lossy()]);
         }
 
-        let result: BuildEnvResult =
-            serde_json::from_value(call_pkgdb(pkgdb_cmd).map_err(CoreEnvironmentError::BuildEnv)?)
-                .map_err(CoreEnvironmentError::ParseBuildEnvOutput)?;
+        let result: BuildEnvResult = serde_json::from_value(
+            call_pkgdb(pkgdb_cmd, true).map_err(CoreEnvironmentError::BuildEnv)?,
+        )
+        .map_err(CoreEnvironmentError::ParseBuildEnvOutput)?;
 
         let store_path = PathBuf::from(result.store_path);
         debug!(
@@ -323,9 +324,10 @@ impl<State> CoreEnvironment<State> {
             .arg("--container")
             .arg(lockfile_path);
 
-        let result: BuildEnvResult =
-            serde_json::from_value(call_pkgdb(pkgdb_cmd).map_err(CoreEnvironmentError::BuildEnv)?)
-                .map_err(CoreEnvironmentError::ParseBuildEnvOutput)?;
+        let result: BuildEnvResult = serde_json::from_value(
+            call_pkgdb(pkgdb_cmd, true).map_err(CoreEnvironmentError::BuildEnv)?,
+        )
+        .map_err(CoreEnvironmentError::ParseBuildEnvOutput)?;
 
         let store_path = PathBuf::from(result.store_path);
 
@@ -347,7 +349,7 @@ impl<State> CoreEnvironment<State> {
             .args(["--store-path", &store_path.as_ref().to_string_lossy()]);
 
         serde_json::from_value::<BuildEnvResult>(
-            call_pkgdb(pkgdb_cmd).map_err(CoreEnvironmentError::BuildEnv)?,
+            call_pkgdb(pkgdb_cmd, true).map_err(CoreEnvironmentError::BuildEnv)?,
         )
         .map_err(CoreEnvironmentError::ParseBuildEnvOutput)?;
 
@@ -663,7 +665,7 @@ impl CoreEnvironment<ReadOnly> {
             pkgdb_cmd.display()
         );
         let json: UpgradeResultJSON = serde_json::from_value(
-            call_pkgdb(pkgdb_cmd).map_err(CoreEnvironmentError::UpgradeFailedPkgDb)?,
+            call_pkgdb(pkgdb_cmd, true).map_err(CoreEnvironmentError::UpgradeFailedPkgDb)?,
         )
         .map_err(CoreEnvironmentError::ParseUpgradeOutput)?;
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1251,7 +1251,7 @@ impl LockedManifestPkgdb {
             .arg(existing_lockfile_path);
 
         debug!("locking manifest with command: {}", pkgdb_cmd.display());
-        call_pkgdb(pkgdb_cmd)
+        call_pkgdb(pkgdb_cmd, true)
             .map_err(LockedManifestError::LockManifest)
             .map(Self)
     }
@@ -1307,8 +1307,9 @@ impl LockedManifestPkgdb {
         pkgdb_cmd.args(inputs);
 
         debug!("updating lockfile with command: {}", pkgdb_cmd.display());
-        let lockfile: LockedManifestPkgdb =
-            LockedManifestPkgdb(call_pkgdb(pkgdb_cmd).map_err(LockedManifestError::UpdateFailed)?);
+        let lockfile: LockedManifestPkgdb = LockedManifestPkgdb(
+            call_pkgdb(pkgdb_cmd, true).map_err(LockedManifestError::UpdateFailed)?,
+        );
 
         Ok(UpdateResult {
             new_lockfile: lockfile,
@@ -1365,7 +1366,7 @@ impl LockedManifestPkgdb {
 
         debug!("checking lockfile with command: {}", pkgdb_cmd.display());
 
-        let value = call_pkgdb(pkgdb_cmd).map_err(LockedManifestError::CheckLockfile)?;
+        let value = call_pkgdb(pkgdb_cmd, true).map_err(LockedManifestError::CheckLockfile)?;
         let warnings: Vec<LockfileCheckWarning> =
             serde_json::from_value(value).map_err(LockedManifestError::ParseCheckWarnings)?;
 

--- a/cli/flox-rust-sdk/src/providers/flox_cpp_utils.rs
+++ b/cli/flox-rust-sdk/src/providers/flox_cpp_utils.rs
@@ -119,7 +119,9 @@ impl InstallableLocker for Pkgdb {
 
         debug!("locking installable: {pkgdb_cmd:?}");
 
-        let lock = call_pkgdb(pkgdb_cmd).map_err(|err| match err {
+        // Locking flakes may require using `ssh` for private flakes,
+        // so don't clear PATH
+        let lock = call_pkgdb(pkgdb_cmd, false).map_err(|err| match err {
             CallPkgDbError::PkgDbError(PkgDbError {
                 exit_code: error_codes::NIX_GENERIC,
                 context_message:


### PR DESCRIPTION
Currently when we call pkgdb we set its PATH so it doesn't use user provided binaries. For locking flakes, we do want to use user provided git and ssh, so don't clear PATH for invocations of pkgdb locking flakes.

Tests will be added in a followup.