### PR TITLE
test(services): Remove dupe test

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -182,26 +182,7 @@ EOF
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     exit_code=0
     source "${TESTS_DIR}/services/register_cleanup.sh"
-    "$FLOX_BIN" services stop one invalid || exit_code=$?
-    "$FLOX_BIN" services status
-    exit $exit_code
-EOF
-)
-  assert_failure
-  assert_output --partial "❌ ERROR: Service 'invalid' not found"
-  assert_output --regexp "one +Running"
-  assert_output --regexp "two +Running"
-}
-
-# bats test_tags=services:stop
-@test "stop: errors without stopping any services if preceeding service doesn't exist" {
-  export FLOX_FEATURES_SERVICES=true
-  setup_sleeping_services
-
-  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
-    exit_code=0
-    source "${TESTS_DIR}/services/register_cleanup.sh"
-    "$FLOX_BIN" services stop invalid one || exit_code=$?
+    "$FLOX_BIN" services stop one two invalid || exit_code=$?
     "$FLOX_BIN" services status
     exit $exit_code
 EOF


### PR DESCRIPTION
## Proposed Changes

The retained test is a superset of the deleted test because it ensures that no services are stopped when the invalid name is given _after_ valid names.

If we test this then we already know that it works the other way round and it wasn't easy to tell the tell the difference between the intent of the two tests at a glance. So we can save ourselves a bit of runtime.

## Release Notes

N/A