### PR TITLE
fix: activate --help formatting

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -58,10 +58,6 @@ pub const FLOX_ACTIVATE_START_SERVICES_VAR: &str = "FLOX_ACTIVATE_START_SERVICES
 pub static KLAUS_BIN: Lazy<PathBuf> =
     Lazy::new(|| PathBuf::from(env::var("KLAUS_BIN").unwrap_or(env!("KLAUS_BIN").to_string())));
 
-/// When called with no arguments 'flox activate' will look for a '.flox' directory
-/// in the current directory. Calling 'flox activate' in your home directory will
-/// activate a default environment. Environments in other directories and remote
-/// environments are activated with the '-d' and '-r' flags respectively.
 #[derive(Bpaf, Clone)]
 pub struct Activate {
     #[bpaf(external(environment_select), fallback(Default::default()))]

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -676,6 +676,12 @@ enum LocalDevelopmentCommands {
     #[bpaf(
         command,
         long("develop"),
+        header(indoc! {"
+            When called with no arguments 'flox activate' will look for a '.flox' directory
+            in the current directory. Calling 'flox activate' in your home directory will
+            activate a default environment. Environments in other directories and remote
+            environments are activated with the '-d' and '-r' flags respectively.
+        "}),
         footer("Run 'man flox-activate' for more details.")
     )]
     Activate(#[bpaf(external(activate::activate))] activate::Activate),


### PR DESCRIPTION
Fix unnecessary indentation and lack of headers in `flox activate --help` by using a bpaf `header()`

Before
```
Enter the environment, type 'exit' to leave

Usage: flox activate [-d=<path> | -r=<owner>/<name>] [-t] -- [<cmd>]...

When called with no arguments 'flox activate' will look for a '.flox' directory
  in the current directory. Calling 'flox activate' in your home directory will
  activate a default environment. Environments in other directories and remote
  environments are activated with the '-d' and '-r' flags respectively.
    -d, --dir=<path>  Path containing a .flox/ directory
    -r, --remote=<owner>/<name>  A remote environment on FloxHub
    -t, --trust       Trust a remote environment temporarily for this activation
    <cmd>             Command to run interactively in the context of the
                      environment

Available options:
    -h, --help        Prints help information

Run 'man flox-activate' for more details.
```

After
```
Enter the environment, type 'exit' to leave

Usage: flox activate [-d=<path> | -r=<owner>/<name>] [-t] -- [<cmd>]...

When called with no arguments 'flox activate' will look for a '.flox' directory
in the current directory. Calling 'flox activate' in your home directory will
activate a default environment. Environments in other directories and remote
environments are activated with the '-d' and '-r' flags respectively.

Available positional items:
    <cmd>             Command to run interactively in the context of the
                      environment

Available options:
    -d, --dir=<path>  Path containing a .flox/ directory
    -r, --remote=<owner>/<name>  A remote environment on FloxHub
    -t, --trust       Trust a remote environment temporarily for this activation
    -h, --help        Prints help information

Run 'man flox-activate' for more details.
```