### PR TITLE
feat(commands): Add flox services status

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -5,6 +5,7 @@
 //! Note that `process-compose` terminates when all services are stopped. To prevent this, we inject
 //! a dummy service (`flox_never_exit`) that sleeps indefinitely.
 
+use std::cmp::max;
 use std::collections::BTreeMap;
 use std::env;
 use std::fmt::Display;
@@ -311,9 +312,18 @@ impl IntoIterator for ProcessStatesDisplay {
 
 impl Display for ProcessStatesDisplay {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{:<20} {:<10} {:>8}", "NAME", "STATUS", "PID")?;
+        let name_width_min = 10;
+        let name_width = max(
+            name_width_min,
+            self.0.iter().map(|proc| proc.name.len()).max().unwrap_or(0),
+        );
+        writeln!(f, "{:<name_width$} {:<10} {:>8}", "NAME", "STATUS", "PID")?;
         for proc in &self.0 {
-            writeln!(f, "{:<20} {:<10} {:>8}", proc.name, proc.status, proc.pid)?;
+            writeln!(
+                f,
+                "{:<name_width$} {:<10} {:>8}",
+                proc.name, proc.status, proc.pid
+            )?;
         }
         Ok(())
     }
@@ -875,11 +885,11 @@ mod tests {
         };
         let states_display: ProcessStatesDisplay = states.into();
         assert_eq!(format!("{states_display}"), indoc! {"
-            NAME                 STATUS          PID
-            aaa                  Running         123
-            bbb                  Running         123
-            ccc                  Running         123
-            zzz                  Running         123
+            NAME       STATUS          PID
+            aaa        Running         123
+            bbb        Running         123
+            ccc        Running         123
+            zzz        Running         123
         "});
     }
 
@@ -910,10 +920,10 @@ mod tests {
         };
         let states_display: ProcessStatesDisplay = states.into();
         assert_eq!(format!("{states_display}"), indoc! {"
-            NAME                 STATUS          PID
-            aaa                  Running         123
-            bbb                  Stopped         123
-            ccc                  Completed       123
+            NAME       STATUS          PID
+            aaa        Running         123
+            bbb        Stopped         123
+            ccc        Completed       123
         "});
     }
 
@@ -930,12 +940,12 @@ mod tests {
         };
         let states_display: ProcessStatesDisplay = states.into();
         assert_eq!(format!("{states_display}"), indoc! {"
-            NAME                 STATUS          PID
-            aaa                  Running           1
-            bbb                  Running          12
-            ccc                  Running         123
-            ddd                  Running        1234
-            eee                  Running       12345
+            NAME       STATUS          PID
+            aaa        Running           1
+            bbb        Running          12
+            ccc        Running         123
+            ddd        Running        1234
+            eee        Running       12345
         "});
     }
 }

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -8,11 +8,16 @@ use tracing::instrument;
 use super::{ConcreteEnvironment, EnvironmentSelect};
 
 mod logs;
+mod status;
 mod stop;
 
 /// Services Commands.
 #[derive(Debug, Clone, Bpaf)]
 pub enum ServicesCommands {
+    /// Status of a service or services
+    #[bpaf(command)]
+    Status(#[bpaf(external(status::status))] status::Status),
+
     /// Stop a service or services
     #[bpaf(command)]
     Stop(#[bpaf(external(stop::stop))] stop::Stop),
@@ -30,6 +35,7 @@ impl ServicesCommands {
         }
 
         match self {
+            ServicesCommands::Status(args) => args.handle(flox).await?,
             ServicesCommands::Stop(args) => args.handle(flox).await?,
             ServicesCommands::Logs(args) => args.handle(flox).await?,
         }

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -13,6 +13,10 @@ pub struct Status {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 
+    /// Display output as JSON
+    #[bpaf(long)]
+    json: bool,
+
     /// Names of the services to query
     #[bpaf(positional("name"))]
     names: Vec<String>,
@@ -31,7 +35,11 @@ impl Status {
             states.filter_names(self.names);
         }
 
-        println!("{}", states);
+        if self.json {
+            println!("{:#}", states);
+        } else {
+            println!("{}", states);
+        }
 
         Ok(())
     }

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -30,10 +30,11 @@ impl Status {
         let env = supported_environment(&flox, self.environment)?;
         let socket = env.services_socket_path(&flox)?;
 
-        let mut states = ProcessStates::read(socket)?;
-        if !self.names.is_empty() {
-            states.filter_names(self.names);
-        }
+        let states = if self.names.is_empty() {
+            ProcessStates::read(socket)?
+        } else {
+            ProcessStates::read_names(socket, self.names)?
+        };
 
         if self.json {
             println!("{:#}", states);

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::providers::services::ProcessStates;
+use tracing::instrument;
+
+use super::supported_environment;
+use crate::commands::{environment_select, EnvironmentSelect};
+use crate::subcommand_metric;
+
+#[derive(Bpaf, Debug, Clone)]
+pub struct Status {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+
+    /// Names of the services to query
+    #[bpaf(positional("name"))]
+    names: Vec<String>,
+}
+
+impl Status {
+    #[instrument(name = "status", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("services::status");
+
+        let env = supported_environment(&flox, self.environment)?;
+        let socket = env.services_socket_path(&flox)?;
+
+        let mut states = ProcessStates::read(socket)?;
+        if !self.names.is_empty() {
+            states.filter_names(self.names);
+        }
+
+        println!("{}", states);
+
+        Ok(())
+    }
+}

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -361,4 +361,8 @@ EOF
   run "$FLOX_BIN" services logs hello --remote "flox/test"
   assert_failure
   assert_output --partial "❌ ERROR: services are not currently supported for remote environments"
+
+  run "$FLOX_BIN" services status hello --remote "flox/test"
+  assert_failure
+  assert_output --partial "❌ ERROR: services are not currently supported for remote environments"
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -54,6 +54,7 @@ setup_sleeping_services() {
 # NOTE: The following functionality is tested elsewhere:
 #
 #   - logs: providers/services.rs
+#   - status: providers/services.rs
 #   - remote environments: tests/environment-remotes.bats
 #
 # ---------------------------------------------------------------------------- #
@@ -154,14 +155,14 @@ EOF
     exit_code=0
     source "${TESTS_DIR}/services/register_cleanup.sh"
     "$FLOX_BIN" services stop one invalid || exit_code=$?
-    "$PROCESS_COMPOSE_BIN" process list --output wide
+    "$FLOX_BIN" services status
     exit $exit_code
 EOF
 )
   assert_failure
   assert_output --partial "❌ ERROR: service 'invalid' is not running"
-  assert_output --regexp " +one +default +Completed +"
-  assert_output --regexp " +two +default +Running +"
+  assert_output --regexp "one +Completed"
+  assert_output --regexp "two +Running"
 }
 
 # bats test_tags=services:stop
@@ -173,14 +174,14 @@ EOF
     exit_code=0
     source "${TESTS_DIR}/services/register_cleanup.sh"
     "$FLOX_BIN" services stop invalid one || exit_code=$?
-    "$PROCESS_COMPOSE_BIN" process list --output wide
+    "$FLOX_BIN" services status
     exit $exit_code
 EOF
 )
   assert_failure
   assert_output --partial "❌ ERROR: service 'invalid' is not running"
-  assert_output --regexp " +one +default +Running +"
-  assert_output --regexp " +two +default +Running +"
+  assert_output --regexp "one +Running"
+  assert_output --regexp "two +Running"
 }
 
 # bats test_tags=services:stop
@@ -205,14 +206,14 @@ EOF
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
     "$FLOX_BIN" services stop
-    "$PROCESS_COMPOSE_BIN" process list --output wide
+    "$FLOX_BIN" services status
 EOF
 )
   assert_success
   assert_output --partial "✅ Service 'one' stopped"
   assert_output --partial "✅ Service 'two' stopped"
-  assert_output --regexp " +one +default +Completed +"
-  assert_output --regexp " +two +default +Completed +"
+  assert_output --regexp "one +Completed"
+  assert_output --regexp "two +Completed"
 }
 
 # bats test_tags=services:stop
@@ -223,13 +224,13 @@ EOF
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
     "$FLOX_BIN" services stop one
-    "$PROCESS_COMPOSE_BIN" process list --output wide
+    "$FLOX_BIN" services status
 EOF
 )
   assert_success
   assert_output --partial "✅ Service 'one' stopped"
-  assert_output --regexp " +one +default +Completed +"
-  assert_output --regexp " +two +default +Running +"
+  assert_output --regexp "one +Completed"
+  assert_output --regexp "two +Running"
 }
 
 # bats test_tags=services:stop
