### PR TITLE
feat(services): Contextualise flox edit warning

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -22,6 +22,7 @@ use tempfile::NamedTempFile;
 use tracing::debug;
 
 use crate::flox::Flox;
+use crate::models::environment::Environment;
 use crate::models::lockfile::LockedManifestCatalog;
 use crate::models::manifest::{ManifestServiceShutdown, ManifestServices};
 use crate::utils::{traceable_path, CommandExt};
@@ -490,6 +491,16 @@ pub fn shutdown_process_compose_if_all_processes_stopped(
         process_compose_down(socket)?;
     }
     Ok(all_processes_stopped)
+}
+
+/// Returns a bool indicating whether services have been started for an
+/// environment. This doesn't guarantee that the service manager is still
+/// working (e.g. hasn't crashed).
+pub fn services_probably_started(flox: &Flox, env: &dyn Environment) -> bool {
+    match env.services_socket_path(flox) {
+        Ok(socket) => socket.exists(),
+        Err(_) => false,
+    }
 }
 
 /// Strings extracted from a process-compose error log.

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -18,12 +18,11 @@ use flox_rust_sdk::models::environment::{
     EnvironmentError,
 };
 use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
-use flox_rust_sdk::providers::services::ServiceError;
+use flox_rust_sdk::providers::services::{services_probably_started, ServiceError};
 use itertools::Itertools;
 use log::debug;
 use tracing::instrument;
 
-use super::services::warn_manifest_changes_for_services;
 use super::{
     activated_environments,
     environment_select,
@@ -245,9 +244,9 @@ impl Edit {
             EditResult::Success { .. } => message::updated("Environment successfully updated."),
         }
 
-        if result != EditResult::Unchanged {
-            warn_manifest_changes_for_services(flox, environment);
-        }
+        if result != EditResult::Unchanged && services_probably_started(flox, environment) {
+            message::warning(manifest_has_changes_for_services_warning());
+        };
 
         Ok(())
     }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -20,12 +20,13 @@ use flox_rust_sdk::models::manifest::{
     PackageToInstall,
 };
 use flox_rust_sdk::models::pkgdb::error_codes;
+use flox_rust_sdk::providers::services::services_probably_started;
 use indoc::formatdoc;
 use itertools::Itertools;
 use log::debug;
 use tracing::instrument;
 
-use super::services::warn_manifest_changes_for_services;
+use super::services::manifest_has_changes_for_services_warning;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{
     ensure_floxhub_token,
@@ -196,9 +197,11 @@ impl Install {
             }
         }
 
-        if installation.new_manifest.is_some() {
-            warn_manifest_changes_for_services(&flox, environment.as_ref());
-        }
+        if installation.new_manifest.is_some()
+            && services_probably_started(&flox, environment.as_ref())
+        {
+            message::warning(manifest_has_changes_for_services_warning());
+        };
 
         Ok(())
     }

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -20,12 +20,13 @@ use flox_rust_sdk::models::environment::{
     ENVIRONMENT_POINTER_FILENAME,
 };
 use flox_rust_sdk::models::manifest;
+use flox_rust_sdk::providers::services::services_probably_started;
 use indoc::formatdoc;
 use log::debug;
 use toml_edit::DocumentMut;
 use tracing::instrument;
 
-use super::services::warn_manifest_changes_for_services;
+use super::services::manifest_has_changes_for_services_warning;
 use super::{open_path, ConcreteEnvironment};
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select, Spinner};
@@ -185,7 +186,9 @@ impl Pull {
                     suffix = if force { " (forced)" } else { "" }
                 });
 
