### PR TITLE
test: remove/port tests that lock with pkgdb

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1334,9 +1334,8 @@ impl ManagedEnvironment {
         // Ensure the environment is locked
         // PathEnvironment may not have a lockfile or an outdated lockfile
         // if the environment was modified primarily through editing the manifest manually.
-        // Call lock rather than ensure_locked because the primary purpose of
-        // ensure_locked is avoiding locking of v0 manifests,
-        // but we don't need to support pushing old manifests.
+        // Call `ensure_locked` to avoid locking of v0 manifests,
+        // but permit pushing old manifests that are already locked.
         core_environment
             .ensure_locked(flox)
             .map_err(ManagedEnvironmentError::Lock)?;

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1338,7 +1338,7 @@ impl ManagedEnvironment {
         // ensure_locked is avoiding locking of v0 manifests,
         // but we don't need to support pushing old manifests.
         core_environment
-            .lock(flox)
+            .ensure_locked(flox)
             .map_err(ManagedEnvironmentError::Lock)?;
 
         // Ensure the environment builds before we push it

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1085,13 +1085,7 @@ EOF
 @test "'flox activate' modifies the current shell (bash)" {
   project_setup_pkgdb
 
-  # set profile scripts
-  sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  # set a hook
-  sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  # set vars
-  sed -i -e "s/^\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  "$FLOX_BIN" install hello
+  cp -r "$MANUALLY_GENERATED"/hello_for_activate_v0/* .flox/env/
 
   run bash -c 'eval "$($FLOX_BIN activate)"; type hello; echo $foo'
   assert_success
@@ -1130,13 +1124,8 @@ EOF
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:fish
 @test "'flox activate' modifies the current shell (fish)" {
   project_setup_pkgdb
-  # set profile scripts
-  sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  # set a hook
-  sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  # set vars
-  sed -i -e "s/^\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  "$FLOX_BIN" install hello
+
+  cp -r "$MANUALLY_GENERATED"/hello_for_activate_v0/* .flox/env/
 
   run fish -c 'eval "$($FLOX_BIN activate)"; type hello; echo $foo'
   assert_success
@@ -1177,13 +1166,8 @@ EOF
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:tcsh
 @test "'flox activate' modifies the current shell (tcsh)" {
   project_setup_pkgdb
-  # set profile scripts
-  sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  # set a hook
-  sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  # set vars
-  sed -i -e "s/^\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  "$FLOX_BIN" install hello
+
+  cp -r "$MANUALLY_GENERATED"/hello_for_activate_v0/* .flox/env/
 
   run tcsh -c 'eval "`$FLOX_BIN activate`"; echo hello is `which hello`; echo $foo'
   assert_success
@@ -1224,13 +1208,8 @@ EOF
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:zsh
 @test "'flox activate' modifies the current shell (zsh)" {
   project_setup_pkgdb
-  # set profile scripts
-  sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  # set a hook
-  sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  # set vars
-  sed -i -e "s/^\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
-  "$FLOX_BIN" install hello
+
+  cp -r "$MANUALLY_GENERATED"/hello_for_activate_v0/* .flox/env/
 
   run zsh -c 'eval "$("$FLOX_BIN" activate)"; type hello; echo $foo'
   assert_success

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1357,33 +1357,6 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate:flox-uses-default-env
-@test "'flox *' uses local environment over 'default' environment" {
-  project_setup # TODO: we need PROJECT_DIR, but not flox init
-  "$FLOX_BIN" delete -f
-  export FLOX_FEATURES_USE_CATALOG=false # todo: port
-
-  mkdir default
-  pushd default >/dev/null || return
-  "$FLOX_BIN" init
-  "$FLOX_BIN" install vim
-  popd >/dev/null || return
-
-  "$FLOX_BIN" init
-  "$FLOX_BIN" install emacs
-
-  # sanity check that flox list lists the local environment
-  run -- "$FLOX_BIN" list -n
-  assert_success
-  assert_line "emacs"
-
-  # Run flox list within the default environment.
-  # Flox should choose the local environment over the default environment.
-  run -- "$FLOX_BIN" activate --dir default -- "$FLOX_BIN" list -n
-  assert_success
-  assert_line "emacs"
-}
-
-# bats test_tags=activate:flox-uses-default-env
 @test "catalog: 'flox *' uses local environment over 'default' environment" {
   project_setup # TODO: we need PROJECT_DIR, but not flox init
   "$FLOX_BIN" delete -f

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -228,11 +228,7 @@ EOF
 
 # bats test_tags=activate,activate:path,activate:path:bash
 @test "bash: interactive activate puts package in path" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  project_setup
-  run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
-  assert_success
-  assert_output --partial "✅ 'hello' installed to environment"
+  project_setup_pkgdb
   FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
@@ -252,11 +248,7 @@ EOF
 
 # bats test_tags=activate,activate:path,activate:path:fish
 @test "fish: interactive activate puts package in path" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  project_setup
-  run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
-  assert_success
-  assert_output --partial "✅ 'hello' installed to environment"
+  project_setup_pkgdb
   FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
@@ -264,11 +256,7 @@ EOF
 
 # bats test_tags=activate,activate:path,activate:path:fish
 @test "catalog: fish: interactive activate puts package in path" {
-  project_setup
-  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
-  run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
-  assert_success
-  assert_output --partial "✅ 'hello' installed to environment"
+  project_setup_pkgdb
   FLOX_SHELL="fish" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
@@ -276,11 +264,7 @@ EOF
 
 # bats test_tags=activate,activate:path,activate:path:tcsh
 @test "tcsh: interactive activate puts package in path" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  project_setup
-  run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
-  assert_success
-  assert_output --partial "✅ 'hello' installed to environment"
+  project_setup_pkgdb
   FLOX_SHELL="tcsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
@@ -926,19 +910,12 @@ EOF
 
 # bats test_tags=activate,activate:path,activate:path:bash
 @test "'flox activate' modifies path (bash)" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  project_setup
-  original_path="$PATH"
-  FLOX_SHELL="bash" run "$FLOX_BIN" activate -- echo '$PATH'
-  assert_success
-  assert_not_equal "$original_path" "$output"
+  project_setup_pkgdb
 
   # hello is not on the path
   run -1 type hello
 
-  run "$FLOX_BIN" install hello
-  assert_success
-
+  # project_setup_pkgdb sets up an environment with hello installed
   FLOX_SHELL="bash" run "$FLOX_BIN" activate -- hello
   assert_success
   assert_output --partial "Hello, world!"
@@ -966,19 +943,12 @@ EOF
 
 # bats test_tags=activate,activate:path,activate:path:fish
 @test "'flox activate' modifies path (fish)" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  project_setup
-  original_path="$PATH"
-  FLOX_SHELL="fish" run "$FLOX_BIN" activate -- echo '$PATH'
-  assert_success
-  assert_not_equal "$original_path" "$output"
+  project_setup_pkgdb
 
   # hello is not on the path
   run -1 type hello
 
-  run "$FLOX_BIN" install hello
-  assert_success
-
+  # project_setup_pkgdb sets up an environment with hello installed
   FLOX_SHELL="fish" run "$FLOX_BIN" activate -- hello
   assert_success
   assert_output --partial "Hello, world!"
@@ -1006,19 +976,12 @@ EOF
 
 # bats test_tags=activate,activate:path,activate:path:tcsh
 @test "'flox activate' modifies path (tcsh)" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  project_setup
-  original_path="$PATH"
-  FLOX_SHELL="tcsh" run "$FLOX_BIN" activate -- echo '$PATH'
-  assert_success
-  assert_not_equal "$original_path" "$output"
+  project_setup_pkgdb
 
   # hello is not on the path
   run -1 type hello
 
-  run "$FLOX_BIN" install hello
-  assert_success
-
+  # project_setup_pkgdb sets up an environment with hello installed
   FLOX_SHELL="tcsh" run "$FLOX_BIN" activate -- hello
   assert_success
   assert_output --partial "Hello, world!"
@@ -1046,19 +1009,12 @@ EOF
 
 # bats test_tags=activate,activate:path,activate:path:zsh
 @test "'flox activate' modifies path (zsh)" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  project_setup
-  original_path="$PATH"
-  FLOX_SHELL="zsh" run "$FLOX_BIN" activate -- echo '$PATH'
-  assert_success
-  assert_not_equal "$original_path" "$output"
+  project_setup_pkgdb
 
   # hello is not on the path
   run -1 type hello
 
-  run "$FLOX_BIN" install hello
-  assert_success
-
+  # project_setup_pkgdb sets up an environment with hello installed
   FLOX_SHELL="zsh" run "$FLOX_BIN" activate -- hello
   assert_success
   assert_output --partial "Hello, world!"
@@ -1373,14 +1329,14 @@ EOF
 
 # bats test_tags=activate,activate:python-detects-installed-python
 @test "'flox activate' sets python vars if python is installed" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  project_setup
+  project_setup_pkgdb
+
+  # Mock flox install of python311Packages.pip
+  cp "$MANUALLY_GENERATED"/python_v0/* "$PROJECT_DIR/.flox/env/"
+
   # unset python vars if any
   unset PYTHONPATH
   unset PIP_CONFIG_FILE
-
-  # install python and pip
-  "$FLOX_BIN" install python311Packages.pip
 
   run -- "$FLOX_BIN" activate -- echo PYTHONPATH is '$PYTHONPATH'
   assert_success

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -72,7 +72,6 @@ EOF
   export __FT_RAN_USER_DOTFILES_SETUP=:
 }
 
-
 setup_file() {
   common_file_setup
   user_dotfiles_setup
@@ -82,14 +81,31 @@ setup_file() {
 
 # Helpers for project based tests.
 
-project_setup() {
+project_setup_common() {
   export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
   export PROJECT_NAME="${PROJECT_DIR##*/}"
 
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
-  pushd "$PROJECT_DIR" > /dev/null || return
+  pushd "$PROJECT_DIR" >/dev/null || return
+
+}
+
+# setup with catalog
+project_setup() {
+  project_setup_common
   "$FLOX_BIN" init -d "$PROJECT_DIR"
+}
+
+# project setup with pkgdb
+project_setup_pkgdb() {
+  project_setup_common
+  mkdir -p "$PROJECT_DIR/.flox/env"
+  cp --no-preserve=mode "$MANUALLY_GENERATED"/hello_v0/* "$PROJECT_DIR/.flox/env"
+  echo '{
+    "name": "'$PROJECT_NAME'",
+    "version": 1
+  }' >>"$PROJECT_DIR/.flox/env.json"
 }
 
 project_teardown() {

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -33,9 +33,13 @@ env_setup_catalog() {
   "$FLOX_BIN" edit -f "$TESTS_DIR/container/manifest1.toml"
 }
 
-env_setup() {
-  "$FLOX_BIN" init
-  "$FLOX_BIN" edit -f "$TESTS_DIR/container/manifest0.toml"
+env_setup_pkgdb() {
+  mkdir -p "$PROJECT_DIR/.flox/env"
+  cp --no-preserve=mode "$MANUALLY_GENERATED"/hello_for_containerize_v0/* "$PROJECT_DIR/.flox/env"
+  echo '{
+    "name": "test",
+    "version": 1
+  }' >>"$PROJECT_DIR/.flox/env.json"
 }
 
 # podman writes containers to ~/.local/share/containers/storage
@@ -102,10 +106,9 @@ function skip_if_linux() {
 
 # bats test_tags=containerize:default-to-file
 @test "container is written to a file by default" {
-  export FLOX_FEATURES_USE_CATALOG=false
   skip_if_not_linux
 
-  env_setup
+  env_setup_pkgdb
 
   run "$FLOX_BIN" containerize
   assert_success
@@ -139,10 +142,9 @@ function skip_if_linux() {
 
 # bats test_tags=containerize:piped-to-stdout
 @test "container is written to stdout when '-o -' is passed" {
-  export FLOX_FEATURES_USE_CATALOG=false
   skip_if_not_linux
 
-  env_setup
+  env_setup_pkgdb
 
   run bash -c '"$FLOX_BIN" containerize -o - | podman load'
   assert_success
@@ -162,10 +164,9 @@ function skip_if_linux() {
 
 # bats test_tags=containerize:run-container-i
 @test "container can be run with 'podman/docker run -i'" {
-  export FLOX_FEATURES_USE_CATALOG=false
   skip_if_not_linux
 
-  env_setup
+  env_setup_pkgdb
 
   CONTAINER_ID="$("$FLOX_BIN" containerize -o - | podman load | sed -nr 's/^Loaded image: (.*)$/\1/p')"
   run --separate-stderr podman run -q -i "$CONTAINER_ID" -c 'echo $foo'
@@ -233,8 +234,7 @@ function skip_if_linux() {
 @test "container can be run with 'podman/docker run'" {
   skip_if_not_linux
 
-  export FLOX_FEATURES_USE_CATALOG=false
-  env_setup
+  env_setup_pkgdb
 
   CONTAINER_ID="$("$FLOX_BIN" containerize -o - | podman load | sed -nr 's/^Loaded image: (.*)$/\1/p')"
   run --separate-stderr podman run "$CONTAINER_ID" -c 'echo $foo'

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -18,11 +18,11 @@ project_setup() {
   export PROJECT_DIR="${BATS_TEST_TMPDIR?}/test"
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
-  pushd "$PROJECT_DIR" > /dev/null || return
+  pushd "$PROJECT_DIR" >/dev/null || return
 }
 
 project_teardown() {
-  popd > /dev/null || return
+  popd >/dev/null || return
   rm -rf "${PROJECT_DIR?}"
   unset PROJECT_DIR
 }
@@ -60,7 +60,7 @@ setup() {
   project_setup
 
   mkdir -p $HOME/.config/containers
-  echo '{ "default": [ {"type": "insecureAcceptAnything"} ] }' > "$HOME/.config/containers/policy.json"
+  echo '{ "default": [ {"type": "insecureAcceptAnything"} ] }' >"$HOME/.config/containers/policy.json"
 }
 
 teardown() {

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -350,24 +350,6 @@ EOF
   refute_output "vim"
 }
 
-# bats test_tags=managed:xyz
-@test "sanity check upgrade works for managed environments" {
-  # update shouldn't work for catalog: https://github.com/flox/flox/issues/1509
-  export FLOX_FEATURES_USE_CATALOG=false
-  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-    make_empty_remote_env
-
-  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_OLD?}" \
-    "$FLOX_BIN" install hello
-
-  # After an update, nixpkgs is the new nixpkgs, but hello is still from the
-  # old one.
-  _PKGDB_GA_REGISTRY_REF_OR_REV="${PKGDB_NIXPKGS_REV_NEW?}" \
-    "$FLOX_BIN" update
-
-  run "$FLOX_BIN" upgrade
-  assert_output --partial "Upgraded 'hello'"
-}
 
 # ---------------------------------------------------------------------------- #
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -51,9 +51,20 @@ teardown() {
 
 # ---------------------------------------------------------------------------- #
 
+# init path environment and push to remote
 function make_empty_remote_env() {
-  # init path environment and push to remote
   "$FLOX_BIN" init
+  "$FLOX_BIN" push --owner "$OWNER"
+}
+
+# create path env from pre-generated locked manifest v0
+function make_remote_env_with_hello() {
+  mkdir -p "$PROJECT_DIR/.flox/env"
+  cp "$MANUALLY_GENERATED"/hello_v0/* "$PROJECT_DIR/.flox/env"
+  echo '{
+    "name": "'$PROJECT_NAME'",
+    "version": 1
+  }' >>"$PROJECT_DIR/.flox/env.json"
   "$FLOX_BIN" push --owner "$OWNER"
 }
 
@@ -278,9 +289,7 @@ EOF
 # Make sure we haven't activate
 # bats test_tags=managed,activate,managed:activate
 @test "m9: activate works in managed environment" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  make_empty_remote_env
-  "$FLOX_BIN" install hello
+  make_remote_env_with_hello
 
   run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- command -v hello
   assert_success

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -64,6 +64,25 @@ function make_empty_remote_env() {
   rm -rf local
 }
 
+# create remote a pkgdb environment with hello installed
+# from pre-generated lock
+make_remote_pkgdb_env_with_hello() {
+  mkdir local
+  pushd local
+
+  # init path environment and push to remote
+  mkdir -p .flox/env
+  cp "$MANUALLY_GENERATED"/hello_v0/* .flox/env
+  echo '{
+    "name": "test",
+    "version": 1
+  }' >.flox/env.json
+  "$FLOX_BIN" push --owner "$OWNER"
+  "$FLOX_BIN" delete -f
+  popd
+  rm -rf local
+}
+
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=hermetic,remote,remote:hermetic
@@ -146,9 +165,7 @@ EOF
 
 # bats test_tags=remote,activate,remote:activate
 @test "m9: activate works in remote environment" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  make_empty_remote_env
-  "$FLOX_BIN" install hello --remote "$OWNER/test"
+  make_remote_pkgdb_env_with_hello
 
   run "$FLOX_BIN" activate --trust --remote "$OWNER/test" -- command -v hello
   assert_success

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -80,17 +80,6 @@ function make_empty_remote_env() {
 }
 
 # bats test_tags=hermetic,remote,remote:outlink
-@test "r0: building a remote environment creates outlink" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  make_empty_remote_env
-
-  run --separate-stderr "$FLOX_BIN" install hello --remote "$OWNER/test"
-  assert_success
-
-  assert [ -h "$FLOX_CACHE_DIR/run/$OWNER/test" ]
-}
-
-# bats test_tags=hermetic,remote,remote:outlink
 @test "catalog: r0: building a remote environment creates outlink" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   make_empty_remote_env

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -120,27 +120,6 @@ function make_empty_remote_env() {
 }
 
 # bats test_tags=edit,remote,remote:edit
-@test "m3: edit a package from a managed environment" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  make_empty_remote_env
-
-  TMP_MANIFEST_PATH="$BATS_TEST_TMPDIR/manifest.toml"
-
-  cat << "EOF" >> "$TMP_MANIFEST_PATH"
-[install]
-hello = {}
-EOF
-
-  run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH" --remote "$OWNER/test"
-  assert_success
-  assert_output --partial "✅ Environment successfully updated."
-
-  run --separate-stderr "$FLOX_BIN" list --name --remote "$OWNER/test"
-  assert_success
-  assert_output "hello"
-}
-
-# bats test_tags=edit,remote,remote:edit
 @test "catalog: m3: edit a package from a managed environment" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   make_empty_remote_env

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -19,7 +19,7 @@ project_setup() {
 
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
-  pushd "$PROJECT_DIR" > /dev/null || return
+  pushd "$PROJECT_DIR" >/dev/null || return
 
 }
 
@@ -33,7 +33,7 @@ floxmeta_setup() {
 }
 
 project_teardown() {
-  popd > /dev/null || return
+  popd >/dev/null || return
   rm -rf "${PROJECT_DIR?}"
   unset PROJECT_DIR
 }
@@ -145,7 +145,7 @@ make_remote_pkgdb_env_with_hello() {
 
   TMP_MANIFEST_PATH="$BATS_TEST_TMPDIR/manifest.toml"
 
-  cat << "EOF" >> "$TMP_MANIFEST_PATH"
+  cat <<"EOF" >>"$TMP_MANIFEST_PATH"
 version = 1
 
 [install]
@@ -300,7 +300,6 @@ EOF
   assert_output --partial "Environment not found in FloxHub."
 }
 
-
 # bats test_tags=remote,remote:not-found
 @test "install --remote fails on a non existent environment" {
   run "$FLOX_BIN" install -r "$OWNER/i-dont-exist"
@@ -317,7 +316,6 @@ EOF
   assert_failure
   assert_output --partial "You are not logged in to FloxHub."
 }
-
 
 # bats test_tags=remote,remote:auth-required,remote:auth-required:uninstall
 @test "'uninstall --remote' fails if not authenticated" {
@@ -354,7 +352,7 @@ EOF
 
   TMP_MANIFEST_PATH="$BATS_TEST_TMPDIR/manifest.toml"
 
-  cat << "EOF" >> "$TMP_MANIFEST_PATH"
+  cat <<"EOF" >>"$TMP_MANIFEST_PATH"
 version = 1
 
 [services.hello]

--- a/cli/tests/lang-node.bats
+++ b/cli/tests/lang-node.bats
@@ -48,35 +48,6 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------- #
-
-@test "flox activate works with npm" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  cp -r "$INPUT_DATA/init/node/common/." .
-  cp -r "$INPUT_DATA/init/node/npm/." .
-  # Files copied from the store are read-only
-  chmod -R +w .
-
-  run "$FLOX_BIN" init --auto-setup
-  assert_output --partial "'nodejs' installed"
-  run "$FLOX_BIN" activate -- npm run start
-  assert_output --partial "86400000"
-}
-
-@test "flox activate works with yarn" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  cp -r "$INPUT_DATA/init/node/common/." .
-  cp -r "$INPUT_DATA/init/node/yarn/." .
-  # Files copied from the store are read-only
-  chmod -R +w .
-
-  run "$FLOX_BIN" init --auto-setup
-  assert_output --partial "'yarn' installed"
-  refute_output "nodejs"
-  run "$FLOX_BIN" activate -- yarn run start
-  assert_output --partial "86400000"
-}
-
-# ---------------------------------------------------------------------------- #
 # catalog tests
 
 # bats test_tags=catalog

--- a/cli/tests/lang-python.bats
+++ b/cli/tests/lang-python.bats
@@ -49,60 +49,6 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------- #
-
-# bats test_tags=python:activate:poetry
-@test "flox activate works with poetry" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  cp -r "$INPUT_DATA"/init/python/common/* "$PROJECT_DIR/"
-  cp -r "$INPUT_DATA"/init/python/poetry/* "$PROJECT_DIR/"
-  # Files copied from the store are read-only
-  chmod -R +w .
-
-  run "$FLOX_BIN" init --auto-setup
-  assert_success
-  assert_output --partial "'poetry' installed"
-
-  "$FLOX_BIN" install zlib
-  run "$FLOX_BIN" activate -- python -m project
-  assert_success
-  assert_line "<class 'numpy.ndarray'>"
-}
-
-# bats test_tags=python:activate:pyproject:pip
-@test "flox activate works with pyproject and pip" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  cp -r "$INPUT_DATA"/init/python/common/* "$PROJECT_DIR/"
-  cp -r "$INPUT_DATA"/init/python/pyproject-pip/* "$PROJECT_DIR/"
-  # Files copied from the store are read-only
-  chmod -R +w .
-
-  run "$FLOX_BIN" init --auto-setup
-  assert_success
-
-  "$FLOX_BIN" install zlib
-  run "$FLOX_BIN" activate -- python -m project
-  assert_success
-  assert_line "<class 'numpy.ndarray'>"
-}
-
-# bats test_tags=python:activate:requirements
-@test "flox activate works with requirements.txt and pip" {
-  export FLOX_FEATURES_USE_CATALOG=false
-  cp -r "$INPUT_DATA"/init/python/common/* "$PROJECT_DIR/"
-  cp -r "$INPUT_DATA"/init/python/requirements/* "$PROJECT_DIR/"
-  # Files copied from the store are read-only
-  chmod -R +w .
-
-  run "$FLOX_BIN" init --auto-setup
-  assert_success
-
-  "$FLOX_BIN" install zlib
-  run "$FLOX_BIN" activate -- python -m project
-  assert_success
-  assert_line "<class 'numpy.ndarray'>"
-}
-
-# ---------------------------------------------------------------------------- #
 # catalog tests
 
 # bats test_tags=catalog

--- a/cli/tests/ld-floxlib.bats
+++ b/cli/tests/ld-floxlib.bats
@@ -50,23 +50,12 @@ project_setup_common() {
 }
 
 project_setup_pkgdb() {
-  # Create environment (verbosely for the logs), specifying a pinned
-  # nixpkgs revision, although it has no effect (see below).
-  sh -xc "_PKGDB_GA_REGISTRY_REF_OR_REV=${PKGDB_NIXPKGS_REV_OLDER?} \
-    $FLOX_BIN init"
-
-  # "Update" lock for this one environment to use a pinned nixpkgs revision
-  # containing old versions of nix (2.10.3) and glibc (2.34) for use in tests.
-  # (Would be preferable if the previous init could honor the revision.)
-  sh -xc "_PKGDB_GA_REGISTRY_REF_OR_REV=${PKGDB_NIXPKGS_REV_OLDER?} \
-    $FLOX_BIN update"
-
-  # Install packages, including boost, curl and libarchive that are
-  # compilation and runtime dependencies of libnixmain.so. Use `flox edit`
-  # so that we can bump the priority of the nix package to avoid a path
-  # clash with boost.
-  sh -xc "_PKGDB_GA_REGISTRY_REF_OR_REV=${PKGDB_NIXPKGS_REV_OLDER?} \
-    $FLOX_BIN edit -f ./manifest-pkgdb.toml"
+  mkdir -p "$PROJECT_DIR/.flox/env"
+  cp "$MANUALLY_GENERATED"/ld_floxlib_test_deps_v0/* "$PROJECT_DIR/.flox/env"
+  echo '{
+    "name": "env",
+    "version": 1
+  }' >>"$PROJECT_DIR/.flox/env.json"
 }
 
 project_setup_catalog() {
@@ -112,7 +101,6 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 #
 @test "test ld-floxlib.so on Linux only" {
-  export FLOX_FEATURES_USE_CATALOG=false
   project_setup_pkgdb
 
   # Revision PKGDB_NIXPKGS_REV_OLDER is expected to provide glibc 2.34.

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -137,12 +137,12 @@ EOF
 # https://github.com/flox/flox/issues/1039
 # bats test_tags=list,list:tolerates-missing-version
 @test "'flox list' tolerates missing version" {
-  export FLOX_FEATURES_USE_CATALOG=false # todo: port
+  init_pkgdb_env
 
-  "$FLOX_BIN" init
-  # `influxdb does not have a version attribute set in nixpkgs (2024-02-19)
+  # `influxdb2 does not have a version attribute set in nixpkgs (2024-02-19)
   # todo: replace with a more predicatable/smaller example
-  "$FLOX_BIN" install influxdb2
+  cp "$MANUALLY_GENERATED"/influxdb2_v0/* "$PROJECT_DIR/.flox/env"
+
   run "$FLOX_BIN" list
   assert_success
   assert_output "influxdb2: influxdb2 (N/A)"

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -40,24 +40,34 @@ teardown() {
   common_test_teardown
 }
 
+# ---------------------------------------------------------------------------- #
+
+init_pkgdb_env() {
+  mkdir -p "$PROJECT_DIR/.flox/env"
+  cp --no-preserve=mode "$MANUALLY_GENERATED"/empty_v0/* "$PROJECT_DIR/.flox/env"
+
+  echo '{
+    "name": "env",
+    "version": 1
+  }' >>"$PROJECT_DIR/.flox/env.json"
+}
+
+# ---------------------------------------------------------------------------- #
+
 @test "'flox list' lists packages of environment in the current dir; fails if no env found" {
   run "$FLOX_BIN" list
   assert_failure
 }
 
 @test "'flox list' lists packages of environment in the current dir; No package" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  "$FLOX_BIN" init
+  init_pkgdb_env
   run "$FLOX_BIN" list
   assert_success
 }
 
 @test "'flox list' lists packages of environment in the current dir; One package from nixpkgs" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  "$FLOX_BIN" init
-  "$FLOX_BIN" install hello
+  init_pkgdb_env
+  cp "$MANUALLY_GENERATED"/hello_v0/* "$PROJECT_DIR/.flox/env"
 
   run "$FLOX_BIN" list
   assert_success
@@ -65,23 +75,21 @@ teardown() {
 }
 
 @test "'flox list' lists packages of environment in the current dir; shows different paths" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  "$FLOX_BIN" init
-  "$FLOX_BIN" install python310Packages.pip
+  init_pkgdb_env
+  cp "$MANUALLY_GENERATED"/python_v0/* "$PROJECT_DIR/.flox/env"
 
   run "$FLOX_BIN" list
   assert_success
   assert_output --regexp - <<EOF
-pip: python310Packages.pip \([0-9]+\.[0-9]+(\.[0-9]+)?\)
+pip: python311Packages.pip \([0-9]+\.[0-9]+(\.[0-9]+)?\)
 EOF
 }
 
 @test "'flox list' lists packages of environment in the current dir; shows different id" {
-  export FLOX_FEATURES_USE_CATALOG=false
+  init_pkgdb_env
 
-  "$FLOX_BIN" init
-  "$FLOX_BIN" install --id greeting hello
+  # install hello with `greeting` as the iid.
+  cp "$MANUALLY_GENERATED"/hello_as_greeting_v0/* "$PROJECT_DIR/.flox/env"
 
   run "$FLOX_BIN" list
   assert_success
@@ -92,45 +100,32 @@ EOF
 
 # bats test_tags=list,list:config
 @test "'flox list --config' shows manifest content" {
-  export FLOX_FEATURES_USE_CATALOG=false
+  init_pkgdb_env
+  # mock files are copied from store with ro permissions
+  tomlq -i -t '.hook."on-activate" = "something suspicious"' "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  "$FLOX_BIN" init
-  MANIFEST_CONTENTS="$(
-    cat <<-EOF
-    [install]
-
-    [hook]
-    on-activate = "something suspicious"
+  MANIFEST_CONTENT="$(
+    cat <<EOF
+[hook]
+on-activate = "something suspicious"
 EOF
-
   )"
-
-  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
   run "$FLOX_BIN" list --config
   assert_success
-  assert_output "$MANIFEST_CONTENTS"
+  assert_output --partial "$MANIFEST_CONTENT"
 }
 
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=list,list:not-applicable
 @test "'flox list' hides packages not installed for the current system" {
-  export FLOX_FEATURES_USE_CATALOG=false
+  init_pkgdb_env
 
-  "$FLOX_BIN" init
-  MANIFEST_CONTENTS="$(
-    cat <<-EOF
-    [options]
-    systems = [ "$NIX_SYSTEM" ]
-    [install]
-    hello.pkg-path = "hello"
-    htop = { pkg-path = "htop", systems = [] }
-EOF
-
-  )"
-
-  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
+  # Mock env with `hello` installed for all systems
+  # and `htop` for no system to emulate a package not installed
+  # for the current system on all systems.
+  cp "$MANUALLY_GENERATED"/hello_and_htop_for_no_system_v0/* "$PROJECT_DIR/.flox/env"
 
   run "$FLOX_BIN" list -n
   assert_success
@@ -142,7 +137,7 @@ EOF
 # https://github.com/flox/flox/issues/1039
 # bats test_tags=list,list:tolerates-missing-version
 @test "'flox list' tolerates missing version" {
-  export FLOX_FEATURES_USE_CATALOG=false
+  export FLOX_FEATURES_USE_CATALOG=false # todo: port
 
   "$FLOX_BIN" init
   # `influxdb does not have a version attribute set in nixpkgs (2024-02-19)

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -218,20 +218,6 @@ function add_incompatible_package() {
   assert [ $(cat .flox/env.json | jq -r '.owner') == "owner" ]
 }
 
-# bats test_tags=pull:l2,pull:l2:c
-@test "l2.c: flox pull with --remote and --dir pulls into the specified directory" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  make_dummy_env "owner" "name"
-
-  run "$FLOX_BIN" pull --remote owner/name --dir ./inner
-  assert_success
-  assert [ -e "inner/.flox/env.json" ]
-  assert [ -e "inner/.flox/env.lock" ]
-  assert [ $(cat inner/.flox/env.json | jq -r '.name') == "name" ]
-  assert [ $(cat inner/.flox/env.json | jq -r '.owner') == "owner" ]
-}
-
 # bats test_tags=pull:l3,pull:l3:a
 @test "l3.a: pulling without namespace/environment" {
   export FLOX_FEATURES_USE_CATALOG=false

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -248,35 +248,6 @@ function add_incompatible_package() {
 
 # ---------------------------------------------------------------------------- #
 
-# bats test_tags=pull:add-system-flag
-# pulling an environment without packages for the current platform
-#should fail with an error
-@test "pull environment inside the same environment without the '--force' flag" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  make_dummy_env "owner" "name"
-  update_dummy_env "owner" "name"
-
-  run "$FLOX_BIN" pull --remote owner/name
-  assert_success
-  run "$FLOX_BIN" pull --remote owner/name
-  assert_failure
-}
-
-# bats test_tags=pull:add-system-flag
-# pulling an environment without packages for the current platform
-@test "pull environment inside the same environment with '--force' flag" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  make_dummy_env "owner" "name"
-  update_dummy_env "owner" "name"
-
-  run "$FLOX_BIN" pull --remote owner/name
-  assert_success
-  run "$FLOX_BIN" pull --remote owner/name --force
-  assert_success
-}
-
 # bats test_tags=pull:unsupported:warning
 # An environment that is not compatible with the current ssystem
 # due to the current system missing <system> in `option.systems`

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -237,39 +237,6 @@ function add_incompatible_package() {
   assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
 }
 
-#
-# Notice: l5 is tested in l2.a and l2.c
-#
-
-# bats test_tags=pull:l6,pull:l6:a
-@test "l6.a: pulling the same remote environment in multiple directories creates unique copies of the environment" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  make_dummy_env "owner" "name"
-
-  mkdir first second
-
-  "$FLOX_BIN" pull --remote owner/name --dir first
-  LOCKED_FIRST_BEFORE=$(cat ./first/.flox/env.lock | jq -r '.rev')
-
-  update_dummy_env "owner" "name"
-  LOCKED_FIRST_AFTER=$(cat ./first/.flox/env.lock | jq -r '.rev')
-
-  "$FLOX_BIN" pull --remote owner/name --dir second
-  LOCKED_SECOND=$(cat ./second/.flox/env.lock | jq -r '.rev')
-
-  assert [ "$LOCKED_FIRST_BEFORE" == "$LOCKED_FIRST_AFTER" ]
-  assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_SECOND" ]
-
-  # after pulling first env, its at the rame rev as the second that was pulled after the update
-  "$FLOX_BIN" pull --dir first
-
-  LOCKED_FIRST_AFTER_PULL=$(cat ./first/.flox/env.lock | jq -r '.rev')
-
-  assert [ "$LOCKED_FIRST_BEFORE" != "$LOCKED_FIRST_AFTER_PULL" ]
-  assert [ "$LOCKED_FIRST_AFTER_PULL" == "$LOCKED_SECOND" ]
-}
-
 # bats test_tags=pull:floxhub
 # try pulling from floxhub authenticated with a test token
 @test "l?: pull environment from FloxHub" {

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -359,9 +359,10 @@ function add_incompatible_package() {
 # bats test_tags=pull:up-to-date
 # updating an up-to-date environment should return with an info message
 @test "pull up-to-date env returns info message" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
   make_dummy_env "owner" "name"
+
+  # dummy environment has no packages to resolve
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.json"
 
   # pull a fresh environment
   "$FLOX_BIN" pull --remote owner/name

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -218,25 +218,6 @@ function add_incompatible_package() {
   assert [ $(cat .flox/env.json | jq -r '.owner') == "owner" ]
 }
 
-# bats test_tags=pull:l3,pull:l3:a
-@test "l3.a: pulling without namespace/environment" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  make_dummy_env "owner" "name"
-
-  "$FLOX_BIN" pull --remote owner/name # dummy remote as we are not actually pulling anything
-  LOCKED_BEFORE=$(cat .flox/env.lock | jq -r '.rev')
-
-  update_dummy_env "owner" "name"
-
-  run "$FLOX_BIN" pull
-  assert_success
-
-  LOCKED_AFTER=$(cat .flox/env.lock | jq -r '.rev')
-
-  assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
-}
-
 # bats test_tags=pull:floxhub
 # try pulling from floxhub authenticated with a test token
 @test "l?: pull environment from FloxHub" {

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -218,21 +218,6 @@ function add_incompatible_package() {
   assert [ $(cat .flox/env.json | jq -r '.owner') == "owner" ]
 }
 
-# bats test_tags=pull:l2,pull:l2:b
-@test "l2.b: flox pull with --remote fails if an env is already present" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  make_dummy_env "owner" "name"
-
-  "$FLOX_BIN" pull --remote owner/name # dummy remote as we are not actually pulling anything
-
-  run "$FLOX_BIN" pull --remote owner/name # dummy remote as we are not actually pulling anything
-  assert_failure
-
-  # todo: error message
-  # assert_output --partial <error message>
-}
-
 # bats test_tags=pull:l2,pull:l2:c
 @test "l2.c: flox pull with --remote and --dir pulls into the specified directory" {
   export FLOX_FEATURES_USE_CATALOG=false

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -276,7 +276,17 @@ function add_incompatible_package() {
 
   make_dummy_env "owner" "name"
   update_dummy_env "owner" "name"
-  make_incompatible "owner" "name"
+
+  if [ -z "${NIX_SYSTEM##*-linux}" ]; then
+    ENV_FILES_DIR="$MANUALLY_GENERATED/ps_v0_aarch64-darwin"
+  elif [ -z "${NIX_SYSTEM#*-darwin}" ]; then
+    ENV_FILES_DIR="$MANUALLY_GENERATED/glibc_v0_x86_64-linux"
+  else
+    echo "unknown system: '$NIX_SYSTEM'"
+    exit 1
+  fi
+
+  copy_manifest_and_lockfile_to_remote "owner" "name" "$ENV_FILES_DIR"
 
   run "$FLOX_BIN" activate --remote owner/name --trust
   assert_failure

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -237,25 +237,6 @@ function add_incompatible_package() {
   assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
 }
 
-# bats test_tags=pull:l3,pull:l3:b
-@test "l3.b: pulling without namespace/environment respects --dir" {
-  export FLOX_FEATURES_USE_CATALOG=false
-
-  make_dummy_env "owner" "name"
-
-  "$FLOX_BIN" pull --remote owner/name --dir ./inner # dummy remote as we are not actually pulling anything
-  LOCKED_BEFORE=$(cat ./inner/.flox/env.lock | jq -r '.rev')
-
-  update_dummy_env "owner" "name"
-
-  run "$FLOX_BIN" pull --dir ./inner
-  assert_success
-
-  LOCKED_AFTER=$(cat ./inner/.flox/env.lock | jq -r '.rev')
-
-  assert [ "$LOCKED_BEFORE" != "$LOCKED_AFTER" ]
-}
-
 #
 # Notice: l5 is tested in l2.a and l2.c
 #

--- a/test_data/manually_generated/hello_and_htop_for_no_system_v0/manifest.lock
+++ b/test_data/manually_generated/hello_and_htop_for_no_system_v0/manifest.lock
@@ -1,0 +1,192 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "install": {
+      "hello": {
+        "pkg-path": "hello"
+      },
+      "htop": {
+        "pkg-path": "htop",
+        "systems": []
+      }
+    },
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ]
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "ref": "release-23.11",
+            "repo": "nixpkgs",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    }
+  },
+  "packages": {
+    "aarch64-darwin": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      },
+      "htop": null
+    },
+    "aarch64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      },
+      "htop": null
+    },
+    "x86_64-darwin": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      },
+      "htop": null
+    },
+    "x86_64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      },
+      "htop": null
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1706666764,
+          "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/test_data/manually_generated/hello_and_htop_for_no_system_v0/manifest.toml
+++ b/test_data/manually_generated/hello_and_htop_for_no_system_v0/manifest.toml
@@ -1,0 +1,12 @@
+# A lock was generated for this manifest with
+# FLOX_FEATURES_USE_CATALOG=false flox init
+# FLOX_FEATURES_USE_CATALOG=false flox edit -f ./test_data/manually_generated/hello_v0/manifest.toml
+# cp .flox/env/manifest.lock test_data/manually_generated/hello_v0/manifest.lock
+
+[install]
+hello.pkg-path = "hello"
+htop.pkg-path = "htop"
+htop.systems = []
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/manually_generated/hello_as_greeting_v0/manifest.lock
+++ b/test_data/manually_generated/hello_as_greeting_v0/manifest.lock
@@ -1,0 +1,184 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "install": {
+      "greeting": {
+        "pkg-path": "hello"
+      }
+    },
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ]
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "ref": "release-23.11",
+            "repo": "nixpkgs",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    }
+  },
+  "packages": {
+    "aarch64-darwin": {
+      "greeting": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "aarch64-linux": {
+      "greeting": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-darwin": {
+      "greeting": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-linux": {
+      "greeting": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1706666764,
+          "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/test_data/manually_generated/hello_as_greeting_v0/manifest.toml
+++ b/test_data/manually_generated/hello_as_greeting_v0/manifest.toml
@@ -1,0 +1,10 @@
+# A lock was generated for this manifest with
+# FLOX_FEATURES_USE_CATALOG=false flox init
+# FLOX_FEATURES_USE_CATALOG=false flox edit -f ./test_data/manually_generated/hello_as_greeting_v0/manifest.toml
+# cp .flox/env/manifest.lock test_data/manually_generated/hello_as_greeting_v0/manifest.lock
+
+[install]
+greeting.pkg-path = "hello"
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/manually_generated/hello_for_activate_v0/manifest.lock
+++ b/test_data/manually_generated/hello_for_activate_v0/manifest.lock
@@ -1,0 +1,197 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "hook": {
+      "on-activate": "  echo \"sourcing hook.on-activate\";\n"
+    },
+    "install": {
+      "hello": {
+        "pkg-path": "hello"
+      }
+    },
+    "options": {
+      "systems": [
+        "x86_64-linux",
+        "x86_64-darwin",
+        "aarch64-linux",
+        "aarch64-darwin"
+      ]
+    },
+    "profile": {
+      "bash": "  echo \"sourcing profile.bash\";\n",
+      "common": "  echo \"sourcing profile.common\";\n",
+      "fish": "  echo \"sourcing profile.fish\";\n",
+      "tcsh": "  echo \"sourcing profile.tcsh\";\n",
+      "zsh": "  echo \"sourcing profile.zsh\";\n"
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "ab5fd150146dcfe41fda501134e6503932cc8dfd",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    },
+    "vars": {
+      "foo": "baz"
+    }
+  },
+  "packages": {
+    "aarch64-darwin": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "aarch64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-darwin": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1706666764,
+          "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/test_data/manually_generated/hello_for_activate_v0/manifest.toml
+++ b/test_data/manually_generated/hello_for_activate_v0/manifest.toml
@@ -1,0 +1,30 @@
+[install]
+hello.pkg-path = "hello"
+
+[vars]
+foo = "baz"
+
+[hook]
+on-activate = """
+  echo "sourcing hook.on-activate";
+"""
+
+[profile]
+common = """
+  echo "sourcing profile.common";
+"""
+bash = """
+  echo "sourcing profile.bash";
+"""
+fish = """
+  echo "sourcing profile.fish";
+"""
+tcsh = """
+  echo "sourcing profile.tcsh";
+"""
+zsh = """
+  echo "sourcing profile.zsh";
+"""
+
+[options]
+systems = ["x86_64-linux", "x86_64-darwin", "aarch64-linux", "aarch64-darwin"]

--- a/test_data/manually_generated/hello_for_catalog_v0/manifest.lock
+++ b/test_data/manually_generated/hello_for_catalog_v0/manifest.lock
@@ -1,0 +1,128 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "hook": {
+      "on-activate": "    command -v hello\n    hello\n"
+    },
+    "install": {
+      "hello": {
+        "pkg-path": "hello"
+      }
+    },
+    "options": {
+      "systems": [
+        "x86_64-linux",
+        "aarch64-linux"
+      ]
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "ref": "release-23.11",
+            "repo": "nixpkgs",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    },
+    "vars": {
+      "foo": "bar"
+    }
+  },
+  "packages": {
+    "aarch64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1706666764,
+          "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/test_data/manually_generated/hello_for_catalog_v0/manifest.toml
+++ b/test_data/manually_generated/hello_for_catalog_v0/manifest.toml
@@ -9,3 +9,6 @@ on-activate = """
     command -v hello
     hello
 """
+
+[options]
+systems = ["x86_64-linux", "aarch64-linux"]

--- a/test_data/manually_generated/hello_for_containerize_v0/manifest.lock
+++ b/test_data/manually_generated/hello_for_containerize_v0/manifest.lock
@@ -1,0 +1,190 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "hook": {
+      "on-activate": "    command -v hello\n    hello\n"
+    },
+    "install": {
+      "hello": {
+        "pkg-path": "hello"
+      }
+    },
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ]
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "ab5fd150146dcfe41fda501134e6503932cc8dfd",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    },
+    "vars": {
+      "foo": "bar"
+    }
+  },
+  "packages": {
+    "aarch64-darwin": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "aarch64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-darwin": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1706666764,
+          "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/test_data/manually_generated/hello_for_containerize_v0/manifest.toml
+++ b/test_data/manually_generated/hello_for_containerize_v0/manifest.toml
@@ -1,0 +1,19 @@
+# A lock was generated for this manifest with
+# FLOX_FEATURES_USE_CATALOG=false flox init
+# FLOX_FEATURES_USE_CATALOG=false flox edit -f ./test_data/manually_generated/hello_for_containerize_v0/manifest.toml
+# cp .flox/env/manifest.lock test_data/manually_generated/hello_for_containerize_v0/manifest.lock
+
+[install]
+hello.pkg-path = "hello"
+
+[vars]
+foo = "bar"
+
+[hook]
+on-activate = """
+    command -v hello
+    hello
+"""
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/manually_generated/hello_v0/manifest.lock
+++ b/test_data/manually_generated/hello_v0/manifest.lock
@@ -6,6 +6,14 @@
         "pkg-path": "hello"
       }
     },
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ]
+    },
     "registry": {
       "defaults": {
         "subtrees": null
@@ -46,15 +54,105 @@
         },
         "input": {
           "attrs": {
-            "lastModified": 1718132686,
-            "narHash": "sha256-JRinkq+FeAkYnrrK8+Bh+jtLHJBN5jDzSimk1ye00EE=",
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
             "owner": "NixOS",
             "repo": "nixpkgs",
-            "rev": "96b3dae4f8753c1f5ce0d06b57fe250fb5d9b0e0",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
             "type": "github"
           },
-          "fingerprint": "d00f00cc0b4a10cd832ce3f73a3fcdfbab77482451eeabfd99c2f0fb1ada3cb0",
-          "url": "github:NixOS/nixpkgs/96b3dae4f8753c1f5ce0d06b57fe250fb5d9b0e0"
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "aarch64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-darwin": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-darwin",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-linux": {
+      "hello": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "hello"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A program that produces a familiar, friendly greeting",
+          "license": "GPL-3.0-or-later",
+          "pname": "hello",
+          "unfree": false,
+          "version": "2.12.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
         },
         "priority": 5
       }
@@ -67,11 +165,11 @@
     "inputs": {
       "nixpkgs": {
         "from": {
-          "lastModified": 1718132686,
-          "narHash": "sha256-JRinkq+FeAkYnrrK8+Bh+jtLHJBN5jDzSimk1ye00EE=",
+          "lastModified": 1706666764,
+          "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
           "owner": "NixOS",
           "repo": "nixpkgs",
-          "rev": "96b3dae4f8753c1f5ce0d06b57fe250fb5d9b0e0",
+          "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
           "type": "github"
         },
         "subtrees": [

--- a/test_data/manually_generated/hello_v0/manifest.toml
+++ b/test_data/manually_generated/hello_v0/manifest.toml
@@ -5,3 +5,6 @@
 
 [install]
 hello.pkg-path = "hello"
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/manually_generated/influxdb2_v0/manifest.lock
+++ b/test_data/manually_generated/influxdb2_v0/manifest.lock
@@ -1,0 +1,184 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "install": {
+      "influxdb2": {
+        "pkg-path": "influxdb2"
+      }
+    },
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ]
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "ab5fd150146dcfe41fda501134e6503932cc8dfd",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    }
+  },
+  "packages": {
+    "aarch64-darwin": {
+      "influxdb2": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-darwin",
+          "influxdb2"
+        ],
+        "info": {
+          "broken": false,
+          "description": null,
+          "license": null,
+          "pname": "influxdb2",
+          "unfree": false,
+          "version": null
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "aarch64-linux": {
+      "influxdb2": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "influxdb2"
+        ],
+        "info": {
+          "broken": false,
+          "description": null,
+          "license": null,
+          "pname": "influxdb2",
+          "unfree": false,
+          "version": null
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-darwin": {
+      "influxdb2": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-darwin",
+          "influxdb2"
+        ],
+        "info": {
+          "broken": false,
+          "description": null,
+          "license": null,
+          "pname": "influxdb2",
+          "unfree": false,
+          "version": null
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-linux": {
+      "influxdb2": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "influxdb2"
+        ],
+        "info": {
+          "broken": false,
+          "description": null,
+          "license": null,
+          "pname": "influxdb2",
+          "unfree": false,
+          "version": null
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1706666764,
+          "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/test_data/manually_generated/influxdb2_v0/manifest.toml
+++ b/test_data/manually_generated/influxdb2_v0/manifest.toml
@@ -1,0 +1,11 @@
+# A lock was generated for this manifest with
+# FLOX_FEATURES_USE_CATALOG=false flox init
+# FLOX_FEATURES_USE_CATALOG=false flox edit -f ./test_data/manually_generated/hello_v0/manifest.toml
+# cp .flox/env/manifest.lock test_data/manually_generated/hello_v0/manifest.lock
+
+[install]
+influxdb2.pkg-path = "influxdb2"
+
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/manually_generated/ld_floxlib_test_deps_v0/manifest.lock
+++ b/test_data/manually_generated/ld_floxlib_test_deps_v0/manifest.lock
@@ -1,0 +1,537 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "install": {
+      "boost": {
+        "pkg-path": "boost"
+      },
+      "curl": {
+        "pkg-path": "curl"
+      },
+      "gcc": {
+        "pkg-path": "gcc"
+      },
+      "gcc-unwrapped": {
+        "pkg-path": "gcc-unwrapped",
+        "priority": 4
+      },
+      "glibc": {
+        "pkg-path": "glibc"
+      },
+      "libarchive": {
+        "pkg-path": "libarchive"
+      },
+      "nix": {
+        "pkg-path": "nix",
+        "priority": 4
+      },
+      "patchelf": {
+        "pkg-path": "patchelf"
+      }
+    },
+    "options": {
+      "systems": [
+        "x86_64-linux",
+        "aarch64-linux"
+      ]
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    }
+  },
+  "packages": {
+    "aarch64-linux": {
+      "boost": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "boost"
+        ],
+        "info": {
+          "broken": false,
+          "description": "Collection of C++ libraries",
+          "license": "BSL-1.0",
+          "pname": "boost",
+          "unfree": false,
+          "version": "1.79.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "curl": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "curl"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A command line tool for transferring files with URL syntax",
+          "license": "curl",
+          "pname": "curl",
+          "unfree": false,
+          "version": "7.84.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "gcc": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "gcc"
+        ],
+        "info": {
+          "broken": false,
+          "description": "GNU Compiler Collection, version 9.5.0 (wrapper script)",
+          "license": "GPL-3.0-or-later",
+          "pname": "gcc-wrapper",
+          "unfree": false,
+          "version": "9.5.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "gcc-unwrapped": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "gcc-unwrapped"
+        ],
+        "info": {
+          "broken": false,
+          "description": "GNU Compiler Collection, version 9.5.0",
+          "license": "GPL-3.0-or-later",
+          "pname": "gcc",
+          "unfree": false,
+          "version": "9.5.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 4
+      },
+      "glibc": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "glibc"
+        ],
+        "info": {
+          "broken": false,
+          "description": "The GNU C Library",
+          "license": "LGPL-2.0-or-later",
+          "pname": "glibc",
+          "unfree": false,
+          "version": "2.34"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "libarchive": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "libarchive"
+        ],
+        "info": {
+          "broken": false,
+          "description": "Multi-format archive and compression library",
+          "license": "BSD-3-Clause",
+          "pname": "libarchive",
+          "unfree": false,
+          "version": "3.6.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "nix": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "nix"
+        ],
+        "info": {
+          "broken": false,
+          "description": "Powerful package manager that makes package management reliable and reproducible",
+          "license": "LGPL-2.0-or-later",
+          "pname": "nix",
+          "unfree": false,
+          "version": "2.10.3"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 4
+      },
+      "patchelf": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "patchelf"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A small utility to modify the dynamic linker and RPATH of ELF executables",
+          "license": "GPL-3.0-or-later",
+          "pname": "patchelf",
+          "unfree": false,
+          "version": "0.14.5"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-linux": {
+      "boost": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "boost"
+        ],
+        "info": {
+          "broken": false,
+          "description": "Collection of C++ libraries",
+          "license": "BSL-1.0",
+          "pname": "boost",
+          "unfree": false,
+          "version": "1.79.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "curl": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "curl"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A command line tool for transferring files with URL syntax",
+          "license": "curl",
+          "pname": "curl",
+          "unfree": false,
+          "version": "7.84.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "gcc": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "gcc"
+        ],
+        "info": {
+          "broken": false,
+          "description": "GNU Compiler Collection, version 11.3.0 (wrapper script)",
+          "license": "GPL-3.0-or-later",
+          "pname": "gcc-wrapper",
+          "unfree": false,
+          "version": "11.3.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "gcc-unwrapped": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "gcc-unwrapped"
+        ],
+        "info": {
+          "broken": false,
+          "description": "GNU Compiler Collection, version 11.3.0",
+          "license": "GPL-3.0-or-later",
+          "pname": "gcc",
+          "unfree": false,
+          "version": "11.3.0"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 4
+      },
+      "glibc": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "glibc"
+        ],
+        "info": {
+          "broken": false,
+          "description": "The GNU C Library",
+          "license": "LGPL-2.0-or-later",
+          "pname": "glibc",
+          "unfree": false,
+          "version": "2.34"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "libarchive": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "libarchive"
+        ],
+        "info": {
+          "broken": false,
+          "description": "Multi-format archive and compression library",
+          "license": "BSD-3-Clause",
+          "pname": "libarchive",
+          "unfree": false,
+          "version": "3.6.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      },
+      "nix": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "nix"
+        ],
+        "info": {
+          "broken": false,
+          "description": "Powerful package manager that makes package management reliable and reproducible",
+          "license": "LGPL-2.0-or-later",
+          "pname": "nix",
+          "unfree": false,
+          "version": "2.10.3"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 4
+      },
+      "patchelf": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "patchelf"
+        ],
+        "info": {
+          "broken": false,
+          "description": "A small utility to modify the dynamic linker and RPATH of ELF executables",
+          "license": "GPL-3.0-or-later",
+          "pname": "patchelf",
+          "unfree": false,
+          "version": "0.14.5"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1658528871,
+            "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+            "type": "github"
+          },
+          "fingerprint": "ff2ba38c55510b7489e81156c88245fdee5a071acff9715dbd67a297a2804118",
+          "url": "github:NixOS/nixpkgs/bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1658528871,
+          "narHash": "sha256-QlD1KEZ4XhjjXAAv8Vi1n+Q7ZqnXBjdjNwikHPN0Tkw=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "bc01a2be500c10f1507dcc8e98c9f5bd72c02aa3",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/test_data/manually_generated/ld_floxlib_test_deps_v0/manifest.toml
+++ b/test_data/manually_generated/ld_floxlib_test_deps_v0/manifest.toml
@@ -7,3 +7,6 @@ glibc.pkg-path = "glibc"
 libarchive.pkg-path = "libarchive"
 nix = { pkg-path = "nix", priority = 4 }
 patchelf.pkg-path = "patchelf"
+
+[options]
+systems = ["x86_64-linux", "aarch64-linux"]

--- a/test_data/manually_generated/python_v0/manifest.lock
+++ b/test_data/manually_generated/python_v0/manifest.lock
@@ -1,0 +1,188 @@
+{
+  "lockfile-version": 0,
+  "manifest": {
+    "install": {
+      "pip": {
+        "pkg-path": "python311Packages.pip"
+      }
+    },
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ]
+    },
+    "registry": {
+      "defaults": {
+        "subtrees": null
+      },
+      "inputs": {
+        "nixpkgs": {
+          "from": {
+            "owner": "NixOS",
+            "ref": "release-23.11",
+            "repo": "nixpkgs",
+            "type": "github"
+          },
+          "subtrees": [
+            "legacyPackages"
+          ]
+        }
+      },
+      "priority": [
+        "nixpkgs"
+      ]
+    }
+  },
+  "packages": {
+    "aarch64-darwin": {
+      "pip": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-darwin",
+          "python311Packages",
+          "pip"
+        ],
+        "info": {
+          "broken": false,
+          "description": "The PyPA recommended tool for installing Python packages",
+          "license": null,
+          "pname": "pip",
+          "unfree": false,
+          "version": "23.2.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "aarch64-linux": {
+      "pip": {
+        "attr-path": [
+          "legacyPackages",
+          "aarch64-linux",
+          "python311Packages",
+          "pip"
+        ],
+        "info": {
+          "broken": false,
+          "description": "The PyPA recommended tool for installing Python packages",
+          "license": null,
+          "pname": "pip",
+          "unfree": false,
+          "version": "23.2.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-darwin": {
+      "pip": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-darwin",
+          "python311Packages",
+          "pip"
+        ],
+        "info": {
+          "broken": false,
+          "description": "The PyPA recommended tool for installing Python packages",
+          "license": null,
+          "pname": "pip",
+          "unfree": false,
+          "version": "23.2.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    },
+    "x86_64-linux": {
+      "pip": {
+        "attr-path": [
+          "legacyPackages",
+          "x86_64-linux",
+          "python311Packages",
+          "pip"
+        ],
+        "info": {
+          "broken": false,
+          "description": "The PyPA recommended tool for installing Python packages",
+          "license": null,
+          "pname": "pip",
+          "unfree": false,
+          "version": "23.2.1"
+        },
+        "input": {
+          "attrs": {
+            "lastModified": 1706666764,
+            "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+            "type": "github"
+          },
+          "fingerprint": "bbc93a7d71106b6b24a3444467780d709b0f0ef8a07ed6c1c8af638e6765443e",
+          "url": "github:NixOS/nixpkgs/7731670498f0a22c361c9d68f73d382bce05d7dc"
+        },
+        "priority": 5
+      }
+    }
+  },
+  "registry": {
+    "defaults": {
+      "subtrees": null
+    },
+    "inputs": {
+      "nixpkgs": {
+        "from": {
+          "lastModified": 1706666764,
+          "narHash": "sha256-M59UCWsadEFO+DMdZFMtTlxpFyT3RQIpBLuEX8oziVc=",
+          "owner": "NixOS",
+          "repo": "nixpkgs",
+          "rev": "7731670498f0a22c361c9d68f73d382bce05d7dc",
+          "type": "github"
+        },
+        "subtrees": [
+          "legacyPackages"
+        ]
+      }
+    },
+    "priority": [
+      "nixpkgs"
+    ]
+  }
+}

--- a/test_data/manually_generated/python_v0/manifest.toml
+++ b/test_data/manually_generated/python_v0/manifest.toml
@@ -1,0 +1,12 @@
+# generated with flox 1.2.2
+#
+# $ export FLOX_FEATURES_USE_CATALOG=false
+# $ flox init
+# $ flox edit -f <this file>
+# $ cp .flox/env/* test_data/manually_generated/python_v0
+
+[install]
+pip.pkg-path = "python311Packages.pip"
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]


### PR DESCRIPTION
* Convert bats tests that were previously depending on `FLOX_FEATURES_USE_CATALOG=false` in their setup to using prepared/bundled manifests and locks.
* Convert bats tests to use catalog based v1 environments that were depending on `FLOX_FEATURES_USE_CATALOG=false` but test behaviour unrelated to the kind of environment where there was no catalog variant yet.
* Delete bats tests that were depending on `FLOX_FEATURES_USE_CATALOG=false` but test behaviour unrelated to the kind of environment.
* Delete bats tests that were depending on `FLOX_FEATURES_USE_CATALOG=false` and testing deprecated functionality (e.g. `edit` and `upgrade`)
* change the behaviour of `push_new` to conditionally lock.