### PR TITLE
refactor(activate): shfmt most scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,7 @@ trim_trailing_whitespace = true
 # Shell files
 # -----------
 
-[*.{sh,bash,bats,zsh}]
+[{*.{sh,bash,bats,zsh},activate}]
 indent_style       = space  # Use spaces not tabs
 indent_size        = 2      # 2 space width
 binary_next_line   = true   # Pipes go at beginning of newline, not end.

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -50,12 +50,12 @@ FLOX_TURBO="${FLOX_TURBO:-}"
 FLOX_NOPROFILE="${FLOX_NOPROFILE:-}"
 while true; do
   case "$1" in
-    -c|--command)
+    -c | --command)
       shift
       if [ -z "$1" ]; then
-	echo "Option -c requires an argument." >&2
-	echo "$USAGE" >&2
-	exit 1
+        echo "Option -c requires an argument." >&2
+        echo "$USAGE" >&2
+        exit 1
       fi
       FLOX_CMD="$1"
       shift
@@ -102,7 +102,7 @@ fi
 #       the value coming from the CLI for now because it won't be set for
 #       container invocations, and it would have the incorrect value for
 #       nested flox activations.
-_FLOX_ENV="$( $_coreutils/bin/dirname -- "${BASH_SOURCE[0]}" )"
+_FLOX_ENV="$($_coreutils/bin/dirname -- "${BASH_SOURCE[0]}")"
 if [ -n "$FLOX_ENV" ] && [ "$FLOX_ENV" != "$_FLOX_ENV" ]; then
   echo "WARN: detected change in FLOX_ENV: $FLOX_ENV -> $_FLOX_ENV" >&2
 fi
@@ -117,14 +117,10 @@ unset FLOX_SHELL
 
 # Bail if the shell is unsupported.
 case "$_flox_shell" in
-  *bash)
-    ;;
-  *fish)
-    ;;
-  *tcsh)
-    ;;
-  *zsh)
-    ;;
+  *bash) ;;
+  *fish) ;;
+  *tcsh) ;;
+  *zsh) ;;
   *)
     echo "Unsupported shell: $_flox_shell" >&2
     exit 1

--- a/assets/activation-scripts/activate.d/attach.bash
+++ b/assets/activation-scripts/activate.d/attach.bash
@@ -10,12 +10,12 @@ fi
 
 # Assert that the expected _{add,del}_env variables are present.
 if [ -z "$_add_env" ] || [ -z "$_del_env" ]; then
-  echo "ERROR (activate): \$_add_env and \$_del_env not found in environment" >&2;
+  echo "ERROR (activate): \$_add_env and \$_del_env not found in environment" >&2
   if [ -h "$FLOX_ENV" ]; then
-    echo "moving $FLOX_ENV link to $FLOX_ENV.$$ - please try again" >&2;
+    echo "moving $FLOX_ENV link to $FLOX_ENV.$$ - please try again" >&2
     $_coreutils/bin/mv "$FLOX_ENV" "$FLOX_ENV.$$"
   fi
-  exit 1;
+  exit 1
 fi
 
 # Replay the environment for the benefit of this shell.

--- a/assets/activation-scripts/activate.d/set-prompt.zsh
+++ b/assets/activation-scripts/activate.d/set-prompt.zsh
@@ -4,30 +4,29 @@ _floxPrompt1="${FLOX_PROMPT-flox}"
 _floxPrompt2="[$FLOX_PROMPT_ENVIRONMENTS]"
 
 if [[ "${NO_COLOR:-0}" == "0" ]]; then
-    _floxPrompt1="%B%F{${FLOX_PROMPT_COLOR_1}}${_floxPrompt1}%f%b"
-    _floxPrompt2="%F{${FLOX_PROMPT_COLOR_2}}${_floxPrompt2}%f"
+  _floxPrompt1="%B%F{${FLOX_PROMPT_COLOR_1}}${_floxPrompt1}%f%b"
+  _floxPrompt2="%F{${FLOX_PROMPT_COLOR_2}}${_floxPrompt2}%f"
 fi
 
 _flox="${_floxPrompt1} ${_floxPrompt2} "
 
-if [ -n "$_flox" -a -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" -a "${_FLOX_SET_PROMPT:-}" != false ];
-then
-    # Start by saving the original value of PS1.
-    if [ -z "${FLOX_SAVE_ZSH_PS1:=}" ]; then
-        export FLOX_SAVE_ZSH_PS1="$PS1"
-    fi
-    case "$FLOX_SAVE_ZSH_PS1" in
-        # If the prompt contains an embedded newline,
-        # then insert the flox indicator immediately after
-        # the (first) newline.
-        *\\n*)      PS1="${FLOX_SAVE_ZSH_PS1/\\n/\\n$_flox}";;
-        *\\012*)    PS1="${FLOX_SAVE_ZSH_PS1/\\012/\\012$_flox}";;
+if [ -n "$_flox" -a -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" -a "${_FLOX_SET_PROMPT:-}" != false ]; then
+  # Start by saving the original value of PS1.
+  if [ -z "${FLOX_SAVE_ZSH_PS1:=}" ]; then
+    export FLOX_SAVE_ZSH_PS1="$PS1"
+  fi
+  case "$FLOX_SAVE_ZSH_PS1" in
+    # If the prompt contains an embedded newline,
+    # then insert the flox indicator immediately after
+    # the (first) newline.
+    *\\n*) PS1="${FLOX_SAVE_ZSH_PS1/\\n/\\n$_flox}" ;;
+    *\\012*) PS1="${FLOX_SAVE_ZSH_PS1/\\012/\\012$_flox}" ;;
 
