### PR TITLE
fix: check if user is logged in before instantiating environment

### DIFF
--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -84,16 +84,17 @@ impl Edit {
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("edit");
 
+        // Ensure the user is logged in for the following remote operations
+        if let EnvironmentSelect::Remote(_) = self.environment {
+            ensure_floxhub_token(&mut flox).await?;
+        };
+
         let mut detected_environment =
             match self.environment.detect_concrete_environment(&flox, "Edit") {
                 Ok(concrete_env) => concrete_env,
                 Err(EnvironmentSelectError::Anyhow(e)) => Err(e)?,
                 Err(e) => Err(e)?,
             };
-        // Ensure the user is logged in for the following remote operations
-        if let ConcreteEnvironment::Remote(_) = detected_environment {
-            ensure_floxhub_token(&mut flox).await?;
-        };
 
         match self.action {
             EditAction::EditManifest { file } => {

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -325,6 +325,41 @@ EOF
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=remote,remote:auth-required,remote:auth-required:install
+@test "'install --remote' fails if not authenticated" {
+  unset FLOX_FLOXHUB_TOKEN # logout, effectively
+  run "$FLOX_BIN" install hello --remote "$OWNER/test"
+  assert_failure
+  assert_output --partial "You are not logged in to FloxHub."
+}
+
+
+# bats test_tags=remote,remote:auth-required,remote:auth-required:uninstall
+@test "'uninstall --remote' fails if not authenticated" {
+  unset FLOX_FLOXHUB_TOKEN # logout, effectively
+  run "$FLOX_BIN" uninstall hello --remote "$OWNER/test"
+  assert_failure
+  assert_output --partial "You are not logged in to FloxHub."
+}
+
+# bats test_tags=remote,remote:auth-required,remote:auth-required:edit
+@test "'edit --remote' fails if not authenticated" {
+  unset FLOX_FLOXHUB_TOKEN # logout, effectively
+  run "$FLOX_BIN" edit --remote "$OWNER/test"
+  assert_failure
+  assert_output --partial "You are not logged in to FloxHub."
+}
+
+# bats test_tags=remote,remote:auth-required,remote:auth-required:upgrade
+@test "'upgrade --remote' fails if not authenticated" {
+  unset FLOX_FLOXHUB_TOKEN # logout, effectively
+  run "$FLOX_BIN" upgrade hello --remote "$OWNER/test"
+  assert_failure
+  assert_output --partial "You are not logged in to FloxHub."
+}
+
+# ---------------------------------------------------------------------------- #
+
 # bats test_tags=remote,remote:services
 @test "services: not currently supported for remote environments" {
   export FLOX_FEATURES_SERVICES=true


### PR DESCRIPTION
Currently a `ConcreteEnvironment` is created with a `Flox` object that may not specify auth credential to Floxhub.
While detect a missing or expired token and update the `floxhub_token` field in `Flox`, this happens after the instantiation of the `ConcreteEnvironment`, which remains configured with the old/absent token. The result was that flox commands would prompt for login but fail to finish anyway. Any subsequent run would instantiate the environment with the now correct token.

```
$ flox rm -r limeytexan/default nodejs
You are not logged in to FloxHub. Logging in...
Go to https://auth.flox.dev/activate?user_code=ZSDT-GNMF in your browser

Your one-time activation code is: ZSDT-GNMF

✅ Authentication complete
✅ Logged in as limeytexan
❌ ERROR: Access denied to the remote environment.

This can happen if the remote is not owned by you
or the owner did not grant you access.

Please check the spelling of the remote environment
and make sure that you have access to it.

$ flox rm -r limeytexan/default nodejs
🗑️   'nodejs' uninstalled from environment 'limeytexan/default' (remote)
```

This PR changes the implementation of mutating commands (`edit`, `install`, `uninstall`, `upgrade), to ensure a valid Floxhub token is present before instantiating the environment, allowing the instance to subsequently be configured correctly.

Thanks to @limeytexan for finding this.