### PR TITLE
refactor(flake): Remove crane.inputs.nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
   inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
 
   inputs.crane.url = "github:ipetkov/crane";
-  inputs.crane.inputs.nixpkgs.follows = "nixpkgs";
 
   inputs.fenix.url = "github:nix-community/fenix";
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## Proposed Changes

To fix this warning on `nix develop` and `direnv reload`:

    warning: input 'crane' has an override for a non-existent input 'nixpkgs'

It was removed upstream here:

- https://github.com/ipetkov/crane/commit/6f7504ad93304e8ddf29c0b82442f61c03900ccb
- https://github.com/ipetkov/crane/blob/master/docs/faq/custom-nixpkgs.md

We already pass an explicit pkgs to `mkLib`:

    % rg crane.mkLib
    pkgs/flox-cli/default.nix
    27:  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;

    pkgs/flox-watchdog/default.nix
    11:  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;

    pkgs/rust-external-deps/default.nix
    13:  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;

    pkgs/rust-internal-deps/default.nix
    19:  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;

    pkgs/rust-pkg/default.nix
    46:  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;

## Release Notes

N/A
