### PR TITLE
chore: bump nixpkgs

### DIFF
--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -58,6 +58,8 @@ pub enum ServiceError {
     ParseOutput(#[source] serde_json::Error),
     #[error("failed to read process log line")]
     ReadLogLine(#[source] std::io::Error),
+    #[error("failed to create pipe for log output")]
+    PipeCreation(#[source] nix::Error),
     #[error("{0}")] // just pass through whatever the message is
     InvalidConfig(String),
 }
@@ -712,35 +714,41 @@ impl ProcessComposeLogTail {
             "running process-compose logs --tail",
         );
 
-        cmd.stdout(Stdio::piped());
+        // Create a pipe to read combined stdout and stderr.
+        // Process-compose logs to stdout, but we want to capture stderr as well,
+        // as it prints an error message after the last line is read,
+        // which we use to stop reading early,
+        // as process-compose will block for about a second after printing the last line.
+        let (read_pipe, stdout_pipe_write) =
+            nix::unistd::pipe().map_err(ServiceError::PipeCreation)?;
+        let stderr_write_pipe = stdout_pipe_write
+            .try_clone()
+            .map_err(ServiceError::ReadLogLine)?;
+        cmd.stdout(Stdio::from(stdout_pipe_write));
+        cmd.stderr(Stdio::from(stderr_write_pipe));
 
         let mut child = cmd.spawn().map_err(ServiceError::ProcessComposeCmd)?;
 
-        let stdout = BufReader::new(child.stdout.take().unwrap());
+        let output = BufReader::new(std::fs::File::from(read_pipe));
 
         let mut lines = Vec::with_capacity(tail);
-        for line in stdout.lines() {
+        for line in output.lines() {
             let line = line.map_err(ServiceError::ReadLogLine)?;
 
-            // process-compose logs --tail will print an error message
+            // `process-compose logs --tail` will print an error message to stderr
             // after the last line is read.
+            //
             // ```
             // write close: write unix ->/tmp/.tmpnYlCZ2/S.process-compose: write: broken pipe
             // ```
-            // Unfortunately, this message is printed to stdout, not stderr,
-            // so we can't filter it out trivially.
-            // For now, assume it's the last line and break out of the loop.
-            // A change to print to stderr instead was proposed in
-            // <https://github.com/F1bonacc1/process-compose/pull/216>.
             //
             // Calling process-compose takes about ~1 second
             // even though process-compose will print the logs immediately,
             // it will block for around a second before exiting :)
-            // Hence we read from the output stream directly,
-            // and break once we see the last line.
+            // Hence, we read both stdout and stderr
+            // and break once we see the line "write close: [..]".
             // This relies on the assumption that the last line is always
-            // the aforementioned error message,
-            // and that this is printed to stdout, incorrectly as that may be.
+            // the aforementioned error message.
             if line.starts_with("write close: write unix") {
                 debug!("last line read, stopping log reader");
                 break;

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -112,7 +112,7 @@ setup_start_counter_services() {
 @test "can call process-compose" {
   run "$PROCESS_COMPOSE_BIN" version
   assert_success
-  assert_output --partial "v1.9"
+  assert_output --partial "v1.27.0"
 }
 
 @test "process-compose can run generated config file" {

--- a/flake.lock
+++ b/flake.lock
@@ -75,33 +75,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721743106,
-        "narHash": "sha256-adRZhFpBTnHiK3XIELA3IBaApz70HwCYfv7xNrHjebA=",
+        "lastModified": 1727122398,
+        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f",
+        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
         "type": "github"
       },
       "original": {
         "owner": "flox",
         "ref": "stable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-process-compose": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1722813957,
-        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
-        "owner": "flox",
-        "repo": "nixpkgs",
-        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flox",
-        "ref": "staging.20240817",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -150,7 +133,6 @@
         "crane": "crane",
         "fenix": "fenix",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-process-compose": "nixpkgs-process-compose",
         "pre-commit-hooks": "pre-commit-hooks",
         "sqlite3pp": "sqlite3pp"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,6 @@
     "flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs="
   ];
 
-  # XXX Temporary: lock process-compose to v1.9 until we can update flox to use
-  # the latest version. v1.9 did not appear on any stable snapshots so we instead
-  # select the most recent staging branch commit on which it appeared.
-  inputs.nixpkgs-process-compose.url = "github:flox/nixpkgs/staging.20240817";
-  inputs.nixpkgs-process-compose.flake = false;
-
   # Roll forward monthly as **our** stable branch advances. Note that we also
   # build against the staging branch in CI to detect regressions before they
   # reach stable.
@@ -39,7 +33,6 @@
     inputs:
     let
       # ------------------------------------------------------------------------ #
-      # Temporarily use nixpkgs-process-compose
       nixpkgs.legacyPackages = {
         inherit (inputs.nixpkgs.legacyPackages)
           x86_64-linux
@@ -55,10 +48,6 @@
       # --------
       overlays.deps = nixpkgs.lib.composeManyExtensions [
         (final: prev: {
-          process-compose = final.callPackage (
-            inputs.nixpkgs-process-compose + "/pkgs/applications/misc/process-compose"
-          ) { };
-
           # Add IWYU pragmas to `nlohmann_json'
           # ( _include what you use_ extensions to headers for static analysis )
           nlohmann_json = final.callPackage ./pkgs/nlohmann_json { inherit (prev) nlohmann_json; };

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -177,8 +177,18 @@ maybeGetCursor( nix::ref<nix::EvalState> &              state,
 {
   debugLog(
     nix::fmt( "getting attr cursor '%s.%s", cursor->getAttrPathStr(), attr ) );
-  auto symbol      = state->symbols.create( attr );
-  auto maybeCursor = cursor->maybeGetAttr( symbol, true );
+  auto        symbol = state->symbols.create( attr );
+  MaybeCursor maybeCursor;
+  try
+    {
+      maybeCursor = cursor->maybeGetAttr( symbol );
+    }
+  catch ( nix::eval_cache::CachedEvalError & e )
+    {
+      /* Force re-evaluating a cached error so we show the original error to the
+       * user */
+      e.force();
+    }
   if ( maybeCursor == nullptr ) { return std::nullopt; }
   auto newCursor
     = static_cast<nix::ref<nix::eval_cache::AttrCursor>>( maybeCursor );

--- a/pkgdb/src/realisepkgs/realise.cc
+++ b/pkgdb/src/realisepkgs/realise.cc
@@ -47,8 +47,18 @@ maybeGetCursor( nix::ref<nix::EvalState> &              state,
 {
   debugLog(
     nix::fmt( "getting attr cursor '%s.%s", cursor->getAttrPathStr(), attr ) );
-  auto symbol      = state->symbols.create( attr );
-  auto maybeCursor = cursor->maybeGetAttr( symbol, true );
+  auto        symbol = state->symbols.create( attr );
+  MaybeCursor maybeCursor;
+  try
+    {
+      maybeCursor = cursor->maybeGetAttr( symbol );
+    }
+  catch ( nix::eval_cache::CachedEvalError & e )
+    {
+      /* Force re-evaluating a cached error so we show the original error to the
+       * user */
+      e.force();
+    }
   if ( maybeCursor == nullptr ) { return std::nullopt; }
   auto newCursor
     = static_cast<nix::ref<nix::eval_cache::AttrCursor>>( maybeCursor );

--- a/pkgdb/tests/buildenv.bats
+++ b/pkgdb/tests/buildenv.bats
@@ -189,6 +189,12 @@ setup_file() {
 # With '--container' produces a script that can be used to build a container.
 # bats test_tags=buildenv:container
 @test "Environment builds container" {
+  # 2024-10-22: fakeroot used in the creation of layers aborts ion macos with:
+  #
+  # dyld[25304]: symbol not found in flat namespace '_fstat$INODE64'
+  # /nix/store/52g78wj19d5bxal1znqgrgnrifhz6z15-fakeroot-1.32.2/bin/fakeroot: line 178: 25304 Abort trap: 6           FAKEROOTKEY=$FAKEROOTKEY DYLD_INSERT_LIBRARIES="$FAKEROOT_LIB" ${SHELL:-/bin/sh}
+  [ "${NIX_SYSTEM#*-}" = "darwin" ] && skip "Container builds are only supported on '*-linux'"
+
   run --separate-stderr \
     "$PKGDB_BIN" buildenv "$LOCKFILES/single-package/manifest.lock" \
     --container flox-env-container
@@ -216,6 +222,12 @@ setup_file() {
 # with a specific tag.
 # bats test_tags=buildenv:container-tag
 @test "Environment builds container with tag" {
+  # 2024-10-22: fakeroot used in the creation of layers aborts ion macos with:
+  #
+  # dyld[25304]: symbol not found in flat namespace '_fstat$INODE64'
+  # /nix/store/52g78wj19d5bxal1znqgrgnrifhz6z15-fakeroot-1.32.2/bin/fakeroot: line 178: 25304 Abort trap: 6           FAKEROOTKEY=$FAKEROOTKEY DYLD_INSERT_LIBRARIES="$FAKEROOT_LIB" ${SHELL:-/bin/sh}
+  [ "${NIX_SYSTEM#*-}" = "darwin" ] && skip "Container builds are only supported on '*-linux'"
+
   container_name='flox-env-container-tag-test'
   container_tag='somereallyhardtoguesstag'
 


### PR DESCRIPTION
This bumps
- Nix 2.18.5 -> 2.18.7. The interface for `maybeGetAttr` was changed in Nix commit 2c88930ef298f6804eb9c064ca918aef01fcd2e3. We currently set `forceErrors = true` in one instance, but `forceErrors` was removed. To preserve current behavior, we could catch CachedEvalError and call force()
- process-compose 1.9 -> 1.27.0. We no longer need to pull process-compose from a pinned nixpkgs because the version in nixpkgs stable is new enough.
- [fix(services-tail): stop on final line on stderr](https://github.com/flox/flox/pull/2231/commits/ea95d5c0a11247c41b2f6d3c308c3521f305051c): 

`process-compose logs --tail` immediately prints logs
and then takes about a second to eventually exit.
In order to avoid this unnecessary pause, we utilise the fact
that process compose will print a warning message

    write close: write unix ->/tmp/.tmpnYlCZ2/S.process-compose: write: broken pipe

as the last line.
Previously, this warning was (incorrectly) printed to stdout as well,
which was eventually fixed upstream.
However, since we inspected only the stdout stream, we were not skipping the pause anymore,
which in effect broke the 'logs: tail does not wait' integration test.

The proposed fix is to combine the output streams of process compose and use them,
as if all messages were printed on a single stream, simulating the previous behaviour.

Eventually, we want to avoid trying to stop reading early, and instead have `process-compose`
exit as soon as possible.