### PR TITLE
fix(services-logs): command argument order

### DIFF
--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -16,12 +16,12 @@ pub struct Logs {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 
+    /// Follow log output
+    follow: bool,
+
     /// Which services' logs to view
     #[bpaf(positional("name"))]
     names: Vec<String>,
-
-    /// Follow log output
-    follow: bool,
 }
 
 impl Logs {


### PR DESCRIPTION
`flox services --help` failed with 

```
thread 'main' panicked at /Users/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bpaf-0.9.12/src/meta.rs:96:29:
bpaf usage BUG: all positional and command items must be placed in the right most position of the structure or tuple they are in but Flag { name: Long("follow"), shorts: [], env: None, help: Some(Doc { payload: "Follow log output", tokens: [Text { bytes: 17, style: Text }] }) } breaks this rule. See bpaf documentation for `positional` for details.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

because the `--follow` flag was defined after the process list argument.


With this fix the help output for `flox services` now renders as

```
Interact with services

Usage: flox services COMMAND ...

Services Commands.
    stop        Stop a service or services
    logs        Print logs of services

Available options:
    -h, --help  Prints help information
```