### PR TITLE
test(activate): Fix flakey tracelevel test

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2112,11 +2112,10 @@ EOF
   # environment, so we also assert that this warning is not present
   # in any of the activation output.
 
-  # Start by adding logic to create semaphore files for all shells.
+  # Start by adding logic to inspect the var within all shells.
   for i in "$HOME/.bashrc.extra" "$HOME/.config/fish/config.fish.extra" "$HOME/.tcshrc.extra" "$HOME/.zshrc.extra"; do
     cat > "$i" <<EOF
-touch "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
-test -n "\$_flox_activate_tracelevel" || touch "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
+test -n "\$_flox_activate_tracelevel" && echo "_flox_activate_tracelevel is set"
 EOF
   done
 
@@ -2135,11 +2134,8 @@ EOF
   for target_shell in bash fish tcsh zsh; do
     echo "Testing $target_shell"
     FLOX_SHELL="$target_shell" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
-    refute_output --partial "_flox_activate_tracelevel not defined"
-    run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
     assert_success
-    run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
-    assert_failure
+    assert_output --partial "_flox_activate_tracelevel is set"
     echo # leave a line between test outputs
   done
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2109,10 +2109,11 @@ EOF
   # environment, so we also assert that this warning is not present
   # in any of the activation output.
 
-  # Start by adding logic to inspect the var within all shells.
+  # Start by adding logic to create semaphore files for all shells.
   for i in "$HOME/.bashrc.extra" "$HOME/.config/fish/config.fish.extra" "$HOME/.tcshrc.extra" "$HOME/.zshrc.extra"; do
     cat > "$i" <<EOF
-test -n "\$_flox_activate_tracelevel" && echo "_flox_activate_tracelevel is set"
+touch "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
+test -n "\$_flox_activate_tracelevel" || touch "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
 EOF
   done
 
@@ -2131,8 +2132,11 @@ EOF
   for target_shell in bash fish tcsh zsh; do
     echo "Testing $target_shell"
     FLOX_SHELL="$target_shell" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
+    refute_output --partial "_flox_activate_tracelevel not defined"
+    run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
     assert_success
-    assert_output --partial "_flox_activate_tracelevel is set"
+    run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
+    assert_failure
     echo # leave a line between test outputs
   done
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -97,6 +97,11 @@ project_teardown() {
   rm -rf "${PROJECT_DIR?}"
   unset PROJECT_DIR
   unset PROJECT_NAME
+  rm -f \
+    "$HOME/.bashrc.extra" \
+    "$HOME/.tcshrc.extra" \
+    "$HOME/.config/fish/config.fish.extra" \
+    "$HOME/.zshrc.extra"
 }
 
 
