### PR TITLE
fix: remove .gz extension for containerize, trim tests

### DIFF
--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -47,7 +47,7 @@ The produced container however can also run on macOS.
 
 `-o`, `--output`
 :   Write the container to `<path>`
-    (default: `./<environment-name>-container.tar.gz`)
+    (default: `./<environment-name>-container.tar`)
     If `<path>` is `-`, writes to `stdout`.
 
 ```{.include}
@@ -60,8 +60,8 @@ The produced container however can also run on macOS.
 Create a container image file and load it into Docker:
 
 ```
-$ flox containerize -o ./mycontainer.tar.gz
-$ docker load -i ./mycontainer.tar.gz
+$ flox containerize -o ./mycontainer.tar
+$ docker load -i ./mycontainer.tar
 ```
 
 Pipe the image into Docker directly:

--- a/cli/flox/src/commands/containerize.rs
+++ b/cli/flox/src/commands/containerize.rs
@@ -37,7 +37,7 @@ impl Containerize {
             Some(output) => output,
             None => std::env::current_dir()
                 .context("Could not get current directory")?
-                .join(format!("{}-container.tar.gz", env.name())),
+                .join(format!("{}-container.tar", env.name())),
         };
 
         let (output, output_name): (Box<dyn Write + Send>, String) =

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -105,24 +105,6 @@ function skip_if_linux() {
 }
 
 # bats test_tags=containerize:default-to-file
-@test "container is written to a file by default" {
-  skip_if_not_linux
-
-  env_setup_pkgdb
-
-  run "$FLOX_BIN" containerize
-  assert_success
-
-  assert [ -f "test-container.tar.gz" ] # <env-name>-container.tar.gz by default
-
-  run which podman
-
-  run podman load -i test-container.tar.gz
-  assert_success
-  assert_line --partial "Loaded image:"
-}
-
-# bats test_tags=containerize:default-to-file
 @test "catalog: container is written to a file by default" {
   skip_if_not_linux
 
@@ -131,17 +113,18 @@ function skip_if_linux() {
   run "$FLOX_BIN" containerize
   assert_success
 
-  assert [ -f "test-container.tar.gz" ] # <env-name>-container.tar.gz by default
+  assert [ -f "test-container.tar" ] # <env-name>-container.tar by default
 
   run which podman
 
-  run podman load -i test-container.tar.gz
+  run podman load -i test-container.tar
   assert_success
   assert_line --partial "Loaded image:"
 }
 
 # bats test_tags=containerize:piped-to-stdout
 @test "catalog: container is written to stdout when '-o -' is passed" {
+  skip "duplicate of next test"
   skip_if_not_linux
 
   env_setup_catalog
@@ -152,7 +135,7 @@ function skip_if_linux() {
 }
 
 # bats test_tags=containerize:run-container-i
-@test "catalog: container can be run with 'podman/docker run -i'" {
+@test "catalog: container can be run with 'podman/docker run' with/without -i'" {
   skip_if_not_linux
 
   env_setup_catalog
@@ -183,15 +166,8 @@ function skip_if_linux() {
   store_path_line="$(($n_stderr_lines - 2))"
   assert_regex "${stderr_lines[$store_path_line]}" "\/nix\/store\/.*\/bin\/hello"
   assert_equal "${stderr_lines[$hello_line]}" "Hello, world!"
-}
 
-# bats test_tags=containerize:run-container-no-i
-@test "catalog: container can be run with 'podman/docker run'" {
-  skip_if_not_linux
-
-  env_setup_catalog
-
-  CONTAINER_ID="$("$FLOX_BIN" containerize -o - | podman load | sed -nr 's/^Loaded image: (.*)$/\1/p')"
+  # Next, test without "-i'
   run --separate-stderr podman run "$CONTAINER_ID" -c 'echo $foo'
   assert_success
 


### PR DESCRIPTION
## Proposed Changes
- removes ".gz" extension when producing a ".tar"
- remove superfluous tests that take a long time (151s -> 41s)

## Release Notes
Fixes: https://github.com/flox/product/issues/769