### PR TITLE
docs: Add man manifest.toml to man flox SEE MORE and modify manifest template to explain version parameter

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -259,7 +259,8 @@ impl RawManifest {
                   # This is a Flox environment manifest.
                   # Visit flox.dev/docs/concepts/manifest/
                   # or see flox-edit(1), manifest.toml(5) for more information.
-                  #
+                  # 
+                  # Flox manifest version managed by Flox CLI
                   {}"#,
                 decor.prefix().and_then(|raw_str| raw_str.as_str()).unwrap_or("")})
             }
@@ -1502,7 +1503,8 @@ pub(super) mod test {
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
             # or see flox-edit(1), manifest.toml(5) for more information.
-            #
+            # 
+            # Flox manifest version managed by Flox CLI
             version = 1
 
             # List packages you wish to install in your environment inside
@@ -1583,7 +1585,8 @@ pub(super) mod test {
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
             # or see flox-edit(1), manifest.toml(5) for more information.
-            #
+            # 
+            # Flox manifest version managed by Flox CLI
             version = 1
 
             # List packages you wish to install in your environment inside
@@ -1668,7 +1671,8 @@ pub(super) mod test {
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
             # or see flox-edit(1), manifest.toml(5) for more information.
-            #
+            # 
+            # Flox manifest version managed by Flox CLI
             version = 1
 
             # List packages you wish to install in your environment inside
@@ -1749,7 +1753,8 @@ pub(super) mod test {
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
             # or see flox-edit(1), manifest.toml(5) for more information.
-            #
+            # 
+            # Flox manifest version managed by Flox CLI
             version = 1
 
             # List packages you wish to install in your environment inside

--- a/cli/flox/doc/flox.md
+++ b/cli/flox/doc/flox.md
@@ -123,6 +123,7 @@ sharing environments, and administration.
 [`flox-search`(1)](./flox-search.md),
 [`flox-show(1)`](./flox-show.md),
 [`flox-edit`(1)](./flox-edit.md),
+[`manifest-toml`(5)](./manifest.toml.md)
 [`flox-list`(1)](./flox-list.md),
 [`flox-auth(1)`](./flox-auth.md),
 [`flox-push`(1)](./flox-push.md),

--- a/test_data/generated/envs/hello/manifest.toml
+++ b/test_data/generated/envs/hello/manifest.toml
@@ -2,7 +2,8 @@
 # This is a Flox environment manifest.
 # Visit flox.dev/docs/concepts/manifest/
 # or see flox-edit(1), manifest.toml(5) for more information.
-#
+# 
+# Flox manifest version managed by Flox CLI
 version = 1
 
 # List packages you wish to install in your environment inside


### PR DESCRIPTION
## Proposed Changes

* adds a missing SEE MORE link to manifest.toml man page to `man flox`
* adds a sentence to the default manifest template to explain the `version = 1` parameter


## Release Notes

n/a


<!-- Many thanks! -->