@@ -240,14 +241,14 @@ EOF
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
     "$FLOX_BIN" services stop one two
-    "$PROCESS_COMPOSE_BIN" process list --output wide
+    "$FLOX_BIN" services status
 EOF
 )
   assert_success
   assert_output --partial "✅ Service 'one' stopped"
   assert_output --partial "✅ Service 'two' stopped"
-  assert_output --regexp " +one +default +Completed +"
-  assert_output --regexp " +two +default +Completed +"
+  assert_output --regexp "one +Completed"
+  assert_output --regexp "two +Completed"
 }
 
 # bats test_tags=services:stop
@@ -258,12 +259,12 @@ EOF
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
     "$FLOX_BIN" services stop one
-    "$PROCESS_COMPOSE_BIN" process list --output wide
+    "$FLOX_BIN" services status
     "$FLOX_BIN" services stop one
 EOF
 )
   assert_failure
-  assert_output --regexp " +one +default +Completed +"
+  assert_output --regexp "one +Completed"
   assert_output --partial "❌ ERROR: service 'one' is not running"
 }
 


### PR DESCRIPTION
## Proposed Changes

**feat(services): impl Display for ProcessStates**

Using the output format described in:

- https://www.notion.so/floxdev/Services-status-output-53ee184e2b5b4b7d8d565041b5b555bf

