### PR TITLE
test(build): Test build functionality

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -161,3 +161,456 @@ fn read_output_to_channel(
         };
     }
 }
+
+/// Unit tests for the `flox-build.mk` "black box" builder, via
+/// the [`FloxBuildMk`] implementation of [`ManifestBuilder`].
+///
+/// Currently, this is _the_ testsuite for the `flox-build.mk` builder.
+#[cfg(test)]
+mod tests {
+    use std::fs::{self};
+
+    use indoc::formatdoc;
+
+    use super::*;
+    use crate::flox::test_helpers::flox_instance;
+    use crate::flox::Flox;
+    use crate::models::environment::path_environment::test_helpers::new_path_environment;
+    use crate::models::environment::path_environment::PathEnvironment;
+    use crate::models::environment::Environment;
+    use crate::providers::catalog::Client;
+
+    fn result_dir(parent: &Path, package: &str) -> PathBuf {
+        parent.join(format!("result-{package}"))
+    }
+
+    fn cache_dir(parent: &Path, package: &str) -> PathBuf {
+        parent.join(format!("result-{package}-buildCache"))
+    }
+
+    /// Runs a build and asserts that the `ExitStatus` matches `expect_status`.
+    fn assert_build_status(
+        flox: &Flox,
+        env: &mut PathEnvironment,
+        package_name: &str,
+        expect_success: bool,
+    ) {
+        let builder = FloxBuildMk;
+        let output = builder
+            .build(
+                &env.parent_path().unwrap(),
+                &env.activation_path(flox).unwrap(),
+                &[package_name.to_owned()],
+            )
+            .unwrap();
+
+        for message in output {
+            match message {
+                Output::Exit(status) => match expect_success {
+                    true => assert!(status.success()),
+                    false => assert!(!status.success()),
+                },
+                // Copy output to debug failing tests.
+                Output::Stdout(line) => println!("stdout: {line}"),
+                Output::Stderr(line) => println!("stderr: {line}"),
+            }
+        }
+    }
+
+    /// Asserts that `file_name` exists with `content` within the build result
+    /// for `package_name`.
+    /// Further, asserts that the result is a symlink into the nix store.
+    fn assert_build_file(parent: &Path, package_name: &str, file_name: &str, content: &str) {
+        let dir = result_dir(parent, package_name);
+        assert!(dir.is_symlink());
+        assert!(dir.read_link().unwrap().starts_with("/nix/store/"));
+
+        let file = dir.join(file_name);
+        assert!(file.is_file());
+        assert_eq!(fs::read_to_string(file).unwrap(), content);
+    }
+
+    /// Reads the content of a file in the build result for `package_name`.
+    fn result_content(parent: &Path, package: &str, file_name: &str) -> String {
+        let dir = result_dir(parent, package);
+        let file = dir.join(file_name);
+        fs::read_to_string(file).unwrap()
+    }
+
+    #[test]
+    fn build_returns_failure_when_package_not_defined() {
+        let package_name = String::from("foo");
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, "version = 1");
+
+        assert_build_status(&flox, &mut env, &package_name, false);
+    }
+
+    #[test]
+    fn build_command_generates_file() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("some content");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            command = """
+                mkdir $out
+                echo -n {file_content} > $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+
+    #[test]
+    #[ignore = "TODO: `files` isn't currently passed to or parsed by `flox-build.mk`."]
+    fn build_includes_files() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("some content");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            files = ["{file_name}"]
+            command = "mkdir $out"
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        fs::write(env_path.join(&file_name), &file_content).unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+
+    #[test]
+    #[ignore = "TODO: `systems` isn't currently passed to or parsed by `flox-build.mk`."]
+    fn build_restricts_systems() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("some content");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            systems = ["invalid"]
+            command = """
+                mkdir $out
+                echo -n {file_content} > $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        fs::write(env_path.join(&file_name), &file_content).unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, false);
+        let dir = result_dir(&env_path, &package_name);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn build_sandbox_pure_as_default() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("some content");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            command = """
+                mkdir $out
+                cp {file_name} $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        // This file is not accessible from a pure build.
+        fs::write(env_path.join(&file_name), &file_content).unwrap();
+        assert_build_status(&flox, &mut env, &package_name, false);
+
+        let dir = result_dir(&env_path, &package_name);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn build_sandbox_off() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("some content");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            sandbox = "off"
+            command = """
+                mkdir $out
+                cp {file_name} $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        // This file is accessible from an impure build.
+        fs::write(env_path.join(&file_name), &file_content).unwrap();
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+
+    #[test]
+    fn build_cache_sandbox_pure_uses_cache() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            sandbox = "pure"
+            command = """
+                mkdir -p $out
+
+                if [ ! -e ./cached-value ]; then
+                    # Generate a random value to cache,
+                    # successive builds should use this value
+                    # RANDOM is a bash builtin that returns a random integer
+                    # each time it's evaluated
+                    echo "$RANDOM" > ./cached-value
+                fi
+
+                cp ./cached-value $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        let file_content = result_content(&env_path, &package_name, &file_name);
+
+        // Asserts that the build result uses the cached value of the previous build
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+
+    #[test]
+    fn build_cache_sandbox_pure_cache_can_be_invalidated() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            sandbox = "pure"
+            command = """
+                mkdir -p $out
+
+                if [ ! -e ./cached-value ]; then
+                    # Generate a random value to cache,
+                    # successive builds should use this value
+                    # RANDOM is a bash builtin that returns a random integer
+                    # each time it's evaluated
+                    echo "$RANDOM" > ./cached-value
+                fi
+
+                cp ./cached-value $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        let file_content_first_run = result_content(&env_path, &package_name, &file_name);
+
+        let cache_dir = cache_dir(&env_path, &package_name);
+        assert!(cache_dir.exists());
+        fs::remove_file(cache_dir).unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        let file_content_second_run = result_content(&env_path, &package_name, &file_name);
+
+        assert_ne!(file_content_first_run, file_content_second_run);
+    }
+
+    #[test]
+    fn build_cache_sandbox_off_uses_fs_as_cache() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            sandbox = "off"
+            command = """
+                # Previous $out is left in place!
+                mkdir -p $out
+
+                if [ ! -e ./cached-value ]; then
+                    # Generate a random value to cache,
+                    # successive builds should use this value
+                    # RANDOM is a bash builtin that returns a random integer
+                    # each time it's evaluated
+                    echo "$RANDOM" > ./cached-value
+                fi
+
+                cp ./cached-value $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        let file_content = result_content(&env_path, &package_name, &file_name);
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+
+    #[test]
+    fn build_uses_package_from_manifest() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("environment/bin/hello\n");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+            [install]
+            hello.pkg-path = "hello"
+
+            [build.{package_name}]
+            command = """
+                mkdir $out
+                type hello | grep -o "{file_content}" > $out/{file_name}
+            """
+        "#};
+
+        let (mut flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        if let Client::Mock(ref mut client) = flox.catalog_client {
+            client.clear_and_load_responses_from_file("resolve/hello.json");
+        } else {
+            panic!("expected Mock client")
+        };
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+
+    #[test]
+    fn build_uses_var_from_manifest() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("some content");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [vars]
+            FOO = "{file_content}"
+
+            [build.{package_name}]
+            command = """
+                mkdir $out
+                echo -n "$FOO" > $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+
+    #[test]
+    fn build_uses_hook_from_manifest() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("some content");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [hook]
+            on-activate = '''
+              export FOO="{file_content}"
+            '''
+
+            [build.{package_name}]
+            command = """
+                mkdir $out
+                echo -n "$FOO" > $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+
+    #[test]
+    fn build_depending_on_another_build() {
+        let package_name = String::from("foo");
+        let file_name = String::from("bar");
+        let file_content = String::from("some content");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.dep]
+            command = """
+                mkdir $out
+                echo -n "{file_content}" > $out/{file_name}
+            """
+
+            [build.{package_name}]
+            command = """
+                mkdir $out
+                cp ${{dep}}/{file_name} $out/{file_name}
+            """
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        assert_build_status(&flox, &mut env, &package_name, true);
+        assert_build_file(&env_path, &package_name, &file_name, &file_content);
+    }
+}

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -1,5 +1,5 @@
 {
-  pkgs ? import (builtins.getFlake "github:nixos/nixpkgs/ab5fd150146dcfe41fda501134e6503932cc8dfd") {},
+  pkgs ? import (builtins.getFlake "github:flox/nixpkgs/dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f") {},
   name,
   flox-env,
   install-prefix,
@@ -26,7 +26,7 @@ assert (srcTarball != null) -> (buildScript != null); let
     then null
     else (/. + buildCache);
 in
-  pkgs.runCommand name {
+  pkgs.runCommandNoCC name {
     inherit buildInputs srcTarball;
     nativeBuildInputs = with pkgs;
       [findutils gnutar gnused makeWrapper]

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -162,7 +162,7 @@ define BUILD_local_template =
 	    --argstr flox-env "$(FLOX_ENV)" \
 	    --argstr install-prefix "$(_out)" \
 	    --out-link "result-$(_pname)" \
-	    --offline 2>&1 | $(_tee) $($(_pvarname)_logfile)
+	    2>&1 | $(_tee) $($(_pvarname)_logfile)
 
 endef
 

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -51,6 +51,7 @@ _mktemp := $(call __package_bin,$(__coreutils),mktemp)
 _nix := $(call __package_bin,$(__nix),nix)
 _pwd := $(call __package_bin,$(__coreutils),pwd)
 _readlink := $(call __package_bin,$(__coreutils),readlink)
+_realpath := $(call __package_bin,$(__coreutils),realpath)
 _rm := $(call __package_bin,$(__coreutils),rm)
 _sed := $(call __package_bin,$(__gnused),sed)
 _sha256sum := $(call __package_bin,$(__coreutils),sha256sum)
@@ -126,7 +127,7 @@ define DEPENDS_template =
   $(foreach package,$(filter-out $(notdir $(build)),$(notdir $(BUILDS))),\
     $(if $(shell $(_grep) '\$${$(package)}' $(build)),\
       $(eval _dep = result-$(package))\
-      $(eval $(_pvarname)_buildDeps += $(realpath $(_dep)))\
+      $(eval $(_pvarname)_buildDeps += $(shell $(_realpath) $(_dep)))\
       $($(_pvarname)_buildScript): $(_dep)))
 endef
 


### PR DESCRIPTION
## [test(build): implement tests for the flox-build.mk blackbox](https://github.com/flox/flox/pull/2063/commits/28a2fe5475517d4dee7450f9ec961a9dffca832c) 

In SDK because focusing on effects rather than CLI output.
Output handling needs to be adjusted and tested in CLI.

* test(build): `flox-build.mk` honors `system` attribute

Currently ignored as the functionality is not implemented in the builder.

* test(build): `flox-build.mk` honors `files` attribute

Currently ignored as the functionality is not implemented in the builder.

* test(build): `flox-build.mk` buildCache

* test(build): test packages, hooks, and vars

* test(build): package depending on another package

## [chore: shrink closure size for builder nix script](https://github.com/flox/flox/pull/2063/commits/d6a02c22b35474b8ee4bbb91026bc4b04d557dc0) 
* chore: Avoid depending on CC toolchain when building packages
Use `runCommandNoCC` over `runCommand`

* chore: Use flox' nixpkgs

## [fix: use coreutils realpath to determine dependency store path](https://github.com/flox/flox/pull/2063/commits/263c98c48450c9a39650a9ebe9defe179fa64321)