### PR TITLE
feat: Add flox-activations crate

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1108,6 +1108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flox-activations"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "clap_derive",
+]
+
+[[package]]
 name = "flox-rust-sdk"
 version = "0.0.0"
 dependencies = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["flox", "flox-rust-sdk", "catalog-api-v1", "mk_data", "flox-watchdog"]
-default-members = ["flox", "flox-watchdog"]
+members = ["flox", "flox-rust-sdk", "catalog-api-v1", "mk_data", "flox-watchdog", "flox-activations"]
+default-members = ["flox", "flox-watchdog", "flox-activations"]
 
 resolver = "2"
 
@@ -91,3 +91,10 @@ openapiv3 = "2.0"
 prettyplease = "0.2"
 progenitor = "0.6"
 syn = "2.0"
+
+[profile.small]
+inherits = "release"
+opt-level = "z"
+strip = true
+lto = true
+codegen-units = 1

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "flox-activations"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+clap = { version = "4.5.18", default-features = false, features = ["std","usage", "help", "error-context", "derive"] }
+clap_derive.workspace = true

--- a/cli/flox-activations/src/cli.rs
+++ b/cli/flox-activations/src/cli.rs
@@ -1,0 +1,84 @@
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand};
+
+const SHORT_HELP: &str = "Monitors activation lifecycle to perform cleanup.";
+const LONG_HELP: &str = "Monitors activation lifecycle to perform cleanup.";
+
+#[derive(Debug, Parser)]
+// #[command(version = Lazy::get(&FLOX_VERSION).map(|v| v.as_str()).unwrap_or("0.0.0"))]
+#[command(about = SHORT_HELP, long_about = LONG_HELP)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    #[command(about = "Start a new activation or attach to an existing one.")]
+    StartOrAttach(StartOrAttachArgs),
+    #[command(about = "Set that the activation is ready to be attached to.")]
+    SetReady(SetReadyArgs),
+    #[command(about = "Attach to an existing activation.")]
+    Attach(AttachArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct StartOrAttachArgs {
+    #[arg(help = "The PID of the shell registering interest in the activation.")]
+    #[arg(short, long, value_name = "PID")]
+    pub pid: i32,
+    #[arg(help = "The path to the .flox directory for the environment.")]
+    #[arg(short, long, value_name = "PATH")]
+    pub flox_env: PathBuf,
+    #[arg(help = "The store path of the rendered environment for this activation.")]
+    #[arg(short, long, value_name = "PATH")]
+    pub store_path: PathBuf,
+}
+
+#[derive(Debug, Args)]
+pub struct SetReadyArgs {
+    #[arg(help = "The path to the .flox directory for the environment.")]
+    #[arg(short, long, value_name = "PATH")]
+    pub flox_env: PathBuf,
+    #[arg(help = "The UUID for this particular activation of this environment.")]
+    #[arg(short, long, value_name = "UUID")]
+    pub id: String,
+}
+
+#[derive(Debug, Args)]
+pub struct AttachArgs {
+    #[arg(help = "The PID of the shell registering interest in the activation.")]
+    #[arg(short, long, value_name = "PID")]
+    pub pid: i32,
+    #[arg(help = "The path to the .flox directory for the environment.")]
+    #[arg(short, long, value_name = "PATH")]
+    pub flox_env: PathBuf,
+    #[arg(help = "The UUID for this particular activation of this environment.")]
+    #[arg(short, long, value_name = "UUID")]
+    pub id: String,
+    #[command(flatten)]
+    pub exclusive: AttachExclusiveArgs,
+}
+
+#[derive(Debug, Args)]
+#[group(required = true, multiple = false)]
+pub struct AttachExclusiveArgs {
+    #[arg(help = "How long to wait between termination of this PID and cleaning up its interest.")]
+    #[arg(short, long, value_name = "TIME_MS")]
+    pub timeout_ms: Option<u32>,
+    #[arg(help = "Remove the specified PID when attaching to this activation.")]
+    #[arg(short, long, value_name = "PID")]
+    pub remove_pid: Option<i32>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cli_works() {
+        use clap::CommandFactory;
+        Cli::command().debug_assert();
+    }
+}

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+use cli::Cli;
+
+mod cli;
+
+type Error = anyhow::Error;
+
+fn main() -> Result<(), Error> {
+    let args = Cli::parse();
+    eprintln!("{args:?}");
+    match args.command {
+        cli::Command::StartOrAttach(_args) => {},
+        cli::Command::SetReady(_args) => {},
+        cli::Command::Attach(_args) => {},
+    }
+    Ok(())
+}

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,7 @@
       # Package Database Utilities: scrape, search, and resolve.
       flox-pkgdb = callPackage ./pkgs/flox-pkgdb {};
       flox-watchdog = callPackage ./pkgs/flox-watchdog {}; # Flox Command Line Interface ( development build ).
+      flox-activations = callPackage ./pkgs/flox-activations {};
       flox-cli = callPackage ./pkgs/flox-cli {};
       flox-manpages = callPackage ./pkgs/flox-manpages {}; # Flox Command Line Interface Manpages
       flox = callPackage ./pkgs/flox {}; # Flox Command Line Interface ( production build ).
@@ -135,6 +136,7 @@
           flox-pkgdb
           flox-package-builder
           flox-watchdog
+          flox-activations
           flox-cli
           flox-cli-tests
           flox-manpages

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -14,6 +14,7 @@
   iconv,
   nawk,
   fd,
+  flox-activations,
 }: let
   ld-floxlib_so =
     if stdenv.isLinux

