### PR TITLE
fix(cuda): Strip fhs_root_prefix slash correctly

### DIFF
--- a/assets/activation-scripts/etc/profile.d/0800_cuda.sh
+++ b/assets/activation-scripts/etc/profile.d/0800_cuda.sh
@@ -10,8 +10,8 @@ export _findutils="@findutils@"
 
 # Only run if _FLOX_ENV_CUDA_DETECTION is set
 activate_cuda(){
-  # Strip any trailing slash so that we can construct it later.
-  local fhs_root_prefix="${1%/:-}"
+  # Strip a trailing or lone slash so that we can construct it later.
+  local fhs_root_prefix="${1%/}"
 
   if [[ "${_FLOX_ENV_CUDA_DETECTION:-}" != 1 ]]; then
     return 0


### PR DESCRIPTION
## Proposed Changes

I noticed some double slashes in the `flox activate -v` output:

    ++ activate_cuda /
    ++ local fhs_root_prefix=/
    ++ [[ 1 != 1 ]]
    ++ /nix/store/zr6klxfjzpdr2674ly1f4fix7ig57mjr-findutils-4.9.0/bin/find //dev -maxdepth 1 -iname 'nvidia*' -o -iname dxg

Fix it by not attempting to combine it with unset substitution. We always pass a value, so we don't actually need it. Examples of the behaviour before and after:

    (2) ~
    % activate_cuda() {
        echo "arg: $1"
        echo "before: ${1%/:-}/dev/nvidia"
        echo "after: ${1%/}/dev/nvidia"
    }

    (2) ~
    % activate_cuda
    arg:
    before: /dev/nvidia
    after: /dev/nvidia

    (2) ~
    % activate_cuda "/"
    arg: /
    before: //dev/nvidia
    after: /dev/nvidia

    (2) ~
    % activate_cuda "/foo/bar"
    arg: /foo/bar
    before: /foo/bar/dev/nvidia
    after: /foo/bar/dev/nvidia

    (2) ~
    % activate_cuda "/foo/bar/"
    arg: /foo/bar/
    before: /foo/bar//dev/nvidia
    after: /foo/bar/dev/nvidia

We can't remove multiple slashes without enabling extended globs but I don't think it's necessary since we control the inputs.

## Release Notes

N/A