### PR TITLE
feat: read logs for services

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "itertools",
  "jsonwebtoken",
  "log",
+ "nix",
  "once_cell",
  "pollster",
  "pretty_assertions",

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -21,6 +21,7 @@ itertools.workspace = true
 jsonwebtoken.workspace = true
 log.workspace = true
 once_cell.workspace = true
+nix = {workspace = true, features = ["signal"]}
 pollster.workspace = true
 regex.workspace = true
 reqwest.workspace = true

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -434,6 +434,7 @@ impl Iterator for ProcessComposeLogStream {
             // Drain remaining reader return values.
             Err(_) => {
                 loop {
+                    // Returns None if there are no readers left
                     let reader: ProcessComposeLogReader = self.readers.pop()?;
                     let joined = reader.handle.join().expect("reader thread panicked");
                     match joined {

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -607,7 +607,7 @@ mod tests {
                 .arg("--tui=false")
                 .arg("up")
                 .stdout(Stdio::null())
-                .stderr(Stdio::null());
+                .stderr(Stdio::inherit());
 
             // Dropping the child as stopping is handled via a process-compose command.
             let child = cmd.spawn().unwrap();

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -597,7 +597,7 @@ mod tests {
         ///
         /// Panics if the socket doesn't appear after 5 tries with backoff.
         fn start(config: &ProcessComposeConfig) -> Self {
-            let temp_dir = TempDir::new().unwrap();
+            let temp_dir = TempDir::new_in("/tmp").unwrap();
 
             let config_path = temp_dir.path().join("config.yaml");
             let socket = temp_dir.path().join("S.process-compose");

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -701,6 +701,8 @@ mod tests {
 
     /// Test that [ProcessComposeLogStream] reads logs from multiple processes in order
     /// and maintains the order of logs from each process.
+    /// Logs across different processes ar printed in a partial order,
+    /// i.e. the order of logs is preserved _per process_.
     #[test]
     fn test_multiple_process_logs_received_in_order() {
         let instance = TestProcessComposeInstance::start(&ProcessComposeConfig {

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -454,6 +454,13 @@ struct ProcessComposeLogReader {
 }
 
 impl ProcessComposeLogReader {
+    /// Start a new log reader for a single process
+    /// and listen to its output on a separate thread.
+    ///
+    /// For each logged line, a [ProcessComposeLogLine] is created
+    /// and sent via an [std::sync::mpsc::channel].
+    /// [ProcessComposeLogReader] is meant to be used in conjunction with [ProcessComposeLogStream],
+    /// which holds the receiver end of the channel, receiving log lines from multiple readers.
     fn start(
         socket: impl AsRef<Path>,
         process: impl AsRef<str>,

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -659,6 +659,7 @@ mod tests {
 
     /// Try to stop the process-compose instance by sending a SIGTERM
     /// to the process-compose process, which will stop all services.
+    /// This should be functionally equivalent to calling `process-compose down`.
     impl std::ops::Drop for TestProcessComposeInstance {
         fn drop(&mut self) {
             let term_result = nix::sys::signal::kill(

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -616,9 +616,17 @@ mod tests {
             for backoff in 1..max_tries {
                 println!("waiting for socket to exist");
                 thread::sleep(Duration::from_millis(100 * backoff));
+
+                // For now just check if the socket exists.
+                // Processes _may_ have not started yet, or the socket is unresponsive.
+                // We can't really check if the process is running,
+                // as it may have already exited.
+                // We could chek if the socket can be connected to
+                // or try to read ProcessStates, if the current approach leads to flaking tests.
                 if socket.exists() {
                     break;
                 }
+
                 if backoff == max_tries {
                     panic!("socket never appeared");
                 }

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -39,7 +39,7 @@ impl Logs {
             tracing::debug!("no service names provided");
             ProcessStates::read(&socket)?.running_process_names()
         } else {
-            self.names.iter().map(String::from).collect::<Vec<_>>()
+            self.names
         };
 
         if !self.follow {

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::services::{
@@ -19,6 +19,9 @@ pub struct Logs {
     /// Which services' logs to view
     #[bpaf(positional("name"))]
     names: Vec<String>,
+
+    /// Follow log output
+    follow: bool,
 }
 
 impl Logs {
@@ -38,6 +41,10 @@ impl Logs {
         } else {
             self.names.iter().map(String::from).collect::<Vec<_>>()
         };
+
+        if !self.follow {
+            bail!("printing logs without following is not yet implemented");
+        }
 
         let log_stream = ProcessComposeLogStream::new(socket, &names)?;
 

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::providers::services::{
+    ProcessComposeLogLine,
+    ProcessComposeLogStream,
+    ProcessStates,
+};
+use tracing::instrument;
+
+use crate::commands::{environment_select, EnvironmentSelect};
+use crate::subcommand_metric;
+
+#[derive(Bpaf, Debug, Clone)]
+pub struct Logs {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+
+    /// Which services' logs to view
+    #[bpaf(positional("name"))]
+    names: Vec<String>,
+}
+
+impl Logs {
+    #[instrument(name = "logs", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("services::logs");
+
+        let env = self
+            .environment
+            .detect_concrete_environment(&flox, "Services in")?
+            .into_dyn_environment();
+        let socket = env.services_socket_path(&flox)?;
+
+        let names = if self.names.is_empty() {
+            tracing::debug!("no service names provided");
+            ProcessStates::read(&socket)?.running_process_names()
+        } else {
+            self.names.iter().map(String::from).collect::<Vec<_>>()
+        };
+
+        let log_stream = ProcessComposeLogStream::new(socket, &names)?;
+
+        let max_name_length = names.iter().map(|name| name.len()).max().unwrap_or(0);
+        for log in log_stream {
+            let ProcessComposeLogLine { process, message } = log?;
+            println!("{process:<max_name_length$}: {message}",);
+        }
+
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -4,6 +4,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::services::ServiceError;
 use tracing::instrument;
 
+mod logs;
 mod stop;
 
 /// Services Commands.
@@ -12,6 +13,10 @@ pub enum ServicesCommands {
     /// Stop a service or services
     #[bpaf(command)]
     Stop(#[bpaf(external(stop::stop))] stop::Stop),
+
+    /// Print logs of services
+    #[bpaf(command)]
+    Logs(#[bpaf(external(logs::logs))] logs::Logs),
 }
 
 impl ServicesCommands {
@@ -23,6 +28,7 @@ impl ServicesCommands {
 
         match self {
             ServicesCommands::Stop(args) => args.handle(flox).await?,
+            ServicesCommands::Logs(args) => args.handle(flox).await?,
         }
 
         Ok(())

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -33,7 +33,7 @@ impl Stop {
             tracing::debug!("no service names provided");
             ProcessStates::read(&socket)?.running_process_names()
         } else {
-            self.names.iter().map(String::from).collect::<Vec<_>>()
+            self.names
         };
 
         stop_services(socket, &names)?;


### PR DESCRIPTION
* Allow starting a temporary `process-compose` instance that is killed when the instance is dropped.

*`Read the output of a single process from `process-compose process logs <process> --follow

* compose multiple readers into a single stream