### PR TITLE
fix(build): Patch and test dynamic linked binaries

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
  "flox-core",
  "fslock",
  "futures",
+ "goblin",
  "httpmock",
  "indent",
  "indexmap 2.6.0",
@@ -1431,6 +1432,17 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -2475,6 +2487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3106,6 +3124,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "sct"

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -46,6 +46,7 @@ serial_test = { workspace = true, features = ["file_locks"] }
 
 [dev-dependencies]
 anyhow.workspace = true
+goblin = "0.8.2"
 httpmock.workspace = true
 pretty_assertions.workspace = true
 proptest.workspace = true

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -40,6 +40,7 @@ pkgs.runCommandNoCC name
         gnused
         makeWrapper
       ]
+      ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ autoPatchelfHook ]
       ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ darwin.autoSignDarwinBinariesHook ];
     outputs = [ "out" ] ++ pkgs.lib.optionals (buildCache != null) [ "buildCache" ];
   }
@@ -63,6 +64,9 @@ pkgs.runCommandNoCC name
             fi
             ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
               signDarwinBinariesInAllOutputs
+            ''}
+            ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+              autoPatchelfPostFixup
             ''}
           ''
       else


### PR DESCRIPTION
## Proposed Changes

Patch ELF binaries from impure builds to use an interpreter from the Nix store. This is the best effort that we can make when an impure build uses toolchains and libraries from the host OS rather than the Flox environment.

Any dynamically linked libraries are resolved by unqualified name at runtime. So we would use `libc` from the Flox environment, if it provides it, in preference over the system. This order can be influenced by setting `rpath` and/or `runpath` on the binary BUT to do so for an impure build we'd have to retrospectively identify the lib/pkg names (which is hard) and add them to the closure (which is too late).

This is tested with a Go environment that doesn't contain `gcc` or `glibc` but explicitly forces CGO compilation and uses `stdio`. This is made complicated by the `devShell` as explained below and in the comments.

The `autoPatchelfHook` needs to be called explicitly because `runCommand` doesn't call any phases/hooks. `autoPatchelfPostFixup` generates a bit of noise in the build output but we can deal with that in either ticket #2044 or #2127.

---

When testing the same project outside of the `devShell` from `main` on a Ubuntu container, no `rpath` or `runpath` are set:

    root@81430f57e252:/mnt# FLOX_FEATURES_BUILD=true nix run github:flox/flox -- build -d tmp
    ✨ Build completed successfully

    root@81430f57e252:/mnt# chrpath -l tmp/result-hello/bin/.hello-wrapped
    tmp/result-hello/bin/.hello-wrapped: no rpath or runpath tag found.

Resolves `libc` from the system:

    root@81430f57e252:/mnt# ldd tmp/result-hello/bin/.hello-wrapped
        linux-vdso.so.1 (0x0000ffffbe4a4000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffbe2a0000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffffbe467000)

Same when inside the environment which doesn't contain `libc`:

    root@81430f57e252:/mnt# nix run github:flox/flox -- activate -d tmp -- ldd tmp/result-hello/bin/.hello-wrapped
        linux-vdso.so.1 (0x0000ffffa7a29000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffa7640000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffffa79ec000)

Resolves `libc` from the environment if it contains it:

    root@81430f57e252:/mnt# nix run github:flox/flox -- install glibc -d tmp
    ⚠️  Installing 'glibc' for the following systems: ["aarch64-linux", "x86_64-linux"]
    ✅ 'glibc' installed to environment 'tmp'
    root@81430f57e252:/mnt# nix run github:flox/flox -- activate -d tmp -- ldd tmp/result-hello/bin/.hello-wrapped
        linux-vdso.so.1 (0x0000ffff992fa000)
        libpthread.so.0 => /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/libpthread.so.0 (0x0000ffff99090000)
        libc.so.6 => /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/libc.so.6 (0x0000ffff98ec0000)
        /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/ld-linux-aarch64.so.1 => /nix/store/mvsq4z2g9l05vfwdkr9nihbxyxm18nak-glibc-2.39-52/lib/ld-linux-aarch64.so.1 (0x0000ffff992bd000)

---

The modified behaviour for ELF is as follows, no `rpath` or `runpath` are set, as before:

    root@81430f57e252:/mnt# FLOX_FEATURES_BUILD=true nix run .#flox -- build -d tmp
    ✨ Build completed successfully

    root@81430f57e252:/mnt# chrpath -l tmp/result-hello/bin/.hello-wrapped
    tmp/result-hello/bin/.hello-wrapped: no rpath or runpath tag found.

The interpreter is now patched but `libc` will continue to be resolved from either the Flox environment or the host OS, in that order:

    root@81430f57e252:/mnt# ldd tmp/result-hello/bin/.hello-wrapped
        linux-vdso.so.1 (0x0000ffffa32b6000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffa30b0000)
        /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/ld-linux-aarch64.so.1 => /lib/ld-linux-aarch64.so.1 (0x0000ffffa3279000)

    root@81430f57e252:/mnt# nix run github:flox/flox -- activate -d tmp -- ldd tmp/result-hello/bin/.hello-wrapped
        linux-vdso.so.1 (0x0000ffff9b295000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff9aeb0000)
        /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/ld-linux-aarch64.so.1 => /lib/ld-linux-aarch64.so.1 (0x0000ffff9b258000)

    root@81430f57e252:/mnt# nix run github:flox/flox -- install glibc -d tmp
    ⚠️  Installing 'glibc' for the following systems: ["aarch64-linux", "x86_64-linux"]
    ✅ 'glibc' installed to environment 'tmp'
    root@81430f57e252:/mnt# nix run github:flox/flox -- activate -d tmp -- ldd tmp/result-hello/bin/.hello-wrapped
        linux-vdso.so.1 (0x0000ffffbc67d000)
        libc.so.6 => /nix/store/mvsq4z2g9l05vfwdkr9nihbxyxm18nak-glibc-2.39-52/lib/libc.so.6 (0x0000ffffbc270000)
        /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/ld-linux-aarch64.so.1 => /nix/store/mvsq4z2g9l05vfwdkr9nihbxyxm18nak-glibc-2.39-52/lib/ld-linux-aarch64.so.1 (0x0000ffffbc640000)

---

When run with `nix develop` it inherits `rpath`/`runpath` from the `devShell` which influences `ldd` from outside:

    root@81430f57e252:/mnt# FLOX_FEATURES_BUILD=true nix develop -c -- nix run github:flox/flox -- build -d tmp
    ✨ Build completed successfully

    root@81430f57e252:/mnt# chrpath -l tmp/result-hello/bin/.hello-wrapped
    tmp/result-hello/bin/.hello-wrapped: RUNPATH=/mnt/outputs/out/lib:/nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib:/nix/store/djqcjdx73hlg4ap96s478snydhpggq3j-gcc-13.3.0-lib/lib

    root@81430f57e252:/mnt# ldd tmp/result-hello/bin/.hello-wrapped
        linux-vdso.so.1 (0x0000ffffa7018000)
        libpthread.so.0 => /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/libpthread.so.0 (0x0000ffffa6fb0000)
        libc.so.6 => /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/libc.so.6 (0x0000ffffa6de0000)
        /nix/store/1c5f3l0rk178ipam8pw24dd20lv1v5a7-glibc-2.39-52/lib/ld-linux-aarch64.so.1 => /lib/ld-linux-aarch64.so.1 (0x0000ffffa6fdb000)

## Release Notes

N/A until builds general availability.