--- a/pkgs/flox-activations/default.nix
+++ b/pkgs/flox-activations/default.nix
@@ -6,7 +6,7 @@
   rustfmt ? rust-toolchain.rustfmt,
   flox-src,
   rust-external-deps,
-  rust-internal-deps
+  rust-internal-deps,
 }: let
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
@@ -92,4 +92,3 @@ in
       };
     }
     // envs)
- 

--- a/pkgs/flox-activations/default.nix
+++ b/pkgs/flox-activations/default.nix
@@ -1,0 +1,95 @@
+{
+  inputs,
+  gnused,
+  pkgsFor,
+  rust-toolchain,
+  rustfmt ? rust-toolchain.rustfmt,
+  flox-src,
+  rust-external-deps,
+  rust-internal-deps
+}: let
+  # crane (<https://crane.dev/>) library for building rust packages
+  craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
+
+  # build time environment variables
+  envs = {} // rust-internal-deps.passthru.envs;
+in
+  craneLib.buildPackage ({
+      pname = "flox-activations";
+      version = envs.FLOX_VERSION;
+      src = flox-src;
+
+      # Set up incremental compilation
+      #
+      # Cargo artifacts are built for the union of features used transitively
+      # by `flox` and `flox-watchdog`.
+      # Compiling either separately would result in a different set of features
+      # and thus cache misses.
+      cargoArtifacts = rust-external-deps;
+      cargoExtraArgs = "--locked -p flox-activations";
+      postPatch = ''
+        rm -rf ./flox/*
+        cp -rf --no-preserve=mode ${craneLib.mkDummySrc {src = flox-src;}}/flox/* ./flox
+      '';
+
+      CARGO_LOG = "cargo::core::compiler::fingerprint=info";
+      CARGO_PROFILE = "small";
+
+      # runtime dependencies
+      buildInputs = rust-external-deps.buildInputs ++ [];
+
+      # build dependencies
+      nativeBuildInputs =
+        rust-external-deps.nativeBuildInputs;
+
+      propagatedBuildInputs = rust-external-deps.propagatedBuildInputs ++ [];
+
+      # https://github.com/ipetkov/crane/issues/385
+      # doNotLinkInheritedArtifacts = true;
+
+      # Tests are disabled inside of the build because the sandbox prevents
+      # internet access and there are tests that require internet access to
+      # resolve flake references among other things.
+      doCheck = false;
+
+      # bundle manpages and completion scripts
+      #
+      # sed: Removes rust-toolchain from binary. Likely due to toolchain overriding.
+      #   unclear about the root cause, so this is a hotfix.
+      postInstall = ''
+        rm -f $out/bin/crane-*
+        for target in "$(basename ${rust-toolchain.rust.outPath} | cut -f1 -d- )" ; do
+          sed -i -e "s|$target|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee|g" $out/bin/flox-activations
+        done
+      '';
+
+      passthru = {
+        inherit
+          envs
+          ;
+
+        ciPackages = [];
+
+        devPackages = [
+          rustfmt
+        ];
+
+        devEnvs =
+          envs
+          // {
+            RUST_SRC_PATH = "${rust-toolchain.rust-src}/lib/rustlib/src/rust/library";
+            RUSTFMT = "${rustfmt}/bin/rustfmt";
+          };
+
+        devShellHook = ''
+          #  # Find the project root and add the `bin' directory to `PATH'.
+          if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            PATH="$( git rev-parse --show-toplevel; )/cli/target/debug":$PATH;
+            REPO_ROOT="$( git rev-parse --show-toplevel; )";
+          fi
+
+        '';
+      };
+    }
+    // envs)
+ 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

**feat: Add flox-activations crate**

This also adds a new build profile called "small" that is tuned to
produce smaller binaries. Using this profile reduces the size of the
compiled binary from 995k ("release" profile) to 471k. This application
shouldn't be doing anything performance intensive, so the difference in
speed should be negligible in practice. Of this 471k, 60% is the Rust standard
library, and 29% is the argument parser, so there's not a lot of fat left to
trim unless you want to remove the Rust standard library.

**feat: add Nix build for flox-activations**
Performs a Nix build of the `flox-activations` crate using the `small` profile.

**chore: add dep for flox-activations**
This makes `flox-activation-scripts` depend on `flox-activations` since it
will be called in the activation scripts.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