-                warn_manifest_changes_for_services(flox, &env);
+                if services_probably_started(flox, &env) {
+                    message::warning(manifest_has_changes_for_services_warning());
+                };
             },
             PullResult::UpToDate => {
                 message::warning(formatdoc! {"

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -25,6 +25,7 @@ use log::debug;
 use toml_edit::DocumentMut;
 use tracing::instrument;
 
+use super::services::warn_manifest_changes_for_services;
 use super::{open_path, ConcreteEnvironment};
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select, Spinner};
@@ -183,6 +184,8 @@ impl Pull {
                     floxhub_host = flox.floxhub.base_url(),
                     suffix = if force { " (forced)" } else { "" }
                 });
+
+                warn_manifest_changes_for_services(flox, &env);
             },
             PullResult::UpToDate => {
                 message::warning(formatdoc! {"

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -10,7 +10,6 @@ use tracing::instrument;
 use super::{ConcreteEnvironment, EnvironmentSelect};
 use crate::commands::activate::Activate;
 use crate::config::Config;
-use crate::utils::message;
 
 mod logs;
 mod restart;
@@ -102,22 +101,6 @@ pub fn supported_environment(
     Ok(dyn_environment)
 }
 
-/// Warn about manifest changes that may require services to be restarted, if
-/// the Environment has a service manager running. It doesn't guarentee that the
-/// service manager is working (e.g. hasn't crashed). It is the caller's
-/// responsibility to determine what manifest changes would affect services.
-pub fn warn_manifest_changes_for_services(flox: &Flox, env: &dyn Environment) {
-    let has_service_manager = match env.services_socket_path(flox) {
-        Ok(socket) => socket.exists(),
-        Err(_) => false,
-    };
-    if has_service_manager {
-        message::warning(
-            "Your manifest has changes that may require running 'flox services restart'.",
-        );
-    }
-}
-
 /// Try to find processes by name, typically provided by the user via arguments,
 /// or default to all processes.
 ///
@@ -198,6 +181,12 @@ pub async fn start_with_new_process_compose(
         names.to_vec()
     };
     Ok(names)
+}
+
+/// Warning to print when there are changes to the manifest that might require
+/// restarting services.
+pub fn manifest_has_changes_for_services_warning() -> String {
+    "Your manifest has changes that may require running 'flox services restart'.".to_string()
 }
 
 /// Error to return when a service doesn't exist, either in the lockfile or the

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -2,12 +2,13 @@ use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::EnvironmentError;
+use flox_rust_sdk::providers::services::services_probably_started;
 use indoc::formatdoc;
 use itertools::Itertools;
 use log::debug;
 use tracing::instrument;
 
-use super::services::warn_manifest_changes_for_services;
+use super::services::manifest_has_changes_for_services_warning;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{
     ensure_floxhub_token,
@@ -93,7 +94,9 @@ impl Uninstall {
             message::deleted(format!("'{p}' uninstalled from environment {description}"))
         });
 
-        warn_manifest_changes_for_services(&flox, environment.as_ref());
+        if services_probably_started(&flox, environment.as_ref()) {
+            message::warning(manifest_has_changes_for_services_warning());
+        };
 
         Ok(())
     }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::providers::services::services_probably_started;
 use tracing::instrument;
 
-use super::services::warn_manifest_changes_for_services;
+use super::services::manifest_has_changes_for_services_warning;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{ensure_floxhub_token, environment_description};
 use crate::subcommand_metric;
@@ -112,7 +113,9 @@ impl Upgrade {
                 ));
             }
 
-            warn_manifest_changes_for_services(&flox, environment.as_ref());
+            if services_probably_started(&flox, environment.as_ref()) {
+                message::warning(manifest_has_changes_for_services_warning());
+            };
         }
 
         Ok(())

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -93,6 +93,27 @@ EOF
   assert_output "✅ Environment successfully updated."
 }
 
+@test "'flox edit' warns about changes that require re-activation" {
+  "$FLOX_BIN" init
+  cp "$MANIFEST_PATH" "$TMP_MANIFEST_PATH"
+  cat << "EOF" > "$TMP_MANIFEST_PATH"
+version = 1
+[vars]
+foo = "bar"
+EOF
+
+  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
+    "$FLOX_BIN" edit -f "$TMP_MANIFEST_PATH"
+EOF
+  )
+  assert_success
+  assert_output - <<EOF
+⚠️  Your manifest changes were recorded but cannot be automatically applied:
+
+- Please 'exit' the environment and run 'flox activate'.
+EOF
+}
+
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=edit:manifest:file

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -246,7 +246,38 @@ EOF
 EOF
 )
   assert_success
-  assert_line "⚠️  Your manifest has changes that may require running 'flox services restart'."
+  assert_output - <<EOF
+⚠️  Your manifest changes were recorded but cannot be automatically applied:
+
+- You may need to restart services with 'flox services restart'.
+
+Shutting down process-compose
+EOF
+}
+
+# bats test_tags=services:manifest-changes
+@test "edit: warns about restarting services with re-activation" {
+  setup_sleeping_services
+  cat > manifest.toml << EOF
+version = 1
+[vars]
+foo = "bar"
+EOF
+
+  run "$FLOX_BIN" activate --start-services -- bash <(cat <<'EOF'
+    source "${TESTS_DIR}/services/register_cleanup.sh"
+    "$FLOX_BIN" edit -f manifest.toml
+EOF
+)
+  assert_success
+  assert_output - <<EOF
+⚠️  Your manifest changes were recorded but cannot be automatically applied:
+
+- Please 'exit' the environment and run 'flox activate'.
+- You may need to restart services with 'flox services restart'.
+
+Shutting down process-compose
+EOF
 }
 
 # bats test_tags=services:manifest-changes


### PR DESCRIPTION
## Proposed Changes

Group the warnings together in a single message so that they're easier
for the user to read. This comes at the cost of adding more complexity
to the conditional.

I'm not completely sold by these changes, so feel free to say if you're also on the fence.

Refactoring required for this is in a separate commit which will make review easier.

Based on https://github.com/flox/flox/pull/1966 which should be merged first.

## Release Notes

Improve warnings when `flox edit` could affect running services.