### PR TITLE
chore: service connection errors and command invariant guards

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -37,7 +37,7 @@ use log::{debug, warn};
 use nix::unistd::getpid;
 use once_cell::sync::Lazy;
 
-use super::services::supported_environment;
+use super::services::ServicesEnvironment;
 use super::{
     activated_environments,
     environment_select,
@@ -325,7 +325,8 @@ impl Activate {
             // services so that the user doesn't assume we're actually starting
             // services.
             if self.start_services {
-                supported_environment(&flox, &self.environment)?; // Error for remote envs.
+                // Error for remote envs and envs with v0 manifests, since they don't support services
+                ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
             }
             if !manifest.services.is_empty() && !in_place {
                 // Always set the socket var because we use it to register

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -321,6 +321,7 @@ impl Activate {
                 debug!("not starting services for in-place activation");
                 message::warning("Skipped starting services. Services are not yet supported for in place activations.");
             }
+
             // We should error for remote environments even if they don't have
             // services so that the user doesn't assume we're actually starting
             // services.

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -10,11 +10,7 @@ use flox_rust_sdk::providers::services::{
 };
 use tracing::instrument;
 
-use crate::commands::services::{
-    guard_service_commands_available,
-    handle_service_connection_error,
-    ServicesEnvironment,
-};
+use crate::commands::services::{guard_service_commands_available, ServicesEnvironment};
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 
@@ -44,8 +40,7 @@ impl Logs {
         guard_service_commands_available(&env)?;
 
         let socket = env.socket();
-        let processes = ProcessStates::read(socket)
-            .map_err(|err| handle_service_connection_error(err, socket))?;
+        let processes = ProcessStates::read(socket)?;
 
         if self.follow {
             let named_processes =

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -11,6 +11,7 @@ use flox_rust_sdk::providers::services::{
 use tracing::instrument;
 
 use super::supported_environment;
+use crate::commands::services::handle_service_connection_error;
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 
@@ -39,7 +40,8 @@ impl Logs {
         let env = supported_environment(&flox, &self.environment)?;
         let socket = env.services_socket_path(&flox)?;
 
-        let processes = ProcessStates::read(&socket)?;
+        let processes = ProcessStates::read(&socket)
+            .map_err(|err| handle_service_connection_error(err, &socket))?;
 
         if self.follow {
             let named_processes =

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -6,13 +6,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{CoreEnvironmentError, Environment};
 use flox_rust_sdk::models::lockfile::LockedManifest;
 use flox_rust_sdk::models::manifest::{TypedManifest, TypedManifestCatalog};
-use flox_rust_sdk::providers::services::{
-    new_services_to_start,
-    LoggedError,
-    ProcessState,
-    ProcessStates,
-    ServiceError,
-};
+use flox_rust_sdk::providers::services::{new_services_to_start, ProcessState, ProcessStates};
 use tracing::instrument;
 
 use super::{
@@ -43,21 +37,6 @@ To activate and start services, run 'flox activate --start-services'"
     NotInActivation { action: String },
     #[error("Environment doesn't have any services defined.")]
     NoDefinedServices,
-    #[error(
-"Service Manager unresponsive.
-
-Retry command or delete {socket}
-and restart services with 'flox activate --start-services'",
-    socket = socket.display())]
-    ServiceManagerQuitUnexpectedly { socket: PathBuf },
-
-    #[error(
-        "Services not started or quit unexpectedly.
-
-To start services, run 'flox services start' in an activated environment,
-or activate the environment with 'flox activate --start-services'."
-    )]
-    ServiceManagerQuitOrServicesNotRunning,
 }
 
 /// Services Commands.
@@ -164,6 +143,12 @@ impl ServicesEnvironment {
     /// but this may change in the future for a more robust solution.
     pub fn socket(&self) -> &Path {
         &self.socket
+    }
+
+    /// Check if services are running, or can at least be expected to be running.
+    /// This is currently determined by the existence of the service manager socket.
+    fn expect_services_running(&self) -> bool {
+        ProcessStates::read(self.socket()).is_ok()
     }
 }
 
@@ -305,36 +290,6 @@ pub async fn start_with_new_process_compose(
 /// current process-compose config.
 pub(crate) fn service_does_not_exist_error(name: &str) -> anyhow::Error {
     anyhow!(format!("Service '{name}' not found."))
-}
-
-/// Add more information to connection errors when talking to the service manager.
-///
-/// Process-Compose commands may fail with [LoggedError::SocketDoesntExist]
-/// if the specific socket doesn't exist,
-/// or if the service manager has quit without cleaning up the socket,
-/// i.e. the socket is unresponsive.
-///
-/// This function adds more context to the error in the latter case.
-///
-/// For practical purposes, we apply this to the [ProcessStates::read] call in
-/// all services commands, as that is typically the first call that can fail.
-/// For following commands, we can assume that the service manager is running.
-///
-/// TODO: we might move this into a `processes` method on [ServicesEnvironment],
-/// as that would bring error handling closer to the environment (i.e the origin of the `socket`).
-pub(super) fn handle_service_connection_error(error: ServiceError, socket: &Path) -> anyhow::Error {
-    let ServiceError::LoggedError(LoggedError::SocketDoesntExist) = error else {
-        return error.into();
-    };
-
-    if socket.exists() {
-        return ServicesCommandsError::ServiceManagerQuitUnexpectedly {
-            socket: socket.to_path_buf(),
-        }
-        .into();
-    }
-
-    ServicesCommandsError::ServiceManagerQuitOrServicesNotRunning.into()
 }
 
 #[cfg(test)]

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -7,6 +7,7 @@ use flox_rust_sdk::providers::services::{process_compose_down, restart_service, 
 use tracing::{debug, instrument};
 
 use crate::commands::services::{
+    handle_service_connection_error,
     start_with_new_process_compose,
     supported_concrete_environment,
     ServicesCommandsError,
@@ -53,7 +54,8 @@ impl Restart {
 
         let existing_process_compose = socket.exists();
         let existing_processes = match existing_process_compose {
-            true => ProcessStates::read(&socket)?,
+            true => ProcessStates::read(&socket)
+                .map_err(|err| handle_service_connection_error(err, &socket))?,
             false => ProcessStates::from(vec![]),
         };
         let all_processes_stopped = existing_processes.iter().all(|p| p.is_stopped());

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -11,6 +11,7 @@ use flox_rust_sdk::providers::services::{
 };
 use tracing::{debug, instrument};
 
+use super::handle_service_connection_error;
 use crate::commands::services::{
     start_with_new_process_compose,
     supported_concrete_environment,
@@ -90,7 +91,8 @@ impl Start {
         names: &[String],
         err_stream: &mut impl std::io::Write,
     ) -> Result<()> {
-        let processes = ProcessStates::read(&socket)?;
+        let processes = ProcessStates::read(&socket)
+            .map_err(|error| handle_service_connection_error(error, socket.as_ref()))?;
         let named_processes = super::processes_by_name_or_default_to_all(&processes, names)?;
 
         let mut failure_count = 0;

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -9,11 +9,7 @@ use itertools::Itertools;
 use serde::Serialize;
 use tracing::instrument;
 
-use crate::commands::services::{
-    guard_service_commands_available,
-    handle_service_connection_error,
-    ServicesEnvironment,
-};
+use crate::commands::services::{guard_service_commands_available, ServicesEnvironment};
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 
@@ -39,9 +35,7 @@ impl Status {
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         guard_service_commands_available(&env)?;
 
-        let socket = env.socket();
-        let processes = ProcessStates::read(socket)
-            .map_err(|err| handle_service_connection_error(err, socket))?;
+        let processes = ProcessStates::read(env.socket())?;
 
         let named_processes = super::processes_by_name_or_default_to_all(&processes, &self.names)?;
 

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 use tracing::instrument;
 
 use super::supported_environment;
+use crate::commands::services::handle_service_connection_error;
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 
@@ -34,8 +35,9 @@ impl Status {
 
         let env = supported_environment(&flox, &self.environment)?;
         let socket = env.services_socket_path(&flox)?;
+        let processes = ProcessStates::read(&socket)
+            .map_err(|err| handle_service_connection_error(err, &socket))?;
 
-        let processes = ProcessStates::read(socket)?;
         let named_processes = super::processes_by_name_or_default_to_all(&processes, &self.names)?;
 
         let process_states_display = named_processes

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -4,11 +4,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::services::{stop_services, ProcessStates};
 use tracing::instrument;
 
-use crate::commands::services::{
-    guard_service_commands_available,
-    handle_service_connection_error,
-    ServicesEnvironment,
-};
+use crate::commands::services::{guard_service_commands_available, ServicesEnvironment};
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 use crate::utils::message;
@@ -33,8 +29,7 @@ impl Stop {
 
         let socket = env.socket();
 
-        let processes = ProcessStates::read(socket)
-            .map_err(|err| handle_service_connection_error(err, socket))?;
+        let processes = ProcessStates::read(socket)?;
         let named_processes = super::processes_by_name_or_default_to_all(&processes, &self.names)?;
 
         for process in named_processes {

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -5,6 +5,7 @@ use flox_rust_sdk::providers::services::{stop_services, ProcessStates};
 use tracing::instrument;
 
 use super::supported_environment;
+use crate::commands::services::handle_service_connection_error;
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 use crate::utils::message;
@@ -27,7 +28,8 @@ impl Stop {
         let env = supported_environment(&flox, &self.environment)?;
         let socket = env.services_socket_path(&flox)?;
 
-        let processes = ProcessStates::read(&socket)?;
+        let processes = ProcessStates::read(&socket)
+            .map_err(|err| handle_service_connection_error(err, &socket))?;
         let named_processes = super::processes_by_name_or_default_to_all(&processes, &self.names)?;
 
         for process in named_processes {

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -9,7 +9,9 @@ use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironmentError;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentError;
 use flox_rust_sdk::models::environment::{init_global_manifest, EnvironmentError};
+use flox_rust_sdk::providers::services::ServiceError;
 use log::{debug, warn};
+use utils::errors::format_service_error;
 use utils::init::{init_logger, init_sentry};
 use utils::{message, populate_default_nix_env_vars};
 
@@ -156,7 +158,8 @@ fn main() -> ExitCode {
                 .or_else(|| {
                     e.downcast_ref::<MigrationError>()
                         .map(format_migration_error)
-                });
+                })
+                .or_else(|| e.downcast_ref::<ServiceError>().map(format_service_error));
 
             if let Some(message) = message {
                 message::error(message);

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -14,6 +14,7 @@ use flox_rust_sdk::models::floxmeta::FloxMetaError;
 use flox_rust_sdk::models::lockfile::LockedManifestError;
 use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, ContextMsgError, PkgDbError};
 use flox_rust_sdk::providers::git::GitRemoteCommandError;
+use flox_rust_sdk::providers::services::{LoggedError, ServiceError};
 use indoc::{formatdoc, indoc};
 use log::{debug, trace};
 
@@ -880,6 +881,25 @@ pub fn format_locked_manifest_error(err: &LockedManifestError) -> String {
         LockedManifestError::UnfreeNotAllowed(_) => display_chain(err),
         LockedManifestError::MissingPackageDescriptor(_) => display_chain(err),
         LockedManifestError::LockFlakeNixError(_) => display_chain(err),
+    }
+}
+
+pub fn format_service_error(err: &ServiceError) -> String {
+    match err {
+        ServiceError::LoggedError(LoggedError::ServiceManagerUnresponsive(socket)) => formatdoc! {"
+            The service manager is unresponsive, please retry later.
+
+            If the problem persists, delete {socket}
+            and restart services with 'flox activate --start-services'
+            or 'flox services start' from an existing activation.
+        ", socket = socket.display()},
+        ServiceError::LoggedError(LoggedError::SocketDoesntExist) => formatdoc! {"
+            Services not started or quit unexpectedly.
+
+            To start services, run 'flox services start' in an activated environment,
+            or activate the environment with 'flox activate --start-services'.
+        "},
+        _ => display_chain(err),
     }
 }
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -559,17 +559,42 @@ EOF
   assert_output --regexp "two +Running"
 }
 
-# bats test_tags=services:stop
-@test "stop: errors if service socket isn't responding" {
+# bats test_tags=services:detect-not-started
+@test "services: errors if services are not started" {
   setup_sleeping_services
 
-  run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
-    export _FLOX_SERVICES_SOCKET=invalid
-    "$FLOX_BIN" services stop one invalid
+  commands=("logs" "status" "stop")
+  for command in "${commands[@]}"; do
+    echo "Testing: flox services $command"
+
+    command="$command" run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
+      rm -f "$_FLOX_SERVICES_SOCKET"
+      "$FLOX_BIN" services "$command" one invalid
 EOF
 )
-  assert_failure
-  assert_output --partial "❌ ERROR: couldn't connect to service manager"
+    assert_failure
+    assert_output --partial "❌ ERROR: Services not started or quit unexpectedly."
+  done
+}
+
+# bats test_tags=services:permit-stopped-for-start-restart
+@test "start, restart: do not require active services" {
+
+  setup_sleeping_services
+
+  commands=("start" "restart")
+  for command in "${commands[@]}"; do
+    echo "Testing: flox services $command"
+    command="$command" run "$FLOX_BIN" activate -- bash <(cat <<EOF
+      source "${TESTS_DIR}/services/register_cleanup.sh"
+
+      [ ! -e "\$_FLOX_SERVICES_SOCKET" ] || exit 2
+
+      "$FLOX_BIN" services "$command"
+EOF
+)
+    assert_success
+  done
 }
 
 # bats test_tags=services:stop
@@ -1111,7 +1136,7 @@ EOF
   run "$FLOX_BIN" activate -- bash -c "$SCRIPT"
   assert_failure
   assert_output --partial "Service 'invalid' not found."
-  assert_output --partial "couldn't connect to service manager"
+  assert_output --partial "Services not started or quit unexpectedly."
 }
 
 # Also tests service names with spaces in them, because starting them is handled


### PR DESCRIPTION
* Add more information to connection errors when talking to the service manager.

Process-Compose commands may fail with [LoggedError::SocketDoesntExist]
if the specific socket doesn't exist,
or if the service manager has quit without cleaning up the socket,
i.e. the socket is unresponsive.

This function adds more context to the error in the latter case.

For practical purposes, we apply this to the [ProcessStates::read] call in
all services commands, as that is typically the first call that can fail.
For following commands, we can assume that the service manager is running.

* Add a `ServicesEnvironment` type that wraps a `ConcreteEnvironment`
  that has been checked for compatibility with service commands.

Constructing a `ServicesEnvironment` requires a local `ConcreteEnvironment`
with a v1 manifest.

* implement "guard" methods for `ServicesEnvironment` to check against common command invariants

To use service commands, we require that the service manager socket exists
and that there are services defined in the environment at all.
The environment's `socket` is used to determine whether services are running,
which may not be the most robust solution, but is currently used consistently.

`start` and `restart` additionally require the current process to run within an activation of the environment.
