### PR TITLE
fix: skip serializing empty manifest tables

### DIFF
--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -3,6 +3,7 @@ use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::lockfile::LockedManifest;
 use flox_rust_sdk::providers::build::{FloxBuildMk, ManifestBuilder, Output};
+use indoc::indoc;
 use tracing::instrument;
 
 use super::{environment_select, EnvironmentSelect};
@@ -81,6 +82,14 @@ fn make_packages_to_build(lockfile: &LockedManifest, packages: Vec<String>) -> R
     };
 
     let environment_packages = &lockfile.manifest.build;
+
+    if environment_packages.is_empty() {
+        bail!(indoc! {"
+        No builds found.
+
+        Add a build by modifying the '[build]' section of the manifest with 'flox edit'
+        "});
+    }
 
     let packages_to_build = if packages.is_empty() {
         environment_packages.keys().cloned().collect()


### PR DESCRIPTION
### fix(build): error if no builds are defined

Currently run the Makefile even if no builds are defined and print
```
make: Entering directory '...'
make: Nothing to be done for 'all'.
make: Leaving directory '...'
✨ Build completed successfully
```

Print an error instead:
```
❌ ERROR: No builds found.

Add a build by modifying the '[build]' section of the manifest with 'flox edit'
```

### fix: skip serializing empty manifest tables

Skip serializing the manifest tables `install`, `vars`, `services`, and
`builds` when they are empty in order to:
1. Make lockfiles smaller
2. Establish a better pattern for backwards compatibility. A newer
   version of flox should try to generate a lockfile that an older
   version of flox can fully understand.

I didn't skip serializing `hook`, `profile`, and `options` since doing
so would require checking if all fields are empty, and that seems more
likely to become stale.