### PR TITLE
test: timeout after 90 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,7 @@ jobs:
   nix-build-bats-tests:
     name: "Flox Bats Tests"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 90
 
     needs:
       - "nix-build"


### PR DESCRIPTION
We've had jobs hanging for hours (see e.g.
https://github.com/flox/flox/actions/runs/10067670807/job/27831900822).

Add a timeout of 90 minutes to avoid this.