### PR TITLE
fix: reduce dev closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
         os:
           - "ubuntu-22.04-8core"
           - "macos-14-xlarge"
+        test-tags:
+          - "activate"
+          - "containerize"
+          - "catalog"
+          - "!activate,!containerize,!catalog"
 
     steps:
       - name: "Checkout"
@@ -145,6 +150,8 @@ jobs:
         run: nix develop -L --no-update-lock-file --command just build-cli
 
       - name: "CLI Unit Tests"
+        # Only run unit tests if when not running specialized integration tests
+        if: ${{ matrix.test-tags == '!activate,!containerize,!catalog' }}
         env:
           RUST_BACKTRACE: 1
         run: nix develop -L --no-update-lock-file --command just impure-tests
@@ -157,7 +164,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           AUTH0_FLOX_DEV_CLIENT_SECRET: "${{ secrets.MANAGED_AUTH0_FLOX_DEV_CLIENT_SECRET }}"
-        run: nix develop -L --no-update-lock-file --command just integ-tests
+        run: nix develop -L --no-update-lock-file --command just integ-tests --  --filter-tags '"${{ matrix.test-tags }}"'
 
       - name: "Capture process tree for failing tests"
         if: ${{ failure() }}
@@ -333,6 +340,11 @@ jobs:
           - "x86_64-darwin"
           - "aarch64-linux"
           - "aarch64-darwin"
+        test-tags:
+          - "activate"
+          - "containerize"
+          - "catalog"
+          - "!activate,!containerize,!catalog"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -381,4 +393,4 @@ jobs:
             nix run \
                 --accept-flake-config \
                 --extra-experimental-features '"nix-command flakes"' \
-                'github:flox/flox/${{ github.sha }}#packages.${{ matrix.system }}.flox-cli-tests'
+                'github:flox/flox/${{ github.sha }}#packages.${{ matrix.system }}.flox-cli-tests' -- -- --filter-tags '"${{ matrix.test-tags }}"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         uses: "actions/deploy-pages@v4"
 
   cli-dev:
-    name: "Flox CLI Tests"
+    name: "dev"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
 
@@ -325,7 +325,7 @@ jobs:
           SLACK_LINK_NAMES: true
 
   nix-build-bats-tests:
