### PR TITLE
feat: attempt install with reduced systems  

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -1305,14 +1305,7 @@ pub fn insert_packages(
             let mut descriptor_table = InlineTable::new();
             match pkg {
                 PackageToInstall::Catalog(pkg) => {
-                    descriptor_table.insert(
-                        "pkg-path",
-                        Value::String(Formatted::new(pkg.pkg_path.clone())),
-                    );
-                    if let Some(ref version) = pkg.version {
-                        descriptor_table
-                            .insert("version", Value::String(Formatted::new(version.clone())));
-                    }
+                    descriptor_table = InlineTable::from(pkg);
                     debug!(
                         "package newly installed: id={}, pkg-path={}",
                         pkg.id, pkg.pkg_path

--- a/cli/flox/src/commands/init/go.rs
+++ b/cli/flox/src/commands/init/go.rs
@@ -150,6 +150,7 @@ impl InitHook for Go {
                 id: "go".to_string(),
                 pkg_path: "go".to_string(),
                 version: go_version,
+                systems: None,
             }]),
         }
     }

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -461,8 +461,8 @@ impl From<ProvidedPackage> for CatalogPackage {
         CatalogPackage {
             id: value.name,
             pkg_path: value.rel_path.into(),
-
             version: value.version,
+            systems: None,
         }
     }
 }
@@ -695,11 +695,13 @@ mod tests {
                         id: "pip".to_string(),
                         pkg_path: "python311Packages.pip".to_string(),
                         version: None,
+                        systems: None,
                     },
                     CatalogPackage {
                         id: "package2".to_string(),
                         pkg_path: "path2".to_string(),
                         version: None,
+                        systems: None,
                     },
                 ]),
             },
@@ -715,11 +717,13 @@ mod tests {
                         id: "pip".to_string(),
                         pkg_path: "python311Packages.pip".to_string(),
                         version: None,
+                        systems: None,
                     },
                     CatalogPackage {
                         id: "package1".to_string(),
                         pkg_path: "path1".to_string(),
                         version: None,
+                        systems: None,
                     },
                 ]),
             },
@@ -804,16 +808,19 @@ mod tests {
                     id: "package1".to_string(),
                     pkg_path: "path1".to_string(),
                     version: None,
+                    systems: None,
                 },
                 CatalogPackage {
                     id: "package2".to_string(),
                     pkg_path: "path2".to_string(),
                     version: None,
+                    systems: None,
                 },
                 CatalogPackage {
                     id: "pip".to_string(),
                     pkg_path: "python311Packages.pip".to_string(),
                     version: None,
+                    systems: None,
                 },
             ]),
         });

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -650,6 +650,7 @@ impl InitHook for Node {
                     // TODO: we probably shouldn't pin this when we're just
                     // providing the default
                     version: yarn_install.yarn.version.clone(),
+                    systems: None,
                 });
                 Some(YARN_HOOK.to_string())
             },
@@ -662,11 +663,13 @@ impl InitHook for Node {
                         id: "nodejs".to_string(),
                         pkg_path: result.rel_path.clone().into(),
                         version: result.version.clone(),
+                        systems: None,
                     },
                     None => CatalogPackage {
                         id: "nodejs".to_string(),
                         pkg_path: "nodejs".to_string(),
                         version: None,
+                        systems: None,
                     },
                 };
                 packages.push(nodejs_to_install);
@@ -778,6 +781,7 @@ mod tests {
                     id: "yarn".to_string(),
                     pkg_path: "yarn.path".to_string(),
                     version: Some("1".to_string()),
+                    systems: None,
                 }]),
                 hook_on_activate: Some(YARN_HOOK.to_string()),
                 profile_common: None,
@@ -829,6 +833,7 @@ mod tests {
                     id: "nodejs".to_string(),
                     pkg_path: "nodejs.path".to_string(),
                     version: Some("1".to_string()),
+                    systems: None,
                 }]),
                 hook_on_activate: Some(NPM_HOOK.to_string()),
                 profile_common: None,
