### PR TITLE
refactor: error for nested activate in Rust

### DIFF
--- a/assets/activation-scripts/activate.d/attach.bash
+++ b/assets/activation-scripts/activate.d/attach.bash
@@ -1,13 +1,5 @@
 # "Reactivation" of this environment.
 
-# If we're attempting to launch an interactive shell then just print a
-# message to say that the environment has already been activated.
-if [ -t 1 ] && [ $# -eq 0 ]; then
-  # TODO: should this be in Rust using message::error?
-  echo "❌ ERROR: Environment '$FLOX_ENV_DESCRIPTION' is already active." >&2
-  exit 1
-fi
-
 # Assert that the expected _{add,del}_env variables are present.
 if [ -z "$_add_env" ] || [ -z "$_del_env" ]; then
   echo "ERROR (activate): \$_add_env and \$_del_env not found in environment" >&2

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1342,6 +1342,8 @@ impl UninitializedEnvironment {
     }
 
     /// The environment description when displayed in a prompt
+    // TODO: we use this for activate errors in Bash since it doesn't have
+    // quotes whereas we use message_description for activate errors in Rust.
     pub fn bare_description(&self) -> Result<String> {
         if self.is_remote() {
             Ok(format!(
@@ -1363,6 +1365,8 @@ impl UninitializedEnvironment {
     }
 
     /// The environment description when displayed in messages
+    // TODO: we use this for activate errors in Rust whereas we use
+    // bare_description for activate errors in Bash since it doesn't add quotes.
     pub fn message_description(&self) -> Result<String> {
         if self.is_remote() {
             Ok(format!(

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2526,3 +2526,15 @@ EOF
   refute_output --partial "_flox"
   refute_output --partial "_FLOX"
 }
+
+@test "nested interactive activate fails" {
+  project_setup
+  run bash <(cat <<'EOF'
+    eval "$("$FLOX_BIN" activate)"
+
+    FLOX_SHELL="bash" expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+EOF
+)
+  assert_failure
+  assert_output --partial "Environment '$PROJECT_NAME' is already active"
+}


### PR DESCRIPTION
    We currently error for an interactive `flox activate` in our Bash
    activation scripts. With upcoming activation changes, Bash won't be
    looking at `_FLOX_ACTIVE_ENVIRONMENTS`, it will only decide whether to
    start or attach based on whether an environment is already activated
    somewhere, which we shouldn't error for.

    Move the error to Rust, which is also consistent with the activation
    design diagram.

    Also add a test as this behavior was not previously covered.