### PR TITLE
ci: less parallelization for remote tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,10 +341,8 @@ jobs:
           - "aarch64-linux"
           - "aarch64-darwin"
         test-tags:
-          - "activate"
           - "containerize"
-          - "catalog"
-          - "!activate,!containerize,!catalog"
+          - "!containerize"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"


### PR DESCRIPTION
## Proposed Changes
Reduce the parallel jobs when using the same machines to avoid excessive load.

## Release Notes
N/A
