### PR TITLE
feat: integrate manifest package builder

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-lite 2.3.0",
  "slab",
 ]
@@ -233,7 +233,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -281,7 +281,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "windows-sys 0.48.0",
 ]
 
@@ -297,7 +297,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -361,9 +361,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "filetime"
@@ -1291,7 +1291,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-core",
  "futures-io",
  "parking",
@@ -1589,7 +1589,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -2420,7 +2420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-io",
 ]
 
@@ -2456,7 +2456,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2624,9 +2624,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2928,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3635,9 +3635,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "windows-sys 0.59.0",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,7 +61,7 @@ sysinfo = "0.30.13"
 # TODO: review if we need this
 sys-info = "0.9"
 tempfile = "3.12.0"
-textwrap = { version = "0.16.0", features = ["terminal_size"] }
+textwrap = { version = "0.16.1", features = ["terminal_size"] }
 thiserror = "1"
 time = { version = "0.3", features = ["serde", "formatting"] }
 tokio = { version = "1", features = ["full"] }

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1,0 +1,163 @@
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::mpsc::Receiver;
+use std::sync::LazyLock;
+use std::thread;
+
+use thiserror::Error;
+use tracing::{debug, warn};
+
+use crate::utils::CommandExt;
+
+static FLOX_BUILD_MK: LazyLock<PathBuf> = LazyLock::new(|| {
+    std::env::var("FLOX_BUILD_MK")
+        .unwrap_or_else(|_| env!("FLOX_BUILD_MK").to_string())
+        .into()
+});
+
+static GNUMAKE_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
+    std::env::var("GNUMAKE_BIN")
+        .unwrap_or_else(|_| env!("GNUMAKE_BIN").to_string())
+        .into()
+});
+
+pub trait ManifestBuilder {
+    /// Build the specified packages defined in the environment at `flox_env`.
+    /// The build process will start in the background.
+    /// To process the output, the caller should iterate over the returned [BuildOutput].
+    /// Once the process is complete, the [BuildOutput] will yield an [Output::Exit] message.
+    fn build(
+        &self,
+        base_dir: &Path,
+        flox_env: &Path,
+        package: &[String],
+    ) -> Result<BuildOutput, ManifestBuilderError>;
+}
+
+#[derive(Debug, Error)]
+pub enum ManifestBuilderError {
+    #[error("failed to call package builder: {0}")]
+    CallBuilderError(#[source] std::io::Error),
+}
+
+pub enum Output {
+    /// A line of stdout output from the build process.
+    Stdout(String),
+    /// A line of stderr output from the build process.
+    Stderr(String),
+    /// The build process has exited with the given status.
+    Exit(ExitStatus),
+}
+
+/// Output received from an ongoing build process.
+/// Callers of [ManifestBuilder::build] should iterate over this type
+/// to process the output of the build process and await its completion.
+#[must_use = "The build process is started in the background.
+To process the output and wait for the process to finish,
+iterate over the returned BuildOutput."]
+pub struct BuildOutput {
+    receiver: Receiver<Output>,
+}
+
+impl Iterator for BuildOutput {
+    type Item = Output;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.receiver.recv().ok()
+    }
+}
+
+/// A manifest builder that uses the [FLOX_BUILD_MK] makefile to build packages.
+pub struct FloxBuildMk;
+
+impl ManifestBuilder for FloxBuildMk {
+    /// Build `packages` defined in the environment rendered at
+    /// `flox_env` using the [FLOX_BUILD_MK] makefile.
+    ///
+    /// `packages` SHOULD be a list of package names defined in the
+    /// environment or an empty list to build all packages.
+    ///
+    /// If a package is not found in the environment,
+    /// the makefile will fail with an error.
+    /// However, currently the caller doesn't distinguish different error cases.
+    ///
+    /// The makefile is executed with its current working directory set to `base_dir`.
+    /// Upon success, the builder will have built the specified packages
+    /// and created links to the respective store paths in `base_dir/result-<build name>`.
+    ///
+    /// The build process will start in the background.
+    /// To process the output, the caller should iterate over the returned [BuildOutput].
+    /// Once the process is complete, the [BuildOutput] will yield an [Output::Exit] message.
+    fn build(
+        &self,
+        base_dir: &Path,
+        flox_env: &Path,
+        packages: &[String],
+    ) -> Result<BuildOutput, ManifestBuilderError> {
+        let mut command = Command::new(&*GNUMAKE_BIN);
+        command.arg("-f").arg(&*FLOX_BUILD_MK);
+        command.arg("-C").arg(base_dir);
+        command.arg(format!("FLOX_ENV={}", flox_env.display()));
+
+        // todo: extra makeflags, eventually
+
+        // add packages
+        command.args(packages);
+
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        debug!("running manifest build builder: {}", command.display());
+        let mut child = command
+            .spawn()
+            .map_err(ManifestBuilderError::CallBuilderError)?;
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let stdout_sender = sender.clone();
+        let stderr_sender = sender.clone();
+        let command_status_sender = sender;
+
+        let stdout = child.stdout.take().unwrap();
+        std::thread::spawn(move || {
+            let stdout = std::io::BufReader::new(stdout);
+            read_output_to_channel(stdout, stdout_sender, Output::Stdout);
+        });
+
+        let stderr = child.stderr.take().unwrap();
+        std::thread::spawn(move || {
+            let stderr = std::io::BufReader::new(stderr);
+            read_output_to_channel(stderr, stderr_sender, Output::Stderr);
+        });
+
+        thread::spawn(move || {
+            let status = child.wait().expect("failed to wait on child");
+            let _ = command_status_sender.send(Output::Exit(status));
+        });
+
+        Ok(BuildOutput { receiver })
+    }
+}
+
+/// Read output from a reader and send it to a channel
+/// until the reader is exhausted or the receiver is dropped.
+fn read_output_to_channel(
+    reader: impl BufRead,
+    sender: std::sync::mpsc::Sender<Output>,
+    mk_output: impl Fn(String) -> Output,
+) {
+    for line in reader.lines() {
+        let line = match line {
+            Err(e) => {
+                warn!("failed to read line: {e}");
+                continue;
+            },
+            Ok(line) => line,
+        };
+
+        let Ok(_) = sender.send(mk_output(line)) else {
+            // if the receiver is dropped, we can stop reading
+            break;
+        };
+    }
+}

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod build;
 pub mod catalog;
 pub mod flox_cpp_utils;
 pub mod git;

--- a/cli/flox/src/build/mod.rs
+++ b/cli/flox/src/build/mod.rs
@@ -1,1 +1,0 @@
-// use anyhow::{Result, anyhow};

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -1,9 +1,12 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::lockfile::LockedManifest;
+use flox_rust_sdk::providers::build::{FloxBuildMk, ManifestBuilder, Output};
 use tracing::instrument;
 
 use super::{environment_select, EnvironmentSelect};
+use crate::commands::ConcreteEnvironment;
 use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::message;
@@ -23,15 +26,73 @@ pub struct Build {
     /// the 'build' table in the environment's manifest.toml.
     /// If not specified, all packages are built.
     #[bpaf(positional("build"))]
-    package: Vec<String>,
+    packages: Vec<String>,
 }
 
 impl Build {
     #[instrument(name = "build", skip_all)]
-    pub async fn handle(self, _config: Config, _flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("build");
 
-        message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
+        if !config.features.unwrap_or_default().build {
+            message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
+            bail!("'build' feature is not enabled.");
+        }
+
+        let env = self
+            .environment
+            .detect_concrete_environment(&flox, "Build")?;
+
+        if let ConcreteEnvironment::Remote(_) = &env {
+            bail!("Cannot build from a remote environment");
+        };
+
+        let mut env = env.into_dyn_environment();
+
+        let base_dir = env.parent_path()?;
+        let flox_env = env.activation_path(&flox)?;
+
+        let packages_to_build = make_packages_to_build(&env.lockfile(&flox)?, self.packages)?;
+
+        let builder = FloxBuildMk;
+        let output = builder.build(&base_dir, &flox_env, &packages_to_build)?;
+
+        for message in output {
+            match message {
+                Output::Stdout(line) => println!("{line}"),
+                Output::Stderr(line) => eprintln!("{line}"),
+                Output::Exit(status) if status.success() => {
+                    message::created("Build completed successfully");
+                    break;
+                },
+                Output::Exit(status) => {
+                    bail!("Build failed with status: {status}");
+                },
+            }
+        }
+
         Ok(())
     }
+}
+
+fn make_packages_to_build(lockfile: &LockedManifest, packages: Vec<String>) -> Result<Vec<String>> {
+    let LockedManifest::Catalog(lockfile) = lockfile else {
+        bail!("Build requires a v1 lockfile");
+    };
+
+    let environment_packages = &lockfile.manifest.build;
+
+    let packages_to_build = if packages.is_empty() {
+        environment_packages.keys().cloned().collect()
+    } else {
+        packages
+    };
+
+    for package in &packages_to_build {
+        if !environment_packages.contains_key(package) {
+            bail!("Package '{}' not found in environment", package);
+        }
+    }
+
+    Ok(packages_to_build)
 }

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -24,7 +24,6 @@ use crate::utils::errors::{
 };
 use crate::utils::metrics::Hub;
 
