### PR TITLE
test: add tests for flox_runtime_dir

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1118,6 +1118,8 @@ dependencies = [
  "serde",
  "serde_json",
  "shared",
+ "temp-env",
+ "tempfile",
  "time",
  "tracing",
  "uuid",

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -16,3 +16,7 @@ tracing.workspace = true
 uuid.workspace = true
 xdg.workspace = true
 
+
+[dev-dependencies]
+tempfile.workspace = true
+temp-env.workspace = true


### PR DESCRIPTION
Adapt the tests for services_socket_path to cover the cases we care about for flox_runtime_dir.