### PR TITLE
Some work on flakey tests

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -76,7 +76,8 @@ start_services_blocking () {
       echo "❌ Failed to start services" >&2
       exit 1
     else
-      echo "❌ Failed to start services, see $log_file for logs" >&2
+      echo "❌ Failed to start services:" >&2
+      "$_coreutils/bin/cat" "$log_file" >&2
       exit 1
     fi
   fi


### PR DESCRIPTION
- fix: print process-compose logs on start failure

Currently we print the path to the logfile, but since `process-compose`
has failed to start, the logfile should be relatively short.

It will help us in debugging failures to just print the log.


- fix: services logs test timing out

The test `logs: follow shows logs for all services if no names provided`
currently has a timeout of .5 seconds. We've seen that fail in CI:
https://github.com/flox/flox/actions/runs/10390132193/job/28770507812?pr=1920#step:6:480

There's likely an underlying issue, but for now, increase the timeout to
1 second. While doing so, restructure the test to background the logs
command with redirection to a file, and poll for the logs we want to
appear. That way, faster runs of the test won't wait for the full
timeout to kill the `logs --follow` command.


- fix: services logs test race

The test `logs: follow will wait for logs` has flaked in CI:
https://github.com/flox/flox/actions/runs/10390132193/job/28770507812?pr=1920#step:6:425

In that failure, the 4th log line was not printed, which occurs after
the service sleeps for 3 seconds. The most likely explanation is that
process-compose was slow to start, so startup time + 3 seconds was
longer than the 4 second timeout we have until failing the test.

Add a fifo to ensure that the 4 second timeout doesn't start until
after process-compose has started the service and the service has
printed the first few logs.