### PR TITLE
fix: use nix provided sleep command

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -41,7 +41,7 @@ wait_for_services_socket () {
   local status
   status=$(poll_services_status "$socket_file")
   while [ "$status" == "$NOT_READY" ]; do
-    sleep 0.02
+    "$_coreutils/bin/sleep" 0.02
     status=$(poll_services_status "$socket_file")
   done
 }

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -126,7 +126,7 @@ mod tests {
     use std::io;
 
     use flox_rust_sdk::providers::services::test_helpers::TestProcessComposeInstance;
-    use flox_rust_sdk::providers::services::{ProcessComposeConfig, ProcessConfig};
+    use flox_rust_sdk::providers::services::{generate_never_exit_process, ProcessComposeConfig};
 
     use super::*;
 
@@ -152,14 +152,8 @@ mod tests {
         let instance = TestProcessComposeInstance::start_services(
             &ProcessComposeConfig {
                 processes: [
-                    ("one".to_string(), ProcessConfig {
-                        command: String::from("sleep infinity"),
-                        vars: None,
-                    }),
-                    ("two".to_string(), ProcessConfig {
-                        command: String::from("sleep infinity"),
-                        vars: None,
-                    }),
+                    ("one".to_string(), generate_never_exit_process()),
+                    ("two".to_string(), generate_never_exit_process()),
                 ]
                 .into(),
             },
@@ -192,18 +186,9 @@ mod tests {
         let instance = TestProcessComposeInstance::start_services(
             &ProcessComposeConfig {
                 processes: [
-                    ("one".to_string(), ProcessConfig {
-                        command: String::from("sleep infinity"),
-                        vars: None,
-                    }),
-                    ("two".to_string(), ProcessConfig {
-                        command: String::from("sleep infinity"),
-                        vars: None,
-                    }),
-                    ("three".to_string(), ProcessConfig {
-                        command: String::from("sleep infinity"),
-                        vars: None,
-                    }),
+                    ("one".to_string(), generate_never_exit_process()),
+                    ("two".to_string(), generate_never_exit_process()),
+                    ("three".to_string(), generate_never_exit_process()),
                 ]
                 .into(),
             },

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -2,6 +2,7 @@
   flox-pkgdb,
   gitMinimal,
   inputs,
+  coreutils,
   lib,
   pkgsFor,
   process-compose,
@@ -25,6 +26,8 @@
       if flox-pkgdb == null
       then "pkgdb"
       else "${flox-pkgdb}/bin/pkgdb";
+
+    SLEEP_BIN = "${coreutils}/bin/sleep";
 
     PROCESS_COMPOSE_BIN = "${process-compose}/bin/process-compose";
 
@@ -71,6 +74,7 @@ in
           ++ [
             gitMinimal
             process-compose
+            coreutils # for `sleep infinity`
           ]
           ++ lib.optional (flox-pkgdb != null) [
             flox-pkgdb


### PR DESCRIPTION
To prevent `process-compose` from exiting when all services are stopped,
we run a dummy service that sleeps indefinitely.
However, not all systems have a `sleep` command that supports `sleep infinity`,
so we use a nix provided `sleep` binary instead.

