### PR TITLE
fix: define references to 3rd party packages

### DIFF
--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -111,6 +111,19 @@ in
           gnused
         ];
 
+      # Ensure all referenced packages are available in the closure.
+      # In the past we had issues with rust optimizing away some constants
+      # referencing 3rd party crates causing runtime failures.
+      #
+      # See: <https://github.com/flox/flox/issues/1820>
+      propagatedBuildInputs =
+        rust-internal-deps.propagatedBuildInputs
+        ++ [
+          bashInteractive
+          nix
+          flox-activation-scripts
+        ];
+
       # https://github.com/ipetkov/crane/issues/385
       # doNotLinkInheritedArtifacts = true;
 

--- a/pkgs/flox-klaus/default.nix
+++ b/pkgs/flox-klaus/default.nix
@@ -45,6 +45,8 @@ in
           gnused
         ];
 
+      propagatedBuildInputs = rust-internal-deps.propagatedBuildInputs ++ [];
+
       # https://github.com/ipetkov/crane/issues/385
       # doNotLinkInheritedArtifacts = true;
 

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -66,6 +66,16 @@ in
         # build dependencies
         nativeBuildInputs = rust-external-deps.nativeBuildInputs ++ [];
 
+        propagatedBuildInputs =
+          rust-external-deps.propagatedBuildInputs
+          ++ [
+            gitMinimal
+            process-compose
+          ]
+          ++ lib.optional (flox-pkgdb != null) [
+            flox-pkgdb
+          ];
+
         # Tests are disabled inside of the build because the sandbox prevents
         # internet access and there are tests that require internet access to
         # resolve flake references among other things.


### PR DESCRIPTION
Use `propagatedBuildInputs` to ensure all referenced packages are available in the closure. In the past we had issues with rust optimizing away some constants referencing 3rd party crates causing runtime failures.

See: <https://github.com/flox/flox/issues/1820>
