### PR TITLE
feat: `flox pull --copy`

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -857,7 +857,7 @@ impl CoreEnvironment<ReadOnly> {
         &mut self,
         tempdir: impl AsRef<Path>,
     ) -> Result<CoreEnvironment<ReadWrite>, CoreEnvironmentError> {
-        copy_dir_recursive(&self.env_dir, &tempdir.as_ref(), true)
+        copy_dir_recursive(&self.env_dir, tempdir.as_ref(), true)
             .map_err(CoreEnvironmentError::MakeTemporaryEnv)?;
 
         Ok(CoreEnvironment {

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -271,7 +271,7 @@ impl Generations<ReadWrite> {
 
         // copy `env/`, i.e. manifest and lockfile (if it exists) and possibly other assets
         // copy into `<generation>/env/` to make creating `PathEnvironment` easier
-        copy_dir_recursive(&environment.path(), &env_path, true).unwrap();
+        copy_dir_recursive(environment.path(), &env_path, true).unwrap();
 
         self.repo
             .add(&[&generation_path])

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1028,8 +1028,8 @@ impl ManagedEnvironment {
             .map_err(ManagedEnvironmentError::CreateLocalEnvironmentView)?;
 
         copy_dir_recursive(
-            &current_generation.path(),
-            &self.path.join(ENV_DIR_NAME),
+            current_generation.path(),
+            self.path.join(ENV_DIR_NAME),
             true,
         )
         .map_err(ManagedEnvironmentError::CreateLocalEnvironmentView)?;
@@ -1054,8 +1054,8 @@ impl ManagedEnvironment {
             fs::create_dir_all(self.path.join(ENV_DIR_NAME))
                 .map_err(ManagedEnvironmentError::CreateLocalEnvironmentView)?;
             copy_dir_recursive(
-                &current_generation.path(),
-                &self.path.join(ENV_DIR_NAME),
+                current_generation.path(),
+                self.path.join(ENV_DIR_NAME),
                 true,
             )
             .map_err(ManagedEnvironmentError::CreateLocalEnvironmentView)?;

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -584,16 +584,16 @@ pub enum UpgradeError {
 /// 2. fs_extra::dir::copy doesn't handle symlinks.
 ///    See: https://github.com/webdesus/fs_extra/issues/61
 fn copy_dir_recursive(
-    from: &impl AsRef<Path>,
-    to: &impl AsRef<Path>,
+    from: impl AsRef<Path>,
+    to: impl AsRef<Path>,
     keep_permissions: bool,
 ) -> Result<(), std::io::Error> {
     if !to.as_ref().exists() {
-        std::fs::create_dir(to).unwrap();
+        std::fs::create_dir(&to).unwrap();
     }
-    for entry in WalkDir::new(from).into_iter().skip(1) {
+    for entry in WalkDir::new(&from).into_iter().skip(1) {
         let entry = entry.unwrap();
-        let new_path = to.as_ref().join(entry.path().strip_prefix(from).unwrap());
+        let new_path = to.as_ref().join(entry.path().strip_prefix(&from).unwrap());
         match entry.file_type() {
             file_type if file_type.is_dir() => {
                 std::fs::create_dir(new_path).unwrap();

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -92,8 +92,8 @@ impl PartialEq for PathEnvironment {
 
 impl PathEnvironment {
     pub fn new(
-        dot_flox_path: CanonicalPath,
         pointer: PathPointer,
+        dot_flox_path: CanonicalPath,
     ) -> Result<Self, EnvironmentError> {
         if &*dot_flox_path == Path::new("/") {
             return Err(EnvironmentError::InvalidPath(dot_flox_path.into_inner()));
@@ -381,7 +381,7 @@ impl PathEnvironment {
             &EnvironmentPointer::Path(pointer.clone()),
         )?;
 
-        PathEnvironment::new(dot_flox_path, pointer)
+        PathEnvironment::new(pointer, dot_flox_path)
     }
 
     /// Create a new env in a `.flox` directory within a specific path or open it if it exists.
@@ -591,8 +591,8 @@ mod tests {
         .unwrap();
 
         let expected = PathEnvironment::new(
-            CanonicalPath::new(environment_temp_dir.path().join(DOT_FLOX)).unwrap(),
             PathPointer::new("test".parse().unwrap()),
+            CanonicalPath::new(environment_temp_dir.path().join(DOT_FLOX)).unwrap(),
         )
         .unwrap();
 

--- a/cli/flox/doc/flox-pull.md
+++ b/cli/flox/doc/flox-pull.md
@@ -4,7 +4,6 @@ section: 1
 header: "Flox User Manuals"
 ...
 
-
 # NAME
 
 flox-pull - pull environment from FloxHub
@@ -14,8 +13,9 @@ flox-pull - pull environment from FloxHub
 ```
 flox [<general-options>] pull
      [-d=<path>]
-     [-a]
      [-r=<owner>/<name> | <owner>/<name> | [-f]]
+     [-f]
+     [-c]
 ```
 
 # DESCRIPTION
@@ -34,14 +34,14 @@ When pulling an environment that has already been pulled, `-d` specifies which
 environment to sync.
 If `-d` is not specified and the current directory contains an environment, that
 environment is synced.
-`-f` may only be specified in this case, forceably updating the environment
+`-f` may be specified in this case, forcibly updating the environment
 locally even if there are local changes not reflected in the remote environment.
 `<owner>/<name>` may be specified in this case and will replace the environment
 with the specified environment.
 
 A remote environment may not support the architecture or operating system of the
 local system pulling the environment,
-in which case `-a` may be passed to forceably add the current system to the
+in which case `-f` may be passed to forcibly add the current system to the
 environment's manifest.
 This may create a broken environment that cannot be pushed back to FloxHub until
 it is repaired with [`flox-edit(1)`](./flox-edit.md).
@@ -56,9 +56,6 @@ environments.
 :   Directory to pull an environment into, or directory that contains an
     environment that has already been pulled (default: current directory).
 
-`-a`, `--add-system`
-:   Forceably add current system to the environment, even if incompatible.
-
 `-r <owner>/<name>`, `--remote <owner>/<name>`
 :   ID of the environment to pull.
 
@@ -66,7 +63,15 @@ environments.
 :   ID of the environment to pull.
 
 `-f`, `--force`
-:   Forceably overwrite the local copy of the environment.
+:   Forcefully overwrite the local copy of the environment,
+    and accept any kind of modification and possibly incompatible results
+    that have to be addressed manually.
+
+`-c`, `--copy`
+:   Create a local copy of an environment by removing the connection to the
+    upstream environment on FloxHub.
+    When pulling a new environment this creates a new environment
+    that can be used locally or pushed to FloxHub under a new user or name.
 
 ```{.include}
 ./include/general-options.md

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -126,24 +126,12 @@ impl Init {
                 message: "Installing Flox suggested packages...",
                 help_message: None,
                 typed: Spinner::new(|| {
-                    PathEnvironment::init(
-                        PathPointer::new(env_name),
-                        &dir,
-                        flox.temp_dir.clone(),
-                        &customization,
-                        &flox,
-                    )
+                    PathEnvironment::init(PathPointer::new(env_name), &dir, &customization, &flox)
                 }),
             }
             .spin()?
         } else {
-            PathEnvironment::init(
-                PathPointer::new(env_name),
-                &dir,
-                flox.temp_dir.clone(),
-                &customization,
-                &flox,
-            )?
+            PathEnvironment::init(PathPointer::new(env_name), &dir, &customization, &flox)?
         };
 
         message::created(format!(

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1237,7 +1237,6 @@ impl UninitializedEnvironment {
                             flox,
                             path_pointer,
                             dot_flox_path,
-                            &flox.temp_dir,
                         )?)
                     },
                     EnvironmentPointer::Managed(managed_pointer) => {

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -131,12 +131,8 @@ impl Push {
         owner: EnvironmentOwner,
         force: bool,
     ) -> Result<ManagedEnvironment> {
-        let path_environment = path_environment::PathEnvironment::open(
-            flox,
-            path_pointer,
-            dot_flox_path,
-            &flox.temp_dir,
-        )?;
+        let path_environment =
+            path_environment::PathEnvironment::open(flox, path_pointer, dot_flox_path)?;
 
         let pointer = ManagedPointer::new(owner.clone(), path_environment.name(), &flox.floxhub);
 

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -248,7 +248,7 @@ function add_incompatible_package() {
     run "$FLOX_BIN" pull --remote owner/name --force
   assert_success
   assert_line --partial "resolution failed: package '$PACKAGE' not available for"
-  assert_line --partial "Migrated the environment to version 1 and included your system but could not"
+  assert_line --partial "Migrated the environment to version 1 and included your system"
 
   run "$FLOX_BIN" list
   assert_success


### PR DESCRIPTION
## [feat: ManagedEnvironment::into_path_environment](https://github.com/flox/flox/commit/a99d47f1099513f6a8eee202bf1ccacfa68820b6) 

Convert a `ManagedEnvironment` and its associated metadata
into a `PathEnvironment`.
Conversion entails:

- delete the associated (local) branch for this instance of the environment
- delete the generation lock which
- rewrite `.flox/env.json` as a `PathPointer

## [refactor(handle_pull_result): return deferred message context](https://github.com/flox/flox/commit/9074be32c7d71d3400bfa7cec49c011a35776ff9) 

Defer printing of the final message during result handling,
to allow conditionally displaying different headers in preparation
of adding support for `--copy`.

Copying (as implemented in the following commit) entails
1. pulling a `ManagedEnvironment`
2. handling the result of pulling the environment
   (e.g. migrating v0 manifests, adding the current system as a supported system)
3. converting the environment to a path environment

When pulling an environment regularly, the header of the message is expected to read:

    Pulled owner/name from hub.flox.dev

While pulling with `--copy` according to <https://github.com/flox/flox/issues/1226>,
is expected to terminate with:

    Created path environment from owner/name

Assuming immediate printing in 2. while respecting the current mode,
would result in the right message being printed _before_ the conversion (3.).
Consequently, the messaging would not be consistent with reality,
if the conversion was to fail.

Alternatively, converting the environment _before_ handling errors,
fails on account of migration functionality currently only being implemented
for `ManagedEnvironment` and requires catching addressable errors twice;
Once before converting to a `PathEnvironment` and a second time
during migration/incompatibility handling.

The approach chosen here, defers the printing of the final message
until after the (conditional) conversion step,
where the final header is added to the context deferred from handling the pull result.

Preferably our messaging would be more linear, allowing for context to be printed
in the order it appears during execution, rather than being accumulated and deferred
into a final custom message.

## [feat: add --copy flag and conditional conversion](https://github.com/flox/flox/commit/694b92a00e1626c58e52826fffeec342e22aafe9) 

Add a `--copy` flag to the `flox pull` command.

With this flag provided `flox pull` will first
pull the provided environment (following the existing rules)
and subsequently convert the environment to a `PathEnvironment`.
Conversion means, detaching from the upstream repository on FloxHub
(environments won't receive anymore updates form their upstream),
and amending associated environment metadata within the `.flox/` directory.

-------

Miscellaneous small refactors:

## [chore: copy_dir_recursive should take impl AsRef<Path>](https://github.com/flox/flox/commit/57d3b219fdfa0e756ee7cfa7458a990ee621cad3) 

The current signature asks enforces borrowed arguments.
although, a blanket implementation `impl AsRef<Path> for &T where T: AsRef<Path>` exists.

## [refactor: remove PathEnvironment::temp_dir field](https://github.com/flox/flox/commit/e8c68b7bbcb993ac222de95b37277242ea3e62d4) 

All usages of the `temp_dir` attribute have been replaced
by referencing `flox.temp_dir` directly, rendering the attribute obsolete.