@@ -862,6 +867,7 @@ mod tests {
                     id: "nodejs".to_string(),
                     pkg_path: "nodejs.path".to_string(),
                     version: Some("1".to_string()),
+                    systems: None,
                 }]),
                 hook_on_activate: None,
                 profile_common: None,

--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -452,11 +452,13 @@ impl Provider for PoetryPyProject {
                     id: "python3".to_string(),
                     pkg_path: "python3".to_string(),
                     version: python_version,
+                    systems: None,
                 },
                 CatalogPackage {
                     id: "poetry".to_string(),
                     pkg_path: "poetry".to_string(),
                     version: None,
+                    systems: None,
                 },
             ]),
         }
@@ -648,6 +650,7 @@ impl Provider for PyProject {
                 id: "python3".to_string(),
                 pkg_path: "python3".to_string(),
                 version: python_version,
+                systems: None,
             }]),
         }
     }
@@ -799,6 +802,7 @@ impl Provider for Requirements {
                 id: "python3".to_string(),
                 pkg_path: "python3".to_string(),
                 version: None,
+                systems: None,
             }]),
         }
     }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -333,6 +333,7 @@ mod tests {
             id: foo_iid.clone(),
             pkg_path: "foo".to_string(),
             version: None,
+            systems: None,
         }];
         assert_eq!(
             Install::generate_warnings(&locked_packages, &packages_to_install),
@@ -361,6 +362,7 @@ mod tests {
             id: foo_iid.clone(),
             pkg_path: "foo".to_string(),
             version: None,
+            systems: None,
         }];
         assert_eq!(
             Install::generate_warnings(&locked_packages, &packages_to_install),
@@ -381,6 +383,7 @@ mod tests {
             id: foo_iid.clone(),
             pkg_path: "foo".to_string(),
             version: None,
+            systems: None,
         }];
         assert_eq!(
             Install::generate_warnings(&locked_packages, &packages_to_install),
@@ -409,6 +412,7 @@ mod tests {
             id: foo_iid.clone(),
             pkg_path: "foo".to_string(),
             version: None,
+            systems: None,
         }];
         assert_eq!(
             Install::generate_warnings(&locked_packages, &packages_to_install),

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -29,11 +29,16 @@ pre_cmd = "flox init"
 cmd = "flox install badpkg1 badpkg2"
 ignore_cmd_errors = true
 
+# Install a package that doesn't exist and a another that does only exist on Linux
+[resolve.badpkg_bpftrace]
+pre_cmd = "flox init"
+cmd = "flox install badpkg bpftrace"
+ignore_cmd_errors = true
+
 # Install a package that only exists on Linux
 [resolve.bpftrace]
 pre_cmd = "flox init"
 cmd = "flox install bpftrace"
-ignore_cmd_errors = true
 
 # Install multiple packages that only exist on Linux
 [resolve.bpftrace_systemd]

--- a/test_data/generated/resolve/badpkg_bpftrace.json
+++ b/test_data/generated/resolve/badpkg_bpftrace.json
@@ -1,0 +1,34 @@
+[
+  [
+    {
+      "msgs": [
+        {
+          "AttrPathNotFoundNotInCatalog": {
+            "attr_path": "badpkg",
+            "install_id": "badpkg",
+            "level": "error",
+            "msg": "The attr_path badpkg is not found in the catalog."
+          }
+        },
+        {
+          "AttrPathNotFoundNotFoundForAllSystems": {
+            "attr_path": "bpftrace",
+            "install_id": "bpftrace",
+            "level": "error",
+            "msg": "The attr_path bpftrace is not found for all the requested systems, suggest limiting systems to (aarch64-linux,x86_64-linux).",
+            "valid_systems": [
+              "aarch64-linux",
+              "x86_64-linux"
+            ]
+          }
+        }
+      ],
+      "name": "toplevel",
+      "page": null
+    }
+  ],
+  {
+    "count": 0,
+    "results": []
+  }
+]

--- a/test_data/generated/resolve/bpftrace.json
+++ b/test_data/generated/resolve/bpftrace.json
@@ -18,5 +18,91 @@
       "name": "toplevel",
       "page": null
     }
