### PR TITLE
feat(containerize): add --load-into-registry flag

### DIFF
--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -19,6 +19,7 @@ flox [<general-options>] containerize
      [-d=<path> | -r=<owner/name>]
      [-o=<path>]
      [--tag=<tag>]
+     [--load-into-registry=backend]
 ```
 
 # DESCRIPTION
@@ -50,6 +51,14 @@ The produced container however can also run on macOS.
 :   Write the container to `<path>`
     (default: `./<environment-name>-container.tar`)
     If `<path>` is `-`, writes to `stdout`.
+
+`-t`, `--tag`
+:   Tag the container with `<tag>`
+    (default: `latest`)
+
+`-l`, `--load-into-registry`
+:   Loads the container into `<backend>` without having to pipe
+    Has to be one of `docker` or `podman`.
 
 ```{.include}
 ./include/environment-options.md
@@ -100,6 +109,17 @@ $ flox init
 $ flox install hello
 $ flox containerize --tag 'v1' -o - | docker load
 $ docker run --rm -it <container name>:v1
+[floxenv] $ hello
+Hello, world!
+```
+
+Create a container, and load it into Docker's local registry directly:
+
+```
+$ flox init
+$ flox install hello
+$ flox containerize --load-into-registry=docker
+$ docker run --rm -it <container name>:latest
 [floxenv] $ hello
 Hello, world!
 ```

--- a/cli/flox/src/commands/containerize.rs
+++ b/cli/flox/src/commands/containerize.rs
@@ -68,8 +68,7 @@ impl Containerize {
         };
 
         let (output, output_name): (Box<dyn Write + Send>, String) =
-            if self.load_into_registry.is_some() {
-                let registry = self.load_into_registry.unwrap();
+            if let Some(registry) = self.load_into_registry {
                 let command = Command::new(&registry)
                     .arg("load")
                     .stdin(Stdio::piped())

--- a/cli/flox/src/commands/containerize.rs
+++ b/cli/flox/src/commands/containerize.rs
@@ -41,7 +41,7 @@ pub struct Containerize {
         short,
         long("load-into-registry"),
         argument("registry"),
-        guard(is_accepted_registry, "one of docker or podman is required")
+        guard(is_accepted_registry, "'--load-into-registry' must be docker or podman")
     )]
     load_into_registry: Option<String>,
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Adds a new flag to the `flox containerize` command, `--load-into-registry`, which accepts `docker` or `podmand` as values. This will cause Flox to automatically stream the image into the "daemon" registry.
This way, the user doesn't have to pipe the output into something like `docker load`. Although it does do it that way in the background. 😅
I've decided to keep the default behavior of `flox containerize` producing a tar archive on disk, since I'd rather not break the existing users their workflow.

Closes flox/product#766

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
- `flox containerize` now supports the `--load-into-registry` flag
- `flox containerize --load-into-registry=docker` will cause the resulting image to be streamed into the local Docker daemon registry
- `flox containerize --load-into-registry=podman` will cause the resulting image to be streamed into the local Podman registry

<!-- Many thanks! -->
