### PR TITLE
build: separate incremental builds of rust binaries

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,7 +31,7 @@ indicatif = "0.17"
 itertools = "0.12.1"
 jsonwebtoken = "9.2"
 log = "0.4.22"
-nix = { version = "0.28", features = ["process", "user"] }
+nix = { version = "0.28", features = ["signal", "process", "user"] }
 oauth2 = "4.4"
 once_cell = "1.16.0"
 pollster = "0.3.0"
@@ -40,9 +40,14 @@ proptest = "1.5.0"
 proptest-derive = "0.5.0"
 regex = "1.10"
 regress = "0.9.1"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json", "blocking", "stream"] }
 semver = "1.0.23"
-sentry = { version = "0.32.3", features = ["test", "tracing"] }
+sentry = { version = "0.32.3", features = [
+    "test",
+    "anyhow",
+    "tracing",
+    "debug-logs",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_with = "3.9.0"
@@ -55,7 +60,7 @@ sysinfo = "0.30.13"
 # TODO: review if we need this
 sys-info = "0.9"
 tempfile = "3.4.0"
-textwrap = "0.16.0"
+textwrap = { version = "0.16.0", features = ["terminal_size"] }
 thiserror = "1"
 time = { version = "0.3", features = ["serde", "formatting"] }
 tokio = { version = "1", features = ["full"] }
@@ -69,6 +74,7 @@ url-escape = "0.1.1"
 uuid = { version = "1.10", features = ["serde", "v4"] }
 walkdir = "2"
 xdg = "2.4"
+path-dedot = "3.1.1"
 
 # dev dependencies
 pretty_assertions = "1.3"

--- a/cli/catalog-api-v1/Cargo.toml
+++ b/cli/catalog-api-v1/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 futures.workspace = true
 progenitor-client.workspace = true
-reqwest = { workspace = true, features = ["json", "stream"] }
-serde = { workspace = true, features = ["derive"] }
+reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 regress.workspace = true

--- a/cli/catalog-api-v1/build.rs
+++ b/cli/catalog-api-v1/build.rs
@@ -4,10 +4,9 @@ use std::path::PathBuf;
 use openapiv3::OpenAPI;
 
 fn main() {
-    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let generate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("src");
 
-    let spec_src = manifest_dir.join("openapi.json");
+    let spec_src = PathBuf::from("openapi.json");
 
     let file = std::fs::File::open(&spec_src).unwrap();
     let spec = serde_json::from_reader(file).expect("Failed to parse openapi spec");

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -29,7 +29,7 @@ once_cell.workspace = true
 reqwest.workspace = true
 semver.workspace = true
 regex.workspace = true
-sentry = { workspace = true, features = ["anyhow", "tracing", "debug-logs"] }
+sentry.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true
@@ -38,7 +38,7 @@ supports-color.workspace = true
 sys-info.workspace = true
 sysinfo.workspace = true
 tempfile.workspace = true
-textwrap = { workspace = true, features = ["terminal_size"] }
+textwrap.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
@@ -50,7 +50,7 @@ tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
 xdg.workspace = true
-path-dedot = "3.1.1"
+path-dedot.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/flake.nix
+++ b/flake.nix
@@ -213,6 +213,7 @@
       ld-floxlib = callPackage ./pkgs/ld-floxlib {};
 
       rust-external-deps = callPackage ./pkgs/rust-external-deps {rust-toolchain = rust-toolchain;};
+      rust-internal-deps = callPackage ./pkgs/rust-internal-deps {rust-toolchain = rust-toolchain;};
     };
 
     # Composes dependency overlays and the overlay defined here.
@@ -256,6 +257,7 @@
         ld-floxlib
         pre-commit-check
         rust-external-deps
+        rust-internal-deps
         ;
       default = pkgs.flox;
     });

--- a/flake.nix
+++ b/flake.nix
@@ -179,6 +179,8 @@
       # Package activation scripts.
       flox-activation-scripts = callPackage ./pkgs/flox-activation-scripts {};
 
