### PR TITLE
test(activate): Test and fix zsh in-place from RC files w/nesting

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -515,6 +515,7 @@ case "$_flox_shell" in
     echo "setenv _del_env \"$_del_env\";"
     echo "source '$FLOX_ENV/activate.d/tcsh';"
     ;;
+  # Any additions should probably be restored in zdotdir/* scripts
   *zsh)
     echo "export _flox_activate_tracelevel=\"$_flox_activate_tracelevel\";"
     echo "export FLOX_ENV=\"$FLOX_ENV\";"

--- a/assets/activation-scripts/activate.d/zdotdir/.zshrc
+++ b/assets/activation-scripts/activate.d/zdotdir/.zshrc
@@ -3,9 +3,25 @@
 #
 # See README.md for more information on the initialization process.
 
-# Save and restore the current tracelevel in the event that sourcing
-# bashrc launches an inner nested activation which unsets it.
+# Save environment variables that could be set if sourcing zshrc launches an
+# inner nested activation.
 _save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+_save_FLOX_ENV="$FLOX_ENV"
+_save_FLOX_ORIG_ZDOTDIR="$FLOX_ORIG_ZDOTDIR"
+_save_ZDOTDIR="$ZDOTDIR"
+_save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
+_save_add_env="$_add_env"
+_save_del_env="$_del_env"
+
+restore_saved_vars() {
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    export FLOX_ENV="$_save_FLOX_ENV"
+    export FLOX_ORIG_ZDOTDIR="$_save_FLOX_ORIG_ZDOTDIR"
+    export ZDOTDIR="$_save_ZDOTDIR"
+    export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
+    export _add_env="$_save_add_env"
+    export _del_env="$_save_del_env"
+}
 
 if [ -f /etc/zshrc ]
 then
@@ -15,7 +31,7 @@ then
     else
         ZDOTDIR= source /etc/zshrc
     fi
-    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    restore_saved_vars
 fi
 
 zshrc="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zshrc"
@@ -27,7 +43,7 @@ then
     else
         ZDOTDIR= source "$zshrc"
     fi
-    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    restore_saved_vars
 fi
 
 # Bring in the Nix and Flox environment customizations, but _not_ if this is

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -305,7 +305,7 @@ EOF
 # the expected hook and profile scripts for the bash and zsh shells, and
 # in each of the following four scenarios:
 #
-# 1. in the interactive case, simulated using using `hook.exp`
+# 1. in the interactive case, simulated using using `activate.exp`
 # 2. in the default command case, invoking the shell primitive `:` (a no-op)
 # 3. in the `--noprofile` command case, again invoking the shell primitive `:`
 # 4. in the `--turbo` command case, which exec()s the provided command without
@@ -322,7 +322,7 @@ EOF
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="bash" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -412,7 +412,7 @@ EOF
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="fish" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  FLOX_SHELL="fish" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -502,7 +502,7 @@ EOF
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="tcsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  FLOX_SHELL="tcsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -595,7 +595,7 @@ EOF
   # current euid. I'm not sure if we should change that, but for now just set
   # USER to REAL_USER.
   # FLOX_SHELL="zsh" USER="$REAL_USER" run -0 bash -c "echo exit | $FLOX_CLI activate --dir $PROJECT_DIR";
-  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -898,7 +898,7 @@ EOF
   refute_output --partial "sourcing profile.zsh for first time"
 
   echo '# Testing interactive bash' >&2
-  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   refute_output --partial "ERROR"
   assert_output --partial "sourcing hook.on-activate for first time"
@@ -914,7 +914,7 @@ EOF
   assert_output --partial "sourcing profile.zsh for first time"
 
   echo '# Testing interactive zsh' >&2
-  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   refute_output --partial "ERROR"
   assert_output --partial "sourcing hook.on-activate for first time"
@@ -2424,7 +2424,7 @@ EOF
   # launch an interactive shell that sources the relevant dotfile.
   for target_shell in bash fish tcsh zsh; do
     echo "Testing $target_shell"
