### PR TITLE
fix: normalize `flox activate -- cmd args` handling in all cases

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -3,6 +3,7 @@
 export _coreutils="@coreutils@"
 export _gnused="@gnused@"
 export _setsid="@setsid@"
+export _getopt="@getopt@"
 export _process_compose="@process-compose@"
 export _jq="@jq@"
 export _zdotdir="@out@/activate.d/zdotdir"
@@ -16,6 +17,15 @@ export _tcsh_home="@out@/activate.d/tcsh_home"
 #   3. (-vvv) zsh `autoload -U compinit` (very verbose)
 export _flox_activate_tracelevel="${_FLOX_PKGDB_VERBOSITY:-0}"
 [ "$_flox_activate_tracelevel" -eq 0 ] || set -x
+
+# Ensure mandatory environment variables are defined as required by
+# other scripts. For example, we provide defaults for the following
+# variables as required by the various set-prompt scripts, and tcsh
+# in particular does not tolerate references to undefined variables.
+export FLOX_PROMPT_ENVIRONMENTS="${FLOX_PROMPT_ENVIRONMENTS:-}"
+export _FLOX_SET_PROMPT="${_FLOX_SET_PROMPT:-true}"
+export FLOX_PROMPT_COLOR_1="${FLOX_PROMPT_COLOR_1:-99}"
+export FLOX_PROMPT_COLOR_2="${FLOX_PROMPT_COLOR_2:-141}"
 
 NOT_READY="SOCKET_NOT_READY"
 
@@ -94,11 +104,72 @@ start_services_blocking () {
   fi
 }
 
+# Parse command-line arguments.
+# shellcheck disable=SC1091
+OPTIONS=c:
+LONGOPTS=command:,noprofile,turbo
+USAGE="Usage: $0 [-c \"<cmd> <args>\"] [--turbo] [--noprofile]"
 
-# TODO: add getopt arg parser for following args:
-# -c "<cmd> <args>": specify exact command args to pass to shell
-# --turbo: invoke commands directly without involving userShell
-# --noprofile: do not source `[profile]` scripts
+PARSED=$("$_getopt/bin/getopt" --options="$OPTIONS" --longoptions="$LONGOPTS" --name "$0" -- "$@")
+# shellcheck disable=SC2181
+if [[ $? -ne 0 ]]; then
+  echo "Failed to parse options."
+  exit 1
+fi
+
+# Use eval to remove quotes and replace them with spaces.
+eval set -- "$PARSED"
+
+# Set default values for options.
+FLOX_CMD=""
+FLOX_TURBO="${FLOX_TURBO:-}"
+FLOX_NOPROFILE="${FLOX_NOPROFILE:-}"
+while true; do
+  case "$1" in
+    -c|--command)
+      shift
+      if [ -z "$1" ]; then
+	echo "Option -c requires an argument." >&2
+	echo "$USAGE" >&2
+	exit 1
+      fi
+      FLOX_CMD="$1"
+      shift
+      ;;
+    --turbo)
+      FLOX_TURBO="true"
+      shift
+      ;;
+    --noprofile)
+      FLOX_NOPROFILE="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Invalid option: $1" >&2
+      echo "$USAGE" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Convert the provided command string into an array of arguments in "$@".
+# Henceforth in the script it is assumed that these are the arguments to be
+# invoked either by this shell (with FLOX_TURBO) or with the chosen userShell.
+if [ -n "$FLOX_CMD" ]; then
+  # Throw an error if passed additional arguments along with the -c arg.
+  if [ $# -gt 0 ]; then
+    echo "Unexpected arguments provided with -c argument: $*" >&2
+    echo "$USAGE" >&2
+    exit 1
+  fi
+
+  # Set $@ to reflect the command to be invoked.
+  set -- "$FLOX_CMD"
+fi
 
 # Set FLOX_ENV as the path by which all flox scripts can make reference to
 # the environment to which they belong. Use this to define the path to the
@@ -295,62 +366,56 @@ fi
 #   b. source the relevant activation script
 #   c. invoke the command in one of "stdin" or "-c" modes
 if [ $# -gt 0 ]; then
-  if [ $# -ne 2 ] || [ "$1" != "-c" ]; then
-    # Marshal the provided args into a single safely-quoted string.
-    # We use the magic "${@@Q}" parameter transformation to return
-    # each element of "$@" as a safely quoted string.
-    declare -a cmdarray=()
-    cmdarray=("-c" "${@@Q}")
-    set -- "${cmdarray[@]}"
-  fi
   if [ -n "$FLOX_TURBO" ]; then
-    # "turbo command" mode: simply exec the provided command and args
-    # without paying the cost of invoking the userShell.
-    eval "exec $2"
+    # "turbo command" mode: simply invoke the provided command and args
+    # from *this shell* without paying the cost of invoking the userShell.
+    # We cannot exec this because we support bash shell internal commands.
+    "$@"
+    exit $?
   fi
   # "-c" command mode: pass both [2] arguments unaltered to shell invocation
   case "$_flox_shell" in
     *bash)
-      if [ -n "$FLOX_NO_PROFILES" ]; then
-        exec "$_flox_shell" --noprofile --norc "$@"
+      if [ -n "$FLOX_NOPROFILE" ]; then
+        exec "$_flox_shell" --noprofile --norc -c "$*"
       else
         if [ -t 1 ]; then
-          exec "$_flox_shell" --noprofile --rcfile "$FLOX_ENV/activate.d/bash" "$@"
+          exec "$_flox_shell" --noprofile --rcfile "$FLOX_ENV/activate.d/bash" -c "$*"
         else
           # The bash --rcfile option only works for interactive shells
           # so we need to cobble together our own means of sourcing our
           # startup script for non-interactive shells.
-          exec "$_flox_shell" --noprofile --norc -s <<< "source $FLOX_ENV/activate.d/bash && $2"
+          exec "$_flox_shell" --noprofile --norc -s <<< "source $FLOX_ENV/activate.d/bash && $*"
         fi
       fi
       ;;
     *fish)
-      if [ -n "$FLOX_NO_PROFILES" ]; then
-        exec "$_flox_shell" "$@"
+      if [ -n "$FLOX_NOPROFILE" ]; then
+        exec "$_flox_shell" -c "$*"
       else
-        exec "$_flox_shell" --init-command "set -gx _flox_activate_tracelevel $_flox_activate_tracelevel; source $FLOX_ENV/activate.d/fish" "$@"
+        exec "$_flox_shell" --init-command "set -gx _flox_activate_tracelevel $_flox_activate_tracelevel; source $FLOX_ENV/activate.d/fish" -c "$*"
       fi
       ;;
     *tcsh)
