### PR TITLE
test(services): Close FD3 on activation tests

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -74,7 +74,7 @@ setup_sleeping_services() {
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
 EOF
-)
+) 3>&-
   assert_success
   [ -e hello.txt ]
 }
@@ -109,7 +109,7 @@ EOF
       done
     '
 EOF
-)
+) 3>&-
   assert_success
   assert_output --partial "PONG"
 }
@@ -133,7 +133,7 @@ EOF
     source "${TESTS_DIR}/services/register_cleanup.sh"
     "$FLOX_BIN" services stop invalid
 EOF
-)
+) 3>&-
   assert_failure
   assert_output --partial "❌ ERROR: service 'invalid' is not running"
 }
@@ -150,7 +150,7 @@ EOF
     "$PROCESS_COMPOSE_BIN" process list --output wide
     exit $exit_code
 EOF
-)
+) 3>&-
   assert_failure
   assert_output --partial "❌ ERROR: service 'invalid' is not running"
   assert_output --regexp " +one +default +Completed +"
@@ -169,7 +169,7 @@ EOF
     "$PROCESS_COMPOSE_BIN" process list --output wide
     exit $exit_code
 EOF
-)
+) 3>&-
   assert_failure
   assert_output --partial "❌ ERROR: service 'invalid' is not running"
   assert_output --regexp " +one +default +Running +"
@@ -185,7 +185,7 @@ EOF
     export _FLOX_SERVICES_SOCKET=invalid
     "$FLOX_BIN" services stop one invalid
 EOF
-)
+) 3>&-
   assert_failure
   assert_output --partial "❌ ERROR: couldn't connect to service manager"
 }
@@ -200,7 +200,7 @@ EOF
     "$FLOX_BIN" services stop
     "$PROCESS_COMPOSE_BIN" process list --output wide
 EOF
-)
+) 3>&-
   assert_success
   assert_output --partial "✅ Service 'one' stopped"
   assert_output --partial "✅ Service 'two' stopped"
@@ -218,7 +218,7 @@ EOF
     "$FLOX_BIN" services stop one
     "$PROCESS_COMPOSE_BIN" process list --output wide
 EOF
-)
+) 3>&-
   assert_success
   assert_output --partial "✅ Service 'one' stopped"
   assert_output --regexp " +one +default +Completed +"
@@ -235,7 +235,7 @@ EOF
     "$FLOX_BIN" services stop one two
     "$PROCESS_COMPOSE_BIN" process list --output wide
 EOF
-)
+) 3>&-
   assert_success
   assert_output --partial "✅ Service 'one' stopped"
   assert_output --partial "✅ Service 'two' stopped"
@@ -254,7 +254,7 @@ EOF
     "$PROCESS_COMPOSE_BIN" process list --output wide
     "$FLOX_BIN" services stop one
 EOF
-)
+) 3>&-
   assert_failure
   assert_output --regexp " +one +default +Completed +"
   assert_output --partial "❌ ERROR: service 'one' is not running"
@@ -297,7 +297,7 @@ EOF
     source "${TESTS_DIR}/services/register_cleanup.sh"
     "$PROCESS_COMPOSE_BIN" process list
 EOF
-)
+) 3>&-
   # Just assert that one of our processes shows up in the output, which indicates
   # that process-compose has responded
   assert_output --partial "flox_never_exit"
@@ -312,7 +312,7 @@ EOF
     # No actual work to do here other than let process-compose
     # start and write to logs
 EOF
-)
+) 3>&-
   # Check that a startup log line shows up in the logs
   run grep "process=flox_never_exit" "$_FLOX_SERVICES_LOG_FILE"
   assert_success


### PR DESCRIPTION
## Proposed Changes

We have seen some integration test jobs hang in CI since 28b33d6. I originally thought that this was due to a bad builder:

- https://github.com/flox/flox/actions/runs/10067670807/job/27831900822
- https://github.com/flox/flox/actions/runs/10067670807/job/27847053039
- https://github.com/flox/flox/actions/runs/10073963290/job/27849361521

However it has also failed on `main` on a GitHub Runner instance after that change was merged, which no longer suggests that it was our builder at fault:

- https://github.com/flox/flox/actions/runs/10084240104/job/27882612749

The output of the failing jobs show that all of the integration tests had finished when the job hung. This smells suspiciously like the BATS fd3 issue when there are stray background processes:

- https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs

We shouldn't be leaving any background processes because each activation is shutting down `process-compose` on EXIT. In fact it would be an indication of a real problem if we're not cleaning up processes. But we also can't live with the tests hanging, so attempt to solve it by closing fd3 whenever we start an activation with background processes.

## Release Notes

N/A