### PR TITLE
feat: add `build` feature flag

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -64,6 +64,9 @@ pub struct Features {
     pub search_strategy: SearchStrategy,
     #[serde(default)]
     pub use_catalog: UseCatalog,
+
+    #[serde(default)]
+    pub build: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, derive_more::Deref)]


### PR DESCRIPTION
Adds a new feature flag key `build: <bool>`,
that can be set via the usual config mechanisms:
- setting `features.build = true | false` in the config files
- modifying the config file imperatively with `flox config --set-bool features.build true`
- set the `FLOX_FEATURES_BUILD` env variable to  `true|false`
