### PR TITLE
fix: don't use unset variables in activation

### DIFF
--- a/assets/activation-scripts/activate.d/bash
+++ b/assets/activation-scripts/activate.d/bash
@@ -16,7 +16,7 @@ fi
 # We use --rcfile to activate using bash which skips sourcing ~/.bashrc,
 # so source that here, but not if we're already in the process of sourcing
 # bashrc in a parent process.
-if [ -f ~/.bashrc ] && [ -z "$_flox_already_sourcing_bashrc" ]
+if [ -f ~/.bashrc ] && [ -z "${_flox_already_sourcing_bashrc:=}" ]
 then
   # Save and restore the current tracelevel in the event that sourcing
   # bashrc launches an inner nested activation which unsets it.
@@ -29,7 +29,7 @@ fi
 
 # The above .bashrc may have performed a nested activation, so confirm
 # _flox_activate_tracelevel is defined before proceeding.
-if [ -z "$_flox_activate_tracelevel" ]; then
+if [ -z "${_flox_activate_tracelevel:=}" ]; then
   echo 'WARNING (bash): _flox_activate_tracelevel not defined .. defaulting to 0' >&2
   export _flox_activate_tracelevel=0
 fi

--- a/assets/activation-scripts/activate.d/set-prompt.bash
+++ b/assets/activation-scripts/activate.d/set-prompt.bash
@@ -24,7 +24,7 @@ unset _esc colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxProm
 
 if [ -n "$_flox" ] && [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ] && [ "${_FLOX_SET_PROMPT}" != false ]; then
   # Start by saving the original value of PS1.
-  if [ -z "$FLOX_SAVE_BASH_PS1" ]; then
+  if [ -z "${FLOX_SAVE_BASH_PS1:=}" ]; then
     export FLOX_SAVE_BASH_PS1="$PS1"
   fi
   case "$FLOX_SAVE_BASH_PS1" in

--- a/assets/activation-scripts/activate.d/set-prompt.zsh
+++ b/assets/activation-scripts/activate.d/set-prompt.zsh
@@ -13,7 +13,7 @@ _flox="${_floxPrompt1} ${_floxPrompt2} "
 if [ -n "$_flox" -a -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" -a "${_FLOX_SET_PROMPT:-}" != false ];
 then
     # Start by saving the original value of PS1.
-    if [ -z "$FLOX_SAVE_ZSH_PS1" ]; then
+    if [ -z "${FLOX_SAVE_ZSH_PS1:=}" ]; then
         export FLOX_SAVE_ZSH_PS1="$PS1"
     fi
     case "$FLOX_SAVE_ZSH_PS1" in

--- a/assets/activation-scripts/activate.d/zsh
+++ b/assets/activation-scripts/activate.d/zsh
@@ -1,7 +1,7 @@
 export _gnused="@gnused@"
 
 # Confirm _flox_activate_tracelevel is defined before proceeding.
-if [ -z "$_flox_activate_tracelevel" ]; then
+if [ -z "${_flox_activate_tracelevel:=}" ]; then
   echo 'WARNING (zsh): _flox_activate_tracelevel not defined .. defaulting to 0' >&2
   export _flox_activate_tracelevel=0
 fi

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2358,3 +2358,25 @@ EOF
   refute_output --partial Error
   assert_output --partial "3.2.2"
 }
+
+@test "no unset variables in bash" {
+  project_setup
+  run bash <(cat <<'EOF'
+  set -u
+  eval "$($FLOX_BIN activate)"
+EOF
+)
+  refute_output --partial "_flox"
+  refute_output --partial "_FLOX"
+}
+
+@test "no unset variables in zsh" {
+  project_setup
+  run zsh <(cat <<'EOF'
+  set -u
+  eval "$($FLOX_BIN activate)"
+EOF
+)
+  refute_output --partial "_flox"
+  refute_output --partial "_FLOX"
+}


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This modifies the activation scripts for bash and zsh (there's no "set -u" option for tcsh or fish) to always initialize certain variables to empty strings rather than letting them be unset. This allows a user with "set -u" in their .bashrc/.zshrc to "eval $(flox activate)" without seeing errors from our activation scripts.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
