### PR TITLE
test(build): Go mocks for non-Darwin

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -871,7 +871,7 @@ mod tests {
         fs::write(env_path.join("main.go"), arg0_code).unwrap();
 
         if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("init/go.json");
+            client.clear_and_load_responses_from_file("resolve/go.json");
         } else {
             panic!("expected Mock client")
         };
@@ -983,7 +983,7 @@ mod tests {
         fs::write(env_path.join("main.go"), exe_code).unwrap();
 
         if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("init/go.json");
+            client.clear_and_load_responses_from_file("resolve/go.json");
         } else {
             panic!("expected Mock client")
         };

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -111,6 +111,10 @@ cmd = "flox install hello"
 pre_cmd = "flox init"
 cmd = "flox install hello-unfree"
 
+[resolve.go]
+pre_cmd = "flox init"
+cmd = "flox install go"
+
 [resolve.krb5_after_prereqs_installed]
 files = ["envs/krb5_prereqs/manifest.toml"]
 pre_cmd = '''

--- a/test_data/generated/resolve/go.json
+++ b/test_data/generated/resolve/go.json
@@ -1,0 +1,140 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "go",
+            "broken": false,
+            "derivation": "/nix/store/x1p2gf1jcqn29l4agdqrb0w09rib7w3m-go-1.22.7.drv",
+            "description": "Go Programming language",
+            "insecure": false,
+            "install_id": "go",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "name": "go-1.22.7",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/rfcwglhhspqx5v5h0sl4b3py14i6vpxa-go-1.22.7"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "go",
+            "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "rev_count": 689866,
+            "rev_date": "2024-10-06T19:07:05Z",
+            "scrape_date": "2024-10-09T03:51:54Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "1.22.7"
+          },
+          {
+            "attr_path": "go",
+            "broken": false,
+            "derivation": "/nix/store/qk95aryv3n1mhmk0lxf55sg9yr0l6138-go-1.22.7.drv",
+            "description": "Go Programming language",
+            "insecure": false,
+            "install_id": "go",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "name": "go-1.22.7",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/64z59pb0ss407rbv1fcvq0ynngrwfa6k-go-1.22.7"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "go",
+            "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "rev_count": 689866,
+            "rev_date": "2024-10-06T19:07:05Z",
+            "scrape_date": "2024-10-09T03:51:54Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "1.22.7"
+          },
+          {
+            "attr_path": "go",
+            "broken": false,
+            "derivation": "/nix/store/4bjrs6k4a0xjyy5zanbc8igv0cffsi0a-go-1.22.7.drv",
+            "description": "Go Programming language",
+            "insecure": false,
+            "install_id": "go",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "name": "go-1.22.7",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/r8199g59rmp6ac0lnx86fpk57fbxc3bk-go-1.22.7"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "go",
+            "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "rev_count": 689866,
+            "rev_date": "2024-10-06T19:07:05Z",
+            "scrape_date": "2024-10-09T03:51:54Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "1.22.7"
+          },
+          {
+            "attr_path": "go",
+            "broken": false,
+            "derivation": "/nix/store/gp0ma9f4n4nxmgbgl1g65kvlf05cl22y-go-1.22.7.drv",
+            "description": "Go Programming language",
+            "insecure": false,
+            "install_id": "go",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "name": "go-1.22.7",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/chzgk756zb2cqlzbjr86m0lfxi63cdfy-go-1.22.7"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "go",
+            "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "rev_count": 689866,
+            "rev_date": "2024-10-06T19:07:05Z",
+            "scrape_date": "2024-10-09T03:51:54Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "1.22.7"
+          }
+        ],
+        "page": 689866,
+        "url": ""
+      }
+    }
+  ]
+]


### PR DESCRIPTION
## Proposed Changes

These tests would fail on Linux systems because they were using a multi-part mock response based on `flox init` where the initial request only resolves for Darwin. This results in the environment that silently omits the package and no `$FLOX_ENV/bin` is generated:

    stdout: make: Entering directory '/tmp/.tmplf5xse/temp/.tmpTH6NaM'
    stdout: Rendering foo build script to /tmp/nix-shell.5Qgf1P/def85939-foo-build.bash
    stdout: Building foo-0.0.0 in local mode
    stdout: MAKEFLAGS= out=/tmp/store_def85939439f94b0d8842804b8c5f21a-foo-0.0.0 /tmp/.tmplf5xse/temp/.tmpTH6NaM/.flox/run/aarch64-linux.name/activate --turbo -- bash -e /tmp/nix-shell.5Qgf1P/def85939-foo-build.bash
    stderr: /tmp/nix-shell.5Qgf1P/def85939-foo-build.bash: line 4: go: command not found
    stderr: make: *** [/mnt/package-builder/flox-build.mk:363: foo_local_build] Error 127
    stdout: make: Leaving directory '/tmp/.tmplf5xse/temp/.tmpTH6NaM'
    test providers::build::tests::build_wraps_binaries_with_preserved_arg0 ... FAILED

I ran into it this running the tests in a Linux container. Bill originally reported this and I _believe_ he's on Linux:

- https://flox-dev.slack.com/archives/C05P6A5J6U8/p1728415411448669?thread_ts=1728415411.448669

What I'm not clear about is why the `cli-dev` job on the Ubuntu Runner in CI hasn't been failing in the same way. This will be made more reliable by:

- https://github.com/flox/flox/issues/2228
- https://github.com/flox/flox/issues/1659

## Release Notes

N/A
