### PR TITLE
fix: recover from build errors due to conflicting packages

### DIFF
--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -17,6 +17,7 @@ use flox_rust_sdk::models::environment::{
     Environment,
     EnvironmentError,
 };
+use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
 use flox_rust_sdk::providers::services::ServiceError;
 use itertools::Itertools;
 use log::debug;
@@ -316,6 +317,12 @@ impl Edit {
             | Err(EnvironmentError::Core(e @ CoreEnvironmentError::DeserializeManifest(_)))
             | Err(EnvironmentError::Core(e @ CoreEnvironmentError::Version0NotSupported))
             | Err(EnvironmentError::Core(
+                e @ CoreEnvironmentError::BuildEnv(CallPkgDbError::PkgDbError(PkgDbError {
+                    exit_code: error_codes::BUILDENV_CONFLICT,
+                    ..
+                })),
+            )) => Ok(Err(e)),
+            Err(EnvironmentError::Core(
                 e @ CoreEnvironmentError::Services(ServiceError::InvalidConfig(_)),
             )) => Ok(Err(e)),
             Err(e) => Err(e),


### PR DESCRIPTION
## Proposed Changes

`buildenv` will fail with status 122 when realising an environment which contains multiple packages that provide the same file.
A package can specify a `priority` to be used instead of the other to resolve the conflict.

In interactive edits, build failures of any kind were treated as unrecoverable. However since conflict can be recovered we are returning that error as recoverable.

Thus now installing e.g. `vim` and `vim-full` to an environment with `flox edit`:

```
version = 1

[install]
vim.pkg-path = "vim"
vim-full.pkg-path = "vim-full"
```

Will prompt to continue editing:

```
❌ ERROR: 'vim' conflicts with 'vim-full'. Both packages provide the file '/bin/rview'

Resolve by uninstalling one of the conflicting packages or setting the priority of the preferred package to a value lower than '5'
! Continue editing? (Y/n)
```
