### PR TITLE
feat(services): Allow restart to load new configs

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -106,6 +106,18 @@ fn arbitrary_process_config_environment(
     ))
 }
 
+/// Appends the `flox_never_exit` service to a non-empty list of services that
+/// will be started by a new `process-compose` instance in order to prevent it
+/// from exiting (and no longer serving `logs`, `status`, etc) if the specified
+/// services finish of their own accord.
+pub fn new_services_to_start(names: &[String]) -> Vec<String> {
+    let mut names_modified = names.to_vec();
+    if !names.is_empty() {
+        names_modified.push(PROCESS_NEVER_EXIT_NAME.to_string());
+    }
+    names_modified
+}
+
 fn generate_never_exit_process() -> ProcessConfig {
     ProcessConfig {
         command: String::from("sleep infinity"),

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -321,8 +321,6 @@ pub fn stop_services(
     let output = cmd
         .arg("stop")
         .args(names)
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
         .output()
         .map_err(ServiceError::ProcessComposeCmd)?;
 
@@ -349,8 +347,6 @@ pub fn start_service(socket: impl AsRef<Path>, name: impl AsRef<str>) -> Result<
     let output = cmd
         .arg("start")
         .arg(name)
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
         .output()
         .map_err(ServiceError::ProcessComposeCmd)?;
 
@@ -381,8 +377,6 @@ pub fn restart_service(
     let mut cmd = base_process_compose_command(socket);
     let output = cmd
         .args(["restart", name.as_ref()])
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
         .output()
         .map_err(ServiceError::ProcessComposeCmd)?;
 

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -3,7 +3,12 @@ use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::models::lockfile::LockedManifest;
-use flox_rust_sdk::providers::services::{ProcessState, ProcessStates, ServiceError};
+use flox_rust_sdk::providers::services::{
+    new_services_to_start,
+    ProcessState,
+    ProcessStates,
+    ServiceError,
+};
 use tracing::instrument;
 
 use super::{ConcreteEnvironment, EnvironmentSelect};
@@ -137,7 +142,13 @@ pub async fn start_with_new_process_compose(
         start_services: true,
         run_args: vec!["true".to_string()],
     }
-    .activate(config, flox, concrete_environment, true, &names)
+    .activate(
+        config,
+        flox,
+        concrete_environment,
+        true,
+        &new_services_to_start(names),
+    )
     .await?;
     // We don't know if the service actually started because we don't have
     // healthchecks.

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -48,7 +48,7 @@ impl ServicesCommands {
         }
 
         match self {
-            ServicesCommands::Restart(args) => args.handle(flox).await?,
+            ServicesCommands::Restart(args) => args.handle(config, flox).await?,
             ServicesCommands::Start(args) => args.handle(config, flox).await?,
             ServicesCommands::Status(args) => args.handle(flox).await?,
             ServicesCommands::Stop(args) => args.handle(flox).await?,

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -42,7 +42,7 @@ impl Restart {
             return Err(anyhow!(indoc! {"
                 Cannot restart services for an environment that is not activated.
 
-                To activate and start services, run 'flox activate -s'
+                To activate and start services, run 'flox activate --start-services'
             "}));
         }
 

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -1,17 +1,20 @@
+use std::path::Path;
+
 use anyhow::{anyhow, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::services::{restart_service, ProcessStates};
+use flox_rust_sdk::providers::services::{process_compose_down, restart_service, ProcessStates};
 use indoc::indoc;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
-use super::supported_concrete_environment;
+use crate::commands::services::{start_with_new_process_compose, supported_concrete_environment};
 use crate::commands::{
     activated_environments,
     environment_select,
     EnvironmentSelect,
     UninitializedEnvironment,
 };
+use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::message;
 
@@ -27,10 +30,10 @@ pub struct Restart {
 
 impl Restart {
     #[instrument(name = "restart", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("services::restart");
 
-        let concrete_environment = supported_concrete_environment(&flox, &self.environment)?;
+        let mut concrete_environment = supported_concrete_environment(&flox, &self.environment)?;
         let activated_environments = activated_environments();
 
         if !activated_environments.is_active(&UninitializedEnvironment::from_concrete_environment(
@@ -43,24 +46,73 @@ impl Restart {
             "}));
         }
 
-        let env = concrete_environment.into_dyn_environment();
+        // TODO: this doesn't need to be mut
+        let env = concrete_environment.dyn_environment_ref_mut();
         let socket = env.services_socket_path(&flox)?;
 
-        let processes = ProcessStates::read(&socket)?;
-        let named_processes = super::processes_by_name_or_default_to_all(&processes, &self.names)?;
-
-        for process in named_processes {
-            if let Err(err) = restart_service(&socket, &process.name) {
-                message::error(format!(
-                    "Failed to restart service '{}': {}",
-                    process.name, err
-                ));
-                continue;
+        let start_new_process_compose = if !socket.exists() {
+            true
+        } else if self.names.is_empty() {
+            // TODO: We could optimise by checking whether the manifest has actually changed.
+            process_compose_down(&socket)?;
+            true
+        } else {
+            let processes = ProcessStates::read(&socket)?;
+            let all_processes_stopped = processes.iter().all(|p| p.is_stopped());
+            if all_processes_stopped {
+                process_compose_down(&socket)?;
             }
+            all_processes_stopped
+        };
 
-            message::updated(format!("Service '{}' restarted", process.name));
+        if start_new_process_compose {
+            debug!("restarting services in new process-compose instance");
+            let names = start_with_new_process_compose(
+                config,
+                flox,
+                self.environment,
+                concrete_environment,
+                &self.names,
+            )
+            .await?;
+            for name in names {
+                message::updated(format!("Service '{name}' restarted."));
+            }
+            Ok(())
+        } else {
+            debug!("restarting services with existing process-compose instance");
+            Self::restart_with_existing_process_compose(socket, &self.names)
+        }
+    }
+
+    // Retarts services using an already running process-compose.
+    // Defaults to restarting all services if no services are specified.
+    fn restart_with_existing_process_compose(
+        socket: impl AsRef<Path>,
+        names: &[String],
+    ) -> Result<()> {
+        let processes = ProcessStates::read(&socket)?;
+        let named_processes = super::processes_by_name_or_default_to_all(&processes, names)?;
+
+        let mut failure_count = 0;
+        for process in named_processes {
+            match restart_service(&socket, &process.name) {
+                Ok(_) => {
+                    message::updated(format!("Service '{}' restarted.", process.name));
+                },
+                Err(e) => {
+                    message::error(format!(
+                        "Failed to restart service '{}': {}",
+                        process.name, e
+                    ));
+                    failure_count += 1;
+                },
+            }
         }
 
+        if failure_count > 0 {
+            return Err(anyhow!("Failed to restart {} services.", failure_count));
+        }
         Ok(())
     }
 }

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -43,7 +43,7 @@ impl Start {
             return Err(anyhow!(indoc! {"
                 Cannot start services for an environment that is not activated.
 
-                To activate and start services, run 'flox activate -s'
+                To activate and start services, run 'flox activate --start-services'
             "}));
         }
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -337,7 +337,7 @@ EOF
 )
   assert_success
   assert_output --partial "✅ Service 'touch_file' restarted"
-  assert_output --regexp "touch_file +Completed"
+  assert_output --regexp "touch_file +(Running|Completed)"
 }
 
 # bats test_tags=services:restart
@@ -954,7 +954,7 @@ EOF
   run "$FLOX_BIN" activate -- bash -c "$SCRIPT"
   assert_success
   assert_output --partial "Service 'one' started."
-  assert_output --regexp "one +Completed"
+  assert_output --regexp "one +(Running|Completed)"
 }
 
 @test "start: picks up changes after environment modification when all services have stopped" {

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -215,6 +215,16 @@ EOF
 }
 
 # bats test_tags=services:restart
+@test "restart: errors when used outside an activation" {
+  export FLOX_FEATURES_SERVICES=true
+  setup_start_counter_services
+
+  run "$FLOX_BIN" services restart one
+  assert_failure
+  assert_line "❌ ERROR: Cannot restart services for an environment that is not activated."
+}
+
+# bats test_tags=services:restart
 @test "restart: restarts a single service" {
   export FLOX_FEATURES_SERVICES=true
   setup_start_counter_services


### PR DESCRIPTION
## Proposed Changes

**feat(services): Prevent restart outside activation**

We don't support this for `start` or `restart` because it may start a
new `process-compose` instance which needs to be shutdown by the
watchdog of an existing activation.

**refactor(services): Move start_with_new_p_c**

Move the function and move the printing of names to the caller so that
the same functionality can be used by `start` and `restart`.

**feat(services): Allow restart to load new configs**

Stop the existing and start a new `process-compose` when:

- there are no services currently running
- all services are going to be restarted

This allows two behaviours:

- restarting in an activation that didn't previously start services
- reloading the services config when changes are made to the manifest

**fix(services): Allow status after named (re)start**

It wasn't previously possible to call `status` if you called `start` or
`restart` on shortlived services because the `process-compose up`
command wasn't starting our `flox_never_exit` service.

## Release Notes

Support `flox services restart` when an activation hasn't previously started services and to reload changes from the manifest.
