### PR TITLE
feat: oneshot logs/tail for flox services

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::env;
-use std::io::{BufRead, Read};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{Receiver, Sender};
@@ -602,15 +602,14 @@ impl ProcessComposeLogTail {
         cmd.arg("logs").arg(process.as_ref());
         cmd.arg("--tail").arg(tail.to_string());
 
-        let output = cmd.output().map_err(ServiceError::ProcessComposeCmd)?;
+        cmd.stdout(Stdio::piped());
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(ServiceError::from_process_compose_log(stderr));
-        }
+        let mut child = cmd.spawn().map_err(ServiceError::ProcessComposeCmd)?;
+
+        let stdout = BufReader::new(child.stdout.take().unwrap());
 
         let mut lines = Vec::with_capacity(tail);
-        for line in output.stdout.lines() {
+        for line in stdout.lines() {
             let line = line.map_err(ServiceError::ReadLogLine)?;
 
             // process-compose logs --tail will print an error message
@@ -623,6 +622,15 @@ impl ProcessComposeLogTail {
             // For now, assume it's the last line and break out of the loop.
             // A change to print to stderr instead was proposed in
             // <https://github.com/F1bonacc1/process-compose/pull/216>.
+            //
+            // Calling process-compose takes about ~1 second
+            // even though process-compose will print the logs immediately,
+            // it will block for around a second before exiting :)
+            // Hence we read from the output stream directly,
+            // and break once we see the last line.
+            // This relies on the assumption that the last line is always
+            // the aforementioned error message,
+            // and that this is printed to stdout, incorrectly as that may be.
             if line.starts_with("write close: write unix") {
                 debug!("last line read, stopping log reader");
                 break;
@@ -630,6 +638,13 @@ impl ProcessComposeLogTail {
 
             lines.push(ProcessComposeLogLine::new(process.as_ref(), line));
         }
+
+        // finished reading, either by reading all lines or by breaking out of the loop early
+        // kill the child process and wait for it to exit to avoid 🧟.
+        child
+            .kill()
+            .and_then(|_| child.wait())
+            .map_err(ServiceError::ProcessComposeCmd)?;
 
         Ok(ProcessComposeLogTail { lines })
     }
@@ -1025,7 +1040,7 @@ mod tests {
     }
 
     /// Test that [ProcessComposeLogReader] reads at most `tail` lines from the process,
-    /// even if the process loggs more lines eventually,
+    /// even if the process logs more lines eventually,
     /// but has yet only logged `tail` lines.
     ///
     /// We rely on the `--tail` behavior of `process-compose process logs`,

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -5,6 +5,7 @@ use flox_rust_sdk::providers::services::{
     ProcessComposeLogLine,
     ProcessComposeLogStream,
     ProcessStates,
+    DEFAULT_TAIL,
 };
 use tracing::instrument;
 
@@ -19,6 +20,10 @@ pub struct Logs {
 
     /// Follow log output
     follow: bool,
+
+    /// Number of lines to show from the end of the logs
+    #[bpaf(short('n'), long, argument("num"), fallback(DEFAULT_TAIL))]
+    tail: usize,
 
     /// Which services' logs to view
     #[bpaf(positional("name"))]
@@ -41,7 +46,7 @@ impl Logs {
             bail!("printing logs without following is not yet implemented");
         }
 
-        let log_stream = ProcessComposeLogStream::new(socket, names.clone())?;
+        let log_stream = ProcessComposeLogStream::new(socket, names.clone(), self.tail)?;
 
         let max_name_length = names.map(|name| name.len()).max().unwrap_or(0);
         for log in log_stream {

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -54,7 +54,7 @@ impl Logs {
             }
         } else {
             let [ref name] = self.names.as_slice() else {
-                bail!("When not following logs, exactly one service name must be provided");
+                bail!("A single service name is required when the --follow flag is not specified");
             };
 
             // Ensure the service exists

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -61,7 +61,7 @@ impl Logs {
             // Avoids attaching to a log of a non-existent service, in which case `process-compose`
             // will block indefinitely.
             if processes.process(name).is_none() {
-                bail!("No such service: {}", name);
+                return Err(super::service_does_not_exist_error(name));
             }
 
             let tail = ProcessComposeLogTail::new(socket, name, self.tail)?;

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -642,7 +642,7 @@ EOF
 EOF
   )
   assert_failure
-  assert_line "❌ ERROR: No such service: doesnotexist"
+  assert_line "❌ ERROR: Service 'doesnotexist' not found."
 }
 
 # Runs a service that will sleep after printing a few lines of logs.

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -717,7 +717,7 @@ EOF
     read < ./resume-mostly-deterministic.pipe
 
     # kill log reading, because with `--follow` the process wil block indefinitely
-    timeout 0.25 "$FLOX_BIN" services logs --follow one mostly-deterministic
+    timeout 0.5 "$FLOX_BIN" services logs --follow one mostly-deterministic
 EOF
   )
 
@@ -745,7 +745,7 @@ EOF
     read < ./resume-mostly-deterministic.pipe
 
     # kill log reading, because with `--follow` the process wil block indefinitely
-    timeout 0.25 "$FLOX_BIN" services logs --follow
+    timeout 0.5 "$FLOX_BIN" services logs --follow
 EOF
   )
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -689,8 +689,6 @@ EOF
 EOF
   )
 
-  # assert that the process was still running and had to be stopped
-  [ "$status" -eq 124 ]
   assert_output - <<EOF
 mostly-deterministic: 1
 mostly-deterministic: 2

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -610,7 +610,7 @@ EOF
 EOF
   )
   assert_failure
