### PR TITLE
fix: support fish 3.2.2

### DIFF
--- a/assets/activation-scripts/activate.d/fish
+++ b/assets/activation-scripts/activate.d/fish
@@ -14,7 +14,7 @@ end
 # Assert that the expected _{add,del}_env variables are present.
 if test -z "$_add_env" -o -z "$_del_env"
   echo 'ERROR (fish): $_add_env and $_del_env not found in environment' >&2
-  return 1
+  exit 1
 end
 
 # The fish --init-command option allows us to source our startup
@@ -23,8 +23,8 @@ end
 # as we do in bash.
 
 # Restore environment variables set in the previous bash initialization.
-eval "$($_gnused/bin/sed -e 's/^/set -e /' -e 's/$/;/' $_del_env)"
-eval "$($_gnused/bin/sed -e 's/^/set -gx /' -e 's/=/ /' -e 's/$/;/' $_add_env)"
+$_gnused/bin/sed -e 's/^/set -e /' -e 's/$/;/' $_del_env | source
+$_gnused/bin/sed -e 's/^/set -gx /' -e 's/=/ /' -e 's/$/;/' $_add_env | source
 
 # Set the prompt if we're in an interactive shell.
 if isatty 1

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2320,7 +2320,7 @@ EOF
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/rust-lib-src.json" \
     "$FLOX_BIN" install rustPlatform.rustLibSrc
-  
+
   run "$FLOX_BIN" activate -- bash <(cat <<'EOF'
     if ! [ -e "$FLOX_ENV/etc/profile.d/0501_rust.sh" ]; then
       echo "profile script did not exist" >&3
@@ -2333,4 +2333,22 @@ EOF
 EOF
 )
   assert_success
+}
+
+@test "activate works with fish 3.2.2" {
+  if [ "$NIX_SYSTEM" == aarch64-linux ]; then
+    # running fish at all on aarch64-linux throws:
+    # terminate called after throwing an instance of 'std::bad_alloc'
+    #   what():  std::bad_alloc
+    skip "fish 3.2.2 is broken on aarch64-linux"
+  fi
+  project_setup
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/fish_3_2_2.json" \
+    "$FLOX_BIN" install fish@3.2.2
+
+  FLOX_SHELL="./.flox/run/$NIX_SYSTEM.$PROJECT_NAME/bin/fish" run "$FLOX_BIN" activate -- echo "\$FISH_VERSION"
+  assert_success
+  # fish doesn't have the equivalent of set -e, so refute "Error"
+  refute_output --partial Error
+  assert_output --partial "3.2.2"
 }

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -94,6 +94,10 @@ cmd = '''
 '''
 ignore_cmd_errors = true # build will fail on linux, thats fine
 
+[resolve.fish_3_2_2]
+pre_cmd = "flox init"
+cmd = "flox install fish@3.2.2"
+
 [resolve.hello]
 pre_cmd = "flox init"
 cmd = "flox install hello"

--- a/test_data/generated/resolve/fish_3_2_2.json
+++ b/test_data/generated/resolve/fish_3_2_2.json
@@ -1,0 +1,140 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "fish",
+            "broken": false,
+            "derivation": "/nix/store/iq8lc5nzgrinjyjikdwwismllws4cg9z-fish-3.2.2.drv",
+            "description": "Smart and user-friendly command line shell",
+            "install_id": "fish",
+            "license": "GPL-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
+            "name": "fish-3.2.2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/an3v67vnw060gkzaynqm1szif38k27q7-fish-3.2.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "fish",
+            "rev": "e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
+            "rev_count": 297796,
+            "rev_date": "2021-06-25T13:06:37Z",
+            "scrape_date": "2024-08-16T04:26:35Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "3.2.2"
+          },
+          {
+            "attr_path": "fish",
+            "broken": false,
+            "derivation": "/nix/store/kzl04x6vpcbdhsl49m8rkqlxj0ijjcm9-fish-3.2.2.drv",
+            "description": "Smart and user-friendly command line shell",
+            "install_id": "fish",
+            "license": "GPL-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
+            "name": "fish-3.2.2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/g5lwfa2fg9jgb88ndvni2azq32bgzz12-fish-3.2.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "fish",
+            "rev": "e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
+            "rev_count": 297796,
+            "rev_date": "2021-06-25T13:06:37Z",
+            "scrape_date": "2024-08-16T04:26:35Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "3.2.2"
+          },
+          {
+            "attr_path": "fish",
+            "broken": false,
+            "derivation": "/nix/store/s6rwx318lf4p6i0vavr13l3xks06b0ip-fish-3.2.2.drv",
+            "description": "Smart and user-friendly command line shell",
+            "install_id": "fish",
+            "license": "GPL-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
+            "name": "fish-3.2.2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/p9g3vq3v5xln1np4dcxz9fmr1k4risjx-fish-3.2.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "fish",
+            "rev": "e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
+            "rev_count": 297796,
+            "rev_date": "2021-06-25T13:06:37Z",
+            "scrape_date": "2024-08-16T04:26:35Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "3.2.2"
+          },
+          {
+            "attr_path": "fish",
+            "broken": false,
+            "derivation": "/nix/store/1myn8ym7qdrm2gppm7szxr8zqzn372cx-fish-3.2.2.drv",
+            "description": "Smart and user-friendly command line shell",
+            "install_id": "fish",
+            "license": "GPL-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
+            "name": "fish-3.2.2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/hczcmlqr9ksl86qa1pm072k791piblfd-fish-3.2.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "fish",
+            "rev": "e1f8852faac7638e88d5e8a5b9ee2a7568685e3f",
+            "rev_count": 297796,
+            "rev_date": "2021-06-25T13:06:37Z",
+            "scrape_date": "2024-08-16T04:26:35Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "3.2.2"
+          }
+        ],
+        "page": 297796,
+        "url": ""
+      }
+    }
+  ]
+]


### PR DESCRIPTION
fish 3.2.2 fails due to our usage of return outside of a function and `$(...)`

Before this commit, the test added in this commit fails with:
```
   /private/var/folders/2w/r9qm37r12qs4xn3sjn4cv2ym0000gn/T/nix-shell.JcSQ0t/bats-run-MtPfNW/test/1/project-1/.flox/run/aarch64-darwin.project-1/activate.d/fish (line 17): 'return' outside of function definition
     return 1
     ^
   from sourcing file /private/var/folders/2w/r9qm37r12qs4xn3sjn4cv2ym0000gn/T/nix-shell.JcSQ0t/bats-run-MtPfNW/test/1/project-1/.flox/run/aarch64-darwin.project-1/activate.d/fish
   source: Error while reading file “/private/var/folders/2w/r9qm37r12qs4xn3sjn4cv2ym0000gn/T/nix-shell.JcSQ0t/bats-run-MtPfNW/test/1/project-1/.flox/run/aarch64-darwin.project-1/activate.d/fish”
```

Fix this by using exit 1 instead of return 1.

After changing that, there is still an error for:

`$(...) is not supported. In fish, please use '(_gnused/bin/sed)'`

Fix this by piping to source.