### PR TITLE
test: add another set -x for debugging

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1597,7 +1597,7 @@ EOF
     set -euxo pipefail
     source "${TESTS_DIR}/services/register_cleanup.sh"
 
-    timeout 2 bash -c "while ! overmind status; do sleep .1; done"
+    timeout 2 bash -c "set -x; while ! overmind status; do sleep .1; done"
 
     "$FLOX_BIN" services status
     "$FLOX_BIN" services stop


### PR DESCRIPTION
Add a set -x for the bash subshell invocation to help with debugging a flakey test.