### PR TITLE
fix(docs): remove broken links from manpages

### DIFF
--- a/cli/flox/doc/flox-pull.md
+++ b/cli/flox/doc/flox-pull.md
@@ -44,8 +44,7 @@ local system pulling the environment,
 in which case `-a` may be passed to forceably add the current system to the
 environment's manifest.
 This may create a broken environment that cannot be pushed back to FloxHub until
-it is repaired with [`flox-edit(1)`](./flox-edit.md) or
-[`flox-remove(1)`](./flox-remove.md).
+it is repaired with [`flox-edit(1)`](./flox-edit.md).
 See [`manifest.toml(5)`](./manifest.toml.md) for more on multi-system
 environments.
 
@@ -77,5 +76,4 @@ environments.
 
 [`flox-push(1)`](./flox-push.md)
 [`flox-edit(1)`](./flox-edit.md)
-[`flox-remove(1)`](./flox-remove.md)
 [`manifest.toml(5)`](./manifest.toml.md)

--- a/cli/flox/doc/flox-push.md
+++ b/cli/flox/doc/flox-push.md
@@ -34,7 +34,7 @@ Once the environment has been pushed, it can be used directly with the
 `--remote` option,
 or it can be used and edited locally before syncing with `flox push`.
 See [`flox-edit(1)`](./flox-edit.md), [`flox-install(1)`](./flox-install.md),
-and [`flox-remove(1)`](./flox-remove.md) for editing the environment.
+and [`flox-uninstall(1)`](./flox-uninstall.md) for editing the environment.
 
 In the same way as a git repo, local changes to an environment that has been
 pushed may diverge from the environment on FloxHub if `flox push` is run from a


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
These links refer to a manpage that no longer exists.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Removes broken links from the command reference documentation.

<!-- Many thanks! -->
