### PR TITLE
refactor(build): Set current_dir and unset MAKEFLAGS for flox-build.mk

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -90,8 +90,8 @@ impl FloxBuildMk {
         // todo: extra makeflags, eventually
         let mut command = Command::new(&*GNUMAKE_BIN);
         command.env_remove("MAKEFLAGS");
-        command.arg("-f").arg(&*FLOX_BUILD_MK);
-        command.arg("-C").arg(base_dir);
+        command.arg("--file").arg(&*FLOX_BUILD_MK);
+        command.arg("--directory").arg(base_dir); // Change dir before reading makefile.
         command.arg(format!("FLOX_ENV={}", flox_env.display()));
 
         command

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -89,6 +89,7 @@ impl FloxBuildMk {
     fn base_command(&self, base_dir: &Path, flox_env: &Path) -> Command {
         // todo: extra makeflags, eventually
         let mut command = Command::new(&*GNUMAKE_BIN);
+        command.env_remove("MAKEFLAGS");
         command.arg("-f").arg(&*FLOX_BUILD_MK);
         command.arg("-C").arg(base_dir);
         command.arg(format!("FLOX_ENV={}", flox_env.display()));


### PR DESCRIPTION
## Proposed Changes

This was split out of https://github.com/flox/flox/pull/2174 to make it easier to review and not hold up the fix.

**refactor(build): Set current_dir for flox-build.mk**

When investigating the build test failures in #2185 we suspected that
one test might be cleaning up the contents of a build from another test
because `flox-build.mk` depends on the current working directory being
the Flox environment and Michael wasn't sure that the `-C` was
sufficient.

This turned out not to be the case. Based on the `Entering directory`
output and man page for the argument it is working as intended:

> Change to directory dir before reading the makefiles or doing anything else.

However if Michael was unsure, and he's most familiar with `make` and
`flox-build.mk`, then it doesn't hurt to make it more explicit by also
changing directory on the command construct.

**refactor(build): unset MAKEFLAGS for flox-build.mk**

To prevent leaking recursion info if a user wraps `flox build` in their
own `make` targets. We already do this when calling a local build script
from `flox-build.mk` but we should protect above this too:

- https://www.gnu.org/software/make/manual/html_node/Options_002fRecursion.html

## Release Notes

N/A