### PR TITLE
feat(activate): Add metric for lockfile_version

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -101,6 +101,13 @@ impl LockedManifest {
         let contents = fs::read(path).map_err(LockedManifestError::ReadLockfile)?;
         serde_json::from_slice(&contents).map_err(LockedManifestError::ParseLockfile)
     }
+
+    pub fn version(&self) -> u8 {
+        match self {
+            LockedManifest::Pkgdb(_) => 0,
+            LockedManifest::Catalog(_) => 1,
+        }
+    }
 }
 
 impl Display for LockedManifest {

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -175,6 +175,13 @@ impl Activate {
             other => other?,
         };
 
+        // Must come after getting an activation path to prevent premature
+        // locking or migration.
+        subcommand_metric!(
+            "activate#version",
+            lockfile_version = environment.lockfile(&flox)?.version()
+        );
+
         // read the currently active environments from the environment
         let mut flox_active_environments = activated_environments();
 


### PR DESCRIPTION
## Proposed Changes

So that we can get an idea of how long we need to support activating already locked pkgdb environments.

We're recording the lockfile version, rather than the manifest version, because a v0 manifest might be automatically migrated to v1 during activation. We could later add metrics for manifest versions in order to determine whether we still need to do migrations but there are a handful of places that it would need to be added other than `activate`.

This is done in a second `subcommand_metric!`, in addition to the early call in `Activate::handle`, because we don't have all of the information required at the start, don't want to cause a premature lock/error, and our in-house metrics don't have a way to additional submit tags on existing metrics.

We can't use Sentry for this metric because of:

- https://github.com/flox/flox/issues/1715

Verified working with:

    (2) ~/projects/flox/flox on dcarley/1972-activate-version-metric [$>]
    % ft init 2>/dev/null

    (2) ~/projects/flox/flox on dcarley/1972-activate-version-metric [$>]
    % FLOX_DISABLE_METRICS=false _FLOX_METRICS_URL_OVERRIDE=localhost ft activate -- true

    (2) ~/projects/flox/flox on dcarley/1972-activate-version-metric [$>]
    % jq -s '.[-1]' ~/.cache/flox/metrics-events-v2.json
    {
      "subcommand": "activate::version",
      "lockfile_version": "1",
      "timestamp": [
        2024,
        235,
        13,
        58,
        45,
        818543000,
        0,
        0,
        0
      ],
      "uuid": "c3318f2c-9e7a-4377-ac81-161ae892fe79",
      "flox_version": "1.3.0",
      "os_family": "Mac OS",
      "os_family_release": "23.5.0",
      "os": null,
      "os_version": null,
      "empty_flags": []
    }

    (2) ~/projects/flox/flox on dcarley/1972-activate-version-metric [$>]
    % cp test_data/manually_generated/hello_v0/manifest.* ~/tmp/.flox/env/

    (2) ~/projects/flox/flox on dcarley/1972-activate-version-metric [$>]
    % FLOX_DISABLE_METRICS=false _FLOX_METRICS_URL_OVERRIDE=localhost ft activate -- true

    (2) ~/projects/flox/flox on dcarley/1972-activate-version-metric [$>]
    % jq -s '.[-1]' ~/.cache/flox/metrics-events-v2.json
    {
      "subcommand": "activate::version",
      "lockfile_version": "0",
      "timestamp": [
        2024,
        235,
        13,
        59,
        5,
        866006000,
        0,
        0,
        0
      ],
      "uuid": "c3318f2c-9e7a-4377-ac81-161ae892fe79",
      "flox_version": "1.3.0",
      "os_family": "Mac OS",
      "os_family_release": "23.5.0",
      "os": null,
      "os_version": null,
      "empty_flags": []
    }

## Release Notes

N/A