### PR TITLE
chore(CI): move build of flox-cli-tests to nix-build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       - name: "Build"
         id: "build"
         run: |
-          for package in '.#packages.${{ matrix.system }}.flox-pkgdb' '.#packages.${{ matrix.system }}.flox-cli' '.#packages.${{ matrix.system }}.flox' ; do
+          for package in '.#packages.${{ matrix.system }}.flox-pkgdb' '.#packages.${{ matrix.system }}.flox-cli' '.#packages.${{ matrix.system }}.flox' '.#packages.${{ matrix.system }}.flox-cli-tests'; do
             echo "Building $package ..."
             git clean -xfd .
             if nix path-info                 \
@@ -360,27 +360,6 @@ jobs:
           TAILSCALE_AUTH_KEY:     "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
           REMOTE_BUILDERS:        "${{    vars.MANAGED_REMOTE_BUILDERS }}"
           SYSTEM:                 "${{ matrix.system }}"
-
-      - name: "Build flox"
-        run: |
-          git clean -xfd
-          nix build -L \
-              --accept-flake-config \
-              --no-update-lock-file \
-              --print-out-paths \
-              '.#packages.${{ matrix.system }}.flox'
-          # We run bats tests later on against the `FLOX_CLI' env
-          echo "FLOX_CLI=$(readlink -f ./result; )/bin/flox" >> "$GITHUB_ENV"
-          rm ./result
-
-      - name: "Build Bats Tests (./#flox-cli-tests)"
-        run: |
-          git clean -xfd
-          nix build -L \
-              --no-update-lock-file \
-              --print-out-paths \
-              '.#packages.${{ matrix.system }}.flox-cli-tests'
-          nix copy --extra-experimental-features 'nix-command' --to "$CONFIGURE_NIX_SUBSTITUTER" ./result
 
       - name: "Run Bats Tests (./#flox-cli-tests)"
         timeout-minutes: 30


### PR DESCRIPTION
The `remote` job currently builds both `flox` and `flox-cli-tests`, which adds ~45 sec to every `remote` job. Most of this work is wasted, since it copies flox to the GitHub runner, even though flox is only needed on our own runner for that job.

Building `flox-cli-tests` in the `nix-build` job is much faster, because that job has already built `flox`. Building `flox-cli-tests` is relatively cheap since it only requires a `writeShellScriptBin`.

The only jobs that depend on `nix-build` are `remote`, `Build installers`, and `Report Falure`. We skip `Build installers` on PRs and in the merge queue, so adding a smaller amount of time to `nix-build` in exchange for subtracting a greater amount of time from `remote` should be an improvement.