I've resisted bringing in a third-party table library for the moment
because they all seem to have massive feature sets or quirks:

- https://github.com/BurntSushi/tabwriter
- https://github.com/phsym/prettytable-rs
- https://github.com/zhiburt/tabled

Some notes about the current implementation:

- NAME column is padded to 20 chars and will no longer align if it
  overflow but it will still be space delimited
- NAME is already sorted for us and the test uses header/footer entries
  to prevent any future regressions.
- PID column is right align to account variable length values

This was quick and easy to unit test with the helpers that Yannik
recently added. I opted to use real `process-compose` output, rather
than `ProcessStates` fixtures, because it's less fiddly and more
realistic than constructing all of the fields manually.

**feat(services): Add ProcessStates::filter_names**

To mutate `ProcessStates` so that it only contains the provided names.
Any unknown names are ignored. This will be used by `services status`
when providing one or more names.

**feat(commands): Add services status (table only)**

Wire in the `flox services status` command. This currently only displays
table output; JSON output will be added in subsequent commits.

The bulk of the functionality is unit tested but I've also replaced all
uses of `process-compose process list` in our integration tests so that
we dogfood our own command.

This doesn't yet implement the original criteria we specified of
erroring if you provide a service that doesn't exist but I'm now less
sure whether that is necessary or desirable; interested in thoughts from
others.

**feat(commands): services status --json**

Implement JSON lines output for `flox services status` per:

- https://www.notion.so/floxdev/Services-status-output-53ee184e2b5b4b7d8d565041b5b555bf

Uses the existing struct and skips serialization for the fields that we
don't currently need/want to expose.

I've implemented this as an alternative display format, which seems neat
in terms of how much effort it was, but I'm not sure if it's idiomatic.

## Release Notes

Added `flox services status` command behind feature flag.