### PR TITLE
fix: stop process-compose in activate

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -433,6 +433,22 @@ pub fn process_compose_down(socket_path: impl AsRef<Path>) -> Result<(), Service
     }
 }
 
+/// Check if all processes are stopped and shutdown `process-compose` if they
+/// are.
+///
+/// Returns true if process-compose was shutdown.
+pub fn shutdown_process_compose_if_all_processes_stopped(
+    socket: impl AsRef<Path>,
+) -> Result<bool, ServiceError> {
+    let processes = ProcessStates::read(&socket)?;
+    let all_processes_stopped = processes.iter().all(|p| p.is_stopped());
+    if all_processes_stopped {
+        tracing::debug!("all processes stopped; shutting down 'process-compose'");
+        process_compose_down(socket)?;
+    }
+    Ok(all_processes_stopped)
+}
+
 /// Strings extracted from a process-compose error log.
 ///
 /// This is just raw data intended to be interpreted into a specific kind of error

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -747,7 +747,7 @@ EOF
 @test "activate services: shows warning when services already running" {
   setup_sleeping_services
   mkfifo fifo
-  "$FLOX_BIN" activate -s -- echo \>\> fifo &
+  "$FLOX_BIN" activate -s -- echo \> fifo &
   activate_pid="$!"
   # Make sure the first `process-compose` gets up and running
   for i in {1..5}; do
@@ -766,7 +766,7 @@ EOF
 
   # Technically this should be a teardown step
   # The test will hang forever if it fails and doesn't get here
-  read < fifo
+  timeout 2 cat fifo
 }
 
 # ---------------------------------------------------------------------------- #
@@ -1279,7 +1279,7 @@ EOF
   # Edit the manifest adding a second service and changing the value of FOO.
   # Then start services again.
   mkfifo fifo
-  "$FLOX_BIN" activate -s -- echo \>\> fifo &
+  "$FLOX_BIN" activate -s -- echo \> fifo &
   activate_pid="$!"
 
   # Make sure we avoid a race of service one failing to complete
@@ -1342,5 +1342,5 @@ EOF
 
   # Technically this should be a teardown step
   # The test will hang forever if it fails and doesn't get here
-  read < fifo
+  timeout 2 cat fifo
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -746,7 +746,8 @@ EOF
 
 @test "activate services: shows warning when services already running" {
   setup_sleeping_services
-  "$FLOX_BIN" activate -s -- sleep infinity &
+  mkfifo fifo
+  "$FLOX_BIN" activate -s -- echo \>\> fifo &
   activate_pid="$!"
   # Make sure the first `process-compose` gets up and running
   for i in {1..5}; do
@@ -765,7 +766,7 @@ EOF
 
   # Technically this should be a teardown step
   # The test will hang forever if it fails and doesn't get here
-  kill -SIGINT "$activate_pid"
+  read < fifo
 }
 
 # ---------------------------------------------------------------------------- #
@@ -1277,7 +1278,8 @@ EOF
 
   # Edit the manifest adding a second service and changing the value of FOO.
   # Then start services again.
-  "$FLOX_BIN" activate -s -- sleep infinity &
+  mkfifo fifo
+  "$FLOX_BIN" activate -s -- echo \>\> fifo &
   activate_pid="$!"
 
   # Make sure we avoid a race of service one failing to complete
@@ -1340,5 +1342,5 @@ EOF
 
   # Technically this should be a teardown step
   # The test will hang forever if it fails and doesn't get here
-  kill -SIGINT "$activate_pid"
+  read < fifo
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -169,7 +169,6 @@ EOF
   setup_sleeping_services
 
   RUST_LOG=debug run "$FLOX_BIN" activate -- true
-  assert_output --partial "start=false"
   assert_output --partial "will not start services"
 }
 