-mod build;
 mod commands;
 mod config;
 mod utils;

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,9 @@
       ld-floxlib = callPackage ./pkgs/ld-floxlib {};
       flox-src = callPackage ./pkgs/flox-src {};
       flox-activation-scripts = callPackage ./pkgs/flox-activation-scripts {};
+      flox-package-builder = callPackage ./pkgs/flox-package-builder {};
+
+      # Package Database Utilities: scrape, search, and resolve.
       flox-pkgdb = callPackage ./pkgs/flox-pkgdb {};
       flox-watchdog = callPackage ./pkgs/flox-watchdog {}; # Flox Command Line Interface ( development build ).
       flox-cli = callPackage ./pkgs/flox-cli {};
@@ -131,6 +134,7 @@
           (pkgs)
           flox-activation-scripts
           flox-pkgdb
+          flox-package-builder
           flox-watchdog
           flox-cli
           flox-cli-tests

--- a/package-builder/Makefile
+++ b/package-builder/Makefile
@@ -1,0 +1,32 @@
+.DEFAULT_GOAL := all
+
+ALL = flox-build.mk build-manifest.nix
+
+OS := $(shell uname -s)
+ifeq (Linux,$(OS))
+  ALL += libsandbox.so
+else
+  ALL += libsandbox.dylib
+endif
+
+closure.o: closure.c closure.h
+	$(CC) -fPIC -c $<
+
+libsandbox.so: sandbox.c closure.o
+	$(CC) -shared -fPIC $^ -o $@
+	patchelf --remove-rpath $@
+
+libsandbox.dylib: sandbox.c closure.o
+	$(CC) -pthread -dynamiclib $^ -o $@
+
+.PHONY: all
+all: $(ALL)
+
+.PHONY: install
+install: $(ALL)
+	mkdir -p $(PREFIX)/libexec
+	cp $^ $(PREFIX)/libexec
+
+.PHONY: tests
+tests:
+	@echo TODO: create sandbox tests

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -1,0 +1,150 @@
+{
+  pkgs ? import (builtins.getFlake "github:nixos/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd") {},
+  name,
+  flox-env,
+  install-prefix,
+  srcTarball ? null, # optional
+  buildDeps ? [], # optional
+  buildScript ? null, # optional
+  buildCache ? null, # optional
+  virtualSandbox ? "off", # optional
+}:
+# First a few assertions to ensure that the inputs are consistent.
+# buildCache is only meaningful with a build script
+assert (buildCache != null) -> (buildScript != null);
+# srcTarball is only required with a build script
+assert (srcTarball != null) -> (buildScript != null); let
+  flox-env-package = builtins.storePath flox-env;
+  buildInputs =
+    (
+      map (d: builtins.storePath d) buildDeps
+    )
+    ++ [flox-env-package];
+  install-prefix-contents = /. + install-prefix;
+  buildScript-contents = /. + buildScript;
+  buildCache-tar-contents =
+    if (buildCache == null)
+    then null
+    else (/. + buildCache);
+in
+  pkgs.runCommand name {
+    inherit buildInputs srcTarball;
+    nativeBuildInputs = with pkgs;
+      [findutils gnutar gnused makeWrapper]
+      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [darwin.autoSignDarwinBinariesHook];
+    outputs = ["out"] ++ pkgs.lib.optionals (buildCache != null) ["buildCache"];
+  } (
+    (
+      if (buildScript == null)
+      then ''
+        # If no build script is provided copy the contents of install prefix
+        # to the output directory, rewriting path references as we go.
+        if [ -e ${install-prefix-contents} ]; then
+          if [ -d ${install-prefix-contents} ]; then
+            mkdir $out
+            tar -C ${install-prefix-contents} -c --mode=u+w -f - . | \
+              sed --binary "s%${install-prefix}%$out%g" | \
+              tar -C $out -xf -
+          else
+            cp ${install-prefix-contents} $out
+            sed --binary "s%${install-prefix}%$out%g" $out
+          fi
+        else
+          echo "ERROR: build did not produce expected \$out (${install-prefix})" 1>&2
+          exit 1
+        fi
+        ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+          signDarwinBinariesInAllOutputs
+        ''}
+      ''
+      else ''
+        echo "---"
+        echo "Input checksums:"
+        md5sum \
+          ${/. + srcTarball} \
+          ${buildScript-contents} \
+          ${pkgs.lib.optionalString (
+            buildCache-tar-contents != null
+          )
+          buildCache-tar-contents}
+        echo "---"
+        # If the build script is provided, then it's expected that we will
+        # invoke it from within the sandbox to create $out. The choice of
+        # pure or impure mode occurs outside of this script as the derivation
+        # is instantiated.
+        source $stdenv/setup # is this necessary?
+
+        # We are currently in /build, and TMPDIR is also set to /build, so
+        # we need to extract the source and work in a subdirectory to avoid
+        # populating our build cache with a bunch of temporary files.
+        mkdir $name && cd $name
+
+        # We pass and extract the source as a tarball to preserve timestamps.
+        # Passing the source as a directory would cause the timestamps to be
+        # set to the UNIX epoch as happens with all files in the Nix store,
+        # which would be older than the intermediate compilation artifacts.
+        tar -xpf ${/. + srcTarball}
+
+        # Extract contents of the cache, if it exists.
+        ${
+          if buildCache-tar-contents == null
+          then ":"
+          else ''
+            tar --skip-old-files -xpf ${buildCache-tar-contents}
+          ''
+        }
+        ${
+          if buildCache == null
+          then ''
+            # When not preserving a cache we just run the build normally.
+            FLOX_VIRTUAL_SANDBOX=${virtualSandbox} FLOX_SRC_DIR=$(pwd) \
+            FLOX_TURBO=1 ${flox-env-package}/activate bash -e ${buildScript-contents}
+          ''
+          else ''
+            # If the build fails we still want to preserve the build cache, so we
+            # remove $out on failure and allow the Nix build to proceed to write
+            # the result symlink.
+            FLOX_VIRTUAL_SANDBOX=${virtualSandbox} FLOX_SRC_DIR=$(pwd) \
+            FLOX_TURBO=1 ${flox-env-package}/activate bash -e ${buildScript-contents} || \
+              ( rm -rf $out && echo "flox build failed (caching build dir)" | tee $out 1>&2 )
+          ''
+        }
+      ''
+    )
+    + ''
+      # Start by patching shebangs in bin and sbin directories.
+      for dir in $out/bin $out/sbin; do
+        if [ -d "$dir" ]; then
+          patchShebangs $dir
+        fi
+      done
+      # Wrap contents of files in bin with ${flox-env-package}/activate
+      for prog in $out/bin/* $out/sbin/*; do
+        if [ -L "$prog" ]; then
+          : # You cannot wrap a symlink, so just leave it be?
+        else
+          assertExecutable "$prog"
+          hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
+          mv "$prog" "$hidden"
+          makeShellWrapper "${flox-env-package}/activate" "$prog" \
+            --inherit-argv0 \
+            --set FLOX_ENV "${flox-env-package}" \
+            --set FLOX_TURBO 1 \
+            --set FLOX_MANIFEST_BUILD_OUT "$out" \
+            --set FLOX_VIRTUAL_SANDBOX "${virtualSandbox}" \
+            --run 'export FLOX_SET_ARG0="$0"' \
+            --add-flags "$hidden"
+        fi
+      done
+    ''
+    + pkgs.lib.optionalString (buildCache != null) ''
+      # Only tar the files to avoid differences in directory {a,c,m}times.
+      # Sort the files to keep the output stable across builds.
+      # Avoid compressing with gzip because that is not stable across
+      # invocations on Mac only. Experimentation shows that xz and bzip2
+      # compression is stable on both Mac and Linux, but that can be slow,
+      # and we probably don't actually need to compress the build cache
+      # because we actively delete the old copy as we create a new one.
+      find . -type f | sort | tar -c --no-recursion -f $buildCache -T -
+    ''
+  )

--- a/package-builder/closure.c
+++ b/package-builder/closure.c
@@ -1,0 +1,206 @@
+/*
+ * The Flox "virtual sandbox" warns or aborts when encountering an ELF access
+ * from outside the closure of packages implied by $FLOX_ENV. In this regard
+ * it can provide the same guarantees at an ELF level provided by the sandbox
+ * itself, but at an _advisory_ level, so that developers are informed of
+ * missing dependencies without actually breaking anything.
+ *
+ * The virtual sandbox is enabled with `FLOX_VIRTUAL_SANDBOX=(warn|enforce)`
+ * set in the environment, and we do this when wrapping files in the bin
+ * directory in the course of performing a manifest build.
+ *
+ * As with the parsing of FLOX_ENV_LIB_DIRS, it is essential that this parsing
+ * of the closure be performant and initialized only once per invocation, so we
+ * start by reading closure paths into a btable from $FLOX_ENV/requisites.txt.
+ */
+
+#define _GNU_SOURCE
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+// Declare version bindings to work with minimum supported GLIBC versions.
+#ifdef linux
+#include "glibc-bindings.h"
+#endif
+
+#define HASH_MULTIPLIER 31
+#define INITIAL_CAPACITY FLOX_ENV_CLOSURE_MAXENTRIES
+
+// Define the maximum number of paths to be tracked in the FLOX_ENV closure.
+// This is somewhat arbitrary but should be more than enough for most cases.
+#define FLOX_ENV_CLOSURE_MAXENTRIES 4096
+
+// Define the maximum length of a directory path in the FLOX_ENV_LIB_DIRS
+// environment variable. This is also somewhat arbitrary, but it should
+// be more than enough for most cases.
+#define FLOX_ENV_REQUISITE_MAXLEN PATH_MAX
+
+typedef struct {
+  char key[FLOX_ENV_REQUISITE_MAXLEN];
+  bool is_filled;
+} hash_entry_t;
+
+typedef struct {
+  hash_entry_t entries[FLOX_ENV_CLOSURE_MAXENTRIES];
+  size_t size;
+  size_t capacity;
+} hash_table_t;
+
+hash_table_t *hash_table_init(size_t capacity);
+int hash_table_store(hash_table_t *table, const char *key);
+bool hash_table_lookup(hash_table_t *table, const char *key);
+
+// Helper macros for printing debug, warnings, errors.
+static int debug_closure = -1;
+static int sandbox_warn_count = 0;
+#define debug(format, ...)                                                     \
+  if (debug_closure)                                                           \
+  fprintf(stderr, "CLOSURE DEBUG[%d]: " format "\n", getpid(), __VA_ARGS__)
+
+// Temporary path buffer for calculating realpath of hash table queries.
+static char realpath_buf[PATH_MAX];
+
+static size_t hash(const char *key, size_t capacity) {
+  size_t hash_value = 0;
+  while (*key) {
+    hash_value = hash_value * HASH_MULTIPLIER + (unsigned char)(*key);
+    key++;
+  }
+  return hash_value % capacity;
+}
+
+hash_table_t *hash_table_init(size_t capacity) {
+  static hash_table_t table;
+  table.size = 0;
+  table.capacity = capacity;
+  for (size_t i = 0; i < capacity; i++) {
+    table.entries[i].is_filled = false;
+  }
+  return &table;
+}
+
+int hash_table_store(hash_table_t *table, const char *key) {
+  if (table->size >= table->capacity) {
+    return -1; // Table is full
+  }
+
+  size_t index = hash(key, table->capacity);
+  while (table->entries[index].is_filled &&
+         strcmp(table->entries[index].key, key) != 0) {
+    index = (index + 1) % table->capacity;
+  }
+
+  if (!table->entries[index].is_filled) {
+    strncpy(table->entries[index].key, key, FLOX_ENV_REQUISITE_MAXLEN - 1);
+    table->entries[index].key[FLOX_ENV_REQUISITE_MAXLEN - 1] =
+        '\0'; // Ensure null termination
+    table->entries[index].is_filled = true;
+    table->size++;
+  }
+  return 0;
+}
+
+bool hash_table_lookup(hash_table_t *table, const char *key) {
+  // look for the first '/' following the expected 44 characters
+  // in a /nix/store path, e.g.
+  //   /nix/store/12345678901234567890123456789012-foobar-1.2.3/bin/foo":
+  //   ^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  const char *pkgend = strchr(key + 44, '/');
+  if (pkgend == NULL)
+    return false;
+
+  static char pkgbuf[PATH_MAX];
+  (void)snprintf(pkgbuf, (pkgend - key) + 1, "%s", key);
+
+  debug("hash_table_lookup(%s), looking for %s in hashtable", key, pkgbuf);
+
+  size_t index = hash(pkgbuf, table->capacity);
+  while (table->entries[index].is_filled) {
+    // With Nix we only have to look at the first 44
+    // characters to know that we have a match. e.g.
+    // "/nix/store/12345678901234567890123456789012-foobar-1.2.3":
+    //  ^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //      10    1              32                1
+    debug("comparing %s to %s", table->entries[index].key, pkgbuf);
+    if (strncmp(table->entries[index].key, pkgbuf, 44) == 0) {
+      debug("%s is in the closure", key);
+      return true;
+    }
+    index = (index + 1) % table->capacity;
+  }
+  debug("%s is not in the closure", key);
+  return false;
+}
+
+bool in_closure(const char *path) {
+  static hash_table_t *table = NULL;
+
+  // Debug closure library with FLOX_DEBUG_CLOSURE=1.
+  debug_closure = (getenv("FLOX_DEBUG_CLOSURE") != NULL);
+
+  if (!table) {
+    const char *env_path = getenv("FLOX_ENV");
+    if (!env_path) {
+      fprintf(stderr, "FLOX_ENV environment variable not set\n");
+      return false;
+    }
+
+    char requisites_path[256];
+    snprintf(requisites_path, sizeof(requisites_path), "%s/requisites.txt",
+             env_path);
+
+    FILE *file = fopen(requisites_path, "r");
+    if (!file) {
+      perror("Error opening requisites.txt");
+      return false;
+    }
+
+    table = hash_table_init(INITIAL_CAPACITY);
+
+    char line[FLOX_ENV_REQUISITE_MAXLEN];
+    static int count = 0;
+    while (fgets(line, sizeof(line), file)) {
+      line[strcspn(line, "\n")] = '\0'; // Remove newline character
+      if (hash_table_store(table, line) != 0) {
+        fprintf(stderr, "Error: Hash table is full, cannot store more paths\n");
+        break;
+      }
+      count++;
+    }
+    fclose(file);
+
+    // Because this library will itself be loaded on account of its presence
+    // in LD_PRELOAD, we should ensure that we don't trip over ourselves.
+    if (hash_table_store(table, "@@out@@") != 0) {
+      fprintf(stderr, "Error: Hash table is full, cannot store more paths\n");
+    }
+    count++;
+
+    // There is one more "blessed" path to be added to the table which is
+    // the path of the manifest-built package itself, and this comes to us
+    // by way of the FLOX_MANIFEST_BUILD_OUT environment variable.
+    const char *additional_path = getenv("FLOX_MANIFEST_BUILD_OUT");
+    if (additional_path) {
+      if (hash_table_store(table, additional_path) != 0) {
+        fprintf(stderr, "Error: Hash table is full, cannot store more paths\n");
+      }
+      count++;
+    }
+
+    debug("loaded %d entries from requisites.txt", count);
+  }
+
+  if (realpath(path, realpath_buf) == NULL) {
+    // Likely that path does not exist, so just return true
+    // so that the real system call can return ENOENT.
+    debug("%s not found, allowing sandbox access", path);
+    return true;
+  }
+
+  return hash_table_lookup(table, realpath_buf);
+}

