### PR TITLE
feat(buildenv): include manifest lock in environment

### DIFF
--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -179,6 +179,21 @@ setup_file() {
   assert "$TEST" -f "${store_path}/package-builds.d/hello"
 }
 
+# bats test_tags=buildenv:include-lockfile
+@test "Built environment contains lockfile" {
+
+  orginalLockfile="$GENERATED_DATA/envs/hello/manifest.lock"
+  run "$PKGDB_BIN" buildenv "${orginalLockfile}"
+  assert_success
+  store_path=$(echo "$output" | jq -er '.store_path')
+  assert "$TEST" -f "${store_path}/manifest.lock"
+
+  assert diff \
+    <(jq --sort-keys . "${store_path}/manifest.lock" ) \
+    <(jq --sort-keys . "${orginalLockfile}")
+}
+
+
 # ---------------------------------------------------------------------------- #
 
 # With '--container' produces a script that can be used to build a container.


### PR DESCRIPTION
Write the lockfile to the environment,
causing semantic changes to the lockfile to invalidate existing environment store paths.

This is useful to determine whether an environment needs to be rebuilt,
as well as reresolve the environment "linktree".
The latter is particularly important when removing package priorities,
that previously resolved package conflicts.

Since the `priority` is not part of the evaluation,
setting the `priority` for a package does not change the evaluated store path
of the environment.
Removing the `priority` will built the previous environment
and _not_ error on file conflicts,
until another change to the manifest causes a rebuild,
or the environment is built on another machine.

![image](https://github.com/user-attachments/assets/1a4d83d8-0389-4b5d-9aed-0a934e11e7d9)
