### PR TITLE
chore(services): Unhide from root --help

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -764,7 +764,7 @@ enum LocalDevelopmentCommands {
     )]
     Delete(#[bpaf(external(delete::delete))] delete::Delete),
     /// Interact with services
-    #[bpaf(command, hide)]
+    #[bpaf(command)]
     Services(#[bpaf(external(services::services_commands))] services::ServicesCommands),
 }
 

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -71,11 +71,13 @@ EOF
   assert_line -n "$line" --regexp '^    list, l[ ]+[\w .,]+'
   line=$((line + 1))
   assert_line -n "$line" --regexp '^    delete[ ]+[\w .,]+'
+  line=$((line + 1))
+  assert_line -n "$line" --regexp '^    services[ ]+[\w .,]+'
 }
 
 @test "f3: command grouping changes 2: 'Sharing Commands' listed in order" {
   run "$FLOX_BIN" --help
-  line=14
+  line=15
   assert_line -n "$line" --regexp '^Sharing Commands'
   line=$((line + 1))
   assert_line -n "$line" --regexp '^    push[ ]+[\w .,]+'


### PR DESCRIPTION
## Proposed Changes

We forgot to unhide this when releasing services. You could find it from `flox services --help` but not `flox --help`.

It may be moved to another section at a later date, possibly when we come to release `flox build`, which is currently under "additional":

- https://github.com/flox/flox/pull/1997
- https://flox-dev.slack.com/archives/C06T9RL3BQT/p1724788772613039

## Release Notes

N/A