@@ -747,12 +746,26 @@ EOF
 
 @test "activate services: shows warning when services already running" {
   setup_sleeping_services
-  dummy_socket="$PWD/sock.sock"
-  touch "$dummy_socket"
-  _FLOX_SERVICES_SOCKET="$dummy_socket" run "$FLOX_BIN" activate -s -- true
+  "$FLOX_BIN" activate -s -- sleep infinity &
+  activate_pid="$!"
+  # Make sure the first `process-compose` gets up and running
+  for i in {1..5}; do
+    if "$FLOX_BIN" services status; then
+      break
+    fi
+    sleep .1
+  done
+  if [ "$i" -eq 5 ]; then
+    exit 1
+  fi
 
+  run "$FLOX_BIN" activate -s -- true
   assert_success
   assert_output --partial "⚠️  Skipped starting services, services are already running"
+
+  # Technically this should be a teardown step
+  # The test will hang forever if it fails and doesn't get here
+  kill -SIGINT "$activate_pid"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -1242,4 +1255,90 @@ EOF
   assert_success
   run [ ! -e "$PWD/overmind.sock" ]
   assert_success
+}
+
+@test "activate: picks up changes after environment modification when all services have stopped" {
+
+  export FLOX_FEATURES_SERVICES=true
+
+  MANIFEST_CONTENTS_1="$(cat << "EOF"
+    version = 1
+
+    [services]
+    one.command = "echo $FOO"
+
+    [hook]
+    on-activate = "export FOO=foo_one"
+EOF
+  )"
+
+  "$FLOX_BIN" init
+  echo "$MANIFEST_CONTENTS_1" | "$FLOX_BIN" edit -f -
+
+  # Edit the manifest adding a second service and changing the value of FOO.
+  # Then start services again.
+  "$FLOX_BIN" activate -s -- sleep infinity &
+  activate_pid="$!"
+
+  # Make sure we avoid a race of service one failing to complete
+  for i in {1..5}; do
+    if "$FLOX_BIN" services status | grep "Completed"; then
+      break
+    fi
+    sleep .1
+  done
+  if [ "$i" -eq 5 ]; then
+    exit 1
+  fi
+
+  run "$FLOX_BIN" services logs one
+  assert_success
+  assert_output "foo_one"
+
+  MANIFEST_CONTENTS_2="$(cat << "EOF"
+    version = 1
+
+    [services]
+    one.command = "echo $FOO"
+    two.command = "sleep infinity"
+
+    [hook]
+    on-activate = "export FOO=foo_two"
+EOF
+  )"
+
+  echo "$MANIFEST_CONTENTS_2" | "$FLOX_BIN" edit -f -
+
+  "$FLOX_BIN" activate -s -- true
+
+  # Make sure we avoid a race of service one failing to complete
+  for i in {1..5}; do
+    if "$FLOX_BIN" services status | grep "Completed"; then
+      break
+    fi
+    sleep .1
+  done
+  if [ "$i" -eq 5 ]; then
+    exit 1
+  fi
+
+  # The added service should be running.
+  for i in {1..5}; do
+    if "$FLOX_BIN" services status | grep "two        Running"; then
+      break
+    fi
+    sleep .1
+  done
+  if [ "$i" -eq 5 ]; then
+    exit 1
+  fi
+
+  # The modified value of FOO should be printed.
+  run "$FLOX_BIN" services logs one
+  assert_success
+  assert_output "foo_two"
+
+  # Technically this should be a teardown step
+  # The test will hang forever if it fails and doesn't get here
+  kill -SIGINT "$activate_pid"
 }


### PR DESCRIPTION
When `activate -s` is called, if process-compose is running and all services are stopped, call `process-compose down` and then start `process-compose` again as part of activation.

This is consistent with how `start` and `restart` handle when to restart `process-compose`, and it allows re-starting `process-compose` in the context of an updated environment.

The logic for starting `process-compose` in activate was refactored with a few behavioral changes:
- We always error for remote environments if `--start-services` is passed. That makes it more clear services aren't ever started for remote environments.
- _FLOX_SERVICES_TO_START is only set when services should actually be started. Previously, it was dependent on the socket being present. Since it is only needed when services are actually started, only set it in that case for the sake of readability.

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
