### PR TITLE
fix(activate): Prevent stray TRACE log

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -176,11 +176,10 @@ impl Activate {
         };
 
         // Must come after getting an activation path to prevent premature
-        // locking or migration.
-        subcommand_metric!(
-            "activate#version",
-            lockfile_version = environment.lockfile(&flox)?.version()
-        );
+        // locking or migration. It must also not be evaluated inline with the
+        // macro or we'll leak TRACE logs for reasons unknown.
+        let lockfile_version = environment.lockfile(&flox)?.version();
+        subcommand_metric!("activate#version", lockfile_version = lockfile_version);
 
         // read the currently active environments from the environment
         let mut flox_active_environments = activated_environments();

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -34,6 +34,9 @@ pub const METRICS_EVENTS_API_KEY: &str = env!("METRICS_EVENTS_API_KEY");
 
 /// Creates a trace event for the given subcommand.
 ///
+/// Do NOT inline functions as fields values because any child tracing events
+/// will cause this event to be logged at TRACE level for reasons unknown.
+///
 /// We set the target to `flox_command` so that we can filter for these exact events.
 #[macro_export]
 macro_rules! subcommand_metric {


### PR DESCRIPTION
## Proposed Changes

Fixes the following since e7b0e893:

    (2) ~/projects/flox/flox on HEAD (eabea829) [$]
    % flox activate -r dcarley/tailscale
    2024-08-30T13:45:57.839901Z TRACE flox_command: subcommand="activate#version" lockfile_version=1
    ✅ You are now using the environment 'dcarley/tailscale (remote)'.
    To stop using this environment, type 'exit'

This would happen for any environment that requires building at the same time as activation, such as a remote environment, where the calls within or below `environment.lockfile()` generate their own tracing events.

It can also be reproduced with a much simpler:

    fn test() -> &'static str {
        tracing::debug!("test");
        "test"
    }
    subcommand_metric!("activate#version", lockfile_version = test());

Moving the function outside of the macro fixes this:

    (2) ~/projects/flox/flox on dcarley/2017-fix-activate-stray-log [$>]
    % flox activate -r dcarley/tailscale
    ✅ You are now using the environment 'dcarley/tailscale (remote)'.
    To stop using this environment, type 'exit'

## Release Notes

N/A because the original bug hasn't made it to a release yet.