### PR TITLE
test: unset XDG_DATA_DIRS

### DIFF
--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -44,7 +44,7 @@ xdg_reals_setup() {
   export REAL_XDG_DATA_HOME="${XDG_DATA_HOME:?}"
   export REAL_XDG_STATE_HOME="${XDG_STATE_HOME:?}"
   # Prevent later routines from referencing real dirs.
-  unset USER HOME XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME XDG_STATE_HOME
+  unset USER HOME XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME XDG_STATE_HOME XDG_DATA_DIRS
   export __FT_RAN_XDG_REALS_SETUP=:
 }
 


### PR DESCRIPTION
We unset a number XDG_* dirs to give our tests some level of isolation. We should also unset XDG_DATA_DIRS because we've seen it cause tests to fail.

More specifically, if a flox environment with `direnv` is activated, activation puts `$FLOX_ENV/share` in `XDG_DATA_DIRS`, and that loads direnv for fish because it contains
`$FLOX_ENV/share/fish/vnedor_conf.d/direnv.fish`.

If doing development with direnv, this can cause some fish tests to fail, e.g.:
```
flox-cli-tests -- -f "catalog: fish: interactive activate puts package in path"
```

This fails because of a `direnv: unloading`, which presumably modifies PATH and breaks the test.