### PR TITLE
feat(services): Warn on most manifest changes

### DIFF
--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -23,6 +23,7 @@ use itertools::Itertools;
 use log::debug;
 use tracing::instrument;
 
+use super::services::warn_manifest_changes_for_services;
 use super::{
     activated_environments,
     environment_select,
@@ -243,6 +244,11 @@ impl Edit {
             },
             EditResult::Success { .. } => message::updated("Environment successfully updated."),
         }
+
+        if result != EditResult::Unchanged {
+            warn_manifest_changes_for_services(flox, environment);
+        }
+
         Ok(())
     }
 

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -169,8 +169,6 @@ impl Edit {
         Ok(())
     }
 
-    // TODO: having to pass environment + active_environment + description
-    // instead of just environment is a pain
     async fn edit_manifest(
         flox: &Flox,
         environment: &mut ConcreteEnvironment,

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -25,6 +25,7 @@ use itertools::Itertools;
 use log::debug;
 use tracing::instrument;
 
+use super::services::warn_manifest_changes_for_services;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{
     ensure_floxhub_token,
@@ -194,6 +195,11 @@ impl Install {
                 ));
             }
         }
+
+        if installation.new_manifest.is_some() {
+            warn_manifest_changes_for_services(&flox, environment.as_ref());
+        }
+
         Ok(())
     }
 

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -183,20 +183,11 @@ impl Install {
             },
         };
 
-        if installation.new_manifest.is_some() {
-            // Print which new packages were installed
-            for pkg in packages_to_install.iter() {
-                if let Some(false) = installation.already_installed.get(pkg.id()) {
-                    message::package_installed(pkg, &description);
-                } else {
-                    message::warning(format!(
-                        "Package with id '{}' already installed to environment {description}",
-                        pkg.id()
-                    ));
-                }
-            }
-        } else {
-            for pkg in packages_to_install.iter() {
+        // Print which new packages were installed
+        for pkg in packages_to_install.iter() {
+            if let Some(false) = installation.already_installed.get(pkg.id()) {
+                message::package_installed(pkg, &description);
+            } else {
                 message::warning(format!(
                     "Package with id '{}' already installed to environment {description}",
                     pkg.id()

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use log::debug;
 use tracing::instrument;
 
+use super::services::warn_manifest_changes_for_services;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{
     ensure_floxhub_token,
@@ -91,6 +92,9 @@ impl Uninstall {
         self.packages.iter().for_each(|p| {
             message::deleted(format!("'{p}' uninstalled from environment {description}"))
         });
+
+        warn_manifest_changes_for_services(&flox, environment.as_ref());
+
         Ok(())
     }
 }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -3,6 +3,7 @@ use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use tracing::instrument;
 
+use super::services::warn_manifest_changes_for_services;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{ensure_floxhub_token, environment_description};
 use crate::subcommand_metric;
@@ -110,6 +111,8 @@ impl Upgrade {
                     "⬆️  Upgraded '{package}' in environment {description}."
                 ));
             }
+
+            warn_manifest_changes_for_services(&flox, environment.as_ref());
         }
 
         Ok(())

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -90,7 +90,7 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
   assert_success
-  assert_output --partial "✅ Environment successfully updated."
+  assert_output "✅ Environment successfully updated."
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -85,7 +85,9 @@ setup_pkgdb_env() {
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade
-  assert_output --partial "Upgraded 'hello'"
+  assert_success
+  assert_output "⬆️  Upgraded 'hello' in environment 'test'."
+
   hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
   assert_equal "$hello_locked_drv" "$hello_response_drv"
@@ -108,10 +110,12 @@ setup_pkgdb_env() {
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade blue
+  assert_success
+  assert_output "⬆️  Upgraded 'hello' in environment 'test'."
+
   hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
   assert_equal "$hello_locked_drv" "$hello_response_drv"
-  assert_output --partial "Upgraded 'hello'"
 
   assert_not_equal "$old_hello_locked_drv" "$hello_locked_drv"
 }
@@ -126,7 +130,9 @@ setup_pkgdb_env() {
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade toplevel
-  assert_output --partial "Upgraded 'hello'"
+  assert_success
+  assert_output "⬆️  Upgraded 'hello' in environment 'test'."
+
   hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
   assert_equal "$hello_locked_drv" "$hello_response_drv"
@@ -144,7 +150,9 @@ setup_pkgdb_env() {
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade hello
-  assert_output --partial "Upgraded 'hello'"
+  assert_success
+  assert_output "⬆️  Upgraded 'hello' in environment 'test'."
+
   hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
   assert_equal "$hello_locked_drv" "$hello_response_drv"
@@ -158,7 +166,8 @@ setup_pkgdb_env() {
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.json" \
     run "$FLOX_BIN" upgrade hello
-  assert_output --partial "package in the group 'toplevel' with multiple packages"
+  assert_failure
+  assert_line "❌ ERROR: 'hello' is a package in the group 'toplevel' with multiple packages."
 }
 
 @test "check confirmation when all packages are up to date" {
@@ -168,7 +177,7 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" \
     run "$FLOX_BIN" upgrade
   assert_success
-  assert_output --partial "No packages need to be upgraded"
+  assert_output "ℹ️  No packages need to be upgraded in environment 'test'."
 }
 
 @test "catalog: page changes should not be considered an upgrade" {
@@ -194,7 +203,7 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$BUMPED_REVS_RESPONE" \
     run "$FLOX_BIN" upgrade
   assert_success
-  assert_output --partial "No packages need to be upgraded"
+  assert_output "ℹ️  No packages need to be upgraded in environment 'test'."
 
   curr_lock_hash=$(jq --sort-keys --compact-output . "$LOCK_PATH" | sha256sum)
   assert_equal "$curr_lock_hash" "$prev_lock_hash"
@@ -221,7 +230,7 @@ EOF
 
   run "$FLOX_BIN" upgrade
   assert_success
-  assert_output --partial "Upgraded 'hello'"
+  assert_output "⬆️  Upgraded 'hello' in environment 'test'."
 }
 
 # bats test_tags=upgrade:migrate:manifest
@@ -255,6 +264,5 @@ EOF
     "$FLOX_BIN" install hello
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade hello
-  assert_output --partial "Upgraded 'hello'"
-  assert_equal "${#lines[@]}" 1
+  assert_output "⬆️  Upgraded 'hello' in environment 'test'."
 }


### PR DESCRIPTION
## Proposed Changes

Warn the user, if they have services running for an environment, that
they will likely need to restart the services in order to pick up
manifest changes to that environment.

We originally planned to not warn about changes to the `profile` section
because those changes would only affect interactive activations. But
I've opted for a simplification for now where we treat all changes as
affecting because it would have required fragmenting the logic in
`EditResult`.

The behaviour of `install` is harder to reason about than the others.
You could have a service that depends on a binary that either isn't
available or accidentally comes from your host system which you then
want to come from the environment.

I've opted for integration tests because they were the easiest to setup
and reason about. They are grouped in `services.bats`, rather than the
individual command test files, because they share some common setup with
the other services tests.

The same changes for `pull` will come in a separate PR.

There is some refactoring in preceding commits which are best reviewed individually.

## Release Notes

N/A until release.