### PR TITLE
fix: wrap metrics blocking reqwest in thread with timeout

### DIFF
--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -465,6 +465,15 @@ impl Connection for AWSDatalakeConnection {
         debug!("Sending metrics to {}", &self.endpoint_url);
         debug!("Metrics: {events:#}");
 
+        // Wrap the blocking reqwest client in a thread where we can provide our
+        // own timeout to kill the thread.
+        // The blocking reqwest client makes a call to getaddrinfo which uses the
+        // system libc. This doesn't respect the timeout of the reqwest client
+        // and can block our program for however long it can take DNS to timeout:
+        // https://github.com/flox/flox/pull/1769#issuecomment-2260675622
+        // This can often be greater than 15 or 30 seconds. It shows up often when
+        // a local resolver is configured to forward to the internet, but Wi-Fi
+        // is disabled, but also could occur whenever DNS doesn't respond.
         let thread_timeout = self.timeout;
         let thread_endpoint_url = self.endpoint_url.clone();
         let thread_api_key = self.api_key.clone();


### PR DESCRIPTION
This works for bounding the reqwest getaddrinfo call to the desired timeout

@ysndr suggested this in https://github.com/flox/flox/pull/1769#issuecomment-2260675622

issue: #1766