### PR TITLE
fix: ensure lsof can find a flox-cli-tests gcroot

### DIFF
--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -257,7 +257,7 @@ in
       find "$TESTS_DIR" "$NIX_BIN" "$PKGDB_BIN" "$WATCHDOG_BIN" "$FLOX_BIN"    \
         |${entr}/bin/entr -s "bats ''${_BATS_ARGS[*]} ''${_FLOX_TESTS[*]}";
     else
-      exec -a "$0" ${batsWith}/bin/bats "''${_BATS_ARGS[@]}"    \
-                                        "''${_FLOX_TESTS[@]}";
+      ${batsWith}/bin/bats "''${_BATS_ARGS[@]}"    \
+                           "''${_FLOX_TESTS[@]}";
     fi
   ''


### PR DESCRIPTION
We've seen test failures on x86_64-darwin where it appears bats files the tests depend on are being removed during the test. Since those files are in the nix store, our best guess is that those files are getting garbage collected. One such failure is https://github.com/flox/flox/actions/runs/10188862002/job/28186108948#step:6:417

The failures have always occurred on x86_64-darwin. Nix doesn't garbage collect paths store in environment variables on Linux, but on macOS it appears to only use lsof, since macOS doesn't have `/proc`. See https://github.com/NixOS/nix/blob/076b6f7bb163a95e6a6537aad21d9661b0c6c8fa/src/libstore/gc.cc#L352

Before this change, running `flox-cli-tests` and then
```
$ sudo nix-store --gc --print-roots | grep flox-cli-tests
```

doesn't show any results.

Instead of exec'ing, we keep the flox-cli-tests executable running while the tests are running so that lsof can detect the flox-cli-tests store path is still in use. After this change, running `flox-cli-tests` and then printing gc roots shows lsof can find the correct store path:

```
$ sudo nix-store --gc --print-roots | grep flox-cli-tests
{lsof} -> /nix/store/h2ln8iqcad2shmg6jm76z8hgkph986cd-flox-cli-tests
```