@@ -776,7 +781,6 @@ EOF
   # USER to REAL_USER.
   FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is aliased to \`echo testing'"
-  rm -f "$HOME/.bashrc.extra"
 }
 
 # bats test_tags=activate,activate:fish,activate:rc:fish
@@ -796,7 +800,6 @@ EOF
   # TODO: come up with a way to invoke fish with the "No colors" theme.
   assert_output --regexp \
     'function.*test_alias.*--wraps=.*echo testing.*--description.*alias test_alias=echo testing'
-  rm -f "$HOME/.config/fish/config.fish.extra"
 }
 
 # bats test_tags=activate,activate:rc:tcsh
@@ -808,7 +811,6 @@ EOF
   # USER to REAL_USER.
   FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc-tcsh.exp" "$PROJECT_DIR"
   assert_line --partial "echo testing"
-  rm -f "$HOME/.tcshrc.extra"
 }
 
 # bats test_tags=activate,activate:rc:zsh
@@ -820,7 +822,6 @@ EOF
   # USER to REAL_USER.
   FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is an alias for echo testing"
-  rm -f "$HOME/.zshrc.extra"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -1887,7 +1888,6 @@ fi
 eval "\$("$FLOX_BIN" activate -d "$PWD")"
 EOF
   bash -ic true
-  rm -f "$HOME/.bashrc.extra"
 }
 
 # bats test_tags=activate,activate:infinite_source,activate:infinite_source:fish
@@ -1902,7 +1902,6 @@ set -gx ALREADY_SOURCED 1
 eval "\$("$FLOX_BIN" activate -d "$PWD")"
 EOF
   fish -ic true
-  rm -f "$HOME/.config/fish/config.fish.extra"
 }
 
 # bats test_tags=activate,activate:infinite_source,activate:infinite_source:tcsh
@@ -1917,7 +1916,6 @@ setenv ALREADY_SOURCED 1
 eval "\`$FLOX_BIN activate -d $PWD\`"
 EOF
   tcsh -ic true
-  rm -f "$HOME/.tcshrc.extra"
 }
 
 # bats test_tags=activate,activate:infinite_source,activate:infinite_source:zsh
@@ -1933,7 +1931,6 @@ fi
 eval "\$("$FLOX_BIN" activate -d "$PWD")"
 EOF
   zsh -ic true
-  rm -f "$HOME/.zshrc.extra"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -2140,11 +2137,6 @@ EOF
   done
 
   rm -rf "$_temp_env"
-  rm \
-    "$HOME/.bashrc.extra" \
-    "$HOME/.tcshrc.extra" \
-    "$HOME/.config/fish/config.fish.extra" \
-    "$HOME/.zshrc.extra"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2132,46 +2132,16 @@ EOF
 
   # Activate the test environment from each shell, each of which will
   # launch an interactive shell that sources the relevant dotfile.
-  echo "Testing bash"
-  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
-  assert_success
-  refute_output --partial "_flox_activate_tracelevel not defined"
-  run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
-  assert_success
-  run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
-  assert_failure
-  echo # leave a line between test outputs
-
-  echo "Testing fish"
-  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
-  assert_success
-  refute_output --partial "_flox_activate_tracelevel not defined"
-  run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
-  assert_success
-  run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
-  assert_failure
-  echo # leave a line between test outputs
-
-  echo "Testing tcsh"
-  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
-  assert_success
-  refute_output --partial "_flox_activate_tracelevel not defined"
-  cat "$HOME/.tcshrc.extra"
-  run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
-  assert_success
-  run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
-  assert_failure
-  echo # leave a line between test outputs
-
-  echo "Testing zsh"
-  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
-  assert_success
-  refute_output --partial "_flox_activate_tracelevel not defined"
-  run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
-  assert_success
-  run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
-  assert_failure
-  echo # leave a line between test outputs
+  for target_shell in bash fish tcsh zsh; do
+    echo "Testing $target_shell"
+    FLOX_SHELL="$target_shell" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
+    refute_output --partial "_flox_activate_tracelevel not defined"
+    run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
+    assert_success
+    run rm "$PROJECT_DIR/_flox_activate_tracelevel.not_defined"
+    assert_failure
+    echo # leave a line between test outputs
+  done
 
   rm -rf "$_temp_env"
   rm \

--- a/cli/tests/activate/hook.exp
+++ b/cli/tests/activate/hook.exp
@@ -11,8 +11,8 @@ expect_after {
   "*\n" { exp_continue }
   "*\r" { exp_continue }
 }
-# check that prompt is set for interactive shell
-expect {flox \[project-*\]}
+
+expect "You are now using the environment"
 
 send "exit\n"
 expect eof

--- a/cli/tests/activate/hook.exp
+++ b/cli/tests/activate/hook.exp
@@ -11,7 +11,8 @@ expect_after {
   "*\n" { exp_continue }
   "*\r" { exp_continue }
 }
-expect "Preparing environment"
+# check that prompt is set for interactive shell
+expect {flox \[project-*\]}
 
 send "exit\n"
 expect eof


### PR DESCRIPTION
## Proposed Changes

**test(activate): Assert on prompt not spinner**

To fix intermittent failures from this test:

- https://github.com/flox/flox/actions/runs/9896583574/job/27339464292#step:6:185

The `zsh` test case didn't get the "Preparing environment" spinner which
may not be outputted if the operation is fast enough. Apply the same fix
that we did for c271f3e by waiting for the shell prompt instead.

**test(activate): Loop over shells for tracelevel**

Make the test easier to read by de-duplicating the common parts.

**test(activate): Consolidate .extra cleanups**

Remove the shell specific `.extra` files in `project_teardown` which is
called by `teardown` after each test, regardless of whether it succeeded
or failed.

Previously a test failure would cause these to leak through to other
tests in the same file and other files, which is why we saw a services
test fail in:

- https://github.com/flox/flox/actions/runs/9896583574/job/27339464292#step:6:474

That services test no longer works the same way but the same issue can
be demonstrated with:

    diff --git a/cli/tests/activate.bats b/cli/tests/activate.bats
    index 021a4ed8..e0875fe6 100644
    --- a/cli/tests/activate.bats
    +++ b/cli/tests/activate.bats
    @@ -2090,7 +2090,7 @@ EOF

     # ---------------------------------------------------------------------------- #

    -# bats test_tags=activate,activate:nested_flox_activate_tracelevel
    +# bats test_tags=activate,activate:nested_flox_activate_tracelevel,bats:focus
     @test "{bash,fish,tcsh,zsh}: confirm _flox_activate_tracelevel set in nested activation" {
       project_setup

    @@ -2113,6 +2113,7 @@ EOF
       for i in "$HOME/.bashrc.extra" "$HOME/.config/fish/config.fish.extra" "$HOME/.tcshrc.extra" "$HOME/.zshrc.extra"; do
         cat > "$i" <<EOF
     test -n "\$_flox_activate_tracelevel" && echo "_flox_activate_tracelevel is set"
    +exit 1
     EOF
       done

    @@ -2140,3 +2141,13 @@ EOF
     }

     # ---------------------------------------------------------------------------- #
    +
    +# bats test_tags=bats:focus
    +@test "demo" {
    +  project_setup
    +  run bash <(cat <<'EOF'
    +    eval $("$FLOX_BIN" activate)
    +EOF
    +)
    +  assert_success
    +}

## Release Notes

N/A