### PR TITLE
fix: update `priority` of already locked packages

### DIFF
--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -213,3 +213,36 @@ EOF
   assert_output "⚠️  No changes made to environment."
 
 }
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=edit:priority
+@test "'flox edit' priority" {
+  "$FLOX_BIN" init
+
+WITHOUT_PRIORITY=$(cat <<EOF
+version = 1
+[install]
+vim.pkg-path = "vim"
+vim-full.pkg-path = "vim-full"
+EOF
+)
+
+WITH_PRIORITY=$(cat <<EOF
+version = 1
+[install]
+vim.pkg-path = "vim"
+vim-full.pkg-path = "vim-full"
+vim-full.priority = 4
+EOF
+)
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/vim-vim-full-conflict.json"
+  run "$FLOX_BIN" edit -f <(echo "$WITHOUT_PRIORITY")
+  assert_failure
+
+  run "$FLOX_BIN" edit -f <(echo "$WITH_PRIORITY")
+  assert_success
+
+  run "$FLOX_BIN" edit -f <(echo "$WITHOUT_PRIORITY")
+  assert_failure
+}

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -196,6 +196,12 @@ cmd = "flox install -i foo rubyPackages_3_2.webmention ripgrep -i bar rubyPackag
 pre_cmd = "flox init"
 cmd = "flox install vim"
 
+[resolve.vim-vim-full-conflict]
+pre_cmd = "flox init"
+cmd = "flox install vim vim-full"
+ignore_cmd_errors = true # pacakges conflict
+
+
 [search.hello]
 cmd = "flox search hello"
 

