### PR TITLE
test(services): Set SHELL for watchdog test

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -388,7 +388,7 @@ EOF
   export FLOX_FEATURES_SERVICES=true
   setup_sleeping_services
   export -f watchdog_pids_called_with_arg
-  run --separate-stderr "$FLOX_BIN" activate -- bash <(cat <<'EOF'
+  SHELL="bash" run --separate-stderr "$FLOX_BIN" activate -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
 
     # Ensure that the watchdog is still running


### PR DESCRIPTION
## Proposed Changes

This is failing for me locally. It's fixed by specifying the SHELL for the activation, because I use `zsh` which doesn't support exporting functions.

However I'm a bit perplexed about why it's using `zsh` at all. I thought that BATS, and the way that we've configured the test setup, isolated us from this.

    ✗ watchdog: lives as long as the activation [271]
       tags: services
       (from function `assert_success' in file /nix/store/dhghqmkjk7fqpdbz71clvbh5zxp6p3lf-bats-with-libraries-1.10.0/share/bats/bats-assert/src/assert_success.bash, line 42,
        in test file services.bats, line 507)
         `assert_success' failed
       ✨ Created environment 'test' (aarch64-darwin)

       Next:
         $ flox search <package>    <- Search for a package
         $ flox install <package>   <- Install a package into an environment
         $ flox activate            <- Enter the environment
         $ flox edit                <- Add environment variables and shell hooks
       ✅ Environment successfully updated.
       stderr:
       /dev/fd/63: line 9: watchdog_pids_called_with_arg: command not found

## Release Notes

N/A