+      flox-src = callPackage ./pkgs/flox-src {};
+
       # Package Database Utilities: scrape, search, and resolve.
       flox-pkgdb = callPackage ./pkgs/flox-pkgdb {};
 

--- a/flake.nix
+++ b/flake.nix
@@ -211,6 +211,8 @@
 
       # (Linux-only) LD_AUDIT library for using dynamic libraries in Flox envs.
       ld-floxlib = callPackage ./pkgs/ld-floxlib {};
+
+      rust-external-deps = callPackage ./pkgs/rust-external-deps {rust-toolchain = rust-toolchain;};
     };
 
     # Composes dependency overlays and the overlay defined here.
@@ -253,6 +255,7 @@
         flox
         ld-floxlib
         pre-commit-check
+        rust-external-deps
         ;
       default = pkgs.flox;
     });

--- a/flake.nix
+++ b/flake.nix
@@ -185,9 +185,7 @@
       flox-pkgdb = callPackage ./pkgs/flox-pkgdb {};
 
       # Flox Command Line Interface ( development build ).
-      flox-klaus = callPackage ./pkgs/rust-pkg {
-        crateName = "klaus";
-        pname = "flox-klaus";
+      flox-klaus = callPackage ./pkgs/flox-klaus {
         rust-toolchain = rust-toolchain;
         rustfmt = rustfmt-nightly;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
       # which would avoid the need to pull another channel altogether.
       rustfmt-nightly = final.fenix.default.withComponents ["rustfmt"];
       rust-toolchain = final.fenix.stable;
-    in rec {
+    in {
       # Generates a `.git/hooks/pre-commit' script.
       pre-commit-check = pre-commit-hooks.lib.${final.system}.run {
         src = builtins.path {path = ./.;};
@@ -190,10 +190,7 @@
         rustfmt = rustfmt-nightly;
       };
 
-      flox-cli = callPackage ./pkgs/rust-pkg {
-        crateName = "flox";
-        pname = "flox-cli";
-        KLAUS_BIN = "${flox-klaus}/bin/klaus";
+      flox-cli = callPackage ./pkgs/flox-cli {
         rust-toolchain = rust-toolchain;
         rustfmt = rustfmt-nightly;
       };
@@ -274,7 +271,10 @@
           FLOX_BIN = null;
           KLAUS_BIN = null;
         };
-        flox-cli = prev.flox-cli.override {flox-pkgdb = null;};
+        flox-cli = prev.flox-cli.override {
+          flox-pkgdb = null;
+          flox-klaus = null;
+        };
       });
       checksFor = builtins.getAttr system checks;
     in {

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -129,6 +129,7 @@ in
           --fish <( "$out/bin/flox" --bpaf-complete-style-fish; ) \
           --zsh <( "$out/bin/flox" --bpaf-complete-style-zsh; );
 
+        rm -f $out/bin/crane-*
         for target in "$(basename ${rust-toolchain.rust.outPath} | cut -f1 -d- )" ; do
           sed -i -e "s|$target|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee|g" $out/bin/flox
         done

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -84,11 +84,21 @@ in
       pname = "flox";
       version = envs.FLOX_VERSION;
       src = flox-src;
-      cargoExtraArgs = "--locked -p flox";
+
+      # Set up incremental compilation
+      #
+      # Cargo artifacts are built for the union of features used transitively
+      # by `flox` and `klaus`.
+      # Compiling either separately would result in a different set of features
+      # and thus cache misses.
+      cargoArtifacts = rust-internal-deps;
+      cargoExtraArgs = "--locked -p flox -p klaus";
+      postPatch = ''
+        rm -rf ./klaus/*
+        cp -rf --no-preserve=mode ${craneLib.mkDummySrc {src = flox-src;}}/klaus/* ./klaus
+      '';
 
       CARGO_LOG = "cargo::core::compiler::fingerprint=info";
-
-      cargoArtifacts = rust-internal-deps;
 
       # runtime dependencies
       buildInputs = rust-internal-deps.buildInputs ++ [];

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -12,8 +12,6 @@
   installShellFiles,
   lib,
   nix,
-  openssl,
-  pkg-config,
   pkgsFor,
   process-compose,
   rust-toolchain,
@@ -93,18 +91,14 @@ in
       cargoArtifacts = rust-internal-deps;
 
       # runtime dependencies
-      buildInputs = [openssl.dev];
+      buildInputs = rust-internal-deps.buildInputs ++ [];
 
       # build dependencies
       nativeBuildInputs =
-        [
-          pkg-config
+        rust-internal-deps.nativeBuildInputs
+        ++ [
           installShellFiles
           gnused
-        ]
-        ++ lib.optional hostPlatform.isDarwin [
-          darwin.libiconv
-          darwin.apple_sdk.frameworks.SystemConfiguration
         ];
 
       # https://github.com/ipetkov/crane/issues/385
@@ -143,9 +137,6 @@ in
       passthru = {
         inherit
           envs
-          rust-toolchain
-          pkgsFor
-          nix
           flox-pkgdb
           flox-klaus
           ;

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -171,7 +171,6 @@ in
           if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
             PATH="$( git rev-parse --show-toplevel; )/cli/target/debug":$PATH;
             REPO_ROOT="$( git rev-parse --show-toplevel; )";
-            KLAUS_BIN="$REPO_ROOT/cli/target/debug/klaus";
           fi
 
         '';

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -1,0 +1,179 @@
+{
+  bashInteractive,
+  cacert,
+  darwin,
+  flox-activation-scripts,
+  flox-pkgdb,
+  gitMinimal,
+  glibcLocalesUtf8,
+  gnused,
+  hostPlatform,
+  inputs,
+  installShellFiles,
+  lib,
+  nix,
+  openssl,
+  pkg-config,
+  pkgsFor,
+  process-compose,
+  rust-toolchain,
+  rustfmt ? rust-toolchain.rustfmt,
+  targetPlatform,
+  rust-internal-deps,
+  flox-klaus,
+  flox-src,
+}: let
+  FLOX_VERSION = lib.fileContents ./../../VERSION;
+
+  # crane (<https://crane.dev/>) library for building rust packages
+  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
+
+  # build time environment variables
+  envs = let
+    auth0BaseUrl = "https://auth.flox.dev";
+  in
+    {
+      # 3rd party CLIs
+      # we want to use our own binaries by absolute path
+      # rather than relying on or modifying the user's `PATH` variable
+      NIX_BIN = "${nix}/bin/nix"; # only used for nix invocations in tests
+      GIT_PKG = gitMinimal;
+
+      KLAUS_BIN =
+        if flox-klaus == null
+        then "klaus"
+        else "${flox-klaus}/bin/klaus";
+
+      FLOX_ZDOTDIR = flox-activation-scripts + activate.d/zdotdir;
+
+      # [sic] nix handles `BASH_` variables specially,
+      # so we need to use a different name.
+      INTERACTIVE_BASH_BIN = "${bashInteractive}/bin/bash";
+
+      # Metrics subsystem configuration
+      METRICS_EVENTS_URL =
+        "https://z7qixlmjr3.execute-api.eu-north-1."
+        + "amazonaws.com/prod/capture";
+      METRICS_EVENTS_API_KEY = "5pAQnBqz5Q7dpqVD9BEXQ4Kdc3D2fGTd3ZgP0XXK";
+
+      # oauth client id
+      OAUTH_CLIENT_ID = "fGrotHBfQr9X1PHGbFoifEWaDPyWZDmc";
+      OAUTH_BASE_URL = "${auth0BaseUrl}";
+      OAUTH_AUTH_URL = "${auth0BaseUrl}/authorize";
+      OAUTH_TOKEN_URL = "${auth0BaseUrl}/oauth/token";
+      OAUTH_DEVICE_AUTH_URL = "${auth0BaseUrl}/oauth/device/code";
+
+      # used internally to ensure CA certificates are available
+      NIXPKGS_CACERT_BUNDLE_CRT =
+        cacert.outPath + "/etc/ssl/certs/ca-bundle.crt";
+
+      # The current version of flox being built
+      inherit FLOX_VERSION;
+
+      # Reexport of the platform flox is being built for
+      NIX_TARGET_SYSTEM = targetPlatform.system;
+    }
+    // rust-internal-deps.passthru.envs
+    // lib.optionalAttrs hostPlatform.isDarwin {
+      NIX_COREFOUNDATION_RPATH = "${darwin.CF}/Library/Frameworks";
+      PATH_LOCALE = "${darwin.locale}/share/locale";
+    }
+    // lib.optionalAttrs hostPlatform.isLinux {
+      LOCALE_ARCHIVE = "${glibcLocalesUtf8}/lib/locale/locale-archive";
+    };
+in
+  craneLib.buildPackage ({
+      pname = "flox";
+      version = envs.FLOX_VERSION;
+      src = flox-src;
+      cargoExtraArgs = "--locked -p flox";
+
+      CARGO_LOG = "cargo::core::compiler::fingerprint=info";
+
+      cargoArtifacts = rust-internal-deps;
+
+      # runtime dependencies
+      buildInputs = [openssl.dev];
+
+      # build dependencies
+      nativeBuildInputs =
+        [
+          pkg-config
+          installShellFiles
+          gnused
+        ]
+        ++ lib.optional hostPlatform.isDarwin [
+          darwin.libiconv
+          darwin.apple_sdk.frameworks.SystemConfiguration
+        ];
+
+      # https://github.com/ipetkov/crane/issues/385
+      # doNotLinkInheritedArtifacts = true;
+
+      # Tests are disabled inside of the build because the sandbox prevents
+      # internet access and there are tests that require internet access to
+      # resolve flake references among other things.
+      doCheck = false;
+
+      # bundle manpages and completion scripts
+      #
+      # sed: Removes rust-toolchain from binary. Likely due to toolchain overriding.
+      #   unclear about the root cause, so this is a hotfix.
+      postInstall = ''
+        installShellCompletion --cmd flox                         \
+          --bash <( "$out/bin/flox" --bpaf-complete-style-bash; ) \
+          --fish <( "$out/bin/flox" --bpaf-complete-style-fish; ) \
+          --zsh <( "$out/bin/flox" --bpaf-complete-style-zsh; );
+
+        for target in "$(basename ${rust-toolchain.rust.outPath} | cut -f1 -d- )" ; do
+          sed -i -e "s|$target|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee|g" $out/bin/flox
+        done
+      '';
+
+      doInstallCheck = false;
+      postInstallCheck = ''
+        # Quick unit test to ensure that we are not using any "naked"
+        # commands within our scripts. Doesn't hit all codepaths but
+        # catches most of them.
+        : "''${USER:=$( id -un; )}";
+        env -i USER="$USER" HOME="$PWD" "$out/bin/flox" --help > /dev/null;
+        env -i USER="$USER" HOME="$PWD" "$out/bin/flox" nix help > /dev/null;
+      '';
+
+      passthru = {
+        inherit
+          envs
+          rust-toolchain
+          pkgsFor
+          nix
+          flox-pkgdb
+          flox-klaus
+          ;
+
+        ciPackages = [
+          process-compose
+        ];
+
+        devPackages = [
+          rustfmt
+        ];
+
+        devEnvs =
+          envs
+          // {
+            RUST_SRC_PATH = "${rust-toolchain.rust-src}/lib/rustlib/src/rust/library";
+            RUSTFMT = "${rustfmt}/bin/rustfmt";
+          };
+
+        devShellHook = ''
+          #  # Find the project root and add the `bin' directory to `PATH'.
+          if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            PATH="$( git rev-parse --show-toplevel; )/cli/target/debug":$PATH;
+            REPO_ROOT="$( git rev-parse --show-toplevel; )";
+            KLAUS_BIN="$REPO_ROOT/cli/target/debug/klaus";
+          fi
+
+        '';
+      };
+    }
+    // envs)

--- a/pkgs/flox-klaus/default.nix
+++ b/pkgs/flox-klaus/default.nix
@@ -19,17 +19,21 @@ in
       pname = "klaus";
       version = envs.FLOX_VERSION;
       src = flox-src;
-      cargoExtraArgs = "--locked -p klaus -p flox";
 
-      CARGO_LOG = "cargo::core::compiler::fingerprint=info";
-
+      # Set up incremental compilation
+      #
+      # Cargo artifacts are built for the union of features used transitively
+      # by `flox` and `klaus`.
+      # Compiling either separately would result in a different set of features
+      # and thus cache misses.
       cargoArtifacts = rust-internal-deps;
-
+      cargoExtraArgs = "--locked -p klaus -p flox";
       postPatch = ''
         rm -rf ./flox/*
         cp -rf --no-preserve=mode ${craneLib.mkDummySrc {src = flox-src;}}/flox/* ./flox
-        ls -la ./flox
       '';
+
+      CARGO_LOG = "cargo::core::compiler::fingerprint=info";
 
       # runtime dependencies
       buildInputs = rust-internal-deps.buildInputs ++ [];

--- a/pkgs/flox-klaus/default.nix
+++ b/pkgs/flox-klaus/default.nix
@@ -1,11 +1,6 @@
 {
-  darwin,
-  hostPlatform,
   inputs,
-  lib,
-  nix,
-  openssl,
-  pkg-config,
+  gnused,
   pkgsFor,
   rust-toolchain,
   rustfmt ? rust-toolchain.rustfmt,
@@ -37,16 +32,13 @@ in
       '';
 
       # runtime dependencies
-      buildInputs = [openssl.dev];
+      buildInputs = rust-internal-deps.buildInputs ++ [];
 
       # build dependencies
       nativeBuildInputs =
-        [
-          pkg-config
-        ]
-        ++ lib.optional hostPlatform.isDarwin [
-          darwin.libiconv
-          darwin.apple_sdk.frameworks.SystemConfiguration
+        rust-internal-deps.nativeBuildInputs
+        ++ [
+          gnused
         ];
 
       # https://github.com/ipetkov/crane/issues/385
@@ -70,9 +62,6 @@ in
       passthru = {
         inherit
           envs
-          rust-toolchain
-          pkgsFor
-          nix
           ;
 
         ciPackages = [];

--- a/pkgs/flox-klaus/default.nix
+++ b/pkgs/flox-klaus/default.nix
@@ -58,6 +58,7 @@ in
       # sed: Removes rust-toolchain from binary. Likely due to toolchain overriding.
       #   unclear about the root cause, so this is a hotfix.
       postInstall = ''
+        rm -f $out/bin/crane-*
         for target in "$(basename ${rust-toolchain.rust.outPath} | cut -f1 -d- )" ; do
           sed -i -e "s|$target|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee|g" $out/bin/klaus
         done

--- a/pkgs/flox-klaus/default.nix
+++ b/pkgs/flox-klaus/default.nix
@@ -1,0 +1,102 @@
+{
+  darwin,
+  hostPlatform,
+  inputs,
+  lib,
+  nix,
+  openssl,
+  pkg-config,
+  pkgsFor,
+  rust-toolchain,
+  rustfmt ? rust-toolchain.rustfmt,
+  rust-internal-deps,
+  flox-src,
+}: let
+  # crane (<https://crane.dev/>) library for building rust packages
+  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
+
+  # build time environment variables
+  envs =
+    {}
+    // rust-internal-deps.passthru.envs;
+in
+  craneLib.buildPackage ({
+      pname = "klaus";
+      version = envs.FLOX_VERSION;
+      src = flox-src;
+      cargoExtraArgs = "--locked -p klaus -p flox";
+
+      CARGO_LOG = "cargo::core::compiler::fingerprint=info";
+
+      cargoArtifacts = rust-internal-deps;
+
+      postPatch = ''
+        rm -rf ./flox/*
+        cp -rf --no-preserve=mode ${craneLib.mkDummySrc {src = flox-src;}}/flox/* ./flox
+        ls -la ./flox
+      '';
+
+      # runtime dependencies
+      buildInputs = [openssl.dev];
+
+      # build dependencies
+      nativeBuildInputs =
+        [
+          pkg-config
+        ]
+        ++ lib.optional hostPlatform.isDarwin [
+          darwin.libiconv
+          darwin.apple_sdk.frameworks.SystemConfiguration
+        ];
+
+      # https://github.com/ipetkov/crane/issues/385
+      # doNotLinkInheritedArtifacts = true;
+
+      # Tests are disabled inside of the build because the sandbox prevents
+      # internet access and there are tests that require internet access to
+      # resolve flake references among other things.
+      doCheck = false;
+
+      # bundle manpages and completion scripts
+      #
+      # sed: Removes rust-toolchain from binary. Likely due to toolchain overriding.
+      #   unclear about the root cause, so this is a hotfix.
+      postInstall = ''
+        for target in "$(basename ${rust-toolchain.rust.outPath} | cut -f1 -d- )" ; do
+          sed -i -e "s|$target|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee|g" $out/bin/klaus
+        done
+      '';
+
+      passthru = {
+        inherit
+          envs
+          rust-toolchain
+          pkgsFor
+          nix
+          ;
+
+        ciPackages = [];
+
+        devPackages = [
+          rustfmt
+        ];
+
+        devEnvs =
+          envs
+          // {
+            RUST_SRC_PATH = "${rust-toolchain.rust-src}/lib/rustlib/src/rust/library";
+            RUSTFMT = "${rustfmt}/bin/rustfmt";
+          };
+
+        devShellHook = ''
+          #  # Find the project root and add the `bin' directory to `PATH'.
+          if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            PATH="$( git rev-parse --show-toplevel; )/cli/target/debug":$PATH;
+            REPO_ROOT="$( git rev-parse --show-toplevel; )";
+            KLAUS_BIN="$REPO_ROOT/cli/target/debug/klaus";
+          fi
+
+        '';
+      };
+    }
+    // envs)

--- a/pkgs/flox-src/default.nix
+++ b/pkgs/flox-src/default.nix
@@ -1,0 +1,17 @@
+{}:
+builtins.path {
+  name = "flox-src";
+  path = "${./../../cli}";
+  filter = path: type:
+    ! builtins.elem path (map (
+        f: "${./../../cli}/${f}"
+      ) [
+        "flake.nix"
+        "flake.lock"
+        "pkgs"
+        "checks"
+        "tests"
+        "shells"
+        "target"
+      ]);
+}

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -27,7 +27,7 @@ in
     name = "flox-${version}";
     inherit version;
 
-    paths = [flox-cli flox-manpages];
+    paths = [flox-cli flox-klaus flox-manpages];
     nativeBuildInputs = [makeBinaryWrapper];
 
     postBuild = ''

--- a/pkgs/rust-external-deps/default.nix
+++ b/pkgs/rust-external-deps/default.nix
@@ -1,0 +1,45 @@
+{
+  darwin,
+  hostPlatform,
+  inputs,
+  lib,
+  openssl,
+  pkg-config,
+  pkgsFor,
+  rust-toolchain,
+  flox-src,
+}: let
+  # crane (<https://crane.dev/>) library for building rust packages
+  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
+
+  # incremental build of third party crates
+  cargoDepsArtifacts = craneLib.buildDepsOnly {
+    pname = "flox-external-crates";
+
+    # We don't want to version the 3rd party crates,
+    #.to avoid cache invalidation.
+    # In particular, we don't want to tie the version of the 3rd party crates
+    # to the version of the flox-cli, as that means that we would have to
+    # rebuild the 3rd party crates every time we update the flox-cli,
+    # even though the dependencies of the flox-cli haven't changed.
+    version = "unversioned";
+
+    src = craneLib.cleanCargoSource (craneLib.path flox-src);
+
+    # runtime dependencies of the dependent crates
+    buildInputs =
+      [
+        # reqwest -> hyper -> openssl-sys
+        openssl.dev
+      ]
+      ++ lib.optional hostPlatform.isDarwin [
+        darwin.libiconv
+        darwin.apple_sdk.frameworks.SystemConfiguration
+      ];
+
+    nativeBuildInputs = [
+      pkg-config
+    ];
+  };
+in
+  cargoDepsArtifacts

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -44,9 +44,15 @@ in
         pname = "flox-internal-deps";
         version = envs.FLOX_VERSION;
         src = flox-src;
-        cargoExtraArgs = "--locked -p flox -p klaus";
 
-        # Compile the **non-dummy** lib crates only
+        # `buildDepsOnly` replaces the source of _all_ crates in the workspace
+        # with "dummy" packages, essentially empty {lib,main}.rs files.
+        # The effect is that cargo will build all required dependencies
+        # but not the actual crates in the workspace -- hence "depsOnly".
+        # In this case we do want to build some of the crates in the workspace,
+        # i.e. flox-rust-sdk and catalog-api-v1 as dependencies of flox and klaus.
+        # To achieve this, we copy the source of these crates back into the workspace.
+        cargoExtraArgs = "--locked -p flox -p klaus";
         postPatch = ''
           cp -rf --no-preserve=mode ${flox-src}/flox-rust-sdk/* ./flox-rust-sdk
           cp -rf --no-preserve=mode ${flox-src}/catalog-api-v1/* ./catalog-api-v1

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -2,11 +2,7 @@
   flox-pkgdb,
   gitMinimal,
   inputs,
-  pkg-config,
   lib,
-  hostPlatform,
-  darwin,
-  openssl,
   pkgsFor,
   process-compose,
   rust-toolchain,
@@ -58,16 +54,11 @@ in
 
         # runtime dependencies
         buildInputs =
-          [openssl.dev]
-          ++ lib.optional hostPlatform.isDarwin [
-            darwin.libiconv
-            darwin.apple_sdk.frameworks.SystemConfiguration
-          ];
+          rust-external-deps.buildInputs
+          ++ [];
 
         # build dependencies
-        nativeBuildInputs = [
-          pkg-config
-        ];
+        nativeBuildInputs = rust-external-deps.nativeBuildInputs ++ [];
 
         # Tests are disabled inside of the build because the sandbox prevents
         # internet access and there are tests that require internet access to

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -1,0 +1,85 @@
+{
+  flox-pkgdb,
+  gitMinimal,
+  inputs,
+  pkg-config,
+  lib,
+  hostPlatform,
+  darwin,
+  openssl,
+  pkgsFor,
+  process-compose,
+  rust-toolchain,
+  targetPlatform,
+  rust-external-deps,
+  flox-src,
+}: let
+  FLOX_VERSION = lib.fileContents ./../../VERSION;
+
+  # crane (<https://crane.dev/>) library for building rust packages
+  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
+
+  # build time environment variables
+  envs = {
+    # 3rd party CLIs
+    # we want to use our own binaries by absolute path
+    # rather than relying on or modifying the user's `PATH` variable
+    GIT_PKG = gitMinimal;
+    PKGDB_BIN =
+      if flox-pkgdb == null
+      then "pkgdb"
+      else "${flox-pkgdb}/bin/pkgdb";
+
+    PROCESS_COMPOSE_BIN = "${process-compose}/bin/process-compose";
+
+    GLOBAL_MANIFEST_TEMPLATE = builtins.path {
+      path = ../../assets/global_manifest_template.toml;
+    };
+
+    # The current version of flox being built
+    inherit FLOX_VERSION;
+
+    # Reexport of the platform flox is being built for
+    NIX_TARGET_SYSTEM = targetPlatform.system;
+  };
+in
+  (craneLib.buildDepsOnly
+    ({
+        pname = "flox-internal-deps";
+        version = envs.FLOX_VERSION;
+        src = flox-src;
+        cargoExtraArgs = "--locked -p flox -p klaus";
+
+        # Compile the **non-dummy** lib crates only
+        postPatch = ''
+          cp -rf --no-preserve=mode ${flox-src}/flox-rust-sdk/* ./flox-rust-sdk
+          cp -rf --no-preserve=mode ${flox-src}/catalog-api-v1/* ./catalog-api-v1
+        '';
+
+        # runtime dependencies
+        buildInputs =
+          [openssl.dev]
+          ++ lib.optional hostPlatform.isDarwin [
+            darwin.libiconv
+            darwin.apple_sdk.frameworks.SystemConfiguration
+          ];
+
+        # build dependencies
+        nativeBuildInputs = [
+          pkg-config
+        ];
+
+        # Tests are disabled inside of the build because the sandbox prevents
+        # internet access and there are tests that require internet access to
+        # resolve flake references among other things.
+        doCheck = false;
+
+        passthru = {
+          inherit envs;
+        };
+      }
+      // envs))
+  .overrideAttrs (oldAttrs: {
+    # avoid rebuilding 3rd party deps
+    cargoArtifacts = rust-external-deps;
+  })

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -13,6 +13,7 @@
   cargo-nextest,
   flox-cli,
   flox-cli-tests,
+  flox-klaus,
   flox-pkgdb,
   flox-manpages,
   ci ? false,
@@ -22,6 +23,7 @@
   # For use in GitHub Actions and local development.
   ciPackages =
     flox-pkgdb.ciPackages
+    ++ flox-klaus.ciPackages
     ++ flox-pkgdb.ciPackages
     ++ flox-cli.ciPackages
     ++ [
@@ -56,6 +58,7 @@ in
         flox-pkgdb
         (flox-cli.override {
           flox-pkgdb = null;
+          flox-klaus = null;
         })
       ];
 
@@ -63,6 +66,7 @@ in
 
       shellHook =
         flox-pkgdb.devShellHook
+        + flox-klaus.devShellHook
         + flox-cli.devShellHook
         + pre-commit-check.shellHook
         + ''
@@ -73,5 +77,6 @@ in
       inherit MANUALLY_GENERATED;
     }
     // flox-pkgdb.devEnvs
+    // flox-klaus.devEnvs
     // flox-cli.devEnvs
   )


### PR DESCRIPTION
This PR splits up the `flox-cli`/`rust-pkg` nix expression into **6** individual expressions, that aim to improve incrementality and factorisation of build steps.

- **`rust-external-deps`** is essentially the `cargoDepsArtifacts` value split into its own separate package and provides all crates from the `Cargo.toml` pulled in by our rust workspace.
- **`rust-internal-deps`** provides the dependencies of our binary crates `flox` and `klaus`, i.e. `flox-rust-sdk` and `catalog-api-v1`.
Note the following commentary:
https://github.com/flox/flox/blob/ec6ae903654981ac612d45ae5e2f073bc56c1b31/pkgs/rust-internal-deps/default.nix#L48-L59
This package also defines (and `passthru`s) all env variables to build `flox-rust-sdk`, including referencing `pkgdb` through `PKGDB_BIN`.
The internal deps are built with the cached crates and build inputs from `rust-external-deps`
thus only incrementally rebuilding our internal crates.
- **`flox-cli`** provides the flox binary. It inherits build inputs, env variables and the crate build cache from `rust-internal-deps`, this only building `flox-cli`.
Due to specialities with cargo's feature unification this builds both `flox` and a "dummyfied" `klaus` crate.
https://github.com/flox/flox/blob/ec6ae903654981ac612d45ae5e2f073bc56c1b31/pkgs/flox-cli/default.nix#L87-L98
- **`flox-klaus`** provides the `klaus` binary. Like  `flox-cli` inherits build inputs, env variables and the crate build cache from `rust-internal-deps`. Same considerations regarding unification apply here as well.
- **`flox-src`** was defined inline for all packages building from the rust workspace. This package just factors out the source filtering applied to the `./cli` folder.