### PR TITLE
feat: prototype manifest build

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -295,6 +295,23 @@ fi
 #   b. source the relevant activation script
 #   c. invoke the command in one of "stdin" or "-c" modes
 if [ $# -gt 0 ]; then
+  if [ -n "$FLOX_TURBO" ]; then
+    # "turbo command" mode: simply exec the provided command and args
+    # without paying the cost of invoking the userShell.
+    if [ "$1" = "-c" ]; then
+      if [ -n "$FLOX_SET_ARG0" ]; then
+        exec -a "$FLOX_SET_ARG0" bash --noprofile --norc "$@"
+      else
+        exec bash --noprofile --norc "$@"
+      fi
+    else
+      if [ -n "$FLOX_SET_ARG0" ]; then
+        exec -a "$FLOX_SET_ARG0" "$@"
+      else
+        exec "$@"
+      fi
+    fi
+  fi
   if [ $# -ne 2 ] || [ "$1" != "-c" ]; then
     # Marshal the provided args into a single safely-quoted string.
     # We use the magic "${@@Q}" parameter transformation to return
@@ -302,11 +319,6 @@ if [ $# -gt 0 ]; then
     declare -a cmdarray=()
     cmdarray=("-c" "${@@Q}")
     set -- "${cmdarray[@]}"
-  fi
-  if [ -n "$FLOX_TURBO" ]; then
-    # "turbo command" mode: simply exec the provided command and args
-    # without paying the cost of invoking the userShell.
-    eval "exec $2"
   fi
   # "-c" command mode: pass both [2] arguments unaltered to shell invocation
   case "$_flox_shell" in

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -357,10 +357,8 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  # Turbo mode exec()s the provided command without involving the
-  # userShell, so cannot invoke shell primitives like ":".
-  FLOX_TURBO=1 FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -127 $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
-  assert_failure
+  FLOX_TURBO=1 FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  assert_success
   FLOX_TURBO=1 FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
   assert_success
   assert_output --partial "sourcing hook.on-activate"
@@ -405,10 +403,8 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  # Turbo mode exec()s the provided command without involving the
-  # userShell, so cannot invoke shell primitives like ":".
-  FLOX_TURBO=1 FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -127 $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
-  assert_failure
+  FLOX_TURBO=1 FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  assert_success
   FLOX_TURBO=1 FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
   assert_success
   assert_output --partial "sourcing hook.on-activate"
@@ -454,10 +450,8 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  # Turbo mode exec()s the provided command without involving the
-  # userShell, so cannot invoke shell primitives like ":".
-  FLOX_TURBO=1 FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -127 $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
-  assert_failure
+  FLOX_TURBO=1 FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  assert_success
   FLOX_TURBO=1 FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
   assert_success
   assert_output --partial "sourcing hook.on-activate"
@@ -505,10 +499,8 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  # Turbo mode exec()s the provided command without involving the
-  # userShell, so cannot invoke shell primitives like ":".
-  FLOX_TURBO=1 FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -127 $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
-  assert_failure
+  FLOX_TURBO=1 FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  assert_success
   FLOX_TURBO=1 FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
   assert_success
   assert_output --partial "sourcing hook.on-activate"

--- a/ld-floxlib/Makefile
+++ b/ld-floxlib/Makefile
@@ -1,22 +1,47 @@
 .DEFAULT_GOAL = ld-floxlib.so
 GREENCHECK = ✅
 REDCROSS = ❌
+OS := $(shell uname -s)
+
+.DEFAULT_GOAL := all
+
+ifeq (Linux,$(OS))
+  ALL = libsandbox.so ld-floxlib.so
+  TESTS = sandbox-tests ld-audit-tests
+  IS_LINUX := true
+else
+  ALL = libsandbox.dylib
+  TESTS = sandbox-tests
+endif
 
 # Define LD_FLOXLIB with macro to allow testing builds from other hosts.
 LD_FLOXLIB ?= $(abspath ld-floxlib.so)
 
 ld-floxlib.so: ld-floxlib.c
 	$(CC) -shared -fPIC $< -o $@
-	# The ld-floxlib.so library only requires libc, which is guaranteed
-	# to either be already loaded or available by way of a default provided
-	# by the linker itself, so to avoid loading a different libc than the
-	# one already loaded we remove RPATH/RUNPATH from the shared library.
+	@# The ld-floxlib.so library only requires libc, which is guaranteed
+	@# to either be already loaded or available by way of a default provided
+	@# by the linker itself, so to avoid loading a different libc than the
+	@# one already loaded we remove RPATH/RUNPATH from the shared library.
 	patchelf --remove-rpath $@
 
+closure.o: closure.c closure.h
+	$(CC) -fPIC -c $<
+
+libsandbox.so: sandbox.c closure.o
+	$(CC) -shared -fPIC $^ -o $@
+	patchelf --remove-rpath $@
+
+libsandbox.dylib: sandbox.c closure.o
+	$(CC) -pthread -dynamiclib $^ -o $@
+
+.PHONY: all
+all: $(ALL)
+
 .PHONY: install
-install: ld-floxlib.so
+install: $(ALL)
 	mkdir -p $(PREFIX)/lib
-	cp $< $(PREFIX)/lib
+	cp $^ $(PREFIX)/lib
 
 # Build unit-test linked with ld-floxlib.so.
 unit-test: unit-test.c ld-floxlib.so
@@ -135,5 +160,12 @@ $(eval $(call integration_test_TEMPLATE,$(strip \
   test3     1 \
 )))
 
-.PHONY: test
-test: $(unit_tests) $(integration_tests)
+.PHONY: ld-audit-tests
+ld-audit-tests: $(unit_tests) $(integration_tests)
+
+.PHONY: sandbox-tests
+sandbox-tests:
+	@echo TODO: create sandbox tests
+
+.PHONY: tests
+tests: $(TESTS)

--- a/ld-floxlib/closure.c
+++ b/ld-floxlib/closure.c
@@ -1,0 +1,204 @@
+/*
+ * The Flox "virtual sandbox" warns or aborts when encountering an ELF access
+ * from outside the closure of packages implied by $FLOX_ENV. In this regard
+ * it can provide the same guarantees at an ELF level provided by the sandbox
+ * itself, but at an _advisory_ level, so that developers are informed of
+ * missing dependencies without actually breaking anything.
+ *
+ * The virtual sandbox is enabled with `FLOX_VIRTUAL_SANDBOX=(warn|enforce)`
+ * set in the environment, and we do this when wrapping files in the bin
+ * directory in the course of performing a manifest build.
+ *
+ * As with the parsing of FLOX_ENV_LIB_DIRS, it is essential that this parsing
+ * of the closure be performant and initialized only once per invocation, so we
+ * start by reading closure paths into a btable from $FLOX_ENV/requisites.txt.
+ */
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+// Declare version bindings to work with minimum supported GLIBC versions.
+#ifdef linux
+  #include "glibc-bindings.h"
+#endif
+
+#define HASH_MULTIPLIER 31
+#define INITIAL_CAPACITY FLOX_ENV_CLOSURE_MAXENTRIES
+
+// Define the maximum number of paths to be tracked in the FLOX_ENV closure.
+// This is somewhat arbitrary but should be more than enough for most cases.
+#define FLOX_ENV_CLOSURE_MAXENTRIES 4096
+
+// Define the maximum length of a directory path in the FLOX_ENV_LIB_DIRS
+// environment variable. This is also somewhat arbitrary, but it should
+// be more than enough for most cases.
+#define FLOX_ENV_REQUISITE_MAXLEN PATH_MAX
+
+typedef struct {
+    char key[FLOX_ENV_REQUISITE_MAXLEN];
+    bool is_filled;
+} hash_entry_t;
+
+typedef struct {
+    hash_entry_t entries[FLOX_ENV_CLOSURE_MAXENTRIES];
+    size_t size;
+    size_t capacity;
+} hash_table_t;
+
+hash_table_t* hash_table_init(size_t capacity);
+int hash_table_store(hash_table_t *table, const char *key);
+bool hash_table_lookup(hash_table_t *table, const char *key);
+
+// Helper macros for printing debug, warnings, errors.
+static int    debug_closure = -1;
+static int    sandbox_warn_count = 0;
+#define debug(format, ...) \
+  if (debug_closure) \
+    fprintf(stderr, "CLOSURE DEBUG[%d]: " format "\n", getpid(), __VA_ARGS__)
+
+// Temporary path buffer for calculating realpath of hash table queries.
+static char realpath_buf[PATH_MAX];
+
+static size_t hash(const char *key, size_t capacity) {
+    size_t hash_value = 0;
+    while (*key) {
+        hash_value = hash_value * HASH_MULTIPLIER + (unsigned char)(*key);
+        key++;
+    }
+    return hash_value % capacity;
+}
+
+hash_table_t* hash_table_init(size_t capacity) {
+    static hash_table_t table;
+    table.size = 0;
+    table.capacity = capacity;
+    for (size_t i = 0; i < capacity; i++) {
+        table.entries[i].is_filled = false;
+    }
+    return &table;
+}
+
+int hash_table_store(hash_table_t *table, const char *key) {
+    if (table->size >= table->capacity) {
+        return -1;  // Table is full
+    }
+
+    size_t index = hash(key, table->capacity);
+    while (table->entries[index].is_filled && strcmp(table->entries[index].key, key) != 0) {
+        index = (index + 1) % table->capacity;
+    }
+
+    if (!table->entries[index].is_filled) {
+        strncpy(table->entries[index].key, key, FLOX_ENV_REQUISITE_MAXLEN - 1);
+        table->entries[index].key[FLOX_ENV_REQUISITE_MAXLEN - 1] = '\0';  // Ensure null termination
+        table->entries[index].is_filled = true;
+        table->size++;
+    }
+    return 0;
+}
+
+bool hash_table_lookup(hash_table_t *table, const char *key) {
+    // look for the first '/' following the expected 44 characters
+    // in a /nix/store path, e.g.
+    //   /nix/store/12345678901234567890123456789012-foobar-1.2.3/bin/foo":
+    //   ^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    const char * pkgend = strchr( key+44, '/' );
+    if (pkgend == NULL)
+        return false;
+
+    static char pkgbuf[PATH_MAX];
+    (void) snprintf( pkgbuf, (pkgend-key)+1, "%s", key );
+
+    debug("hash_table_lookup(%s), looking for %s in hashtable", key, pkgbuf);
+
+    size_t index = hash(pkgbuf, table->capacity);
+    while (table->entries[index].is_filled) {
+        // With Nix we only have to look at the first 44
+        // characters to know that we have a match. e.g.
+        // "/nix/store/12345678901234567890123456789012-foobar-1.2.3":
+        //  ^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        //      10    1              32                1
+        debug("comparing %s to %s", table->entries[index].key, pkgbuf);
+        if (strncmp(table->entries[index].key, pkgbuf, 44) == 0) {
+            debug( "%s is in the closure", key );
+            return true;
+        }
+        index = (index + 1) % table->capacity;
+    }
+    debug( "%s is not in the closure", key );
+    return false;
+}
+
+bool in_closure(const char *path) {
+    static hash_table_t *table = NULL;
+
+    // Debug closure library with FLOX_DEBUG_CLOSURE=1.
+    debug_closure = ( getenv( "FLOX_DEBUG_CLOSURE" ) != NULL );
+
+    if (!table) {
+        const char *env_path = getenv("FLOX_ENV");
+        if (!env_path) {
+            fprintf(stderr, "FLOX_ENV environment variable not set\n");
+            return false;
+        }
+
+        char requisites_path[256];
+        snprintf(requisites_path, sizeof(requisites_path), "%s/requisites.txt", env_path);
+
+        FILE *file = fopen(requisites_path, "r");
+        if (!file) {
+            perror("Error opening requisites.txt");
+            return false;
+        }
+
+        table = hash_table_init(INITIAL_CAPACITY);
+
+        char line[FLOX_ENV_REQUISITE_MAXLEN];
+        static int count=0;
+        while (fgets(line, sizeof(line), file)) {
+            line[strcspn(line, "\n")] = '\0'; // Remove newline character
+            if (hash_table_store(table, line) != 0) {
+                fprintf(stderr, "Error: Hash table is full, cannot store more paths\n");
+                break;
+            }
+            count++;
+        }
+        fclose(file);
+
+        // Because this library will itself be loaded on account of its presence
+        // in LD_PRELOAD, we should ensure that we don't trip over ourselves.
+        if (hash_table_store(table, "@@out@@") != 0) {
+            fprintf(stderr, "Error: Hash table is full, cannot store more paths\n");
+        }
+        count++;
+
+        // There is one more "blessed" path to be added to the table which is
+        // the path of the manifest-built package itself, and this comes to us
+        // by way of the FLOX_MANIFEST_BUILD_OUT environment variable.
+        const char *additional_path = getenv("FLOX_MANIFEST_BUILD_OUT");
+        if (additional_path) {
+            if (hash_table_store(table, additional_path) != 0) {
+                fprintf(stderr, "Error: Hash table is full, cannot store more paths\n");
+            }
+            count++;
+        }
+
+        debug("loaded %d entries from requisites.txt", count);
+    }
+
+    if (realpath( path, realpath_buf ) == NULL)
+      {
+        // Likely that path does not exist, so just return true
+        // so that the real system call can return ENOENT.
+        debug( "%s not found, allowing sandbox access", path );
+        return true;
+      }
+
+    return hash_table_lookup(table, realpath_buf);
+}

--- a/ld-floxlib/closure.h
+++ b/ld-floxlib/closure.h
@@ -1,0 +1,8 @@
+#ifndef CLOSURE_H
+#define CLOSURE_H
+
+#include <stdbool.h>
+
+bool in_closure(const char *path);
+
+#endif // CLOSURE_H

--- a/ld-floxlib/glibc-bindings.h
+++ b/ld-floxlib/glibc-bindings.h
@@ -1,0 +1,50 @@
+#ifndef GLIBC_BINDINGS_H
+#define GLIBC_BINDINGS_H
+
+// Declare version bindings to work with minimum supported GLIBC versions.
+//
+// This file needs to be updated whenever we start using a new GLIBC function.
+// The procedure to update the file is as follows:
+//
+//   make -C ld-floxlib libsandbox.so
+//   nm -D ld-floxlib/libsandbox.so | \
+//     sed 's/@GLIBC_.*/@GLIBC_MIN_VERSION/' | awk '/GLIBC/ {print $NF}' | \
+//     awk -F@ '{printf("__asm__( \".symver %s,%s@\" %s );\n",$1,$1,$2)}' >> ld-floxlib/glibc-bindings.h
+//   vi ld-floxlib/glibc-bindings.h
+//     /* remove previous bindings section, leaving newly-appended one */
+//
+#if defined( __aarch64__ )
+  // aarch64 Linux only goes back to 2.17.
+  #define GLIBC_MIN_VERSION "GLIBC_2.17"
+#elif defined( __x86_64__ )
+  // x86_64 Linux goes back to 2.2.5.
+  #define GLIBC_MIN_VERSION "GLIBC_2.2.5"
+#else
+  #error "Unsupported architecture"
+#endif
+
+__asm__( ".symver __cxa_finalize,__cxa_finalize@" GLIBC_MIN_VERSION );
+__asm__( ".symver dlsym,dlsym@" GLIBC_MIN_VERSION );
+__asm__( ".symver __errno_location,__errno_location@" GLIBC_MIN_VERSION );
+__asm__( ".symver fclose,fclose@" GLIBC_MIN_VERSION );
+__asm__( ".symver fgets,fgets@" GLIBC_MIN_VERSION );
+__asm__( ".symver fopen,fopen@" GLIBC_MIN_VERSION );
+__asm__( ".symver __fprintf_chk,__fprintf_chk@" GLIBC_MIN_VERSION );
+__asm__( ".symver fwrite,fwrite@" GLIBC_MIN_VERSION );
+__asm__( ".symver getenv,getenv@" GLIBC_MIN_VERSION );
+__asm__( ".symver getpid,getpid@" GLIBC_MIN_VERSION );
+__asm__( ".symver perror,perror@" GLIBC_MIN_VERSION );
+__asm__( ".symver __realpath_chk,__realpath_chk@" GLIBC_MIN_VERSION );
+__asm__( ".symver __snprintf_chk,__snprintf_chk@" GLIBC_MIN_VERSION );
+__asm__( ".symver __stack_chk_fail,__stack_chk_fail@" GLIBC_MIN_VERSION );
+__asm__( ".symver __stack_chk_guard,__stack_chk_guard@" GLIBC_MIN_VERSION );
+__asm__( ".symver stderr,stderr@" GLIBC_MIN_VERSION );
+__asm__( ".symver strchr,strchr@" GLIBC_MIN_VERSION );
+__asm__( ".symver strcmp,strcmp@" GLIBC_MIN_VERSION );
+__asm__( ".symver strcspn,strcspn@" GLIBC_MIN_VERSION );
+__asm__( ".symver strlen,strlen@" GLIBC_MIN_VERSION );
+__asm__( ".symver strncmp,strncmp@" GLIBC_MIN_VERSION );
+__asm__( ".symver strncpy,strncpy@" GLIBC_MIN_VERSION );
+__asm__( ".symver strtok_r,strtok_r@" GLIBC_MIN_VERSION );
+
+#endif // GLIBC_BINDINGS_H

--- a/ld-floxlib/sandbox.c
+++ b/ld-floxlib/sandbox.c
@@ -1,0 +1,392 @@
+/*
+ * The Flox "virtual sandbox" warns or aborts when encountering an ELF access
+ * from outside the closure of packages implied by $FLOX_ENV. In this regard
+ * it can provide the same guarantees at an ELF level provided by the sandbox
+ * itself, but at an _advisory_ level, so that developers are informed of
+ * missing dependencies without actually breaking anything.
+ *
+ * The virtual sandbox is enabled with `FLOX_VIRTUAL_SANDBOX=(warn|enforce)`
+ * set in the environment, and we do this when wrapping files in the bin
+ * directory in the course of performing a manifest build.
+ *
+ * As with the parsing of FLOX_ENV_LIB_DIRS, it is essential that this parsing
+ * of the closure be performant and initialized only once per invocation, so we
+ * start by reading closure paths into a btable from $FLOX_ENV/requisites.txt.
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+// Declare version bindings to work with minimum supported GLIBC versions.
+#ifdef linux
+  #include "glibc-bindings.h"
+#endif
+
+// For access to the in_closure() function.
+#include "closure.h"
+
+// Derive audit level from FLOX_VIRTUAL_SANDBOX environment variable.
+int    sandbox_level = -1;
+
+// Thread lock
+pthread_mutex_t lock;
+
+// Function pointers to hold the original functions
+#ifdef Linux
+  static int (*orig_open)(const char *pathname, int flags, ...) = NULL;
+  static int (*orig_openat)(int dirfd, const char *pathname, int flags, ...) = NULL;
+#endif
+
+// Helper macros for printing debug, warnings, errors.
+static int    debug_sandbox = -1;
+static int    warn_count = 0;
+#define debug(format, ...) \
+  if (debug_sandbox) \
+    fprintf(stderr, "SANDBOX DEBUG[%d]: " format "\n", getpid(), __VA_ARGS__)
+#define warn(format, ...) fprintf(stderr, "SANDBOX WARNING[%d]: " format "\n", getpid(), ##__VA_ARGS__)
+#define warn_once(format, ...) \
+  if (debug_sandbox) \
+    warn(format, ##__VA_ARGS__); \
+  else if (warn_count++ == 0) \
+    warn(format " (further warnings suppressed)", ##__VA_ARGS__)
+#define _error(format, ...) fprintf(stderr, "SANDBOX ERROR[%d]: " format "\n", getpid(), ##__VA_ARGS__)
+
+// Perform various initialization, which includes loading the original
+// glibc functions to be wrapped using dlsym().
+void sandbox_init() {
+
+    // Debug sandbox library with FLOX_DEBUG_SANDBOX=1.
+    debug_sandbox = ( getenv( "FLOX_DEBUG_SANDBOX" ) != NULL );
+
+    // Derive audit level from FLOX_VIRTUAL_SANDBOX environment variable.
+    const char * flox_virtual_sandbox_value = getenv( "FLOX_VIRTUAL_SANDBOX" );
+    if (flox_virtual_sandbox_value == NULL ||
+       (strcmp(flox_virtual_sandbox_value, "off") == 0)) {
+      sandbox_level = 0;
+    } else if (strcmp(flox_virtual_sandbox_value, "warn") == 0) {
+      sandbox_level = 1;
+    } else if (strcmp(flox_virtual_sandbox_value, "enforce") == 0) {
+      sandbox_level = 2;
+    } else if (strcmp(flox_virtual_sandbox_value, "pure") == 0) {
+      // Pure mode is just like enforce, but invoked within the Nix sandbox.
+      sandbox_level = 3;
+    } else {
+      warn_once( "FLOX_VIRTUAL_SANDBOX must be (off|warn|enforce|pure) ... ignoring" );
+      sandbox_level = 0;
+    }
+    debug( "sandbox_level=%d", sandbox_level );
+
+#ifdef Linux
+    // Declare new functions to be intercepted here, then add stub
+    // functions below.
+    orig_open = dlsym(RTLD_NEXT, "open");
+    orig_openat = dlsym(RTLD_NEXT, "openat");
+#endif
+}
+
+// Accessor method for determining sandbox_level defined as a
+// static int in this file.
+int get_sandbox_level() {
+    return sandbox_level;
+}
+
+#ifdef Linux
+bool sandbox_check_argv0() {
+    static char argv0_path[PATH_MAX];
+    if (sandbox_level < 0) sandbox_init();
+    // Identify the argv[0] realpath from /proc and flag if it's
+    // not in the closure.
+    // TODO: find way to detect changes in /proc/self/exe rather than
+    //       running realpath() on every path access.
+    if (realpath( "/proc/self/exe", argv0_path ) == NULL)
+      {
+        _error( "sandbox_check_argv0() realpath() failed" );
+        fflush(stderr);
+        // If realpath() failed to set the realpath then explicitly
+        // ensure our buffer returns an empty string.
+        argv0_path[0] = '\0';
+      }
+    // The use of certain paths like `/usr/bin/env` path is ubiquitous and
+    // hardcoded to an extent that we cannot really expect developers to
+    // replace it in code, so we instead allow exceptions for a limited
+    // number of these paths.
+    // simply let it be an allowed exception.
+    //
+    // Once requested by way of the la_version() call, we know that all
+    // libraries requested by this PID are similarly linked from /usr/bin/env
+    // so we can simply give all lookups a free pass.
+    if (
+        strcmp(argv0_path, "/usr/bin/env") == 0 ||
+        strcmp(argv0_path, "/bin/sh") == 0 ||
+        strcmp(argv0_path, "/usr/bin/dash") == 0
+    ) {
+      debug( "%s is a permitted argv0", argv0_path );
+      return true;
+    } else {
+      return false;
+    }
+}
+#else // Darwin
+bool sandbox_check_argv0() {
+    return false;
+}
+#endif
+
+// Some paths are derived from allowed basenames.
+
+// Define the maximum number of directories that can be specified in
+// the FLOX_SANDBOX_ALLOW_DIRS environment variable. This is a somewhat
+// arbitrary limit, but it should be more than enough for most cases.
+#define FLOX_SANDBOX_ALLOW_DIRS_MAXENTRIES 256
+
+// Define the maximum length of a directory path in the FLOX_SANDBOX_ALLOW_DIRS
+// environment variable. This is also somewhat arbitrary, but it should
+// be more than enough for most cases.
+#define FLOX_SANDBOX_ALLOW_DIRS_MAXLEN PATH_MAX
+
+static int    allow_dirs_count = -1;
+static char   allow_dirs_buf[FLOX_SANDBOX_ALLOW_DIRS_MAXLEN];
+static char * allow_dirs[FLOX_SANDBOX_ALLOW_DIRS_MAXENTRIES];
+bool check_allowed_basenames( const char * pathname ) {
+  // Start by reading the contents of FLOX_ALLOW_SANDBOX_DIRS into array
+  pthread_mutex_lock(&lock);
+  if ( allow_dirs_count == -1 )
+    {
+      // Copy the contents of the FLOX_SANDBOX_ALLOW_DIRS variable into
+      // allow_dirs_buf and tokenize the buffer by replacing
+      // colons with NULLs as we count the entries, saving pointers
+      // to each of the paths in the allow_dirs[] array.
+      allow_dirs_count = 0;
+      const char * allow_dirs_env
+        = getenv( "FLOX_SANDBOX_ALLOW_DIRS" );
+      if ( allow_dirs_env != NULL )
+        {
+          if ( sizeof( allow_dirs_env )
+               >= FLOX_SANDBOX_ALLOW_DIRS_MAXLEN )
+            {
+              _error( "check_allowed_basenames() FLOX_SANDBOX_ALLOW_DIRS is too long, "
+                     "truncating to %d characters\n",
+                     FLOX_SANDBOX_ALLOW_DIRS_MAXLEN );
+              fflush(stderr);
+            }
+
+          strncpy( allow_dirs_buf,
+                   allow_dirs_env,
+                   sizeof( allow_dirs_buf ) );
+
+
+          // Iterate over the space-separated list of paths in the
+          // allow_dirs buffer, tokenizing as we go and
+          // maintaining a count of the number of entries found.
+          char * allow_dir = NULL;
+          char * saveptr   = NULL;  // For strtok_r() context
+
+          allow_dir
+            = strtok_r( allow_dirs_buf, " ", &saveptr );
+          while ( allow_dir != NULL )
+            {
+              if ( allow_dirs_count
+                   >= FLOX_SANDBOX_ALLOW_DIRS_MAXENTRIES )
+                {
+                  _error( "check_allowed_basenames() "
+                          "FLOX_SANDBOX_ALLOW_DIRS has too many entries, "
+                          "truncating to the first %d",
+                          FLOX_SANDBOX_ALLOW_DIRS_MAXENTRIES );
+                  fflush(stderr);
+                  break;
+                }
+              debug( "check_allowed_basenames() allow_dirs[%d] = %s",
+                      allow_dirs_count,
+                      allow_dir );
+              allow_dirs[allow_dirs_count]
+                = allow_dir;
+              allow_dir = strtok_r( NULL, " ", &saveptr );
+              allow_dirs_count++;
+            }
+        }
+
+      // Add a few static entries to the end of the list.
+      allow_dirs[allow_dirs_count++] = "/tmp";
+      allow_dirs[allow_dirs_count++] = "/dev";
+#ifdef Linux
+      allow_dirs[allow_dirs_count++] = "/sys";
+      allow_dirs[allow_dirs_count++] = "/proc";
+#else // Darwin
+      allow_dirs[allow_dirs_count++] = "/System/Library";
+      allow_dirs[allow_dirs_count++] = "/usr/share";
+      allow_dirs[allow_dirs_count++] = "/var/db/timezone";
+#endif
+
+      // Infer a couple from the environment.
+      char *flox_src_dir = getenv("FLOX_SRC_DIR");
+      if (flox_src_dir) allow_dirs[allow_dirs_count++] = flox_src_dir;
+      char *tmpdir = getenv("TMPDIR");
+      if (tmpdir) allow_dirs[allow_dirs_count++] = tmpdir;
+    }
+
+  // Iterate over the allow_dirs list looking for pathname.
+  char allow_dir_real_path[PATH_MAX];
+  bool allowed = false;
+
+  uint64_t tid;
+  pthread_threadid_np(NULL, &tid);
+
+  for ( int i = 0; i < allow_dirs_count; i++ )
+    {
+        // Recall we've been passed a realpath, so we must in turn
+        // convert our allow dirs to realpaths as well. TODO: find
+        // a way to do this as we populate allow_dirs; we don't do
+        // this now because we're indexing the same memory returned
+        // by getenv().
+        if (realpath( allow_dirs[i], allow_dir_real_path ) == NULL) {
+            debug( "check_allowed_basenames(): skipping path '%s', does not exist", allow_dir_real_path );
+        } else {
+            debug( "check_allowed_basenames('%s'): tid=%d, i=%d, comparing to '%s'", pathname, tid, i, allow_dir_real_path );
+//            if ( strncmp(pathname, allow_dir_real_path, strlen(allow_dir_real_path)) == 0 &&
+//              ( pathname[strlen(allow_dir_real_path)] == '/' || pathname[strlen(allow_dir_real_path)] == '\0' )
+            if ( strncmp(pathname, allow_dir_real_path, strlen(allow_dir_real_path)) == 0 ) {
+                debug( "%s is an allowed basename", pathname );
+                allowed = true;
+                break;
+            }
+        }
+    }
+  pthread_mutex_unlock(&lock);
+  return allowed;
+}
+
+// Check if path access represents something that may not be reproducible
+// on another machine. Any path within the environment's closure is fine,
+// but there are also other specific paths and basenames accessed during a
+// build that we can similarly rely to be present on any machine.
+//
+// The challenge here is that some path accesses are discrete while others
+// are modal, implying a different handling for subsequent path accesses.
+// One example of this is the use of `/usr/bin/env`, which is ubiquitous
+// and hardcoded to an extent that we cannot really expect users to replace
+// references to it in code, so when invoking this path we suspend all
+// further path checking until argv0 is updated to a new path.
+bool sandbox_check_path( const char * pathname ) {
+    static char real_path[PATH_MAX];
+    if (sandbox_level < 0) sandbox_init();
+    if (sandbox_level == 0) return true;
+    debug( "sandbox_check_path('%s'), sandbox_level=%d", pathname, sandbox_level );
+    if (sandbox_check_argv0()) return true;
+
+    // From here on out, operate on realpath. If a file doesn't exist
+    // then return true and let ENOENT be the eventual result.
+    if (realpath( pathname, real_path ) == NULL) return true;
+    if (check_allowed_basenames(real_path)) return true;
+    if (in_closure(real_path)) {
+        debug( "%s is in the closure", pathname );
+        return true;
+    }
+    if (sandbox_level == 1) {
+        warn( "%s is not in the sandbox", pathname );
+        return true;
+    } else {
+        _error( "%s is not in the sandbox", pathname );
+        fflush(stderr);
+        // XXX Do we exit hard or rely on EACCESS?
+        exit(1);
+        // return false;
+    }
+}
+
+#ifdef Linux
+
+// Interceptor for open
+int open(const char *pathname, int flags, ...) {
+    if (!orig_open) sandbox_init();
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+        va_list args;
+        va_start(args, flags);
+        mode = va_arg(args, mode_t);
+        va_end(args);
+    }
+    if (sandbox_check_path(pathname)) {
+        return orig_open(pathname, flags, mode);
+    } else {
+        errno = EACCES;
+        return -1;
+    }
+}
+
+// Interceptor for openat
+int openat(int dirfd, const char *pathname, int flags, ...) {
+    if (!orig_openat) sandbox_init();
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+        va_list args;
+        va_start(args, flags);
+        mode = va_arg(args, mode_t);
+        va_end(args);
+    }
+    if (sandbox_check_path(pathname)) {
+        return orig_openat(dirfd, pathname, flags, mode);
+    } else {
+        errno = EACCES;
+        return -1;
+    }
+}
+
+#else
+
+// Interceptor for open
+int my_open(const char *pathname, int flags, ...) {
+    if (sandbox_level < 0) sandbox_init();
+    debug( "my_open('%s'), sandbox_level=%d", pathname, sandbox_level );
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+        va_list args;
+        va_start(args, flags);
+        mode = va_arg(args, int);
+        va_end(args);
+    }
+    if (sandbox_check_path(pathname)) {
+        return open(pathname, flags, mode);
+    } else {
+        errno = EACCES;
+        return -1;
+    }
+}
+
+// Interceptor for openat
+int my_openat(int dirfd, const char *pathname, int flags, ...) {
+    if (sandbox_level < 0) sandbox_init();
+    debug( "my_openat('%s'), sandbox_level=%d", pathname, sandbox_level );
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+        va_list args;
+        va_start(args, flags);
+        mode = va_arg(args, int);
+        va_end(args);
+    }
+    if (sandbox_check_path(pathname)) {
+        return openat(dirfd, pathname, flags, mode);
+    } else {
+        errno = EACCES;
+        return -1;
+    }
+}
+
+// Thank you https://www.emergetools.com/blog/posts/DyldInterposing
+#define DYLD_INTERPOSE(_replacement,_replacee) \
+   __attribute__((used)) static struct{ const void* replacement; const void* replacee; } _interpose_##_replacee \
+               __attribute__ ((section ("__DATA,__interpose"))) = { (const void*)(unsigned long)&_replacement, (const void*)(unsigned long)&_replacee };
+DYLD_INTERPOSE(my_open, open)
+DYLD_INTERPOSE(my_openat, openat)
+
+#endif

--- a/ld-floxlib/sandbox.h
+++ b/ld-floxlib/sandbox.h
@@ -1,0 +1,10 @@
+#ifndef SANDBOX_H
+#define SANDBOX_H
+
+#include <stdbool.h>
+
+bool sandbox_check_argv0();
+bool sandbox_check_path(const char *path);
+int get_sandbox_level();
+
+#endif // SANDBOX_H

--- a/ld-floxlib/unit-test.c
+++ b/ld-floxlib/unit-test.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <assert.h>
 #include <link.h>
+extern int sandbox_level;
 extern unsigned int la_version( unsigned int version );
 extern char * la_objsearch( const char * name, uintptr_t * cookie, unsigned int flag );
 

--- a/libexec/build-manifest.nix
+++ b/libexec/build-manifest.nix
@@ -1,0 +1,139 @@
+{
+  pkgs ? import <nixpkgs> {},
+  name,
+  flox-env,
+  install-prefix,
+  srcTarball ? null, # optional
+  buildDeps ? [], # optional
+  buildScript ? null, # optional
+  buildCache ? null, # optional
+  virtualSandbox ? "off", # optional
+}:
+
+# First a few assertions to ensure that the inputs are consistent.
+
+# buildCache is only meaningful with a build script
+assert (buildCache != null) -> (buildScript != null);
+# srcTarball is only required with a build script
+assert (srcTarball != null) -> (buildScript != null);
+
+let
+
+  flox-env-package = builtins.storePath flox-env;
+  buildInputs = (
+    map (d: builtins.storePath d) buildDeps
+  ) ++ [flox-env-package];
+  install-prefix-contents = /. + install-prefix;
+  buildScript-contents = /. + buildScript;
+  buildCache-tar-contents = if (buildCache == null) then null else (/. + buildCache);
+
+in
+  pkgs.runCommand name {
+    inherit buildInputs srcTarball;
+    nativeBuildInputs = with pkgs; [findutils gnutar gnused makeWrapper]
+      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ darwin.autoSignDarwinBinariesHook ];
+    outputs = [ "out" ] ++ pkgs.lib.optionals ( buildCache != null ) [ "buildCache" ];
+  } ( (
+      if (buildScript == null)
+      then ''
+        # If no build script is provided copy the contents of install prefix
+        # to the output directory, rewriting path references as we go.
+        if [ -e ${install-prefix-contents} ]; then
+          if [ -d ${install-prefix-contents} ]; then
+            mkdir $out
+            tar -C ${install-prefix-contents} -c --mode=u+w -f - . | \
+              sed --binary "s%${install-prefix}%$out%g" | \
+              tar -C $out -xf -
+          else
+            cp ${install-prefix-contents} $out
+            sed --binary "s%${install-prefix}%$out%g" $out
+          fi
+        else
+          echo "ERROR: build did not produce expected \$out (${install-prefix})" 1>&2
+          exit 1
+        fi
+        ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+          signDarwinBinariesInAllOutputs
+        ''}
+      ''
+      else ''
+        echo "---"
+        echo "Input checksums:"
+        md5sum \
+          ${/. + srcTarball} \
+          ${buildScript-contents} \
+          ${pkgs.lib.optionalString (
+            buildCache-tar-contents != null
+          ) buildCache-tar-contents}
+        echo "---"
+        # If the build script is provided, then it's expected that we will
+        # invoke it from within the sandbox to create $out. The choice of
+        # pure or impure mode occurs outside of this script as the derivation
+        # is instantiated.
+        source $stdenv/setup # is this necessary?
+
+        # We are currently in /build, and TMPDIR is also set to /build, so
+        # we need to extract the source and work in a subdirectory to avoid
+        # populating our build cache with a bunch of temporary files.
+        mkdir $name && cd $name
+
+        # We pass and extract the source as a tarball to preserve timestamps.
+        # Passing the source as a directory would cause the timestamps to be
+        # set to the UNIX epoch as happens with all files in the Nix store,
+        # which would be older than the intermediate compilation artifacts.
+        tar -xpf ${/. + srcTarball}
+
+        # Extract contents of the cache, if it exists.
+        ${ if buildCache-tar-contents == null then ":" else ''
+          tar --skip-old-files -xpf ${buildCache-tar-contents}
+        '' }
+        ${ if buildCache == null then ''
+          # When not preserving a cache we just run the build normally.
+          FLOX_VIRTUAL_SANDBOX=${virtualSandbox} FLOX_SRC_DIR=$(pwd) \
+          FLOX_TURBO=1 ${flox-env-package}/activate bash -e ${buildScript-contents}
+        '' else ''
+          # If the build fails we still want to preserve the build cache, so we
+          # remove $out on failure and allow the Nix build to proceed to write
+          # the result symlink.
+          FLOX_VIRTUAL_SANDBOX=${virtualSandbox} FLOX_SRC_DIR=$(pwd) \
+          FLOX_TURBO=1 ${flox-env-package}/activate bash -e ${buildScript-contents} || \
+            ( rm -rf $out && echo "flox build failed (caching build dir)" | tee $out 1>&2 )
+        '' }
+      ''
+    )
+    + ''
+      # Start by patching shebangs in bin and sbin directories.
+      for dir in $out/bin $out/sbin; do
+        if [ -d "$dir" ]; then
+          patchShebangs $dir
+        fi
+      done
+      # Wrap contents of files in bin with ${flox-env-package}/activate
+      for prog in $out/bin/* $out/sbin/*; do
+        if [ -L "$prog" ]; then
+          : # You cannot wrap a symlink, so just leave it be?
+        else
+          assertExecutable "$prog"
+          hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
+          mv "$prog" "$hidden"
+          makeShellWrapper "${flox-env-package}/activate" "$prog" \
+            --inherit-argv0 \
+            --set FLOX_ENV "${flox-env-package}" \
+            --set FLOX_TURBO 1 \
+            --set FLOX_MANIFEST_BUILD_OUT "$out" \
+            --set FLOX_VIRTUAL_SANDBOX "${virtualSandbox}" \
+            --run 'export FLOX_SET_ARG0="$0"' \
+            --add-flags "$hidden"
+        fi
+      done
+    '' + pkgs.lib.optionalString (buildCache != null) ''
+      # Only tar the files to avoid differences in directory {a,c,m}times.
+      # Sort the files to keep the output stable across builds.
+      # Avoid compressing with gzip because that is not stable across
+      # invocations on Mac only. Experimentation shows that xz and bzip2
+      # compression is stable on both Mac and Linux, but that can be slow,
+      # and we probably don't actually need to compress the build cache
+      # because we actively delete the old copy as we create a new one.
+      find . -type f | sort | tar -c --no-recursion -f $buildCache -T -
+    ''
+  )

--- a/libexec/flox-build.mk
+++ b/libexec/flox-build.mk
@@ -1,0 +1,275 @@
+#
+# This makefile implements Tom's stepladder from manifest to Nix builds:
+#
+# 1. "local" (aka in-situ): sets $out in the environment, invokes the build
+#    commands in a subshell (using bash), then turns the $out directory into
+#    a Nix package with all outpath references replaced with the real $out
+#    and all bin/* commands wrapped with $FLOX_ENV/activate
+# 2. "sandbox": invokes that same script from within the runCommand builder,
+#    with no network and filesystem access and a fake home directory
+# 3. "sandbox with buildCache": does as above, with the build directory
+#    persisted across builds
+# 4. "staged": splits the builds into stages, each of which can be any of
+#    the above, and whose "locked" values are stored as a result symlink or
+#    as a storePath within the manifest
+#
+
+# Start by checking that the FLOX_ENV environment variable is set.
+ifeq (,$(FLOX_ENV))
+  $(error ERROR: FLOX_ENV not defined)
+endif
+
+# Identify target O/S.
+OS := $(shell uname -s)
+
+# Set the default goal to be all builds if one is not specified.
+.DEFAULT_GOAL := all
+
+# Set a default TMPDIR variable if one is not already defined.
+TMPDIR ?= /tmp
+
+# Use the wildcard operator to identify builds in the provided $FLOX_ENV.
+BUILDS := $(wildcard $(FLOX_ENV)/package-builds.d/*)
+
+# The `nix build` command will attempt a rebuild in every instance,
+# and we will presumably want `flox build` to do the same. However,
+# we cannot just mark the various build targets as PHONY because they
+# must be INTERMEDIATE to prevent `flox build foo` from rebuilding
+# `bar` and `baz` as well (unless of course it was a prerequsite).
+# So we instead derive the packages to be force-rebuilt from the special
+# MAKECMDGOALS variable if defined, and otherwise rebuild them all.
+BUILDGOALS = $(if $(MAKECMDGOALS),$(MAKECMDGOALS),$(notdir $(BUILDS)))
+$(foreach _build,$(BUILDGOALS),\
+  $(eval _pname = $(notdir $(_build)))\
+  $(foreach _buildtype,local sandbox,\
+    $(eval $(_pname)_$(_buildtype)_build: FORCE)))
+
+# Scan for "${package}" references within the build instructions and add
+# target prerequisites for any inter-package prerequisites, letting make
+# flag any circular dependencies encountered along the way.
+define DEPENDS_template =
+  # Infer pname from script path.
+  $(eval _pname = $(notdir $(build)))
+  # We want to create build-specific variables, and variable names cannot
+  # have "-" in them so we create a version of the build "pname" replacing
+  # this with "_" for use in variable names.
+  $(eval _pvarname = $(subst -,_,$(_pname)))
+  # Compute 32-character stable string for use in stable path generation
+  # based on hash of pname, current working directory and FLOX_ENV.
+  $(eval $(_pvarname)_hash = $(shell ( \
+    ( echo $(_pname) $(realpath $(FLOX_ENV)) && pwd ) | sha256sum | head -c32)))
+  # Render a shorter 8-character version as well.
+  $(eval $(_pvarname)_shortHash = $(shell echo $($(_pvarname)_hash) | head -c8))
+  # And while we're at it, set a temporary basename using the short hash.
+  $(eval $(_pvarname)_tmpBasename = $(TMPDIR)/$($(_pvarname)_shortHash)-$(_pname))
+
+  # We need to render a version of the build script with package prerequisites
+  # replaced with their corresponding outpaths, and we create that at a stable
+  # temporary path so that we only perform Nix rebuilds when necessary.
+  $(eval $(_pvarname)_buildScript = $($(_pvarname)_tmpBasename)-build.bash)
+
+  # Iterate over each possible {build,package} pair looking for references to
+  # ${package} in the build script, being careful to avoid looking for references
+  # to the package in its own build. If found, declare dependency from the build
+  # script to the package.
+  $(foreach package,$(filter-out $(notdir $(build)),$(notdir $(BUILDS))),\
+    $(if $(shell grep '\$${$(package)}' $(build)),\
+      $(eval _dep = result-$(package))\
+      $(eval $(_pvarname)_buildDeps += $(realpath $(_dep)))\
+      $($(_pvarname)_buildScript): $(_dep)))
+endef
+
+$(foreach build,$(BUILDS),$(eval $(call DEPENDS_template)))
+
+# Define macro containing single space character for use in string substitution.
+space := $(subst x,,x x)
+
+# The method of calling the sandbox differs based on O/S. Define
+# PRELOAD_ARGS to denote the correct way.
+ifeq (Darwin,$(OS))
+  PRELOAD_ARGS = DYLD_INSERT_LIBRARIES=__FLOX_CLI_OUTPATH__/lib/libsandbox.dylib
+else
+  ifeq (Linux,$(OS))
+    PRELOAD_ARGS = LD_PRELOAD=__FLOX_CLI_OUTPATH__/lib/libsandbox.so
+  else
+    $(error unknown OS: $(OS))
+  endif
+endif
+
+# The following template renders targets for the in-situ build mode.
+define BUILD_local_template =
+  .INTERMEDIATE: $(_pname)_local_build
+  $(_pname)_local_build: $($(_pvarname)_buildScript)
+	@echo "Building $(_name) in local mode"
+	$(if $(_virtualSandbox),$(PRELOAD_ARGS) FLOX_SRC_DIR=$$$$(pwd) FLOX_VIRTUAL_SANDBOX=$(strip $(_virtualSandbox))) \
+	MAKEFLAGS= FLOX_TURBO=1 out=$(_out) $(FLOX_ENV)/activate bash -e $($(_pvarname)_buildScript)
+	nix --extra-experimental-features nix-command \
+	  build -L --file __FLOX_CLI_OUTPATH__/libexec/build-manifest.nix \
+	    --argstr name "$(_name)" \
+	    --argstr flox-env "$(FLOX_ENV)" \
+	    --argstr install-prefix "$(_out)" \
+	    $(if $(_virtualSandbox),--argstr virtualSandbox "$(strip $(_virtualSandbox))") \
+	    --out-link "result-$(_pname)" \
+	    --offline 2>&1 | tee $($(_pvarname)_logfile)
+
+endef
+
+# The following template renders targets for the sandbox build mode.
+define BUILD_sandbox_template =
+  # Again, it is expected that the sandbox and caching modes will be specified
+  # on a per-build basis within the manifest, but in the meantime while we wait
+  # for the manifest parser to be implemented we will grep for the explicit
+  # "buildCache" setting within the build script itself. (See below)
+  $(eval _do_buildCache = $(if $(shell grep -E '\.buildCache = true$$' $(build)),true))
+
+  # The sourceTarball value needs to be stable when nothing changes across builds,
+  # so we create a tarball at a stable TMPDIR path and pass that to the derivation
+  # instead.
+  $(eval $(_pvarname)_src_tar = $($(_pvarname)_tmpBasename)-src.tar)
+  $($(_pvarname)_src_tar): FORCE
+	tar -cf - --no-recursion -T <(git ls-files) > $$@
+
+  # The buildCache value needs to be similarly stable when nothing changes across
+  $(eval $(_pvarname)_buildCache = $($(_pvarname)_tmpBasename)-buildCache.tar)
+  $($(_pvarname)_buildCache): FORCE
+	-rm -f $$@
+	@# If a previous buildCache exists, then copy, don't link to the
+	@# previous buildCache because we want nix to import it as a
+	@# content-addressed input rather than an ever-changing series
+	@# of storePaths. And if it does not exist, then create a new
+	@# tarball containing only a single file indicating the time that
+	@# the buildCache was created to differentiate it from other
+	@# prior otherwise-empty buildCaches.
+	@if [ -f "$(_result)-buildCache" ]; then \
+	  cp $(_result)-buildCache $$@; \
+	else \
+	  tmpdir=$$$$(mktemp -d); \
+	  echo "Build cache initialized on $$$$(date)" > $$$$tmpdir/.buildCache.init; \
+	  tar -cf $$@ -C $$$$tmpdir .buildCache.init; \
+	  rm -rf $$$$tmpdir; \
+	fi
+
+  .PHONY: $(_pname)_sandbox_build
+  $(_pname)_sandbox_build: $($(_pvarname)_buildScript) $($(_pvarname)_src_tar) \
+		$(if $(_do_buildCache),$($(_pvarname)_buildCache))
+	@echo "Building $(_name) in sandbox mode"
+	@# If a previous buildCache exists then move it out of the way
+	@# so that we can detect later if it has been updated.
+	@if [ -n "$(_do_buildCache)" ] && [ -f "$(_result)-buildCache" ]; then \
+	  rm -f "$(_result)-buildCache.prevOutPath"; \
+	  readlink "$(_result)-buildCache" > "$(_result)-buildCache.prevOutPath"; \
+	fi
+	nix --extra-experimental-features nix-command \
+	  build -L --file __FLOX_CLI_OUTPATH__/libexec/build-manifest.nix \
+	    --argstr name "$(_name)" \
+	    --argstr srcTarball "$($(_pvarname)_src_tar)" \
+	    --argstr flox-env "$(FLOX_ENV)" \
+	    --argstr install-prefix "$(_out)" \
+	    $(if $($(_pvarname)_buildDeps),--arg buildDeps $($(_pvarname)_buildDeps_arg)) \
+	    --argstr buildScript "$($(_pvarname)_buildScript)" \
+	    $(if $(_do_buildCache),--argstr buildCache "$($(_pvarname)_buildCache)") \
+	    $(if $(_virtualSandbox),--argstr virtualSandbox "$(strip $(_virtualSandbox))") \
+	    --out-link "result-$(_pname)" \
+	    '^*' 2>&1 | tee $($(_pvarname)_logfile)
+	@# Check to see if a new buildCache has been created, and if so then go
+	@# ahead and run 'nix store delete' on the previous cache, keeping in
+	@# mind that the symlink will remain unchanged in the event of an
+	@# unsuccessful build.
+	@if [ -n "$(_do_buildCache)" ]; then \
+	  if [ -f "$(_result)-buildCache" ] && [ -f "$(_result)-buildCache.prevOutPath" ]; then \
+	    if [ $$$$(readlink "$(_result)-buildCache") != $$$$(cat "$(_result)-buildCache.prevOutPath") ]; then \
+	      nix --extra-experimental-features nix-command store delete \
+	        $$$$(cat "$(_result)-buildCache.prevOutPath") >/dev/null 2>&1 || true; \
+	    fi; \
+	  fi; \
+	  rm -f "$(_result)-buildCache.prevOutPath"; \
+	fi
+
+endef
+
+define BUILD_template =
+  # build mode passed as $(1)
+  $(eval _build_mode = $(1))
+  # Infer pname from script path.)
+  $(eval _pname = $(notdir $(build)))
+  # We want to create build-specific variables, and variable names cannot
+  # have "-" in them so we create a version of the build "pname" replacing
+  # this with "_" for use in variable names.
+  $(eval _pvarname = $(subst -,_,$(_pname)))
+  # Identify result symlink basename.
+  $(eval _result = result-$(_pname))
+  # Eventually derive version somehow, but hardcode it in the meantime.
+  $(eval _version = 0.0.0)
+  # Calculate name.
+  $(eval _name = $(_pname)-$(_version))
+  # Short variable name for buildDependencies derived in the DEPENDS step.
+  $(eval $(_pvarname)_buildDeps_arg = $(strip \
+    $(if $($(_pvarname)_buildDeps),\
+      '["$(subst $(space),",$($(_pvarname)_buildDeps))"]')))
+
+  # Set temp outpath of same strlen as eventual package storePath using the
+  # 32-char hash previously derived from the package name, current working
+  # directory and FLOX_ENV.
+  $(eval _out = /tmp/store_$($(_pvarname)_hash)-$(_name))
+
+  # By the time this rule will be evaluated all of its package dependencies
+  # will have been added to the set of rule prerequisites in $^, using their
+  # "safe" name (with "-" characters replaced with "_"), and these targets
+  # will have successfully built the corresponding result-$(_pname) symlinks.
+  # Iterate through this list, replacing all instances of "${package}" with the
+  # corresponding storePath as identified by the result-* symlink.
+  .INTERMEDIATE: $($(_pvarname)_buildScript)
+  $($(_pvarname)_buildScript): $(build)
+	@echo "Rendering $(_pname) build script to $$@"
+	@cp $$< $$@
+	@for i in $$^; do \
+	  if [ -L "$$$$i" ]; then \
+	    outpath="$$$$(readlink $$$$i)"; \
+	    if [ -n "$$$$outpath" ]; then \
+	      pkgname="$$$$(echo $$$$i | cut -d- -f2-)"; \
+	      sed -i "s%\$$$${$$$$pkgname}%$$$$outpath%g" $$@; \
+	    fi; \
+	  fi; \
+	done
+
+  # Prepare temporary log file for capturing build output for inspection.
+  $(eval $(_pvarname)_logfile := $(shell mktemp --dry-run --suffix=-build-$(_pname).log))
+
+  # Insert mode-specific template.
+  $(call BUILD_$(_build_mode)_template)
+
+  # Select the desired build mode as we declare the result symlink target.
+  $(_result): $(_pname)_$(_build_mode)_build
+	@# Take this opportunity to fail the build if we spot fatal errors in the log.
+	@if grep -q "flox build failed (caching build dir)" $($(_pvarname)_logfile); then \
+	  echo "ERROR: flox build failed (see $($(_pvarname)_logfile))" 1>&2; \
+	  rm -f $$@; \
+	  exit 1; \
+	fi
+
+  # Create a helper target for referring to the package by its name rather
+  # than the [real] result symlink we're looking to create.
+  .PHONY: $(_pname)
+  $(_pname): $(_result)
+
+  # Accumulate a list of known build targets for the "all" target.
+  all += $(_result)
+endef
+
+# It is expected that the sandbox and caching modes will be specified on a
+# per-build basis within the manifest, but in the meantime while we wait for
+# the manifest parser to be implemented we will grep for explicit "buildCache"
+# and "sandbox" settings within the build script for setting the build and
+# caching modes.
+$(foreach build,$(BUILDS), \
+  $(eval _virtualSandbox = $(shell grep -E '\.virtual-sandbox = ' $(build) | cut -d= -f2)) \
+  $(if $(shell grep -E '\.sandbox = true$$' $(build)), \
+    $(eval $(call BUILD_template,sandbox)), \
+    $(eval $(call BUILD_template,local))))
+
+# Finally, we create the "all" target to build all known packages.
+.PHONY: all
+all: $(all)
+
+.PHONY: FORCE
+FORCE:

--- a/libexec/makedot.pl
+++ b/libexec/makedot.pl
@@ -1,0 +1,2 @@
+#!/usr/local/bin/perl -d
+print("Coming soon!\n");

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -44,6 +44,8 @@ namespace flox::buildenv {
 
 static constexpr std::string_view ACTIVATION_SCRIPT_NAME = "activate";
 static constexpr std::string_view ACTIVATION_SUBDIR_NAME = "activate.d";
+static constexpr std::string_view PACKAGE_BUILDS_SUBDIR_NAME
+  = "package-builds.d";
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -46,6 +46,7 @@ static constexpr std::string_view ACTIVATION_SCRIPT_NAME = "activate";
 static constexpr std::string_view ACTIVATION_SUBDIR_NAME = "activate.d";
 static constexpr std::string_view PACKAGE_BUILDS_SUBDIR_NAME
   = "package-builds.d";
+static constexpr std::string_view REQUISITES_TXT_NAME = "requisites.txt";
 
 /* -------------------------------------------------------------------------- */
 
@@ -107,13 +108,23 @@ FLOX_DEFINE_EXCEPTION( PackageBuildFailure,
 /** @} */
 
 /**
- * @class flox::buildenv::PackageBuildFailure
+ * @class flox::buildenv::ActivationScriptBuildFailure
  * @brief An exception thrown when a package fails to build.
  * @{
  */
 FLOX_DEFINE_EXCEPTION( ActivationScriptBuildFailure,
                        EC_ACTIVATION_SCRIPT_BUILD_ERROR,
                        "failure building activation script" )
+/** @} */
+
+/**
+ * @class flox::buildenv::RequisitesTxtBuildFailure
+ * @brief An exception thrown when a package fails to build.
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( RequisitesTxtBuildFailure,
+                       EC_REQUISITES_TXT_BUILD_ERROR,
+                       "failure building requisites.txt" )
 /** @} */
 
 /* -------------------------------------------------------------------------- */
@@ -412,6 +423,15 @@ void
 addScriptToScriptsDir( const std::string &           scriptContents,
                        const std::filesystem::path & scriptsDir,
                        const std::string &           scriptName );
+
+/**
+ * @brief Adds requisites.txt to the environment root directory.
+ * @param tempDir The temporary scripts directory being assembled.
+ */
+void
+addRequisitesTxt( nix::EvalState &              state,
+                  nix::StorePathSet &           references,
+                  const std::filesystem::path & tempDir );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/core/exceptions.hh
+++ b/pkgdb/include/flox/core/exceptions.hh
@@ -111,6 +111,11 @@ enum error_category {
    * due to file I/O failing.
    */
   EC_ACTIVATION_SCRIPT_BUILD_ERROR,
+  /**
+   * A failure encountered while building requisites.txt. This could be
+   * due to file I/O failing.
+   */
+  EC_REQUISITES_TXT_BUILD_ERROR,
 
   /**
    * Attempted lock of a local flake, which is not allowed for floxhub

--- a/pkgdb/include/flox/resolver/manifest-raw.hh
+++ b/pkgdb/include/flox/resolver/manifest-raw.hh
@@ -333,6 +333,20 @@ from_json( const nlohmann::json & jfrom, ProfileScriptsRaw & profile );
 
 /* -------------------------------------------------------------------------- */
 
+/** @brief Declares scripts to be sourced by the user's interactive shell after
+ * activating the environment.*/
+struct BuildDescriptorRaw
+{
+  std::string command;
+};
+
+void
+from_json( const nlohmann::json & jfrom, BuildDescriptorRaw & profile );
+
+void
+to_json( nlohmann::json & jto, const BuildDescriptorRaw & manifest );
+/* -------------------------------------------------------------------------- */
+
 /**
  * @brief A _raw_ description of an environment to be read from a file.
  *
@@ -357,6 +371,7 @@ struct ManifestRaw : public GlobalManifestRaw
 
   std::optional<HookRaw> hook;
 
+  std::optional<std::unordered_map<std::string, BuildDescriptorRaw>> build;
 
   ~ManifestRaw() override            = default;
   ManifestRaw()                      = default;
@@ -418,6 +433,7 @@ struct ManifestRaw : public GlobalManifestRaw
     this->vars    = std::nullopt;
     this->hook    = std::nullopt;
     this->profile = std::nullopt;
+    this->build   = std::nullopt;
   }
 
   /**

--- a/pkgdb/src/buildenv/buildenv-lockfile.cc
+++ b/pkgdb/src/buildenv/buildenv-lockfile.cc
@@ -299,6 +299,19 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
         extract_json_errmsg( err ) );
     }
 
+  // load build scripts
+  try
+    {
+      auto build = jfrom["manifest"]["build"];
+      build.get_to( this->manifest.build );
+    }
+  catch ( nlohmann::json::exception & err )
+    {
+      throw resolver::InvalidLockfileException(
+        "couldn't parse lockfile field 'manifest.build'",
+        extract_json_errmsg( err ) );
+    }
+
   debugLog( nix::fmt( "loaded lockfile v1" ) );
 }
 

--- a/pkgdb/src/buildenv/buildenv-lockfile.cc
+++ b/pkgdb/src/buildenv/buildenv-lockfile.cc
@@ -191,7 +191,7 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load vars
   try
     {
-      auto value = jfrom["manifest"]["vars"];
+      auto value = jfrom.at( "manifest" ).value( "vars", nlohmann::json() );
       value.get_to( this->manifest.vars );
     }
   catch ( nlohmann::json::exception & err )
@@ -204,7 +204,7 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load hooks
   try
     {
-      auto hook = jfrom["manifest"]["hook"];
+      auto hook = jfrom.at( "manifest" ).value( "hook", nlohmann::json() );
       hook.get_to( this->manifest.hook );
     }
   catch ( nlohmann::json::exception & err )
@@ -217,8 +217,9 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load profile
   try
     {
-      auto hook = jfrom["manifest"]["profile"];
-      hook.get_to( this->manifest.profile );
+      auto profile
+        = jfrom.at( "manifest" ).value( "profile", nlohmann::json() );
+      profile.get_to( this->manifest.profile );
     }
   catch ( nlohmann::json::exception & err )
     {
@@ -239,7 +240,7 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
           std::string system;
           try
             {
-              installId = package["install_id"];
+              installId = package.at( "install_id" );
             }
           catch ( nlohmann::json::exception & err )
             {
@@ -251,7 +252,7 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
 
           try
             {
-              system = package["system"];
+              system = package.at( "system" );
             }
           catch ( nlohmann::json::exception & err )
             {
@@ -289,7 +290,8 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load options
   try
     {
-      auto options = jfrom["manifest"]["options"];
+      auto options
+        = jfrom.at( "manifest" ).value( "options", nlohmann::json() );
       options.get_to( this->manifest.options );
     }
   catch ( nlohmann::json::exception & err )
@@ -302,8 +304,8 @@ BuildenvLockfile::from_v1_content( const nlohmann::json & jfrom )
   // load build scripts
   try
     {
-      auto build = jfrom["manifest"]["build"];
-      build.get_to( this->manifest.build );
+      auto value = jfrom.at( "manifest" ).value( "build", nlohmann::json() );
+      value.get_to( this->manifest.build );
     }
   catch ( nlohmann::json::exception & err )
     {

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -758,6 +758,11 @@ makePackageBuildScripts( nix::EvalState &         state,
       for ( auto [name, descriptor] : *lockfile.manifest.build )
         {
           addScriptToScriptsDir( descriptor.command, packageBuildsDir, name );
+          std::filesystem::permissions( packageBuildsDir / name,
+                                        std::filesystem::perms::owner_exec
+                                          | std::filesystem::perms::group_exec
+                                          | std::filesystem::perms::others_exec,
+                                        std::filesystem::perm_options::add );
         }
     }
 

--- a/pkgdb/src/resolver/manifest-raw.cc
+++ b/pkgdb/src/resolver/manifest-raw.cc
@@ -646,6 +646,29 @@ HookRaw::check() const
     }
 }
 
+/* -------------------------------------------------------------------------- */
+
+void
+from_json( const nlohmann::json & jfrom, BuildDescriptorRaw & build )
+{
+  for ( const auto & [key, value] : jfrom.items() )
+    {
+      if ( key == "command" ) { value.get_to( build.command ); }
+      else
+        {
+          throw InvalidManifestFileException(
+            "unrecognized manifest field 'build." + key + "'." );
+        }
+    }
+}
+
+void
+to_json( nlohmann::json & jto, const BuildDescriptorRaw & build )
+{
+  jto            = nlohmann::json::object();
+  jto["command"] = build.command;
+}
+
 
 /* -------------------------------------------------------------------------- */
 
@@ -744,6 +767,7 @@ from_json( const nlohmann::json & jfrom, ManifestRaw & manifest )
           manifest.vars = varsFromJSON( value );
         }
       else if ( key == "profile" ) { value.get_to( manifest.profile ); }
+      else if ( key == "build" ) { value.get_to( manifest.build ); }
       else if ( key == "hook" ) { value.get_to( manifest.hook ); }
       else if ( key == "options" ) { value.get_to( manifest.options ); }
       else if ( key == "env-base" ) { value.get_to( manifest.envBase ); }
@@ -774,6 +798,8 @@ to_json( nlohmann::json & jto, const ManifestRaw & manifest )
   if ( manifest.vars.has_value() ) { jto["vars"] = *manifest.vars; }
 
   if ( manifest.profile.has_value() ) { jto["profile"] = *manifest.profile; }
+
+  if ( manifest.build.has_value() ) { jto["build"] = *manifest.build; }
 
   if ( manifest.hook.has_value() ) { jto["hook"] = *manifest.hook; }
 }

--- a/pkgs/ld-floxlib/default.nix
+++ b/pkgs/ld-floxlib/default.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation {
     name = "ld-floxlib-src";
     path = "${./../../ld-floxlib}";
   };
+  postPatch = ''
+    substituteInPlace closure.c --replace '@@out@@' "$out"
+  '';
   makeFlags = ["PREFIX=$(out)"];
   doCheck = true;
 }


### PR DESCRIPTION
## Proposed Changes

DO NOT MERGE

This patch implements a PoC of the manifest build which uses the instructions as found in the `[build]` section to build the package exactly as it would be built by manually invoking the same commands within a `flox activate` shell.

- sets $out in the environment
- invokes the build commands in a subshell (using bash)
- turns the $out directory into a Nix package with all outpath references replaced with the real $out
- wraps all `bin/*` commands with `$FLOX_ENV/activate`

Usage: flox-build [ pkgname ]

N.B. this patch utilises the (hitherto-unused) $FLOX_TURBO flag to invoke the provided command without an intervening shell, and in the process I tripped across and fixed a bug in the activate script.

## Release Notes

N/A