### PR TITLE
fix(build): Consistent errors when $out is not populated

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -290,6 +290,33 @@ mod tests {
     }
 
     #[test]
+    fn build_no_dollar_out_sandbox_off() {
+        let package_name = String::from("foo");
+
+        let manifest = formatdoc! {r#"
+            version = 1
+
+            [build.{package_name}]
+            command = "[ ! -e $out ]"
+            sandbox = "off"
+        "#};
+
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, &manifest);
+
+        let output = assert_build_status(&flox, &mut env, &package_name, false);
+
+        // Weird string formatting because indoc strips leading whitespace
+        assert!(output.stdout.contains(
+            r#"
+       > ERROR: Build command did not copy outputs to '$out'.
+       > - copy a single file with 'cp bin $out'
+       > - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
+       > - copy files from an Autotools project with 'make install PREFIX=$out'"#
+        ));
+    }
+
+    #[test]
     #[ignore = "TODO: `files` isn't currently passed to or parsed by `flox-build.mk`."]
     fn build_includes_files() {
         let package_name = String::from("foo");

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -25,6 +25,13 @@ assert (srcTarball != null) -> (buildScript != null); let
     if (buildCache == null)
     then null
     else (/. + buildCache);
+  dollar_out_error_and_exit = ''
+    echo "ERROR: Build command did not copy outputs to '\$out'." 1>&2
+    echo "- copy a single file with 'cp bin \$out'" 1>&2
+    echo "- copy multiple files with 'mkdir -p \$out && cp bin/* \$out/'" 1>&2
+    echo "- copy files from an Autotools project with 'make install PREFIX=\$out'" 1>&2
+    exit 1
+  '';
 in
   pkgs.runCommandNoCC name {
     inherit buildInputs srcTarball;


### PR DESCRIPTION
## Proposed Changes

**fix(build): impure build error when no $out**

Raise a clearer error if a build script doesn't write anything to `$out`
before the contents are passed to `nix build`.

It's worth noting that `$out` should not be interpolated because it has
a special user-facing meaning that they should reference in their build
commands and there won't be anything to inspect at the interpolated path
because this error is only triggered when the path doesn't exist.

The previous error looked like this:

    % FLOX_FEATURES_BUILD=true ft build
    make: Entering directory '/Users/dcarley/tmp'
    Rendering foo build script to /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.V2I4sp/9686f39a-foo-build.bash
    Building foo-0.0.0 in local mode
    MAKEFLAGS= out=/tmp/store_9686f39a3ff6d4f9d37cf289816940e7-foo-0.0.0 /Users/dcarley/tmp/.flox/run/aarch64-darwin.tmp/activate --turbo -- /nix/store/jscar2jpx1x1mnlw37igfp0j0jgz2adx-bash-interactive-5.2p26/bin/bash -e /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.V2I4sp/9686f39a-foo-build.bash
    foo
    set -o pipefail && /nix/store/0gsq84l1imlir3xlqd6s16lgxlbq6fnf-nix-2.18.5/bin/nix --extra-experimental-features "flakes nix-command" build -L --file /nix/store/p341bwldmd3lv2yxq16pv6dndvmlzsmi-package-builder-1.0.0/libexec/build-manifest.nix --argstr name "foo-0.0.0" --argstr flox-env "/Users/dcarley/tmp/.flox/run/aarch64-darwin.tmp" --argstr install-prefix "/tmp/store_9686f39a3ff6d4f9d37cf289816940e7-foo-0.0.0" --out-link "result-foo" 2>&1 | /nix/store/pldbvp0p2z2pa76h17g797vvk201155r-coreutils-9.5/bin/tee /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.V2I4sp/tmp.N4ArPUHvvx-build-foo.log
    error (ignored): error: end of string reached
    error:
           … while calling the 'derivationStrict' builtin

             at /builtin/derivation.nix:9:12: (source not available)

           … while evaluating derivation 'foo-0.0.0'
             whose name attribute is located at /nix/store/72vz3idq9zwhmsbc0xssnyq52iziwlgy-source/pkgs/stdenv/generic/make-derivation.nix:334:7

           … while evaluating attribute 'buildCommand' of derivation 'foo-0.0.0'

             at /nix/store/72vz3idq9zwhmsbc0xssnyq52iziwlgy-source/pkgs/build-support/trivial-builders/default.nix:68:16:

               67|         enableParallelBuilding = true;
               68|         inherit buildCommand name;
                 |                ^
               69|         passAsFile = [ "buildCommand" ]

           error: getting status of '/tmp/store_9686f39a3ff6d4f9d37cf289816940e7-foo-0.0.0': No such file or directory
    make: *** [/nix/store/p341bwldmd3lv2yxq16pv6dndvmlzsmi-package-builder-1.0.0/libexec/flox-build.mk:315: foo_local_build] Error 1
    rm /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.V2I4sp/9686f39a-foo-build.bash
    make: Leaving directory '/Users/dcarley/tmp'
    ❌ ERROR: Build failed with status: exit status: 2

The revised error looks like this:

    …
    foo> ERROR: Build command did not copy outputs to '$out'.
    foo> - copy a single file with 'cp bin $out'
    foo> - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
    foo> - copy files from an Autotools project with 'make install PREFIX=$out'
    error: builder for '/nix/store/a19z671g67pzizwga8rdnn3qr2jvz9vp-foo-0.0.0.drv' failed with exit code 1;
           last 10 log lines:
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/gps9qrh99j7g02840wv5x78ykmz30byp-strip.sh
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/wp896k23mv2shmrb1bn61k5zyi3i5jfq-environment
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/04w1mgkhawycg64s4q3n8mkcvma5ppx0-apple-framework-CoreFoundation-11.0.0
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/lybzq28v1ay0zac24hp0pw38s76ijvsj-libobjc-11.0.0
           > ERROR: Build command did not copy outputs to '$out'.
           > - copy a single file with 'cp bin $out'
           > - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
           > - copy files from an Autotools project with 'make install PREFIX=$out'
           For full logs, run 'nix log /nix/store/a19z671g67pzizwga8rdnn3qr2jvz9vp-foo-0.0.0.drv'.
    make: *** [/nix/store/xxb9n6barfjhb0kqswbd80ydpspxpk0i-package-builder-1.0.0/libexec/flox-build.mk:315: foo_local_build] Error 1
    rm /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.s6s3h4/6a335ee9-foo-build.bash
    make: Leaving directory '/Users/dcarley/tmp'
    ❌ ERROR: Build failed with status: exit status: 2


**fix(build): pure build error when no $out**

Raise a clearer error if a build script doesn't write anything to
`$out`. The provides parity with impure builds and fixes a bug where the
conditional for `! -e ${install-prefix-contents}` was never reached
because it failed eagerly.

It's worth noting that `$out` should not be interpolated because it has
a special user-facing meaning that they should reference in their build
commands and there won't be anything to inspect at the interpolated path
because this error is only triggered when the path doesn't exist.

The previous error looked like this:

    …
    foo> bar
    error: builder for '/nix/store/4kg7i9kf4n4dz4bc7323s4qhl6r1bkwx-foo-0.0.0.drv' failed to produce output path for output 'out' at '/nix/store/plkaihfglaj8s9h1vv7mzmahax3b2kxl-foo-0.0.0'
    make: *** [/nix/store/p341bwldmd3lv2yxq16pv6dndvmlzsmi-package-builder-1.0.0/libexec/flox-build.mk:317: foo_nix_sandbox_build] Error 1
    rm /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.V2I4sp/291fe2a7-foo-build.bash
    make: Leaving directory '/Users/dcarley/tmp'
    ❌ ERROR: Build failed with status: exit status: 2

The revised error looks like this:

    …
    foo> ERROR: Build command did not copy outputs to '$out'.
    foo> - copy a single file with 'cp bin $out'
    foo> - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
    foo> - copy files from an Autotools project with 'make install PREFIX=$out'
    error: builder for '/nix/store/v3xg9qahnxjx9dizzapi94p53b7bba0w-foo-0.0.0.drv' failed with exit code 1;
           last 10 log lines:
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/gps9qrh99j7g02840wv5x78ykmz30byp-strip.sh
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/505k98rmay60a12qn7bdz3fxfyx5wnr6-environment
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/04w1mgkhawycg64s4q3n8mkcvma5ppx0-apple-framework-CoreFoundation-11.0.0
           > calling 'envHostTargetHook' function hook 'sdkRootHook' /nix/store/lybzq28v1ay0zac24hp0pw38s76ijvsj-libobjc-11.0.0
           > /nix/store/8ai7wnasb4sw2v410arjnsz7ha70xn7p-foo-0.0.0
           > ERROR: Build command did not copy outputs to '$out'.
           > - copy a single file with 'cp bin $out'
           > - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
           > - copy files from an Autotools project with 'make install PREFIX=$out'
           For full logs, run 'nix log /nix/store/v3xg9qahnxjx9dizzapi94p53b7bba0w-foo-0.0.0.drv'.
    make: *** [/nix/store/xxb9n6barfjhb0kqswbd80ydpspxpk0i-package-builder-1.0.0/libexec/flox-build.mk:317: foo_nix_sandbox_build] Error 1
    rm /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.s6s3h4/903821b4-foo-build.bash
    make: Leaving directory '/Users/dcarley/tmp'
    ❌ ERROR: Build failed with status: exit status: 2

## Release Notes

N/A until build is released.
