### PR TITLE
test: add set -x for overmind test

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1508,7 +1508,10 @@ EOF
   echo "sleep: sleep 999999" > ./Procfile
 
   SCRIPT="$(cat << "EOF"
-    set -euo pipefail
+    # The timeout below has timed out,
+    # but it's hard to reproduce,
+    # so add set -x for more info in the future.
+    set -euxo pipefail
     source "${TESTS_DIR}/services/register_cleanup.sh"
 
     timeout 2 bash -c "while ! overmind status; do sleep .1; done"


### PR DESCRIPTION
The `kills daemon process` test flaked in
https://github.com/flox/flox/actions/runs/10742333592/job/29794735526#step:8:297

It's unclear why that run flaked. `overmind status` printed something, and it doesn't seem to have ever failed since there is no output for failure to connect.

It's odd that PID 0 was printed, but when run locally, that happens occasionally when `overmind start` and `overmind status` are racing. Locally, that still exits 0.

So it seems `overmind status` should have succeeded, but then timeout still timed out.

Add set -x to help with debugging in the future.