-      if [ -n "$FLOX_NO_PROFILES" ]; then
-        exec "$_flox_shell" "$@"
+      if [ -n "$FLOX_NOPROFILE" ]; then
+        exec "$_flox_shell" -c "$*"
       else
         export FLOX_ORIG_HOME="$HOME"
         export HOME="$_tcsh_home"
         export FLOX_TCSH_INIT_SCRIPT="$FLOX_ENV/activate.d/tcsh"
-        exec "$_flox_shell" -m "$@"
+        exec "$_flox_shell" -m -c "$*"
       fi
       ;;
     *zsh)
-      if [ -n "$FLOX_NO_PROFILES" ]; then
-        exec "$_flox_shell" -o NO_GLOBAL_RCS -o NO_RCS "$@"
+      if [ -n "$FLOX_NOPROFILE" ]; then
+        exec "$_flox_shell" -o NO_GLOBAL_RCS -o NO_RCS -c "$*"
       else
         export FLOX_ORIG_ZDOTDIR="$ZDOTDIR"
         export ZDOTDIR="$_zdotdir"
         export FLOX_ZSH_INIT_SCRIPT="$FLOX_ENV/activate.d/zsh"
         # The "NO_GLOBAL_RCS" option is necessary to prevent zsh from
         # automatically sourcing /etc/zshrc et al.
-        exec "$_flox_shell" -o NO_GLOBAL_RCS "$@"
+        exec "$_flox_shell" -o NO_GLOBAL_RCS -c "$*"
       fi
       ;;
     *)
@@ -366,7 +431,7 @@ fi
 if [ -t 1 ] || [ -n "$_FLOX_FORCE_INTERACTIVE" ]; then
   case "$_flox_shell" in
     *bash)
-      if [ -n "$FLOX_NO_PROFILES" ]; then
+      if [ -n "$FLOX_NOPROFILE" ]; then
         exec "$_flox_shell" --noprofile --norc
       else
         if [ -t 1 ]; then
@@ -383,14 +448,14 @@ if [ -t 1 ] || [ -n "$_FLOX_FORCE_INTERACTIVE" ]; then
       fi
       ;;
     *fish)
