### PR TITLE
feat(watchdog): GC watchdog and services logs

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1030,6 +1030,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,13 +1162,16 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_derive",
+ "filetime",
  "flox-rust-sdk",
+ "glob",
  "kqueue",
  "nix",
  "once_cell",
  "sentry",
  "serde",
  "signal-hook",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1361,6 +1376,12 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -1908,6 +1929,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -174,6 +174,8 @@ pub trait Environment: Send {
 
     /// Return a path that environment should use to store logs.
     ///
+    /// New log file patterns need to be added to `flox-watchdog` for garbage collection.
+    ///
     /// The returned path will exist.
     fn log_path(&self) -> Result<CanonicalPath, EnvironmentError>;
 

--- a/cli/flox-watchdog/Cargo.toml
+++ b/cli/flox-watchdog/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 clap.workspace = true
 clap_derive.workspace = true
 flox-rust-sdk.workspace = true
+glob = "0.3.1"
 nix.workspace = true
 once_cell.workspace = true
 sentry.workspace = true
@@ -20,3 +21,7 @@ tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 kqueue.workspace = true
+
+[dev-dependencies]
+filetime = "0.2.25"
+tempfile.workspace = true

--- a/cli/flox-watchdog/src/logger.rs
+++ b/cli/flox-watchdog/src/logger.rs
@@ -1,15 +1,18 @@
-use std::fs::OpenOptions;
-use std::path::PathBuf;
+use std::fs::{remove_file, OpenOptions};
+use std::path::{Path, PathBuf};
 use std::thread::{sleep, spawn};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
-use anyhow::Context;
-use tracing::debug;
+use anyhow::{Context, Result};
+use glob::glob;
+use tracing::{debug, error};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3600);
+const KEEP_WATCHDOG_DAYS: u64 = 3;
+const KEEP_SERVICES_LAST: usize = 5;
 
 /// Initializes a logger that persists logs to an optional file in addition to `stderr`
 pub(crate) fn init_logger(file_path: &Option<PathBuf>) -> Result<(), anyhow::Error> {
@@ -60,4 +63,230 @@ pub(crate) fn spawn_heartbeat_log() {
         debug!("still watching, woof woof");
         sleep(HEARTBEAT_INTERVAL);
     });
