### PR TITLE
docs: missing comma in man pages

### DIFF
--- a/cli/flox/doc/flox.md
+++ b/cli/flox/doc/flox.md
@@ -123,7 +123,7 @@ sharing environments, and administration.
 [`flox-search`(1)](./flox-search.md),
 [`flox-show(1)`](./flox-show.md),
 [`flox-edit`(1)](./flox-edit.md),
-[`manifest-toml`(5)](./manifest.toml.md)
+[`manifest-toml`(5)](./manifest.toml.md),
 [`flox-list`(1)](./flox-list.md),
 [`flox-auth(1)`](./flox-auth.md),
 [`flox-push`(1)](./flox-push.md),


### PR DESCRIPTION
## Proposed Changes

There is now a comma in the `man flox` SEE MORE section. There was great rejoicing


## Release Notes

n/a


<!-- Many thanks! -->
