### PR TITLE
fix(uninstall): Correct package uninstallation with dotted attr_path

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -897,7 +897,7 @@ pub enum TomlEditError {
     /// The `[install]` table was missing entirely
     #[error("'install' table not found")]
     MissingInstallTable,
-    #[error("couldn't find package '{0}' in the manifest")]
+    #[error("couldn't find package with install id '{0}' in the manifest")]
     PackageNotFound(String),
     #[error("'options' must be a table, but found {0} instead")]
     MalformedOptionsTable(String),
@@ -1202,10 +1202,10 @@ pub fn insert_packages(
     })
 }
 
-/// Remove package names from the `[install]` table of a manifest
+/// Remove package names from the `[install]` table of a manifest based on their install IDs.
 pub fn remove_packages(
     manifest_contents: &str,
-    pkgs: &[String],
+    install_ids: &[String],
 ) -> Result<DocumentMut, TomlEditError> {
     debug!("attempting to remove packages from the manifest");
     let mut toml = manifest_contents
@@ -1216,7 +1216,7 @@ pub fn remove_packages(
     let installs_table = {
         let installs_field = toml
             .get_mut("install")
-            .ok_or(TomlEditError::PackageNotFound(pkgs[0].clone()))?;
+            .ok_or(TomlEditError::PackageNotFound(install_ids[0].clone()))?;
 
         let type_name = installs_field.type_name().into();
 
@@ -1225,14 +1225,14 @@ pub fn remove_packages(
             .ok_or(TomlEditError::MalformedInstallTable(type_name))?
     };
 
-    for pkg in pkgs {
-        debug!("checking for presence of package '{pkg}'");
-        if !installs_table.contains_key(pkg) {
-            debug!("package '{pkg}' wasn't found");
-            return Err(TomlEditError::PackageNotFound(pkg.clone()));
+    for id in install_ids {
+        debug!("checking for presence of package '{id}'");
+        if !installs_table.contains_key(id) {
+            debug!("package with install id '{id}' wasn't found");
+            return Err(TomlEditError::PackageNotFound(id.clone()));
         } else {
-            installs_table.remove(pkg);
-            debug!("package '{pkg}' was removed");
+            installs_table.remove(id);
+            debug!("package with install id '{id}' was removed");
         }
     }
 

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -897,8 +897,7 @@ pub enum TomlEditError {
     /// The `[install]` table was missing entirely
     #[error("'install' table not found")]
     MissingInstallTable,
-    /// Tried to uninstall a package that wasn't installed
-    #[error("couldn't uninstall '{0}', wasn't previously installed")]
+    #[error("couldn't find package '{0}' in the manifest")]
     PackageNotFound(String),
     #[error("'options' must be a table, but found {0} instead")]
     MalformedOptionsTable(String),
@@ -1857,7 +1856,11 @@ pub(super) mod test {
 
     #[test]
     fn error_when_removing_nonexistent_package() {
-        let test_packages = vec!["hello".to_owned(), "DOES_NOT_EXIST".to_owned()];
+        let test_packages = vec![
+            "hello".to_owned(),
+            "DOES_NOT_EXIST".to_owned(),
+            "nodePackages.@".to_owned(),
+        ];
         let removal = remove_packages(DUMMY_MANIFEST, &test_packages);
         assert!(matches!(removal, Err(TomlEditError::PackageNotFound(_))));
     }

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -315,6 +315,8 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
 
             Please ensure that you have write permissions to '.flox/env/manifest.toml'.
         "},
+        CoreEnvironmentError::PackageNotFound(_) => display_chain(err),
+        CoreEnvironmentError::MultiplePackagesMatch(_, _) => display_chain(err),
 
         // internal error, a bug if this happens to users!
         CoreEnvironmentError::BadLockfilePath(_) => display_chain(err),

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -170,6 +170,27 @@ teardown() {
   assert_output --partial "couldn't uninstall 'hello', wasn't previously installed"
 }
 
+@test "'flox uninstall' can uninstall packages with dotted att_paths" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/rubyPackages_3_2.rails.json"
+  run "$FLOX_BIN" init
+  assert_success
+  # Install a dotted package
+  run "$FLOX_BIN" install rubyPackages_3_2.rails
+  assert_success
+
+  # The package should be in the manifest
+  manifest_after_install=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
+  assert_regex "$manifest_after_install" 'rails\.pkg-path = "rubyPackages_3_2\.rails"'
+
+  # Flox can uninstall the dotted package
+  run "$FLOX_BIN" uninstall rubyPackages_3_2.rails
+  assert_success
+
+  # The package should be removed from the manifest
+  manifest_after_uninstall=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
+  ! assert_regex "$manifest_after_uninstall" 'rails\.pkg-path = "rubyPackages_3_2\.rails"'
+}
+
 @test "'flox install' installs by path" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   run "$FLOX_BIN" init


### PR DESCRIPTION
This resolves the issue causing confusing messages when uninstalling packages with a dotted attr_path (e.g., foo.bar). The package name is now correctly parsed, allowing such packages to be uninstalled from the environment.

fixes #1714 
