### PR TITLE
fix: race between closing stdout and exit

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -508,13 +508,13 @@ impl ProcessComposeLogReader {
 
             // Here, process-compose has closed stdout.
             // It should have exited or be about to exit.
+            // kill() it just to be sure
+            child.kill().map_err(ServiceError::ProcessComposeCmd)?;
+
             // Communicate why it exited through the channel.
             // The most likely error is that the socket doesn't exist,
             // trying to read logs for a non existent process
             // unfortunately just blocks indefinitely without any error message.
-            // If process-compose closes stdout but doesn't exit, this will hang
-            // forever.
-
             let exit_status = child.wait().map_err(ServiceError::ProcessComposeCmd)?;
             if !exit_status.success() {
                 let mut output = String::new();

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -19,7 +19,7 @@ use regex::Regex;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tempfile::NamedTempFile;
-use tracing::{debug, trace};
+use tracing::debug;
 
 use crate::flox::Flox;
 use crate::models::lockfile::LockedManifestCatalog;
@@ -526,7 +526,7 @@ impl ProcessComposeLogReader {
                     .read_to_string(&mut output)
                     .map_err(ServiceError::ProcessComposeCmd)?;
 
-                trace!(output, "child process quit with error");
+                debug!(output, "child process quit with error");
 
                 let err = ServiceError::from_process_compose_log(output);
                 Err(err)?;


### PR DESCRIPTION
Current code assumes that once process-compose closes stdout, it will have exited. When this is not the case, we kill process-compose rather than reporting any error process-compose has printed to stderr.

It is possible that stdout gets closed before process-compose exits. So kill process-compose just to be sure it's exiting, and then use wait instead of try_wait. After waiting, we can always report any error printed to stderr.