### PR TITLE
feat(watchdog): Track activations in registry

### DIFF
--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -42,6 +42,7 @@ url-escape.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
 xdg.workspace = true
+nix = { workspace = true, features = ["signal"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -20,8 +20,8 @@ indoc.workspace = true
 itertools.workspace = true
 jsonwebtoken.workspace = true
 log.workspace = true
-once_cell.workspace = true
 nix = {workspace = true, features = ["signal"]}
+once_cell.workspace = true
 pollster.workspace = true
 regex.workspace = true
 reqwest.workspace = true
@@ -42,7 +42,6 @@ url-escape.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
 xdg.workspace = true
-nix = { workspace = true, features = ["signal"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -275,7 +275,10 @@ pub fn env_registry_path(flox: &Flox) -> PathBuf {
     flox.data_dir.join(ENV_REGISTRY_FILENAME)
 }
 
-/// Returns the path to the user's environment registry lock file.
+/// Returns the path to the user's environment registry lock file. The presensce
+/// of the lock file does not indicate an active lock because the file isn't
+/// removed after use. This is a separate file because we replace the registry
+/// on write.
 pub(crate) fn env_registry_lock_path(reg_path: impl AsRef<Path>) -> PathBuf {
     reg_path.as_ref().with_extension("lock")
 }

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -215,17 +215,13 @@ impl RegistryEntry {
 
     /// Remove any activation PIDs that are no longer running and weren't explicitly deregistered.
     fn remove_stale_activations(&mut self) {
-        let stale_pids: Vec<Pid> = self
-            .activations
-            .iter()
-            .filter(|pid| !pid.is_running())
-            .cloned()
-            .collect();
-
-        for pid in stale_pids {
-            tracing::debug!("removing stale activation: {}", &pid);
-            self.activations.remove(&pid);
-        }
+        self.activations.retain(|pid| {
+            let running = pid.is_running();
+            if !running {
+                tracing::debug!("removing stale activation: {}", pid);
+            }
+            running
+        })
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -237,7 +237,7 @@ pub struct RegisteredEnv {
 }
 
 /// PID of an environment's activation.
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct Pid(u32);
 

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -243,7 +243,7 @@ pub struct Pid(u32);
 
 impl Pid {
     /// Construct a Pid from the current running process.
-    pub fn from_self() -> Self {
+    pub fn from_current_process() -> Self {
         Pid(nix::unistd::getpid().as_raw() as u32)
     }
 

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -246,6 +246,11 @@ pub struct RegisteredEnv {
 pub struct Pid(u32);
 
 impl Pid {
+    /// Construct a Pid from the current running process.
+    pub fn from_self() -> Self {
+        Pid(nix::unistd::getpid().as_raw() as u32)
+    }
+
     /// Check whether an activation is still running.
     fn is_running(&self) -> bool {
         // TODO: Compare name or check for watchdog child to see if it's a real activation?

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -254,10 +254,11 @@ impl ActivationPid {
         // TODO: Compare name or check for watchdog child to see if it's a real activation?
         let pid = NixPid::from_raw(self.0);
         match kill(pid, None) {
-            Ok(_) => true,              // known running
-            Err(Errno::EPERM) => true,  // no perms but running
-            Err(Errno::ESRCH) => false, // known not running
-            Err(_) => false,            // assumed not running
+            // These semantics come from kill(2).
+            Ok(_) => true,              // Process received the signal and is running.
+            Err(Errno::EPERM) => true,  // No permission to send a signal but we know it's running.
+            Err(Errno::ESRCH) => false, // No process running to receive the signal.
+            Err(_) => false,            // Unknown error, assume no running process.
         }
     }
 }

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -210,8 +210,8 @@ pub fn env_registry_path(flox: &Flox) -> PathBuf {
 }
 
 /// Returns the path to the user's environment registry lock file.
-pub(crate) fn env_registry_lock_path(flox: &Flox) -> PathBuf {
-    env_registry_path(flox).with_extension("lock")
+pub(crate) fn env_registry_lock_path(reg_path: impl AsRef<Path>) -> PathBuf {
+    reg_path.as_ref().with_extension("lock")
 }
 
 /// Returns the parsed environment registry file or `None` if it doesn't yet exist.
@@ -265,8 +265,8 @@ pub fn write_environment_registry(
 }
 
 /// Acquires the filesystem-based lock on the user's environment registry file
-pub fn acquire_env_registry_lock(flox: &Flox) -> Result<LockFile, EnvRegistryError> {
-    let lock_path = env_registry_lock_path(flox);
+pub fn acquire_env_registry_lock(reg_path: impl AsRef<Path>) -> Result<LockFile, EnvRegistryError> {
+    let lock_path = env_registry_lock_path(reg_path);
     LockFile::open(lock_path.as_os_str()).map_err(EnvRegistryError::AcquireLock)
 }
 
@@ -278,8 +278,8 @@ pub fn ensure_registered(
 ) -> Result<(), EnvRegistryError> {
     // Acquire the lock before reading the registry so that we know there are no modifications while
     // we're editing it.
-    let lock = acquire_env_registry_lock(flox)?;
     let reg_path = env_registry_path(flox);
+    let lock = acquire_env_registry_lock(&reg_path)?;
     let mut reg = read_environment_registry(&reg_path)?.unwrap_or_default();
     let dot_flox_hash = path_hash(&dot_flox_path);
     // Skip writing the registry if the environment was already registered
@@ -303,8 +303,8 @@ pub fn deregister(
 ) -> Result<(), EnvRegistryError> {
     // Acquire the lock before reading the registry so that we know there are no modifications while
     // we're editing it.
-    let lock = acquire_env_registry_lock(flox)?;
     let reg_path = env_registry_path(flox);
+    let lock = acquire_env_registry_lock(&reg_path)?;
     let mut reg = read_environment_registry(&reg_path)?.unwrap_or_default();
     let dot_flox_hash = path_hash(&dot_flox_path);
     reg.deregister_env(&dot_flox_hash, env_pointer)?;

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -204,13 +204,13 @@ impl RegistryEntry {
 
     /// Register an activation for an existing enviroment.
     fn register_activation(&mut self, pid: ActivationPid) {
-        tracing::debug!("registering activation: {}", &pid);
+        tracing::debug!(%pid, "registering activation");
         self.activations.insert(pid);
     }
 
     /// Deregister an activation for an existing enviroment.
     fn deregister_activation(&mut self, pid: ActivationPid) {
-        tracing::debug!("deregistering activation: {}", &pid);
+        tracing::debug!(%pid, "deregistering activation");
         self.activations.remove(&pid);
     }
 
@@ -219,7 +219,7 @@ impl RegistryEntry {
         self.activations.retain(|pid| {
             let running = pid.is_running();
             if !running {
-                tracing::debug!("removing stale activation: {}", pid);
+                tracing::debug!(%pid, "removing stale activation");
             }
             running
         })

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -349,7 +349,7 @@ pub fn ensure_registered(
     let reg_path = env_registry_path(flox);
     let lock = acquire_env_registry_lock(&reg_path)?;
     let mut reg = read_environment_registry(&reg_path)?.unwrap_or_default();
-    let dot_flox_hash = path_hash(&dot_flox_path);
+    let dot_flox_hash = path_hash(dot_flox_path);
     // Skip writing the registry if the environment was already registered
     if reg
         .register_env(dot_flox_path, &dot_flox_hash, env_pointer)?
@@ -374,7 +374,7 @@ pub fn deregister(
     let reg_path = env_registry_path(flox);
     let lock = acquire_env_registry_lock(&reg_path)?;
     let mut reg = read_environment_registry(&reg_path)?.unwrap_or_default();
-    let dot_flox_hash = path_hash(&dot_flox_path);
+    let dot_flox_hash = path_hash(dot_flox_path);
     reg.deregister_env(&dot_flox_hash, env_pointer)?;
     write_environment_registry(&reg, &reg_path, lock)?;
     Ok(())
@@ -595,7 +595,7 @@ mod test {
 
         #[test]
         fn entries_register_activation(mut entry: RegistryEntry, activation: ActivationPid) {
-            entry.register_activation(activation.clone());
+            entry.register_activation(activation);
             prop_assert!(entry.activations.contains(&activation));
         }
 
@@ -604,8 +604,8 @@ mod test {
             prop_assume!(!entry.activations.is_empty());
             let activations = entry.activations.clone();
             let activation = activations.iter().next().unwrap();
-            entry.deregister_activation(activation.clone());
-            prop_assert!(!entry.activations.contains(&activation));
+            entry.deregister_activation(*activation);
+            prop_assert!(!entry.activations.contains(activation));
         }
     }
 

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -649,11 +649,17 @@ mod test {
         child.wait().expect("failed to wait");
     }
 
+    impl From<&Child> for ActivationPid {
+        fn from(child: &Child) -> Self {
+            Self(child.id() as i32)
+        }
+    }
+
     #[test]
     fn test_pid_is_running_lifecycle() {
         let child = start_process();
 
-        let pid = ActivationPid(child.id() as i32);
+        let pid = ActivationPid::from(&child);
         assert!(pid.is_running());
 
         stop_process(child);
@@ -672,8 +678,8 @@ mod test {
         let child2 = start_process();
         let activations_before = HashSet::from([
             ActivationPid(1),
-            ActivationPid(child1.id() as i32),
-            ActivationPid(child2.id() as i32),
+            ActivationPid::from(&child1),
+            ActivationPid::from(&child2),
         ]);
         let mut entry = RegistryEntry {
             path: PathBuf::from("foo"),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1640,6 +1640,7 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
     use std::str::FromStr;
 
     use fslock::LockFile;
@@ -2570,6 +2571,7 @@ mod test {
                     created_at: 0,
                     pointer: EnvironmentPointer::Managed(pointer.clone()),
                 }],
+                activations: HashSet::new(),
             }],
         };
         let reg_path = env_registry_path(&flox);

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -2572,7 +2572,8 @@ mod test {
                 }],
             }],
         };
-        let lock = LockFile::open(&env_registry_lock_path(&flox)).unwrap();
+        let reg_path = env_registry_path(&flox);
+        let lock = LockFile::open(&env_registry_lock_path(reg_path)).unwrap();
         write_environment_registry(&reg, &env_registry_path(&flox), lock).unwrap();
         let branch_name = branch_name(&pointer, &path);
         let decoded_path = ManagedEnvironment::decode(&flox, &branch_name).unwrap();

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -24,6 +24,7 @@ use super::{
     UninstallationAttempt,
     UpdateResult,
     CACHE_DIR_NAME,
+    DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
     ENV_DIR_NAME,
     N_HASH_CHARS,
@@ -456,6 +457,12 @@ impl Environment for ManagedEnvironment {
             .parent()
             .ok_or(EnvironmentError::InvalidPath(self.path.to_path_buf()))
             .map(|p| p.to_path_buf())
+    }
+
+    /// Path to the environment's .flox directory
+    fn dot_flox_path(&self) -> Result<PathBuf, EnvironmentError> {
+        let parent = self.parent_path()?;
+        Ok(parent.join(DOT_FLOX))
     }
 
     /// Path to the environment definition file

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -24,7 +24,6 @@ use super::{
     UninstallationAttempt,
     UpdateResult,
     CACHE_DIR_NAME,
-    DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
     ENV_DIR_NAME,
     N_HASH_CHARS,
@@ -460,9 +459,8 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Path to the environment's .flox directory
-    fn dot_flox_path(&self) -> Result<PathBuf, EnvironmentError> {
-        let parent = self.parent_path()?;
-        Ok(parent.join(DOT_FLOX))
+    fn dot_flox_path(&self) -> CanonicalPath {
+        self.path.clone()
     }
 
     /// Path to the environment definition file

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -715,7 +715,7 @@ pub(super) fn gcroots_dir(flox: &Flox, owner: &EnvironmentOwner) -> PathBuf {
 }
 
 /// Returns the truncated hash of a [Path]
-pub fn path_hash(p: &impl AsRef<Path>) -> String {
+pub fn path_hash(p: impl AsRef<Path>) -> String {
     let mut chars = blake3::hash(p.as_ref().as_os_str().as_bytes()).to_hex();
     chars.truncate(N_HASH_CHARS);
     chars.to_string()

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -194,6 +194,9 @@ pub trait Environment: Send {
     /// TODO: figure out what to store for remote environments
     fn parent_path(&self) -> Result<PathBuf, EnvironmentError>;
 
+    /// Path to the environment's .flox directory
+    fn dot_flox_path(&self) -> Result<PathBuf, EnvironmentError>;
+
     /// Path to the environment definition file
     ///
     /// Implementations may use process context from [Flox]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -195,7 +195,7 @@ pub trait Environment: Send {
     fn parent_path(&self) -> Result<PathBuf, EnvironmentError>;
 
     /// Path to the environment's .flox directory
-    fn dot_flox_path(&self) -> Result<PathBuf, EnvironmentError>;
+    fn dot_flox_path(&self) -> CanonicalPath;
 
     /// Path to the environment definition file
     ///

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -344,6 +344,12 @@ impl Environment for PathEnvironment {
         }
     }
 
+    /// Path to the environment's .flox directory
+    fn dot_flox_path(&self) -> Result<PathBuf, EnvironmentError> {
+        let parent = self.parent_path()?;
+        Ok(parent.join(DOT_FLOX))
+    }
+
     /// Path to the environment definition file
     fn manifest_path(&self, _flox: &Flox) -> Result<PathBuf, EnvironmentError> {
         Ok(self.path.join(ENV_DIR_NAME).join(MANIFEST_FILENAME))

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -345,9 +345,8 @@ impl Environment for PathEnvironment {
     }
 
     /// Path to the environment's .flox directory
-    fn dot_flox_path(&self) -> Result<PathBuf, EnvironmentError> {
-        let parent = self.parent_path()?;
-        Ok(parent.join(DOT_FLOX))
+    fn dot_flox_path(&self) -> CanonicalPath {
+        self.path.clone()
     }
 
     /// Path to the environment definition file

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -289,7 +289,7 @@ impl Environment for RemoteEnvironment {
     }
 
     /// Path to the environment's .flox directory
-    fn dot_flox_path(&self) -> Result<PathBuf, EnvironmentError> {
+    fn dot_flox_path(&self) -> CanonicalPath {
         self.inner.dot_flox_path()
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -61,9 +61,6 @@ pub enum RemoteEnvironmentError {
 
     #[error("could not set a new install prefix")]
     WriteNewOutlink(#[source] std::io::Error),
-
-    #[error("services are not currently supported for remote environments")]
-    ServicesUnsupported,
 }
 
 #[derive(Debug)]
@@ -334,9 +331,7 @@ impl Environment for RemoteEnvironment {
         Ok(())
     }
 
-    fn services_socket_path(&self, _flox: &Flox) -> Result<PathBuf, EnvironmentError> {
-        Err(EnvironmentError::RemoteEnvironment(
-            RemoteEnvironmentError::ServicesUnsupported,
-        ))
+    fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
+        self.inner.services_socket_path(flox)
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -291,6 +291,11 @@ impl Environment for RemoteEnvironment {
         self.inner.parent_path()
     }
 
+    /// Path to the environment's .flox directory
+    fn dot_flox_path(&self) -> Result<PathBuf, EnvironmentError> {
+        self.inner.dot_flox_path()
+    }
+
     /// Path to the environment definition file
     fn manifest_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
         self.inner.manifest_path(flox)

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -39,6 +39,8 @@ pub enum ServiceError {
     GenerateConfig(#[source] serde_yaml::Error),
     #[error("failed to write service config")]
     WriteConfig(#[source] std::io::Error),
+    #[error("services are not currently supported for remote environments")]
+    RemoteEnvsNotSupported,
     #[error("services are not enabled")]
     FeatureFlagDisabled,
     #[error("services have not been started in this activation")]

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use bpaf::Bpaf;
 use crossterm::tty::IsTty;
 use flox_rust_sdk::flox::{Flox, DEFAULT_NAME};
-use flox_rust_sdk::models::env_registry::{env_registry_path, register_activation, Pid};
+use flox_rust_sdk::models::env_registry::{env_registry_path, register_activation, ActivationPid};
 use flox_rust_sdk::models::environment::{
     path_hash,
     CoreEnvironmentError,
@@ -305,7 +305,7 @@ impl Activate {
             register_activation(
                 env_registry_path(&flox),
                 &path_hash(&dot_flox_path),
-                Pid::from_current_process(),
+                ActivationPid::from_current_process(),
             )?;
         }
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -113,7 +113,6 @@ impl Activate {
             UninitializedEnvironment::from_concrete_environment(&concrete_environment)?;
 
         let environment = concrete_environment.dyn_environment_ref_mut();
-        let dot_flox_path = environment.dot_flox_path()?;
 
         let in_place = self.print_script || (!stdout().is_tty() && self.run_args.is_empty());
         // Don't spin in bashrcs and similar contexts
@@ -299,7 +298,7 @@ impl Activate {
         Activate::launch_watchdog(
             &flox,
             environment.cache_path()?.to_path_buf(),
-            &path_hash(dot_flox_path),
+            &path_hash(environment.dot_flox_path()),
             socket_path,
         )?;
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -305,7 +305,7 @@ impl Activate {
             register_activation(
                 env_registry_path(&flox),
                 &path_hash(&dot_flox_path),
-                Pid::from_self(),
+                Pid::from_current_process(),
             )?;
         }
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -274,7 +274,9 @@ impl Activate {
             }
 
             if flox.features.services && !manifest.services.is_empty() {
-                supported_environment(&flox, self.environment)?; // Error for remote envs.
+                if self.start_services {
+                    supported_environment(&flox, self.environment)?; // Error for remote envs.
+                }
                 tracing::debug!(start = self.start_services, "setting service variables");
                 if socket_path.exists() {
                     debug!("detected existing services socket");

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -35,6 +35,7 @@ use log::{debug, warn};
 use nix::unistd::getpid;
 use once_cell::sync::Lazy;
 
+use super::services::supported_environment;
 use super::{
     activated_environments,
     environment_select,
@@ -274,6 +275,7 @@ impl Activate {
             }
 
             if flox.features.services && !manifest.services.is_empty() {
+                supported_environment(&flox, self.environment)?; // Error for remote envs.
                 tracing::debug!(start = self.start_services, "setting service variables");
                 if socket_path.exists() {
                     debug!("detected existing services socket");

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -8,6 +8,7 @@ use flox_rust_sdk::providers::services::{
 };
 use tracing::instrument;
 
+use super::supported_environment;
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 
@@ -29,10 +30,7 @@ impl Logs {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("services::logs");
 
-        let env = self
-            .environment
-            .detect_concrete_environment(&flox, "Services in")?
-            .into_dyn_environment();
+        let env = supported_environment(&flox, self.environment)?;
         let socket = env.services_socket_path(&flox)?;
 
         let names = if self.names.is_empty() {

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -4,6 +4,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::services::{stop_services, ProcessStates};
 use tracing::instrument;
 
+use super::supported_environment;
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 use crate::utils::message;
@@ -23,10 +24,7 @@ impl Stop {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("services::stop");
 
-        let env = self
-            .environment
-            .detect_concrete_environment(&flox, "Services in")?
-            .into_dyn_environment();
+        let env = supported_environment(&flox, self.environment)?;
         let socket = env.services_socket_path(&flox)?;
 
         let names = if self.names.is_empty() {

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -713,7 +713,6 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
         RemoteEnvironmentError::ReadInternalOutLink(_) => display_chain(err),
         RemoteEnvironmentError::DeleteOldOutLink(_) => display_chain(err),
         RemoteEnvironmentError::WriteNewOutlink(_) => display_chain(err),
-        RemoteEnvironmentError::ServicesUnsupported => display_chain(err),
     }
 }
 

--- a/cli/klaus/src/listen.rs
+++ b/cli/klaus/src/listen.rs
@@ -44,29 +44,6 @@ pub async fn wait_for_shutdown(flag: Arc<AtomicBool>) {
     }
 }
 
-/// Returns the PID that will be waited on
-pub fn target_pid(args: &crate::Cli) -> Pid {
-    #[cfg(target_os = "linux")]
-    let pid = if let Some(_pid) = args.pid {
-        debug!("ignoring user-provided PID, not available on Linux, using parent PID instead");
-        nix::unistd::getppid()
-    } else {
-        debug!("using parent PID for target PID");
-        nix::unistd::getppid()
-    };
-
-    #[cfg(target_os = "macos")]
-    let pid = if let Some(pid) = args.pid {
-        debug!("using user-provided target PID");
-        Pid::from_raw(pid)
-    } else {
-        debug!("using parent PID for target PID");
-        nix::unistd::getppid()
-    };
-
-    pid
-}
-
 /// What should be done in response to receiving a signal
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum Action {

--- a/cli/klaus/src/main.rs
+++ b/cli/klaus/src/main.rs
@@ -7,11 +7,7 @@ use clap::Parser;
 use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::utils::{maybe_traceable_path, traceable_path};
 use listen::{
-    listen,
-    signal_listener,
-    spawn_signal_listener,
-    spawn_termination_listener,
-    target_pid,
+    listen, signal_listener, spawn_signal_listener, spawn_termination_listener, target_pid,
 };
 use logger::init_logger;
 use nix::errno::Errno;
@@ -48,6 +44,10 @@ pub struct Cli {
     #[arg(short, long = "registry", value_name = "PATH")]
     pub registry_path: PathBuf,
 
+    /// The hash of the environment's .flox path
+    #[arg(short, long = "dot-flox-hash", value_name = "DOT_FLOX_HASH")]
+    pub dot_flox_hash: String,
+
     /// The path to the process-compose socket
     #[arg(short, long = "socket", value_name = "PATH")]
     pub socket_path: Option<PathBuf>,
@@ -76,6 +76,7 @@ async fn main() -> Result<(), Error> {
     let span = tracing::Span::current();
     span.record("pid", args.pid);
     span.record("registry", traceable_path(&args.registry_path));
+    span.record("dot_flox_hash", &args.dot_flox_hash);
     span.record("socket", maybe_traceable_path(&args.socket_path));
     span.record("log", maybe_traceable_path(&args.log_path));
     if let Some(ref path) = args.socket_path {

--- a/cli/klaus/src/main.rs
+++ b/cli/klaus/src/main.rs
@@ -63,6 +63,7 @@ pub struct Cli {
     fields(
         pid = tracing::field::Empty,
         registry = tracing::field::Empty,
+        dot_flox_hash = tracing::field::Empty,
         socket = tracing::field::Empty,
         log = tracing::field::Empty))]
 async fn main() -> Result<(), Error> {

--- a/cli/klaus/src/main.rs
+++ b/cli/klaus/src/main.rs
@@ -50,7 +50,7 @@ pub struct Cli {
 
     /// The path to the process-compose socket
     #[arg(short, long = "socket", value_name = "PATH")]
-    pub socket_path: Option<PathBuf>,
+    pub socket_path: PathBuf,
 
     /// Where to store watchdog logs
     #[arg(short, long = "logs", value_name = "PATH")]
@@ -78,13 +78,15 @@ async fn main() -> Result<(), Error> {
     span.record("pid", args.pid);
     span.record("registry", traceable_path(&args.registry_path));
     span.record("dot_flox_hash", &args.dot_flox_hash);
-    span.record("socket", maybe_traceable_path(&args.socket_path));
+    span.record("socket", traceable_path(&args.socket_path));
     span.record("log", maybe_traceable_path(&args.log_path));
-    if let Some(ref path) = args.socket_path {
-        debug!(socket_path = traceable_path(&path), "was provided a socket");
-    }
 
     debug!("starting");
+    debug!(
+        path = traceable_path(&args.socket_path),
+        exists = &args.socket_path.exists(),
+        "checked socket"
+    );
 
     // The parent may have already died, in which case we just want to exit
     if let Some(ref pid) = args.pid {

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -348,4 +348,12 @@ EOF
   run "$FLOX_BIN" activate --remote "flox/test" -- true
   assert_failure
   assert_output --partial "❌ ERROR: services are not currently supported for remote environments"
+
+  run "$FLOX_BIN" services stop hello --remote "flox/test"
+  assert_failure
+  assert_output --partial "❌ ERROR: services are not currently supported for remote environments"
+
+  run "$FLOX_BIN" services logs hello --remote "flox/test"
+  assert_failure
+  assert_output --partial "❌ ERROR: services are not currently supported for remote environments"
 }

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -345,7 +345,12 @@ EOF
   assert_success
   assert_output --partial "✅ Environment successfully updated."
 
+  # Normal activation should still work.
   run "$FLOX_BIN" activate --remote "flox/test" -- true
+  assert_success
+
+  # Everything else that explicitly uses services shouldn't work.
+  run "$FLOX_BIN" activate --start-services --remote "flox/test" -- true
   assert_failure
   assert_output --partial "❌ ERROR: services are not currently supported for remote environments"
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -50,6 +50,13 @@ setup_sleeping_services() {
 }
 
 # ---------------------------------------------------------------------------- #
+#
+# NOTE: The following functionality is tested elsewhere:
+#
+#   - logs: providers/services.rs
+#   - remote environments: tests/environment-remotes.bats
+#
+# ---------------------------------------------------------------------------- #
 
 @test "feature flag works" {
   RUST_LOG=flox=debug run "$FLOX_BIN" init

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -364,8 +364,14 @@ EOF
 
 @test "watchdog: exits on termination signal (SIGUSR1)" {
   log_file=klaus.log
-  # This 'foo' is because we don't actually do anything with the registry yet
-  _FLOX_WATCHDOG_LOG_LEVEL=debug "$KLAUS_BIN" -r foo -l "$log_file" &
+  registry_file=registry.json
+  dummy_registry path/to/env abcde123 > "$registry_file"
+  _FLOX_WATCHDOG_LOG_LEVEL=debug "$KLAUS_BIN" \
+    --logs "$log_file" \
+    --pid $$ \
+    --registry "$registry_file" \
+    --hash abcde123 \
+    --socket does_not_exist &
   klaus_pid="$!"
 
   # Wait for start.
@@ -393,8 +399,14 @@ EOF
 
 @test "watchdog: exits on shutdown signal (SIGINT)" {
   log_file=klaus.log
-  # This 'foo' is because we don't actually do anything with the registry yet
-  _FLOX_WATCHDOG_LOG_LEVEL=debug "$KLAUS_BIN" -r foo -l "$log_file" &
+  registry_file=registry.json
+  dummy_registry path/to/env abcde123 > "$registry_file"
+  _FLOX_WATCHDOG_LOG_LEVEL=debug "$KLAUS_BIN" \
+    --logs "$log_file" \
+    --pid $$ \
+    --registry "$registry_file" \
+    --hash abcde123 \
+    --socket does_not_exist &
   klaus_pid="$!"
 
   # Wait for start.
@@ -420,7 +432,7 @@ EOF
   "
 }
 
-@test "watchdog: exits when parent doesn't match provided PID" {
+@test "watchdog: exits when provided PID isn't running" {
   log_file=klaus.log
 
   # We need a test PID, but PIDs can be reused. There's also no delay on reusing
@@ -432,8 +444,14 @@ EOF
     skip "test PID is in use"
   fi
 
-  # This 'foo' is because we don't actually do anything with the registry yet
-  _FLOX_WATCHDOG_LOG_LEVEL=debug "$KLAUS_BIN" -r foo -l "$log_file" -p "$test_pid" &
+  registry_file=registry.json
+  dummy_registry path/to/env abcde123 > "$registry_file"
+  _FLOX_WATCHDOG_LOG_LEVEL=debug "$KLAUS_BIN" \
+    --logs "$log_file" \
+    --pid "$test_pid" \
+    --registry "$registry_file" \
+    --hash abcde123 \
+    --socket does_not_exist &
   klaus_pid="$!"
 
   # Wait for start.

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -208,6 +208,33 @@ jq_edit() {
   mv "$_tmp" "$_file"
 }
 
+dummy_registry() {
+  local path="$1"; shift
+  local hash="$1"
+  REGISTRY_CONTENT="$(cat << EOF
+  {
+    "version": 1,
+    "entries": [
+      {
+        "hash": "$hash",
+        "path": "$path",
+        "envs": [
+          {
+            "created_at": 123,
+            "pointer": {
+              "name": "dummy_env",
+              "version": 1
+            }
+          }
+        ]
+      }
+    ]
+  }
+EOF
+)"
+  echo "$REGISTRY_CONTENT"
+}
+
 # ---------------------------------------------------------------------------- #
 #
 #


### PR DESCRIPTION
## Proposed Changes

**refactor(registry): Take reg_path for lock_path**

So that we don't need to construct `Flox` in `klaus` when accessing the
registry. All of the existing callers already have the registry path
when constructing the lock path.

**feat(klaus): Pass in dot_flox_hash for registry**

So that we can access the environment registry without having to
reconstruct information from `Flox` or `.flox`.

**feat(registry): Track activation PIDs**

This will be used by the watchdog `klaus` to track when the last
activation of an environment exits and we should clean up any running
services.

Stale activations are removed when updating the registry on disk to
catch watchdog processes that may have died without cleaning up after
themselves.

The new field needs to use `default` in order to read registry files
from existing Flox versions where the field isn't present.

Some assumptions in the implementation:

- environments are already registered by the time we're activating or
  starting the watchdog; an error will be returned if not
- an activation will only be registered and deregistered once;
  subsequent calls are noops
- we can't record activations for remote environments because they
  aren't currently registered in the environment registry; that's not
  currently an issue for service management because we don't support
  services for remote environments at the moment
- testing focuses on unit testing the inner parts because the file
  handling part is relatively simple, proven, and more fiddly to
  co-ordinate in a series of tests

**refactor(watchdog): Make socket mandatory**

We'll later have klaus check whether the socket exists in order to
determine whether it needs to shutdown `process-compose` to allow for
environments that start services imperatively after the watchdog has
been started.

refactor(env): Expose dot_flox_path()

Needed to construct an environment registry path hash that we can pass
to the watchdog.

**refactor: Wire activation registration into watchdog**

Now that the watchdog has been merged. Uses the newly added
`dot_flox_path()`. This appears to work for remote envs too, which I
previously thought weren't registered.

**refactor(watchdog): Always use PID from flox**

We know ahead of time what the activation PID will be when we start the
watchdog because Flox execs into the activation and keeps the same PID.
So we don't need to infer it from the watchdog.

This prevents race conditions where the activation may have exited
before the watchdog completely starts and it gets re-parented to PID1.
When this happens we exit early with an error if the PID that was passed
is no longer the parent of the watchdog.

**refactor(services): Move logic for prevent remote**

Previously we relied on `services_socket_path()` giving us an error for
remote environments but we now need to always pass a socket path to the
watchdog regardless of whether it does or will exist.

I was hoping to implement this on `ServicesCommands` but we don't have
access to the environment there. It's kinda ugly to throw away the `dyn
Environment` in activate but it serves the most common use case where we
need it for `services` commands.

## Release Notes

N/A (scaffolding for an actual feature)