+}
+
+/// Starts a background thread which garbage collects known log files. This is
+/// done on a best effort basis; errors are traced rather than being bubbled up
+/// and the thread will run until the watchdog exits.
+pub(crate) fn spawn_gc_logs(dir: impl AsRef<Path>) {
+    let dir = dir.as_ref().to_path_buf();
+    std::thread::spawn(move || {
+        gc_logs_watchdog(&dir, KEEP_WATCHDOG_DAYS)
+            .unwrap_or_else(|err| error!(%err, "failed to delete watchdog logs"));
+        gc_logs_services(&dir, KEEP_SERVICES_LAST)
+            .unwrap_or_else(|err| error!(%err, "failed to delete services logs"));
+    });
+}
+
+/// Garbage collects watchdog log files, keeping the last N days by modified
+/// time. This relies on the watchdog emitting a heartbeat log file from
+/// `log_heartbeat`.
+fn gc_logs_watchdog(dir: impl AsRef<Path>, keep_days: u64) -> Result<()> {
+    let mut files = glob_log_files(dir, "watchdog.*.log")?;
+    let threshold = duration_from_days(keep_days);
+    let now = SystemTime::now();
+
+    // Defaults to keeping if mtime is not supported by platform or filesystem.
+    files.retain(|file| file_older_than(file, now, threshold).unwrap_or(false));
+
+    for file in files {
+        try_delete_log(file);
+    }
+
+    Ok(())
+}
+
+/// Garbage collects services log files, keeping the last N files by filename.
+/// This relies on the log files having a timestamp in their filename.
+fn gc_logs_services(dir: impl AsRef<Path>, keep_last: usize) -> Result<()> {
+    let mut files = glob_log_files(dir, "services.*.log")?;
+    if files.len() <= keep_last {
+        return Ok(());
+    }
+
+    files.sort_unstable();
+    files.truncate(files.len() - keep_last);
+
+    for file in files {
+        try_delete_log(file);
+    }
+
+    Ok(())
+}
+
+/// Construct a Duration from `days`.
+const fn duration_from_days(days: u64) -> Duration {
+    let seconds_in_day = 24 * 60 * 60;
+    Duration::from_secs(days * seconds_in_day)
+}
+
+/// Returns whether a file is older than `threshold`.
+fn file_older_than(file: impl AsRef<Path>, now: SystemTime, threshold: Duration) -> Result<bool> {
+    let metadata = file
+        .as_ref()
+        .metadata()
+        .context("failed to get file metadata")?;
+    let modified = metadata.modified()?;
+    let elapsed = now.duration_since(modified)?;
+    let older = elapsed > threshold;
+
+    Ok(older)
+}
+
+/// Glob files matching a pattern, ignoring any unreadable paths.
+fn glob_log_files(dir: impl AsRef<Path>, name: &str) -> Result<Vec<PathBuf>> {
+    let pattern = format!("{}/{name}", dir.as_ref().to_string_lossy());
+    let paths = glob(&pattern).context("failed to glob logs")?;
+    let files = paths
+        .filter_map(Result::ok)
+        .filter(|path| Path::is_file(path))
+        .collect();
+    Ok(files)
+}
+
+/// Delete a log file. Errors are traced and not bubbled up, so that we don't
+/// get stuck on individual files.
+fn try_delete_log(file: impl AsRef<Path>) {
+    remove_file(file.as_ref()).unwrap_or_else(|err| error!(%err, "failed to delete log"));
+    debug!(path = %file.as_ref().display(), "deleted log");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{create_dir, File};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// Create a test log file. Optionally set a modified time in days.
+    fn create_log_file(dir: &Path, name: &str, days: Option<u64>) -> PathBuf {
+        let path = dir.join(name);
+        File::create(&path).unwrap();
+
+        if let Some(days) = days {
+            let mtime = SystemTime::now() - duration_from_days(days);
+            File::open(&path).unwrap().set_modified(mtime).unwrap();
+        }
+
+        path
+    }
+
+    #[test]
+    fn test_gc_logs_watchdog_removes_old_files() {
+        let keep_last = 2;
+        let dir = tempdir().unwrap();
+        let file_now = create_log_file(&dir.path(), "watchdog.now.log", None);
+        let file_one = create_log_file(&dir.path(), "watchdog.one.log", Some(keep_last - 1));
+        let file_two = create_log_file(&dir.path(), "watchdog.two.log", Some(keep_last));
+        let file_three = create_log_file(&dir.path(), "watchdog.three.log", Some(keep_last + 1));
+
+        gc_logs_watchdog(dir.path(), keep_last).unwrap();
+        assert!(file_now.exists());
+        assert!(file_one.exists());
+        assert!(!file_two.exists());
+        assert!(!file_three.exists());
+
+        // Keeps the same files on second run.
+        gc_logs_watchdog(dir.path(), keep_last).unwrap();
+        assert!(file_now.exists());
+        assert!(file_one.exists());
+    }
+
+    #[test]
+    fn test_gc_logs_watchdog_ignores_other_files() {
+        let keep_last = 2;
+        let dir = tempdir().unwrap();
+        let filenames = vec![
+            "watchdog",
+            "watchdog.log",
+            "services.log",
+            "services.123.log",
+        ];
+        let files: Vec<PathBuf> = filenames
+            .clone()
+            .into_iter()
+            .map(|filename| create_log_file(&dir.path(), filename, Some(keep_last - 1)))
+            .collect();
+        assert_eq!(files.len(), filenames.len());
+
+        gc_logs_watchdog(dir.path(), keep_last).unwrap();
+        for file in files {
+            assert!(file.exists(), "file should exist: {}", file.display());
+        }
+    }
+
+    #[test]
+    fn test_gc_logs_services_removes_old_files() {
+        let keep_days = 2;
+        let dir = tempdir().unwrap();
+        let files: Vec<PathBuf> = (1..=keep_days * 2)
+            .map(|i| create_log_file(&dir.path(), &format!("services.{}.log", i), None))
+            .collect();
+
+        gc_logs_services(dir.path(), keep_days).unwrap();
+        assert!(!files[0].exists());
+        assert!(!files[1].exists());
+        assert!(files[2].exists());
+        assert!(files[3].exists());
+
+        // Keeps the same files on second run.
+        gc_logs_services(dir.path(), keep_days).unwrap();
+        assert!(files[2].exists());
+        assert!(files[3].exists());
+    }
+
+    #[test]
+    fn test_gc_logs_services_ignores_other_files() {
+        let keep_days: usize = 2;
+        let dir = tempdir().unwrap();
+        let filenames = vec![
+            "services",
+            "services.log",
+            "watchdog.log",
+            "watchdog.123.log",
+        ];
+        let files: Vec<PathBuf> = filenames
+            .clone()
+            .into_iter()
+            .map(|filename| create_log_file(&dir.path(), filename, None))
+            .collect();
+        assert_eq!(files.len(), filenames.len());
+
+        gc_logs_services(dir.path(), keep_days).unwrap();
+        for file in files {
+            assert!(file.exists(), "file should exist: {}", file.display());
+        }
+    }
+
+    #[test]
+    fn test_glob_files() {
+        let dir = tempdir().unwrap();
+        let expected = dir.path().join("file.log");
+        File::create(&expected).unwrap();
+
+        // The following are ignored.
+        File::create(dir.path().join("file.other")).unwrap();
+        let sub_dir = dir.path().join("sub");
+        create_dir(&sub_dir).unwrap();
+        File::create(sub_dir.join("sub.log")).unwrap();
+        File::create(sub_dir.join("sub.other")).unwrap();
+
+        let files = glob_log_files(dir.path(), "*.log").unwrap();
+        assert_eq!(files, vec![expected]);
+    }
+
+    #[test]
+    fn test_file_older_than() {
+        let threshold_days = 3;
+        let threshold_dur = duration_from_days(threshold_days);
+        let dir = tempdir().unwrap();
+        let now = SystemTime::now();
+
+        let old_file = create_log_file(&dir.path(), "old.log", Some(threshold_days + 1));
+        assert!(file_older_than(&old_file, now, threshold_dur).unwrap());
+
+        let new_file = create_log_file(&dir.path(), "new.log", Some(threshold_days - 1));
+        assert!(!file_older_than(&new_file, now, threshold_dur).unwrap());
+    }
 }

