### PR TITLE
feat: render top-level requisites.txt file to flox environments

### DIFF
--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -46,6 +46,7 @@ static constexpr std::string_view ACTIVATION_SCRIPT_NAME = "activate";
 static constexpr std::string_view ACTIVATION_SUBDIR_NAME = "activate.d";
 static constexpr std::string_view PACKAGE_BUILDS_SUBDIR_NAME
   = "package-builds.d";
+static constexpr std::string_view REQUISITES_TXT_NAME = "requisites.txt";
 
 /* -------------------------------------------------------------------------- */
 
@@ -107,13 +108,23 @@ FLOX_DEFINE_EXCEPTION( PackageBuildFailure,
 /** @} */
 
 /**
- * @class flox::buildenv::PackageBuildFailure
+ * @class flox::buildenv::ActivationScriptBuildFailure
  * @brief An exception thrown when a package fails to build.
  * @{
  */
 FLOX_DEFINE_EXCEPTION( ActivationScriptBuildFailure,
                        EC_ACTIVATION_SCRIPT_BUILD_ERROR,
                        "failure building activation script" )
+/** @} */
+
+/**
+ * @class flox::buildenv::RequisitesTxtBuildFailure
+ * @brief An exception thrown when a package fails to build.
+ * @{
+ */
+FLOX_DEFINE_EXCEPTION( RequisitesTxtBuildFailure,
+                       EC_REQUISITES_TXT_BUILD_ERROR,
+                       "failure building requisites.txt" )
 /** @} */
 
 /* -------------------------------------------------------------------------- */
@@ -412,6 +423,15 @@ void
 addScriptToScriptsDir( const std::string &           scriptContents,
                        const std::filesystem::path & scriptsDir,
                        const std::string &           scriptName );
+
+/**
+ * @brief Adds requisites.txt to the environment root directory.
+ * @param tempDir The temporary scripts directory being assembled.
+ */
+void
+addRequisitesTxt( nix::EvalState &              state,
+                  nix::StorePathSet &           references,
+                  const std::filesystem::path & tempDir );
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkgdb/include/flox/core/exceptions.hh
+++ b/pkgdb/include/flox/core/exceptions.hh
@@ -111,6 +111,11 @@ enum error_category {
    * due to file I/O failing.
    */
   EC_ACTIVATION_SCRIPT_BUILD_ERROR,
+  /**
+   * A failure encountered while building requisites.txt. This could be
+   * due to file I/O failing.
+   */
+  EC_REQUISITES_TXT_BUILD_ERROR,
 
   /**
    * Attempted lock of a local flake, which is not allowed for floxhub

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -122,6 +122,9 @@ createEnvironmentStorePath(
 {
   /* build the profile into a tempdir */
   auto tempDir = nix::createTempDir();
+  /* add "requisites.txt" file containing full list of requisites */
+  addRequisitesTxt( state, references, tempDir );
+  /* drop the service management config in place if defined */
   if ( serviceConfigPath.has_value() )
     {
       try
@@ -596,6 +599,49 @@ addScriptToScriptsDir( const std::string &           scriptContents,
                       scriptPath ) );
   std::filesystem::copy_file( scriptTempPath, scriptPath );
 }
+
+/* -------------------------------------------------------------------------- */
+
+void
+addRequisitesTxt( nix::EvalState &              state,
+                  nix::StorePathSet &           references,
+                  const std::filesystem::path & tempDir )
+{
+  /* Compute the full store closure of the references. */
+  nix::StorePathSet closure;
+  state.store->computeFSClosure( references, closure );
+
+  /* Write the script to a temporary file. */
+  std::filesystem::path tempPath( nix::createTempFile().second );
+  debugLog(
+    nix::fmt( "created tempfile for requisites.txt file: script=%s, path=%s",
+              REQUISITES_TXT_NAME,
+              tempPath ) );
+  std::ofstream tempFile( tempPath );
+  if ( ! tempFile.is_open() )
+    {
+      throw RequisitesTxtBuildFailure( std::string( strerror( errno ) ) );
+    }
+  for ( auto storePath : closure )
+    {
+      auto sStorePath = state.store->printStorePath( storePath );
+      tempFile << sStorePath << std::endl;
+    }
+  if ( tempFile.fail() )
+    {
+      throw RequisitesTxtBuildFailure( std::string( strerror( errno ) ) );
+    }
+  tempFile.close();
+
+  /* Copy the script to the temp directory. */
+  auto requisitesTxtPath = tempDir / REQUISITES_TXT_NAME;
+  debugLog( nix::fmt( "copying requisites.txt to scripts dir: src=%s, dest=%s",
+                      tempPath,
+                      requisitesTxtPath ) );
+  std::filesystem::copy_file( tempPath, requisitesTxtPath );
+}
+
+/* -------------------------------------------------------------------------- */
 
 std::string
 activationScriptEnvironmentPath( const std::string & scriptName )

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -210,6 +210,19 @@ setup_file() {
   assert_line 'manifest.json'
 }
 
+# --------------------------------------------------------------------------- #
+
+# bats test_tags=requisites
+@test "Verify contents of requisites.txt" {
+  run "$PKGDB_BIN" buildenv "$LOCKFILES/single-package/manifest.lock"
+  assert_success
+  store_path=$(echo "$output" | jq -er '.store_path')
+  assert "$TEST" -f "${store_path}/requisites.txt"
+  nix-store -qR "${store_path}" | grep -v "${store_path}" | sort > "$BATS_TEST_TMPDIR/verify-requisites"
+  run diff "$BATS_TEST_TMPDIR/verify-requisites" "${store_path}/requisites.txt"
+  assert_success
+}
+
 # ---------------------------------------------------------------------------- #
 #
 #


### PR DESCRIPTION
## Proposed Changes

Create `requisites.txt` containing a list of all packages in the closure as a file in the top directory of the rendered flox environment.

This file can be useful for a variety of reasons, but we are adding it at this stage in preparation for the upcoming flox manifest build "sandbox" features which requires a way to discern the Nix packages that are in and out of the environment closure without having to first query narinfo data from the Nix database.

## Release Notes

N/A