### PR TITLE
fix: support private flake installables

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -331,7 +331,7 @@ impl<State> CoreEnvironment<State> {
         // Locking flakes may require using `ssh` for private flakes,
         // so don't clear PATH
         let result: BuildEnvResult = serde_json::from_value(
-            call_pkgdb(pkgdb_cmd, true).map_err(CoreEnvironmentError::BuildEnv)?,
+            call_pkgdb(pkgdb_cmd, false).map_err(CoreEnvironmentError::BuildEnv)?,
         )
         .map_err(CoreEnvironmentError::ParseBuildEnvOutput)?;
 

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -272,8 +272,12 @@ impl<State> CoreEnvironment<State> {
             pkgdb_cmd.args(["--service-config", &service_config_path.to_string_lossy()]);
         }
 
+        // Locking flakes may require using `ssh` for private flakes,
+        // so don't clear PATH
+        // We don't have tests for private flakes,
+        // so make sure private flakes work after touching this.
         let result: BuildEnvResult = serde_json::from_value(
-            call_pkgdb(pkgdb_cmd, true).map_err(CoreEnvironmentError::BuildEnv)?,
+            call_pkgdb(pkgdb_cmd, false).map_err(CoreEnvironmentError::BuildEnv)?,
         )
         .map_err(CoreEnvironmentError::ParseBuildEnvOutput)?;
 
@@ -324,6 +328,8 @@ impl<State> CoreEnvironment<State> {
             .arg("--container")
             .arg(lockfile_path);
 
+        // Locking flakes may require using `ssh` for private flakes,
+        // so don't clear PATH
         let result: BuildEnvResult = serde_json::from_value(
             call_pkgdb(pkgdb_cmd, true).map_err(CoreEnvironmentError::BuildEnv)?,
         )

--- a/cli/flox-rust-sdk/src/models/pkgdb.rs
+++ b/cli/flox-rust-sdk/src/models/pkgdb.rs
@@ -122,13 +122,17 @@ pub fn call_pkgdb(mut pkgdb_cmd: Command, clear_path: bool) -> Result<Value, Cal
         // pkgdb with an explicit PATH of our making.
         //
         // It really shouldn't be necessary to append $PATH, so we won't.
+        debug!("Setting PATH to only include git");
         git_path
     } else if let Some(current_path) = env::var_os("PATH") {
         // Add our git binary as a fallback in case the user doesn't have git
         let mut split_paths = env::split_paths(&current_path).collect::<Vec<_>>();
         split_paths.push(git_path.into());
-        env::join_paths(split_paths).map_err(CallPkgDbError::AppendGitToPath)?
+        let joined = env::join_paths(split_paths).map_err(CallPkgDbError::AppendGitToPath)?;
+        debug!("appending git, setting PATH to: {:?}", joined);
+        joined
     } else {
+        debug!("Setting PATH to only include git");
         // PATH is unset, has non-unicode characters, or has an = character, so we don't mind overwriting it
         git_path
     };

--- a/cli/flox-rust-sdk/src/providers/flox_cpp_utils.rs
+++ b/cli/flox-rust-sdk/src/providers/flox_cpp_utils.rs
@@ -122,7 +122,9 @@ impl InstallableLocker for Pkgdb {
         debug!("locking installable: {pkgdb_cmd:?}");
 
         // Locking flakes may require using `ssh` for private flakes,
-        // so don't clear PATH
+        // so don't clear PATH.
+        // We don't have tests for private flakes,
+        // so make sure private flakes work after touching this.
         let lock = call_pkgdb(pkgdb_cmd, false).map_err(|err| match err {
             CallPkgDbError::PkgDbError(PkgDbError {
                 exit_code: error_codes::NIX_GENERIC,

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -229,9 +229,6 @@ and `flake` is described below:
     If an attrpath is specified, it is checked whether
     `packages.$system.$attrpath` or `legacyPackages.$system.$attrpath` exist.
 
-    Private flakes (e.g. flakes authenticated with `git+ssh`) are not yet
-    supported.
-
 ## `[vars]`
 
 The `[vars]` section allows you to define environment variables for your


### PR DESCRIPTION
Building flake installables may require ssh from PATH. Currently PATH is cleared when we call pkgdb buildenv. Instead, append git to PATH for this case.

Also append git to PATH for when we call `pkgdb lock-flake-installable` so we have a fallback.