### PR TITLE
refactor(pkgdb): inputFromURL unused arg

### DIFF
--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -293,8 +293,9 @@ WrappedNixpkgsInputScheme::inputFromAttrs(
  *        `flox-nixpkgs:v<RULES-VERSION>/owner/<REV-OR-REF>`.
  */
 std::optional<nix::fetchers::Input>
-WrappedNixpkgsInputScheme::inputFromURL( const nix::ParsedURL & url,
-                                         bool requireTree ) const
+WrappedNixpkgsInputScheme::inputFromURL(
+  const nix::ParsedURL & url,
+  bool /* requireTree ( unused ) */ ) const
 {
   if ( url.scheme != this->type() ) { return std::nullopt; }
 


### PR DESCRIPTION
## Proposed Changes

This was added to the function signature and callers in 5a6c0a68 to
match Nix 2.18 but isn't used in our function body, which causes this
warning when recompiling `pkgdb`:

    src/fetchers/wrapped-nixpkgs-input.cc:297:47: warning: unused parameter 'requireTree' [-Wunused-parameter]
                                             bool requireTree ) const
                                                  ^

It seems that there's a handful of different way that you can workaround
an argument not being used in C++ but I copied this pattern from
`startActivity` in our logger.

## Release Notes

N/A