-    name: "Flox Bats Tests"
+    name: "remote"
     runs-on: "ubuntu-latest"
     timeout-minutes: 90
 

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -439,7 +439,7 @@ EOF
 
 @test "flake: github ref added to manifest" {
   "$FLOX_BIN" init
-  input_flake="github:nixos/nixpkgs/$PKGDB_NIXPKGS_REV_OLD#hello"
+  input_flake="github:nixos/nixpkgs/$PKGDB_NIXPKGS_REV_NEW#hello"
   run "$FLOX_BIN" install "$input_flake"
   assert_success
   installed_flake=$(tomlq -r -c -t ".install.hello" "$MANIFEST_PATH")
@@ -448,7 +448,7 @@ EOF
 
 @test "flake: https ref added to manifest" {
   "$FLOX_BIN" init
-  input_flake="https://github.com/nixos/nixpkgs/archive/master.tar.gz#hello"
+  input_flake="https://github.com/nixos/nixpkgs/archive/$PKGDB_NIXPKGS_REV_NEW.tar.gz#hello"
   run "$FLOX_BIN" install "$input_flake"
   assert_success
   installed_flake=$(tomlq -r -c -t ".install.hello" "$MANIFEST_PATH")

--- a/flake.lock
+++ b/flake.lock
@@ -112,22 +112,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-bear": {
-      "locked": {
-        "lastModified": 1705957679,
-        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-process-compose": {
       "locked": {
         "lastModified": 1722415718,
@@ -189,7 +173,6 @@
         "crane": "crane",
         "fenix": "fenix",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-bear": "nixpkgs-bear",
         "nixpkgs-process-compose": "nixpkgs-process-compose",
         "pre-commit-hooks": "pre-commit-hooks",
         "sqlite3pp": "sqlite3pp"

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,6 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
 
-  # drop once bear is no longer broken in a newer release
-  inputs.nixpkgs-bear.url = "github:NixOS/nixpkgs/release-23.05";
-
   inputs.nixpkgs-process-compose.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
   inputs.sqlite3pp.url = "github:aakropotkin/sqlite3pp";
@@ -87,11 +84,6 @@
       cpp-semver = final.callPackage ./pkgs/cpp-semver {};
     };
 
-    # bear is broken in release 23.11 on darwin
-    overlays.bear = final: prev: {
-      inherit (inputs.nixpkgs-bear.legacyPackages.${prev.system}) bear;
-    };
-
     # Use a more recent version of process-compose
     overlays.process-compose = final: prev: {
       inherit (inputs.nixpkgs-process-compose.legacyPackages.${prev.system}) process-compose;
@@ -103,7 +95,6 @@
       overlays.nlohmann
       overlays.semver
       overlays.nix
-      overlays.bear
       overlays.process-compose
       sqlite3pp.overlays.default
       fenix.overlays.default
@@ -169,6 +160,7 @@
         tools = {
           # use fenix provided clippy
           clippy = rust-toolchain.clippy;
+          cargo = rust-toolchain.cargo;
           clang-tools = final.clang-tools_16;
         };
       };

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -42,7 +42,7 @@
         then "flox-watchdog"
         else "${flox-watchdog}/bin/flox-watchdog";
 
-      FLOX_ZDOTDIR = flox-activation-scripts + activate.d/zdotdir;
+      FLOX_ZDOTDIR = flox-activation-scripts + "/activate.d/zdotdir";
 
       # [sic] nix handles `BASH_` variables specially,
       # so we need to use a different name.

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -183,12 +183,12 @@ in
           lcov
           remake
           # For IDEs
-          ccls
-          bear
+          # ccls
+          # bear
           # For lints/fmt
           clang-tools_16
-          include-what-you-use
-          llvm # for `llvm-symbolizer'
+          # include-what-you-use
+          # llvm # for `llvm-symbolizer'
           # For debugging
           (
             if stdenv.cc.isGNU or false


### PR DESCRIPTION
## [fix: reduce dev closure](https://github.com/flox/flox/pull/2023/commits/0d0fcf4e29e2fb05ca0b0374917395ed3d5a8e36) 

* Remove less frequently used dev tools for the C++ part of the codebase.
In the past we maintained a separate CI devshell which excluded all dev tooling.
* Reuse the single fenix provided toolchain for git hooks
Before we were missing the dependency on `tools.cargo` which pulled in nixpkgs' rust toolchain
in addition to the fenix tracked toolchain providing clippy.

Before the single devshell we use weighs >7G,
removing some tools and unifying the rust toolchains used reduced the closure size to ~5.6G

## [build: use consistent pinned nixpkgs](https://github.com/flox/flox/pull/2023/commits/e70f5e89b06584924b758ebcb19515981dfd3331) 

Avoid pulling more revisions of nixpkgs than necessary.
The revision corresponding to `PKGDB_NIXPKGS_REV_OLD` is entirely unused
besides this after the removal of pkgdb scraping.
While `PKGDB_NIXPKGS_REV_NEW` is still a misnomer,
the corresponding revision is pinned in additional tests
thus avoiding pulling a _new_ copy of nixpkgs.

## [ci: split dev tests into batches](https://github.com/flox/flox/pull/2023/commits/56443c93ff474e58fec5faac640bba42ab9823d2) 

Run dev tests in multiple parallel batches to avoid environment builds outgrow
the CI runners disk size.

In the past we've seen that several tests incur a sizeable storage load.
Examples are
- krb5 tests for node which consumes ~1.2G
- containerize tests which pack an entire environment closure into a tarball

## [ci: shorter more descriptive workflow name](https://github.com/flox/flox/pull/2023/commits/e47c9058236f17f9f72ef64dbadb8d10b6ef7d01)