### PR TITLE
test: fix race in test_process_states_read

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -1394,9 +1394,15 @@ mod tests {
                 })
                 .ok();
 
-            if states.is_some() {
-                break;
-            };
+            if let Some(ref states) = states {
+                // Even if `process-compose list` succeeded, the processes might
+                // be "Running"
+                if states.process("bar").unwrap().status == "Completed"
+                    && states.process("baz").unwrap().status == "Completed"
+                {
+                    break;
+                }
+            }
         }
         let states = states.expect("failed to read process states");
 


### PR DESCRIPTION
I've seen the failure:
```
thread ‘providers::services::tests::test_process_states_read’ panicked at flox-rust-sdk/src/providers/services.rs:1410:9:
assertion failed: `(left == right)`
Diff < left / right > :
<Running
>Completed
```

There's a race between when we run `process-compose list` and when short-lived processes exit. Poll for processes to complete rather than assuming they have completed the first time `process-compose list` succeeds.