### PR TITLE
fix: workaround process-compose race in tests

### DIFF
--- a/cli/tests/services/logging_services.toml
+++ b/cli/tests/services/logging_services.toml
@@ -22,4 +22,7 @@ echo >> ./resume-mostly-deterministic.pipe
 sleep 3
 
 echo 4
+# It currently appears process-compose has a race in which it doesn't always
+# collect log output emitted right before the process exits
+sleep .1
 '''


### PR DESCRIPTION
It currently appears process-compose has a race in which it doesn't always collect log output emitted right before a service exits. A reproducer is included below. When running on an x86_64-linux machine under resource load, the log line containing `2` is dropped at least once every 20 runs.

If a `sleep .1` is added after the `echo 2`, I haven't seen the log line dropped in 200 runs.

Add the same workaround for our tests.

```

set -euo pipefail

cat << EOF > process-compose.yml
version: "0.5"
log_level: debug

processes:
  sleep:
    command: "sleep 100"
  echo:
    command: |
      echo 1
      sleep .1
      echo 2
EOF

process-compose up -u pc.sock -L pc.log --tui=false >/dev/null 2>&1 &

for i in {1..5}; do
  if process-compose process list -u pc.sock 2>/dev/null | grep sleep >/dev/null; then
    break;
  fi
  sleep .1
done

if [ "$i" == 5 ]; then
  echo "didn't start"
  exit 1
fi

sleep .2
process-compose -u pc.sock process logs echo --tail 5 > echo.log
if ! grep 2 echo.log; then
  echo "waiting longer"
  sleep 10
  process-compose -u pc.sock process logs echo --tail 5
  process-compose down -u pc.sock
  exit 1
fi
process-compose down -u pc.sock
```