### PR TITLE
refactor: update process selection errors and `stop` messages

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -267,6 +267,11 @@ impl ProcessStates {
         self.0.iter().find(|state| state.name == name)
     }
 
+    /// Iterater over references to the contained [ProcessState]s.
+    pub fn iter(&self) -> impl Iterator<Item = &ProcessState> {
+        self.0.iter()
+    }
+
     /// Get the names of processes that are currently running.
     pub fn running_process_names(&self) -> Vec<String> {
         self.0

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -250,16 +250,6 @@ impl ProcessStates {
         Ok(processes)
     }
 
-    /// Query the status of all processes and filter for the named processes.
-    pub fn read_names(
-        socket: impl AsRef<Path>,
-        names: Vec<String>,
-    ) -> Result<ProcessStates, ServiceError> {
-        let mut processes = ProcessStates::read(socket)?;
-        processes.0.retain(|state| names.contains(&state.name));
-        Ok(processes)
-    }
-
     /// Get the state of a single process by name.
     ///
     /// Returns `None` if the process is not found.
@@ -270,15 +260,6 @@ impl ProcessStates {
     /// Iterater over references to the contained [ProcessState]s.
     pub fn iter(&self) -> impl Iterator<Item = &ProcessState> {
         self.0.iter()
-    }
-
-    /// Get the names of processes that are currently running.
-    pub fn running_process_names(&self) -> Vec<String> {
-        self.0
-            .iter()
-            .filter(|state| state.is_running)
-            .map(|state| state.name.clone())
-            .collect()
     }
 }
 

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
-use flox_rust_sdk::providers::services::ServiceError;
+use flox_rust_sdk::providers::services::{ProcessState, ProcessStates, ServiceError};
 use tracing::instrument;
 
 use super::{ConcreteEnvironment, EnvironmentSelect};
@@ -55,4 +55,71 @@ pub fn supported_environment(
     }
     let dyn_environment = concrete_environment.into_dyn_environment();
     Ok(dyn_environment)
+}
+
+/// Try to find processes by name, typically provided by the user via arguments,
+/// or default to all processes.
+///
+/// If names are provided, all names must be names of actual services.
+/// If an invalid name is provided, an error is returned.
+fn processes_by_name_or_default_to_all<'a>(
+    processes: &'a ProcessStates,
+    names: &[String],
+) -> Result<Vec<&'a ProcessState>> {
+    if !names.is_empty() {
+        names
+            .iter()
+            .map(|name| {
+                processes
+                    .process(name)
+                    .ok_or_else(|| anyhow!("service '{name}' not found"))
+            })
+            .collect::<Result<Vec<_>>>()
+    } else {
+        tracing::debug!("No service names provided, stopping all services");
+        Ok(Vec::from_iter(processes.iter()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flox_rust_sdk::providers::services::test_helpers::generate_process_state;
+
+    use super::*;
+
+    #[test]
+    fn processes_by_name_returns_named_processes() {
+        let processes = [
+            generate_process_state("foo", "Running", 123, true),
+            generate_process_state("bar", "Completed", 123, false),
+        ]
+        .into();
+
+        let all_processes = processes_by_name_or_default_to_all(&processes, &["foo".to_string()])
+            .expect("naming 'foo' should return one process");
+
+        assert_eq!(all_processes.len(), 1);
+        assert_eq!(all_processes[0].name, "foo");
+    }
+
+    #[test]
+    fn processes_by_name_returns_all_if_no_process_provided() {
+        let processes = [
+            generate_process_state("foo", "Running", 123, true),
+            generate_process_state("bar", "Completed", 123, false),
+        ]
+        .into();
+
+        let all_processes = processes_by_name_or_default_to_all(&processes, &[])
+            .expect("no process names should return all processes");
+
+        assert_eq!(all_processes.len(), 2);
+    }
+
+    #[test]
+    fn processes_by_name_fails_for_invalid_names() {
+        let processes = [generate_process_state("foo", "Running", 123, true)].into();
+        processes_by_name_or_default_to_all(&processes, &["bar".to_string()])
+            .expect_err("invalid process name should error");
+    }
 }

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -37,7 +37,3 @@ pub(crate) fn package_installed(pkg: &PackageToInstall, environment_description:
         pkg.id()
     ));
 }
-
-pub(crate) fn service_stopped(service_name: &str) {
-    updated(format!("Service '{}' stopped", service_name));
-}

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -143,11 +143,11 @@ EOF
 EOF
 )
   assert_failure
-  assert_output --partial "❌ ERROR: service 'invalid' is not running"
+  assert_output --partial "❌ ERROR: service 'invalid' not found"
 }
 
 # bats test_tags=services:stop
-@test "stop: errors after stopping one service if subsequent service doesn't exist" {
+@test "stop: errors before stopping if any service doesn't exist" {
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
 
@@ -160,8 +160,8 @@ EOF
 EOF
 )
   assert_failure
-  assert_output --partial "❌ ERROR: service 'invalid' is not running"
-  assert_output --regexp "one +Completed"
+  assert_output --partial "❌ ERROR: service 'invalid' not found"
+  assert_output --regexp "one +Running"
   assert_output --regexp "two +Running"
 }
 
@@ -179,7 +179,7 @@ EOF
 EOF
 )
   assert_failure
-  assert_output --partial "❌ ERROR: service 'invalid' is not running"
+  assert_output --partial "❌ ERROR: service 'invalid' not found"
   assert_output --regexp "one +Running"
   assert_output --regexp "two +Running"
 }
@@ -210,8 +210,8 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' stopped"
-  assert_output --partial "✅ Service 'two' stopped"
+  assert_output --partial "✅ service 'one' stopped"
+  assert_output --partial "✅ service 'two' stopped"
   assert_output --regexp "one +Completed"
   assert_output --regexp "two +Completed"
 }
@@ -228,7 +228,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' stopped"
+  assert_output --partial "✅ service 'one' stopped"
   assert_output --regexp "one +Completed"
   assert_output --regexp "two +Running"
 }
@@ -245,8 +245,8 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' stopped"
-  assert_output --partial "✅ Service 'two' stopped"
+  assert_output --partial "✅ service 'one' stopped"
+  assert_output --partial "✅ service 'two' stopped"
   assert_output --regexp "one +Completed"
   assert_output --regexp "two +Completed"
 }
@@ -263,9 +263,9 @@ EOF
     "$FLOX_BIN" services stop one
 EOF
 )
-  assert_failure
+  assert_success
   assert_output --regexp "one +Completed"
-  assert_output --partial "❌ ERROR: service 'one' is not running"
+  assert_output --partial "⚠️  service 'one' is not running"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
* implement common process name selection in cli based on `ProcessStates` to use by all process subcommands
* update messaging for `stop` command
	+ fail if any named process does not exist
	+ stop processes individually
	+ warn if a process is not running -- do not attempt to stop
* add test for parsing process states from a running process-compose instance