### PR TITLE
test: drop workaround for process-compose bug

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -293,18 +293,8 @@ EOF
   # Close FD 3 so bats doesn't hang forever.
   # Kill sleep for now just to be safe.
 
-  # pgrep is not in procps for some reason
-  pgrep_sleep() {
-    ps -o comm -o pid | grep sleep | sed "s/sleep\s*//"
-  }
-  pgrep_sleep > sleeping_before || echo > sleeping_before
-  run "$FLOX_BIN" activate -s -- true 3>&-
+  run "$FLOX_BIN" activate -s -- true
   assert_output --partial "❌ Failed to start services"
-  pgrep_sleep > sleeping_after
-  SLEEP_PID="$(comm -13 sleeping_before sleeping_after)"
-  if [ -n "$SLEEP_PID" ]; then
-    kill "$SLEEP_PID"
-  fi
 }
 
 @test "blocking: activation blocks on socket creation" {


### PR DESCRIPTION
We currently close fd3 and kill any sleep processes left behind by process-compose in the test
`blocking: error message when startup times out`

Since bumping to process-compose 1.9, this appears to no longer be necessary.

With 1.6.1, the following would fail within a few runs on aarch64-linux. With 1.9, I've run it through all 10k runs.

```
i=0; while ! ps | grep sleep && [ $i -le 10000 ]; do process-compose up --config service-config.yaml --unix-socket /no-perms; (( i++ )); done; echo "$i"
```

(sidenote for the diligent reader of git log: the pgrep_sleep invocation had a bug anyways because it didn't sort by PID, so comm wouldn't work correctly)