-      if [ -n "$FLOX_NO_PROFILES" ]; then
+      if [ -n "$FLOX_NOPROFILE" ]; then
         exec "$_flox_shell"
       else
         exec "$_flox_shell" --init-command "set -gx _flox_activate_tracelevel $_flox_activate_tracelevel; source $FLOX_ENV/activate.d/fish"
       fi
       ;;
     *tcsh)
-      if [ -n "$FLOX_NO_PROFILES" ]; then
+      if [ -n "$FLOX_NOPROFILE" ]; then
         exec "$_flox_shell" -f
       else
         export FLOX_ORIG_HOME="$HOME"
@@ -402,7 +467,7 @@ if [ -t 1 ] || [ -n "$_FLOX_FORCE_INTERACTIVE" ]; then
       fi
       ;;
     *zsh)
-      if [ -n "$FLOX_NO_PROFILES" ]; then
+      if [ -n "$FLOX_NOPROFILE" ]; then
         exec "$_flox_shell" -o NO_GLOBAL_RCS -o NO_RCS
       else
         export FLOX_ORIG_ZDOTDIR="$ZDOTDIR"

--- a/assets/activation-scripts/activate.d/set-prompt.tcsh
+++ b/assets/activation-scripts/activate.d/set-prompt.tcsh
@@ -19,7 +19,7 @@ endif
 unset _esc colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
 
 # Save the current 'tcsh_prompt' if not already saved.
-if ( $?prompt && $?FLOX_PROMPT_ENVIRONMENTS && "$FLOX_PROMPT_ENVIRONMENTS" != ""  && "$_FLOX_SET_PROMPT" != false ) then
+if ( $?prompt && "$FLOX_PROMPT_ENVIRONMENTS" != "" && "$_FLOX_SET_PROMPT" != "false" ) then
     if ( ! $?FLOX_SAVE_TCSH_PROMPT ) then
         setenv FLOX_SAVE_TCSH_PROMPT "$prompt"
     endif

--- a/assets/activation-scripts/activate.d/zdotdir/README.md
+++ b/assets/activation-scripts/activate.d/zdotdir/README.md
@@ -5,7 +5,7 @@ be in a position to configure the environment _last_, after all system and
 user-specific configuration "rc" files have been processed, simply to prevent
 these scripts from perturbing the flox environment.
 
-Unlike `bash`, `zsh` does not support `--rcfile`, `--norc` or `--no-profile`
+Unlike `bash`, `zsh` does not support `--rcfile`, `--norc` or `--noprofile`
 options for manipulating the user and system-specific initialization, but it
 does offer a `ZDOTDIR` environment variable that can be used to specify an
 entirely new set of "system" configuration files to be used at startup.

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -348,7 +348,7 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  FLOX_NO_PROFILES=1 FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  FLOX_NOPROFILE=1 FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -357,11 +357,53 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  # Turbo mode exec()s the provided command without involving the
-  # userShell, so cannot invoke shell primitives like ":".
-  FLOX_TURBO=1 FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -127 $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
-  assert_failure
+  FLOX_TURBO=1 FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  assert_success
   FLOX_TURBO=1 FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  refute_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly in various forms.
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c :
+  assert_success
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command :
+  assert_success
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c true
+  assert_success
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command true
+  assert_success
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate :
+  assert_success
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- :
+  assert_success
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate true
+  assert_success
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- true
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  assert_output --partial "sourcing profile.common"
+  assert_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly with --noprofile.
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --noprofile :
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  refute_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly with --turbo.
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --turbo :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -396,7 +438,7 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  FLOX_NO_PROFILES=1 FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  FLOX_NOPROFILE=1 FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -405,11 +447,53 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  # Turbo mode exec()s the provided command without involving the
-  # userShell, so cannot invoke shell primitives like ":".
-  FLOX_TURBO=1 FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -127 $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
-  assert_failure
+  FLOX_TURBO=1 FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  assert_success
   FLOX_TURBO=1 FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  refute_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly in various forms.
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c :
+  assert_success
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command :
+  assert_success
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c true
+  assert_success
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command true
+  assert_success
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate :
+  assert_success
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- :
+  assert_success
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate true
+  assert_success
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- true
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  assert_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  assert_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly with --noprofile.
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --noprofile :
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  refute_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly with --turbo.
+  FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --turbo :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -435,7 +519,6 @@ EOF
   assert_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  cat $HOME/.logout
   FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
@@ -445,7 +528,7 @@ EOF
   assert_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  FLOX_NO_PROFILES=1 FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  FLOX_NOPROFILE=1 FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -454,11 +537,53 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  # Turbo mode exec()s the provided command without involving the
