### PR TITLE
fix: backport concurrent gc issue to nix 2.18

### DIFF
--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -27,6 +27,7 @@ nixVersions.stable.overrideAttrs (prev: {
   patches =
     prev.patches
     ++ [
+      (builtins.path {path = ./patches/nix-7370.patch;})
       (builtins.path {path = ./patches/nix-9147.patch;})
       (builtins.path {path = ./patches/multiple-github-tokens.2.13.2.patch;})
     ];
@@ -65,9 +66,3 @@ nixVersions.stable.overrideAttrs (prev: {
     EOF
   '';
 })
-# ---------------------------------------------------------------------------- #
-#
-#
-#
-# ============================================================================ #
-

--- a/pkgs/nix/patches/nix-7370.patch
+++ b/pkgs/nix/patches/nix-7370.patch
@@ -1,0 +1,34 @@
+From c5fdbdae321903740e0e735aa89fab5647992687 Mon Sep 17 00:00:00 2001
+From: Eelco Dolstra <edolstra@gmail.com>
+Date: Mon, 19 Jun 2023 16:54:05 +0200
+Subject: [PATCH] LocalStore::addTempRoot(): Handle ENOENT
+
+If the garbage collector has acquired the global GC lock, but hasn't
+created the GC socket yet, then a client attempting to connect would
+get ENOENT. Note that this only happens when the GC runs for the first
+time on a machine. Subsequently clients will get ECONNREFUSED which
+was already handled.
+
+Fixes #7370.
+---
+ src/libstore/gc.cc       | 13 +++++++++----
+ tests/gc-non-blocking.sh |  7 ++++++-
+ 2 files changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/libstore/gc.cc b/src/libstore/gc.cc
+index 0038ec80257..b5b9e2049d4 100644
+--- a/src/libstore/gc.cc
++++ b/src/libstore/gc.cc
+@@ -138,9 +138,9 @@ void LocalStore::addTempRoot(const StorePath & path)
+             try {
+                 nix::connect(fdRootsSocket->get(), socketPath);
+             } catch (SysError & e) {
+-                /* The garbage collector may have exited, so we need to
+-                   restart. */
+-                if (e.errNo == ECONNREFUSED) {
++                /* The garbage collector may have exited or not
++                   created the socket yet, so we need to restart. */
++                if (e.errNo == ECONNREFUSED || e.errNo == ENOENT) {
+                     debug("GC socket connection refused");
+                     fdRootsSocket->close();
+                     goto restart;


### PR DESCRIPTION
We ran into occasional issues with the nix gc-socket in our unit test suite. <https://github.com/flox/flox/issues/2116> was logged against it to investigate. The error we are seeing is:

    error: cannot connect to socket at '/nix/var/nix/gc-socket/socket': No such file or directory

Which appears to be discussed upstream in <https://github.com/NixOS/nix/issues/7370>. The upstream issue was closed via <https://github.com/NixOS/nix/commit/c5fdbdae321903740e0e735aa89fab5647992687> but only on nix >=2.20.
nix 2.18, the current stable version used by flox, still uses the existing implementation:
<https://github.com/NixOS/nix/blob/d4d300c2084b5e81ee0ea2aba8215d03133f14f8/src/libstore/gc.cc#L145-L151>.

This commit adds the upstream changes as a patch,
until nixpkgs upgrades to nix > 2.18 for good.
The patch was amended by removing testing related hunks that don't apply.
