### PR TITLE
feat: add `set_prompt` and `hide_default_prompt`

### DIFF
--- a/assets/activation-scripts/activate.d/set-prompt.bash
+++ b/assets/activation-scripts/activate.d/set-prompt.bash
@@ -22,7 +22,7 @@ fi
 
 unset _esc colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
 
-if [ -n "$_flox" ] && [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
+if [ -n "$_flox" ] && [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ] && [ "${_FLOX_SET_PROMPT}" != false ]; then
   # Start by saving the original value of PS1.
   if [ -z "$FLOX_SAVE_BASH_PS1" ]; then
     export FLOX_SAVE_BASH_PS1="$PS1"

--- a/assets/activation-scripts/activate.d/set-prompt.fish
+++ b/assets/activation-scripts/activate.d/set-prompt.fish
@@ -1,4 +1,4 @@
-if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS"
+if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS" && [ "$_FLOX_SET_PROMPT" != false ]
     if not set -q FLOX_PROMPT
         set FLOX_PROMPT "flox"
     end

--- a/assets/activation-scripts/activate.d/set-prompt.tcsh
+++ b/assets/activation-scripts/activate.d/set-prompt.tcsh
@@ -19,7 +19,7 @@ endif
 unset _esc colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
 
 # Save the current 'tcsh_prompt' if not already saved.
-if ( $?prompt && $?FLOX_PROMPT_ENVIRONMENTS && "$FLOX_PROMPT_ENVIRONMENTS" != "" ) then
+if ( $?prompt && $?FLOX_PROMPT_ENVIRONMENTS && "$FLOX_PROMPT_ENVIRONMENTS" != ""  && "$_FLOX_SET_PROMPT" != false ) then
     if ( ! $?FLOX_SAVE_TCSH_PROMPT ) then
         setenv FLOX_SAVE_TCSH_PROMPT "$prompt"
     endif

--- a/assets/activation-scripts/activate.d/set-prompt.zsh
+++ b/assets/activation-scripts/activate.d/set-prompt.zsh
@@ -10,7 +10,7 @@ fi
 
 _flox="${_floxPrompt1} ${_floxPrompt2} "
 
-if [ -n "$_flox" -a -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]
+if [ -n "$_flox" -a -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" -a "${_FLOX_SET_PROMPT:-}" != false ];
 then
     # Start by saving the original value of PS1.
     if [ -z "$FLOX_SAVE_ZSH_PS1" ]; then

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -94,7 +94,7 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
 
    The services started with this flag will be cleaned up once the last
    activation of this environment terminates.
- 
+
 
 ```{.include}
 ./include/environment-options.md
@@ -113,9 +113,8 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
 `$FLOX_PROMPT_ENVIRONMENTS`
 :   Contains a space-delimited list of the active environments,
     e.g. `owner1/foo owner2/bar local_env`.
-    This is set to an _empty string_ if the config value for `shell_prompt`
-    is `hide-all` or `hide-default` and only environments named 'default'
-    are active.
+    If, `hide_default_prompt` is set to `true`, environments named `default` are
+    excluded.
 
 `$FLOX_ENV_CACHE`
 :   `activate` sets this variable to a directory that can be used by an

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -97,12 +97,20 @@ flox config --set 'trusted_environments."owner/name"' trust
 `floxhub_token`
 :   Token to authenticate on FloxHub.
 
+`hide_default_prompt`
+:   Hide environments named 'default' from the shell prompt,
+    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: false).
+
 `search_limit`
 :   How many items `flox search` should show by default.
 
-`shell_prompt`
+`set_prompt`
+:   Set shell prompt when activating an environment (default: true).
+
+`shell_prompt` - DEPRECATED
 :   Rule whether to change the shell prompt in activated environments
     (default: "show-all").
+    This has been deprecated in favor of `set_prompt` and `hide_default_prompt`.
     Possible values are
     * "show-all": shows all active anvironments
     * "hide-all": disables the modification of the shell prompt

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -78,8 +78,15 @@ pub struct FloxConfig {
     // so just use a String.
     pub catalog_url: Option<String>,
 
-    /// Rule whether to change the shell prompt in activated environments
+    /// Rule whether to change the shell prompt in activated environments.
+    /// Deprecated in favor of set_prompt and hide_default_prompt.
     pub shell_prompt: Option<EnvironmentPromptConfig>,
+
+    /// Set shell prompt when activating an environment
+    pub set_prompt: Option<bool>,
+
+    /// Hide environments named 'default' from the shell prompt
+    pub hide_default_prompt: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Add `set_prompt` and `hide_default_prompt` config options and deprecate `shell_prompt`.

`set_prompt` defaults to true and configures whether activate modifies the prompt.

`hide_default_prompt` defaults to false and configures whether environments named default are added to both the prompt and the environment variable `FLOX_PROMPT_ENVIRONMENTS`

`shell_prompt` is marked deprecated in the man page. If it is set and `set_prompt` and `hide_default_prompt` are unset, it is used to configure the values of `set_prompt` and `hide_default_prompt`.

If `shell_prompt` is set when either `set_prompt` or `hide_default_prompt` is set, error with:

```
❌ ERROR: 'shell_prompt' has been deprecated and cannot be set when 'set_prompt' or
'hide_default_prompt' is set.

Remove 'shell_prompt' with 'flox config --delete shell_prompt'
```

Add a `_FLOX_SET_PROMPT` variable to communicate the value of `set_prompt` to the activation script.

The new config settings require a tty to test, so they were tested manually rather than adding tests.