### PR TITLE
ci: Limit and debug failing integ-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
       #   - a cargo-built debug binary is used, like you would in local development
       #   - envrionment variables unskip some tests against live systems
       - name: "CLI Integration Tests"
+        timeout-minutes: 30
         env:
           RUST_BACKTRACE: 1
           AUTH0_FLOX_DEV_CLIENT_SECRET: "${{ secrets.MANAGED_AUTH0_FLOX_DEV_CLIENT_SECRET }}"
@@ -368,6 +369,7 @@ jobs:
           nix copy --extra-experimental-features 'nix-command' --to "$CONFIGURE_NIX_SUBSTITUTER" ./result
 
       - name: "Run Bats Tests (./#flox-cli-tests)"
+        timeout-minutes: 30
         run: |
           git clean -xfd
           ssh github@$REMOTE_SERVER \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,10 @@ jobs:
           AUTH0_FLOX_DEV_CLIENT_SECRET: "${{ secrets.MANAGED_AUTH0_FLOX_DEV_CLIENT_SECRET }}"
         run: nix develop -L --no-update-lock-file --command just integ-tests
 
+      - name: "Capture process tree for failing tests"
+        if: ${{ failure() }}
+        run: nix develop -L --no-update-lock-file --command pstree
+
   nix-build:
     name: "Nix build"
     runs-on: "ubuntu-latest"

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -8,6 +8,7 @@
   mkShell,
   procps,
   pre-commit-check,
+  pstree,
   shfmt,
   mitmproxy,
   cargo-nextest,
@@ -48,6 +49,7 @@
       yq
       cargo-nextest
       procps
+      pstree
     ];
 in
   mkShell (


### PR DESCRIPTION
## Proposed Changes

**ci: Limit integ-tests step to 30mins**

This step takes <10 mins in normal execution but sometimes hangs
indefinitely. Setting a stricter timeout on the step, but leaving the
more relaxed timeout on the job, will give us faster feedback whilst
also allowing us to capture information in an additional
step (subsequent commit).

**ci: Run pstree when Runner integ-tests fail**

To help us figure out what's still running when the integration tests
hang. I'm only doing this on the Runner jobs, not the Nix remote builder
jobs, because it will be hard to tell on those shared instance which
processes belong to this CI run.

There's an example of this working here:

- https://github.com/flox/flox/actions/runs/10388611281/job/28764639190#step:8:1

## Release Notes

N/A