-  assert_line "❌ ERROR: When not following logs, exactly one service name must be provided"
+  assert_line "❌ ERROR: A single service name is required when the --follow flag is not specified"
 }
 
 # bats test_tags=services:logs:tail:exactly-one-service
@@ -626,7 +626,7 @@ EOF
 EOF
   )
   assert_failure
-  assert_line "❌ ERROR: When not following logs, exactly one service name must be provided"
+  assert_line "❌ ERROR: A single service name is required when the --follow flag is not specified"
 }
 
 # bats test_tags=services:logs:tail:no-such-service

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -646,7 +646,7 @@ EOF
 }
 
 # Runs a service that will sleep after printing a few lines of logs.
-# Assert that flox is _not_ waitinf for the service to finish.
+# Assert that flox is _not_ waiting for the service to finish.
 # bats test_tags=services:logs:tail:instant
 @test "logs: tail does not wait" {
   export FLOX_FEATURES_SERVICES=true
@@ -655,11 +655,8 @@ EOF
   run --separate-stderr "$FLOX_BIN" activate --start-services -- bash <(
     cat << 'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
-    # calling process-compose takes about ~1 second
-    # even though process-compose will print the logs immediately,
-    # it will block for around a second before exiting :)
 
-    timeout 2 "$FLOX_BIN" services logs mostly-deterministic
+    timeout 1 "$FLOX_BIN" services logs mostly-deterministic
 EOF
   )
 

--- a/cli/tests/services/logging_services.toml
+++ b/cli/tests/services/logging_services.toml
@@ -5,7 +5,7 @@ command = '''
 echo 0
 echo >> ./resume-one.pipe
 
-i=1; while [ $i -lt 10 ]; do echo "${i}"; sleep 0.1; i=$((i+1)); done
+i=1; while [ $((i)) -lt 10 ]; do echo "$((i))"; sleep 0.1; i=$((i+1)); done
 '''
 
 [services.mostly-deterministic]

--- a/cli/tests/services/logging_services.toml
+++ b/cli/tests/services/logging_services.toml
@@ -2,14 +2,20 @@ version = 1
 
 [services.one]
 command = '''
-i=1; while [ $i -lt 10 ]; do echo "$(i)"; sleep 0.1; i=$((i+1)); done
+echo 0
+echo >> ./resume-one.pipe
+
+i=1; while [ $i -lt 10 ]; do echo "${i}"; sleep 0.1; i=$((i+1)); done
 '''
 
 [services.mostly-deterministic]
 command = '''
+
 echo 1
 echo 2
 echo 3
+
+echo >> ./resume-mostly-deterministic.pipe
 
 # Asserting any output past this is prone to race conditions,
 # since we cant guarantee that tests will run before the sleep ends

--- a/cli/tests/services/logging_services.toml
+++ b/cli/tests/services/logging_services.toml
@@ -1,0 +1,19 @@
+version = 1
+
+[services.one]
+command = '''
+i=1; while [ $i -lt 10 ]; do echo "$(i)"; sleep 0.1; i=$((i+1)); done
+'''
+
+[services.mostly-deterministic]
+command = '''
+echo 1
+echo 2
+echo 3
+
+# Asserting any output past this is prone to race conditions,
+# since we cant guarantee that tests will run before the sleep ends
+sleep 3
+
+echo 4
+'''


### PR DESCRIPTION
## Proposed Changes

### feat: impl ProcessComposeLogTail to read logs with --tail

Empirically, process-compose will
* log the last _up to_ `<n>` lines logged by a process
* exit with `0` exit code
* not wait for more logs of running processes, even if they logged less than `<n>` lines yet
* print a particular error message to `stderr`:
  ```
  $ process-compose process logs -u test.sock -n 2 foo 2>/dev/null
  2
  3
  write close: write unix ->test.sock: write: broken pipe
  ```
  Currently we use this as another cue that the reading completed,
  however we cannot know whether this was printed by process compose or a running service.
  A PR to banish these logs to stderr was opened upstream at
  <https://github.com/F1bonacc1/process-compose/pull/216>

This adds a new `ProcessComposeLogTail` that calls `process-compose process logs` with `--tail`
and directly reads its output, storing all lines in a vector.

Because log lines are currently not timestamped,
we can only meaningfully provide tail logs for a single process.
Thus the complexity of the multiplexed readers we need for streaming logs can be sidestepped here,
with an independent reading implementation and `Command::output`.


### feat: allow configuring tail for log streams and add `--tail` flag

This is a convenience enabled by recent process-compose updates.
By default, `process-compose process logs --follow` will _also_ print the entirety of the currently buffered lines for the logged process.
Since that can be a few, we provide the same `--tail`/`-n` flag we would like for non following logs, to following logs as well.
My memory tells me that previously `process-compose` ignored `-n` when `--follow` was provided.
This also ensures that the interface for following and non-following logs is closer.

### feat: impl one shot log for single processes

Implement the currently stubbed out branch of `!self.follow`.
Ensure that only a single service name was provided and that the service indeed exists.
Without the latter check, we would ask `process-compose` for logs of a non-existent service,
which would block indefinitely without output.


### test: add `logs` integration tests


* Test service name arg handling for oneshot logs and `--follow`
Oneshot logs require exactly one argument while with `--follow`
multiple logs can be specified, or omitted to default to all processes.

* Test whether without `--follow`, `logs` exits by itself
and does not wait for the service to finish or produce more logs.
More detailed tests are found in the respective unit tests for `ProcessComposeLogTail`.
Apparently `process-compose` blocks for another second or so
after printing logs almost instantaneously.
We heuristically account for that with a timeout.

* Test that --follows waits for logs and keeps receiving new lines.
Wrapping these calls in a `timeout` to ensure they are being killed
as they would otherwise run indefinitely.