### PR TITLE
test: remove stale #[serial]

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1485,7 +1485,6 @@ mod tests {
     use chrono::{DateTime, Utc};
     use indoc::{formatdoc, indoc};
     use pretty_assertions::assert_eq;
-    use serial_test::serial;
     use tempfile::{tempdir_in, TempDir};
     use test_helpers::{new_core_environment_from_env_files, new_core_environment_with_lockfile};
     use tests::test_helpers::MANIFEST_INCOMPATIBLE_SYSTEM;
@@ -1515,7 +1514,6 @@ mod tests {
 
     /// Check that `edit` updates the manifest and creates a lockfile
     #[test]
-    #[serial]
     #[cfg(feature = "impure-unit-tests")]
     fn edit_env_creates_manifest_and_lockfile() {
         let (mut flox, tempdir) = flox_instance();
@@ -1546,7 +1544,6 @@ mod tests {
 
     /// A no-op with edit returns EditResult::Unchanged
     #[test]
-    #[serial]
     fn edit_no_op_returns_unchanged() {
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env_view = new_core_environment(&flox, "version = 1");
@@ -1559,7 +1556,6 @@ mod tests {
     /// Trying to build a manifest with a system other than the current one
     /// results in an error that is_incompatible_system_error()
     #[test]
-    #[serial]
     fn build_incompatible_system() {
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env_view = new_core_environment(&flox, "");
@@ -1580,7 +1576,6 @@ mod tests {
     /// Trying to build a manifest with a package that is incompatible with the current system
     /// results in an error that is_incompatible_package_error()
     #[test]
-    #[serial]
     fn build_incompatible_package() {
         #[cfg(target_os = "macos")]
         let env_files_dirname = "glibc_incompatible_v0_both_darwin";
@@ -1601,7 +1596,6 @@ mod tests {
     /// Trying to build a manifest with an insecure package results in an error
     /// that is_incompatible_package_error()
     #[test]
-    #[serial]
     fn build_insecure_package() {
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env_view = new_core_environment_from_env_files(
@@ -1637,7 +1631,6 @@ mod tests {
 
     /// Installing hello with edit returns EditResult::Success
     #[test]
-    #[serial]
     fn edit_adding_package_returns_success() {
         let (mut env_view, mut flox, _temp_dir_handle) = empty_core_environment();
 
@@ -1661,7 +1654,6 @@ mod tests {
 
     /// Adding a hook with edit returns EditResult::ReActivateRequired
     #[test]
-    #[serial]
     fn edit_adding_hook_returns_re_activate_required() {
         let (mut env_view, flox, _temp_dir_handle) = empty_core_environment();
 
@@ -1794,7 +1786,6 @@ mod tests {
 
     /// linking an environment should set a gc-root
     #[test]
-    #[serial]
     #[cfg(feature = "impure-unit-tests")]
     fn build_flox_environment_and_links() {
         let (mut flox, tempdir) = flox_instance();

--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -817,7 +817,6 @@ mod tests {
     use flox_rust_sdk::providers::catalog::test_helpers::resolved_pkg_group_with_dummy_package;
     use flox_rust_sdk::providers::catalog::Client;
     use pretty_assertions::assert_eq;
-    use serial_test::serial;
 
     use super::*;
     use crate::commands::init::ProvidedPackage;
@@ -898,7 +897,6 @@ mod tests {
 
     /// ProvidedVersion::Compatible should be returned for an empty pyproject.toml
     #[tokio::test]
-    #[serial]
     async fn pyproject_empty_with_catalog() {
         let (mut flox, _temp_dir_handle) = flox_instance();
 
@@ -925,7 +923,6 @@ mod tests {
 
     /// ProvidedVersion::Compatible should be returned for requires-python = ">=3.8"
     #[tokio::test]
-    #[serial]
     async fn pyproject_available_version_with_catalog() {
         let (mut flox, _temp_dir_handle) = flox_instance();
 
@@ -959,7 +956,6 @@ mod tests {
 
     /// ProvidedVersion::Incompatible should be returned for requires-python = "1"
     #[tokio::test]
-    #[serial]
     async fn pyproject_unavailable_version_with_catalog() {
         let (mut flox, _temp_dir_handle) = flox_instance();
 
@@ -995,7 +991,6 @@ mod tests {
 
     /// ProvidedVersion::Incompatible should be returned for requires-python = "1"
     #[tokio::test]
-    #[serial]
     async fn pyproject_parse_version_with_catalog() {
         let (mut flox, _temp_dir_handle) = flox_instance();
 
@@ -1088,7 +1083,6 @@ mod tests {
 
     /// ProvidedVersion::Compatible should be returned for python = "^3.7"
     #[tokio::test]
-    #[serial]
     async fn poetry_pyproject_available_version_with_catalog() {
         let (mut flox, _temp_dir_handle) = flox_instance();
 
@@ -1131,7 +1125,6 @@ mod tests {
 
     /// ProvidedVersion::Incompatible should be returned for python = "1"
     #[tokio::test]
-    #[serial]
     async fn poetry_pyproject_unavailable_version_with_catalog() {
         let (mut flox, _temp_dir_handle) = flox_instance();
 


### PR DESCRIPTION
No one wants stale cereal.

These were added to avoid pkgdb concurrency issues. If I remember
correctly, init hooks called search which could trigger a pkgdb scrape,
and the core_environment tests installed actual packages which could
also trigger a pkgdb scrape.

We can drop #[serial] now that we're no longer calling pkgdb.

The `serial_test` crate was not dropped since we still use it for
metrics tests.