### PR TITLE
fix(tracing): Sentry improvements

### DIFF
--- a/cli/flox-watchdog/src/main.rs
+++ b/cli/flox-watchdog/src/main.rs
@@ -58,6 +58,10 @@ pub struct Cli {
     /// Where to store watchdog logs
     #[arg(short, long = "logs", value_name = "PATH")]
     pub log_path: Option<PathBuf>,
+
+    /// Disable metric reporting
+    #[arg(long)]
+    pub disable_metrics: bool,
 }
 
 #[instrument("watchdog",
@@ -75,7 +79,7 @@ fn main() -> Result<(), Error> {
     if let Err(err) = ensure_process_group_leader() {
         error!(%err, "failed to ensure watchdog is detached from terminal");
     }
-    let _sentry_guard = init_sentry();
+    let _sentry_guard = (!args.disable_metrics).then(init_sentry);
     let span = tracing::Span::current();
     span.record("pid", args.pid);
     span.record("registry", traceable_path(&args.registry_path));

--- a/cli/flox-watchdog/src/sentry.rs
+++ b/cli/flox-watchdog/src/sentry.rs
@@ -1,5 +1,7 @@
+use std::borrow::Cow;
+
 use anyhow::anyhow;
-use flox_rust_sdk::flox::FLOX_SENTRY_ENV;
+use flox_rust_sdk::flox::{FLOX_SENTRY_ENV, FLOX_VERSION};
 use sentry::{ClientInitGuard, IntoDsn};
 use tracing::{debug, warn};
 
@@ -38,8 +40,7 @@ pub fn init_sentry() -> Option<ClientInitGuard> {
         dsn: Some(sentry_dsn),
 
         // https://docs.sentry.io/platforms/rust/configuration/releases/
-        // TODO: should we maybe just use commit hash
-        release: sentry::release_name!(),
+        release: Some(Cow::Owned(format!("flox-watchdog@{}", &*FLOX_VERSION))),
 
         // https://docs.sentry.io/platforms/rust/configuration/environments/
         environment: Some(sentry_env.into()),

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -372,6 +372,7 @@ impl Activate {
                 environment.log_path()?.to_path_buf(),
                 &path_hash(environment.dot_flox_path()),
                 socket_path,
+                config.flox.disable_metrics,
             )?;
         }
 
@@ -404,8 +405,12 @@ impl Activate {
         log_dir: PathBuf,
         path_hash: &str,
         socket_path: impl AsRef<Path>,
+        disable_metrics: bool,
     ) -> Result<()> {
         let mut cmd = Command::new(&*WATCHDOG_BIN);
+        if disable_metrics {
+            cmd.arg("--disable-metrics");
+        }
 
         // This process may terminate before the watchdog installs its signal handler,
         // so we pass it the PID of this process unconditionally (note that on Linux passing this

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -79,10 +79,15 @@ fn main() -> ExitCode {
             .unwrap_or_default()
     };
 
+    let disable_metrics = config::Config::parse()
+        .unwrap_or_default()
+        .flox
+        .disable_metrics;
+
     init_logger(Some(verbosity));
     // Sentry client must be initialized before starting an async runtime or spawning threads
     // https://docs.sentry.io/platforms/rust/#async-main-function
-    let _sentry_guard = init_sentry();
+    let _sentry_guard = (!disable_metrics).then(init_sentry);
     let _metrics_guard = Hub::global().try_guard().ok();
 
     // Pass down the verbosity level to all pkgdb calls

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -79,11 +79,10 @@ fn main() -> ExitCode {
             .unwrap_or_default()
     };
 
+    init_logger(Some(verbosity));
     // Sentry client must be initialized before starting an async runtime or spawning threads
     // https://docs.sentry.io/platforms/rust/#async-main-function
     let _sentry_guard = init_sentry();
-    init_logger(Some(verbosity));
-
     let _metrics_guard = Hub::global().try_guard().ok();
 
     // Pass down the verbosity level to all pkgdb calls

--- a/cli/flox/src/utils/init/sentry.rs
+++ b/cli/flox/src/utils/init/sentry.rs
@@ -1,5 +1,7 @@
+use std::borrow::Cow;
+
 use anyhow::anyhow;
-use flox_rust_sdk::flox::FLOX_SENTRY_ENV;
+use flox_rust_sdk::flox::{FLOX_SENTRY_ENV, FLOX_VERSION};
 use log::{debug, warn};
 use sentry::{ClientInitGuard, IntoDsn};
 
@@ -38,8 +40,7 @@ pub fn init_sentry() -> Option<ClientInitGuard> {
         dsn: Some(sentry_dsn),
 
         // https://docs.sentry.io/platforms/rust/configuration/releases/
-        // TODO: should we maybe just use commit hash
-        release: sentry::release_name!(),
+        release: Some(Cow::Owned(format!("flox-cli@{}", &*FLOX_VERSION))),
 
         // https://docs.sentry.io/platforms/rust/configuration/environments/
         environment: Some(sentry_env.into()),

--- a/cli/flox/src/utils/init/sentry.rs
+++ b/cli/flox/src/utils/init/sentry.rs
@@ -28,14 +28,6 @@ pub fn init_sentry() -> Option<ClientInitGuard> {
         .clone()
         .unwrap_or_else(|| "development".to_string());
 
-    // TODO: configure user
-    // https://docs.sentry.io/platforms/rust/enriching-events/identify-user/
-    // sentry::configure_scope(|scope| {
-    //     scope.set_user(Some(sentry::User {
-    //     ..
-    //    }));
-    // });
-
     let sentry = sentry::init(sentry::ClientOptions {
         dsn: Some(sentry_dsn),
 


### PR DESCRIPTION
## Proposed Changes

Honour disabling metrics, set the version correctly, and allow logs from Sentry initialisation.

This is best reviewed commit-by-commit.

I've created some follow-up issues for the other things that I noted in demos that will require more thought or work:

- https://github.com/flox/flox/issues/1986
- https://github.com/flox/flox/issues/1987
- https://github.com/flox/flox/issues/1988

## Release Notes

Data is no longer sent to Sentry when metrics are disabled. Apologies for the oversight!
