### PR TITLE
fix: cleanup when parent exits before watchdog

### DIFF
--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -209,6 +209,9 @@ impl RegistryEntry {
     }
 
     /// Deregister an activation for an existing enviroment.
+    ///
+    /// Doesn't error if the activation wasn't found, because another watchdog
+    /// may have already cleaned it up as stale.
     fn deregister_activation(&mut self, pid: ActivationPid) {
         tracing::debug!(%pid, hash = self.path_hash, "deregistering activation");
         self.activations.remove(&pid);


### PR DESCRIPTION
For a short-lived activation, e.g. `flox activate -s -- true`, the
parent of the watchdog may exit quickly. Currently we error when we
detect that case, but that means we may leave behind a running
process-compose. Instead, perform cleanup.