+  ],
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "bpftrace",
+            "broken": false,
+            "derivation": "/nix/store/iskf0w9ijnpswyd6jh1yc0aba164alj4-bpftrace-0.21.2.drv",
+            "description": "High-level tracing language for Linux eBPF",
+            "insecure": false,
+            "install_id": "bpftrace",
+            "license": "Apache-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "name": "bpftrace-0.21.2",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/7x4y4vdjdqq5vw6m4v06k41wrwsvckqp-bpftrace-0.21.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/nsxhqzrcpy1r3a0f0z06bjy3mkck5vyc-bpftrace-0.21.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "bpftrace",
+            "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "rev_count": 681973,
+            "rev_date": "2024-09-16T05:08:36Z",
+            "scrape_date": "2024-09-18T03:14:07Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "0.21.2"
+          },
+          {
+            "attr_path": "bpftrace",
+            "broken": false,
+            "derivation": "/nix/store/32cmsz189h00nkgjg874v78qiniya6dn-bpftrace-0.21.2.drv",
+            "description": "High-level tracing language for Linux eBPF",
+            "insecure": false,
+            "install_id": "bpftrace",
+            "license": "Apache-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "name": "bpftrace-0.21.2",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/4zsnhbragvvyf9qksk84wqswd9xb8lcw-bpftrace-0.21.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/k56kgsknbvis83wgviacg3j3rp85p8fk-bpftrace-0.21.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "bpftrace",
+            "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "rev_count": 681973,
+            "rev_date": "2024-09-16T05:08:36Z",
+            "scrape_date": "2024-09-18T03:14:07Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "0.21.2"
+          }
+        ],
+        "page": 681973,
+        "url": ""
+      }
+    }
   ]
 ]

--- a/test_data/generated/resolve/bpftrace_systemd.json
+++ b/test_data/generated/resolve/bpftrace_systemd.json
@@ -30,5 +30,179 @@
       "name": "toplevel",
       "page": null
     }
