### PR TITLE
feat(services): Improve error messaging for start and restart

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -57,8 +57,6 @@ To activate and start services, run 'flox activate --start-services'"
     LoggedError(#[from] LoggedError),
     #[error("failed to parse service manager output")]
     ParseOutput(#[source] serde_json::Error),
-    #[error("environment doesn't have any running services")]
-    NoRunningServices,
     #[error("Environment doesn't have any services defined.")]
     NoDefinedServices,
     #[error("failed to read process log line")]

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -43,8 +43,12 @@ pub enum ServiceError {
     RemoteEnvsNotSupported,
     #[error("services are not enabled")]
     FeatureFlagDisabled,
-    #[error("services have not been started in this activation")]
-    NotInActivation,
+    #[error(
+        "Cannot {action} services for an environment that is not activated.
+
+To activate and start services, run 'flox activate --start-services'"
+    )]
+    NotInActivation { action: String },
     #[error("there was a problem calling the service manager")]
     ProcessComposeCmd(#[source] std::io::Error),
     /// This variant is specifically for errors that are logged by process-compose as opposed to

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -39,7 +39,7 @@ pub enum ServiceError {
     GenerateConfig(#[source] serde_yaml::Error),
     #[error("failed to write service config")]
     WriteConfig(#[source] std::io::Error),
-    #[error("services are not currently supported for remote environments")]
+    #[error("Services are not currently supported for remote environments.")]
     RemoteEnvsNotSupported,
     #[error("services are not enabled")]
     FeatureFlagDisabled,

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -39,16 +39,6 @@ pub enum ServiceError {
     GenerateConfig(#[source] serde_yaml::Error),
     #[error("failed to write service config")]
     WriteConfig(#[source] std::io::Error),
-    #[error("Services are not currently supported for remote environments.")]
-    RemoteEnvsNotSupported,
-    #[error("Services are not enabled in this environment.")]
-    FeatureFlagDisabled,
-    #[error(
-        "Cannot {action} services for an environment that is not activated.
-
-To activate and start services, run 'flox activate --start-services'"
-    )]
-    NotInActivation { action: String },
     #[error("there was a problem calling the service manager")]
     ProcessComposeCmd(#[source] std::io::Error),
     /// This variant is specifically for errors that are logged by process-compose as opposed to
@@ -57,8 +47,6 @@ To activate and start services, run 'flox activate --start-services'"
     LoggedError(#[from] LoggedError),
     #[error("failed to parse service manager output")]
     ParseOutput(#[source] serde_json::Error),
-    #[error("Environment doesn't have any services defined.")]
-    NoDefinedServices,
     #[error("failed to read process log line")]
     ReadLogLine(#[source] std::io::Error),
 }

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -41,7 +41,7 @@ pub enum ServiceError {
     WriteConfig(#[source] std::io::Error),
     #[error("Services are not currently supported for remote environments.")]
     RemoteEnvsNotSupported,
-    #[error("services are not enabled")]
+    #[error("Services are not enabled in this environment.")]
     FeatureFlagDisabled,
     #[error(
         "Cannot {action} services for an environment that is not activated.

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -55,6 +55,8 @@ pub enum ServiceError {
     ParseOutput(#[source] serde_json::Error),
     #[error("environment doesn't have any running services")]
     NoRunningServices,
+    #[error("Environment doesn't have any services defined.")]
+    NoDefinedServices,
     #[error("failed to read process log line")]
     ReadLogLine(#[source] std::io::Error),
 }

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -28,7 +28,6 @@ use flox_rust_sdk::models::environment::{
 };
 use flox_rust_sdk::models::manifest::TypedManifest;
 use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
-use flox_rust_sdk::providers::services::ServiceError;
 use indexmap::IndexSet;
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -43,6 +42,7 @@ use super::{
     EnvironmentSelect,
     UninitializedEnvironment,
 };
+use crate::commands::services::ServicesCommandsError;
 use crate::commands::{ensure_environment_trust, ConcreteEnvironment, EnvironmentSelectError};
 use crate::config::{Config, EnvironmentPromptConfig};
 use crate::utils::dialog::{Dialog, Spinner};
@@ -86,7 +86,7 @@ impl Activate {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("activate");
         if !flox.features.services && self.start_services {
-            return Err(ServiceError::FeatureFlagDisabled.into());
+            return Err(ServicesCommandsError::FeatureFlagDisabled.into());
         }
         let concrete_environment = match self.environment.to_concrete_environment(&flox) {
             Ok(concrete_environment) => concrete_environment,

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -28,6 +28,7 @@ use flox_rust_sdk::models::environment::{
 };
 use flox_rust_sdk::models::manifest::TypedManifest;
 use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
+use flox_rust_sdk::providers::services::ServiceError;
 use indexmap::IndexSet;
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -85,7 +86,7 @@ impl Activate {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("activate");
         if !flox.features.services && self.start_services {
-            bail!("Services are not enabled in this environment");
+            return Err(ServiceError::FeatureFlagDisabled.into());
         }
         let concrete_environment = match self.environment.to_concrete_environment(&flox) {
             Ok(concrete_environment) => concrete_environment,

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1114,6 +1114,14 @@ impl ConcreteEnvironment {
         }
     }
 
+    pub fn dyn_environment_ref(&self) -> &dyn Environment {
+        match self {
+            ConcreteEnvironment::Path(path_env) => path_env,
+            ConcreteEnvironment::Managed(managed_env) => managed_env,
+            ConcreteEnvironment::Remote(remote_env) => remote_env,
+        }
+    }
+
     pub fn dyn_environment_ref_mut(&mut self) -> &mut dyn Environment {
         match self {
             ConcreteEnvironment::Path(path_env) => path_env,

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -70,14 +70,12 @@ pub fn supported_concrete_environment(
     flox: &Flox,
     environment: &EnvironmentSelect,
 ) -> Result<ConcreteEnvironment> {
-    let mut concrete_environment = environment.detect_concrete_environment(flox, "Services in")?;
+    let concrete_environment = environment.detect_concrete_environment(flox, "Services in")?;
     if let ConcreteEnvironment::Remote(_) = concrete_environment {
         return Err(ServiceError::RemoteEnvsNotSupported.into());
     }
 
-    let manifest = concrete_environment
-        .dyn_environment_ref_mut()
-        .manifest(&flox)?;
+    let manifest = concrete_environment.dyn_environment_ref().manifest(flox)?;
     let TypedManifest::Catalog(manifest) = manifest else {
         return Err(CoreEnvironmentError::ServicesWithV0.into());
     };

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -33,7 +33,7 @@ impl Restart {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("services::restart");
 
-        let mut concrete_environment = supported_concrete_environment(&flox, &self.environment)?;
+        let concrete_environment = supported_concrete_environment(&flox, &self.environment)?;
         let activated_environments = activated_environments();
 
         if !activated_environments.is_active(&UninitializedEnvironment::from_concrete_environment(
@@ -46,8 +46,7 @@ impl Restart {
             "}));
         }
 
-        // TODO: this doesn't need to be mut
-        let env = concrete_environment.dyn_environment_ref_mut();
+        let env = concrete_environment.dyn_environment_ref();
         let socket = env.services_socket_path(&flox)?;
 
         let start_new_process_compose = if !socket.exists() {

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -3,8 +3,12 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::services::{process_compose_down, restart_service, ProcessStates};
-use indoc::indoc;
+use flox_rust_sdk::providers::services::{
+    process_compose_down,
+    restart_service,
+    ProcessStates,
+    ServiceError,
+};
 use tracing::{debug, instrument};
 
 use crate::commands::services::{start_with_new_process_compose, supported_concrete_environment};
@@ -39,11 +43,10 @@ impl Restart {
         if !activated_environments.is_active(&UninitializedEnvironment::from_concrete_environment(
             &concrete_environment,
         )?) {
-            return Err(anyhow!(indoc! {"
-                Cannot restart services for an environment that is not activated.
-
-                To activate and start services, run 'flox activate --start-services'
-            "}));
+            return Err(ServiceError::NotInActivation {
+                action: "restart".to_string(),
+            }
+            .into());
         }
 
         let env = concrete_environment.dyn_environment_ref();

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -3,15 +3,14 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::services::{
-    process_compose_down,
-    restart_service,
-    ProcessStates,
-    ServiceError,
-};
+use flox_rust_sdk::providers::services::{process_compose_down, restart_service, ProcessStates};
 use tracing::{debug, instrument};
 
-use crate::commands::services::{start_with_new_process_compose, supported_concrete_environment};
+use crate::commands::services::{
+    start_with_new_process_compose,
+    supported_concrete_environment,
+    ServicesCommandsError,
+};
 use crate::commands::{
     activated_environments,
     environment_select,
@@ -43,7 +42,7 @@ impl Restart {
         if !activated_environments.is_active(&UninitializedEnvironment::from_concrete_environment(
             &concrete_environment,
         )?) {
-            return Err(ServiceError::NotInActivation {
+            return Err(ServicesCommandsError::NotInActivation {
                 action: "restart".to_string(),
             }
             .into());

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -4,8 +4,12 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::services::{process_compose_down, start_service, ProcessStates};
-use indoc::indoc;
+use flox_rust_sdk::providers::services::{
+    process_compose_down,
+    start_service,
+    ProcessStates,
+    ServiceError,
+};
 use tracing::{debug, instrument};
 
 use crate::commands::services::{start_with_new_process_compose, supported_concrete_environment};
@@ -40,11 +44,10 @@ impl Start {
         if !activated_environments.is_active(&UninitializedEnvironment::from_concrete_environment(
             &concrete_environment,
         )?) {
-            return Err(anyhow!(indoc! {"
-                Cannot start services for an environment that is not activated.
-
-                To activate and start services, run 'flox activate --start-services'
-            "}));
+            return Err(ServiceError::NotInActivation {
+                action: "start".to_string(),
+            }
+            .into());
         }
 
         let env = concrete_environment.dyn_environment_ref();

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -34,7 +34,7 @@ impl Start {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("services::start");
 
-        let mut concrete_environment = supported_concrete_environment(&flox, &self.environment)?;
+        let concrete_environment = supported_concrete_environment(&flox, &self.environment)?;
         let activated_environments = activated_environments();
 
         if !activated_environments.is_active(&UninitializedEnvironment::from_concrete_environment(
@@ -47,8 +47,7 @@ impl Start {
             "}));
         }
 
-        // TODO: this doesn't need to be mut
-        let env = concrete_environment.dyn_environment_ref_mut();
+        let env = concrete_environment.dyn_environment_ref();
         let socket = env.services_socket_path(&flox)?;
 
         let start_new_process_compose = if !socket.exists() {

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -4,15 +4,14 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::services::{
-    process_compose_down,
-    start_service,
-    ProcessStates,
-    ServiceError,
-};
+use flox_rust_sdk::providers::services::{process_compose_down, start_service, ProcessStates};
 use tracing::{debug, instrument};
 
-use crate::commands::services::{start_with_new_process_compose, supported_concrete_environment};
+use crate::commands::services::{
+    start_with_new_process_compose,
+    supported_concrete_environment,
+    ServicesCommandsError,
+};
 use crate::commands::{
     activated_environments,
     environment_select,
@@ -44,7 +43,7 @@ impl Start {
         if !activated_environments.is_active(&UninitializedEnvironment::from_concrete_environment(
             &concrete_environment,
         )?) {
-            return Err(ServiceError::NotInActivation {
+            return Err(ServicesCommandsError::NotInActivation {
                 action: "start".to_string(),
             }
             .into());

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -372,7 +372,7 @@ EOF
   assert_failure
   assert_output --partial "❌ ERROR: Services are not currently supported for remote environments."
 
-  unsupported_commands=("logs" "restart" "status" "stop")
+  unsupported_commands=("logs" "restart" "start" "status" "stop")
   for command in "${unsupported_commands[@]}"; do
     run "$FLOX_BIN" services "$command" hello --remote "flox/test"
     assert_failure

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -370,12 +370,12 @@ EOF
   # Everything else that explicitly uses services shouldn't work.
   run "$FLOX_BIN" activate --start-services --remote "flox/test" -- true
   assert_failure
-  assert_output --partial "❌ ERROR: services are not currently supported for remote environments"
+  assert_output --partial "❌ ERROR: Services are not currently supported for remote environments."
 
   unsupported_commands=("logs" "restart" "status" "stop")
   for command in "${unsupported_commands[@]}"; do
     run "$FLOX_BIN" services "$command" hello --remote "flox/test"
     assert_failure
-    assert_output --partial "❌ ERROR: services are not currently supported for remote environments"
+    assert_output --partial "❌ ERROR: Services are not currently supported for remote environments."
   done
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -155,7 +155,7 @@ EOF
   unset output
   run "$FLOX_BIN" activate -s
   assert_failure
-  assert_output --partial "Services are not enabled in this environment"
+  assert_line "❌ ERROR: Services are not enabled in this environment."
 }
 
 @test "can start redis-server and access it using redis-cli" {
@@ -201,6 +201,19 @@ EOF
     run "$FLOX_BIN" activate -- "$FLOX_BIN" services "$command"
     assert_failure
     assert_line "❌ ERROR: Environment doesn't have any services defined."
+  done
+}
+
+@test "all imperative commands error without feature flag" {
+  run "$FLOX_BIN" init
+
+  commands=("logs" "restart" "start" "status" "stop")
+  for command in "${commands[@]}"; do
+    echo "Testing: flox services $command"
+    # NB: No --start-services.
+    run "$FLOX_BIN" activate -- "$FLOX_BIN" services "$command"
+    assert_failure
+    assert_line "❌ ERROR: Services are not enabled in this environment."
   done
 }
 
@@ -464,13 +477,6 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
-
-# bats test_tags=services:stop
-@test "stop: can't be used without feature flag" {
-  run "$FLOX_BIN" services stop
-  assert_failure
-  assert_output "❌ ERROR: services are not enabled"
-}
 
 # bats test_tags=services:stop
 @test "stop: errors if a service doesn't exist" {

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -190,6 +190,20 @@ EOF
   assert_output --partial "will not start services"
 }
 
+@test "all imperative commands error when no services are defined" {
+  export FLOX_FEATURES_SERVICES=true
+  run "$FLOX_BIN" init
+
+  commands=("logs" "restart" "start" "status" "stop")
+  for command in "${commands[@]}"; do
+    echo "Testing: flox services $command"
+    # NB: No --start-services.
+    run "$FLOX_BIN" activate -- "$FLOX_BIN" services "$command"
+    assert_failure
+    assert_line "❌ ERROR: Environment doesn't have any services defined."
+  done
+}
+
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=services:restart


### PR DESCRIPTION
## Proposed Changes

A handful of improvements to error messaging for `flox services start` and `flox services restart` that came out of https://github.com/flox/flox/pull/1923#discussion_r1713945833

This is best reviewed commit-by-commit.

## Release Notes

N/A until services release.
