### PR TITLE
fix: deserialize MessageType's other than Unknown

### DIFF
--- a/cli/catalog-api-v1/src/error.rs
+++ b/cli/catalog-api-v1/src/error.rs
@@ -2,8 +2,16 @@ use std::hash::Hash;
 
 use serde::{Deserialize, Serialize};
 
+/// Type of the error returned by the catalog API
+/// Since we were unable to represent earlier error structures returned by the API
+/// using the progenitor client generator,
+/// errors are now serialized as a blob of values
+/// (`context` in [crate::ResolutionMessageGeneral]).
+///
+/// The context may be parsed into a higher level structure later,
+/// or ignored in which case the `message` field in [crate::ResolutionMessageGeneral]
+/// is expected to provide a relevant fallback message.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[serde(untagged)]
 pub enum MessageType {
     #[serde(rename = "general")]
     General,
@@ -14,5 +22,30 @@ pub enum MessageType {
     #[serde(rename = "constraints_too_tight")]
     ConstraintsTooTight,
 
+    #[serde(untagged)]
     Unknown(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+
+    use super::*;
+    #[test]
+    #[ignore = "useful when developing"]
+    fn deserializes_known_and_unknown_variants() {
+        let map: HashMap<String, MessageType> = serde_json::from_value(json!({
+         "known_type": "constraints_too_tight",
+         "unknown_type": "something unknown"
+        }))
+        .unwrap();
+
+        assert_eq!(map["known_type"], MessageType::ConstraintsTooTight);
+        assert_eq!(
+            map["unknown_type"],
+            MessageType::Unknown("something unknown".to_string())
+        );
+    }
 }


### PR DESCRIPTION
456cc7b07052e84571d514b395609f608a962850 made MessageType an untagged enum so that the Unknown variant would deserialize correctly, but this meant that all strings would deserialize as Unknown rather than being deserialized into the correct variant. "constraints_too_tight" for example was being deserialized as `Unknown("constraints_too_tight")`.

The Unknown variant should be untagged, but the enum as a whole should not be.