--- a/test_data/generated/resolve/vim-vim-full-conflict.json
+++ b/test_data/generated/resolve/vim-vim-full-conflict.json
@@ -1,0 +1,296 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "vim",
+            "broken": false,
+            "derivation": "/nix/store/1wp4hcnydk3m67wlb5bxm1k51jwvlcba-vim-9.1.0595.drv",
+            "description": "Most popular clone of the VI editor",
+            "install_id": "vim",
+            "license": "Vim",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "name": "vim-9.1.0595",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/s7arni8gjj5b77sw1qv8xpklqazcx9yd-vim-9.1.0595"
+              },
+              {
+                "name": "xxd",
+                "store_path": "/nix/store/6i7lgynna1bk44319xiap4a7ymi9v2fm-vim-9.1.0595-xxd"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "xxd"
+            ],
+            "pname": "vim",
+            "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "rev_count": 671089,
+            "rev_date": "2024-08-24T06:09:45Z",
+            "scrape_date": "2024-08-27T03:15:44Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "9.1.0595"
+          },
+          {
+            "attr_path": "vim",
+            "broken": false,
+            "derivation": "/nix/store/sldrjnry871gs3nsrqk8zbajh95dwjzz-vim-9.1.0595.drv",
+            "description": "Most popular clone of the VI editor",
+            "install_id": "vim",
+            "license": "Vim",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "name": "vim-9.1.0595",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/r1b7bp9bn00mx6zp6nziwhv6c9a9zpl7-vim-9.1.0595"
+              },
+              {
+                "name": "xxd",
+                "store_path": "/nix/store/5hbsr0fzs0qg7kadbccmkd67ib3chs7p-vim-9.1.0595-xxd"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "xxd"
+            ],
+            "pname": "vim",
+            "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "rev_count": 671089,
+            "rev_date": "2024-08-24T06:09:45Z",
+            "scrape_date": "2024-08-27T03:15:44Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "9.1.0595"
+          },
+          {
+            "attr_path": "vim",
+            "broken": false,
+            "derivation": "/nix/store/pmyz90bljdd36vd8ppxqcwcp62y2djb7-vim-9.1.0595.drv",
+            "description": "Most popular clone of the VI editor",
+            "install_id": "vim",
+            "license": "Vim",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "name": "vim-9.1.0595",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/llqzlc672c9ch6a86zvh76gq5v5jnsv1-vim-9.1.0595"
+              },
+              {
+                "name": "xxd",
+                "store_path": "/nix/store/39w4fgmvnqajmn3pw8r0j81zrhpam7n3-vim-9.1.0595-xxd"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "xxd"
+            ],
+            "pname": "vim",
+            "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "rev_count": 671089,
+            "rev_date": "2024-08-24T06:09:45Z",
+            "scrape_date": "2024-08-27T03:15:44Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "9.1.0595"
+          },
+          {
+            "attr_path": "vim",
+            "broken": false,
+            "derivation": "/nix/store/sl7hdpms2jvbrg4v832fq0ha9zk6fn8a-vim-9.1.0595.drv",
+            "description": "Most popular clone of the VI editor",
+            "install_id": "vim",
+            "license": "Vim",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "name": "vim-9.1.0595",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/r2sjxb4zyl5jrb6s9jh78snv0si5h2gy-vim-9.1.0595"
+              },
+              {
+                "name": "xxd",
+                "store_path": "/nix/store/vzbif1ja5r0pscrndhcvfc38y07r33q6-vim-9.1.0595-xxd"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "xxd"
+            ],
+            "pname": "vim",
+            "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "rev_count": 671089,
+            "rev_date": "2024-08-24T06:09:45Z",
+            "scrape_date": "2024-08-27T03:15:44Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "9.1.0595"
+          },
+          {
+            "attr_path": "vim-full",
+            "broken": false,
+            "derivation": "/nix/store/npjc0n1n0k1hb5d8xm2xjnar0l32rx9p-vim-full-9.1.0595.drv",
+            "description": "Most popular clone of the VI editor",
+            "install_id": "vim-full",
+            "license": "Vim",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "name": "vim-full-9.1.0595",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/h45lccfxa8ywrbk40m34iqvx89q2jsdv-vim-full-9.1.0595"
+              },
+              {
+                "name": "xxd",
+                "store_path": "/nix/store/ywdck0g73nzqgvkh3rzxkk67z04rzlpf-vim-full-9.1.0595-xxd"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "xxd"
+            ],
+            "pname": "vim-full",
+            "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "rev_count": 671089,
+            "rev_date": "2024-08-24T06:09:45Z",
+            "scrape_date": "2024-08-27T03:15:44Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "9.1.0595"
+          },
+          {
+            "attr_path": "vim-full",
+            "broken": false,
+            "derivation": "/nix/store/byg86q6w8vzrcmlzkb7pir2f60jxg46k-vim-full-9.1.0595.drv",
+            "description": "Most popular clone of the VI editor",
+            "install_id": "vim-full",
+            "license": "Vim",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "name": "vim-full-9.1.0595",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/wj30hm4sbpy378imd5z8rif493qb9ydj-vim-full-9.1.0595"
+              },
+              {
+                "name": "xxd",
+                "store_path": "/nix/store/9f52x4vy1kqnzf5dlszlqbzgx1ylm5gp-vim-full-9.1.0595-xxd"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "xxd"
+            ],
+            "pname": "vim-full",
+            "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "rev_count": 671089,
+            "rev_date": "2024-08-24T06:09:45Z",
+            "scrape_date": "2024-08-27T03:15:44Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "9.1.0595"
+          },
+          {
+            "attr_path": "vim-full",
+            "broken": false,
+            "derivation": "/nix/store/8ars1jygnph5hgmavqmsklf0hsfsznb5-vim-full-9.1.0595.drv",
+            "description": "Most popular clone of the VI editor",
+            "install_id": "vim-full",
+            "license": "Vim",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "name": "vim-full-9.1.0595",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/4pa8lra70yn9mh8a6d2k1f89j0qkds4r-vim-full-9.1.0595"
+              },
+              {
+                "name": "xxd",
+                "store_path": "/nix/store/k1rqsp7dw55cr42v84q14dwyq83y2v86-vim-full-9.1.0595-xxd"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "xxd"
+            ],
+            "pname": "vim-full",
+            "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "rev_count": 671089,
+            "rev_date": "2024-08-24T06:09:45Z",
+            "scrape_date": "2024-08-27T03:15:44Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "9.1.0595"
+          },
+          {
+            "attr_path": "vim-full",
+            "broken": false,
+            "derivation": "/nix/store/8js41vk1shib4y57z7h3rpgg33chqcdv-vim-full-9.1.0595.drv",
+            "description": "Most popular clone of the VI editor",
+            "install_id": "vim-full",
+            "license": "Vim",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "name": "vim-full-9.1.0595",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/axljbg1irw600vvv2xhkfkwgaprgcv7g-vim-full-9.1.0595"
+              },
+              {
+                "name": "xxd",
+                "store_path": "/nix/store/j1ndja2cbb5qb43y3qdm9dn5741rcq0i-vim-full-9.1.0595-xxd"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "xxd"
+            ],
+            "pname": "vim-full",
+            "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+            "rev_count": 671089,
+            "rev_date": "2024-08-24T06:09:45Z",
+            "scrape_date": "2024-08-27T03:15:44Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "9.1.0595"
+          }
+        ],
+        "page": 671089,
+        "url": ""
+      }
+    }
+  ]
+]


### PR DESCRIPTION
The `priority` field is originally set when constructing in [LockedPackageCatalog::from_parts], after resolution.
Already locked packages are not re-resolved for priority changes as priority is not a constraint for resolution.
Thus removing (or setting) a priority attribute to an existing and previously locked manifest descriptor had no effect on the original priority of the locked package.

This change includes a step within the locking implementation to update the priority field of all already locked packages to the respective value in the manifest.