-  # userShell, so cannot invoke shell primitives like ":".
-  FLOX_TURBO=1 FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -127 $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
-  assert_failure
+  FLOX_TURBO=1 FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  assert_success
   FLOX_TURBO=1 FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  refute_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly in various forms.
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c :
+  assert_success
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command :
+  assert_success
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c true
+  assert_success
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command true
+  assert_success
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate :
+  assert_success
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- :
+  assert_success
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate true
+  assert_success
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- true
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  assert_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  assert_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly with --noprofile.
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --noprofile :
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  refute_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly with --turbo.
+  FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --turbo :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -496,7 +621,7 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   assert_output --partial "sourcing profile.zsh"
 
-  FLOX_NO_PROFILES=1 FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  FLOX_NOPROFILE=1 FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -505,11 +630,53 @@ EOF
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
 
-  # Turbo mode exec()s the provided command without involving the
-  # userShell, so cannot invoke shell primitives like ":".
-  FLOX_TURBO=1 FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -127 $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
-  assert_failure
+  FLOX_TURBO=1 FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- :
+  assert_success
   FLOX_TURBO=1 FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $FLOX_BIN activate --dir "$PROJECT_DIR" -- true
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  refute_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly in various forms.
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c :
+  assert_success
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command :
+  assert_success
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c true
+  assert_success
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command true
+  assert_success
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate :
+  assert_success
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- :
+  assert_success
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate true
+  assert_success
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- true
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  assert_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  assert_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly with --noprofile.
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --noprofile :
+  assert_success
+  assert_output --partial "sourcing hook.on-activate"
+  refute_output --partial "sourcing profile.common"
+  refute_output --partial "sourcing profile.bash"
+  refute_output --partial "sourcing profile.fish"
+  refute_output --partial "sourcing profile.tcsh"
+  refute_output --partial "sourcing profile.zsh"
+
+  # Test running the activate script directly with --turbo.
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --turbo :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -2,6 +2,7 @@
   bash,
   coreutils,
   findutils,
+  getopt,
   gnused,
   util-linux,
   ld-floxlib,
@@ -30,6 +31,7 @@ in
 
     substituteInPlace $out/activate \
       --replace "@coreutils@" "${coreutils}" \
+      --replace "@getopt@" "${getopt}" \
       --replace "@gnused@" "${gnused}" \
       --replace "@setsid@" "${util-linux}/bin/setsid" \
       --replace "@out@" "$out" \


### PR DESCRIPTION
## Proposed Changes

The handling of command args within the `activate` script was incomplete, and did not expose sufficient functionality to be able to invoke a bash script without employing the [previously undocumented] `FLOX_TURBO` mode. This PR addresses these issues by adding `getopt` argument parsing to the `activate` script, normalising the use of `-c` for invoking commands in each of the [3] command modes, and documents the `--turbo` and `--noprofile` command invocation modes.

### `activate` script arg parsing

This PR adds argument parsing that makes it possible to invoke any of the following:
```
  % /path/to/activate bash <file>
  % /path/to/activate -- bash <file>
  % /path/to/activate -c "bash <file>"
```

By way of explanation, when `activate` parses the command line:

* the `--` delimiter delineates the `activate` script arguments from the command and arguments to be invoked
    * e.g. `activate --bing -- foo --arg bar` makes it clear that the `--bing` argument is for the `activate` script, and the `--arg bar` part is to be processed by the `foo` command
* in cases where there are no args to be invoked then the `--` delimiter is optional
    * this is long-standing UNIX convention; I recognise that our rust CLI doesn't obey this convention
    * I do agree that it is best practice to provide the `--` delimiter, it's just clear that while all shells support it I am not aware of any other that _enforces_ it
* the `-c "<cmd> <args>"` option is provided for compatibility with other shells, and is exactly equivalent to `-- <cmd> <args>`
    * the latter is more useful on the command line because it avoids having to quote arguments
    * the former may be more useful in cases where the `-c` syntax is already being provided from some other context, and passing it unaltered avoids the requirement to dequote/requote
* if people want to run a specific language shell script then they must explicitly specify the interpreter as part of the command arguments
    * e.g. `activate -- tcsh <tcshScript>`

**In general our aim is for the activate script to behave like a shell**, and in particular to be able to invoke commands with `activate -c "<cmd> <args>"` and have that be functionally equivalent to `activate -- <cmd> <args>`.

### "turbo" and "no profile" modes

