### PR TITLE
feat: support services that spawn daemons

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -3,6 +3,7 @@ use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
 use indoc::{formatdoc, indoc};
+use itertools::Itertools;
 use log::debug;
 #[cfg(test)]
 use proptest::prelude::*;
@@ -14,6 +15,7 @@ use url::Url;
 
 use super::environment::path_environment::InitCustomization;
 use crate::data::{System, Version};
+use crate::providers::services::ServiceError;
 #[cfg(test)]
 use crate::utils::proptest_btree_map_alphanum_keys;
 
@@ -744,6 +746,49 @@ pub struct ManifestServiceDescriptor {
     pub command: String,
     /// Service-specific environment variables
     pub vars: Option<ManifestVariables>,
+    /// Whether the service spawns a background process (daemon)
+    // TODO: This option _requires_ the shutdown command, so we'll need to add
+    //       that explanation to the manifest.toml docs and service mgmt guide
+    pub is_daemon: Option<bool>,
+    /// How to shut down the service
+    pub shutdown: Option<ManifestServiceShutdown>,
+}
+
+impl ManifestServices {
+    pub fn validate(&self) -> Result<(), ServiceError> {
+        let mut bad_services = vec![];
+        for (name, desc) in self.0.iter() {
+            let daemonizes = desc.is_daemon.is_some_and(|_self| _self);
+            let has_shutdown_cmd = desc.shutdown.is_some();
+            if daemonizes && !has_shutdown_cmd {
+                bad_services.push(name.clone());
+            }
+        }
+        let list = bad_services
+            .into_iter()
+            .map(|name| format!("- {name}"))
+            .join("\n");
+        if list.is_empty() {
+            Ok(())
+        } else {
+            let msg = formatdoc! {"
+                Services that spawn daemon processes must supply a shutdown command.
+
+                The following services did not specify a shutdown command:
+                {list}
+            "};
+            Err(ServiceError::InvalidConfig(msg))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub struct ManifestServiceShutdown {
+    /// What command to run to shut down the service
+    pub command: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -17,6 +17,7 @@ use flox_rust_sdk::models::environment::{
     Environment,
     EnvironmentError,
 };
+use flox_rust_sdk::providers::services::ServiceError;
 use itertools::Itertools;
 use log::debug;
 use tracing::instrument;
@@ -313,9 +314,10 @@ impl Edit {
         match result {
             Err(EnvironmentError::Core(e @ CoreEnvironmentError::LockedManifest(_)))
             | Err(EnvironmentError::Core(e @ CoreEnvironmentError::DeserializeManifest(_)))
-            | Err(EnvironmentError::Core(e @ CoreEnvironmentError::Version0NotSupported)) => {
-                Ok(Err(e))
-            },
+            | Err(EnvironmentError::Core(e @ CoreEnvironmentError::Version0NotSupported))
+            | Err(EnvironmentError::Core(
+                e @ CoreEnvironmentError::Services(ServiceError::InvalidConfig(_)),
+            )) => Ok(Err(e)),
             Err(e) => Err(e),
             Ok(result) => Ok(Ok(result)),
         }

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -138,6 +138,10 @@ pre_cmd = "flox init"
 cmd = "flox install nodejs@14.16.1"
 ignore_cmd_errors = true
 
+[resolve.overmind]
+pre_cmd = "flox init"
+cmd = "flox install overmind"
+
 # Try to install a package that doesn't exist, but that *does* have suggestions
 [resolve.package_suggestions]
 pre_cmd = "flox init"

--- a/test_data/generated/resolve/overmind.json
+++ b/test_data/generated/resolve/overmind.json
@@ -1,0 +1,136 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "overmind",
+            "broken": false,
+            "derivation": "/nix/store/qzbbv3597sr4mvhkbxbrfrizi3nckd5j-overmind-2.5.1.drv",
+            "description": "Process manager for Procfile-based applications and tmux",
+            "install_id": "overmind",
+            "license": "[ MIT ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5e0ca22929f3342b19569b21b2f3462f053e497b",
+            "name": "overmind-2.5.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/m29m1wflwyr0lgfc9jdv52km8lx60fph-overmind-2.5.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "overmind",
+            "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+            "rev_count": 664135,
+            "rev_date": "2024-08-09T03:53:12Z",
+            "scrape_date": "2024-08-11T02:08:20Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "2.5.1"
+          },
+          {
+            "attr_path": "overmind",
+            "broken": false,
+            "derivation": "/nix/store/nn4vrjqmfa1kd69drl528s659sr5gfki-overmind-2.5.1.drv",
+            "description": "Process manager for Procfile-based applications and tmux",
+            "install_id": "overmind",
+            "license": "[ MIT ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5e0ca22929f3342b19569b21b2f3462f053e497b",
+            "name": "overmind-2.5.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/ngz7mhw5gd0sfc0dgr9i0hq4a54dp8ap-overmind-2.5.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "overmind",
+            "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+            "rev_count": 664135,
+            "rev_date": "2024-08-09T03:53:12Z",
+            "scrape_date": "2024-08-11T02:08:20Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "2.5.1"
+          },
+          {
+            "attr_path": "overmind",
+            "broken": false,
+            "derivation": "/nix/store/rcmb3w37mixwxfzv4pszp0chbin5rsb2-overmind-2.5.1.drv",
+            "description": "Process manager for Procfile-based applications and tmux",
+            "install_id": "overmind",
+            "license": "[ MIT ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5e0ca22929f3342b19569b21b2f3462f053e497b",
+            "name": "overmind-2.5.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/z73z6lm5ianabp7v3sd5aqhfqrsdfyf6-overmind-2.5.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "overmind",
+            "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+            "rev_count": 664135,
+            "rev_date": "2024-08-09T03:53:12Z",
+            "scrape_date": "2024-08-11T02:08:20Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "2.5.1"
+          },
+          {
+            "attr_path": "overmind",
+            "broken": false,
+            "derivation": "/nix/store/rv5g8fqizimx8804l93sk69x6bw6v5dz-overmind-2.5.1.drv",
+            "description": "Process manager for Procfile-based applications and tmux",
+            "install_id": "overmind",
+            "license": "[ MIT ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5e0ca22929f3342b19569b21b2f3462f053e497b",
+            "name": "overmind-2.5.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/rnvq71pfwrab0amizn4lzgsmmgy12vvx-overmind-2.5.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "overmind",
+            "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+            "rev_count": 664135,
+            "rev_date": "2024-08-09T03:53:12Z",
+            "scrape_date": "2024-08-11T02:08:20Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "2.5.1"
+          }
+        ],
+        "page": 664135,
+        "url": ""
+      }
+    }
+  ]
+]


### PR DESCRIPTION
## Proposed Changes

By default `process-compose` shuts down services by sending the service a signal (SIGTERM by default). If a service spawns a background process then the process that `process-compose` delivers the signal to may not be the process that we need to stop. Other service managers, like supervisord, get around this by having some kind of proxy process that forwards signals to the background process. `process-compose` lets you specify a shutdown command instead.

This change adds `is-daemon` and `shutdown.command` fields to a service descriptor so that a user can properly configure a service that will background itself or another process (`pg_ctl`, etc). When a user lists an `is-daemon` service, they also need to provide a `shutdown.command`, otherwise we have no way of shutting the process down.

Getting the `serde` machinery figured out was taking too long, so instead of spending more time on that I simply added a `validate` method to `ManifestServices`. In general I think we should move more towards manual parsing/validation because we can provide better error messages that way, but this was simply done out of expediency in this case.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
