### PR TITLE
refactor(pre-commit): Move deprecated settings

### DIFF
--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -17,6 +17,7 @@ pre-commit-hooks.lib.${system}.run {
   ];
   hooks = {
     alejandra.enable = true;
+    alejandra.settings.verbosity = "quiet";
     clang-format = {
       enable = true;
       types_or = lib.mkForce [
@@ -44,13 +45,12 @@ pre-commit-hooks.lib.${system}.run {
       entry = lib.mkForce "${wrapper}/bin/cargo-fmt fmt --all --manifest-path 'cli/Cargo.toml' -- --color always";
     };
     clippy.enable = true;
+    clippy.settings.denyWarnings = true;
     commitizen.enable = true;
     shfmt.enable = false;
     # shellcheck.enable = true; # disabled until we have time to fix all the warnings
   };
   settings = {
-    clippy.denyWarnings = true;
-    alejandra.verbosity = "quiet";
     rust.cargoManifestPath = "cli/Cargo.toml";
   };
   tools = {


### PR DESCRIPTION
## Proposed Changes

To fix these warnings from `nix develop` and `direnv reload`:

    trace: evaluation warning: The option `settings.clippy' defined in `<unknown-file>' has been renamed to `hooks.clippy.settings'.
    trace: evaluation warning: The option `settings.alejandra.verbosity' defined in `<unknown-file>' has been renamed to `hooks.alejandra.settings.verbosity'.

## Release Notes

N/A