### PR TITLE
fix(tracing): Change fields to tags

### DIFF
--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -38,6 +38,7 @@ use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::didyoumean::{DidYouMean, InstallSuggestion};
 use crate::utils::errors::apply_doc_link_for_unsupported_packages;
 use crate::utils::message;
+use crate::utils::tracing::sentry_set_tag;
 
 // Install a package into an environment
 #[derive(Bpaf, Clone)]
@@ -73,7 +74,7 @@ pub struct PkgWithIdOption {
 }
 
 impl Install {
-    #[instrument(name = "install", fields(packages), skip_all)]
+    #[instrument(name = "install", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("install");
 
@@ -140,7 +141,7 @@ impl Install {
         }
 
         // We don't know the contents of the packages field when the span is created
-        tracing::Span::current().record(
+        sentry_set_tag(
             "packages",
             Install::format_packages_for_tracing(&packages_to_install),
         );

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -57,6 +57,7 @@ pub enum ListMode {
 impl List {
     #[instrument(name = "list", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
+        sentry_set_tag("list_mode", format!("{:?}", &self.list_mode));
         subcommand_metric!("list");
 
         let mut env = self
@@ -66,8 +67,6 @@ impl List {
 
         let manifest_contents = env.manifest_contents(&flox)?;
         if self.list_mode == ListMode::Config {
-            sentry_set_tag("mode", "config");
-
             println!("{}", manifest_contents);
             return Ok(());
         }
@@ -93,15 +92,12 @@ impl List {
 
         match self.list_mode {
             ListMode::NameOnly => {
-                sentry_set_tag("mode", "name");
                 Self::print_name_only(stdout().lock(), &packages)?;
             },
             ListMode::Extended => {
-                sentry_set_tag("mode", "extended");
                 Self::print_extended(stdout().lock(), &packages)?;
             },
             ListMode::All => {
-                sentry_set_tag("mode", "all");
                 Self::print_detail(stdout().lock(), &packages)?;
             },
             ListMode::Config => unreachable!(),

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -23,6 +23,7 @@ use super::{environment_select, EnvironmentSelect};
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::message;
+use crate::utils::tracing::sentry_set_tag;
 
 // List packages installed in an environment
 #[derive(Bpaf, Clone)]
@@ -54,7 +55,7 @@ pub enum ListMode {
 }
 
 impl List {
-    #[instrument(name = "list", fields(mode), skip_all)]
+    #[instrument(name = "list", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("list");
 
@@ -65,7 +66,8 @@ impl List {
 
         let manifest_contents = env.manifest_contents(&flox)?;
         if self.list_mode == ListMode::Config {
-            tracing::Span::current().record("mode", "config");
+            sentry_set_tag("mode", "config");
+
             println!("{}", manifest_contents);
             return Ok(());
         }
@@ -91,15 +93,15 @@ impl List {
 
         match self.list_mode {
             ListMode::NameOnly => {
-                tracing::Span::current().record("mode", "name");
+                sentry_set_tag("mode", "name");
                 Self::print_name_only(stdout().lock(), &packages)?;
             },
             ListMode::Extended => {
-                tracing::Span::current().record("mode", "extended");
+                sentry_set_tag("mode", "extended");
                 Self::print_extended(stdout().lock(), &packages)?;
             },
             ListMode::All => {
-                tracing::Span::current().record("mode", "all");
+                sentry_set_tag("mode", "all");
                 Self::print_detail(stdout().lock(), &packages)?;
             },
             ListMode::Config => unreachable!(),

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -18,6 +18,7 @@ use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::didyoumean::{DidYouMean, SearchSuggestion};
 use crate::utils::message;
 use crate::utils::search::{construct_search_params, manifest_and_lockfile, DisplaySearchResults};
+use crate::utils::tracing::sentry_set_tag;
 
 pub(crate) const DEFAULT_SEARCH_LIMIT: Option<NonZeroU8> = NonZeroU8::new(10);
 const FLOX_SHOW_HINT: &str = "Use 'flox show <package>' to see available versions";
@@ -49,8 +50,11 @@ pub struct Search {
 // which is TODO.
 // Luckily most flakes don't.
 impl Search {
-    #[instrument(name = "search", fields(json = self.json, show_all = self.all, search_term = self.search_term), skip_all)]
+    #[instrument(name = "search", skip_all)]
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        sentry_set_tag("json", self.json);
+        sentry_set_tag("show_all", self.all);
+        sentry_set_tag("search_term", &self.search_term);
         subcommand_metric!("search", search_term = &self.search_term);
 
         debug!("performing search for term: {}", self.search_term);

--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -21,6 +21,7 @@ use tracing::instrument;
 
 use crate::subcommand_metric;
 use crate::utils::search::{manifest_and_lockfile, DEFAULT_DESCRIPTION, SEARCH_INPUT_SEPARATOR};
+use crate::utils::tracing::sentry_set_tag;
 
 // Show detailed package information
 #[derive(Debug, Bpaf, Clone)]
@@ -32,9 +33,10 @@ pub struct Show {
 }
 
 impl Show {
-    #[instrument(name = "show", fields(pkg_path = self.pkg_path), skip_all)]
+    #[instrument(name = "show", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
         subcommand_metric!("show");
+        sentry_set_tag("pkg_path", &self.pkg_path);
 
         if let Some(client) = flox.catalog_client {
             tracing::debug!("using catalog client for show");

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -18,6 +18,7 @@ use crate::commands::{
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::message;
+use crate::utils::tracing::sentry_set_tag;
 
 // Uninstall installed packages from an environment
 #[derive(Bpaf, Clone)]
@@ -31,13 +32,10 @@ pub struct Uninstall {
 }
 
 impl Uninstall {
-    #[instrument(name = "uninstall", fields(packages), skip_all)]
+    #[instrument(name = "uninstall", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("uninstall");
-
-        // Vec<T> doesn't implement tracing::Value, so you have to join the strings
-        // yourself.
-        tracing::Span::current().record("packages", self.packages.iter().join(","));
+        sentry_set_tag("packages", self.packages.iter().join(","));
 
         debug!(
             "uninstalling packages [{}] from {:?}",

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -15,6 +15,7 @@ pub mod message;
 pub mod metrics;
 pub mod openers;
 pub mod search;
+pub mod tracing;
 
 pub static TERMINAL_STDERR: Lazy<Mutex<Stderr>> = Lazy::new(|| Mutex::new(std::io::stderr()));
 /// Timeout used for network operations that run after the main flox command has

--- a/cli/flox/src/utils/tracing.rs
+++ b/cli/flox/src/utils/tracing.rs
@@ -1,0 +1,21 @@
+use sentry::configure_scope;
+
+/// Sets a tracing tag for the current scope.
+///
+/// In practice these appear to always be rolled up to the root transaction/span
+/// but that shouldn't make a difference for searching.
+///
+/// We use this in place of the following because they aren't searchable in
+/// Sentry:
+///
+/// - `#instrument(fields(foo = "bar"))`
+/// - `Span::current().record("foo", "bar")`
+///
+/// They may support converting fields to tags in future:
+///
+/// - https://github.com/getsentry/sentry-rust/issues/653
+pub fn sentry_set_tag<V: ToString>(key: &str, value: V) {
+    configure_scope(|scope| {
+        scope.set_tag(key, value);
+    });
+}


### PR DESCRIPTION
## Proposed Changes

Replace all uses of `instrument` and `record` to set fields with a
helper function that sets tags on the current scope. This allows us to
search them in the Sentry UI.

Tags are the only custom keys that you can search on:

- https://docs.sentry.io/concepts/search/searchable-properties/
- https://docs.sentry.io/platforms/rust/enriching-events/tags/
- https://docs.sentry.io/concepts/key-terms/enrich-data/#types-of-data
- https://sentry.zendesk.com/hc/en-us/articles/26861002545691-How-to-search-context

The other-other form of sending arbitrary data has been deprecated:

- https://docs.sentry.io/platforms/rust/enriching-events/context/#additional-data

They have no cost implications because billing is by span quantity:

- https://sentry.io/pricing/

The docstring explains more about why we have to do this currently. I
attempted automating the conversion in-house but the following only have
access to events and not transactions/spans:

- `ClientOptions.integrations`
- `ClientOptions.before_send`

You can see an example of this here:

- https://flox-dev.sentry.io/traces/?end=2024-08-22T16%3A53%3A12&query=project%3Acli-flox+user.id%3Ac3318f2c-9e7a-4377-ac81-161ae892fe79&source=traces&start=2024-08-22T16%3A47%3A14&utc=true

## Release Notes

N/a
