### PR TITLE
fix: remove one of the two -r flags in flox edit

### DIFF
--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -74,7 +74,7 @@ pub enum EditAction {
         /// Reset the environment to the current generation
         ///
         /// (Only available for managed environments)
-        #[bpaf(long, short)]
+        #[bpaf(long)]
         reset: (),
     },
 }


### PR DESCRIPTION
## Proposed Changes

resolves https://github.com/flox/flox/issues/1915#issuecomment-2283544271

## Release Notes

N/A


<!-- Many thanks! -->
