### PR TITLE
fix(activate): Warn for -s if there are none

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -44,6 +44,7 @@ use super::{
     EnvironmentSelect,
     UninitializedEnvironment,
 };
+use crate::commands::services::ServicesCommandsError;
 use crate::commands::{ensure_environment_trust, ConcreteEnvironment, EnvironmentSelectError};
 use crate::config::{Config, EnvironmentPromptConfig};
 use crate::utils::dialog::{Dialog, Spinner};
@@ -342,6 +343,10 @@ impl Activate {
             if self.start_services {
                 // Error for remote envs and envs with v0 manifests, since they don't support services
                 ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+
+                if manifest.services.is_empty() {
+                    message::warning(ServicesCommandsError::NoDefinedServices);
+                }
             }
 
             let should_have_services =

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -932,6 +932,15 @@ EOF
   assert_success
 }
 
+@test "activate: --start-services warns if environment doesn't have services" {
+  run "$FLOX_BIN" init
+  assert_success
+
+  run "$FLOX_BIN" activate --start-services -- true
+  assert_success
+  assert_output "⚠️  Environment doesn't have any services defined."
+}
+
 @test "activate: outer activation starts services and inner activation doesn't" {
   setup_sleeping_services
 


### PR DESCRIPTION
## Proposed Changes

Print a warning if you `flox activate --start-services` on an
environment that doesn't have any defined.

Previously we would continue and silently not start services, which
caught me out when manually testing something on an environment that I
thought would start services but didn't because I used the wrong
manifest.

Currently opting for warning and continuing instead of an error and
exiting because you might be iterating manifest changes and re-running
the same command knowing that it won't fully work.

## Release Notes

Print an warning if you `flox activate --start-services` on an environment that doesn't have any defined.