### PR TITLE
chore: build flox using only one nixpkgs revision

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,12 @@
 {
   "nodes": {
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1717383740,
-        "narHash": "sha256-559HbY4uhNeoYvK3H6AMZAtVfmR3y8plXZ1x6ON/cWU=",
+        "lastModified": 1725125250,
+        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b65673fce97d277934488a451724be94cc62499a",
+        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
         "type": "github"
       },
       "original": {
@@ -28,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1723616992,
-        "narHash": "sha256-jDHYfEECzFwZm4huz7AbPjlH3jJ4/2ns9PddtFA5XMY=",
+        "lastModified": 1725258763,
+        "narHash": "sha256-7s5RfYlTljWnKGkK4hOMJCJ0sNQoLYjMxezX3Vijy/0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "7bad6c7ff73b784a9c7de9147626c8d5d5072809",
+        "rev": "0774f58cf1025bbb713971deecc7f07c856be6ed",
         "type": "github"
       },
       "original": {
@@ -44,34 +39,16 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -83,11 +60,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -98,48 +75,49 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704300003,
-        "narHash": "sha256-FRC/OlLVvKkrdm+RtrODQPufD0vVZYA0hpH9RPaHmp4=",
-        "owner": "NixOS",
+        "lastModified": 1721743106,
+        "narHash": "sha256-adRZhFpBTnHiK3XIELA3IBaApz70HwCYfv7xNrHjebA=",
+        "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "ab5fd150146dcfe41fda501134e6503932cc8dfd",
+        "rev": "dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "release-23.11",
+        "owner": "flox",
+        "ref": "stable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-process-compose": {
+      "flake": false,
       "locked": {
-        "lastModified": 1722415718,
-        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
-        "owner": "NixOS",
+        "lastModified": 1722813957,
+        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
+        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "owner": "flox",
+        "ref": "staging.20240817",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1685801374,
-        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -147,7 +125,6 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -155,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703939133,
-        "narHash": "sha256-Gxe+mfOT6bL7wLC/tuT2F+V+Sb44jNr8YsJ3cyIl4Mo=",
+        "lastModified": 1724857454,
+        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "9d3d7e18c6bc4473d7520200d4ddab12f8402d38",
+        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
         "type": "github"
       },
       "original": {
@@ -181,11 +158,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723561310,
-        "narHash": "sha256-a3KMMsIDvdo+ClLabh5wfJoa17YTSvy2wDLb8yZCXvc=",
+        "lastModified": 1725191098,
+        "narHash": "sha256-YH0kH5CSOnAuPUB1BUzUqvnKiv5SgDhfMNjrkki9Ahk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "78c2bdce860dbd996a8083224d01a96660dd6a15",
+        "rev": "779d9eee2ea403da447278a7007c9627c8878856",
         "type": "github"
       },
       "original": {
@@ -212,21 +189,6 @@
       "original": {
         "owner": "aakropotkin",
         "repo": "sqlite3pp",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/pkgdb/include/flox/fetchers/wrapped-nixpkgs-input.hh
+++ b/pkgdb/include/flox/fetchers/wrapped-nixpkgs-input.hh
@@ -40,7 +40,7 @@ struct WrappedNixpkgsInputScheme : nix::fetchers::InputScheme
 
   /** @brief Convert a URL string into an input. */
   [[nodiscard]] std::optional<nix::fetchers::Input>
-  inputFromURL( const nix::ParsedURL & url ) const override;
+  inputFromURL( const nix::ParsedURL & url, bool requireTree ) const override;
 
   /** @brief Convert input to a URL representation. */
   [[nodiscard]] nix::ParsedURL

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -15,6 +15,7 @@
 #include <nix/derived-path.hh>
 #include <nix/eval-cache.hh>
 #include <nix/eval-inline.hh>
+#include <nix/eval-settings.hh>
 #include <nix/eval.hh>
 #include <nix/flake/flake.hh>
 #include <nix/get-drvs.hh>
@@ -975,7 +976,7 @@ createContainerBuilder( nix::EvalState &       state,
   state.allowPath( environmentStorePath );
 
   // the derivation uses `builtins.storePath`
-  // to ensure that all store references of the enfironment
+  // to ensure that all store references of the environment
   // are included in the derivation/container.
   //
   // `builtins.storePath` however requires impure evaluation

--- a/pkgdb/src/eval.cc
+++ b/pkgdb/src/eval.cc
@@ -9,6 +9,7 @@
 
 #include <fstream>
 
+#include <nix/eval-settings.hh>
 #include <nix/eval.hh>
 #include <nix/value-to-json.hh>
 

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -293,7 +293,8 @@ WrappedNixpkgsInputScheme::inputFromAttrs(
  *        `flox-nixpkgs:v<RULES-VERSION>/owner/<REV-OR-REF>`.
  */
 std::optional<nix::fetchers::Input>
-WrappedNixpkgsInputScheme::inputFromURL( const nix::ParsedURL & url ) const
+WrappedNixpkgsInputScheme::inputFromURL( const nix::ParsedURL & url,
+                                         bool requireTree ) const
 {
   if ( url.scheme != this->type() ) { return std::nullopt; }
 

--- a/pkgdb/src/flox-flake.cc
+++ b/pkgdb/src/flox-flake.cc
@@ -16,6 +16,7 @@
 #include <nix/config.hh>
 #include <nix/eval-cache.hh>
 #include <nix/eval-inline.hh> /**< for inline `allocValue', and `forceAttrs'. */
+#include <nix/eval-settings.hh>
 #include <nix/eval.hh>
 #include <nix/flake/flake.hh>
 #include <nix/flake/flakeref.hh>

--- a/pkgdb/src/lock-flake-installable.cc
+++ b/pkgdb/src/lock-flake-installable.cc
@@ -344,10 +344,10 @@ lockFlakeInstallable( const nix::ref<nix::EvalState> & state,
                   }
                 return outputNamesSet;
               } },
-            e.raw() );
+            e.raw );
         },
       },
-      extendedOutputsSpec.raw() );
+      extendedOutputsSpec.raw );
   }
 
   std::string systemAttribute;

