### PR TITLE
feat: skip starting services when already running

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -731,6 +731,10 @@ pub fn path_hash(p: &impl AsRef<Path>) -> String {
 /// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 /// If unset, fallback to cache_dir like for macOS.
 fn services_socket_path(id: &str, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
+    if let Ok(path) = std::env::var(FLOX_SERVICES_SOCKET_VAR) {
+        return Ok(PathBuf::from(path));
+    }
+
     #[cfg(target_os = "macos")]
     let runtime_dir = None;
     #[cfg(target_os = "linux")]

--- a/cli/flox/doc/services/flox-activate.md
+++ b/cli/flox/doc/services/flox-activate.md
@@ -86,6 +86,8 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
 
 `-s`, `--start-services`
 :  Start the services listed in the manifest when activating the environment.
+   If services are already running, new instances of the environment's services
+   will not be started and a warning will be displayed.
 
 ```{.include}
 ./include/environment-options.md

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -268,16 +268,19 @@ impl Activate {
 
             if flox.features.services && !manifest.services.is_empty() {
                 tracing::debug!(start = self.start_services, "setting service variables");
-                exports.insert(
-                    FLOX_ACTIVATE_START_SERVICES_VAR,
-                    self.start_services.to_string(),
-                );
+                let socket_path = environment.services_socket_path(&flox)?;
+                if socket_path.exists() {
+                    debug!("detected existing services socket");
+                    message::warning("Skipped starting services, services are already running");
+                } else {
+                    exports.insert(
+                        FLOX_ACTIVATE_START_SERVICES_VAR,
+                        self.start_services.to_string(),
+                    );
+                }
                 exports.insert(
                     FLOX_SERVICES_SOCKET_VAR,
-                    environment
-                        .services_socket_path(&flox)?
-                        .to_string_lossy()
-                        .to_string(),
+                    socket_path.to_string_lossy().to_string(),
                 );
             }
         }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -235,3 +235,14 @@ EOF
   assert_output --regexp " +one +default +Completed +"
   assert_output --partial "❌ ERROR: service 'one' is not running"
 }
+
+@test "activate services: shows warning when services already running" {
+  export FLOX_FEATURES_SERVICES=true
+  setup_sleeping_services
+  dummy_socket="$PWD/sock.sock"
+  touch "$dummy_socket"
+  _FLOX_SERVICES_SOCKET="$dummy_socket" run "$FLOX_BIN" activate -s -- true
+
+  assert_success
+  assert_output --partial "⚠️  Skipped starting services, services are already running"
+}


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

This uses the presence of the socket file to determine when to skip starting services. A warning message is printed to inform the user that they requested to start services as part of the activation and we intentionally did not do what they requested.

In order to make this easy to test I reverted the socket path function to the previous behavior where it would defer to an explicitly set environment variable.

It would be nice to test that `process-compose` is also not started when we show this message, but that seems tricky to test in a cross-platform way (e.g. no access to `/proc` on macOS).

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->

N/A

<!-- Many thanks! -->
