### PR TITLE
test: process-compose shutdown race

### DIFF
--- a/cli/tests/services/start_shuts_down_process_compose.sh
+++ b/cli/tests/services/start_shuts_down_process_compose.sh
@@ -22,6 +22,11 @@ process_compose_pids_called_with_arg() {
 
 process_compose_pids_before="$(process_compose_pids_called_with_arg "$(pwd)/.flox/run")"
 "$FLOX_BIN" services start
-process_compose_pids_after="$(process_compose_pids_called_with_arg "$(pwd)/.flox/run")"
 
-[[ "$process_compose_pids_after" != *"$process_compose_pids_before"* ]]
+export process_compose_pids_before
+export -f process_compose_pids_called_with_arg
+timeout 2s bash -c '
+  while [[ "$process_compose_pids_before" == "$(process_compose_pids_called_with_arg "$(pwd)/.flox/run")" ]]; do
+    sleep 0.1
+  done
+'


### PR DESCRIPTION
I ran into this test flaking locally. `flox services start` calls `process-compose down`, but `process-compose down` is not blocking, so `flox services start` may exit before `process-compose` exits.

Add a polling loop to wait for `process-compose` to exit.