### PR TITLE
feat(commands): Indicate running PID in status out

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -5,16 +5,13 @@
 //! Note that `process-compose` terminates when all services are stopped. To prevent this, we inject
 //! a dummy service (`flox_never_exit`) that sleeps indefinitely.
 
-use std::cmp::max;
 use std::collections::BTreeMap;
 use std::env;
-use std::fmt::Display;
 use std::io::{BufRead, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{Receiver, Sender};
 
-use itertools::Itertools;
 use once_cell::sync::Lazy;
 #[cfg(test)]
 use proptest::prelude::*;
@@ -210,16 +207,16 @@ pub fn maybe_make_service_config_file(
 
 /// The parsed output of `process-compose process list` for a single process.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-struct ProcessState {
-    name: String,
+pub struct ProcessState {
+    pub name: String,
     namespace: String,
-    status: String,
+    pub status: String,
     system_time: String,
     age: u64,
     is_ready: String,
     restarts: u64,
     exit_code: i32,
-    pid: u64,
+    pub pid: u64,
     #[serde(skip_serializing, rename = "IsRunning")]
     is_running: bool,
 }
@@ -272,60 +269,18 @@ impl ProcessStates {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-/// Simplified version of ProcessState for display in the CLI.
-pub struct ProcessStateDisplay {
-    name: String,
-    status: String,
-    pid: u64,
-}
-
-#[derive(Clone, Debug, Serialize)]
-/// Simplified version of ProcessStates for display in the CLI.
-pub struct ProcessStatesDisplay(Vec<ProcessStateDisplay>);
-
-impl From<ProcessStates> for ProcessStatesDisplay {
-    fn from(procs: ProcessStates) -> Self {
-        ProcessStatesDisplay(
-            procs
-                .0
-                .into_iter()
-                .sorted_by_key(|proc| proc.name.clone())
-                .map(|proc| ProcessStateDisplay {
-                    name: proc.name,
-                    status: proc.status,
-                    pid: proc.pid,
-                })
-                .collect(),
-        )
-    }
-}
-
-impl IntoIterator for ProcessStatesDisplay {
-    type IntoIter = std::vec::IntoIter<ProcessStateDisplay>;
-    type Item = ProcessStateDisplay;
+impl IntoIterator for ProcessStates {
+    type IntoIter = std::vec::IntoIter<ProcessState>;
+    type Item = ProcessState;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl Display for ProcessStatesDisplay {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name_width_min = 10;
-        let name_width = max(
-            name_width_min,
-            self.0.iter().map(|proc| proc.name.len()).max().unwrap_or(0),
-        );
-        writeln!(f, "{:<name_width$} {:<10} {:>8}", "NAME", "STATUS", "PID")?;
-        for proc in &self.0 {
-            writeln!(
-                f,
-                "{:<name_width$} {:<10} {:>8}",
-                proc.name, proc.status, proc.pid
-            )?;
-        }
-        Ok(())
+impl From<Vec<ProcessState>> for ProcessStates {
+    fn from(procs: Vec<ProcessState>) -> Self {
+        ProcessStates(procs)
     }
 }
 
@@ -608,6 +563,26 @@ impl ProcessComposeLogReader {
     }
 }
 
+pub mod test_helpers {
+    use super::*;
+
+    /// Shorthand for generating a ProcessState with fields that we care about.
+    pub fn generate_process_state(name: &str, status: &str, pid: u64) -> ProcessState {
+        ProcessState {
+            name: name.to_string(),
+            namespace: "".to_string(),
+            status: status.to_string(),
+            system_time: "".to_string(),
+            age: 0,
+            is_ready: "".to_string(),
+            restarts: 0,
+            exit_code: 0,
+            pid,
+            is_running: true,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -852,97 +827,5 @@ mod tests {
             "expected no more messages, got: {:?}",
             remaining_messages
         );
-    }
-
-    /// Shorthand for generating a ProcessState with fields that we care about.
-    fn generate_process_state(name: &str, status: &str, pid: u64) -> ProcessState {
-        ProcessState {
-            name: name.to_string(),
-            namespace: "".to_string(),
-            status: status.to_string(),
-            system_time: "".to_string(),
-            age: 0,
-            is_ready: "".to_string(),
-            restarts: 0,
-            exit_code: 0,
-            pid,
-            is_running: true,
-        }
-    }
-
-    #[test]
-    fn test_processstatesdisplay_name_sorted() {
-        let states = ProcessStates {
-            0: vec![
-                generate_process_state("bbb", "Running", 123),
-                generate_process_state("zzz", "Running", 123),
-                generate_process_state("aaa", "Running", 123),
-                generate_process_state("ccc", "Running", 123),
-            ],
-        };
-        let states_display: ProcessStatesDisplay = states.into();
-        assert_eq!(format!("{states_display}"), indoc! {"
-            NAME       STATUS          PID
-            aaa        Running         123
-            bbb        Running         123
-            ccc        Running         123
-            zzz        Running         123
-        "});
-    }
-
-    #[test]
-    fn test_processstatesdisplay_name_padded() {
-        let states = ProcessStates {
-            0: vec![
-                generate_process_state("short", "Running", 123),
-                generate_process_state("longlonglonglonglong", "Running", 123),
-            ],
-        };
-        let states_display: ProcessStatesDisplay = states.into();
-        assert_eq!(format!("{states_display}"), indoc! {"
-            NAME                 STATUS          PID
-            longlonglonglonglong Running         123
-            short                Running         123
-        "});
-    }
-
-    #[test]
-    fn test_processstatesdisplay_status_variants() {
-        let states = ProcessStates {
-            0: vec![
-                generate_process_state("aaa", "Running", 123),
-                generate_process_state("bbb", "Stopped", 123),
-                generate_process_state("ccc", "Completed", 123),
-            ],
-        };
-        let states_display: ProcessStatesDisplay = states.into();
-        assert_eq!(format!("{states_display}"), indoc! {"
-            NAME       STATUS          PID
-            aaa        Running         123
-            bbb        Stopped         123
-            ccc        Completed       123
-        "});
-    }
-
-    #[test]
-    fn test_processstatesdisplay_pid_aligned() {
-        let states = ProcessStates {
-            0: vec![
-                generate_process_state("aaa", "Running", 1),
-                generate_process_state("bbb", "Running", 12),
-                generate_process_state("ccc", "Running", 123),
-                generate_process_state("ddd", "Running", 1234),
-                generate_process_state("eee", "Running", 12345),
-            ],
-        };
-        let states_display: ProcessStatesDisplay = states.into();
-        assert_eq!(format!("{states_display}"), indoc! {"
-            NAME       STATUS          PID
-            aaa        Running           1
-            bbb        Running          12
-            ccc        Running         123
-            ddd        Running        1234
-            eee        Running       12345
-        "});
     }
 }

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -221,7 +221,8 @@ pub struct ProcessState {
     pub is_running: bool,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, derive_more::From)]
+#[from(forward)]
 pub struct ProcessStates(Vec<ProcessState>);
 
 impl ProcessStates {
@@ -275,12 +276,6 @@ impl IntoIterator for ProcessStates {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
-    }
-}
-
-impl From<Vec<ProcessState>> for ProcessStates {
-    fn from(procs: Vec<ProcessState>) -> Self {
-        ProcessStates(procs)
     }
 }
 

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -218,7 +218,7 @@ pub struct ProcessState {
     exit_code: i32,
     pub pid: u64,
     #[serde(skip_serializing, rename = "IsRunning")]
-    is_running: bool,
+    pub is_running: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -567,7 +567,12 @@ pub mod test_helpers {
     use super::*;
 
     /// Shorthand for generating a ProcessState with fields that we care about.
-    pub fn generate_process_state(name: &str, status: &str, pid: u64) -> ProcessState {
+    pub fn generate_process_state(
+        name: &str,
+        status: &str,
+        pid: u64,
+        is_running: bool,
+    ) -> ProcessState {
         ProcessState {
             name: name.to_string(),
             namespace: "".to_string(),
@@ -578,7 +583,7 @@ pub mod test_helpers {
             restarts: 0,
             exit_code: 0,
             pid,
-            is_running: true,
+            is_running,
         }
     }
 }

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -1,7 +1,12 @@
+use std::cmp::max;
+use std::fmt::Display;
+
 use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::services::{ProcessStates, ProcessStatesDisplay};
+use flox_rust_sdk::providers::services::ProcessStates;
+use itertools::Itertools;
+use serde::Serialize;
 use tracing::instrument;
 
 use super::supported_environment;
@@ -46,5 +51,138 @@ impl Status {
         }
 
         Ok(())
+    }
+}
+
+/// Simplified version of ProcessState for display in the CLI.
+#[derive(Clone, Debug, Serialize)]
+struct ProcessStateDisplay {
+    name: String,
+    status: String,
+    pid: u64,
+}
+
+/// Simplified version of ProcessStates for display in the CLI.
+#[derive(Clone, Debug, Serialize)]
+struct ProcessStatesDisplay(Vec<ProcessStateDisplay>);
+
+impl From<ProcessStates> for ProcessStatesDisplay {
+    fn from(procs: ProcessStates) -> Self {
+        ProcessStatesDisplay(
+            procs
+                .into_iter()
+                .sorted_by_key(|proc| proc.name.clone())
+                .map(|proc| ProcessStateDisplay {
+                    name: proc.name,
+                    status: proc.status,
+                    pid: proc.pid,
+                })
+                .collect(),
+        )
+    }
+}
+
+impl IntoIterator for ProcessStatesDisplay {
+    type IntoIter = std::vec::IntoIter<ProcessStateDisplay>;
+    type Item = ProcessStateDisplay;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Display for ProcessStatesDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name_width_min = 10;
+        let name_width = max(
+            name_width_min,
+            self.0.iter().map(|proc| proc.name.len()).max().unwrap_or(0),
+        );
+        writeln!(f, "{:<name_width$} {:<10} {:>8}", "NAME", "STATUS", "PID")?;
+        for proc in &self.0 {
+            writeln!(
+                f,
+                "{:<name_width$} {:<10} {:>8}",
+                proc.name, proc.status, proc.pid
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flox_rust_sdk::providers::services::test_helpers::generate_process_state;
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_processstatesdisplay_name_sorted() {
+        let states = ProcessStates::from(vec![
+            generate_process_state("bbb", "Running", 123),
+            generate_process_state("zzz", "Running", 123),
+            generate_process_state("aaa", "Running", 123),
+            generate_process_state("ccc", "Running", 123),
+        ]);
+        let states_display: ProcessStatesDisplay = states.into();
+        assert_eq!(format!("{states_display}"), indoc! {"
+            NAME       STATUS          PID
+            aaa        Running         123
+            bbb        Running         123
+            ccc        Running         123
+            zzz        Running         123
+        "});
+    }
+
+    #[test]
+    fn test_processstatesdisplay_name_padded() {
+        let states = ProcessStates::from(vec![
+            generate_process_state("short", "Running", 123),
+            generate_process_state("longlonglonglonglong", "Running", 123),
+        ]);
+        let states_display: ProcessStatesDisplay = states.into();
+        assert_eq!(format!("{states_display}"), indoc! {"
+            NAME                 STATUS          PID
+            longlonglonglonglong Running         123
+            short                Running         123
+        "});
+    }
+
+    #[test]
+    fn test_processstatesdisplay_status_variants() {
+        let states = ProcessStates::from(vec![
+            generate_process_state("aaa", "Running", 123),
+            generate_process_state("bbb", "Stopped", 123),
+            generate_process_state("ccc", "Completed", 123),
+        ]);
+        let states_display: ProcessStatesDisplay = states.into();
+        assert_eq!(format!("{states_display}"), indoc! {"
+            NAME       STATUS          PID
+            aaa        Running         123
+            bbb        Stopped         123
+            ccc        Completed       123
+        "});
+    }
+
+    #[test]
+    fn test_processstatesdisplay_pid_aligned() {
+        let states = ProcessStates::from(vec![
+            generate_process_state("aaa", "Running", 1),
+            generate_process_state("bbb", "Running", 12),
+            generate_process_state("ccc", "Running", 123),
+            generate_process_state("ddd", "Running", 1234),
+            generate_process_state("eee", "Running", 12345),
+        ]);
+        let states_display: ProcessStatesDisplay = states.into();
+        assert_eq!(format!("{states_display}"), indoc! {"
+            NAME       STATUS          PID
+            aaa        Running           1
+            bbb        Running          12
+            ccc        Running         123
+            ddd        Running        1234
+            eee        Running       12345
+        "});
     }
 }

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -105,6 +105,7 @@ impl IntoIterator for ProcessStatesDisplay {
     }
 }
 
+/// Formats `ProcessStates` as a table for display in the CLI.
 impl Display for ProcessStatesDisplay {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // TODO: Use a table writer library if we add any more variable width calculations.

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -107,16 +107,25 @@ impl IntoIterator for ProcessStatesDisplay {
 
 impl Display for ProcessStatesDisplay {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: Use a table writer library if we add any more variable width calculations.
         let name_width_min = 10;
         let name_width = max(
             name_width_min,
             self.0.iter().map(|proc| proc.name.len()).max().unwrap_or(0),
         );
-        writeln!(f, "{:<name_width$} {:<10} {:>8}", "NAME", "STATUS", "PID")?;
+        // Max value based on the possible states in:
+        // https://github.com/F1bonacc1/process-compose/blob/v1.9.0/src/types/process.go#L125-L137
+        let status_width = 12;
+
+        writeln!(
+            f,
+            "{:<name_width$} {:<status_width$} {:>8}",
+            "NAME", "STATUS", "PID"
+        )?;
         for proc in &self.0 {
             writeln!(
                 f,
-                "{:<name_width$} {:<10} {:>8}",
+                "{:<name_width$} {:<status_width$} {:>8}",
                 proc.name,
                 proc.status,
                 proc.pid_display()
@@ -146,11 +155,11 @@ mod tests {
         ]);
         let states_display: ProcessStatesDisplay = states.into();
         assert_eq!(format!("{states_display}"), indoc! {"
-            NAME       STATUS          PID
-            aaa        Running         123
-            bbb        Running         123
-            ccc        Running         123
-            zzz        Running         123
+            NAME       STATUS            PID
+            aaa        Running           123
+            bbb        Running           123
+            ccc        Running           123
+            zzz        Running           123
         "});
     }
 
@@ -162,9 +171,9 @@ mod tests {
         ]);
         let states_display: ProcessStatesDisplay = states.into();
         assert_eq!(format!("{states_display}"), indoc! {"
-            NAME                 STATUS          PID
-            longlonglonglonglong Running         123
-            short                Running         123
+            NAME                 STATUS            PID
+            longlonglonglonglong Running           123
+            short                Running           123
         "});
     }
 
@@ -177,10 +186,10 @@ mod tests {
         ]);
         let states_display: ProcessStatesDisplay = states.into();
         assert_eq!(format!("{states_display}"), indoc! {"
-            NAME       STATUS          PID
-            aaa        Running         123
-            bbb        Stopped       [123]
-            ccc        Completed     [123]
+            NAME       STATUS            PID
+            aaa        Running           123
+            bbb        Stopped         [123]
+            ccc        Completed       [123]
         "});
     }
 
@@ -195,12 +204,12 @@ mod tests {
         ]);
         let states_display: ProcessStatesDisplay = states.into();
         assert_eq!(format!("{states_display}"), indoc! {"
-            NAME       STATUS          PID
-            aaa        Running           1
-            bbb        Running          12
-            ccc        Running         123
-            ddd        Running        1234
-            eee        Running       12345
+            NAME       STATUS            PID
+            aaa        Running             1
+            bbb        Running            12
+            ccc        Running           123
+            ddd        Running          1234
+            eee        Running         12345
         "});
     }
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -268,6 +268,25 @@ EOF
   assert_output --partial "❌ ERROR: service 'one' is not running"
 }
 
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=services:status
+@test "status: lists the statuses for services" {
+  export FLOX_FEATURES_SERVICES=true
+  setup_sleeping_services
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/register_cleanup.sh"
+    "$FLOX_BIN" services status
+EOF
+)
+  assert_success
+  assert_output --regexp "NAME +STATUS +PID"
+  assert_output --regexp "one +Running +[0-9]+"
+  assert_output --regexp "two +Running +[0-9]+"
+}
+
+# ---------------------------------------------------------------------------- #
+
 @test "activate services: shows warning when services already running" {
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services


### PR DESCRIPTION
## Proposed Changes

**refactor(services): ProcessStateDisplay SDK->CLI**

Move it to the command as it's concerned with user facing display. We
have to make `ProcessState` public as a result. Added some `IntoIter`
and `From` to make `ProcessStates` easier to use from the outside.

**test(services): ProcessStateDisplay as JSON lines**

Add a test that will double check whether we expose more from the struct
than we intend to. This duplicates the iteration and `json::to_string`
in the command but it seems simple enough not to worry or warrant making
it a method on the struct right now.

**feat(commands): Indicate running PID in status out**

Wrap the PID in square brackets if the process is no longer running, to
make it clear that you'll no longer be able to see the process but the
value may still be useful for cross-checking with logs.

I've exposed `is_running` from `ProcessState` but we're not currently
including it in the JSON output of `ProcessStateDisplay` as verified by
the test in the preceding commit.

## Release Notes

Indicate inactive PIDs in `flox services status` output.