### PR TITLE
fix: re-add pkgsFor to allow extracting the full package set used

### DIFF
--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -150,6 +150,7 @@ in
           envs
           flox-pkgdb
           flox-klaus
+          pkgsFor # Needed to build installers
           ;
 
         ciPackages = [

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -9,6 +9,7 @@
   flox-cli,
   flox-manpages,
   process-compose,
+  pkgsFor,
   SENTRY_DSN ? null,
   SENTRY_ENV ? null,
   FLOX_VERSION ? null,
@@ -40,4 +41,5 @@ in
         --set PROCESS_COMPOSE_BIN "${process-compose}/bin/process-compose" \
         --set FLOX_VERSION    "${version}"
     '';
+    passthru = {inherit pkgsFor;};
   }


### PR DESCRIPTION
## Proposed Changes
Expose the original package set in passthru. Used to help make installers without messing around with overlays.


## Release Notes
N/A
