### PR TITLE
chore: bump process-compose

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -63,7 +63,7 @@ setup_sleeping_services() {
 @test "can call process-compose" {
   run "$PROCESS_COMPOSE_BIN" version
   assert_success
-  assert_output --partial "v1.6.1"
+  assert_output --partial "v1.9"
 }
 
 @test "process-compose can run generated config file" {

--- a/flake.lock
+++ b/flake.lock
@@ -130,16 +130,16 @@
     },
     "nixpkgs-process-compose": {
       "locked": {
-        "lastModified": 1719406840,
-        "narHash": "sha256-f28HAjj6t6Uioe6KavnYvTC63VzO8+leRqRSIZM9qUU=",
+        "lastModified": 1722415718,
+        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a67ad0452b1ecd013ed3c0e2d4a50cabca396db7",
+        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
   # drop once bear is no longer broken in a newer release
   inputs.nixpkgs-bear.url = "github:NixOS/nixpkgs/release-23.05";
 
-  inputs.nixpkgs-process-compose.url = "github:NixOS/nixpkgs/release-24.05";
+  inputs.nixpkgs-process-compose.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
   inputs.sqlite3pp.url = "github:aakropotkin/sqlite3pp";
   inputs.sqlite3pp.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Bump process-compose from version 1.6.1 to 1.9.0

Contrary to appearances, 1.9.0 is the release immediately after 1.6.1

1.9.0 contains a fix for a race condition we've encountered.