### PR TITLE
fix(pkgs/flox): use semver build metadata

### DIFF
--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -20,9 +20,9 @@ let
     if (FLOX_VERSION != null) then
       FLOX_VERSION
     else if !(self ? revCount || self ? shortRev) then
-      "${fileVersion}-dirty"
+      "${fileVersion}+git.dirty"
     else if !(self ? revCount) then
-      "${fileVersion}-g${self.shortRev}"
+      "${fileVersion}+git.${self.shortRev}"
     else
       fileVersion;
 in


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Instead of using a version identifier that isn't really parsable by semver, use [semver build metadata] to denote the git hash or dirty working directory.

So that when I install flox with `nix profile install github:flox/flox`, it has a proper semver version string. It'll look something as follows.

```console
$ realpath "$(which flox)"
/nix/store/4cd2mak5as0br4232b6bpqfcmxa57gn9-flox-1.3.3+git.010f25e/bin/flox
$ flox --version
1.3.3+git.010f25e
```

[semver build metadata]: https://semver.org/#spec-item-10

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
- Flox installed with `nix profile install github:flox/flox` now gives a proper semver version when `flox --version` is run.

<!-- Many thanks! -->
