### PR TITLE
fix(services): Prevent activate vars leaking

### DIFF
--- a/cli/tests/services/echo_activate_vars.sh
+++ b/cli/tests/services/echo_activate_vars.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NESTING="$1"
+echo "${NESTING} FLOX_ACTIVATE_START_SERVICES=${FLOX_ACTIVATE_START_SERVICES}"
+echo "${NESTING} _FLOX_SERVICES_TO_START=${_FLOX_SERVICES_TO_START:-unset}"


### PR DESCRIPTION
## Proposed Changes

Always set the activate environment variables for services in order to prevent them leaking from an outer activation that has services to an inner activation that doesn't have services.

I believe that this, including the two new integration tests, will cover the bug that Leigh reported in our private Slack:

- https://flox-dev.slack.com/archives/C054SAD6NLD/p1724299932792289

I don't feel 100% good about testing the environment variables, rather than the effects, especially for the `_FLOX_SERVICES_TO_START` because it's asserting a negative result.

However the only way that I could reproduce the original error of failing to start services with normal activation commands was to run two commands within the inner activation, possibly because the first one is using the wrong socket and config per this bug:

- https://github.com/flox/flox/issues/1937

I tried to break the refactoring down into smaller pieces but it was harder to reason about so I've lumped it together and I'm leaning heavily on the integration tests to determine whether it's working.

At the same time I have moved:

- the socket path, which is now always needed by the watchdog, even if it doesn't currently exist
- the services to start var, which is only used by ephemeral activations

Prior to these changes the new tests would fail with:

    ✗ activate: outer activation starts services and inner activation doesn't [687]
    …
    -- output does not contain line --
       line : inner FLOX_ACTIVATE_START_SERVICES=false
       output (5 lines):
         outer FLOX_ACTIVATE_START_SERVICES=true
         outer _FLOX_SERVICES_TO_START=unset
         inner FLOX_ACTIVATE_START_SERVICES=true
         inner _FLOX_SERVICES_TO_START=unset
         Shutting down process-compose
       --
    …
    ✗ activate: outer activation imperatively starts services and inner activation doesn't [391]
    …
    -- command failed --
       status : 1
       output (4 lines):
         ✅ Service 'one' started.
         ✅ Service 'two' started.
         /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.qtYwZJ/flox-cli-tests-FH1uKT/services/echo_activate_vars.sh: line 5: FLOX_ACTIVATE_START_SERVICES: unbound variable
         Shutting down process-compose
       --

## Release Notes

Fixed a bug where outer activations use services and inner activations don't.