### PR TITLE
style: print warning when installing with reduced systems

### DIFF
--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -276,13 +276,17 @@ impl Install {
                     };
 
                     *systems = Some(valid_systems.clone());
+                    message::warning(format!(
+                        "Installing '{install_id}' for the following systems: {:?}",
+                        valid_systems
+                    ));
                 }
 
                 let packages = packages.into_values().collect::<Vec<_>>();
 
                 let install_result = Dialog {
                     message: "Installing packages for available systems...",
-                    help_message: Some("Some packages were not available on all requested systems"),
+                    help_message: None,
                     typed: Spinner::new(|| environment.install(&packages, flox)),
                 }
                 .spin();


### PR DESCRIPTION
Follow up on <https://github.com/flox/flox/pull/2110>

* Print a warning to notify that a package is not being installed for all systems. This should avoid too much confusion when running `flox list` after an install of a package that is not available on the current system.

Before:

```
% flox install bpftrace
✅ 'bpftrace' installed to environment 'tmp'

% flox list
hello: hello (2.12.1)
```

After:

```
% flox install bpftrace
⚠️  Installing 'bpftrace' for the following systems: ["aarch64-linux", "x86_64-linux"]
✅ 'bpftrace' installed to environment 'tmp'

% flox list
hello: hello (2.12.1)
```

The installed package will still be missing from `flox list`, since it is not available on the current system.

* Remove help message from spinner. With the additional warning, the help message is less informative and redundant.
Apparently it also renders weirdly in some situations.
