### PR TITLE
feat(services): Warn on flox pull changes

### DIFF
--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -25,6 +25,7 @@ use log::debug;
 use toml_edit::DocumentMut;
 use tracing::instrument;
 
+use super::services::warn_manifest_changes_for_services;
 use super::{open_path, ConcreteEnvironment};
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select, Spinner};
@@ -183,6 +184,8 @@ impl Pull {
                     floxhub_host = flox.floxhub.base_url(),
                     suffix = if force { " (forced)" } else { "" }
                 });
+
+                warn_manifest_changes_for_services(flox, &env);
             },
             PullResult::UpToDate => {
                 message::warning(formatdoc! {"


### PR DESCRIPTION
## Proposed Changes

Add the same warning to `flox pull` as we have for `install`, `uninstall`, `upgrade`, and `edit`.

This only covers the happy path where you are successfully pulling into an existing environment. In the case where a pull fails and needs to be manually resolved the warning would be emitted on one of the other commands.

We don't currently emit any context specific warnings if you forcibly pull over the top of an existing environment. I think that's OK for the moment though because:

- it's inline with not warning about existing activations and not warning on `flox delete`
- services will still be cleaned up by the watchdog when all existing activations exit

## Release Notes

Warn when `flox pull` could affect running services.