--- a/package-builder/closure.h
+++ b/package-builder/closure.h
@@ -1,0 +1,8 @@
+#ifndef CLOSURE_H
+#define CLOSURE_H
+
+#include <stdbool.h>
+
+bool in_closure(const char *path);
+
+#endif // CLOSURE_H

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -1,0 +1,274 @@
+#
+# This makefile implements Tom's stepladder from manifest to Nix builds:
+#
+# 1. "local" (aka in-situ): sets $out in the environment, invokes the build
+#    commands in a subshell (using bash), then turns the $out directory into
+#    a Nix package with all outpath references replaced with the real $out
+#    and all bin/* commands wrapped with $FLOX_ENV/activate
+# 2. "sandbox": invokes that same script from within the runCommand builder,
+#    with no network and filesystem access and a fake home directory
+# 3. "sandbox with buildCache": does as above, with the build directory
+#    persisted across builds
+# 4. "staged": splits the builds into stages, each of which can be any of
+#    the above, and whose "locked" values are stored as a result symlink or
+#    as a storePath within the manifest
+#
+
+# Start by checking that the FLOX_ENV environment variable is set.
+ifeq (,$(FLOX_ENV))
+  $(error ERROR: FLOX_ENV not defined)
+endif
+
+# Identify target O/S.
+OS := $(shell uname -s)
+
+# Set the default goal to be all builds if one is not specified.
+.DEFAULT_GOAL := all
+
+# Set a default TMPDIR variable if one is not already defined.
+TMPDIR ?= /tmp
+
+# Use the wildcard operator to identify builds in the provided $FLOX_ENV.
+BUILDS := $(wildcard $(FLOX_ENV)/package-builds.d/*)
+
+# The `nix build` command will attempt a rebuild in every instance,
+# and we will presumably want `flox build` to do the same. However,
+# we cannot just mark the various build targets as PHONY because they
+# must be INTERMEDIATE to prevent `flox build foo` from rebuilding
+# `bar` and `baz` as well (unless of course it was a prerequsite).
+# So we instead derive the packages to be force-rebuilt from the special
+# MAKECMDGOALS variable if defined, and otherwise rebuild them all.
+BUILDGOALS = $(if $(MAKECMDGOALS),$(MAKECMDGOALS),$(notdir $(BUILDS)))
+$(foreach _build,$(BUILDGOALS),\
+  $(eval _pname = $(notdir $(_build)))\
+  $(foreach _buildtype,local sandbox,\
+    $(eval $(_pname)_$(_buildtype)_build: FORCE)))
+
+# Scan for "${package}" references within the build instructions and add
+# target prerequisites for any inter-package prerequisites, letting make
+# flag any circular dependencies encountered along the way.
+define DEPENDS_template =
+  # Infer pname from script path.
+  $(eval _pname = $(notdir $(build)))
+  # We want to create build-specific variables, and variable names cannot
+  # have "-" in them so we create a version of the build "pname" replacing
+  # this with "_" for use in variable names.
+  $(eval _pvarname = $(subst -,_,$(_pname)))
+  # Compute 32-character stable string for use in stable path generation
+  # based on hash of pname, current working directory and FLOX_ENV.
+  $(eval $(_pvarname)_hash = $(shell ( \
+    ( echo $(_pname) $(realpath $(FLOX_ENV)) && pwd ) | sha256sum | head -c32)))
+  # Render a shorter 8-character version as well.
+  $(eval $(_pvarname)_shortHash = $(shell echo $($(_pvarname)_hash) | head -c8))
+  # And while we're at it, set a temporary basename using the short hash.
+  $(eval $(_pvarname)_tmpBasename = $(TMPDIR)/$($(_pvarname)_shortHash)-$(_pname))
+
+  # We need to render a version of the build script with package prerequisites
+  # replaced with their corresponding outpaths, and we create that at a stable
+  # temporary path so that we only perform Nix rebuilds when necessary.
+  $(eval $(_pvarname)_buildScript = $($(_pvarname)_tmpBasename)-build.bash)
+
+  # Iterate over each possible {build,package} pair looking for references to
+  # ${package} in the build script, being careful to avoid looking for references
+  # to the package in its own build. If found, declare dependency from the build
+  # script to the package.
+  $(foreach package,$(filter-out $(notdir $(build)),$(notdir $(BUILDS))),\
+    $(if $(shell grep '\$${$(package)}' $(build)),\
+      $(eval _dep = result-$(package))\
+      $(eval $(_pvarname)_buildDeps += $(realpath $(_dep)))\
+      $($(_pvarname)_buildScript): $(_dep)))
+endef
+
+$(foreach build,$(BUILDS),$(eval $(call DEPENDS_template)))
+
+# Define macro containing single space character for use in string substitution.
+space := $(subst x,,x x)
+
+# The method of calling the sandbox differs based on O/S. Define
+# PRELOAD_ARGS to denote the correct way.
+ifeq (Darwin,$(OS))
+  PRELOAD_ARGS = DYLD_INSERT_LIBRARIES=__FLOX_CLI_OUTPATH__/lib/libsandbox.dylib
+else
+  ifeq (Linux,$(OS))
+    PRELOAD_ARGS = LD_PRELOAD=__FLOX_CLI_OUTPATH__/lib/libsandbox.so
+  else
+    $(error unknown OS: $(OS))
+  endif
+endif
+
+# The following template renders targets for the in-situ build mode.
+define BUILD_local_template =
+  .INTERMEDIATE: $(_pname)_local_build
+  $(_pname)_local_build: $($(_pvarname)_buildScript)
+	@echo "Building $(_name) in local mode"
+	$(if $(_virtualSandbox),$(PRELOAD_ARGS) FLOX_SRC_DIR=$$$$(pwd) FLOX_VIRTUAL_SANDBOX=$(strip $(_virtualSandbox))) \
+	MAKEFLAGS= FLOX_TURBO=1 out=$(_out) $(FLOX_ENV)/activate bash -e $($(_pvarname)_buildScript)
+	nix --extra-experimental-features nix-command \
+	  build -L --file __FLOX_CLI_OUTPATH__/libexec/build-manifest.nix \
+	    --argstr name "$(_name)" \
+	    --argstr flox-env "$(FLOX_ENV)" \
+	    --argstr install-prefix "$(_out)" \
+	    $(if $(_virtualSandbox),--argstr virtualSandbox "$(strip $(_virtualSandbox))") \
+	    --out-link "result-$(_pname)" \
+	    --offline 2>&1 | tee $($(_pvarname)_logfile)
+
+endef
+
+# The following template renders targets for the sandbox build mode.
+define BUILD_sandbox_template =
+  # Again, it is expected that the sandbox and caching modes will be specified
+  # on a per-build basis within the manifest, but in the meantime while we wait
+  # for the manifest parser to be implemented we will grep for the explicit
+  # "buildCache" setting within the build script itself. (See below)
+  $(eval _do_buildCache = $(if $(shell grep -E '\.buildCache = true$$' $(build)),true))
+
+  # The sourceTarball value needs to be stable when nothing changes across builds,
+  # so we create a tarball at a stable TMPDIR path and pass that to the derivation
+  # instead.
+  $(eval $(_pvarname)_src_tar = $($(_pvarname)_tmpBasename)-src.tar)
+  $($(_pvarname)_src_tar): FORCE
+	tar -cf - --no-recursion -T <(git ls-files) > $$@
+
+  # The buildCache value needs to be similarly stable when nothing changes across
+  $(eval $(_pvarname)_buildCache = $($(_pvarname)_tmpBasename)-buildCache.tar)
+  $($(_pvarname)_buildCache): FORCE
+	-rm -f $$@
+	@# If a previous buildCache exists, then copy, don't link to the
+	@# previous buildCache because we want nix to import it as a
+	@# content-addressed input rather than an ever-changing series
+	@# of storePaths. And if it does not exist, then create a new
+	@# tarball containing only a single file indicating the time that
+	@# the buildCache was created to differentiate it from other
+	@# prior otherwise-empty buildCaches.
+	@if [ -f "$(_result)-buildCache" ]; then \
+	  cp $(_result)-buildCache $$@; \
+	else \
+	  tmpdir=$$$$(mktemp -d); \
+	  echo "Build cache initialized on $$$$(date)" > $$$$tmpdir/.buildCache.init; \
+	  tar -cf $$@ -C $$$$tmpdir .buildCache.init; \
+	  rm -rf $$$$tmpdir; \
+	fi
+
+  .PHONY: $(_pname)_sandbox_build
+  $(_pname)_sandbox_build: $($(_pvarname)_buildScript) $($(_pvarname)_src_tar) \
+		$(if $(_do_buildCache),$($(_pvarname)_buildCache))
+	@echo "Building $(_name) in sandbox mode"
+	@# If a previous buildCache exists then move it out of the way
+	@# so that we can detect later if it has been updated.
+	@if [ -n "$(_do_buildCache)" ] && [ -f "$(_result)-buildCache" ]; then \
+	  rm -f "$(_result)-buildCache.prevOutPath"; \
+	  readlink "$(_result)-buildCache" > "$(_result)-buildCache.prevOutPath"; \
+	fi
+	nix --extra-experimental-features nix-command \
+	  build -L --file __FLOX_CLI_OUTPATH__/libexec/build-manifest.nix \
+	    --argstr name "$(_name)" \
+	    --argstr srcTarball "$($(_pvarname)_src_tar)" \
+	    --argstr flox-env "$(FLOX_ENV)" \
+	    --argstr install-prefix "$(_out)" \
+	    $(if $($(_pvarname)_buildDeps),--arg buildDeps $($(_pvarname)_buildDeps_arg)) \
+	    --argstr buildScript "$($(_pvarname)_buildScript)" \
+	    $(if $(_do_buildCache),--argstr buildCache "$($(_pvarname)_buildCache)") \
+	    $(if $(_virtualSandbox),--argstr virtualSandbox "$(strip $(_virtualSandbox))") \
+	    --out-link "result-$(_pname)" \
+	    '^*' 2>&1 | tee $($(_pvarname)_logfile)
+	@# Check to see if a new buildCache has been created, and if so then go
+	@# ahead and run 'nix store delete' on the previous cache, keeping in
+	@# mind that the symlink will remain unchanged in the event of an
+	@# unsuccessful build.
+	@if [ -n "$(_do_buildCache)" ]; then \
+	  if [ -f "$(_result)-buildCache" ] && [ -f "$(_result)-buildCache.prevOutPath" ]; then \
+	    if [ $$$$(readlink "$(_result)-buildCache") != $$$$(cat "$(_result)-buildCache.prevOutPath") ]; then \
+	      nix --extra-experimental-features nix-command store delete \
+	        $$$$(cat "$(_result)-buildCache.prevOutPath") >/dev/null 2>&1 || true; \
+	    fi; \
+	  fi; \
+	  rm -f "$(_result)-buildCache.prevOutPath"; \
+	fi
+
+endef
+
+define BUILD_template =
+  # build mode passed as $(1)
+  $(eval _build_mode = $(1))
+  # Infer pname from script path.)
+  $(eval _pname = $(notdir $(build)))
+  # We want to create build-specific variables, and variable names cannot
+  # have "-" in them so we create a version of the build "pname" replacing
+  # this with "_" for use in variable names.
+  $(eval _pvarname = $(subst -,_,$(_pname)))
+  # Identify result symlink basename.
+  $(eval _result = result-$(_pname))
+  # Eventually derive version somehow, but hardcode it in the meantime.
+  $(eval _version = 0.0.0)
+  # Calculate name.
+  $(eval _name = $(_pname)-$(_version))
+  # Short variable name for buildDependencies derived in the DEPENDS step.
+  $(eval $(_pvarname)_buildDeps_arg = $(strip \
+    $(if $($(_pvarname)_buildDeps),\
+      '["$(subst $(space),",$($(_pvarname)_buildDeps))"]')))
+
+  # Set temp outpath of same strlen as eventual package storePath using the
+  # 32-char hash previously derived from the package name, current working
+  # directory and FLOX_ENV.
+  $(eval _out = /tmp/store_$($(_pvarname)_hash)-$(_name))
+
+  # By the time this rule will be evaluated all of its package dependencies
+  # will have been added to the set of rule prerequisites in $^, using their
+  # "safe" name (with "-" characters replaced with "_"), and these targets
+  # will have successfully built the corresponding result-$(_pname) symlinks.
+  # Iterate through this list, replacing all instances of "${package}" with the
+  # corresponding storePath as identified by the result-* symlink.
+  .INTERMEDIATE: $($(_pvarname)_buildScript)
+  $($(_pvarname)_buildScript): $(build)
+	@echo "Rendering $(_pname) build script to $$@"
+	@cp $$< $$@
+	@for i in $$^; do \
+	  if [ -L "$$$$i" ]; then \
+	    outpath="$$$$(readlink $$$$i)"; \
+	    if [ -n "$$$$outpath" ]; then \
+	      pkgname="$$$$(echo $$$$i | cut -d- -f2-)"; \
+	      sed -i "s%\$$$${$$$$pkgname}%$$$$outpath%g" $$@; \
+	    fi; \
+	  fi; \
+	done
+
+  # Prepare temporary log file for capturing build output for inspection.
+  $(eval $(_pvarname)_logfile := $(shell mktemp --dry-run --suffix=-build-$(_pname).log))
+
+  # Insert mode-specific template.
+  $(call BUILD_$(_build_mode)_template)
+
+  # Select the desired build mode as we declare the result symlink target.
+  $(_result): $(_pname)_$(_build_mode)_build
+	@# Take this opportunity to fail the build if we spot fatal errors in the log.
+	@if grep -q "flox build failed (caching build dir)" $($(_pvarname)_logfile); then \
+	  echo "ERROR: flox build failed (see $($(_pvarname)_logfile))" 1>&2; \
+	  rm -f $$@; \
+	  exit 1; \
+	fi
+
+  # Create a helper target for referring to the package by its name rather
+  # than the [real] result symlink we're looking to create.
+  .PHONY: $(_pname)
+  $(_pname): $(_result)
+
+  # Accumulate a list of known build targets for the "all" target.
+  all += $(_result)
+endef
+
+# It is expected that the sandbox and caching modes will be specified on a
+# per-build basis within the manifest, but in the meantime while we wait for
+# the manifest parser to be implemented we will grep for explicit "buildCache"
+# and "sandbox" settings within the build script for setting the build and
+# caching modes.
+
+# TODO: conditional sandboxing
+$(foreach build,$(BUILDS), \
+  $(eval $(call BUILD_template,local)))
+
+# Finally, we create the "all" target to build all known packages.
+.PHONY: all
+all: $(all)
+
+.PHONY: FORCE
+FORCE:

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -202,10 +202,11 @@ define BUILD_template =
   $(eval _version = 0.0.0)
   # Calculate name.
   $(eval _name = $(_pname)-$(_version))
-  # Short variable name for buildDependencies derived in the DEPENDS step.
+  # Variable for providing buildDependencies derived in the DEPENDS step
+  # to the Nix expression as a safely-quoted string.
   $(eval $(_pvarname)_buildDeps_arg = $(strip \
     $(if $($(_pvarname)_buildDeps),\
-      '["$(subst $(space),",$($(_pvarname)_buildDeps))"]')))
+      '["$(subst $(space)," ",$($(_pvarname)_buildDeps))"]')))
 
   # Set temp outpath of same strlen as eventual package storePath using the
   # 32-char hash previously derived from the package name, current working

--- a/package-builder/glibc-bindings.h
+++ b/package-builder/glibc-bindings.h
@@ -1,0 +1,55 @@
+#ifndef GLIBC_BINDINGS_H
+#define GLIBC_BINDINGS_H
+
+// Declare version bindings to work with minimum supported GLIBC versions.
+//
+// This file needs to be updated whenever we start using a new GLIBC function.
+// The procedure to update the file is as follows:
+//
+//   make -C ld-floxlib libsandbox.so
+//   nm -D ld-floxlib/libsandbox.so | \
+//     sed 's/@GLIBC_.*/@GLIBC_MIN_VERSION/' | awk '/GLIBC/ {print $NF}' | \
+//     awk -F@ '{printf("__asm__( \".symver %s,%s@\" %s );\n",$1,$1,$2)}' >>
+//     ld-floxlib/glibc-bindings.h
+//   vi ld-floxlib/glibc-bindings.h
+//     /* remove previous bindings section, leaving newly-appended one */
+//
+#if defined(__aarch64__)
+// aarch64 Linux only goes back to 2.17.
+#define GLIBC_MIN_VERSION "GLIBC_2.17"
+#define ALT_GLIBC_MIN_VERSION "GLIBC_2.17"
+#define ALT_ALT_GLIBC_MIN_VERSION "GLIBC_2.17"
+#elif defined(__x86_64__)
+// x86_64 Linux goes back to 2.2.5.
+#define GLIBC_MIN_VERSION "GLIBC_2.2.5"
+#define ALT_GLIBC_MIN_VERSION "GLIBC_2.3.4"
+#define ALT_ALT_GLIBC_MIN_VERSION "GLIBC_2.4"
+#else
+#error "Unsupported architecture"
+#endif
+
+__asm__(".symver __cxa_finalize,__cxa_finalize@" GLIBC_MIN_VERSION);
+__asm__(".symver dlsym,dlsym@" GLIBC_MIN_VERSION);
+__asm__(".symver __errno_location,__errno_location@" GLIBC_MIN_VERSION);
+__asm__(".symver fclose,fclose@" GLIBC_MIN_VERSION);
+__asm__(".symver fgets,fgets@" GLIBC_MIN_VERSION);
+__asm__(".symver fopen,fopen@" GLIBC_MIN_VERSION);
+__asm__(".symver __fprintf_chk,__fprintf_chk@" ALT_GLIBC_MIN_VERSION);
+__asm__(".symver fwrite,fwrite@" GLIBC_MIN_VERSION);
+__asm__(".symver getenv,getenv@" GLIBC_MIN_VERSION);
+__asm__(".symver getpid,getpid@" GLIBC_MIN_VERSION);
+__asm__(".symver perror,perror@" GLIBC_MIN_VERSION);
+__asm__(".symver __realpath_chk,__realpath_chk@" ALT_ALT_GLIBC_MIN_VERSION);
+__asm__(".symver __snprintf_chk,__snprintf_chk@" ALT_GLIBC_MIN_VERSION);
+__asm__(".symver __stack_chk_fail,__stack_chk_fail@" ALT_ALT_GLIBC_MIN_VERSION);
+__asm__(".symver __stack_chk_guard,__stack_chk_guard@" GLIBC_MIN_VERSION);
+__asm__(".symver stderr,stderr@" GLIBC_MIN_VERSION);
+__asm__(".symver strchr,strchr@" GLIBC_MIN_VERSION);
+__asm__(".symver strcmp,strcmp@" GLIBC_MIN_VERSION);
+__asm__(".symver strcspn,strcspn@" GLIBC_MIN_VERSION);
+__asm__(".symver strlen,strlen@" GLIBC_MIN_VERSION);
+__asm__(".symver strncmp,strncmp@" GLIBC_MIN_VERSION);
+__asm__(".symver strncpy,strncpy@" GLIBC_MIN_VERSION);
+__asm__(".symver strtok_r,strtok_r@" GLIBC_MIN_VERSION);
+
+#endif // GLIBC_BINDINGS_H

--- a/package-builder/sandbox.c
+++ b/package-builder/sandbox.c
@@ -1,0 +1,399 @@
+/*
+ * The Flox "virtual sandbox" warns or aborts when encountering an ELF access
+ * from outside the closure of packages implied by $FLOX_ENV. In this regard
+ * it can provide the same guarantees at an ELF level provided by the sandbox
+ * itself, but at an _advisory_ level, so that developers are informed of
+ * missing dependencies without actually breaking anything.
+ *
+ * The virtual sandbox is enabled with `FLOX_VIRTUAL_SANDBOX=(warn|enforce)`
+ * set in the environment, and we do this when wrapping files in the bin
+ * directory in the course of performing a manifest build.
+ *
+ * As with the parsing of FLOX_ENV_LIB_DIRS, it is essential that this parsing
+ * of the closure be performant and initialized only once per invocation, so we
+ * start by reading closure paths into a btable from $FLOX_ENV/requisites.txt.
+ */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// Declare version bindings to work with minimum supported GLIBC versions.
+#ifdef linux
+#include "glibc-bindings.h"
+#endif
+
+// For access to the in_closure() function.
+#include "closure.h"
+
+// Derive audit level from FLOX_VIRTUAL_SANDBOX environment variable.
+int sandbox_level = -1;
+
+// Thread lock
+pthread_mutex_t lock;
+
+// Function pointers to hold the original functions
+#ifdef linux
+static int (*orig_open)(const char *pathname, int flags, ...) = NULL;
+static int (*orig_openat)(int dirfd, const char *pathname, int flags,
+                          ...) = NULL;
+#endif
+
+// Helper macros for printing debug, warnings, errors.
+static int debug_sandbox = -1;
+static int warn_count = 0;
+#define debug(format, ...)                                                     \
+  if (debug_sandbox)                                                           \
+  fprintf(stderr, "SANDBOX DEBUG[%d]: " format "\n", getpid(), __VA_ARGS__)
+#define warn(format, ...)                                                      \
+  fprintf(stderr, "SANDBOX WARNING[%d]: " format "\n", getpid(), ##__VA_ARGS__)
+#define warn_once(format, ...)                                                 \
+  if (debug_sandbox)                                                           \
+    warn(format, ##__VA_ARGS__);                                               \
+  else if (warn_count++ == 0)                                                  \
+  warn(format " (further warnings suppressed)", ##__VA_ARGS__)
+#define _error(format, ...)                                                    \
+  fprintf(stderr, "SANDBOX ERROR[%d]: " format "\n", getpid(), ##__VA_ARGS__)
+
+// Perform various initialization, which includes loading the original
+// glibc functions to be wrapped using dlsym().
+void sandbox_init() {
+
+  // Debug sandbox library with FLOX_DEBUG_SANDBOX=1.
+  debug_sandbox = (getenv("FLOX_DEBUG_SANDBOX") != NULL);
+
+  // Derive audit level from FLOX_VIRTUAL_SANDBOX environment variable.
+  const char *flox_virtual_sandbox_value = getenv("FLOX_VIRTUAL_SANDBOX");
+  if (flox_virtual_sandbox_value == NULL ||
+      (strcmp(flox_virtual_sandbox_value, "off") == 0)) {
+    sandbox_level = 0;
+  } else if (strcmp(flox_virtual_sandbox_value, "warn") == 0) {
+    sandbox_level = 1;
+  } else if (strcmp(flox_virtual_sandbox_value, "enforce") == 0) {
+    sandbox_level = 2;
+  } else if (strcmp(flox_virtual_sandbox_value, "pure") == 0) {
+    // Pure mode is just like enforce, but invoked within the Nix sandbox.
+    sandbox_level = 3;
+  } else {
+    warn_once(
+        "FLOX_VIRTUAL_SANDBOX must be (off|warn|enforce|pure) ... ignoring");
+    sandbox_level = 0;
+  }
+  debug("sandbox_level=%d", sandbox_level);
+
+#ifdef linux
+  // Declare new functions to be intercepted here, then add stub
+  // functions below.
+  orig_open = dlsym(RTLD_NEXT, "open");
+  orig_openat = dlsym(RTLD_NEXT, "openat");
+#endif
+}
+
+// Accessor method for determining sandbox_level defined as a
+// static int in this file.
+int get_sandbox_level() { return sandbox_level; }
+
+#ifdef linux
+bool sandbox_check_argv0() {
+  static char argv0_path[PATH_MAX];
+  if (sandbox_level < 0)
+    sandbox_init();
+  // Identify the argv[0] realpath from /proc and flag if it's
+  // not in the closure.
+  // TODO: find way to detect changes in /proc/self/exe rather than
+  //       running realpath() on every path access.
+  if (realpath("/proc/self/exe", argv0_path) == NULL) {
+    _error("sandbox_check_argv0() realpath() failed");
+    fflush(stderr);
+    // If realpath() failed to set the realpath then explicitly
+    // ensure our buffer returns an empty string.
+    argv0_path[0] = '\0';
+  }
+  // The use of certain paths like `/usr/bin/env` path is ubiquitous and
+  // hardcoded to an extent that we cannot really expect developers to
+  // replace it in code, so we instead allow exceptions for a limited
+  // number of these paths.
+  // simply let it be an allowed exception.
+  //
+  // Once requested by way of the la_version() call, we know that all
+  // libraries requested by this PID are similarly linked from /usr/bin/env
+  // so we can simply give all lookups a free pass.
+  if (strcmp(argv0_path, "/usr/bin/env") == 0 ||
+      strcmp(argv0_path, "/bin/sh") == 0 ||
+      strcmp(argv0_path, "/usr/bin/dash") == 0) {
+    debug("%s is a permitted argv0", argv0_path);
+    return true;
+  } else {
+    return false;
+  }
+}
+#else // Darwin
+bool sandbox_check_argv0() { return false; }
+#endif
+
+// Some paths are derived from allowed basenames.
+
+// Define the maximum number of directories that can be specified in
+// the FLOX_SANDBOX_ALLOW_DIRS environment variable. This is a somewhat
+// arbitrary limit, but it should be more than enough for most cases.
+#define FLOX_SANDBOX_ALLOW_DIRS_MAXENTRIES 256
+
+// Define the maximum length of a directory path in the FLOX_SANDBOX_ALLOW_DIRS
+// environment variable. This is also somewhat arbitrary, but it should
+// be more than enough for most cases.
+#define FLOX_SANDBOX_ALLOW_DIRS_MAXLEN PATH_MAX
+
+static int allow_dirs_count = -1;
+static char allow_dirs_buf[FLOX_SANDBOX_ALLOW_DIRS_MAXLEN];
+static char *allow_dirs[FLOX_SANDBOX_ALLOW_DIRS_MAXENTRIES];
+bool check_allowed_basenames(const char *pathname) {
+  // Start by reading the contents of FLOX_ALLOW_SANDBOX_DIRS into array
+  pthread_mutex_lock(&lock);
+  if (allow_dirs_count == -1) {
+    // Copy the contents of the FLOX_SANDBOX_ALLOW_DIRS variable into
+    // allow_dirs_buf and tokenize the buffer by replacing
+    // colons with NULLs as we count the entries, saving pointers
+    // to each of the paths in the allow_dirs[] array.
+    allow_dirs_count = 0;
+    const char *allow_dirs_env = getenv("FLOX_SANDBOX_ALLOW_DIRS");
+    if (allow_dirs_env != NULL) {
+      if (sizeof(allow_dirs_env) >= FLOX_SANDBOX_ALLOW_DIRS_MAXLEN) {
+        _error("check_allowed_basenames() FLOX_SANDBOX_ALLOW_DIRS is too long, "
+               "truncating to %d characters\n",
+               FLOX_SANDBOX_ALLOW_DIRS_MAXLEN);
+        fflush(stderr);
+      }
+
+      strncpy(allow_dirs_buf, allow_dirs_env, sizeof(allow_dirs_buf));
+
+      // Iterate over the space-separated list of paths in the
+      // allow_dirs buffer, tokenizing as we go and
+      // maintaining a count of the number of entries found.
+      char *allow_dir = NULL;
+      char *saveptr = NULL; // For strtok_r() context
+
+      allow_dir = strtok_r(allow_dirs_buf, " ", &saveptr);
+      while (allow_dir != NULL) {
+        if (allow_dirs_count >= FLOX_SANDBOX_ALLOW_DIRS_MAXENTRIES) {
+          _error("check_allowed_basenames() "
+                 "FLOX_SANDBOX_ALLOW_DIRS has too many entries, "
+                 "truncating to the first %d",
+                 FLOX_SANDBOX_ALLOW_DIRS_MAXENTRIES);
+          fflush(stderr);
+          break;
+        }
+        debug("check_allowed_basenames() allow_dirs[%d] = %s", allow_dirs_count,
+              allow_dir);
+        allow_dirs[allow_dirs_count] = allow_dir;
+        allow_dir = strtok_r(NULL, " ", &saveptr);
+        allow_dirs_count++;
+      }
+    }
+
+    // Add a few static entries to the end of the list.
+    allow_dirs[allow_dirs_count++] = "/tmp";
+    allow_dirs[allow_dirs_count++] = "/dev";
+#ifdef linux
+    allow_dirs[allow_dirs_count++] = "/sys";
+    allow_dirs[allow_dirs_count++] = "/proc";
+#else // Darwin
+    allow_dirs[allow_dirs_count++] = "/System/Library";
+    allow_dirs[allow_dirs_count++] = "/usr/share";
+    allow_dirs[allow_dirs_count++] = "/var/db/timezone";
+#endif
+
+    // Infer a couple from the environment.
+    char *flox_src_dir = getenv("FLOX_SRC_DIR");
+    if (flox_src_dir)
+      allow_dirs[allow_dirs_count++] = flox_src_dir;
+    char *tmpdir = getenv("TMPDIR");
+    if (tmpdir)
+      allow_dirs[allow_dirs_count++] = tmpdir;
+  }
+
+  // Iterate over the allow_dirs list looking for pathname.
+  char allow_dir_real_path[PATH_MAX];
+  bool allowed = false;
+
+#ifdef linux
+  pid_t tid = gettid();
+#else // Darwin
+  uint64_t tid;
+  pthread_threadid_np(NULL, &tid);
+#endif
+
+  for (int i = 0; i < allow_dirs_count; i++) {
+    // Recall we've been passed a realpath, so we must in turn
+    // convert our allow dirs to realpaths as well. TODO: find
+    // a way to do this as we populate allow_dirs; we don't do
+    // this now because we're indexing the same memory returned
+    // by getenv().
+    if (realpath(allow_dirs[i], allow_dir_real_path) == NULL) {
+      debug("check_allowed_basenames(): skipping path '%s', does not exist",
+            allow_dir_real_path);
+    } else {
+      debug("check_allowed_basenames('%s'): tid=%d, i=%d, comparing to '%s'",
+            pathname, tid, i, allow_dir_real_path);
+      //            if ( strncmp(pathname, allow_dir_real_path,
+      //            strlen(allow_dir_real_path)) == 0 &&
+      //              ( pathname[strlen(allow_dir_real_path)] == '/' ||
+      //              pathname[strlen(allow_dir_real_path)] == '\0' )
+      if (strncmp(pathname, allow_dir_real_path, strlen(allow_dir_real_path)) ==
+          0) {
+        debug("%s is an allowed basename", pathname);
+        allowed = true;
+        break;
+      }
+    }
+  }
+  pthread_mutex_unlock(&lock);
+  return allowed;
+}
+
+// Check if path access represents something that may not be reproducible
+// on another machine. Any path within the environment's closure is fine,
+// but there are also other specific paths and basenames accessed during a
+// build that we can similarly rely to be present on any machine.
+//
+// The challenge here is that some path accesses are discrete while others
+// are modal, implying a different handling for subsequent path accesses.
+// One example of this is the use of `/usr/bin/env`, which is ubiquitous
+// and hardcoded to an extent that we cannot really expect users to replace
+// references to it in code, so when invoking this path we suspend all
+// further path checking until argv0 is updated to a new path.
+bool sandbox_check_path(const char *pathname) {
+  static char real_path[PATH_MAX];
+  if (sandbox_level < 0)
+    sandbox_init();
+  if (sandbox_level == 0)
+    return true;
+  debug("sandbox_check_path('%s'), sandbox_level=%d", pathname, sandbox_level);
+  if (sandbox_check_argv0())
+    return true;
+
+  // From here on out, operate on realpath. If a file doesn't exist
+  // then return true and let ENOENT be the eventual result.
+  if (realpath(pathname, real_path) == NULL)
+    return true;
+  if (check_allowed_basenames(real_path))
+    return true;
+  if (in_closure(real_path)) {
+    debug("%s is in the closure", pathname);
+    return true;
+  }
+  if (sandbox_level == 1) {
+    warn("%s is not in the sandbox", pathname);
+    return true;
+  } else {
+    _error("%s is not in the sandbox", pathname);
+    fflush(stderr);
+    // XXX Do we exit hard or rely on EACCESS?
+    exit(1);
+    // return false;
+  }
+}
+
+#ifdef linux
+
+// Interceptor for open
+int open(const char *pathname, int flags, ...) {
+  if (!orig_open)
+    sandbox_init();
+  mode_t mode = 0;
+  if (flags & O_CREAT) {
+    va_list args;
+    va_start(args, flags);
+    mode = va_arg(args, mode_t);
+    va_end(args);
+  }
+  if (sandbox_check_path(pathname)) {
+    return orig_open(pathname, flags, mode);
+  } else {
+    errno = EACCES;
+    return -1;
+  }
+}
+
+// Interceptor for openat
+int openat(int dirfd, const char *pathname, int flags, ...) {
+  if (!orig_openat)
+    sandbox_init();
+  mode_t mode = 0;
+  if (flags & O_CREAT) {
+    va_list args;
+    va_start(args, flags);
+    mode = va_arg(args, mode_t);
+    va_end(args);
+  }
+  if (sandbox_check_path(pathname)) {
+    return orig_openat(dirfd, pathname, flags, mode);
+  } else {
+    errno = EACCES;
+    return -1;
+  }
+}
+
+#else
+
+// Interceptor for open
+int my_open(const char *pathname, int flags, ...) {
+  if (sandbox_level < 0)
+    sandbox_init();
+  debug("my_open('%s'), sandbox_level=%d", pathname, sandbox_level);
+  mode_t mode = 0;
+  if (flags & O_CREAT) {
+    va_list args;
+    va_start(args, flags);
+    mode = va_arg(args, int);
+    va_end(args);
+  }
+  if (sandbox_check_path(pathname)) {
+    return open(pathname, flags, mode);
+  } else {
+    errno = EACCES;
+    return -1;
+  }
+}
+
+// Interceptor for openat
+int my_openat(int dirfd, const char *pathname, int flags, ...) {
+  if (sandbox_level < 0)
+    sandbox_init();
+  debug("my_openat('%s'), sandbox_level=%d", pathname, sandbox_level);
+  mode_t mode = 0;
+  if (flags & O_CREAT) {
+    va_list args;
+    va_start(args, flags);
+    mode = va_arg(args, int);
+    va_end(args);
+  }
+  if (sandbox_check_path(pathname)) {
+    return openat(dirfd, pathname, flags, mode);
+  } else {
+    errno = EACCES;
+    return -1;
+  }
+}
+
+// Thank you https://www.emergetools.com/blog/posts/DyldInterposing
+#define DYLD_INTERPOSE(_replacement, _replacee)                                \
+  __attribute__((used)) static struct {                                        \
+    const void *replacement;                                                   \
+    const void *replacee;                                                      \
+  } _interpose_##_replacee __attribute__((section("__DATA,__interpose"))) = {  \
+      (const void *)(unsigned long)&_replacement,                              \
+      (const void *)(unsigned long)&_replacee};
+DYLD_INTERPOSE(my_open, open)
+DYLD_INTERPOSE(my_openat, openat)
+
+#endif

--- a/package-builder/sandbox.h
+++ b/package-builder/sandbox.h
@@ -1,0 +1,10 @@
+#ifndef SANDBOX_H
+#define SANDBOX_H
+
+#include <stdbool.h>
+
+bool sandbox_check_argv0();
+bool sandbox_check_path(const char *path);
+int get_sandbox_level();
+
+#endif // SANDBOX_H

--- a/pkgs/flox-package-builder/default.nix
+++ b/pkgs/flox-package-builder/default.nix
@@ -1,5 +1,4 @@
 {
-  runCommandNoCC,
   bashInteractive,
   coreutils,
   gitMinimal,
@@ -7,20 +6,26 @@
   gnused,
   gnutar,
   jq,
-  ld-floxlib,
   nix,
+  stdenv,
   substituteAll,
 }: let
   flox-build-mk = substituteAll {
     name = "flox-build.mk";
     src = ../../package-builder/flox-build.mk;
-    ld_floxlib = ld-floxlib; # Cannot inherit attributes containing "-".
     inherit bashInteractive coreutils gitMinimal gnugrep gnused gnutar jq nix;
   };
 in
-  runCommandNoCC "flox-package-builder" {} ''
-    # include builder makefile and utility nix script
-    mkdir -p $out/libexec
-    cp ${flox-build-mk} $out/libexec/flox-build.mk
-    cp ${../../package-builder/build-manifest.nix} $out/libexec/build-manifest.nix
-  ''
+  stdenv.mkDerivation {
+    pname = "package-builder";
+    version = "1.0.0";
+    src = builtins.path {
+      name = "package-builder-src";
+      path = "${./../../package-builder}";
+    };
+    postPatch = ''
+      cp ${flox-build-mk} flox-build.mk
+    '';
+    makeFlags = ["PREFIX=$(out)"];
+    doCheck = true;
+  }

--- a/pkgs/flox-package-builder/default.nix
+++ b/pkgs/flox-package-builder/default.nix
@@ -1,18 +1,26 @@
-{runCommandNoCC}:
-runCommandNoCC "flox-package-builder" {} ''
-
-  # include builder makefile and unitility nix script
-  mkdir -p $out/libexec
-
-  # todo: substitute external executables and remove __FLOX_CLI_OUTPATH__
-  cp ${../../package-builder/flox-build.mk} $out/libexec/flox-build.mk
-  substituteInPlace $out/libexec/flox-build.mk \
-    --replace "__FLOX_CLI_OUTPATH__" "$out"
-
-  # todo: substitute external executables and remove __FLOX_CLI_OUTPATH__
-  cp ${../../package-builder/build-manifest.nix} $out/libexec/build-manifest.nix
-  substituteInPlace $out/libexec/build-manifest.nix \
-    --replace "__FLOX_CLI_OUTPATH__" "$out"
-
-  # todo: add links for sandbox
-''
+{
+  runCommandNoCC,
+  bashInteractive,
+  coreutils,
+  gitMinimal,
+  gnugrep,
+  gnused,
+  gnutar,
+  jq,
+  ld-floxlib,
+  nix,
+  substituteAll,
+}: let
+  flox-build-mk = substituteAll {
+    name = "flox-build.mk";
+    src = ../../package-builder/flox-build.mk;
+    ld_floxlib = ld-floxlib; # Cannot inherit attributes containing "-".
+    inherit bashInteractive coreutils gitMinimal gnugrep gnused gnutar jq nix;
+  };
+in
+  runCommandNoCC "flox-package-builder" {} ''
+    # include builder makefile and utility nix script
+    mkdir -p $out/libexec
+    cp ${flox-build-mk} $out/libexec/flox-build.mk
+    cp ${../../package-builder/build-manifest.nix} $out/libexec/build-manifest.nix
+  ''

--- a/pkgs/flox-package-builder/default.nix
+++ b/pkgs/flox-package-builder/default.nix
@@ -1,0 +1,18 @@
+{runCommandNoCC}:
+runCommandNoCC "flox-package-builder" {} ''
+
+  # include builder makefile and unitility nix script
+  mkdir -p $out/libexec
+
+  # todo: substitute external executables and remove __FLOX_CLI_OUTPATH__
+  cp ${../../package-builder/flox-build.mk} $out/libexec/flox-build.mk
+  substituteInPlace $out/libexec/flox-build.mk \
+    --replace "__FLOX_CLI_OUTPATH__" "$out"
+
+  # todo: substitute external executables and remove __FLOX_CLI_OUTPATH__
+  cp ${../../package-builder/build-manifest.nix} $out/libexec/build-manifest.nix
+  substituteInPlace $out/libexec/build-manifest.nix \
+    --replace "__FLOX_CLI_OUTPATH__" "$out"
+
+  # todo: add links for sandbox
+''

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -1,6 +1,7 @@
 {
   flox-pkgdb,
   gitMinimal,
+  gnumake,
   inputs,
   coreutils,
   lib,
@@ -10,6 +11,7 @@
   targetPlatform,
   rust-external-deps,
   flox-src,
+  flox-package-builder,
 }: let
   FLOX_VERSION = lib.fileContents ./../../VERSION;
 
@@ -26,6 +28,11 @@
       if flox-pkgdb == null
       then "pkgdb"
       else "${flox-pkgdb}/bin/pkgdb";
+
+    # todo: provide this in devshells via an updatable path
+    FLOX_BUILD_MK = "${flox-package-builder}/libexec/flox-build.mk";
+
+    GNUMAKE_BIN = "${gnumake}/bin/make";
 
     SLEEP_BIN = "${coreutils}/bin/sleep";
 


### PR DESCRIPTION
## [build: add package-builder package](https://github.com/flox/flox/pull/2019/commits/499519b73cc6792b6959c3f1a9aa69970ebefe54) 

Create a package for the (manifest build) package builder,
and provide its path to the build of flok-rust-sdk,
which will implement bindings to the script in the following commit.

The source for the builder is derived from the Manifest build PoC
<https://github.com/flox/flox/pull/1809>.

Notable changes from that PR:
* build pacakges using nixpkgs fetched with `getFlake` rather than using the `<nixpkgs>` channel.
* disable sandboxing for the lack of macOS support in ld-floxlib (at this point)

## [feat: builder implementation](https://github.com/flox/flox/pull/2019/commits/e16f635ce8c1175b460cd215d5b3bf22d9c478c7) 

Define a `ManifestBuilder` trait that provides an interface to building packages.
The signature of this trait is inspired by the requirements
of calling the `flox-build.mk` subsystem, outlined in
<https://github.com/flox/flox/issues/1998>.
Namely, builds require
* a `basedir`: the directory containing the .flox of the package for reference
* a rendered `flox_env`: a symlink or realpath to the built environment
  which contains build instructions and build metadata.
* the names of packages to build

The build will run in the background but can be observed using the returned `BuildOutput`.
`BuildOutput` implements an iterator over events from the build,
currently lines of `std{out,err}` and an `Exit` event to wait for termination or the build.

## [feat: implement build command](https://github.com/flox/flox/pull/2019/commits/46bc791a4053cedccf359fc4c9f3d3e29f975e89) 

Implements the `build` command by creating a `FloxBuildMk` builder
and listening to its output, thereby forwarding `std{out,err}`.
On `Exit` events the either a success or error message is printed.

Attempting to build without the `build` feature flag
or using packages from remote environments
will result in an error.

chore: remove empty legacy `build` module

## [fix: quoting of buildDependencies array](https://github.com/flox/flox/pull/2019/commits/83efd24214d8be374ea47a0960aa6c75b3619d90) 

Previous version was replacing spaces in the array with only a single
`"` character while they should have been replaced with `" "`.

For example, `FOO BAR` was converted to `"FOO"BAR"`, and with this update
it would instead be correctly converted to `"FOO" "BAR"`.

## [feat: add libsandbox.{so,dylib} to package-builder](https://github.com/flox/flox/pull/2019/commits/21df999159a6e02b527962601497d44c5532adfd) 

The sandbox library will required by the manifest builder in the second
phase of the manifest build project, and while it's not required in the
first phase it's less work to simply import the PoC unchanged and then
we can elect to use it (or not) from within the manifest build makefile.

Note that the sandbox library may be of use for ld-floxlib.so as well
in future, but for now it's only required from the package builder so
we instead maintain it in the package-builder directory.
