### PR TITLE
chore: set default for manifest builds to sandbox = "off"

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn build_sandbox_pure_as_default() {
+    fn build_sandbox_pure() {
         let package_name = String::from("foo");
         let file_name = String::from("bar");
         let file_content = String::from("some content");
@@ -335,6 +335,7 @@ mod tests {
             version = 1
 
             [build.{package_name}]
+            sandbox = "pure"
             command = """
                 mkdir $out
                 cp {file_name} $out/{file_name}
@@ -354,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    fn build_sandbox_off() {
+    fn build_sandbox_off_as_default() {
         let package_name = String::from("foo");
         let file_name = String::from("bar");
         let file_content = String::from("some content");
@@ -363,7 +364,6 @@ mod tests {
             version = 1
 
             [build.{package_name}]
-            sandbox = "off"
             command = """
                 mkdir $out
                 cp {file_name} $out/{file_name}
@@ -508,6 +508,7 @@ mod tests {
             hello.pkg-path = "hello"
 
             [build.{package_name}]
+            sandbox = "pure"
             command = """
                 mkdir $out
                 type hello | grep -o "{file_content}" > $out/{file_name}

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -150,7 +150,7 @@ endif
 
 # The following template renders targets for the in-situ build mode.
 define BUILD_local_template =
-  $(eval _virtualSandbox = $(filter-out off,$(_sandbox)))
+  $(eval _virtualSandbox = $(filter-out null off,$(_sandbox)))
 
   .INTERMEDIATE: $(_pname)_local_build
   $(_pname)_local_build: $($(_pvarname)_buildScript)
@@ -314,9 +314,9 @@ $(foreach build,$(BUILDS), \
   $(eval _pname = $(notdir $(build))) \
   $(eval _sandbox = $(shell \
     $(_jq) -r '.manifest.build."$(_pname)".sandbox' $(MANIFEST_LOCK))) \
-  $(if $(filter null pure,$(_sandbox)), \
-    $(eval $(call BUILD_template,nix_sandbox)), \
-    $(eval $(call BUILD_template,local))))
+  $(if $(filter null off,$(_sandbox)), \
+    $(eval $(call BUILD_template,local)), \
+    $(eval $(call BUILD_template,nix_sandbox))))
 
 # Finally, we create the "all" target to build all known packages.
 .PHONY: all


### PR DESCRIPTION
## Proposed Changes

Change the interpretation of "null" when reading the sandbox value from the manifest.lock to instead mean that sandbox should be set to "off" as described in #2107.

## Release Notes

N/A