### PR TITLE
feat(services): Indicate whether restart or start

### DIFF
--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -50,22 +50,22 @@ impl Restart {
         let env = concrete_environment.dyn_environment_ref_mut();
         let socket = env.services_socket_path(&flox)?;
 
-        let start_new_process_compose = if !socket.exists() {
-            true
-        } else if self.names.is_empty() {
-            // TODO: We could optimise by checking whether the manifest has actually changed.
-            process_compose_down(&socket)?;
-            true
-        } else {
-            let processes = ProcessStates::read(&socket)?;
-            let all_processes_stopped = processes.iter().all(|p| p.is_stopped());
-            if all_processes_stopped {
-                process_compose_down(&socket)?;
-            }
-            all_processes_stopped
+        let existing_process_compose = socket.exists();
+        let existing_processes = match existing_process_compose {
+            true => ProcessStates::read(&socket)?,
+            false => ProcessStates::from(vec![]),
         };
+        let all_processes_stopped = existing_processes.iter().all(|p| p.is_stopped());
+        let restart_all = self.names.is_empty();
+
+        // TODO: We could optimise by checking whether the manifest has actually changed.
+        let start_new_process_compose = restart_all || all_processes_stopped;
 
         if start_new_process_compose {
+            if existing_process_compose {
+                debug!("stopping existing process-compose instance");
+                process_compose_down(&socket)?;
+            }
             debug!("restarting services in new process-compose instance");
             let names = start_with_new_process_compose(
                 config,
@@ -76,12 +76,28 @@ impl Restart {
             )
             .await?;
             for name in names {
-                message::updated(format!("Service '{name}' restarted."));
+                message::updated(format!(
+                    "Service '{name}' {}.",
+                    Self::action_for_service_name(&name, &existing_processes)
+                ));
             }
             Ok(())
         } else {
             debug!("restarting services with existing process-compose instance");
-            Self::restart_with_existing_process_compose(socket, &self.names)
+            Self::restart_with_existing_process_compose(socket, &self.names, existing_processes)
+        }
+    }
+
+    // Return a "started" or "restarted" action depending on whether the service
+    // was previous consider running.
+    fn action_for_service_name(name: &str, processes: &ProcessStates) -> String {
+        let process = match processes.process(name) {
+            Some(proc) => proc,
+            None => return "started".to_string(),
+        };
+        match process.is_stopped() {
+            true => "started".to_string(),
+            false => "restarted".to_string(),
         }
     }
 
@@ -90,20 +106,26 @@ impl Restart {
     fn restart_with_existing_process_compose(
         socket: impl AsRef<Path>,
         names: &[String],
+        processes: ProcessStates,
     ) -> Result<()> {
-        let processes = ProcessStates::read(&socket)?;
         let named_processes = super::processes_by_name_or_default_to_all(&processes, names)?;
 
         let mut failure_count = 0;
         for process in named_processes {
             match restart_service(&socket, &process.name) {
                 Ok(_) => {
-                    message::updated(format!("Service '{}' restarted.", process.name));
+                    message::updated(format!(
+                        "Service '{}' {}.",
+                        process.name,
+                        Self::action_for_service_name(&process.name, &processes),
+                    ));
                 },
                 Err(e) => {
                     message::error(format!(
-                        "Failed to restart service '{}': {}",
-                        process.name, e
+                        "Failed to {} service '{}': {}",
+                        Self::action_for_service_name(&process.name, &processes),
+                        process.name,
+                        e
                     ));
                     failure_count += 1;
                 },

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -235,7 +235,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' restarted"
+  assert_output --partial "✅ Service 'one' started"
 
   wait_for_file_content start_counter.one 2
   wait_for_file_content start_counter.two 1
@@ -253,8 +253,8 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' restarted"
-  assert_output --partial "✅ Service 'two' restarted"
+  assert_output --partial "✅ Service 'one' started"
+  assert_output --partial "✅ Service 'two' started"
 
   wait_for_file_content start_counter.one 2
   wait_for_file_content start_counter.two 2
@@ -272,8 +272,8 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' restarted"
-  assert_output --partial "✅ Service 'two' restarted"
+  assert_output --partial "✅ Service 'one' started"
+  assert_output --partial "✅ Service 'two' started"
   assert_output --partial "✅ Service 'sleeping' restarted"
 
   wait_for_file_content start_counter.one 2
@@ -294,7 +294,7 @@ EOF
 )
   assert_success
   assert_output --partial "✅ Service 'sleeping' stopped"
-  assert_output --partial "✅ Service 'sleeping' restarted"
+  assert_output --partial "✅ Service 'sleeping' started"
 
   wait_for_file_content start_counter.sleeping 2
 }
@@ -311,9 +311,9 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' restarted"
-  refute_output --partial "✅ Service 'two' restarted"
-  refute_output --partial "✅ Service 'sleeping' restarted"
+  assert_output --partial "✅ Service 'one' started"
+  refute_output --partial "Service 'two'"
+  refute_output --partial "Service 'sleeping'"
 
   # Can't reliably assert that the other services didn't start.
   wait_for_file_content start_counter.one 1
@@ -336,7 +336,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'touch_file' restarted"
+  assert_output --partial "✅ Service 'touch_file' started"
   assert_output --regexp "touch_file +(Running|Completed)"
 }
 
@@ -352,9 +352,9 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' restarted"
-  assert_output --partial "✅ Service 'two' restarted"
-  assert_output --partial "✅ Service 'sleeping' restarted"
+  assert_output --partial "✅ Service 'one' started"
+  assert_output --partial "✅ Service 'two' started"
+  assert_output --partial "✅ Service 'sleeping' started"
 
   wait_for_file_content start_counter.one 1
   wait_for_file_content start_counter.two 1
@@ -373,10 +373,10 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'one' restarted"
-  refute_output --partial "Service 'two' restarted"
-  refute_output --partial "Service 'sleeping' restarted"
-  refute_output --partial "Service 'touch_file' restarted"
+  assert_output --partial "✅ Service 'one' started"
+  refute_output --partial "Service 'two'"
+  refute_output --partial "Service 'sleeping'"
+  refute_output --partial "Service 'touch_file'"
 
   wait_for_file_content start_counter.one 2
 }
@@ -393,7 +393,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'touch_file' restarted"
+  assert_output --partial "✅ Service 'touch_file' started"
   [ -e hello.txt ]
 }
 
@@ -410,7 +410,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'touch_file' restarted"
+  assert_output --partial "✅ Service 'touch_file' started"
   [ -e hello.txt ]
 }
 
