### PR TITLE
fix: close fd3 in process-compose test

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -281,8 +281,10 @@ EOF
   # process-compose will never be able to create this socket,
   # which looks the same as taking a long time to create the socket
   export _FLOX_SERVICES_SOCKET="/no_permission.sock"
-  # Don't need to run cleanup because it will never start services
-  run "$FLOX_BIN" activate -s -- true
+  # As of version 1.6.1, there's a race condition in process-compose such that
+  # it may leave behind a sleep process.
+  # Close FD 3 so bats doesn't hang forever.
+  run "$FLOX_BIN" activate -s -- true 3>&-
   assert_output --partial "❌ Failed to start services"
 }
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -284,8 +284,20 @@ EOF
   # As of version 1.6.1, there's a race condition in process-compose such that
   # it may leave behind a sleep process.
   # Close FD 3 so bats doesn't hang forever.
+  # Kill sleep for now just to be safe.
+
+  # pgrep is not in procps for some reason
+  pgrep_sleep() {
+    ps -o comm -o pid | grep sleep | sed "s/sleep //"
+  }
+  pgrep_sleep > sleeping_before || echo > sleeping_before
   run "$FLOX_BIN" activate -s -- true 3>&-
   assert_output --partial "❌ Failed to start services"
+  pgrep_sleep > sleeping_after
+  SLEEP_PID="$(comm -13 sleeping_before sleeping_after)"
+  if [ -n "$SLEEP_PID" ]; then
+    kill "$SLEEP_PID"
+  fi
 }
 
 @test "blocking: activation blocks on socket creation" {

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -28,6 +28,7 @@
   openssh,
   parallel,
   podman,
+  procps,
   unixtools,
   which,
   writeShellScriptBin,


### PR DESCRIPTION
process-compose 1.6.1 has a race condition when started with a socket
that it cannot write to. It sometimes leaves running services behind.

Bats will hang forever if a child process doesn't exit because it's
waiting for file descriptor 3 to close. See:
https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs

Close FD 3 so that tests don't hang forever if the sleep process is left
behind.

A reproducer on aarch64-linux for the race condition is:
$ cat service-config.yaml
processes:
  sleep:
    command: "sleep infinity"
$ ps -A | grep sleep
$ while ! ps -A | grep sleep; do process-compose up --config service-config.yaml --unix-socket /no-perms; done
24-07-26 20:50:45.882 FTL start UDS http server on /no-perms failed error="listen unix /no-perms: bind: permission denied"
...
24-07-26 20:50:47.319 FTL start UDS http server on /no-perms failed error="listen unix /no-perms: bind: permission denied"
1588157 pts/1    00:00:00 sleep


fix: kill sleep if process-compose leaves it behind

This will prevent running the tests from leaving sleep processes behind