### PR TITLE
test(build): Serial tests to workaround EOF bug

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3387,6 +3387,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
 dependencies = [
+ "fslock",
  "futures",
  "log",
  "once_cell",

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -42,6 +42,7 @@ url-escape.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
 xdg.workspace = true
+serial_test = { workspace = true, features = ["file_locks"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -253,6 +253,10 @@ fn read_output_to_channel(
 ///
 /// Currently, this is _the_ testsuite for the `flox-build.mk` builder.
 #[cfg(test)]
+// TODO: https://github.com/flox/flox/issues/2185
+// Serialise all build tests to workaround potential Nix bug.
+// Use file-based locking to be compatible with `nextest`.
+#[serial_test::file_serial(build)]
 mod tests {
     use std::fs::{self};
 


### PR DESCRIPTION
Related debugging thread: https://flox-dev.slack.com/archives/C05P6A5J6U8/p1727913617359869

## Proposed Changes

To workaround the bug in the commented issue which affects a variety of tests like this:

    stdout: lock released on '/nix/store/2gj49g4zw03y1mlzvs26kxyq6bxh5paq-foo-0.0.0.lock'
    stdout: lock released on '/nix/store/hxvflmc8635w15bpsmjqy8ixwdgb8pqs-foo-0.0.0-buildCache.lock'
    stdout: building of '/nix/store/4i5kip3jnpcchzjky78zlw41yscigvzl-foo-0.0.0.drv^*' from .drv file: done
    stdout: building of '/nix/store/4i5kip3jnpcchzjky78zlw41yscigvzl-foo-0.0.0.drv^*' from .drv file: goal destroyed
    stdout: performing daemon worker op: 11
    stdout: sending GC root '/nix/store/hxvflmc8635w15bpsmjqy8ixwdgb8pqs-foo-0.0.0-buildCache'
    stdout: closing daemon connection because of an exception
    stdout: error: unexpected end-of-file
    stderr: make: *** [/Users/dcarley/projects/flox/flox/package-builder/flox-build.mk:369: foo_nix_sandbox_build] Error 1
    stdout: make: Leaving directory '/private/tmp/.tmpmSuiUp/temp/.tmpix9T16'
    test providers::build::tests::cleans_up_all ... FAILED

Plain `serial_test::serial` doesn't work with `nextest` because they are run in separate processes, so we have to use `serial_test::file_serial`:

- https://docs.rs/serial_test/latest/serial_test/attr.file_serial.html

`nextest` groups work but they are configured out-of-band from the tests themselves and wouldn't fix the issue when running `cargo test` from a standard IDE:

- https://nexte.st/docs/configuration/test-groups/

## Release Notes

N/A
