### PR TITLE
feat: allow descriptors with versions to uninstall packages

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -442,7 +442,10 @@ impl CoreEnvironment<ReadOnly> {
                     install_ids.push(pkg);
                     continue;
                 }
+
                 // User passed a package path to uninstall
+                // To support version constraints, we match the provided value against
+                // `<pkg-path>` and `<pkg-path>@<version>`.
                 let matching_iids_by_pkg_path = manifest
                     .install
                     .iter()

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -2173,5 +2173,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.len(), 1);
+        assert_eq!(result[0], "testInstallID");
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -2072,16 +2072,14 @@ mod tests {
         for (test_iid, dotted_package) in entries {
             typed_manifest_mock.install.insert(
                 test_iid.to_string(),
-                ManifestPackageDescriptor::Catalog(
-                    ManifestPackageDescriptorCatalog {
-                        pkg_path: dotted_package.to_string(),
-                        pkg_group: None,
-                        priority: None,
-                        version: None,
-                        systems: None,
-                    }
-                    .into(),
-                ),
+                ManifestPackageDescriptorCatalog {
+                    pkg_path: dotted_package.to_string(),
+                    pkg_group: None,
+                    priority: None,
+                    version: None,
+                    systems: None,
+                }
+                .into(),
             );
         }
 

--- a/cli/flox/doc/flox-uninstall.md
+++ b/cli/flox/doc/flox-uninstall.md
@@ -33,7 +33,13 @@ and no packages will be uninstalled.
 ## Remove Options
 
 `<packages>`
-:   The install IDs of the packages to remove.
+:   The install IDs or package path of the packages to remove.
+    If the manifest contains both an install ID and a pacakge
+    with matching package path, the install ID takes precedence.
+    If the same pacakge path is installed under different install IDs,
+    an error is returned.
+    A package path can optionally contain the original version constraint.
+
 
 ```{.include}
 ./include/environment-options.md

--- a/cli/flox/doc/flox-uninstall.md
+++ b/cli/flox/doc/flox-uninstall.md
@@ -33,10 +33,10 @@ and no packages will be uninstalled.
 ## Remove Options
 
 `<packages>`
-:   The install IDs or package path of the packages to remove.
-    If the manifest contains both an install ID and a pacakge
+:   The install IDs or package paths of the packages to remove.
+    If the manifest contains both an install ID and a package
     with matching package path, the install ID takes precedence.
-    If the same pacakge path is installed under different install IDs,
+    If the same package path is installed under different install IDs,
     an error is returned.
     A package path can optionally contain the original version constraint.
 

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -25,7 +25,7 @@ pub struct Uninstall {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 
-    /// The install IDs of the packages to remove
+    /// The install IDs or package paths of the packages to remove
     #[bpaf(positional("packages"), some("Must specify at least one package"))]
     packages: Vec<String>,
 }


### PR DESCRIPTION
Try matching uninstall target against descriptor with version spec.
Approaches the second alternative in [flox/flox#1512](https://github.com/flox/flox/issues/1512):

```
flox init
flox install --id vbox virtualbox@7.0.12
...
flox uninstall vbox                 # works
flox uninstall virtualbox           # works since #1810
flox uninstall virtualbox@7.0.12    # works now with #1834
```

`<version>` has to match the original version specifier exactly; in the example above `virtualbox@7` would not match.
 