-    FLOX_SHELL="$target_shell" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/hook.exp" "$_temp_env"
+    FLOX_SHELL="$target_shell" USER="$REAL_USER" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$_temp_env"
     refute_output --partial "_flox_activate_tracelevel not defined"
     run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
     assert_success

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -68,8 +68,6 @@ EOF
 
 setup_file() {
   common_file_setup
-
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -20,7 +20,6 @@ load test_support.bash
 # disrupt flox's attempts to configure the environment. Please append to this
 # growing list of nightmare scenarios as you encounter them in the wild.
 user_dotfiles_setup() {
-  if [[ -n ${__FT_RAN_USER_DOTFILES_SETUP-} ]]; then return 0; fi
   # N.B. $HOME is set to the test user's home directory by flox_vars_setup
   # so none of these should exist, and we abort if we find otherwise.
   if
@@ -70,13 +69,10 @@ if ( -e "$HOME/.$i.extra" ) then
 endif
 EOF
   done
-
-  export __FT_RAN_USER_DOTFILES_SETUP=:
 }
 
 setup_file() {
   common_file_setup
-  user_dotfiles_setup
 
   export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 }
@@ -128,6 +124,7 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  user_dotfiles_setup
   setup_isolated_flox # concurrent pkgdb database creation
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.json"
 }

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -20,8 +20,9 @@ load test_support.bash
 # disrupt flox's attempts to configure the environment. Please append to this
 # growing list of nightmare scenarios as you encounter them in the wild.
 user_dotfiles_setup() {
-  # N.B. $HOME is set to the test user's home directory by flox_vars_setup
-  # so none of these should exist, and we abort if we find otherwise.
+  # N.B. $HOME is set to a test-isolated directory by `common_file_setup`,
+  # `home_setup`, and `flox_vars_setup` so none of the files below should exist
+  # and we abort if we find otherwise.
   set -o noclobber
 
   BADPATH="/usr/local/bin:/usr/bin:/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
@@ -107,17 +108,13 @@ project_teardown() {
   rm -rf "${PROJECT_DIR?}"
   unset PROJECT_DIR
   unset PROJECT_NAME
-  rm -f \
-    "$HOME/.bashrc.extra" \
-    "$HOME/.tcshrc.extra" \
-    "$HOME/.config/fish/config.fish.extra" \
-    "$HOME/.zshrc.extra"
 }
 
 # ---------------------------------------------------------------------------- #
 
 setup() {
   common_test_setup
+  home_setup test # Isolate $HOME for each test.
   user_dotfiles_setup
   setup_isolated_flox # concurrent pkgdb database creation
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.json"

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2132,43 +2132,65 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:zdotdir,activate:zdotdir:zshenv
-@test "zdotdir: test zshenv activation" {
+@test "zsh: in-place activation with non-interactive non-login shell" {
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
+
   run zsh -c 'eval "$("$FLOX_BIN" activate)"'
   assert_success
-  assert_line "Sourcing .zshenv"
-  refute_line "Sourcing .zshrc"
-  refute_line "Sourcing .zlogin"
-  assert_line "sourcing hook.on-activate for first time"
-  assert_line "sourcing profile.zsh for first time"
+  assert_output - <<EOF
+Sourcing .zshenv
+Setting PATH from .zshenv
+sourcing hook.on-activate for first time
+sourcing profile.zsh for first time
+EOF
+  refute_output --partial "zprofile"
+  refute_output --partial "zshrc"
+  refute_output --partial "zlogin"
+  refute_output --partial "zlogout"
 }
 
 # bats test_tags=activate,activate:zdotdir,activate:zdotdir:zshrc
-@test "zdotdir: test zshrc activation" {
+@test "zsh: in-place activation with interactive non-login shell" {
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
-  cat $HOME/.zshrc
-  run zsh -i -c 'eval "$("$FLOX_BIN" activate)"'
+
+  run zsh --interactive -c 'eval "$("$FLOX_BIN" activate)"'
   assert_success
-  assert_line "Sourcing .zshenv"
-  assert_line "Sourcing .zshrc"
-  refute_line "Sourcing .zlogin"
-  assert_line "sourcing hook.on-activate for first time"
-  assert_line "sourcing profile.zsh for first time"
+  assert_output - <<EOF
+Sourcing .zshenv
+Setting PATH from .zshenv
+Sourcing .zshrc
+Setting PATH from .zshrc
+sourcing hook.on-activate for first time
+sourcing profile.zsh for first time
+EOF
+  refute_output --partial "zprofile"
+  refute_output --partial "zlogin"
+  refute_output --partial "zlogout"
 }
 
 # bats test_tags=activate,activate:zdotdir,activate:zdotdir:zlogin
-@test "zdotdir: test zlogin activation" {
+@test "zsh: in-place activation with interactive login shell" {
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
-  run zsh -i -l -c 'eval "$("$FLOX_BIN" activate)"'
+
+  run zsh --interactive --login -c 'eval "$("$FLOX_BIN" activate)"'
   assert_success
-  assert_line "Sourcing .zshenv"
-  assert_line "Sourcing .zshrc"
-  assert_line "Sourcing .zlogin"
-  assert_line "sourcing hook.on-activate for first time"
-  assert_line "sourcing profile.zsh for first time"
+  assert_output - <<EOF
+Sourcing .zshenv
+Setting PATH from .zshenv
+Sourcing .zprofile
+Setting PATH from .zprofile
+Sourcing .zshrc
+Setting PATH from .zshrc
+Sourcing .zlogin
+Setting PATH from .zlogin
+sourcing hook.on-activate for first time
+sourcing profile.zsh for first time
+Sourcing .zlogout
+Setting PATH from .zlogout
+EOF
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2198,6 +2198,112 @@ EOF
 
 # ---------------------------------------------------------------------------- #
 
+# bats test_tags=activate,activate:zdotdir,activate:zdotdir:zshenv
+@test "zsh: in-place activation from .zshenv" {
+  project_setup
+  "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
+
+  echo 'eval "$("$FLOX_BIN" activate)"' >> "$HOME/.zshenv"
+
+  run zsh --interactive --login -c 'true'
+  assert_success
+  assert_output - <<EOF
+Sourcing .zshenv
+Setting PATH from .zshenv
+sourcing hook.on-activate for first time
+sourcing profile.common for first time
+sourcing profile.zsh for first time
+Sourcing .zprofile
+Setting PATH from .zprofile
+Sourcing .zshrc
+Setting PATH from .zshrc
+Sourcing .zlogin
+Setting PATH from .zlogin
+Sourcing .zlogout
+Setting PATH from .zlogout
+EOF
+}
+
+# bats test_tags=activate,activate:zdotdir,activate:zdotdir:zshrc
+@test "zsh: in-place activation from .zshrc" {
+  project_setup
+  "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
+
+  echo 'eval "$("$FLOX_BIN" activate)"' >> "$HOME/.zshrc"
+
+  run zsh --interactive --login -c 'true'
+  assert_success
+  assert_output - <<EOF
+Sourcing .zshenv
+Setting PATH from .zshenv
+Sourcing .zprofile
+Setting PATH from .zprofile
+Sourcing .zshrc
+Setting PATH from .zshrc
+sourcing hook.on-activate for first time
+sourcing profile.common for first time
+sourcing profile.zsh for first time
+Sourcing .zlogin
+Setting PATH from .zlogin
+Sourcing .zlogout
+Setting PATH from .zlogout
+EOF
+}
+
+# bats test_tags=activate,activate:zdotdir,activate:zdotdir:zlogin
+@test "zsh: in-place activation from .zlogin" {
+  project_setup
+  "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
+
+  echo 'eval "$("$FLOX_BIN" activate)"' >> "$HOME/.zlogin"
+
+  run zsh --interactive --login -c 'true'
+  assert_success
+  assert_output - <<EOF
+Sourcing .zshenv
+Setting PATH from .zshenv
+Sourcing .zprofile
+Setting PATH from .zprofile
+Sourcing .zshrc
+Setting PATH from .zshrc
+Sourcing .zlogin
+Setting PATH from .zlogin
+sourcing hook.on-activate for first time
+sourcing profile.common for first time
+sourcing profile.zsh for first time
+Sourcing .zlogout
+Setting PATH from .zlogout
+EOF
+}
+
+# bats test_tags=activate,activate:zdotdir,activate:zdotdir:zprofile
+@test "zsh: in-place activation from .zprofile" {
+  project_setup
+  "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
+
+  echo 'eval "$("$FLOX_BIN" activate)"' >> "$HOME/.zprofile"
+
+  run zsh -i -l -c 'true'
+  assert_success
+  assert_output - <<EOF
+Sourcing .zshenv
+Setting PATH from .zshenv
+Sourcing .zprofile
+Setting PATH from .zprofile
+sourcing hook.on-activate for first time
+sourcing profile.common for first time
+sourcing profile.zsh for first time
+Sourcing .zshrc
+Setting PATH from .zshrc
+Sourcing .zlogin
+Setting PATH from .zlogin
+Sourcing .zlogout
+Setting PATH from .zlogout
+EOF
+}
+
+# ---------------------------------------------------------------------------- #
+
 # bats test_tags=activate,activate:do_not_leak_FLOX_SHELL
 @test "activation does not leak FLOX_SHELL variable" {
   project_setup

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2142,6 +2142,7 @@ EOF
 Sourcing .zshenv
 Setting PATH from .zshenv
 sourcing hook.on-activate for first time
+sourcing profile.common for first time
 sourcing profile.zsh for first time
 EOF
   refute_output --partial "zprofile"
@@ -2163,6 +2164,7 @@ Setting PATH from .zshenv
 Sourcing .zshrc
 Setting PATH from .zshrc
 sourcing hook.on-activate for first time
+sourcing profile.common for first time
 sourcing profile.zsh for first time
 EOF
   refute_output --partial "zprofile"
@@ -2187,6 +2189,7 @@ Setting PATH from .zshrc
 Sourcing .zlogin
 Setting PATH from .zlogin
 sourcing hook.on-activate for first time
+sourcing profile.common for first time
 sourcing profile.zsh for first time
 Sourcing .zlogout
 Setting PATH from .zlogout

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -22,16 +22,8 @@ load test_support.bash
 user_dotfiles_setup() {
   # N.B. $HOME is set to the test user's home directory by flox_vars_setup
   # so none of these should exist, and we abort if we find otherwise.
-  if
-    [ -f "$HOME/.bashrc" -o -f "$HOME/.zshrc" -o -f "$HOME/.zshenv" -o
-    -f "$HOME/.zlogin" -o -f "$HOME/.zlogout" -o -f "$HOME/.zprofile" -o
-    -f "$HOME/.profile" -o -f "$HOME/.login" -o -f "$HOME/.logout" -o
-    -f "$HOME/.config/fish/config.fish" -o
-    -f "$HOME/.cshrc" -o -f "$HOME/.tcshrc" ]
-  then
-    echo "user_dotfiles_setup: found preexisting dotfile(s) in $HOME" >&2
-    return 1
-  fi
+  set -o noclobber
+
   BADPATH="/usr/local/bin:/usr/bin:/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
 
   # Posix-compliant shells
@@ -69,6 +61,8 @@ if ( -e "$HOME/.$i.extra" ) then
 endif
 EOF
   done
+
+  set +o noclobber
 }
 
 setup_file() {

--- a/cli/tests/activate/activate.exp
+++ b/cli/tests/activate/activate.exp
@@ -1,5 +1,4 @@
-# Activate a project environment using --dir and check the environment's hook is
-# run.
+# Activate a project environment using --dir
 
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)

--- a/cli/tests/activate/only-once.toml
+++ b/cli/tests/activate/only-once.toml
@@ -14,6 +14,16 @@ on-activate = """
 
 [profile]
 
+common = """
+  if [ -n "$_already_ran_profile_common" ]; then
+    echo "ERROR: profile section sourced twice" >&2
+    exit 1
+  else
+    echo "sourcing profile.common for first time" >&2
+  fi
+  export _already_ran_profile_common=1
+"""
+
 bash = """
   if [ -n "$_already_ran_profile_bash" ]; then
     echo "ERROR: profile section sourced twice" >&2

--- a/cli/tests/activate/only-once.toml
+++ b/cli/tests/activate/only-once.toml
@@ -16,7 +16,7 @@ on-activate = """
 
 common = """
   if [ -n "$_already_ran_profile_common" ]; then
-    echo "ERROR: profile section sourced twice" >&2
+    echo "ERROR: profile.common section sourced twice" >&2
     exit 1
   else
     echo "sourcing profile.common for first time" >&2


### PR DESCRIPTION
## Proposed Changes

Test that in-place activation works from zsh RC files. This is a
variation of the tests above it which do something similar but not quite
the same by hooking into the RC process later on.

I was hoping to reproduce the issue in #1946 but I haven't been able to
either manually or with these tests. If the problem still exists from
Graham then we may be able to tweak these new tests to reproduce it.

Plus a bunch of test improvements that were necessary to get these working. They are best reviewed commit-by-commit.

Plus a fix when using an outer in-place activation with an inner interactive activation.

## Release Notes

N/A