### PR TITLE
feat: add scaffold for `flox build` command

### DIFF
--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+use super::{environment_select, EnvironmentSelect};
+use crate::config::Config;
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[allow(unused)] // remove when we implement the command
+#[derive(Bpaf, Clone)]
+pub struct Build {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+
+    /// Whether to print logs to stderr during build.
+    /// Logs are always written to <TBD>
+    #[bpaf(short('L'), long)]
+    build_logs: bool,
+
+    /// The package to build, corresponds to the entries in
+    /// the 'build' table in the environment's manifest.toml.
+    /// If not specified, all packages are built.
+    #[bpaf(positional("build"))]
+    package: Vec<String>,
+}
+
+impl Build {
+    #[instrument(name = "build", skip_all)]
+    pub async fn handle(self, _config: Config, _flox: Flox) -> Result<()> {
+        subcommand_metric!("build");
+
+        message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod activate;
 mod auth;
+mod build;
 mod containerize;
 mod delete;
 mod edit;
@@ -886,6 +887,9 @@ enum InternalCommands {
     /// FloxHub authentication commands
     #[bpaf(command, footer("Run 'man flox-auth' for more details."))]
     Auth(#[bpaf(external(auth::auth))] auth::Auth),
+    /// Build packages for flox
+    #[bpaf(command, hide, footer("Run 'man flox-build' for more details."))]
+    Build(#[bpaf(external(build::build))] build::Build),
 }
 
 impl InternalCommands {
@@ -893,6 +897,7 @@ impl InternalCommands {
         match self {
             InternalCommands::ResetMetrics(args) => args.handle(config, flox).await?,
             InternalCommands::Auth(args) => args.handle(config, flox).await?,
+            InternalCommands::Build(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
Implement the parser for the `flox build` command. The current implementation only prints a message and quits.

The usage as defined will look like this:

```
Build packages for flox

Usage: flox build [-d=<path> | -r=<owner>/<name>] [-L] [<build>]...

Available positional items:
    <build>           The package to build, corresponds to the entries in the
                      'build' table in the environment's manifest.toml. If not
                      specified, all packages are built.

Available options:
    -d, --dir=<path>  Path containing a .flox/ directory
    -r, --remote=<owner>/<name>  A remote environment on FloxHub
    -L, --build-logs  Whether to print logs to stderr during build Logs are
                      always written to <TBD>
    -h, --help        Prints help information

Run 'man flox-build' for more details.
```