+  ],
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "bpftrace",
+            "broken": false,
+            "derivation": "/nix/store/iskf0w9ijnpswyd6jh1yc0aba164alj4-bpftrace-0.21.2.drv",
+            "description": "High-level tracing language for Linux eBPF",
+            "insecure": false,
+            "install_id": "bpftrace",
+            "license": "Apache-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "name": "bpftrace-0.21.2",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/7x4y4vdjdqq5vw6m4v06k41wrwsvckqp-bpftrace-0.21.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/nsxhqzrcpy1r3a0f0z06bjy3mkck5vyc-bpftrace-0.21.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "bpftrace",
+            "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "rev_count": 681973,
+            "rev_date": "2024-09-16T05:08:36Z",
+            "scrape_date": "2024-09-18T03:14:07Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "0.21.2"
+          },
+          {
+            "attr_path": "bpftrace",
+            "broken": false,
+            "derivation": "/nix/store/32cmsz189h00nkgjg874v78qiniya6dn-bpftrace-0.21.2.drv",
+            "description": "High-level tracing language for Linux eBPF",
+            "insecure": false,
+            "install_id": "bpftrace",
+            "license": "Apache-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "name": "bpftrace-0.21.2",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/4zsnhbragvvyf9qksk84wqswd9xb8lcw-bpftrace-0.21.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/k56kgsknbvis83wgviacg3j3rp85p8fk-bpftrace-0.21.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "bpftrace",
+            "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "rev_count": 681973,
+            "rev_date": "2024-09-16T05:08:36Z",
+            "scrape_date": "2024-09-18T03:14:07Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "0.21.2"
+          },
+          {
+            "attr_path": "systemd",
+            "broken": false,
+            "derivation": "/nix/store/8c86p7b0kpn7czrf7spdh5q54z29a9d6-systemd-256.4.drv",
+            "description": "System and service manager for Linux",
+            "insecure": false,
+            "install_id": "systemd",
+            "license": "[ BSD-2-Clause, BSD-3-Clause, CC0-1.0, LGPL-2.1-or-later, LGPL-2.0-or-later, MIT, MIT-0, OFL-1.1, Public Domain ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "name": "systemd-256.4",
+            "outputs": [
+              {
+                "name": "dev",
+                "store_path": "/nix/store/8mh4f6gs5569br2j4z2hvr69822cbrsf-systemd-256.4-dev"
+              },
+              {
+                "name": "man",
+                "store_path": "/nix/store/kgfcllangf3njr0fybmq9kfbpcszcvqx-systemd-256.4-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/p0n0m1j2lzz1kmrxk1pxq9pb4x7mlk0i-systemd-256.4"
+              },
+              {
+                "name": "debug",
+                "store_path": "/nix/store/z2m4s8ygnjsg55a6723lhmr04409j07w-systemd-256.4-debug"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "systemd",
+            "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "rev_count": 681973,
+            "rev_date": "2024-09-16T05:08:36Z",
+            "scrape_date": "2024-09-18T03:14:07Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "256.4"
+          },
+          {
+            "attr_path": "systemd",
+            "broken": false,
+            "derivation": "/nix/store/qb8izq5fyjv2g1qasqq8isijrsjff231-systemd-256.4.drv",
+            "description": "System and service manager for Linux",
+            "insecure": false,
+            "install_id": "systemd",
+            "license": "[ BSD-2-Clause, BSD-3-Clause, CC0-1.0, LGPL-2.1-or-later, LGPL-2.0-or-later, MIT, MIT-0, OFL-1.1, Public Domain ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "name": "systemd-256.4",
+            "outputs": [
+              {
+                "name": "dev",
+                "store_path": "/nix/store/bymhjvlyylz4m33dbv0wfw3cybxpp9rb-systemd-256.4-dev"
+              },
+              {
+                "name": "man",
+                "store_path": "/nix/store/x9dj2pb8jzaswkjmgsaddg43hcy4r4sn-systemd-256.4-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4"
+              },
+              {
+                "name": "debug",
+                "store_path": "/nix/store/0klm6f7ill0qb4aavq93m0rpf0y5z0hj-systemd-256.4-debug"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "systemd",
+            "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+            "rev_count": 681973,
+            "rev_date": "2024-09-16T05:08:36Z",
+            "scrape_date": "2024-09-18T03:14:07Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "256.4"
+          }
+        ],
+        "page": 681973,
+        "url": ""
+      }
+    }
   ]
 ]


### PR DESCRIPTION
Currently installing packages through `Environment::install`
always installs packages for _all_ systems.
In case a package is not available on all platforms,
the package can only be installed by manually editing the manifest.

## [refactor: add systems field to PackageToInstall::CatalogPackage](https://github.com/flox/flox/pull/2110/commits/d923eaab7e08743dee4dc71235742ec3e04888ab) 

This commit adds a `system` field to the `PackageToInstall` variant
for catalog packages, to allow callers to amend the systems
that the package is installed for.
Since we do not have a formal syntax to expose this on the CLI,
the `FromStr` implementation remains unchanged and will not explicitly
restrict the systems in any way.

## [feat: attempt install with reduced systems](https://github.com/flox/flox/pull/2110/commits/a946fa3b49540dc68b2e0b8e8365a6f967843205)

During `flox install`, when all resolution errors are "package unavailable on some systems",
modify the `systems` attribute in the original list of packages to install,
to match the suggested systems returned by the catalog service
and attempt to install again.


* Warn if the catalog service returned nonsensical data.
That is resolution errors for install-ids that were not requested,
or resolution errors for non-catalog packages.

* test: amend tests for unsupported packages

* test: cannot install with reduced systems with other failures
When a resolution fails with errors other than missing systems,
do not attempt installing with suggested constraints.
Instead, format the error as before.