### PR TITLE
fix(cuda): Adjust behaviour for nested opt-out

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -268,10 +268,14 @@ impl Activate {
 
         let socket_path = environment.services_socket_path(&flox)?;
         if let TypedManifest::Catalog(manifest) = environment.manifest(&flox)? {
-            // default to enabling CUDA
-            if manifest.options.cuda_detection != Some(false) {
-                exports.insert("_FLOX_ENV_CUDA_DETECTION", "1".to_string());
-            }
+            exports.insert(
+                "_FLOX_ENV_CUDA_DETECTION",
+                match manifest.options.cuda_detection {
+                    Some(false) => "0", // manifest opts-out
+                    _ => "1",           // default to enabling CUDA
+                }
+                .to_string(),
+            );
 
             // TODO: we should clean up the different conditionals here
             if in_place && self.start_services {

--- a/cli/tests/cuda.bats
+++ b/cli/tests/cuda.bats
@@ -118,7 +118,7 @@ teardown() {
   assert_success
 }
 
-@test "cuda enabled when nested activation opts-out" {
+@test "cuda disabled when nested activation opts-out" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
   mkdir -p "${FAKE_FHS_ROOT}/run/opengl-drivers"
   touch "${FAKE_FHS_ROOT}/run/opengl-drivers/libcuda.so.1"

--- a/cli/tests/cuda.bats
+++ b/cli/tests/cuda.bats
@@ -118,8 +118,7 @@ teardown() {
   assert_success
 }
 
-# This is the current, rather than necessarily desired, behaviour.
-@test "cuda enabled when nested activation attempts to opt-out" {
+@test "cuda enabled when nested activation opts-out" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
   mkdir -p "${FAKE_FHS_ROOT}/run/opengl-drivers"
   touch "${FAKE_FHS_ROOT}/run/opengl-drivers/libcuda.so.1"
@@ -130,6 +129,6 @@ teardown() {
 
   FLOX_SHELL=bash run "$FLOX_BIN" activate -- \
     "$FLOX_BIN" activate -d "$NESTED_PROJECT_DIR" -- \
-    bash "$TESTS_DIR/cuda/cuda-enabled.sh" "${FAKE_FHS_ROOT}"
+    bash "$TESTS_DIR/cuda/cuda-disabled.sh" "${FAKE_FHS_ROOT}"
   assert_success
 }


### PR DESCRIPTION
## Proposed Changes

The test for "libcuda present but manifest opts-out" was failing for me locally. I wasn't using a Flox environment as my default shell when I originally wrote the test. Now that I am, the environment variable gets inherited by the test from my default shell and doesn't get reset when a nested activation opts-out. Fix this by always setting the value based on the manifest of the target activation.

## Release Notes

Honour `options.cuda-detection = false` for nested activations.