### PR TITLE
ci: run integ-tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         run: |
           nix develop -L --no-update-lock-file --command just integ-tests --\
             --filter-tags '"${{ matrix.test-tags }}"' \
-            --jobs "$(nproc)" \
+            --jobs 4 \
             --no-parallelize-across-files
 
       - name: "Capture process tree for failing tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,11 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           AUTH0_FLOX_DEV_CLIENT_SECRET: "${{ secrets.MANAGED_AUTH0_FLOX_DEV_CLIENT_SECRET }}"
-        run: nix develop -L --no-update-lock-file --command just integ-tests --  --filter-tags '"${{ matrix.test-tags }}"'
+        run: |
+          nix develop -L --no-update-lock-file --command just integ-tests --\
+            --filter-tags '"${{ matrix.test-tags }}"' \
+            --jobs "$(nproc)" \
+            --no-parallelize-across-files
 
       - name: "Capture process tree for failing tests"
         if: ${{ failure() }}

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -30,7 +30,6 @@ mod utils;
 
 async fn run(args: FloxArgs) -> Result<()> {
     init_logger(Some(args.verbosity));
-    set_user()?;
     set_parent_process_id();
     populate_default_nix_env_vars();
     let config = config::Config::parse()?;
@@ -78,6 +77,11 @@ fn main() -> ExitCode {
             .run_inner(Args::current_args())
             .unwrap_or_default()
     };
+
+    if let Err(err) = set_user() {
+        message::error(err.to_string());
+        return ExitCode::from(1);
+    }
 
     let disable_metrics = config::Config::parse()
         .unwrap_or_default()

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -77,6 +77,8 @@ EOF
 setup_file() {
   common_file_setup
   user_dotfiles_setup
+
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -93,6 +93,7 @@ setup() {
 teardown() {
   # Wait for watchdogs before project teardown, otherwise some tests will hang
   # forever.
+  #
   # I'm guessing this is because the watchdog and process-compose have logfiles
   # in the project directory,
   # so maybe one of them tries to log something and hangs.
@@ -101,6 +102,14 @@ teardown() {
   # See https://github.com/flox/flox/actions/runs/10820753745/job/30021432134#step:9:26
   # I'd check the logs to confirm what's happening...
   # ...if only the reproducer wasn't to delete the logs.
+  #
+  # When running in parallel `wait_for_watchdogs`
+  # may wait for watchdog processes of unrelated tests.
+  # It tries to avoid non-test processes by looking for the data dir argument,
+  # passed to the watchdog process.
+  # Within the `services` tests, we call `setup_isolated_flox` during `setup()`,
+  # which sets the data dir to a unique value for every test,
+  # thus avoiding waiting for unrelated watchdog processes.
   wait_for_watchdogs
   project_teardown
   common_test_teardown

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -214,8 +214,6 @@ wait_for_watchdogs() {
 }
 
 common_test_teardown() {
-  wait_for_watchdogs
-
   # Delete test tmpdir unless the user requests to preserve them.
   # XXX: We do not attempt to delete envs here.
   if [[ -z "${FLOX_TEST_KEEP_TMP:-}" ]]; then rm -rf "$BATS_TEST_TMPDIR"; fi


### PR DESCRIPTION
## [ci: run integ-tests in parallel](https://github.com/flox/flox/commit/eb8d816253f6cdc536285857a8e52da2ad69d83d)

* Run bats tests with `--jobs $(nproc)`.
* Disallow parallel runs across files
* Do not run `activate` tests in parallel
These tests break frequently, likely do to $HOME/$USER discrepancy.## Proposed Changes

## [refactor: set euid user earlier](https://github.com/flox/flox/commit/7c78b0cbce756b34c3709155cf1539d90a75d1c2) 

Run the `set_user` function earlier to allow `config` to read from the right user.