-        # Otherwise, prepend the flox indicator.
-        *)          PS1="$_flox$FLOX_SAVE_ZSH_PS1";;
-    esac
+    # Otherwise, prepend the flox indicator.
+    *) PS1="$_flox$FLOX_SAVE_ZSH_PS1" ;;
+  esac
 
-    # TODO: figure out zsh way of setting window and icon title.
+  # TODO: figure out zsh way of setting window and icon title.
 fi
 
 unset _flox _floxPrompt1 _floxPrompt2

--- a/assets/activation-scripts/activate.d/start-services.bash
+++ b/assets/activation-scripts/activate.d/start-services.bash
@@ -1,6 +1,6 @@
 NOT_READY="SOCKET_NOT_READY"
 
-poll_services_status () {
+poll_services_status() {
   local socket_file="$1"
   local output
   output=$($_process_compose process list -u "$socket_file" -o json 2>&1)
@@ -10,14 +10,14 @@ poll_services_status () {
   # We don't want to exit on pipe failures here
   set +o pipefail
   local parsed_json
-  parsed_json=$(echo "$output" | "$_jq" -r -c '.[0].status' 2>/dev/null)
+  parsed_json=$(echo "$output" | "$_jq" -r -c '.[0].status' 2> /dev/null)
   # Restore the previous shell settings
   eval "$saved_options"
   # `parsed_json` will be a null string if anything went wrong
   echo "${parsed_json:-${NOT_READY}}"
 }
 
-wait_for_services_socket () {
+wait_for_services_socket() {
   local socket_file="$1"
   local status
   status=$(poll_services_status "$socket_file")
@@ -27,9 +27,11 @@ wait_for_services_socket () {
   done
 }
 
-start_services_blocking () {
-  local config_file="$1"; shift
-  local socket_file="$1"; shift
+start_services_blocking() {
+  local config_file="$1"
+  shift
+  local socket_file="$1"
+  shift
   local log_dir="$1"
   local timestamp_ms
   timestamp_ms=$("$_coreutils/bin/date" "+%Y%m%d%H%M%S%6N")
@@ -45,9 +47,9 @@ start_services_blocking () {
   # services
   if [ -n "$_FLOX_SERVICES_TO_START" ]; then
     readarray -t services_to_start < <(echo "$_FLOX_SERVICES_TO_START" | "$_jq" -r '.[]')
-    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up "${services_to_start[@]}" -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false >/dev/null 2>&1 &
+    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up "${services_to_start[@]}" -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
   else
-    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false >/dev/null 2>&1 &
+    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
   fi
   # Make these functions available in subshells so that `timeout` can call them
   export -f wait_for_services_socket poll_services_status

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -89,13 +89,13 @@ if [ $flox_env_found -eq 0 ]; then
 
   # Capture environment variables to _set_ as "key=value" pairs.
   # comm -13: only env declarations unique to `$_end_env` (new declarations)
-  $_coreutils/bin/comm -13 "$_start_env" "$_end_env" | \
-    $_gnused/bin/sed -e 's/^declare -x //' > "$_add_env"
+  $_coreutils/bin/comm -13 "$_start_env" "$_end_env" \
+    | $_gnused/bin/sed -e 's/^declare -x //' > "$_add_env"
 
   # Capture environment variables to _unset_ as a list of keys.
   # TODO: remove from $_del_env keys set in $_add_env
-  $_coreutils/bin/comm -23 "$_start_env" "$_end_env" | \
-    $_gnused/bin/sed -e 's/^declare -x //' -e 's/=.*//' > "$_del_env"
+  $_coreutils/bin/comm -23 "$_start_env" "$_end_env" \
+    | $_gnused/bin/sed -e 's/^declare -x //' -e 's/=.*//' > "$_del_env"
 
   # Don't need these anymore.
   $_coreutils/bin/rm -f "$_start_env" "$_end_env"

--- a/assets/activation-scripts/etc/profile.d/0501_rust.sh
+++ b/assets/activation-scripts/etc/profile.d/0501_rust.sh
@@ -1,4 +1,3 @@
-
 # shellcheck shell=bash
 export _coreutils="@coreutils@"
 # ============================================================================ #
@@ -9,7 +8,7 @@ export _coreutils="@coreutils@"
 
 # Only run if 'rustLibSrc' is in the environment
 if [[ -d "$FLOX_ENV/rustc-std-workspace-std" ]]; then
-  export RUST_SRC_PATH="$FLOX_ENV";
+  export RUST_SRC_PATH="$FLOX_ENV"
 fi
 
 # ---------------------------------------------------------------------------- #

--- a/assets/activation-scripts/etc/profile.d/0800_cuda.sh
+++ b/assets/activation-scripts/etc/profile.d/0800_cuda.sh
@@ -11,7 +11,7 @@ export _nawk="@nawk@"
 #
 # ---------------------------------------------------------------------------- #
 
-activate_cuda(){
+activate_cuda() {
   # Strip a trailing or lone slash so that we can construct it later.
   local fhs_root_prefix="${1%/}"
   # Path to ldconfig that can be substituted for testing.
@@ -30,18 +30,18 @@ activate_cuda(){
   fi
 
   # Skip when no Nvidia device
-  if ! ( "$_findutils/bin/find" "${fhs_root_prefix}/dev" -maxdepth 1 -iname 'nvidia*' -o -iname dxg | read -r ;); then
+  if ! ("$_findutils/bin/find" "${fhs_root_prefix}/dev" -maxdepth 1 -iname 'nvidia*' -o -iname dxg | read -r); then
     return 0
   fi
 
   # Use system library cache.
-  SYSTEM_LIBS=$("$ldconfig_bin" --print-cache -C /etc/ld.so.cache 2>/dev/null \
+  SYSTEM_LIBS=$("$ldconfig_bin" --print-cache -C /etc/ld.so.cache 2> /dev/null \
     | "$_nawk/bin/nawk" "\$1 ~ /${lib_pattern}/ { print \$4 }")
 
   # Fallback for NixOS.
   if [ -z "$SYSTEM_LIBS" ]; then
     # LD_AUDIT workaround for Linux: https://github.com/flox/flox/issues/1341
-    SYSTEM_LIBS=$(LD_AUDIT="" "$_fd/bin/fd" "$lib_pattern" "${fhs_root_prefix}/run/opengl-driver" 2>/dev/null)
+    SYSTEM_LIBS=$(LD_AUDIT="" "$_fd/bin/fd" "$lib_pattern" "${fhs_root_prefix}/run/opengl-driver" 2> /dev/null)
   fi
 
   # No matching libs from either results.

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -15,6 +15,7 @@
   nawk,
   fd,
   flox-activations,
+  shfmt,
 }:
 let
   ld-floxlib_so = if stdenv.isLinux then "${ld-floxlib}/lib/ld-floxlib.so" else "__LINUX_ONLY__";
@@ -66,4 +67,10 @@ runCommand "flox-activation-scripts"
       $out/activate.d/bash \
       $out/activate.d/set-prompt.bash \
       $out/etc/profile.d/*
+
+    chmod 0755 $out
+    cp ${../../.editorconfig} $out/.editorconfig
+    # This will only catch extensions and shebangs that `shfmt --find` knows about.
+    ${shfmt}/bin/shfmt --diff $out
+    rm $out/.editorconfig
   ''

--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -52,6 +52,7 @@ pre-commit-hooks.lib.${system}.run {
     clippy.enable = true;
     clippy.settings.denyWarnings = true;
     commitizen.enable = true;
+    # NB: `flox-activation-scripts` implements these at build time.
     shfmt.enable = false;
     # shellcheck.enable = true; # disabled until we have time to fix all the warnings
   };


### PR DESCRIPTION
## Proposed Changes

Split from https://github.com/flox/flox/pull/2209 because it turned out to be a yak-shave.

**fix(editorconfig): Add rule for activate**

`shfmt --find` identifies this file by shebang but it didn't apply the
same rules as the other files (e.g. defaulted to hard tabs) because it
only matched the `[*]` rule in `.editorconfig`.

**refactor(activate): Run shfmt --write on assets**

To consistently format all scripts that `shfmt` identifies by extension
or shebang. Lint checking will be applied in a subsequent commit.

**test(activate): Run shfmt on build**

To ensure that we don't regress formatting after applying it in a
preceding commit. This is limited to activation scripts for now, like
`shellcheck` is, because we haven't dealt with formatting of other
scripts in the repo.

This misses a small number of files that don't have an extension or
shebang. I did experiment with renaming the `{bash,zsh,tcsh,fish}` files
to have extensions but `shfmt` incorrectly attempts to format `.zsh`
files at the moment (PR incoming). Also naming them is hard. So we'll
live with this for now.

We temporarily need `.editorconfig` so that `shfmt` can apply the same
rules that our editors will use. `shfmt` discovers this file
automatically and doesn't have any options for specify its path.

The `chmod` is necessary to prevent the following error because the
directory is copied with `0555` by default:

    cp: cannot create regular file '/nix/store/gvgp6a7m21ifmc55794frnff16y19nzq-flox-activation-scripts/.editorconfig': Permission denied

## Release Notes

N/A