### PR TITLE
feat(containerize): add `--tag` option

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -385,6 +385,7 @@ impl CoreEnvironment<()> {
     pub fn build_container(
         lockfile_path: CanonicalPath,
         name: &str,
+        tag: &str,
     ) -> Result<ContainerBuilder, CoreEnvironmentError> {
         if std::env::consts::OS != "linux" {
             return Err(CoreEnvironmentError::ContainerizeUnsupportedSystem(
@@ -397,6 +398,8 @@ impl CoreEnvironment<()> {
             .arg("buildenv")
             .arg("--container")
             .arg(name)
+            .arg("--container-tag")
+            .arg(tag)
             .arg(lockfile_path);
 
         // Locking flakes may require using `ssh` for private flakes,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -214,14 +214,18 @@ impl Environment for ManagedEnvironment {
     }
 
     /// This will lock if there is an out of sync local checkout
-    fn build_container(&mut self, flox: &Flox) -> Result<ContainerBuilder, EnvironmentError> {
+    fn build_container(
+        &mut self,
+        flox: &Flox,
+        tag: &str,
+    ) -> Result<ContainerBuilder, EnvironmentError> {
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
         self.ensure_locked(flox, &mut local_checkout)?;
 
         let lockfile_path = CanonicalPath::new(local_checkout.lockfile_path())
             .expect("a locked environment must have a lockfile");
 
-        let builder = CoreEnvironment::build_container(lockfile_path, self.name().as_ref())?;
+        let builder = CoreEnvironment::build_container(lockfile_path, self.name().as_ref(), tag)?;
         Ok(builder)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -118,8 +118,12 @@ pub struct MigrationInfo {
 }
 
 pub trait Environment: Send {
-    /// Create a container image from the environment
-    fn build_container(&mut self, flox: &Flox) -> Result<ContainerBuilder, EnvironmentError>;
+    /// Create a container image from the environment, tagged with the given tag
+    fn build_container(
+        &mut self,
+        flox: &Flox,
+        tag: &str,
+    ) -> Result<ContainerBuilder, EnvironmentError>;
 
     /// Install packages to the environment atomically
     fn install(

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -177,8 +177,12 @@ impl Environment for RemoteEnvironment {
         self.inner.lockfile(flox)
     }
 
-    fn build_container(&mut self, flox: &Flox) -> Result<ContainerBuilder, EnvironmentError> {
-        self.inner.build_container(flox)
+    fn build_container(
+        &mut self,
+        flox: &Flox,
+        tag: &str,
+    ) -> Result<ContainerBuilder, EnvironmentError> {
+        self.inner.build_container(flox, tag)
     }
 
     /// Install packages to the environment atomically

--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -18,6 +18,7 @@ flox-containerize - export an environment as a container image
 flox [<general-options>] containerize
      [-d=<path> | -r=<owner/name>]
      [-o=<path>]
+     [--tag=<tag>]
 ```
 
 # DESCRIPTION
@@ -90,6 +91,17 @@ $ flox install hello
 $ flox containerize -o - | docker load
 $ docker run <container id> hello
 Hello, world
+```
+
+Create a container with a specific tag:
+
+```
+$ flox init
+$ flox install hello
+$ flox containerize --tag 'v1' -o - | docker load
+$ docker run --rm -it <container name>:v1
+[floxenv] $ hello
+Hello, world!
 ```
 
 # SEE ALSO

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -120,7 +120,25 @@ function skip_if_linux() {
 
   run podman load -i test-container.tar
   assert_success
-  assert_line --partial "Loaded image: localhost/test"
+  assert_line --partial "Loaded image: localhost/test:latest"
+}
+
+# bats test_tags=containerize:container-tag
+@test "catalog: container is tagged with specified tag" {
+  skip_if_not_linux
+
+  env_setup_catalog
+
+  run "$FLOX_BIN" containerize --tag 'sometag'
+  assert_success
+
+  assert [ -f "test-container.tar" ] # <env-name>-container.tar by default
+
+  run which podman
+
+  run podman load -i test-container.tar
+  assert_success
+  assert_line --partial "Loaded image: localhost/test:sometag"
 }
 
 # bats test_tags=containerize:piped-to-stdout

--- a/pkgdb/include/flox/buildenv/command.hh
+++ b/pkgdb/include/flox/buildenv/command.hh
@@ -41,6 +41,7 @@ private:
   std::optional<std::string> serviceConfigPath;
   bool                       buildContainer = false;
   std::optional<std::string> containerName;
+  std::optional<std::string> containerTag;
 
 
 public:

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -379,10 +379,11 @@ createEnvironmentStorePath(
  * @return A @a nix::StorePath to a container builder.
  */
 nix::StorePath
-createContainerBuilder( nix::EvalState &       state,
-                        const nix::StorePath & environmentStorePath,
-                        const System &         system,
-                        const std::string &    containerName );
+createContainerBuilder( nix::EvalState &         state,
+                        const nix::StorePath &   environmentStorePath,
+                        const System &           system,
+                        const std::string_view & containerName,
+                        const std::string_view & containerTag );
 
 /* -------------------------------------------------------------------------- */
 

--- a/pkgdb/src/buildenv/command.cc
+++ b/pkgdb/src/buildenv/command.cc
@@ -46,11 +46,16 @@ BuildEnvCommand::BuildEnvCommand() : parser( "buildenv" )
     .help( "build a container builder script" )
     .metavar( "CONTAINER-NAME" )
     .action(
-      [&]( const std::string & str )
+      [&]( const std::string & arg )
       {
         this->buildContainer = true;
-        this->containerName  = str;
+        this->containerName  = arg;
       } );
+
+  this->parser.add_argument( "--container-tag" )
+    .help( "set the container's tag" )
+    .metavar( "CONTAINER-TAG" )
+    .action( [&]( const std::string & arg ) { this->containerTag = arg; } );
 }
 
 
@@ -80,11 +85,12 @@ BuildEnvCommand::run()
     {
       debugLog( "container requested, building container build script" );
 
-      auto containerBuilderStorePath
-        = createContainerBuilder( *state,
-                                  storePath,
-                                  system,
-                                  *( this->containerName ) );
+      auto containerBuilderStorePath = createContainerBuilder(
+        *state,
+        storePath,
+        system,
+        this->containerName.value_or( "flox-env-container" ),
+        this->containerTag.value_or( "latest" ) );
 
       debugLog( "built container builder: "
                 + store->printStorePath( containerBuilderStorePath ) );

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -955,10 +955,11 @@ createFloxEnv( nix::ref<nix::EvalState> &         state,
 
 
 nix::StorePath
-createContainerBuilder( nix::EvalState &       state,
-                        const nix::StorePath & environmentStorePath,
-                        const System &         system,
-                        const std::string &    containerName )
+createContainerBuilder( nix::EvalState &         state,
+                        const nix::StorePath &   environmentStorePath,
+                        const System &           system,
+                        const std::string_view & containerName,
+                        const std::string_view & containerTag )
 {
   static const nix::FlakeRef nixpkgsRef
     = nix::parseFlakeRef( COMMON_NIXPKGS_URL );
@@ -990,8 +991,11 @@ createContainerBuilder( nix::EvalState &       state,
   nix::Value vContainerName {};
   vContainerName.mkString( containerName );
 
+  nix::Value vContainerTag {};
+  vContainerTag.mkString( containerTag );
+
   nix::Value vBindings {};
-  auto       bindings = state.buildBindings( 5 );
+  auto       bindings = state.buildBindings( 6 );
   bindings.push_back(
     { state.symbols.create( "nixpkgsFlake" ), &vNixpkgsFlake } );
   bindings.push_back(
@@ -1001,6 +1005,8 @@ createContainerBuilder( nix::EvalState &       state,
     { state.symbols.create( "containerSystem" ), &vContainerSystem } );
   bindings.push_back(
     { state.symbols.create( "containerName" ), &vContainerName } );
+  bindings.push_back(
+    { state.symbols.create( "containerTag" ), &vContainerTag } );
 
   vBindings.mkAttrs( bindings );
 

--- a/pkgdb/src/libexec/mkContainer.nix
+++ b/pkgdb/src/libexec/mkContainer.nix
@@ -9,6 +9,7 @@
   system,
   containerSystem,
   containerName ? "flox-env-container",
+  containerTag ? null,
 }: let
   environment = builtins.storePath environmentOutPath;
   pkgs = nixpkgsFlake.legacyPackages.${system};
@@ -18,6 +19,7 @@
 
   buildLayeredImageArgs = {
     name = containerName;
+    tag = containerTag;
     # symlinkJoin fails when drv contains a symlinked bin directory, so wrap in an additional buildEnv
     contents = pkgs.buildEnv {
       name = "contents";


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Closes: flox/product#771


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
- `flox containerize --tag ...` now sets the resulting container's tag to the value of the `tag` flag.
- `flox containerize` now sets the resulting container's tag to `latest` by default if `--tag` isn't set.

<!-- Many thanks! -->