The [previously undocumented] "turbo" and "no profile" modes exist to launch a command without invoking an intervening subshell or sourcing the manifest `[profile]` scripts as shown in the diagram included in the appendix below. This PR adds `activate` script argument parsing for the optional `--turbo` and `--noprofile` options which have the same effect as setting the `FLOX_TURBO` and `FLOX_NO_PROFILE` environment variables.

This change makes equivalent the following pairs of statements:
```
  % /path/to/activate --turbo -- bash <file>
  % FLOX_TURBO=1 /path/to/activate -- bash <file>
```
```
  % /path/to/activate --noprofile -- bash <file>
  % FLOX_NO_PROFILE=1 /path/to/activate -- bash <file>
```

## Release Notes

N/A

## Appendix - `flox activate` flow chart

```mermaid
flowchart TB
 subgraph subgraph_p67vwuh5h["Activation PID . . . . ."]
        node_glmdmumem["flox"]
        no{"--turbo\ncmd mode?"}
        nu{"--noprofile\ncmd mode?"}
        n9(["cmd; exit 0"])
        n8(["exec cmd"])
        n4[["Initialize state<br>ACTIVATION_PID=getpid()<br>(create temp files, etc.)"]]
        nb[["fork()"]]
        n3[["exec(bash activate)"]]
        n7[["snapshot env"]]
        nq[["exec userShell"]]
        n5[["source profile.*"]]
        nm{"cmd mode?"}
        nx(["exec cmd"])
        ng(["interactive"])
        nk{"in place mode?"}
        nr((("See: inplace mode")))
        nl{"already active?"}
        n6[["flox initializations"]]
        nd[["source hook.on-activate"]]
        nt[["record watchdog PID<br>in environment"]]
        na[["record env diffs<br>in registry"]]
        n2[["process-compose"]]
        nc{"Connect to<br>existing env?"}
        nf[["load env diffs<br>from registry"]]
        nh(["ERROR"])
  end
 subgraph subgraph_ru7zjclbt["Watchdog PID"]
        ns[["Await death of ppid()"]]
        ny[["Clean up state<br>(remove temp files, etc.)"]]
        nv[["Rust Destructors<br>(Submit metrics, etc.)"]]
  end
 subgraph subgraph_7x7san49a["Color Key"]
        node_aqepkktvr["flox CLI<br>(rust)"]
        n0["bash"]
        nz["userShell"]
  end
    no -- no --> nq
    no -- yes --> n9
    nu -- yes --> n8
    nu -- no --> n5
    A(["Parent shell (parent PID)<br>flox activate"]) -- fork() && exec(flox) --> node_glmdmumem
    node_glmdmumem --> nk
    ns --> ny
    ny --> nv
    n7 --> n6
    nq --> nu
    n5 --> nm
    nm -- yes --> nx
    nm -- no --> ng
    n3 --> nl
    nv ~~~ subgraph_7x7san49a
    nb -- child --> ns
    node_aqepkktvr --> n0
    n0 --> nz
    nk -- yes --> n4
    nk -- no --> nr
    n4 --> n3
    nl -- no --> n7
    n6 --> nd
    nd --> n2
    nb -- parent --> nt
    nt --> na
    na --> no
    n2 --> nb
    nl -- yes --> nc
    nc -- yes --> nf
    nc -- no --> nh
    nf --> no
    style node_glmdmumem fill:#FFE0B2
    style no fill:#BBDEFB
    style nu fill:#E1BEE7
    style n9 fill:#BBDEFB
    style n8 fill:#E1BEE7
    style n4 fill:#FFE0B2
    style nb fill:#BBDEFB
    style n3 fill:#FFE0B2
    style n7 fill:#BBDEFB
    style nq fill:#BBDEFB
    style n5 fill:#E1BEE7
    style nm fill:#E1BEE7
    style nx fill:#E1BEE7
    style ng fill:#E1BEE7
    style nk fill:#FFE0B2
    style nl fill:#BBDEFB
    style n6 fill:#BBDEFB
    style nd fill:#BBDEFB
    style nt fill:#BBDEFB
    style na fill:#BBDEFB
    style n2 fill:#BBDEFB
    style nc fill:#BBDEFB
    style nf fill:#BBDEFB
    style nh fill:#BBDEFB
    style ns fill:#FFE0B2
    style ny fill:#FFE0B2
    style nv fill:#FFE0B2
    style node_aqepkktvr fill:#FFE0B2
    style n0 fill:#BBDEFB
    style nz fill:#E1BEE7
```