--- a/cli/flox-watchdog/src/main.rs
+++ b/cli/flox-watchdog/src/main.rs
@@ -15,7 +15,7 @@ use flox_rust_sdk::models::env_registry::{
 };
 use flox_rust_sdk::providers::services::process_compose_down;
 use flox_rust_sdk::utils::{maybe_traceable_path, traceable_path};
-use logger::{init_logger, spawn_heartbeat_log};
+use logger::{init_logger, spawn_gc_logs, spawn_heartbeat_log};
 use nix::libc::{SIGINT, SIGQUIT, SIGTERM, SIGUSR1};
 use nix::unistd::{getpgid, getpid, setsid};
 use once_cell::sync::Lazy;
@@ -55,7 +55,7 @@ pub struct Cli {
     #[arg(short, long = "socket", value_name = "PATH")]
     pub socket_path: PathBuf,
 
-    /// The directory to store logs
+    /// The directory to store and garbage collect logs
     #[arg(short, long = "log-dir", value_name = "PATH")]
     pub log_dir: Option<PathBuf>,
 
@@ -153,6 +153,9 @@ fn main() -> Result<(), Error> {
         "watchdog is on duty"
     );
     spawn_heartbeat_log();
+    if let Some(log_dir) = args.log_dir {
+        spawn_gc_logs(log_dir);
+    }
 
     // Listen for a notification, getting an error if we should terminate
     #[cfg(target_os = "macos")]

--- a/cli/flox-watchdog/src/main.rs
+++ b/cli/flox-watchdog/src/main.rs
@@ -15,7 +15,7 @@ use flox_rust_sdk::models::env_registry::{
 };
 use flox_rust_sdk::providers::services::process_compose_down;
 use flox_rust_sdk::utils::{maybe_traceable_path, traceable_path};
-use logger::init_logger;
+use logger::{init_logger, spawn_heartbeat_log};
 use nix::libc::{SIGINT, SIGQUIT, SIGTERM, SIGUSR1};
 use nix::unistd::{getpgid, getpid, setsid};
 use once_cell::sync::Lazy;
@@ -152,6 +152,7 @@ fn main() -> Result<(), Error> {
         target_pid = args.pid,
         "watchdog is on duty"
     );
+    spawn_heartbeat_log();
 
     // Listen for a notification, getting an error if we should terminate
     #[cfg(target_os = "macos")]

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -435,10 +435,8 @@ impl Activate {
         cmd.arg(getpid().as_raw().to_string());
 
         // Set the log path
-        let pid = getpid();
-        let log_path = log_dir.join(format!("watchdog.{}.log", pid.as_raw()));
-        cmd.arg("--logs");
-        cmd.arg(log_path);
+        cmd.arg("--log-dir");
+        cmd.arg(log_dir);
         cmd.env("_FLOX_WATCHDOG_LOG_LEVEL", "debug"); // always write to log file
 
         // Set the socket path

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1153,9 +1153,8 @@ EOF
     --hash abcde123 \
     --socket does_not_exist &
 
-  # Don't forget to export this so that it's set in the subshells
-  export watchdog_pid="$!"
-  export log_file="$PWD/watchdog.${target_pid}.log"
+  watchdog_pid="$!"
+  log_file="$PWD/watchdog.${target_pid}.log"
 
   # Wait for start.
   timeout 1s bash -c "
@@ -1199,9 +1198,8 @@ EOF
     --hash abcde123 \
     --socket does_not_exist &
 
-  # Don't forget to export this so that it's set in the subshells
-  export watchdog_pid="$!"
-  export log_file="$PWD/watchdog.${test_pid}.log"
+  watchdog_pid="$!"
+  log_file="$PWD/watchdog.${test_pid}.log"
 
   # Wait for start.
   timeout 1s bash -c "

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1095,10 +1095,9 @@ EOF
   # Don't forget to export this so that it's set in the subshells
   export registry_file="$PWD/registry.json"
 
-  log_file="$PWD/flox-watchdog.log"
   dummy_registry path/to/env abcde123 > "$registry_file"
   _FLOX_WATCHDOG_LOG_LEVEL=debug "$WATCHDOG_BIN" \
-    --logs "$log_file" \
+    --log-dir "$PWD" \
     --pid $$ \
     --registry "$registry_file" \
     --hash abcde123 \
@@ -1144,20 +1143,19 @@ EOF
 }
 
 @test "watchdog: exits on shutdown signal (SIGINT)" {
-  # Don't forget to export this so that it's set in the subshells
-  export log_file="$PWD/flox-watchdog.log"
-
+  target_pid="$$"
   registry_file="$PWD/registry.json"
   dummy_registry path/to/env abcde123 > "$registry_file"
   _FLOX_WATCHDOG_LOG_LEVEL=debug "$WATCHDOG_BIN" \
-    --logs "$log_file" \
-    --pid $$ \
+    --log-dir "$PWD" \
+    --pid "$target_pid" \
     --registry "$registry_file" \
     --hash abcde123 \
     --socket does_not_exist &
 
   # Don't forget to export this so that it's set in the subshells
   export watchdog_pid="$!"
+  export log_file="$PWD/watchdog.${target_pid}.log"
 
   # Wait for start.
   timeout 1s bash -c "
@@ -1183,9 +1181,6 @@ EOF
 }
 
 @test "watchdog: exits when provided PID isn't running" {
-  # Don't forget to export this so that it's set in the subshells
-  export log_file="$PWD/flox-watchdog.log"
-
   # We need a test PID, but PIDs can be reused. There's also no delay on reusing
   # PIDs, so you can't create and kill a process to use its PID during that
   # make-believe no-reuse window. At best we can choose a random PID and skip
@@ -1198,7 +1193,7 @@ EOF
   registry_file="$PWD/registry.json"
   dummy_registry path/to/env abcde123 > "$registry_file"
   _FLOX_WATCHDOG_LOG_LEVEL=debug "$WATCHDOG_BIN" \
-    --logs "$log_file" \
+    --log-dir "$PWD" \
     --pid "$test_pid" \
     --registry "$registry_file" \
     --hash abcde123 \
@@ -1206,6 +1201,7 @@ EOF
 
   # Don't forget to export this so that it's set in the subshells
   export watchdog_pid="$!"
+  export log_file="$PWD/watchdog.${test_pid}.log"
 
   # Wait for start.
   timeout 1s bash -c "


### PR DESCRIPTION
This is best reviewed commit-by-commit.

## Proposed Changes

To prevent the recently added `.flox/log` directory from growing too
large whilst still keeping enough logs that users can use to inspect and
report issues. We will now keep:

**- Watchdog logs that have been updated within the last 3 days.**

A new file is created every time a watchdog is started, which happens
with every non-ephemeral activation. The file haves a PID in their name
but we don't parse it.

This relies on the preceding commit that emits a heartbeat log entry
every hour so that we can determine whether a watchdog is still using
the file without needing to look it up or check open files.

A side-effect of this is that upgrading from 1.3.0 will blow away the
watchdog logs for any activations that were started more than 3 days ago
because they won't have the heartbeats. The watchdogs will still be able
to continue writing to the unlinked files and shutdown correctly though.

**- Services logs from the last 5 invocations.**

A new file is created every time `process-compose` is started with
`activate --start-services`, `flox services start`, or `flox services
restart`.
The files have a timestamp in their name so they can be sorted
by oldest to newest.

I briefly explored using `lsof` to exclude currently open files, so that
we wouldn't need to maintain separate heuristics for each type of log
file that we have now and in future, but the open-source binary was
dramatically slower on MacOS (~3s) and it felt cumbersome to integrate
with. So we'll have to add explicit support for other types of log files
that we introduce in the future.

All of the outer functions err on the side of reporting and continuing
on errors so that we don't get stuck on a "poison pill" file that
prevents the deletion of other files. This could happen for instance if
someone runs an activation and watchdog under a different user but it
would correct itself if there were subsequent runs under the same user.
I'm not able to simulate this in a unit test though.

The deletion is started in an async thread fairly early in the main
thread, once we've verified that we can run and before we block on the
signal watchers. It's my understanding that the async thread will
naturally exit, regardless of how far it got, when the main thread shuts
down.

Concurrent deletions from multiple watchdogs should also be fine whilst
they use the same criteria; we'll need to bear it in mind when changing
the criteria though.

## Release Notes

Garbage collect old logs from the `.flox/log` directory.
