### PR TITLE
fix: Wait for klaus processes to finish between tests

### DIFF
--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -174,6 +174,25 @@ common_file_teardown() {
 teardown_file() { common_file_teardown; }
 
 common_test_teardown() {
+  # wait for any running klaus proceses to finish
+  if [[ -n "${FLOX_DATA_DIR:-}" ]]; then
+    if pids="$(pgrep -f klaus.*${FLOX_DATA_DIR?})"; then
+      tries=0
+      while true; do
+        tries=$((tries + 1))
+        if ! kill -0 $pids > /dev/null 2>&1; then
+          break
+        else
+          if [[ $tries -gt 1000 ]]; then
+            echo "ERROR: klaus processes did not finish after 10 seconds."
+            break
+          fi
+          sleep 0.01;
+        fi
+      done
+    fi
+  fi
+
   # Delete test tmpdir unless the user requests to preserve them.
   # XXX: We do not attempt to delete envs here.
   if [[ -z "${FLOX_TEST_KEEP_TMP:-}" ]]; then rm -rf "$BATS_TEST_TMPDIR"; fi


### PR DESCRIPTION
Klaus runs asynchronously, which means that if the last command a test
runs is `flox activate`, there is a chance it will move on to teardown
before klaus has finished its work. Specifically, klaus might try to
read and then write the env-registry.json file in the data dir, which
can fail in at least two ways:
1) Klaus itself might fail because that file has been deleted
2) The deletion of the data dir might fail because klaus has recreated
the file after it was deleted, before the directory was removed

We now provide a standard teardown step that waits for any klaus
processes associated with this test run to exit. Associated processes
are identified by the presence of the test-specific data dir in their
command line, as klaus is invoked with a reference to the env-registry
file in the data dir.