### PR TITLE
fix: trim whitespace from sleep PID

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -288,7 +288,7 @@ EOF
 
   # pgrep is not in procps for some reason
   pgrep_sleep() {
-    ps -o comm -o pid | grep sleep | sed "s/sleep //"
+    ps -o comm -o pid | grep sleep | sed "s/sleep\s*//"
   }
   pgrep_sleep > sleeping_before || echo > sleeping_before
   run "$FLOX_BIN" activate -s -- true 3>&-


### PR DESCRIPTION
The test `blocking: error message when startup times out` currently uses `ps` to find left behind `sleep` invocations.

`ps` includes a variable amount of whitespace between process name and PID in its output, but currently only a single space is stripped, which can cause the following failure:

```
/tmp/flox-cli-tests-eNqhXo/services.bats: line 306: kill:           2511431
          2511432: arguments must be process or job IDs
```

https://github.com/flox/flox/actions/runs/10183811288/job/28170018401?pr=1837#step:6:413

Trim any amount of whitespace instead.