### PR TITLE
fix: socket conflict for layered activations

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -71,7 +71,11 @@ pub const FLOX_ENV_LIB_DIRS_VAR: &str = "FLOX_ENV_LIB_DIRS";
 pub const FLOX_ENV_LOG_DIR_VAR: &str = "_FLOX_ENV_LOG_DIR";
 pub const FLOX_ACTIVE_ENVIRONMENTS_VAR: &str = "_FLOX_ACTIVE_ENVIRONMENTS";
 pub const FLOX_PROMPT_ENVIRONMENTS_VAR: &str = "FLOX_PROMPT_ENVIRONMENTS";
+/// This variable is used to communicate what socket to use to the activate
+/// script.
 pub const FLOX_SERVICES_SOCKET_VAR: &str = "_FLOX_SERVICES_SOCKET";
+/// This variable is used in tests to override what path to use for the socket.
+pub const FLOX_SERVICES_SOCKET_OVERRIDE_VAR: &str = "_FLOX_SERVICES_SOCKET_OVERRIDE";
 
 pub const N_HASH_CHARS: usize = 8;
 
@@ -705,7 +709,7 @@ pub fn path_hash(p: impl AsRef<Path>) -> String {
 /// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 /// If unset, fallback to cache_dir like for macOS.
 fn services_socket_path(id: &str, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
-    if let Ok(path) = std::env::var(FLOX_SERVICES_SOCKET_VAR) {
+    if let Ok(path) = std::env::var(FLOX_SERVICES_SOCKET_OVERRIDE_VAR) {
         return Ok(PathBuf::from(path));
     }
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -890,10 +890,6 @@ EOF
   # process-compose will never be able to create this socket,
   # which looks the same as taking a long time to create the socket
   export _FLOX_SERVICES_SOCKET_OVERRIDE="/no_permission.sock"
-  # As of version 1.6.1, there's a race condition in process-compose such that
-  # it may leave behind a sleep process.
-  # Close FD 3 so bats doesn't hang forever.
-  # Kill sleep for now just to be safe.
 
   run "$FLOX_BIN" activate -s -- true
   assert_output --partial "❌ Failed to start services"


### PR DESCRIPTION
We currently set `_FLOX_SERVICES_SOCKET` when we activate an environment with services. We also check `_FLOX_SERVICES_SOCKET` when running an activation to allow overriding the path for the socket. This means that when an activation is performed within another activation, it uses the value of `_FLOX_SERVICES_SOCKET` set by the outer activation, which causes services for two different environments to interfere.

Instead, introduce a second variable `_FLOX_SERVICES_SOCKET_OVERRIDE` to provide the overriding behavior, and use `_FLOX_SERVICES_SOCKET` to communicate with the activate script.

We could instead drop the one test that uses the overriding behavior, but I figure it could be useful in debugging to be able to set the socket path explicitly.