### PR TITLE
feat: services start

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -659,6 +659,17 @@ pub mod test_helpers {
         ///
         /// Panics if the socket doesn't appear after 5 tries with backoff.
         pub fn start(config: &ProcessComposeConfig) -> Self {
+            Self::start_services(config, &[])
+        }
+
+        /// Start a `process-compose` instance with the given [ProcessComposeConfig].
+        /// Wait for the socket to appear before returning.
+        ///
+        /// Panics if the socket doesn't appear after 5 tries with backoff.
+        ///
+        /// Only starts specified services,
+        /// or if none are specified starts all services.
+        pub fn start_services(config: &ProcessComposeConfig, services: &[String]) -> Self {
             let temp_dir = TempDir::new_in("/tmp").unwrap();
 
             let config_path = temp_dir.path().join("config.yaml");
@@ -677,6 +688,10 @@ pub mod test_helpers {
                 .arg("up")
                 .stdout(Stdio::null())
                 .stderr(Stdio::inherit());
+
+            if !services.is_empty() {
+                cmd.args(services);
+            }
 
             // Dropping the child as stopping is handled via a process-compose command.
             let child = cmd.spawn().unwrap();

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -221,6 +221,17 @@ pub struct ProcessState {
     pub is_running: bool,
 }
 
+impl ProcessState {
+    /// We restart `process-compose` with updated config after all services are stopped.
+    /// We treat Disabled, Completed, Skipped, and Error as stopped.
+    /// This means Foreground, Pending, Running, Launching, Launched,
+    /// Restarting, and Terminating are treated as not stopped.
+    /// https://github.com/F1bonacc1/process-compose/blob/8d6a662c71d24608daf93b51ca1d462a0d5725f9/src/types/process.go#L125-L137
+    pub fn is_stopped(&self) -> bool {
+        ["Disabled", "Completed", "Skipped", "Error"].contains(&self.status.as_str())
+    }
+}
+
 #[derive(Deserialize, Debug, Clone, PartialEq, derive_more::From)]
 #[from(forward)]
 pub struct ProcessStates(Vec<ProcessState>);

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -7,7 +7,6 @@
 
 use std::collections::BTreeMap;
 use std::env;
-use std::ffi::OsStr;
 use std::io::{BufRead, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -332,7 +331,7 @@ pub fn stop_services(
 /// running.
 pub fn start_service(socket: impl AsRef<Path>, name: impl AsRef<str>) -> Result<(), ServiceError> {
     let name = name.as_ref();
-    tracing::debug!(name = name, "starting service");
+    tracing::debug!(%name, "starting service");
 
     let mut cmd = base_process_compose_command(socket);
     let output = cmd
@@ -354,17 +353,17 @@ pub fn start_service(socket: impl AsRef<Path>, name: impl AsRef<str>) -> Result<
         // process not existing.
         // Exec failures are just treated as the process having an exit code of
         // 1
-        tracing::debug!("starting services failed");
+        tracing::debug!("starting service '{}' failed", name);
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(ServiceError::from_process_compose_log(stderr))
     }
 }
 
-pub fn process_compose_down(socket_path: impl AsRef<OsStr>) -> Result<(), ServiceError> {
+pub fn process_compose_down(socket_path: impl AsRef<Path>) -> Result<(), ServiceError> {
     let mut cmd = Command::new(&*PROCESS_COMPOSE_BIN);
     cmd.arg("down");
     cmd.arg("--unix-socket");
-    cmd.arg(socket_path);
+    cmd.arg(socket_path.as_ref());
     cmd.env("NO_COLOR", "1");
     let output = cmd.output().map_err(ServiceError::ProcessComposeCmd)?;
     if output.status.success() {

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -7,6 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::env;
+use std::ffi::OsStr;
 use std::io::{BufRead, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -354,6 +355,22 @@ pub fn start_service(socket: impl AsRef<Path>, name: impl AsRef<str>) -> Result<
         // Exec failures are just treated as the process having an exit code of
         // 1
         tracing::debug!("starting services failed");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(ServiceError::from_process_compose_log(stderr))
+    }
+}
+
+pub fn process_compose_down(socket_path: impl AsRef<OsStr>) -> Result<(), ServiceError> {
+    let mut cmd = Command::new(&*PROCESS_COMPOSE_BIN);
+    cmd.arg("down");
+    cmd.arg("--unix-socket");
+    cmd.arg(socket_path);
+    cmd.env("NO_COLOR", "1");
+    let output = cmd.output().map_err(ServiceError::ProcessComposeCmd)?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        tracing::debug!("'process-compose down' failed");
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(ServiceError::from_process_compose_log(stderr))
     }

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -62,23 +62,23 @@ pub static KLAUS_BIN: Lazy<PathBuf> =
 #[derive(Bpaf, Clone)]
 pub struct Activate {
     #[bpaf(external(environment_select), fallback(Default::default()))]
-    environment: EnvironmentSelect,
+    pub environment: EnvironmentSelect,
 
     /// Trust a remote environment temporarily for this activation
     #[bpaf(long, short)]
-    trust: bool,
+    pub trust: bool,
 
     /// Print an activation script to stdout instead of spawning a subshell
     #[bpaf(long("print-script"), short, hide)]
-    print_script: bool,
+    pub print_script: bool,
 
     /// Whether to start services when activating the environment
     #[bpaf(long, short, hide)]
-    start_services: bool,
+    pub start_services: bool,
 
     /// Command to run interactively in the context of the environment
     #[bpaf(positional("cmd"), strict, many)]
-    run_args: Vec<String>,
+    pub run_args: Vec<String>,
 }
 
 impl Activate {
@@ -300,7 +300,7 @@ impl Activate {
             }
             if flox.features.services && !manifest.services.is_empty() && !in_place {
                 if self.start_services {
-                    supported_environment(&flox, self.environment)?; // Error for remote envs.
+                    supported_environment(&flox, &self.environment)?; // Error for remote envs.
                 }
                 tracing::debug!(
                     start = self.start_services,

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -113,13 +113,13 @@ impl Activate {
     /// services will be started.
     // TODO: there's probably a cleaner way to extract the functionality we need
     // for start and restart,
-    // but for now just hack through the for_start_or_restart bool.
+    // but for now just hack through the is_ephemeral bool.
     pub async fn activate(
         self,
         mut config: Config,
         flox: Flox,
         mut concrete_environment: ConcreteEnvironment,
-        for_start_or_restart: bool,
+        is_ephemeral: bool,
         services_to_start: &[String],
     ) -> Result<()> {
         if let ConcreteEnvironment::Remote(ref env) = concrete_environment {
@@ -343,7 +343,7 @@ impl Activate {
         exports.extend(default_nix_env_vars());
 
         // Launch the watchdog process
-        if !in_place && !for_start_or_restart {
+        if !in_place && !is_ephemeral {
             Activate::launch_watchdog(
                 &flox,
                 environment.cache_path()?.to_path_buf(),
@@ -369,13 +369,7 @@ impl Activate {
         let shell = Self::detect_shell_for_subshell();
         // These functions will only return if exec fails
         if !self.run_args.is_empty() {
-            Self::activate_command(
-                self.run_args,
-                shell,
-                exports,
-                activation_path,
-                for_start_or_restart,
-            )
+            Self::activate_command(self.run_args, shell, exports, activation_path, is_ephemeral)
         } else {
             Self::activate_interactive(shell, exports, activation_path, now_active)
         }
@@ -470,7 +464,7 @@ impl Activate {
         shell: Shell,
         exports: HashMap<&str, String>,
         activation_path: PathBuf,
-        for_start_or_restart: bool,
+        is_ephemeral: bool,
     ) -> Result<()> {
         // Previous versions of pkgdb rendered activation scripts into a
         // subdirectory called "activate", but now that path is occupied by
@@ -504,7 +498,7 @@ impl Activate {
 
         debug!("running activation command: {:?}", command);
 
-        if for_start_or_restart {
+        if is_ephemeral {
             let output = command
                 .stderr(Stdio::piped())
                 .stdout(Stdio::piped())

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -741,7 +741,7 @@ impl LocalDevelopmentCommands {
             LocalDevelopmentCommands::Search(args) => args.handle(config, flox).await?,
             LocalDevelopmentCommands::Show(args) => args.handle(flox).await?,
             LocalDevelopmentCommands::Delete(args) => args.handle(flox).await?,
-            LocalDevelopmentCommands::Services(args) => args.handle(flox).await?,
+            LocalDevelopmentCommands::Services(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -30,7 +30,7 @@ impl Logs {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("services::logs");
 
-        let env = supported_environment(&flox, self.environment)?;
+        let env = supported_environment(&flox, &self.environment)?;
         let socket = env.services_socket_path(&flox)?;
 
         let processes = ProcessStates::read(&socket)?;

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -6,6 +6,7 @@ use flox_rust_sdk::providers::services::{ProcessState, ProcessStates, ServiceErr
 use tracing::instrument;
 
 use super::{ConcreteEnvironment, EnvironmentSelect};
+use crate::config::Config;
 
 mod logs;
 mod start;
@@ -34,13 +35,13 @@ pub enum ServicesCommands {
 
 impl ServicesCommands {
     #[instrument(name = "services", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         if !flox.features.services {
             return Err(ServiceError::FeatureFlagDisabled.into());
         }
 
         match self {
-            ServicesCommands::Start(args) => args.handle(flox).await?,
+            ServicesCommands::Start(args) => args.handle(config, flox).await?,
             ServicesCommands::Status(args) => args.handle(flox).await?,
             ServicesCommands::Stop(args) => args.handle(flox).await?,
             ServicesCommands::Logs(args) => args.handle(flox).await?,
@@ -50,15 +51,24 @@ impl ServicesCommands {
     }
 }
 
-/// Return an Environment for variants that support services.
-pub fn supported_environment(
+/// Return a ConcreteEnvironment for variants that support services.
+pub fn supported_concrete_environment(
     flox: &Flox,
-    environment: EnvironmentSelect,
-) -> Result<Box<dyn Environment>> {
+    environment: &EnvironmentSelect,
+) -> Result<ConcreteEnvironment> {
     let concrete_environment = environment.detect_concrete_environment(flox, "Services in")?;
     if let ConcreteEnvironment::Remote(_) = concrete_environment {
         return Err(ServiceError::RemoteEnvsNotSupported.into());
     }
+    Ok(concrete_environment)
+}
+
+/// Return an Environment for variants that support services.
+pub fn supported_environment(
+    flox: &Flox,
+    environment: &EnvironmentSelect,
+) -> Result<Box<dyn Environment>> {
+    let concrete_environment = supported_concrete_environment(flox, environment)?;
     let dyn_environment = concrete_environment.into_dyn_environment();
     Ok(dyn_environment)
 }
@@ -78,13 +88,19 @@ fn processes_by_name_or_default_to_all<'a>(
             .map(|name| {
                 processes
                     .process(name)
-                    .ok_or_else(|| anyhow!("Service '{name}' not found"))
+                    .ok_or_else(|| service_does_not_exist_error(name))
             })
             .collect::<Result<Vec<_>>>()
     } else {
         tracing::debug!("No service names provided, defaulting to all services");
         Ok(Vec::from_iter(processes.iter()))
     }
+}
+
+/// Error to return when a service doesn't exist, either in the lockfile or the
+/// current process-compose config.
+pub(crate) fn service_does_not_exist_error(name: &str) -> anyhow::Error {
+    anyhow!(format!("Service '{name}' not found."))
 }
 
 #[cfg(test)]

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -8,22 +8,27 @@ use tracing::instrument;
 use super::{ConcreteEnvironment, EnvironmentSelect};
 
 mod logs;
+mod start;
 mod status;
 mod stop;
 
 /// Services Commands.
 #[derive(Debug, Clone, Bpaf)]
 pub enum ServicesCommands {
+    /// Ensure a service or services are running
+    #[bpaf(command, footer("Run 'man flox-services-start' for more details."))]
+    Start(#[bpaf(external(start::start))] start::Start),
+
     /// Status of a service or services
-    #[bpaf(command)]
+    #[bpaf(command, footer("Run 'man flox-services-status' for more details."))]
     Status(#[bpaf(external(status::status))] status::Status),
 
-    /// Stop a service or services
-    #[bpaf(command)]
+    /// Ensure a service or services are stopped
+    #[bpaf(command, footer("Run 'man flox-services-stop' for more details."))]
     Stop(#[bpaf(external(stop::stop))] stop::Stop),
 
     /// Print logs of services
-    #[bpaf(command)]
+    #[bpaf(command, footer("Run 'man flox-services-logs' for more details."))]
     Logs(#[bpaf(external(logs::logs))] logs::Logs),
 }
 
@@ -35,6 +40,7 @@ impl ServicesCommands {
         }
 
         match self {
+            ServicesCommands::Start(args) => args.handle(flox).await?,
             ServicesCommands::Status(args) => args.handle(flox).await?,
             ServicesCommands::Stop(args) => args.handle(flox).await?,
             ServicesCommands::Logs(args) => args.handle(flox).await?,

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -58,6 +58,9 @@ impl Start {
         } else {
             let processes = ProcessStates::read(&socket)?;
             let all_processes_stopped = processes.iter().all(|p| p.is_stopped());
+            if all_processes_stopped {
+                process_compose_down(&socket)?;
+            }
             all_processes_stopped
         };
 

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -150,3 +150,26 @@ impl Start {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use flox_rust_sdk::providers::services::test_helpers::TestProcessComposeInstance;
+    use flox_rust_sdk::providers::services::ProcessComposeConfig;
+
+    use super::*;
+
+    /// start_with_existing_process_compose errors when called with a nonexistent service
+    #[test]
+    fn start_errors_for_nonexistent_service() {
+        let instance = TestProcessComposeInstance::start(&ProcessComposeConfig {
+            processes: BTreeMap::new(),
+        });
+
+        let err =
+            Start::start_with_existing_process_compose(instance.socket(), &["one".to_string()])
+                .unwrap_err();
+        assert!(err.to_string().contains("Service 'one' not found."));
+    }
+}

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -207,39 +207,4 @@ mod tests {
         let two_state = states.process("two").unwrap();
         assert!(two_state.is_running);
     }
-
-    // #[test]
-    // fn errors_for_failure_to_start() {
-    //     let instance = TestProcessComposeInstance::start_services(
-    //         &ProcessComposeConfig {
-    //             processes: [
-    //                 ("one".to_string(), ProcessConfig {
-    //                     command: String::from("sleep infinity"),
-    //                     vars: None,
-    //                 }),
-    //                 ("fails".to_string(), ProcessConfig {
-    //                     command: String::from("false"),
-    //                     vars: Some(
-    //                         [(
-    //                             String::from("FOO"),
-    //                             String::from_utf8(vec![b'X'; 1]).unwrap(),
-    //                         )]
-    //                         .into(),
-    //                     ),
-    //                 }),
-    //             ]
-    //             .into(),
-    //         },
-    //         &["one".to_string()],
-    //     );
-
-    //     Start::start_with_existing_process_compose(instance.socket(), &["fails".to_string()])
-    //         .unwrap();
-    //     let processes = ProcessStates::read(instance.socket()).unwrap();
-    //     for p in processes {
-    //         println!("{:?}", p);
-    //     }
-    //     assert!(false)
-    //     // assert_eq!(err.to_string(), "hi");
-    // }
 }

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -1,0 +1,149 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::lockfile::LockedManifest;
+use flox_rust_sdk::providers::services::{process_compose_down, start_service, ProcessStates};
+use indoc::indoc;
+use tracing::{debug, instrument};
+
+use crate::commands::activate::Activate;
+use crate::commands::services::{service_does_not_exist_error, supported_concrete_environment};
+use crate::commands::{
+    activated_environments,
+    environment_select,
+    ConcreteEnvironment,
+    EnvironmentSelect,
+    UninitializedEnvironment,
+};
+use crate::config::Config;
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[derive(Bpaf, Debug, Clone)]
+pub struct Start {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+
+    /// Names of the services to start
+    #[bpaf(positional("name"))]
+    names: Vec<String>,
+}
+
+impl Start {
+    #[instrument(name = "start", skip_all)]
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        subcommand_metric!("services::start");
+
+        let mut concrete_environment = supported_concrete_environment(&flox, &self.environment)?;
+        let activated_environments = activated_environments();
+
+        if !activated_environments.is_active(&UninitializedEnvironment::from_concrete_environment(
+            &concrete_environment,
+        )?) {
+            return Err(anyhow!(indoc! {"
+                Cannot start services for an environment that is not activated.
+
+                To activate and start services, run 'flox activate -s'
+            "}));
+        }
+
+        // TODO: this doesn't need to be mut
+        let env = concrete_environment.dyn_environment_ref_mut();
+        let socket = env.services_socket_path(&flox)?;
+
+        let start_new_process_compose = if !socket.exists() {
+            true
+        } else {
+            let processes = ProcessStates::read(&socket)?;
+            let all_processes_stopped = processes.iter().all(|p| p.is_stopped());
+            all_processes_stopped
+        };
+
+        if start_new_process_compose {
+            debug!("starting services in new process-compose instance");
+            self.start_with_new_process_compose(config, flox, concrete_environment)
+                .await
+        } else {
+            debug!("starting services with existing process-compose instance");
+            Self::start_with_existing_process_compose(socket, &self.names)
+        }
+    }
+
+    /// Note that this must be called within an existing activation, otherwise it
+    /// will leave behind a process-compose since it doesn't start a watchdog.
+    async fn start_with_new_process_compose(
+        &self,
+        config: Config,
+        flox: Flox,
+        mut concrete_environment: ConcreteEnvironment,
+    ) -> Result<()> {
+        let environment = concrete_environment.dyn_environment_ref_mut();
+        let lockfile = environment.lockfile(&flox)?;
+        let LockedManifest::Catalog(lockfile) = lockfile else {
+            unreachable!("at least it should be after https://github.com/flox/flox/issues/1858")
+        };
+        for name in &self.names {
+            if !lockfile.manifest.services.contains_key(name) {
+                return Err(service_does_not_exist_error(name));
+            }
+        }
+        Activate {
+            environment: self.environment.clone(),
+            trust: false,
+            print_script: false,
+            start_services: true,
+            run_args: vec!["true".to_string()],
+        }
+        .activate(config, flox, concrete_environment, false, &self.names)
+        .await?;
+        // We don't know if the service actually started because we don't have
+        // healthchecks.
+        // But we do know that activate blocks until `process-compose` is running.
+        // mytodo: test
+        if self.names.is_empty() {
+            for name in lockfile.manifest.services.keys() {
+                message::updated(format!("Service '{name}' started."));
+            }
+        } else {
+            for name in &self.names {
+                message::updated(format!("Service '{name}' started."));
+            }
+        }
+        Ok(())
+    }
+
+    // Starts services using an already running process-compose.
+    // Defaults to starting all services if no services are specified.
+    fn start_with_existing_process_compose(
+        socket: impl AsRef<Path>,
+        names: &[String],
+    ) -> Result<()> {
+        let processes = ProcessStates::read(&socket)?;
+        let named_processes = super::processes_by_name_or_default_to_all(&processes, names)?;
+
+        let mut failure_count = 0;
+        for process in named_processes {
+            if process.is_running {
+                message::warning(format!("Service '{}' is running.", process.name));
+                continue;
+            }
+
+            match start_service(&socket, &process.name) {
+                Ok(_) => {
+                    message::updated(format!("Service '{}' started.", process.name));
+                },
+                Err(e) => {
+                    message::error(format!("Failed to start service '{}': {}", process.name, e));
+                    failure_count += 1;
+                },
+            }
+        }
+
+        if failure_count > 0 {
+            return Err(anyhow!("Failed to start {} services.", failure_count));
+        }
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -99,7 +99,7 @@ impl Start {
             start_services: true,
             run_args: vec!["true".to_string()],
         }
-        .activate(config, flox, concrete_environment, false, &self.names)
+        .activate(config, flox, concrete_environment, true, &self.names)
         .await?;
         // We don't know if the service actually started because we don't have
         // healthchecks.

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -207,4 +207,39 @@ mod tests {
         let two_state = states.process("two").unwrap();
         assert!(two_state.is_running);
     }
+
+    // #[test]
+    // fn errors_for_failure_to_start() {
+    //     let instance = TestProcessComposeInstance::start_services(
+    //         &ProcessComposeConfig {
+    //             processes: [
+    //                 ("one".to_string(), ProcessConfig {
+    //                     command: String::from("sleep infinity"),
+    //                     vars: None,
+    //                 }),
+    //                 ("fails".to_string(), ProcessConfig {
+    //                     command: String::from("false"),
+    //                     vars: Some(
+    //                         [(
+    //                             String::from("FOO"),
+    //                             String::from_utf8(vec![b'X'; 1]).unwrap(),
+    //                         )]
+    //                         .into(),
+    //                     ),
+    //                 }),
+    //             ]
+    //             .into(),
+    //         },
+    //         &["one".to_string()],
+    //     );
+
+    //     Start::start_with_existing_process_compose(instance.socket(), &["fails".to_string()])
+    //         .unwrap();
+    //     let processes = ProcessStates::read(instance.socket()).unwrap();
+    //     for p in processes {
+    //         println!("{:?}", p);
+    //     }
+    //     assert!(false)
+    //     // assert_eq!(err.to_string(), "hi");
+    // }
 }

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -32,7 +32,7 @@ impl Status {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("services::status");
 
-        let env = supported_environment(&flox, self.environment)?;
+        let env = supported_environment(&flox, &self.environment)?;
         let socket = env.services_socket_path(&flox)?;
 
         let processes = ProcessStates::read(socket)?;

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -24,7 +24,7 @@ impl Stop {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("services::stop");
 
-        let env = supported_environment(&flox, self.environment)?;
+        let env = supported_environment(&flox, &self.environment)?;
         let socket = env.services_socket_path(&flox)?;
 
         let processes = ProcessStates::read(&socket)?;

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::io::Write;
 
 use flox_rust_sdk::models::manifest::PackageToInstall;
 /// Write a message to stderr.
@@ -7,6 +8,10 @@ use flox_rust_sdk::models::manifest::PackageToInstall;
 /// to include logging, word wrapping, ANSI filtereing etc.
 fn print_message(v: impl Display) {
     eprintln!("{v}");
+}
+
+fn print_message_to_buffer(out: &mut impl Write, v: impl Display) {
+    writeln!(out, "{v}").unwrap();
 }
 
 /// alias for [print_message]
@@ -29,6 +34,11 @@ pub(crate) fn updated(v: impl Display) {
 /// double width character, add an additional space for alignment
 pub(crate) fn warning(v: impl Display) {
     print_message(std::format_args!("⚠️  {v}"));
+}
+
+/// double width character, add an additional space for alignment
+pub(crate) fn warning_to_buffer(out: &mut impl Write, v: impl Display) {
+    print_message_to_buffer(out, std::format_args!("⚠️  {v}"));
 }
 
 pub(crate) fn package_installed(pkg: &PackageToInstall, environment_description: &str) {

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -623,7 +623,7 @@ EOF
   assert_output --partial "two        Running"
 }
 
-@test "start: picks up changes after environment modification" {
+@test "start: picks up changes after environment modification when all services have stopped" {
 
   export FLOX_FEATURES_SERVICES=true
 
@@ -651,7 +651,6 @@ EOF
 
   # TODO: once https://github.com/flox/flox/issues/1910 is resolved, the
   # modified value of FOO should be printed.
+  # run cat one.log
   # assert_output --partial "one: foo_two"
-  run cat one.log
-  assert_output --partial "one: foo_one"
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -654,3 +654,25 @@ EOF
   # run cat one.log
   # assert_output --partial "one: foo_two"
 }
+
+@test "start: does not pick up changes after environment modification when some services still running" {
+
+  export FLOX_FEATURES_SERVICES=true
+
+  MANIFEST_CONTENTS_1="$(cat << "EOF"
+    version = 1
+
+    [services]
+    one.command = "sleep infinity"
+EOF
+  )"
+
+  "$FLOX_BIN" init
+  echo "$MANIFEST_CONTENTS_1" | "$FLOX_BIN" edit -f -
+
+  # Edit the manifest adding a second service.
+  # Then try to start the second service.
+  run "$FLOX_BIN" activate -s -- bash "${TESTS_DIR}/services/start_does_not_pick_up_modifications.sh"
+  assert_failure
+  assert_output --partial "Service 'two' not found."
+}

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -676,3 +676,25 @@ EOF
   assert_failure
   assert_output --partial "Service 'two' not found."
 }
+
+
+@test "start: shuts down existing process-compose" {
+  export FLOX_FEATURES_SERVICES=true
+
+  MANIFEST_CONTENTS_1="$(cat << "EOF"
+    version = 1
+
+    [services]
+    one.command = "true"
+EOF
+  )"
+
+  "$FLOX_BIN" init
+  echo "$MANIFEST_CONTENTS_1" | "$FLOX_BIN" edit -f -
+
+  # Call flox services start and check if the prior process-compose gets shutdown
+  # This also appears to hang forever if process-compose doesn't get shutdown
+  run "$FLOX_BIN" activate -s -- bash "${TESTS_DIR}/services/start_shuts_down_process_compose.sh"
+  assert_success
+}
+

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -593,7 +593,7 @@ EOF
   )"
 
   run "$FLOX_BIN" activate -- bash -c "$SCRIPT"
-  assert_success
+  assert_failure
   assert_output --partial "Service 'invalid' not found."
   assert_output --partial "couldn't connect to service manager"
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -641,8 +641,17 @@ EOF
   "$FLOX_BIN" init
   echo "$MANIFEST_CONTENTS_1" | "$FLOX_BIN" edit -f -
 
+  # Edit the manifest adding a second service and changing the value of FOO.
+  # Then start services again.
   run "$FLOX_BIN" activate -s -- bash "${TESTS_DIR}/services/start_picks_up_modifications.sh"
   assert_success
+
+  # The added service should be running.
+  assert_output --partial "two        Running"
+
+  # TODO: once https://github.com/flox/flox/issues/1910 is resolved, the
+  # modified value of FOO should be printed.
+  # assert_output --partial "one: foo_two"
   run cat one.log
-  assert_output --partial "baz"
+  assert_output --partial "one: foo_one"
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -584,6 +584,8 @@ EOF
 
   run "$FLOX_BIN" activate -- bash -c "$SCRIPT"
   assert_success
+  assert_output --partial "Service 'no_space' started."
+  assert_output --partial "Service 'with space' started."
   assert_output --partial "no_space   Running"
   assert_output --partial "with space Running"
   assert_output --partial "skip       Disabled"
@@ -615,6 +617,8 @@ EOF
 
   run "$FLOX_BIN" activate -- bash -c "$SCRIPT"
   assert_success
+  assert_output --partial "Service 'one' started."
+  assert_output --partial "Service 'two' started."
   assert_output --partial "one        Running"
   assert_output --partial "two        Running"
 }

--- a/cli/tests/services/start_does_not_pick_up_modifications.sh
+++ b/cli/tests/services/start_does_not_pick_up_modifications.sh
@@ -1,0 +1,14 @@
+set -euo pipefail
+
+MANIFEST_CONTENTS_2="$(cat << "EOF"
+  version = 1
+
+  [services]
+  one.command = "sleep infinity"
+  two.command = "sleep infinity"
+EOF
+)"
+
+echo "$MANIFEST_CONTENTS_2" | "$FLOX_BIN" edit -f -
+
+"$FLOX_BIN" services start two

--- a/cli/tests/services/start_picks_up_modifications.sh
+++ b/cli/tests/services/start_picks_up_modifications.sh
@@ -14,9 +14,17 @@ EOF
 
 echo "$MANIFEST_CONTENTS_2" | "$FLOX_BIN" edit -f -
 
-# TODO: don't use follow once logs without follow are implemented
-"$FLOX_BIN" services logs one --follow > one.log &
-LOGS_PID="$!"
+# Make sure we avoid a race of service one failing to complete
+for i in {1..5}; do
+  if "$FLOX_BIN" services status | grep "Completed"; then
+    break
+  fi
+  sleep .1
+done
+if [ "$i" -eq 5 ]; then
+  exit 1
+fi
+
 "$FLOX_BIN" services start
-kill "$LOGS_PID"
 "$FLOX_BIN" services status
+# TODO: check logs once implemented without --follow

--- a/cli/tests/services/start_picks_up_modifications.sh
+++ b/cli/tests/services/start_picks_up_modifications.sh
@@ -1,0 +1,22 @@
+set -euo pipefail
+
+MANIFEST_CONTENTS_2="$(cat << "EOF"
+  version = 1
+
+  [services]
+  one.command = "echo $FOO"
+  two.command = "sleep infinity"
+
+  [hook]
+  on-activate = "export FOO=foo_two"
+EOF
+)"
+
+echo "$MANIFEST_CONTENTS_2" | "$FLOX_BIN" edit -f -
+
+# TODO: don't use follow once logs without follow are implemented
+"$FLOX_BIN" services logs one --follow > one.log &
+LOGS_PID="$!"
+"$FLOX_BIN" services start
+kill "$LOGS_PID"
+"$FLOX_BIN" services status

--- a/cli/tests/services/start_shuts_down_process_compose.sh
+++ b/cli/tests/services/start_shuts_down_process_compose.sh
@@ -1,0 +1,35 @@
+set -euo pipefail
+
+# TODO: not very DRY, but I just copied this out of services.bats
+process_compose_pids_called_with_arg() {
+  # This is a hack to essentially do a `pgrep` without having access to `pgrep`.
+  # The `ps` prints `<pid> <cmd>`, then we use two separate `grep`s so that the
+  # grep command itself doesn't get listed when we search for the data dir.
+  # The `cut` just extracts the PID.
+  pattern="$1"
+  ps_output="$(ps -eo pid,args)"
+  process_composes="$(echo "$ps_output" | grep process-compose)"
+  matches="$(echo "$process_composes" | grep "$pattern")"
+  # This is a load-bearing 'xargs', it strips leading/trailing whitespace that
+  # trips up 'cut'
+  pids="$(echo "$matches" | xargs | cut -d' ' -f1)"
+  echo "$pids"
+}
+
+
+# Make sure we avoid a race of service one failing to complete
+for i in {1..5}; do
+  if "$FLOX_BIN" services status | grep "Completed"; then
+    break
+  fi
+  sleep .1
+done
+if [ "$i" -eq 5 ]; then
+  exit 1
+fi
+
+process_compose_pids_before="$(process_compose_pids_called_with_arg "$(pwd)/.flox/run")"
+"$FLOX_BIN" services start
+process_compose_pids_after="$(process_compose_pids_called_with_arg "$(pwd)/.flox/run")"
+
+[[ "$process_compose_pids_after" != *"$process_compose_pids_before"* ]]


### PR DESCRIPTION
Add `flox services start` subcommand.

- Check if the specified environment is active. Error if not
- If no process-compose is running or all processes are stopped, start the specified services with Activate::activate which is roughly equivalent to `flox activate -s -- true`. Differences are not starting a watchdog and forking rather than execing.
- If process-compose is running, use the existing process-compose to start the specified services. Warn if any processes are already running. Error if any services fail to start, but only after attempting to start all processes.

For testing:

All of the tests for creating a new process compose were added using
bats. This was because `services-start`:
- relies on the watchdog started by activate to cleanup
- relies on the state of an already running `process-compose`
- relies on checking for a prior activation
- can have behavior affected by a prior activation, since it uses a nested activation

All of these moving parts made an integration test seem like it made the most sense.

I added a `message::warning_to_buffer` function to allow unit testing messages. I think the approach is generally consistent with what we'd like to do in https://github.com/flox/flox/issues/1816