### PR TITLE
test(services): Flakey test process-compose log

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -783,9 +783,7 @@ EOF
   # Kill sleep for now just to be safe.
 
   run "$FLOX_BIN" activate -s -- true
-  assert_line "❌ Failed to start services:"
-  # Outputs process-compose log file on failure:
-  assert_output --partial "listening /no_permission.sock"
+  assert_output --partial "❌ Failed to start services"
 }
 
 @test "blocking: activation blocks on socket creation" {


### PR DESCRIPTION
## Proposed Changes

Remove the stricter assertions that were added in 130ad75e because we appear to sometimes race `process-compose` creating the log file on our x86-64_linux instance:

- https://github.com/flox/flox/actions/runs/10451722456/job/28938781344#step:6:403
- https://github.com/flox/flox/actions/runs/10451722456/job/28938781344#step:6:403

We already have a separate test for reading the log file from the correct location.

## Release Notes

N/A