### PR TITLE
fix: re-render ACTIVATION_SCRIPTS_PACKAGE_DIR with flake

### DIFF
--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -359,8 +359,9 @@ ifdef ACTIVATION_SCRIPTS_PACKAGE_DIR
 	echo '$(ACTIVATION_SCRIPTS_PACKAGE_DIR)' > $@.new
 	( cmp $@ $@.new && rm $@.new ) || mv -f $@.new $@
 else
-  _rebuild_dirs = ../assets/activation-scripts ../pkgs/flox-activation-scripts
-  .ACTIVATION_SCRIPTS_PACKAGE_DIR: $(shell find $(_rebuild_dirs) -type f)
+  _rebuild_paths = ../flake.nix ../flake.lock \
+    ../assets/activation-scripts ../pkgs/flox-activation-scripts
+  .ACTIVATION_SCRIPTS_PACKAGE_DIR: $(shell find $(_rebuild_paths) -type f)
 	$(NIX) build --print-out-paths .#flox-activation-scripts > $@
 endif
 


### PR DESCRIPTION
## Proposed Changes

The pkgdb Makefile was not picking up changes to the activation scripts package when inputs were changed, which of course can cause changes in the string-substituted versions of activation scripts as created by the Nix package build. This change updates the conditions for re-rendering the package to include changes in either/both of the top-level flake.{nix,lock} files.

## Release Notes

N/A