### PR TITLE
docs(CONTRIBUTING): Testing from Linux container

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,6 +358,37 @@ subsets of tests.
 See the [bats usage documentation](https://bats-core.readthedocs.io/en/stable/usage.html)
 for details.
 
+##### Running tests in a Linux container
+
+It's possible to shorten the feedback loop when developing Linux dependent
+features on a MacOS system by running the tests from a container.
+
+Start a container with the code mounted in so that you can continue to use your normal editor:
+
+    docker run \
+        --rm --interactive --tty \
+        --volume $(pwd):/mnt --workdir /mnt \
+        --name flox-dev \
+        nixos/nix
+
+Within the container:
+
+    echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf
+    nix develop
+
+Outside the container, snapshot the store so that you don't have to download the world next time:
+
+    docker commit flox-dev flox:dev
+
+Within the container, remove any existing MacOS binaries and rebuild for Linux:
+
+    just clean
+    just build
+
+Within the container, to avoid `variable $src or $srcs should point to the source` errors per [NixOS/nix#8355](https://github.com/NixOS/nix/issues/8355):
+
+    unset TMPDIR
+
 ## Man Pages
 
 Unreleased changes to `man` pages are available from the `nix develop` shell but

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -352,6 +352,7 @@ endif # ifeq (Linux,$(OS))
 # Save path for most recent build of flox-activation-scripts package
 # in a file, and automatically rebuild that file when assets change,
 # or overwrite it with the value from the environment if defined.
+CLEANFILES += .ACTIVATION_SCRIPTS_PACKAGE_DIR
 ifdef ACTIVATION_SCRIPTS_PACKAGE_DIR
   .ACTIVATION_SCRIPTS_PACKAGE_DIR: FORCE
 	@# Only update the file if the value has changed.


### PR DESCRIPTION
## Proposed Changes

**docs(CONTRIBUTING): Testing from Linux container**

Write up my personal notes in case they're useful to anyone else now
that I've done this a few times when working on:

- CUDA support hooks
- Watchdog PID monitoring
- Patching binaries from `flox build`

**fix(pkgdb): Clean .ACTIVATION_SCRIPTS_PACKAGE_DIR**

So that `just clean` catches everything when you need to rebuild from
the same source tree between MacOS and Linux.

## Release Notes

N/A
