### PR TITLE
feat: activation script changes needed for start

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -4,6 +4,7 @@ export _coreutils="@coreutils@"
 export _gnused="@gnused@"
 export _setsid="@setsid@"
 export _process_compose="@process-compose@"
+export _jq="@jq@"
 export _zdotdir="@out@/activate.d/zdotdir"
 export _tcsh_home="@out@/activate.d/tcsh_home"
 
@@ -28,7 +29,7 @@ poll_services_status () {
   # We don't want to exit on pipe failures here
   set +o pipefail
   local parsed_json
-  parsed_json=$(echo "$output" | jq -r -c '.[0].status' 2>/dev/null)
+  parsed_json=$(echo "$output" | "$_jq" -r -c '.[0].status' 2>/dev/null)
   # Restore the previous shell settings
   eval "$saved_options"
   # `parsed_json` will be a null string if anything went wrong
@@ -55,7 +56,15 @@ start_services_blocking () {
   export NO_COLOR=1
   # [sic] within scripts setsid needs to be called twice to work properly:
   # <https://stackoverflow.com/a/25398828>
-  "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false >/dev/null 2>&1 &
+
+  # flox services start [service...] needs to be able to start some but not all
+  # services
+  if [ -n "$_FLOX_SERVICES_TO_START" ]; then
+    readarray -t services_to_start < <(echo "$_FLOX_SERVICES_TO_START" | "$_jq" -r '.[]')
+    "$_setsid" "$_setsid" "$_process_compose" up "${services_to_start[@]}" -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false >/dev/null 2>&1 &
+  else
+    "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false >/dev/null 2>&1 &
+  fi
   # Make these functions available in subshells so that `timeout` can call them
   export -f wait_for_services_socket poll_services_status
   local activation_timeout="${_FLOX_SERVICES_ACTIVATE_TIMEOUT:-1}"

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -104,17 +104,24 @@ impl Activate {
             Err(e) => Err(e)?,
         };
 
-        self.activate(config, flox, concrete_environment, true, None)
+        self.activate(config, flox, concrete_environment, true, &[])
             .await
     }
 
+    /// This function contains the bulk of the implementation for
+    /// Activate::handle,
+    /// but it allows us to create an activation for use by `services start` or
+    /// `services-restart`.
+    ///
+    /// If self.start_services is true and services_to_start is empty, all
+    /// services will be started.
     pub async fn activate(
         self,
         mut config: Config,
         flox: Flox,
         mut concrete_environment: ConcreteEnvironment,
         start_watchdog: bool,
-        services_to_start: Option<Vec<String>>,
+        services_to_start: &[String],
     ) -> Result<()> {
         if let ConcreteEnvironment::Remote(ref env) = concrete_environment {
             if !self.trust {
@@ -303,7 +310,7 @@ impl Activate {
                         FLOX_ACTIVATE_START_SERVICES_VAR,
                         self.start_services.to_string(),
                     );
-                    if let Some(services_to_start) = services_to_start {
+                    if !services_to_start.is_empty() {
                         exports.insert(
                             FLOX_SERVICES_TO_START_VAR,
                             // Store JSON in an env var because bash doesn't

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -55,6 +55,7 @@ pub static INTERACTIVE_BASH_BIN: Lazy<PathBuf> = Lazy::new(|| {
     )
 });
 pub const FLOX_ACTIVATE_START_SERVICES_VAR: &str = "FLOX_ACTIVATE_START_SERVICES";
+pub const FLOX_SERVICES_TO_START_VAR: &str = "_FLOX_SERVICES_TO_START";
 pub static KLAUS_BIN: Lazy<PathBuf> =
     Lazy::new(|| PathBuf::from(env::var("KLAUS_BIN").unwrap_or(env!("KLAUS_BIN").to_string())));
 
@@ -85,12 +86,12 @@ pub struct Activate {
 }
 
 impl Activate {
-    pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("activate");
         if !flox.features.services && self.start_services {
             bail!("Services are not enabled in this environment");
         }
-        let mut concrete_environment = match self.environment.to_concrete_environment(&flox) {
+        let concrete_environment = match self.environment.to_concrete_environment(&flox) {
             Ok(concrete_environment) => concrete_environment,
             Err(e @ EnvironmentSelectError::EnvNotFoundInCurrentDirectory) => {
                 bail!(formatdoc! {"
@@ -103,6 +104,18 @@ impl Activate {
             Err(e) => Err(e)?,
         };
 
+        self.activate(config, flox, concrete_environment, true, None)
+            .await
+    }
+
+    pub async fn activate(
+        self,
+        mut config: Config,
+        flox: Flox,
+        mut concrete_environment: ConcreteEnvironment,
+        start_watchdog: bool,
+        services_to_start: Option<Vec<String>>,
+    ) -> Result<()> {
         if let ConcreteEnvironment::Remote(ref env) = concrete_environment {
             if !self.trust {
                 ensure_environment_trust(&mut config, &flox, env).await?;
@@ -290,6 +303,14 @@ impl Activate {
                         FLOX_ACTIVATE_START_SERVICES_VAR,
                         self.start_services.to_string(),
                     );
+                    if let Some(services_to_start) = services_to_start {
+                        exports.insert(
+                            FLOX_SERVICES_TO_START_VAR,
+                            // Store JSON in an env var because bash doesn't
+                            // support storing arrays in env vars
+                            serde_json::to_string(&services_to_start)?,
+                        );
+                    }
                 }
                 exports.insert(
                     FLOX_SERVICES_SOCKET_VAR,
@@ -301,7 +322,7 @@ impl Activate {
         exports.extend(default_nix_env_vars());
 
         // Launch the watchdog process
-        if !in_place {
+        if !in_place && start_watchdog {
             Activate::launch_watchdog(
                 &flox,
                 environment.cache_path()?.to_path_buf(),

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -9,6 +9,7 @@
   shellcheck,
   stdenv,
   process-compose,
+  jq,
 }: let
   ld-floxlib_so =
     if stdenv.isLinux
@@ -26,6 +27,7 @@ in
       --replace "@setsid@" "${util-linux}/bin/setsid" \
       --replace "@out@" "$out" \
       --replace "@process-compose@" "${process-compose}/bin/process-compose" \
+      --replace "@jq@" "${jq}/bin/jq" \
       --replace "/usr/bin/env bash" "${bash}/bin/bash"
 
     substituteInPlace $out/activate.d/bash \


### PR DESCRIPTION
When `flox services start name` is implemented, when `process-compose` is not running, we will need to call `process-compose up name` in order to start an instance of `process-compose` without starting more services than just `name`. In this case, we'll additionally want to skip starting the watchdog, because the activation `flox services start` is running inside will already have a watchdog.

To support this, split the bulk of `Activate::handle` out into an `Activate::activate` function that accepts additional arguments:
- `start_watchdog`: this will allow start and restart to skip starting a watchdog for ephemeral activations
- `services_to_start`: `flox services start` may be called with a list of service names, and these must be passed to the activation script

Pass `services_to_start` to the activation script as a serialized JSON array in the `_FLOX_SERVICES_TO_START` environment variable.

This functionality will be exercised when tests are added for `flox services start`