### PR TITLE
fix: detach `process-compose` from activation using `setsid`

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -2,6 +2,7 @@
 # shellcheck shell=bash disable=SC1090,SC1091
 export _coreutils="@coreutils@"
 export _gnused="@gnused@"
+export _setsid="@setsid@"
 export _process_compose="@process-compose@"
 export _zdotdir="@out@/activate.d/zdotdir"
 export _tcsh_home="@out@/activate.d/tcsh_home"
@@ -52,7 +53,9 @@ start_services_blocking () {
   # process-compose will vomit all over your log files unless you tell it otherwise
   local previous_no_color="${NO_COLOR:-}"
   export NO_COLOR=1
-  "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false >/dev/null 2>&1 &
+  # [sic] within scripts setsid needs to be called twice to work properly:
+  # <https://stackoverflow.com/a/25398828>
+  "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false >/dev/null 2>&1 &
   # Make these functions available in subshells so that `timeout` can call them
   export -f wait_for_services_socket poll_services_status
   local activation_timeout="${_FLOX_SERVICES_ACTIVATE_TIMEOUT:-1}"

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -3,6 +3,7 @@
   coreutils,
   findutils,
   gnused,
+  util-linux,
   ld-floxlib,
   runCommand,
   shellcheck,
@@ -22,6 +23,7 @@ in
     substituteInPlace $out/activate \
       --replace "@coreutils@" "${coreutils}" \
       --replace "@gnused@" "${gnused}" \
+      --replace "@setsid@" "${util-linux}/bin/setsid" \
       --replace "@out@" "$out" \
       --replace "@process-compose@" "${process-compose}/bin/process-compose" \
       --replace "/usr/bin/env bash" "${bash}/bin/bash"


### PR DESCRIPTION
Avoid process-compose accidentally handling signals sent in the shell,
such as terminating upon `^C`.

Using the `setsid` from the `util-linux` package, which contrary to its name
does provide several utilities on macos as well, including the setsid binary.