### PR TITLE
chore: update README.md to reflect problems invoking mitmproxy on Darwin

### DIFF
--- a/cli/catalog-api-v1/README.md
+++ b/cli/catalog-api-v1/README.md
@@ -34,9 +34,15 @@ Mid-term updating the client library and proposing it as a PR will be done by au
 [mitmproxy](https://mitmproxy.org/) can be used to debug requests and responses from the Catalog API.
 
 1. Start the interface and leave it running in a separate terminal:
-
-        mitmproxy
-
+    ```
+    nix run github:flox/nixpkgs/stable.20240203#mitmproxy
+    ```
+    Note that `mitmproxy` has been broken on Darwin for some time now,
+    hence the need to run it from an old nixpkgs revision.
+    Of course once we implement catalog binary cache verification
+    then using this will be as simple as `flox install mitmproxy`,
+    but in the meantime we just run it from the most recent stable
+    nixpkgs revision on which it is known to build.
 1. Install the Certificate Authority per [these instructions](https://docs.mitmproxy.org/stable/concepts-certificates/).
 1. Run a `flox` command, using the catalog and the proxy:
 


### PR DESCRIPTION
## Proposed Changes

The `mitmproxy` package is not available on Darwin for recent nixpkgs revisions. Update the catalog-api-v1 developer instructions to invoke it from the most recent stable nixpkgs revision on which it is known to build.

## Release Notes

N/A