@@ -427,7 +427,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --partial "✅ Service 'touch_file' restarted"
+  assert_output --partial "✅ Service 'touch_file' started"
   [ -e hello.txt ]
 }
 
@@ -445,7 +445,7 @@ EOF
 )
   assert_failure
   assert_output --partial "❌ ERROR: Service 'one' not found"
-  refute_output --partial "Service 'touch_file' restarted"
+  refute_output --partial "Service 'touch_file'"
   [ ! -e hello.txt ]
 }
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -231,6 +231,8 @@ EOF
 
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
+    # Wait for completion so that we indicate "start" instead of "restart"
+    "${TESTS_DIR}"/services/wait_for_service_status.sh one:Completed
     "$FLOX_BIN" services restart one
 EOF
 )
@@ -249,6 +251,8 @@ EOF
 
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
+    # Wait for completion so that we indicate "start" instead of "restart"
+    "${TESTS_DIR}"/services/wait_for_service_status.sh one:Completed two:Completed
     "$FLOX_BIN" services restart one two
 EOF
 )
@@ -268,6 +272,8 @@ EOF
 
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
+    # Wait for completion so that we indicate "start" instead of "restart"
+    "${TESTS_DIR}"/services/wait_for_service_status.sh one:Completed two:Completed sleeping:Running
     "$FLOX_BIN" services restart
 EOF
 )
@@ -368,6 +374,8 @@ EOF
 
   run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
     source "${TESTS_DIR}/services/register_cleanup.sh"
+    # Wait for completion so that we indicate "start" instead of "restart"
+    "${TESTS_DIR}"/services/wait_for_service_status.sh one:Completed
     "$FLOX_BIN" edit -f "${TESTS_DIR}/services/touch_file.toml"
     "$FLOX_BIN" services restart one
 EOF

--- a/cli/tests/services/wait_for_service_status.sh
+++ b/cli/tests/services/wait_for_service_status.sh
@@ -1,0 +1,32 @@
+
+#!/usr/bin/env bash
+#
+# Usage: wait_for_services_status.sh [name:status ...]
+#
+# Waits for all of the name:status pairs to reach their desired status to
+# prevent race conditions in our tests where we depend on something happening
+# after a certain state.
+#
+set -euo pipefail
+
+check_status() {
+    name_status_pairs=("$@")
+    status_output=$("$FLOX_BIN" services status --json)
+
+    for status in "${name_status_pairs[@]}"; do
+        service_name=$(echo $status | cut -d':' -f1)
+        expected_status=$(echo $status | cut -d':' -f2)
+        current_status=$(echo "$status_output" | jq --slurp --raw-output ".[] | select(.name==\"$service_name\") | .status")
+
+        if [ "$current_status" != "$expected_status" ]; then
+            echo "Service '$service_name' status current=$current_status, expected=$expected_status"
+            return 1
+        fi
+    done
+
+    echo "All services reached their expected status."
+    return 0
+}
+
+export -f check_status
+timeout 1s bash -c "while ! check_status ${*}; do sleep 0.1; done"


### PR DESCRIPTION
## Proposed Changes

Improvement suggested in https://github.com/flox/flox/pull/1923#discussion_r1714382987

Indicate whether `flox services restart` did a start or restart based on whether the service was running previously.

This removes an unnecessary `ProcessStates::read` when we're using an existing `process-compose` instance.

I considered checking the names against a HashSet of running processes so that `ProcessStates.process()` doesn't have to filter by name each time but passing it around made it harder to read so I've contained it all in one private function.

## Release Notes

N/A until services release.
