### PR TITLE
feat: allow restricting services to specific systems

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -259,7 +259,7 @@ impl RawManifest {
                   # This is a Flox environment manifest.
                   # Visit flox.dev/docs/concepts/manifest/
                   # or see flox-edit(1), manifest.toml(5) for more information.
-                  # 
+                  #
                   # Flox manifest version managed by Flox CLI
                   {}"#,
                 decor.prefix().and_then(|raw_str| raw_str.as_str()).unwrap_or("")})
@@ -858,6 +858,8 @@ pub struct ManifestServiceDescriptor {
     pub is_daemon: Option<bool>,
     /// How to shut down the service
     pub shutdown: Option<ManifestServiceShutdown>,
+    /// Systems to allow running the service on
+    pub systems: Option<Vec<System>>,
 }
 
 impl ManifestServices {
@@ -1503,7 +1505,7 @@ pub(super) mod test {
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
             # or see flox-edit(1), manifest.toml(5) for more information.
-            # 
+            #
             # Flox manifest version managed by Flox CLI
             version = 1
 
@@ -1585,7 +1587,7 @@ pub(super) mod test {
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
             # or see flox-edit(1), manifest.toml(5) for more information.
-            # 
+            #
             # Flox manifest version managed by Flox CLI
             version = 1
 
@@ -1671,7 +1673,7 @@ pub(super) mod test {
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
             # or see flox-edit(1), manifest.toml(5) for more information.
-            # 
+            #
             # Flox manifest version managed by Flox CLI
             version = 1
 
@@ -1753,7 +1755,7 @@ pub(super) mod test {
             # This is a Flox environment manifest.
             # Visit flox.dev/docs/concepts/manifest/
             # or see flox-edit(1), manifest.toml(5) for more information.
-            # 
+            #
             # Flox manifest version managed by Flox CLI
             version = 1
 

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -278,7 +278,14 @@ pub fn maybe_make_service_config_file(
 ) -> Result<Option<PathBuf>, ServiceError> {
     let service_config_path = if !lockfile.manifest.services.is_empty() {
         let config_path = service_config_write_location(&flox.temp_dir)?;
-        write_process_compose_config(&lockfile.manifest.services.clone().into(), &config_path)?;
+        write_process_compose_config(
+            &lockfile
+                .manifest
+                .services
+                .copy_for_system(&flox.system)
+                .into(),
+            &config_path,
+        )?;
         tracing::debug!(path = traceable_path(&config_path), "wrote service config");
         Some(config_path)
     } else {

--- a/cli/flox-watchdog/src/logger.rs
+++ b/cli/flox-watchdog/src/logger.rs
@@ -176,10 +176,10 @@ mod tests {
     fn test_gc_logs_watchdog_removes_old_files() {
         let keep_last = 2;
         let dir = tempdir().unwrap();
-        let file_now = create_log_file(&dir.path(), "watchdog.now.log", None);
-        let file_one = create_log_file(&dir.path(), "watchdog.one.log", Some(keep_last - 1));
-        let file_two = create_log_file(&dir.path(), "watchdog.two.log", Some(keep_last));
-        let file_three = create_log_file(&dir.path(), "watchdog.three.log", Some(keep_last + 1));
+        let file_now = create_log_file(dir.path(), "watchdog.now.log", None);
+        let file_one = create_log_file(dir.path(), "watchdog.one.log", Some(keep_last - 1));
+        let file_two = create_log_file(dir.path(), "watchdog.two.log", Some(keep_last));
+        let file_three = create_log_file(dir.path(), "watchdog.three.log", Some(keep_last + 1));
 
         gc_logs_watchdog(dir.path(), keep_last).unwrap();
         assert!(file_now.exists());
@@ -206,7 +206,7 @@ mod tests {
         let files: Vec<PathBuf> = filenames
             .clone()
             .into_iter()
-            .map(|filename| create_log_file(&dir.path(), filename, Some(keep_last - 1)))
+            .map(|filename| create_log_file(dir.path(), filename, Some(keep_last - 1)))
             .collect();
         assert_eq!(files.len(), filenames.len());
 
@@ -221,7 +221,7 @@ mod tests {
         let keep_days = 2;
         let dir = tempdir().unwrap();
         let files: Vec<PathBuf> = (1..=keep_days * 2)
-            .map(|i| create_log_file(&dir.path(), &format!("services.{}.log", i), None))
+            .map(|i| create_log_file(dir.path(), &format!("services.{}.log", i), None))
             .collect();
 
         gc_logs_services(dir.path(), keep_days).unwrap();
@@ -249,7 +249,7 @@ mod tests {
         let files: Vec<PathBuf> = filenames
             .clone()
             .into_iter()
-            .map(|filename| create_log_file(&dir.path(), filename, None))
+            .map(|filename| create_log_file(dir.path(), filename, None))
             .collect();
         assert_eq!(files.len(), filenames.len());
 
@@ -283,10 +283,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let now = SystemTime::now();
 
-        let old_file = create_log_file(&dir.path(), "old.log", Some(threshold_days + 1));
+        let old_file = create_log_file(dir.path(), "old.log", Some(threshold_days + 1));
         assert!(file_older_than(&old_file, now, threshold_dur).unwrap());
 
-        let new_file = create_log_file(&dir.path(), "new.log", Some(threshold_days - 1));
+        let new_file = create_log_file(dir.path(), "new.log", Some(threshold_days - 1));
         assert!(!file_older_than(&new_file, now, threshold_dur).unwrap());
     }
 }

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -380,6 +380,7 @@ ServiceDescriptor ::= {
 , vars       = null | Map[STRING, STRING]
 , is-daemon  = null | BOOL
 , shutdown   = null | Shutdown
+, systems    = null | [<STRING>, ...]
 }
 
 Shutdown ::= {
@@ -417,6 +418,10 @@ Shutdown ::= {
     shutdown command to run instead of relying on the default behavior of
     sending a SIGTERM to the service. This field is required if the `is-daemon`
     field is `true`.
+
+`systems`
+:   An optional list of systems on which to run this service.
+    If omitted, the service is not restricted.
 
 ## `[options]`
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -346,11 +346,16 @@ impl Activate {
 
                 if manifest.services.is_empty() {
                     message::warning(ServicesCommandsError::NoDefinedServices);
+                } else if manifest.services.copy_for_system(&flox.system).is_empty() {
+                    message::warning(ServicesCommandsError::NoDefinedServicesForSystem {
+                        system: flox.system.clone(),
+                    });
                 }
             }
 
-            let should_have_services =
-                self.start_services && !manifest.services.is_empty() && !in_place;
+            let should_have_services = self.start_services
+                && !manifest.services.copy_for_system(&flox.system).is_empty()
+                && !in_place;
             let start_new_process_compose = should_have_services
                 && if socket_path.exists() {
                     // Returns `Ok(true)` if `process-compose` was shutdown

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -37,7 +37,7 @@ impl Logs {
         subcommand_metric!("services::logs");
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
-        guard_service_commands_available(&env)?;
+        guard_service_commands_available(&env, &flox.system)?;
 
         let socket = env.socket();
         let processes = ProcessStates::read(socket)?;

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -40,7 +40,7 @@ impl Restart {
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         guard_is_within_activation(&env, "restart")?;
-        guard_service_commands_available(&env)?;
+        guard_service_commands_available(&env, &flox.system)?;
 
         let socket = env.socket();
         let existing_process_compose = socket.exists();

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -39,7 +39,7 @@ impl Start {
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         guard_is_within_activation(&env, "start")?;
-        guard_service_commands_available(&env)?;
+        guard_service_commands_available(&env, &flox.system)?;
 
         let start_new_process_compose = if !env.expect_services_running() {
             true

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -33,7 +33,7 @@ impl Status {
         subcommand_metric!("services::status");
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
-        guard_service_commands_available(&env)?;
+        guard_service_commands_available(&env, &flox.system)?;
 
         let processes = ProcessStates::read(env.socket())?;
 

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -37,7 +37,12 @@ impl Status {
 
         let processes = ProcessStates::read(env.socket())?;
 
-        let named_processes = super::processes_by_name_or_default_to_all(&processes, &self.names)?;
+        let named_processes = super::processes_by_name_or_default_to_all(
+            &processes,
+            &env.manifest.services,
+            &flox.system,
+            &self.names,
+        )?;
 
         let process_states_display = named_processes
             .into_iter()

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -25,7 +25,7 @@ impl Stop {
         subcommand_metric!("services::stop");
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
-        guard_service_commands_available(&env)?;
+        guard_service_commands_available(&env, &flox.system)?;
 
         let socket = env.socket();
 

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -30,7 +30,12 @@ impl Stop {
         let socket = env.socket();
 
         let processes = ProcessStates::read(socket)?;
-        let named_processes = super::processes_by_name_or_default_to_all(&processes, &self.names)?;
+        let named_processes = super::processes_by_name_or_default_to_all(
+            &processes,
+            &env.manifest.services,
+            &flox.system,
+            &self.names,
+        )?;
 
         for process in named_processes {
             if !process.is_running {

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -181,7 +181,7 @@ EOF
     # NB: No --start-services.
     run "$FLOX_BIN" activate -- "$FLOX_BIN" services "$command"
     assert_failure
-    assert_line "❌ ERROR: Environment doesn't have any services defined."
+    assert_line "❌ ERROR: Environment does not have any services defined."
   done
 }
 
@@ -206,7 +206,7 @@ EOF
     # NB: No --start-services.
     run "$FLOX_BIN" activate -- "$FLOX_BIN" services "$command"
     assert_failure
-    assert_line "❌ ERROR: Environment doesn't have any services defined for '$NIX_SYSTEM'."
+    assert_line "❌ ERROR: Environment does not have any services defined for '$NIX_SYSTEM'."
   done
 }
 
@@ -309,7 +309,7 @@ EOF
 EOF
 )
   assert_failure
-  assert_output --partial "❌ ERROR: Service 'invalid' not found"
+  assert_output --partial "❌ ERROR: Service 'invalid' does not exist."
 
   # This doesn't guarantee that the services haven't been restarted _after_
   # we've read the counter files. So an intermittent failure could indicate that
@@ -545,7 +545,7 @@ EOF
 EOF
 )
   assert_failure
-  assert_output --partial "❌ ERROR: Service 'one' not found"
+  assert_output --partial "❌ ERROR: Service 'one' does not exist."
   refute_output --partial "Service 'touch_file'"
   [ ! -e hello.txt ]
 }
@@ -562,7 +562,7 @@ EOF
 EOF
 )
   assert_failure
-  assert_output --partial "❌ ERROR: Service 'invalid' not found"
+  assert_output --partial "❌ ERROR: Service 'invalid' does not exist."
 }
 
 # bats test_tags=services:stop
@@ -578,7 +578,7 @@ EOF
 EOF
 )
   assert_failure
-  assert_output --partial "❌ ERROR: Service 'invalid' not found"
+  assert_output --partial "❌ ERROR: Service 'invalid' does not exist."
   assert_output --regexp "one +Running"
   assert_output --regexp "two +Running"
 }
@@ -743,7 +743,7 @@ EOF
 EOF
   )
   assert_failure
-  assert_line "❌ ERROR: Service 'doesnotexist' not found."
+  assert_line "❌ ERROR: Service 'doesnotexist' does not exist."
 }
 
 # Runs a service that will sleep after printing a few lines of logs.
@@ -956,13 +956,13 @@ EOF
   assert_success
 }
 
-@test "activate: --start-services warns if environment doesn't have services" {
+@test "activate: --start-services warns if environment does not have services" {
   run "$FLOX_BIN" init
   assert_success
 
   run "$FLOX_BIN" activate --start-services -- true
   assert_success
-  assert_output "⚠️  Environment doesn't have any services defined."
+  assert_output "⚠️  Environment does not have any services defined."
 }
 
 @test "activate: outer activation starts services and inner activation doesn't" {
@@ -1339,7 +1339,7 @@ EOF
 
   run "$FLOX_BIN" activate -- bash -c "$SCRIPT"
   assert_failure
-  assert_output --partial "Service 'invalid' not found."
+  assert_output --partial "Service 'invalid' does not exist."
   assert_output --partial "Services not started or quit unexpectedly."
 }
 
@@ -1367,7 +1367,7 @@ EOF
 
   run "$FLOX_BIN" activate -- bash -c "$SCRIPT"
   assert_failure
-  assert_output --partial "Service 'invalid' not available on '$NIX_SYSTEM'."
+  assert_output --partial "Service 'invalid' is not available on '$NIX_SYSTEM'."
   assert_output --partial "Services not started or quit unexpectedly."
 }
 
@@ -1540,7 +1540,7 @@ EOF
   # Then try to start the second service.
   run "$FLOX_BIN" activate -s -- bash "${TESTS_DIR}/services/start_does_not_pick_up_modifications.sh"
   assert_failure
-  assert_output --partial "Service 'two' not found."
+  assert_output --partial "Service 'two' was defined after services were started."
 }
 
 


### PR DESCRIPTION
## [feat: add `services.<service>.systems` attribute to manifest](https://github.com/flox/flox/commit/709363400618f89ece8624d98dbe07c7bdf9ec28) 

* Add a new field to the service descriptor that restricts running a service on the specified systems.


## [feat: err/warn for services that are not enabled on the current system](https://github.com/flox/flox/commit/7b493ce974b1d74bf554595aa7bbe3ccba970afe) 

* Add `ManifestServices::copy_for_system` to create a new ManifestServices instance
with services for systems other than provided `system` filtered out.

Clone the services rather than filter in place
to avoid accidental mutation of the original in memory manifest/lockfile.

* Where previously checking `manifest.services.is_empty()`
add an additional check whether `copy_for_system` is empty as well and warn/err
if the manifest provides no service for the current system.
The messages will be different from _not having services at all_ for clarity.

* Check service names against services for current system
When providing services as an argument, the service name
will now be checked against `copy_for_system` and raise an error
if the service is not available.

* Only resolve to supported services if all services are implied.
`flox services *` will substitute only supported services
for the current system if not explicit service names are provided.