--- a/pkgdb/src/nix-state.cc
+++ b/pkgdb/src/nix-state.cc
@@ -11,6 +11,7 @@
 
 #include <nix/config.hh>
 #include <nix/error.hh>
+#include <nix/eval-settings.hh>
 #include <nix/eval.hh>
 #include <nix/globals.hh>
 #include <nix/logging.hh>

--- a/pkgdb/tests/data/lock-flake-installable/flake.lock
+++ b/pkgdb/tests/data/lock-flake-installable/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704300003,
-        "narHash": "sha256-FRC/OlLVvKkrdm+RtrODQPufD0vVZYA0hpH9RPaHmp4=",
-        "owner": "nixos",
+        "lastModified": 1721743106,
+        "narHash": "sha256-adRZhFpBTnHiK3XIELA3IBaApz70HwCYfv7xNrHjebA=",
+        "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "ab5fd150146dcfe41fda501134e6503932cc8dfd",
+        "rev": "dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "flox",
+        "ref": "stable",
         "repo": "nixpkgs",
-        "rev": "ab5fd150146dcfe41fda501134e6503932cc8dfd",
         "type": "github"
       }
     },

--- a/pkgdb/tests/flox-nixpkgs.cc
+++ b/pkgdb/tests/flox-nixpkgs.cc
@@ -30,7 +30,7 @@ test_URLRoundtrip()
 {
   WrappedNixpkgsInputScheme inputScheme;
   auto                      url = "flox-nixpkgs:v0/flox/" + nixpkgsRev;
-  auto input = inputScheme.inputFromURL( nix::parseURL( url ) );
+  auto input = inputScheme.inputFromURL( nix::parseURL( url ), true );
   EXPECT( input.has_value() );
   EXPECT_EQ( inputScheme.toURL( *input ).to_string(), url );
   return true;
@@ -66,7 +66,7 @@ test_lockedFromUrl( nix::ref<nix::EvalState> & state )
 {
   WrappedNixpkgsInputScheme inputScheme;
   auto                      url = "flox-nixpkgs:v0/flox/" + nixpkgsRev;
-  auto                 input = inputScheme.inputFromURL( nix::parseURL( url ) );
+  auto input = inputScheme.inputFromURL( nix::parseURL( url ), true );
   nix::fetchers::Attrs attrs
     = inputScheme.fetch( state->store, *input ).second.toAttrs();
   auto owner      = nix::fetchers::getStrAttr( attrs, "owner" );

--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -8,13 +8,18 @@
 # against `nix'.
 # This fixes that issue too.
 #
+# N.B. we select the "stable" revision in the full knowledge/expectation that
+# this will change out from underneath us over time. We do this along with a
+# commitment to continually build against the (flox) nixpkgs staging and
+# unstable branches in CI so that we will notified when upcoming upgrades of
+# nixVersions.stable upstream break our build.
 #
 # ---------------------------------------------------------------------------- #
 {
   nixVersions,
   stdenv,
 }:
-nixVersions.nix_2_17.overrideAttrs (prev: {
+nixVersions.stable.overrideAttrs (prev: {
   # Necessary for compiling with debug symbols
   inherit stdenv;
 
@@ -53,7 +58,7 @@ nixVersions.nix_2_17.overrideAttrs (prev: {
 
     Name: Nix
     Description: Nix Package Manager
-    Version: 2.17.1
+    Version: stable
     Requires: nix-store bdw-gc
     Libs: -L\''${libdir} -lnixfetchers
     Cflags: -isystem \''${includedir} -std=c++2a

--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  pre-commit-hooks,
+  symlinkJoin,
+  system,
+  rustfmt,
+  fenix,
+  rust-toolchain,
+  clang-tools_16,
+  makeWrapper,
+}:
+pre-commit-hooks.lib.${system}.run {
+  src = builtins.path {path = ./.;};
+  default_stages = [
+    "manual"
+    "push"
+  ];
+  hooks = {
+    alejandra.enable = true;
+    clang-format = {
+      enable = true;
+      types_or = lib.mkForce [
+        "c"
+        "c++"
+      ];
+    };
+    rustfmt = let
+      wrapper = symlinkJoin {
+        name = "rustfmt-wrapped";
+        paths = [rustfmt];
+        nativeBuildInputs = [makeWrapper];
+        postBuild = let
+          # Use nightly rustfmt
+          PATH = lib.makeBinPath [
+            fenix.stable.cargo
+            rustfmt
+          ];
+        in ''
+          wrapProgram $out/bin/cargo-fmt --prefix PATH : ${PATH};
+        '';
+      };
+    in {
+      enable = true;
+      entry = lib.mkForce "${wrapper}/bin/cargo-fmt fmt --all --manifest-path 'cli/Cargo.toml' -- --color always";
+    };
+    clippy.enable = true;
+    commitizen.enable = true;
+    shfmt.enable = false;
+    # shellcheck.enable = true; # disabled until we have time to fix all the warnings
+  };
+  settings = {
+    clippy.denyWarnings = true;
+    alejandra.verbosity = "quiet";
+    rust.cargoManifestPath = "cli/Cargo.toml";
+  };
+  tools = {
+    # use fenix provided clippy
+    clippy = rust-toolchain.clippy;
+    cargo = rust-toolchain.cargo;
+    clang-tools = clang-tools_16;
+  };
+}

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -17,6 +17,7 @@
   flox-watchdog,
   flox-pkgdb,
   flox-manpages,
+  stdenv,
   ci ? false,
   GENERATED_DATA ? ./../../test_data/generated,
   MANUALLY_GENERATED ? ./../../test_data/manually_generated,
@@ -45,11 +46,17 @@
       commitizen
       alejandra
       shfmt
-      mitmproxy
       yq
       cargo-nextest
       procps
       pstree
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      # The python3Packages.mitmproxy-macos package is broken on mac:
+      #   nix-repl> legacyPackages.aarch64-darwin.python3Packages.mitmproxy-macos.meta.broken
+      #   true
+      # ... so only install it on Linux. It's only an optional dev dependency.
+      mitmproxy
     ];
 in
   mkShell (


### PR DESCRIPTION
## Proposed Changes

Update flox build to only use a single nixpkgs revision derived from one of the github:flox/nixpkgs stability branches, and switch to using the `nixVersions.stable` version of `nix`.

This is being done to reduce the closure size and assure regular upgrades of `nix` going forward.

## Release Notes

* Upgraded version of `nix` included in Flox installation to follow the upstream "stable" version of Nix.