### PR TITLE
fix: Update AttrCursor API

### DIFF
--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -178,7 +178,7 @@ maybeGetCursor( nix::ref<nix::EvalState> &              state,
   debugLog(
     nix::fmt( "getting attr cursor '%s.%s", cursor->getAttrPathStr(), attr ) );
   auto symbol      = state->symbols.create( attr );
-  auto maybeCursor = cursor->maybeGetAttr( symbol, true );
+  auto maybeCursor = cursor->maybeGetAttr( symbol );
   if ( maybeCursor == nullptr ) { return std::nullopt; }
   auto newCursor
     = static_cast<nix::ref<nix::eval_cache::AttrCursor>>( maybeCursor );


### PR DESCRIPTION
From nix 1.18 we have to align with

AttrCursor: Remove forceErrors

Instead, force evaluation of the original value only if we need to show the exception to the user.

Commit: 6644b6099be2d3393206bf1c9c091c888c0a0f57

## Proposed Changes

I'm just removing the force parameter which has been removed from the API.

## Release Notes

N/A
