### PR TITLE
fix: re-run activation for start and restart

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -150,7 +150,7 @@ for d in "${flox_env_dirs[@]}"; do
     break
   fi
 done
-if [ $flox_env_found -eq 0 ]; then
+if [ $flox_env_found -eq 0 ] || [ "$_FLOX_ACTIVATE_FORCE_REACTIVATE" == true ]; then
 
   # If interactive and a command has not been passed, this is an interactive
   # activate,
@@ -163,9 +163,14 @@ if [ $flox_env_found -eq 0 ]; then
     echo >&2
   fi
 
-  # First activation of this environment. Snapshot environment to start.
-  _start_env="$($_coreutils/bin/mktemp --suffix=.start-env)"
-  export | $_coreutils/bin/sort > "$_start_env"
+  if [ $flox_env_found -eq 0 ]; then
+    # First activation of this environment. Snapshot environment to start.
+    _start_env="$($_coreutils/bin/mktemp --suffix=.start-env)"
+    export | $_coreutils/bin/sort > "$_start_env"
+  else # we know "$_FLOX_ACTIVATE_FORCE_REACTIVATE" == true
+    # TODO: restore _start_env
+    :
+  fi
 
   # Capture PID of this "first" activation. This provides the unique
   # identifier with which to refer to environment variables associated
@@ -211,35 +216,39 @@ if [ $flox_env_found -eq 0 ]; then
     source "$FLOX_ENV/activate.d/hook-on-activate" 1>&2
   fi
 
-  # Capture ending environment.
-  _end_env="$($_coreutils/bin/mktemp --suffix=.$FLOX_ENV_PID.end-env)"
-  export | $_coreutils/bin/sort > "$_end_env"
+  # We only need to capture the ending environment when
+  # "$_FLOX_ACTIVATE_FORCE_REACTIVATE" isn't set
+  if [ $flox_env_found -eq 0 ]; then
+    # Capture ending environment.
+    _end_env="$($_coreutils/bin/mktemp --suffix=.$FLOX_ENV_PID.end-env)"
+    export | $_coreutils/bin/sort > "$_end_env"
 
-  # The userShell initialization scripts that follow have the potential to undo
-  # the environment modifications performed above, so we must first calculate
-  # all changes made to the environment so far so that we can restore them after
-  # the userShell initialization scripts have run. We use the `comm(1)` command
-  # to compare the starting and ending environment captures (think of it as a
-  # better diff for comparing sorted files), and `sed(1)` to format the output
-  # in the best format for use in each language-specific activation script.
-  _add_env="$($_coreutils/bin/mktemp --suffix=.$FLOX_ENV_PID.add-env)"
-  _del_env="$($_coreutils/bin/mktemp --suffix=.$FLOX_ENV_PID.del-env)"
+    # The userShell initialization scripts that follow have the potential to undo
+    # the environment modifications performed above, so we must first calculate
+    # all changes made to the environment so far so that we can restore them after
+    # the userShell initialization scripts have run. We use the `comm(1)` command
+    # to compare the starting and ending environment captures (think of it as a
+    # better diff for comparing sorted files), and `sed(1)` to format the output
+    # in the best format for use in each language-specific activation script.
+    _add_env="$($_coreutils/bin/mktemp --suffix=.$FLOX_ENV_PID.add-env)"
+    _del_env="$($_coreutils/bin/mktemp --suffix=.$FLOX_ENV_PID.del-env)"
 
-  # Export tempfile paths for use within shell-specific activation scripts.
-  export _add_env _del_env
+    # Export tempfile paths for use within shell-specific activation scripts.
+    export _add_env _del_env
 
-  # Capture environment variables to _set_ as "key=value" pairs.
-  # comm -13: only env declarations unique to `$_end_env` (new declarations)
-  $_coreutils/bin/comm -13 "$_start_env" "$_end_env" | \
-    $_gnused/bin/sed -e 's/^declare -x //' > "$_add_env"
+    # Capture environment variables to _set_ as "key=value" pairs.
+    # comm -13: only env declarations unique to `$_end_env` (new declarations)
+    $_coreutils/bin/comm -13 "$_start_env" "$_end_env" | \
+      $_gnused/bin/sed -e 's/^declare -x //' > "$_add_env"
 
-  # Capture environment variables to _unset_ as a list of keys.
-  # TODO: remove from $_del_env keys set in $_add_env
-  $_coreutils/bin/comm -23 "$_start_env" "$_end_env" | \
-    $_gnused/bin/sed -e 's/^declare -x //' -e 's/=.*//' > "$_del_env"
+    # Capture environment variables to _unset_ as a list of keys.
+    # TODO: remove from $_del_env keys set in $_add_env
+    $_coreutils/bin/comm -23 "$_start_env" "$_end_env" | \
+      $_gnused/bin/sed -e 's/^declare -x //' -e 's/=.*//' > "$_del_env"
 
-  # Don't need these anymore.
-  $_coreutils/bin/rm -f "$_start_env" "$_end_env"
+    # Don't need these anymore.
+    $_coreutils/bin/rm -f "$_start_env" "$_end_env"
+  fi
 
 else
 

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -292,8 +292,15 @@ Currently, environment variables set by the first run of the `on-activate`
 script are captured and then later set by the nested activation,
 but this behavior may change.
 
-It is best to write hooks defensively, assuming the user is using the
-environment from any directory on their machine.
+The `on-activate` script may be re-run by other commands;
+we may create ephemeral activations and thus run the script multiple times for
+commands such as `services start`.
+For this reason, it's best practice to make `on-activate` idempotent.
+However, the environment of your current shell is only affected by the initial
+run of the script for the first activation for your shell.
+
+It's also best practice to write hooks defensively, assuming the user is using
+the environment from any directory on their machine.
 
 ### `script` - DEPRECATED
 This field was deprecated in favor of the `profile` section.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -283,6 +283,10 @@ impl Activate {
             ),
         ]);
 
+        if is_ephemeral {
+            exports.insert("_FLOX_ACTIVATE_FORCE_REACTIVATE", "true".to_string());
+        }
+
         let socket_path = environment.services_socket_path(&flox)?;
         if let TypedManifest::Catalog(manifest) = environment.manifest(&flox)? {
             exports.insert(

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1110,11 +1110,8 @@ EOF
 
   # The added service should be running.
   assert_output --partial "two        Running"
-
-  # TODO: once https://github.com/flox/flox/issues/1910 is resolved, the
-  # modified value of FOO should be printed.
-  # run cat one.log
-  # assert_output --partial "one: foo_two"
+  # The updated value of FOO should be printed
+  assert_output --partial "foo_two"
 }
 
 @test "start: does not pick up changes after environment modification when some services still running" {

--- a/cli/tests/services/start_picks_up_modifications.sh
+++ b/cli/tests/services/start_picks_up_modifications.sh
@@ -27,4 +27,4 @@ fi
 
 "$FLOX_BIN" services start
 "$FLOX_BIN" services status
-# TODO: check logs once implemented without --follow
+"$FLOX_BIN" services logs one


### PR DESCRIPTION
When `services start` and `services restart` restart `process-compose`,
they need to do so in an up-to-date activation. To support this, they
have to run the activate script. Currently the activate script skips
running hooks and setting vars if it has already been run.

Add a `_FLOX_ACTIVATE_FORCE_REACTIVATE` variable and use it to control
whether the hooks should be re-run and vars set.
This has some limitations:
- Hooks that aren't idempotent might have unexpected behavior
- Variables aren't yet unset, so if a variable is removed from an
  environment, it won't be unset

We'll address those issues later on.

Add a note to the man page saying hooks should be able to be run
multiple times non-interactively.