### PR TITLE
fix: cleanup cache directories

### DIFF
--- a/cli/tests/auth.bats
+++ b/cli/tests/auth.bats
@@ -20,6 +20,7 @@ setup_file() {
 
 teardown_file() {
   unset _FLOX_USE_CATALOG_MOCK
+  common_file_teardown
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -70,6 +70,7 @@ teardown() {
 
 teardown_file() {
   podman_cache_reset
+  common_file_teardown
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/delete.bats
+++ b/cli/tests/delete.bats
@@ -18,6 +18,7 @@ setup_file() {
 
 teardown_file() {
   unset _FLOX_USE_CATALOG_MOCK
+  common_file_teardown
 }
 
 # Helpers for project based tests.

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -18,6 +18,7 @@ setup_file() {
 
 teardown_file() {
   unset _FLOX_USE_CATALOG_MOCK
+  common_file_teardown
 }
 
 # Helpers for project based tests.

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -334,6 +334,8 @@ EOF
   # We should only see the path environnment
   run jq '.entries[0].envs | length' "$FLOX_DATA_DIR/env-registry.json"
   assert_output "1"
+
+  rm -rf "$FLOX_CACHE_DIR"
 }
 
 # bats test_tags=managed,delete,managed:fresh-deleted

--- a/cli/tests/floxhub-cross-systems.bats
+++ b/cli/tests/floxhub-cross-systems.bats
@@ -47,6 +47,7 @@ setup_file() {
 teardown_file() {
   "$FLOX_BIN" config --delete floxhub_url
   unset FLOX_FLOXHUB_TOKEN
+  common_file_teardown
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -381,6 +381,14 @@ flox_vars_setup() {
 # Set `FLOX_TEST_HOME' to a temporary directory and setup essential files.
 # Homedirs can be created "globally" for the entire test suite ( default ), or
 # for individual files or single tests by passing an optional argument.
+#
+# `home_setup` will set the `FLOX_CACHE_DIR` to a new tempdir through
+# `flox_vars_setup`.
+# Where called in `setup_suite`, or `file_setup`
+# (e.g. through `common_file_setup`), `teardown_suite`, or `teardown_file`
+# should delete the directory.
+# When calling `home_setup test` in a test, the test itself should delete the
+# `$FLOX_CACHE_DIR`.
 home_setup() {
   if [[ "${__FT_RAN_HOME_SETUP:-}" = "real" ]]; then
     export FLOX_TEST_HOME="$REAL_HOME"
@@ -469,8 +477,8 @@ common_suite_teardown() {
   # Delete suite tmpdir and envs unless the user requests to preserve them.
   if [[ -z ${FLOX_TEST_KEEP_TMP-} ]]; then
     rm -rf "$BATS_SUITE_TMPDIR"
+    rm -rf "$FLOX_CACHE_DIR"
   fi
-  rm -rf "$FLOX_CACHE_DIR"
   # Our agent was useful, but it's time for them to retire.
   # We force true in case we are tearing down when an agent never launched.
   eval "$(ssh-agent -k 2> /dev/null || echo ':')"

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -166,6 +166,7 @@ common_file_teardown() {
   if [[ -z "${FLOX_TEST_KEEP_TMP:-}" ]]; then
     deleteEnvForce "$TEST_ENVIRONMENT"
     rm -rf "$BATS_FILE_TMPDIR"
+    rm -rf "$FLOX_CACHE_DIR"
   fi
   unset FLOX_TEST_HOME
 }

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -19,6 +19,7 @@ setup_file() {
 
 teardown_file() {
   unset _FLOX_USE_CATALOG_MOCK
+  common_file_teardown
 }
 
 setup() {


### PR DESCRIPTION
A _new_ cache directory in `/tmp/flox.tests.XXXXXX` is created with every call to `flox_vars_setup`[1]. The only call to `flox_vars_setup` is within `home_setup`[2], thus any call to `home_setup` will create a new tempdir.
Further, `home_setup` is called once during `common_suite_setup` [3], and then again for every file via `common_file_setup`[4], as well as once during `"m10: deletes existing environment"`[5].

The only place to remove `$FLOX_CACHE_DIR` is within `common_suite_teardown` [6]. Consequently, any cache dir created by [4] and [5] remain on disk:

```shell
$ ls /tmp | sort > before
$ just integ-tests
$ ls /tmp | sort > after
$ comm -3 before after
	flox.tests.12lLgE
	flox.tests.2fRUrE
	flox.tests.6Rh9wF
	flox.tests.BKzWtx
    [...]
```

To address this issue

1. remove the cache dir created by `common_file_setup` in `common_file_teardown`
2. ensure that `common_file_teardown` is called by every file. Only `file_teardown` used to call `common_file_teardown`, but since its a default, file specific overrides of this method have to call `common_file_teardown` explicitly.
3. remove the cache dir created by the `home_setup test` call in [5]

[1] https://github.com/flox/flox/blob/e8874c55b8bf871f2aabb4182893794e8cac9a08/cli/tests/setup_suite.bash#L366-L367
[2] https://github.com/flox/flox/blob/e8874c55b8bf871f2aabb4182893794e8cac9a08/cli/tests/setup_suite.bash#L402
[3] https://github.com/flox/flox/blob/e8874c55b8bf871f2aabb4182893794e8cac9a08/cli/tests/setup_suite.bash#L422-L423
[4] https://github.com/flox/flox/blob/e8874c55b8bf871f2aabb4182893794e8cac9a08/cli/tests/test_support.bash#L152
[5] https://github.com/flox/flox/blob/e8874c55b8bf871f2aabb4182893794e8cac9a08/cli/tests/environment-managed.bats#L317
[6] https://github.com/flox/flox/blob/e8874c55b8bf871f2aabb4182893794e8cac9a08/cli/tests/setup_suite.bash#L473-L474
