### PR TITLE
feat: use 'now' as the creation timestamp

### DIFF
--- a/pkgdb/src/libexec/mkContainer.nix
+++ b/pkgdb/src/libexec/mkContainer.nix
@@ -10,6 +10,7 @@
   containerSystem,
   containerName ? "flox-env-container",
   containerTag ? null,
+  containerCreated ? "now",
 }:
 let
   environment = builtins.storePath environmentOutPath;
@@ -31,6 +32,7 @@ let
   buildLayeredImageArgs = {
     name = containerName;
     tag = containerTag;
+    created = containerCreated;
     # symlinkJoin fails when drv contains a symlinked bin directory, so wrap in an additional buildEnv
     contents = pkgs.buildEnv {
       name = "contents";


### PR DESCRIPTION
## Proposed Changes

Use "now" as the timestamp.

## Release Notes
- use a reasonable timestamp