### PR TITLE
fix(tracing): Enable tracing for activate

### DIFF
--- a/cli/flox/src/utils/tracing.rs
+++ b/cli/flox/src/utils/tracing.rs
@@ -1,4 +1,10 @@
-use sentry::configure_scope;
+use std::time::Duration;
+
+use sentry::{configure_scope, Hub};
+use tracing::debug;
+use tracing::span::EnteredSpan;
+
+const SHUTDOWN_TIMEOUT: Option<Duration> = Some(Duration::from_secs(1));
 
 /// Sets a tracing tag for the current scope.
 ///
@@ -18,4 +24,32 @@ pub fn sentry_set_tag<V: ToString>(key: &str, value: V) {
     configure_scope(|scope| {
         scope.set_tag(key, value);
     });
+}
+
+/// Guard against any existing spans being started so that we can ensure that
+/// a single span is closed by `sentry_shutdown()`.
+pub fn sentry_guard_no_existing_span() {
+    if configure_scope(|scope| scope.get_span()).is_some() {
+        unreachable!("no existing span should be started");
+    }
+}
+
+/// Shuts down the Sentry client and flushes data immediately. This should only
+/// be used before a function calls `exec()`, which prevents the normal
+/// destructors from flushing spans.
+///
+/// `span` must be the only span active. `sentry_guard_no_existing_span()`
+/// should be used before starting/entering `span` to ensure that is true.
+///
+/// If any other spans are active, which we have no way of checking for, then no
+/// data will be flushed to Sentry.
+pub fn sentry_shutdown(current_span: EnteredSpan) {
+    debug!("closing span");
+    current_span.exit();
+
+    if let Some(client) = Hub::main().client() {
+        debug!("closing sentry client");
+        // close appears to always return `false`, even when data is sent.
+        client.close(SHUTDOWN_TIMEOUT);
+    }
 }


### PR DESCRIPTION
## Proposed Changes

Enable tracing for `flox activate` and add extra tags.

Inspired by the amount of effort it's taken to add a new field to our in-house metrics in:

- https://github.com/flox/flox/issues/1972

Depending on how happy we are with the timeout behaviour this could close:

- https://github.com/flox/flox/issues/1715

You can see a trace which has the new `lockfile_version` and `activate_mode` tags here:

- https://flox-dev.sentry.io/performance/trace/1abc135759eec0bec0e66538cb428a0a/?node=trace-root

And you can test this it yourself with:
```
FLOX_DISABLE_METRICS=false \
  FLOX_SENTRY_DSN=REDACTED_UNTIL_1986 \
  just flox activate -d ~/tmp -- echo hello world
```

## Release Notes

N/A