### PR TITLE
chore: upgrade process-compose 1.9.0 -> 1.24.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
     },
     "nixpkgs-process-compose": {
       "locked": {
-        "lastModified": 1722415718,
-        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
+        "lastModified": 1724114134,
+        "narHash": "sha256-V/w5MIQy4jTG/L7/V/AL2BF5gSEWCfxHVDQdzLBCV18=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
+        "rev": "f02fa2f654c7bcc45f0e815c29d093da7f1245b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Notable changes:
- If the socket for process-compose is already in use, it will error
- A detached mode has been added, which will allow us to get rid of our usage of `setsid` + `&`