### PR TITLE
refactor: remove support for v0 manifests

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::str::FromStr;
 
 use log::debug;
 use pollster::FutureExt;
@@ -13,7 +12,6 @@ use super::{
     copy_dir_recursive,
     CanonicalizeError,
     InstallationAttempt,
-    MigrationInfo,
     UninstallationAttempt,
     UpgradeError,
     LOCKFILE_FILENAME,
@@ -23,7 +21,6 @@ use crate::data::CanonicalPath;
 use crate::flox::Flox;
 use crate::models::container_builder::ContainerBuilder;
 use crate::models::lockfile::{
-    LockedManifest,
     LockedManifestCatalog,
     LockedManifestError,
     LockedPackage,
@@ -35,11 +32,8 @@ use crate::models::manifest::{
     ManifestError,
     ManifestPackageDescriptor,
     PackageToInstall,
-    RawManifest,
     TomlEditError,
-    TypedManifest,
     TypedManifestCatalog,
-    MANIFEST_VERSION_KEY,
 };
 use crate::models::pkgdb::{
     call_pkgdb,
@@ -110,11 +104,11 @@ impl<State> CoreEnvironment<State> {
 
     /// Return a [LockedManifest] if the lockfile exists,
     /// otherwise return None
-    pub fn existing_lockfile(&self) -> Result<Option<LockedManifest>, CoreEnvironmentError> {
+    pub fn existing_lockfile(&self) -> Result<Option<LockedManifestCatalog>, CoreEnvironmentError> {
         let lockfile_path = self.lockfile_path();
         if let Ok(lockfile_path) = CanonicalPath::new(lockfile_path) {
             Ok(Some(
-                LockedManifest::read_from_file(&lockfile_path)
+                LockedManifestCatalog::read_from_file(&lockfile_path)
                     .map_err(CoreEnvironmentError::LockedManifest)?,
             ))
         } else {
@@ -122,73 +116,30 @@ impl<State> CoreEnvironment<State> {
         }
     }
 
-    pub fn manifest(&self) -> Result<TypedManifest, CoreEnvironmentError> {
+    pub fn manifest(&self) -> Result<TypedManifestCatalog, CoreEnvironmentError> {
         toml::from_str(&self.manifest_contents()?)
             .map_err(CoreEnvironmentError::DeserializeManifest)
     }
 
     /// Return a [LockedManifest] if the environment is already locked and has
     /// the same manifest contents as the manifest, otherwise return None.
-    /// Error if there is a v0 manifest that needs to be locked, because
-    /// locking with pkgdb is no longer supported
-    fn lockfile_if_up_to_date(&self) -> Result<Option<LockedManifest>, CoreEnvironmentError> {
+    fn lockfile_if_up_to_date(
+        &self,
+    ) -> Result<Option<LockedManifestCatalog>, CoreEnvironmentError> {
         let lockfile_path = self.lockfile_path();
 
         let Ok(lockfile_path) = CanonicalPath::new(lockfile_path) else {
             return Ok(None);
         };
 
-        let manifest_contents = self.manifest_contents()?;
-        let manifest: TypedManifest = toml::from_str(&self.manifest_contents()?)
+        let manifest: TypedManifestCatalog = toml::from_str(&self.manifest_contents()?)
             .map_err(CoreEnvironmentError::DeserializeManifest)?;
-        let lockfile = LockedManifest::read_from_file(&lockfile_path)
+        let lockfile = LockedManifestCatalog::read_from_file(&lockfile_path)
             .map_err(CoreEnvironmentError::LockedManifest)?;
 
         // Check if the manifest embedded in the lockfile and the manifest
         // itself have the same contents
-        let already_locked = match (manifest, &lockfile) {
-            (TypedManifest::Catalog(manifest), LockedManifest::Catalog(lock)) => {
-                *manifest == lock.manifest
-            },
-            (TypedManifest::Pkgdb(_), LockedManifest::Catalog(_)) => {
-                return Err(CoreEnvironmentError::LockingVersion0NotSupported);
-            },
-            (TypedManifest::Catalog(_), LockedManifest::Pkgdb(_)) => false,
-            (TypedManifest::Pkgdb(_), LockedManifest::Pkgdb(locked)) => {
-                // Try to deserialize TOML content into a JSON value
-                let manifest_value = toml::from_str::<serde_json::Value>(&manifest_contents).ok();
-                let manifest_object = manifest_value
-                    .as_ref()
-                    .and_then(|manifest_value| manifest_value.as_object());
-                match manifest_object {
-                    None => {
-                        // If we can't deserialize the manifest content as an
-                        // object, the lockfile is invalid and we can't relock,
-                        // so error.
-                        return Err(CoreEnvironmentError::LockingVersion0NotSupported);
-                    },
-                    Some(manifest_object) => {
-                        let lockfile_manifest = (*locked)
-                            .get("manifest")
-                            .and_then(|lockfile_manifest| lockfile_manifest.as_object());
-                        if let Some(lockfile_manifest) = lockfile_manifest {
-                            // pkgdb lock inserts the GA registry into the
-                            // manifest in the lockfile,
-                            // but the actual manifest won't have it
-                            let mut lockfile_manifest = lockfile_manifest.clone();
-                            lockfile_manifest.remove("registry");
-                            if manifest_object == &lockfile_manifest {
-                                true
-                            } else {
-                                return Err(CoreEnvironmentError::LockingVersion0NotSupported);
-                            }
-                        } else {
-                            return Err(CoreEnvironmentError::LockingVersion0NotSupported);
-                        }
-                    },
-                }
-            },
-        };
+        let already_locked = manifest == lockfile.manifest;
 
         if already_locked {
             Ok(Some(lockfile))
@@ -198,8 +149,6 @@ impl<State> CoreEnvironment<State> {
     }
 
     /// Lock the environment if it isn't already locked.
-    /// Error if there is a v0 manifest that needs to be locked, because
-    /// locking with pkgdb is no longer supported
     ///
     /// This might be a slight optimization as compared to calling [Self::lock],
     /// but [Self::lock] skips re-locking already locked packages,
@@ -207,7 +156,10 @@ impl<State> CoreEnvironment<State> {
     /// The real point of this method is letting us skip locking for an already
     /// locked pkgdb manifest,
     /// since pkgdb manifests can no longer be locked.
-    pub fn ensure_locked(&mut self, flox: &Flox) -> Result<LockedManifest, CoreEnvironmentError> {
+    pub fn ensure_locked(
+        &mut self,
+        flox: &Flox,
+    ) -> Result<LockedManifestCatalog, CoreEnvironmentError> {
         match self.lockfile_if_up_to_date()? {
             Some(lock) => Ok(lock),
             None => self.lock(flox),
@@ -218,7 +170,6 @@ impl<State> CoreEnvironment<State> {
     ///
     /// When a catalog client is provided, the catalog will be used to lock any
     /// "V1" manifest.
-    /// Without a catalog client, only "V0" manifests can be locked using the pkgdb.
     /// If a "V1" manifest is locked without a catalog client, an error will be returned.
     ///
     /// This re-writes the lock if it exists.
@@ -230,23 +181,14 @@ impl<State> CoreEnvironment<State> {
     /// The caller is responsible for skipping calls to lock when an environment
     /// is already locked.
     /// For that reason, this always writes the lockfile to disk.
-    pub fn lock(&mut self, flox: &Flox) -> Result<LockedManifest, CoreEnvironmentError> {
+    pub fn lock(&mut self, flox: &Flox) -> Result<LockedManifestCatalog, CoreEnvironmentError> {
         let manifest = self.manifest()?;
 
-        let lockfile = match manifest {
-            TypedManifest::Pkgdb(_) => {
-                return Err(CoreEnvironmentError::LockingVersion0NotSupported);
-            },
-            TypedManifest::Catalog(manifest) => {
-                tracing::debug!("using catalog client to lock");
-                LockedManifest::Catalog(self.lock_with_catalog_client(
-                    &flox.catalog_client,
-                    &flox.installable_locker,
-                    *manifest,
-                )?)
-            },
-        };
-
+        let lockfile = self.lock_with_catalog_client(
+            &flox.catalog_client,
+            &flox.installable_locker,
+            manifest,
+        )?;
         let environment_lockfile_path = self.lockfile_path();
 
         // Write the lockfile to disk
@@ -278,18 +220,10 @@ impl<State> CoreEnvironment<State> {
             let Ok(lockfile_path) = CanonicalPath::new(self.lockfile_path()) else {
                 break 'lockfile None;
             };
-            let lockfile = LockedManifest::read_from_file(&lockfile_path)
-                .map_err(CoreEnvironmentError::LockedManifest)?;
-            match lockfile {
-                LockedManifest::Catalog(lockfile) => Some(lockfile),
-                _ => {
-                    // This will be the case when performing a migration
-                    debug!(
-                        "Found version 1 manifest, but lockfile doesn't match: Ignoring lockfile."
-                    );
-                    None
-                },
-            }
+            Some(
+                LockedManifestCatalog::read_from_file(&lockfile_path)
+                    .map_err(CoreEnvironmentError::LockedManifest)?,
+            )
         };
 
         LockedManifestCatalog::lock_manifest(
@@ -328,17 +262,13 @@ impl<State> CoreEnvironment<State> {
     pub fn build(&mut self, flox: &Flox) -> Result<PathBuf, CoreEnvironmentError> {
         let lockfile_path = CanonicalPath::new(self.lockfile_path())
             .map_err(CoreEnvironmentError::BadLockfilePath)?;
-        let lockfile = LockedManifest::read_from_file(&lockfile_path)
+        let lockfile = LockedManifestCatalog::read_from_file(&lockfile_path)
             .map_err(CoreEnvironmentError::LockedManifest)?;
 
         let mut pkgdb_cmd = Command::new(Path::new(&*PKGDB_BIN));
         pkgdb_cmd.arg("buildenv").arg(lockfile_path);
 
-        let service_config_path = if let LockedManifest::Catalog(ref lockfile) = lockfile {
-            maybe_make_service_config_file(flox, lockfile)?
-        } else {
-            None
-        };
+        let service_config_path = maybe_make_service_config_file(flox, &lockfile)?;
         if let Some(service_config_path) = &service_config_path {
             pkgdb_cmd.args(["--service-config", &service_config_path.to_string_lossy()]);
         }
@@ -502,70 +432,65 @@ impl CoreEnvironment<ReadOnly> {
     }
 
     fn get_install_ids_to_uninstall(
-        manifest: &TypedManifest,
+        manifest: &TypedManifestCatalog,
         packages: Vec<String>,
     ) -> Result<Vec<String>, CoreEnvironmentError> {
-        let iids = if let TypedManifest::Catalog(manifest) = manifest {
-            let mut install_ids = Vec::new();
-            for pkg in packages {
-                // User passed an install id directly
-                if manifest.install.contains_key(&pkg) {
-                    install_ids.push(pkg);
-                    continue;
-                }
-
-                // User passed a package path to uninstall
-                // To support version constraints, we match the provided value against
-                // `<pkg-path>` and `<pkg-path>@<version>`.
-                let matching_iids_by_pkg_path = manifest
-                    .install
-                    .iter()
-                    .filter(|(_iid, descriptor)| {
-                        // Find matching pkg-paths and select for uninstall
-
-                        // If the descriptor is not a catalog descriptor, skip.
-                        // flakes descriptors are only matched by install_id.
-                        let ManifestPackageDescriptor::Catalog(des) = descriptor else {
-                            return false;
-                        };
-
-                        // Select if the descriptor's pkg_path matches the user's input
-                        if des.pkg_path == pkg {
-                            return true;
-                        }
-
-                        // Select if the descriptor matches the user's input when the version is included
-                        // Future: if we want to allow uninstalling a specific outputs as well,
-                        //         parsing of uninstall specs will need to be more sophisticated.
-                        //         For now going with a simple check for pkg-path@version.
-                        if let Some(version) = &des.version {
-                            format!("{}@{}", des.pkg_path, version) == pkg
-                        } else {
-                            false
-                        }
-                    })
-                    .map(|(iid, _)| iid.to_owned())
-                    .collect::<Vec<String>>();
-
-                // Extend the install_ids with the matching install id from pkg-path
-                match matching_iids_by_pkg_path.len() {
-                    0 => return Err(CoreEnvironmentError::PackageNotFound(pkg)),
-                    // if there is only one package with the given pkg-path, uninstall it
-                    1 => install_ids.extend(matching_iids_by_pkg_path),
-                    // if there are multiple packages with the given pkg-path, ask for a specific install id
-                    _ => {
-                        return Err(CoreEnvironmentError::MultiplePackagesMatch(
-                            pkg,
-                            matching_iids_by_pkg_path,
-                        ))
-                    },
-                }
+        let mut install_ids = Vec::new();
+        for pkg in packages {
+            // User passed an install id directly
+            if manifest.install.contains_key(&pkg) {
+                install_ids.push(pkg);
+                continue;
             }
-            install_ids
-        } else {
-            packages
-        };
-        Ok(iids)
+
+            // User passed a package path to uninstall
+            // To support version constraints, we match the provided value against
+            // `<pkg-path>` and `<pkg-path>@<version>`.
+            let matching_iids_by_pkg_path = manifest
+                .install
+                .iter()
+                .filter(|(_iid, descriptor)| {
+                    // Find matching pkg-paths and select for uninstall
+
+                    // If the descriptor is not a catalog descriptor, skip.
+                    // flakes descriptors are only matched by install_id.
+                    let ManifestPackageDescriptor::Catalog(des) = descriptor else {
+                        return false;
+                    };
+
+                    // Select if the descriptor's pkg_path matches the user's input
+                    if des.pkg_path == pkg {
+                        return true;
+                    }
+
+                    // Select if the descriptor matches the user's input when the version is included
+                    // Future: if we want to allow uninstalling a specific outputs as well,
+                    //         parsing of uninstall specs will need to be more sophisticated.
+                    //         For now going with a simple check for pkg-path@version.
+                    if let Some(version) = &des.version {
+                        format!("{}@{}", des.pkg_path, version) == pkg
+                    } else {
+                        false
+                    }
+                })
+                .map(|(iid, _)| iid.to_owned())
+                .collect::<Vec<String>>();
+
+            // Extend the install_ids with the matching install id from pkg-path
+            match matching_iids_by_pkg_path.len() {
+                0 => return Err(CoreEnvironmentError::PackageNotFound(pkg)),
+                // if there is only one package with the given pkg-path, uninstall it
+                1 => install_ids.extend(matching_iids_by_pkg_path),
+                // if there are multiple packages with the given pkg-path, ask for a specific install id
+                _ => {
+                    return Err(CoreEnvironmentError::MultiplePackagesMatch(
+                        pkg,
+                        matching_iids_by_pkg_path,
+                    ))
+                },
+            }
+        }
+        Ok(install_ids)
     }
 
     /// Atomically edit this environment, ensuring that it still builds
@@ -652,35 +577,29 @@ impl CoreEnvironment<ReadOnly> {
     ) -> Result<UpgradeResult, CoreEnvironmentError> {
         tracing::debug!(to_upgrade = groups_or_iids.join(","), "upgrading");
         let manifest = self.manifest()?;
+        let (lockfile, upgraded) = {
+            Self::ensure_valid_upgrade(groups_or_iids, &manifest)?;
+            tracing::debug!("using catalog client to upgrade");
 
-        let (lockfile, upgraded) = match manifest {
-            TypedManifest::Pkgdb(_) => {
-                return Err(CoreEnvironmentError::LockingVersion0NotSupported);
-            },
-            TypedManifest::Catalog(catalog) => {
-                Self::ensure_valid_upgrade(groups_or_iids, &catalog)?;
-                tracing::debug!("using catalog client to upgrade");
+            let (lockfile, upgraded) = self.upgrade_with_catalog_client(
+                &flox.catalog_client,
+                &flox.installable_locker,
+                groups_or_iids,
+                &manifest,
+            )?;
 
-                let (lockfile, upgraded) = self.upgrade_with_catalog_client(
-                    &flox.catalog_client,
-                    &flox.installable_locker,
-                    groups_or_iids,
-                    &catalog,
-                )?;
+            let upgraded = {
+                let mut install_ids = upgraded
+                    .into_iter()
+                    .map(|(_, pkg)| pkg.install_id().to_owned())
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                install_ids.sort();
+                install_ids
+            };
 
-                let upgraded = {
-                    let mut install_ids = upgraded
-                        .into_iter()
-                        .map(|(_, pkg)| pkg.install_id().to_owned())
-                        .collect::<HashSet<_>>()
-                        .into_iter()
-                        .collect::<Vec<_>>();
-                    install_ids.sort();
-                    install_ids
-                };
-
-                (LockedManifest::Catalog(lockfile), upgraded)
-            },
+            (lockfile, upgraded)
         };
 
         let store_path =
@@ -759,18 +678,10 @@ impl CoreEnvironment<ReadOnly> {
             let Ok(lockfile_path) = CanonicalPath::new(self.lockfile_path()) else {
                 break 'lockfile None;
             };
-            let lockfile = LockedManifest::read_from_file(&lockfile_path)
-                .map_err(CoreEnvironmentError::LockedManifest)?;
-            match lockfile {
-                LockedManifest::Catalog(lockfile) => Some(lockfile),
-                _ => {
-                    // This will be the case when performing a migration
-                    debug!(
-                        "Found version 1 manifest, but lockfile doesn't match: Ignoring lockfile."
-                    );
-                    None
-                },
-            }
+            Some(
+                LockedManifestCatalog::read_from_file(&lockfile_path)
+                    .map_err(CoreEnvironmentError::LockedManifest)?,
+            )
         };
 
         // Record a nested map where you retrieve the locked package
@@ -923,18 +834,9 @@ impl CoreEnvironment<ReadOnly> {
         manifest_contents: impl AsRef<str>,
         flox: &Flox,
     ) -> Result<PathBuf, CoreEnvironmentError> {
-        // Return an error for deprecated modifications of v0 manifests
-
-        let manifest: TypedManifest = toml::from_str(manifest_contents.as_ref())
+        let manifest: TypedManifestCatalog = toml::from_str(manifest_contents.as_ref())
             .map_err(CoreEnvironmentError::DeserializeManifest)?;
-        match manifest {
-            TypedManifest::Catalog(manifest) => {
-                manifest.services.validate()?;
-            },
-            TypedManifest::Pkgdb(_) => {
-                Err(CoreEnvironmentError::Version0NotSupported)?;
-            },
-        }
+        manifest.services.validate()?;
 
         let tempdir = tempfile::tempdir_in(&flox.temp_dir)
             .map_err(CoreEnvironmentError::MakeSandbox)?
@@ -995,146 +897,6 @@ impl CoreEnvironment<ReadOnly> {
         self.replace_with(temp_env)?;
         Ok(store_path)
     }
-
-    /// Should not be called with
-    /// !migration_info.needs_manifest_migration && !migration_info.needs_upgrade
-    pub fn migrate_to_v1(
-        &mut self,
-        flox: &Flox,
-        mut migration_info: MigrationInfo,
-    ) -> Result<PathBuf, CoreEnvironmentError> {
-        let tempdir = tempfile::tempdir_in(&flox.temp_dir)
-            .map_err(CoreEnvironmentError::MakeSandbox)?
-            .into_path();
-
-        debug!(
-            "migration transaction: making temporary environment in {}",
-            tempdir.display()
-        );
-        let mut temp_env = self.writable(&tempdir)?;
-
-        if migration_info.needs_manifest_migration {
-            Self::migrate_manifest_contents_to_v1(&mut migration_info.raw_manifest)?;
-
-            debug!("migration transaction: updating manifest");
-            temp_env.update_manifest(migration_info.raw_manifest.to_string())?;
-        }
-
-        // Lock if there's a v0 manifest, regardless of whether there's a
-        // lockfile or what version it is.
-        // This could lock an environment that isn't already locked,
-        // but particularly for managed and remote environments, we want to keep
-        // the lock in sync with the manifest,
-        // so we don't want to perform a transaction without locking.
-        debug!("migration transaction: locking environment");
-        temp_env
-            .lock(flox)
-            .map_err(|e| CoreEnvironmentError::LockForMigration(Box::new(e)))?;
-
-        debug!("migration transaction: building environment");
-        let store_path = temp_env.build(flox)?;
-
-        debug!("migration transaction: replacing environment");
-        self.replace_with(temp_env)?;
-        Ok(store_path)
-    }
-
-    /// Migrate a v0 [RawManifest] to a v1 [RawManifest] by inserting
-    /// `version = 1` and moving `hook.script` to `hook.on-activate` if
-    /// `hook.on-activate` doesn't already exist.
-    ///
-    /// `raw_manifest` is expected to be a v0 manifest.
-    /// Return an error if the resulting manifest is not a valid v1 manifest.
-    /// Note that the modifications are still made even if an error is returned to allow
-    /// [Self::migrate_and_edit_unsafe] to use the invalid manifest.
-    fn migrate_manifest_contents_to_v1(
-        raw_manifest: &mut RawManifest,
-    ) -> Result<(), CoreEnvironmentError> {
-        // // Insert `version = 1`
-        raw_manifest.insert(MANIFEST_VERSION_KEY, toml_edit::value(1));
-
-        // Migrate `hook.script` to `hook.on-activate`
-        let hook = raw_manifest.get_mut("hook").and_then(|s| s.as_table_mut());
-        if let Some(hook) = hook {
-            if hook.get("on-activate").is_none() {
-                // Rename `hook.script` to `hook.on-activate`, preserving
-                // comments and formatting
-                if let Some((script_key, script_item)) = hook.remove_entry("script") {
-                    // Unit tests cover this is safe to unwrap
-                    let mut on_activate = toml_edit::Key::from_str("on-activate").unwrap();
-                    let mut on_activate_key = on_activate.as_mut();
-                    let decor = on_activate_key.leaf_decor_mut();
-                    *decor = script_key.leaf_decor().clone();
-                    let dotted_decor = on_activate_key.dotted_decor_mut();
-                    *dotted_decor = script_key.dotted_decor().clone();
-                    // Does not preserve order of hooks,
-                    // but we only have one field in the hook section.
-                    hook.insert_formatted(&on_activate, script_item);
-                }
-            }
-        }
-
-        // Make sure it parses
-        raw_manifest
-            .to_typed()
-            .map_err(CoreEnvironmentError::MigrateManifest)?;
-        Ok(())
-    }
-
-    /// Replace manifest with provided `contents` and perform migration in a
-    /// single transaction
-    pub fn migrate_and_edit_unsafe(
-        &mut self,
-        flox: &Flox,
-        contents: String,
-    ) -> Result<Result<PathBuf, CoreEnvironmentError>, CoreEnvironmentError> {
-        let tempdir = tempfile::tempdir_in(&flox.temp_dir)
-            .map_err(CoreEnvironmentError::MakeSandbox)?
-            .into_path();
-
-        debug!(
-            "migration transaction: making temporary environment in {}",
-            tempdir.display()
-        );
-        let mut temp_env = self.writable(&tempdir)?;
-
-        let mut raw_manifest = RawManifest::from_str(&contents)
-            .map_err(|e| CoreEnvironmentError::ModifyToml(TomlEditError::ParseManifest(e)))?;
-
-        let migrate_result = Self::migrate_manifest_contents_to_v1(&mut raw_manifest);
-
-        debug!("migration transaction: updating manifest");
-        temp_env.update_manifest(raw_manifest.to_string())?;
-
-        // Check if the manifest is valid after updating it, because we want to
-        // update it no matter what.
-        if let Err(migrate_error) = migrate_result {
-            debug!(
-                "migration transaction: migration failed: {:?}",
-                migrate_error
-            );
-            debug!("migration transaction: replacing environment");
-            self.replace_with(temp_env)?;
-            return Ok(Err(migrate_error));
-        }
-
-        if let Err(lock_err) = temp_env.lock(flox) {
-            debug!("migration transaction: lock failed: {:?}", lock_err);
-            debug!("migration transaction: replacing environment");
-            self.replace_with(temp_env)?;
-            return Ok(Err(lock_err));
-        };
-
-        let build_attempt = temp_env.build(flox);
-
-        debug!("migration transaction: replacing environment");
-        self.replace_with(temp_env)?;
-
-        match build_attempt {
-            Ok(store_path) => Ok(Ok(store_path)),
-            Err(err) => Ok(Err(err)),
-        }
-    }
 }
 
 /// A writable view of an environment directory
@@ -1177,49 +939,28 @@ pub enum EditResult {
 
 impl EditResult {
     pub fn new(
-        old_manifest: &str,
-        new_manifest: &str,
+        old_manifest_contents: &str,
+        new_manifest_contents: &str,
         store_path: Option<PathBuf>,
     ) -> Result<Self, CoreEnvironmentError> {
-        if old_manifest == new_manifest {
+        if old_manifest_contents == new_manifest_contents {
             Ok(Self::Unchanged)
         } else {
-            // todo: use a single toml crate (toml_edit already implements serde traits)
+            // TODO: use a single toml crate (toml_edit already implements serde traits)
             // TODO: use different error variants, users _can_ fix errors in the _new_ manifest
             //       but they _can't_ fix errors in the _old_ manifest
-            let old_manifest: TypedManifest =
-                toml::from_str(old_manifest).map_err(CoreEnvironmentError::DeserializeManifest)?;
-            let new_manifest: TypedManifest =
-                toml::from_str(new_manifest).map_err(CoreEnvironmentError::DeserializeManifest)?;
+            let old_manifest: TypedManifestCatalog = toml::from_str(old_manifest_contents)
+                .map_err(CoreEnvironmentError::DeserializeManifest)?;
+            let new_manifest: TypedManifestCatalog = toml::from_str(new_manifest_contents)
+                .map_err(CoreEnvironmentError::DeserializeManifest)?;
 
-            match (&old_manifest, &new_manifest) {
-                (TypedManifest::Pkgdb(old), TypedManifest::Pkgdb(new)) => {
-                    if old.hook != new.hook || old.vars != new.vars || old.profile != new.profile {
-                        Ok(Self::ReActivateRequired { store_path })
-                    } else {
-                        Ok(Self::Success { store_path })
-                    }
-                },
-                (TypedManifest::Catalog(old), TypedManifest::Catalog(new)) => {
-                    if old.hook != new.hook || old.vars != new.vars || old.profile != new.profile {
-                        Ok(Self::ReActivateRequired { store_path })
-                    } else {
-                        Ok(Self::Success { store_path })
-                    }
-                },
-                (TypedManifest::Catalog(catalog), TypedManifest::Pkgdb(pkgdb))
-                | (TypedManifest::Pkgdb(pkgdb), TypedManifest::Catalog(catalog)) => {
-                    if toml::Value::try_from(&pkgdb.hook) != toml::Value::try_from(&catalog.hook)
-                        || toml::Value::try_from(&pkgdb.vars)
-                            != toml::Value::try_from(&catalog.vars)
-                        || toml::Value::try_from(&pkgdb.profile)
-                            != toml::Value::try_from(&catalog.profile)
-                    {
-                        Ok(Self::ReActivateRequired { store_path })
-                    } else {
-                        Ok(Self::Success { store_path })
-                    }
-                },
+            if old_manifest.hook != new_manifest.hook
+                || old_manifest.vars != new_manifest.vars
+                || old_manifest.profile != new_manifest.profile
+            {
+                Ok(Self::ReActivateRequired { store_path })
+            } else {
+                Ok(Self::Success { store_path })
             }
         }
     }
@@ -1321,19 +1062,8 @@ pub enum CoreEnvironmentError {
     #[error("failed to create version 1 lock")]
     LockForMigration(#[source] Box<CoreEnvironmentError>),
 
-    #[error(
-        "Modifying version 0 manifests is no longer supported.\nSet 'version = 1' in the manifest."
-    )]
-    Version0NotSupported,
-    #[error(
-        "Locking version 0 manifests is no longer supported.\nSet 'version = 1' in the manifest."
-    )]
-    LockingVersion0NotSupported,
-
     #[error(transparent)]
     Services(#[from] ServiceError),
-    #[error("cannot use services with v0 manifests")]
-    ServicesWithV0,
 }
 
 impl CoreEnvironmentError {
@@ -1388,26 +1118,11 @@ pub mod test_helpers {
     use super::*;
     use crate::flox::Flox;
 
-    pub const MANIFEST_V0_FIELDS: &str = indoc! {r#"
-        [options]
-        semver.prefer-pre-releases = true
-        "#};
     #[cfg(target_os = "macos")]
     pub const MANIFEST_INCOMPATIBLE_SYSTEM: &str = indoc! {r#"
         version = 1
         [options]
         systems = ["x86_64-linux"]
-        "#};
-    #[cfg(target_os = "macos")]
-    pub const MANIFEST_INCOMPATIBLE_SYSTEM_V0: &str = indoc! {r#"
-        [options]
-        systems = ["x86_64-linux"]
-        "#};
-    #[cfg(target_os = "macos")]
-    pub const MANIFEST_INCOMPATIBLE_SYSTEM_V0_FIELDS: &str = indoc! {r#"
-        [options]
-        systems = ["x86_64-linux"]
-        semver.prefer-pre-releases = true
         "#};
     #[cfg(target_os = "macos")]
     pub const MANIFEST_INCOMPATIBLE_SYSTEM_V1: &str = indoc! {r#"
@@ -1415,23 +1130,11 @@ pub mod test_helpers {
         [options]
         systems = ["x86_64-linux"]
         "#};
-
     #[cfg(target_os = "linux")]
     pub const MANIFEST_INCOMPATIBLE_SYSTEM: &str = indoc! {r#"
         version = 1
         [options]
         systems = ["aarch64-darwin"]
-        "#};
-    #[cfg(target_os = "linux")]
-    pub const MANIFEST_INCOMPATIBLE_SYSTEM_V0: &str = indoc! {r#"
-        [options]
-        systems = ["aarch64-darwin"]
-        "#};
-    #[cfg(target_os = "linux")]
-    pub const MANIFEST_INCOMPATIBLE_SYSTEM_V0_FIELDS: &str = indoc! {r#"
-        [options]
-        systems = ["aarch64-darwin"]
-        semver.prefer-pre-releases = true
         "#};
     #[cfg(target_os = "linux")]
     pub const MANIFEST_INCOMPATIBLE_SYSTEM_V1: &str = indoc! {r#"
@@ -1473,18 +1176,12 @@ pub mod test_helpers {
 #[cfg(test)]
 mod tests {
     use std::os::unix::fs::PermissionsExt;
-    use std::str::FromStr;
 
-    use catalog::{
-        Client,
-        MsgAttrPathNotFoundNotFoundForAllSystems,
-        GENERATED_DATA,
-        MANUALLY_GENERATED,
-    };
-    use catalog_api_v1::types::{MessageLevel, ResolvedPackageDescriptor, SystemEnum};
+    use catalog::{Client, GENERATED_DATA, MANUALLY_GENERATED};
+    use catalog_api_v1::types::{ResolvedPackageDescriptor, SystemEnum};
     use chrono::{DateTime, Utc};
     use flox_core::Version;
-    use indoc::{formatdoc, indoc};
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
     use tempfile::{tempdir_in, TempDir};
     use test_helpers::{new_core_environment_from_env_files, new_core_environment_with_lockfile};
@@ -1496,12 +1193,7 @@ mod tests {
     use crate::flox::test_helpers::flox_instance;
     use crate::models::lockfile;
     use crate::models::lockfile::test_helpers::fake_catalog_package_lock;
-    use crate::models::lockfile::ResolutionFailures;
-    use crate::models::manifest::{
-        ManifestPackageDescriptorCatalog,
-        RawManifest,
-        DEFAULT_GROUP_NAME,
-    };
+    use crate::models::manifest::{ManifestPackageDescriptorCatalog, DEFAULT_GROUP_NAME};
     use crate::providers::flox_cpp_utils::InstallableLockerMock;
     use crate::providers::services::SERVICE_CONFIG_FILENAME;
 
@@ -1519,7 +1211,7 @@ mod tests {
         let (mut flox, tempdir) = flox_instance();
 
         let env_path = tempfile::tempdir_in(&tempdir).unwrap();
-        fs::write(env_path.path().join(MANIFEST_FILENAME), "").unwrap();
+        fs::write(env_path.path().join(MANIFEST_FILENAME), "version = 1").unwrap();
 
         let mut env_view = CoreEnvironment::new(&env_path);
 
@@ -1571,41 +1263,6 @@ mod tests {
         let result = env_view.build(&flox).unwrap_err();
 
         assert!(result.is_incompatible_system_error());
-    }
-
-    /// Trying to build a manifest with a package that is incompatible with the current system
-    /// results in an error that is_incompatible_package_error()
-    #[test]
-    fn build_incompatible_package() {
-        #[cfg(target_os = "macos")]
-        let env_files_dirname = "glibc_incompatible_v0_both_darwin";
-
-        #[cfg(target_os = "linux")]
-        let env_files_dirname = "ps_incompatible_v0_both_linux";
-
-        let (flox, _temp_dir_handle) = flox_instance();
-
-        let mut env_view =
-            new_core_environment_from_env_files(&flox, MANUALLY_GENERATED.join(env_files_dirname));
-
-        let result = env_view.build(&flox).unwrap_err();
-
-        assert!(result.is_incompatible_package_error());
-    }
-
-    /// Trying to build a manifest with an insecure package results in an error
-    /// that is_incompatible_package_error()
-    #[test]
-    fn build_insecure_package() {
-        let (flox, _temp_dir_handle) = flox_instance();
-        let mut env_view = new_core_environment_from_env_files(
-            &flox,
-            MANUALLY_GENERATED.join("python2_insecure_v0"),
-        );
-
-        let result = env_view.build(&flox).unwrap_err();
-
-        assert!(result.is_incompatible_package_error());
     }
 
     #[test]
@@ -1825,229 +1482,6 @@ mod tests {
     }
 
     #[test]
-    fn migrate_to_v1_error_for_dropped_field() {
-        let (flox, _temp_dir_handle) = flox_instance();
-        let contents = indoc! {r#"
-            [options]
-            semver.prefer-pre-releases = true
-            "#};
-
-        let mut environment = new_core_environment(&flox, contents);
-
-        let raw_manifest = RawManifest::from_str(contents).unwrap();
-
-        let err = environment
-            .migrate_to_v1(&flox, MigrationInfo {
-                raw_manifest,
-                needs_manifest_migration: true,
-                needs_upgrade: false,
-            })
-            .unwrap_err();
-
-        if let CoreEnvironmentError::MigrateManifest(e) = err {
-            assert!(e.message().contains("unknown field `prefer-pre-releases`"));
-        } else {
-            panic!("expected MigrateManifest error");
-        }
-    }
-
-    #[test]
-    fn migrate_to_v1_error_for_locking() {
-        let (mut flox, _temp_dir_handle) = flox_instance();
-        // The v0 lockfile should get ignored,
-        // but create it just to keep this more realistic
-        let mut environment = new_core_environment_from_env_files(
-            &flox,
-            MANUALLY_GENERATED.join("glibc_incompatible_v0"),
-        );
-
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/glibc_incompatible.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
-        let manifest_contents = fs::read_to_string(
-            MANUALLY_GENERATED
-                .join("glibc_incompatible_v0")
-                .join(MANIFEST_FILENAME),
-        )
-        .unwrap();
-
-        let raw_manifest = RawManifest::from_str(&manifest_contents).unwrap();
-
-        let err = environment
-            .migrate_to_v1(&flox, MigrationInfo {
-                raw_manifest,
-                needs_manifest_migration: true,
-                needs_upgrade: true,
-            })
-            .unwrap_err();
-
-        if let CoreEnvironmentError::LockForMigration(e) = err {
-            if let CoreEnvironmentError::LockedManifest(LockedManifestError::ResolutionFailed(
-                ResolutionFailures(failures),
-            )) = *e
-            {
-                assert!(failures.len() == 1);
-                assert_eq!(
-                    failures[0],
-                    ResolutionFailure::PackageUnavailableOnSomeSystems {
-                        catalog_message: MsgAttrPathNotFoundNotFoundForAllSystems {
-                            level: MessageLevel::Error,
-                            msg: "The attr_path glibc is not found for all the requested systems, suggest limiting systems to (aarch64-linux,x86_64-linux).".to_string(),
-                            install_id: "glibc".to_string(),
-                            valid_systems: vec![
-                                "aarch64-linux".to_string(),
-                                "x86_64-linux".to_string()
-                            ],
-                            attr_path: "glibc".to_string(),
-                        },
-                        invalid_systems: vec!["aarch64-darwin".to_string()],
-                    }
-                );
-            } else {
-                panic!("expected ResolutionFailures")
-            }
-        } else {
-            panic!("expected LockForMigration error");
-        }
-    }
-
-    /// [CoreEnvironment::migrate_manifest_contents_to_v1] migrates a manifest
-    /// with `script` in a `[hook]` table correctly, maintaining comments and
-    /// formatting.
-    #[test]
-    fn migrate_script_hook_table() {
-        let contents = formatdoc! {r#"
-            [vars]
-            foo = "bar"
-
-            # comment 1
-            [hook] # comment 2
-            # comment 3
-             script = "echo hello" # comment 4
-            # comment 5
-
-            [options]
-            "#};
-        let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
-        CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap();
-        assert_eq!(raw_manifest.to_string(), formatdoc! {r#"
-                version = 1
-                [vars]
-                foo = "bar"
-
-                # comment 1
-                [hook] # comment 2
-                # comment 3
-                 on-activate = "echo hello" # comment 4
-                # comment 5
-
-                [options]
-                "#
-        });
-    }
-
-    /// [CoreEnvironment::migrate_manifest_contents_to_v1] migrates a manifest
-    /// with hook.script as a dotted key correctly, maintaining comments and
-    /// formatting.
-    #[test]
-    fn migrate_script_hook_dotted_decor() {
-        let contents = formatdoc! {r#"
-            vars.foo = "bar"
-
-            # comment 1
-            hook . script = "echo hello" # comment 2
-            # comment 3
-
-            options.allow.unfree = false
-            "#};
-        let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
-        CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap();
-        assert_eq!(raw_manifest.to_string(), formatdoc! {r#"
-                vars.foo = "bar"
-
-                # comment 1
-                hook . on-activate = "echo hello" # comment 2
-                # comment 3
-
-                options.allow.unfree = false
-                version = 1
-                "#
-        });
-    }
-
-    /// If a manifest contains both `hook.script` and `hook.on-activate`,
-    /// [CoreEnvironment::migrate_manifest_contents_to_v1] returns an error.
-    #[test]
-    fn migrate_script_skip_for_on_activate() {
-        let contents = formatdoc! {r#"
-            [hook]
-            script = "echo foo"
-            on-activate = "echo bar"
-            "#};
-        let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
-        let err = CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap_err();
-        assert_eq!(raw_manifest.to_string(), formatdoc! {r#"
-                version = 1
-                [hook]
-                script = "echo foo"
-                on-activate = "echo bar"
-                "#
-        });
-        if let CoreEnvironmentError::MigrateManifest(e) = err {
-            assert!(e.message().contains("unknown field `script`"));
-        } else {
-            panic!("expected MigrateManifest error");
-        }
-    }
-
-    /// Even if a manifest fails validation, it is still modified by
-    /// [CoreEnvironment::migrate_manifest_contents_to_v1].
-    #[test]
-    fn migrate_script_modifies_on_error() {
-        let contents = formatdoc! {r#"
-            [hook]
-            script = "echo hello"
-            on-activate = "echo hello"
-            "#};
-        let mut raw_manifest = RawManifest::from_str(&contents).unwrap();
-        assert!(raw_manifest.get("version").is_none());
-        CoreEnvironment::migrate_manifest_contents_to_v1(&mut raw_manifest).unwrap_err();
-        assert_eq!(
-            raw_manifest.get("version").unwrap().as_integer().unwrap(),
-            1
-        );
-    }
-
-    #[test]
-    fn v0_does_not_need_relock() {
-        let (flox, _temp_dir_handle) = flox_instance();
-        let environment =
-            new_core_environment_from_env_files(&flox, MANUALLY_GENERATED.join("hello_v0"));
-        assert!(environment.lockfile_if_up_to_date().unwrap().is_some());
-    }
-
-    #[test]
-    fn modified_v0_errors() {
-        let (flox, _temp_dir_handle) = flox_instance();
-        let manifest_contents =
-            fs::read_to_string(MANUALLY_GENERATED.join("empty_v0").join(MANIFEST_FILENAME))
-                .unwrap();
-        let lockfile_contents =
-            fs::read_to_string(MANUALLY_GENERATED.join("hello_v0").join(LOCKFILE_FILENAME))
-                .unwrap();
-        let environment =
-            new_core_environment_with_lockfile(&flox, &manifest_contents, &lockfile_contents);
-        let err = environment.lockfile_if_up_to_date().unwrap_err();
-        assert!(matches!(
-            err,
-            CoreEnvironmentError::LockingVersion0NotSupported
-        ));
-    }
-
-    #[test]
     fn v1_does_not_need_relock() {
         let (flox, _temp_dir_handle) = flox_instance();
         let environment =
@@ -2081,7 +1515,7 @@ mod tests {
     /// # Returns
     ///
     /// * `TypedManifest` - A mock `TypedManifest` containing the provided entries.
-    fn generate_mock_manifest(entries: Vec<(&str, &str)>) -> TypedManifest {
+    fn generate_mock_manifest(entries: Vec<(&str, &str)>) -> TypedManifestCatalog {
         let mut typed_manifest_mock = TypedManifestCatalog::default();
 
         for (test_iid, dotted_package) in entries {
@@ -2097,7 +1531,7 @@ mod tests {
             );
         }
 
-        TypedManifest::Catalog(Box::new(typed_manifest_mock))
+        typed_manifest_mock
     }
     /// Return the install ID if it matches the user input
     #[test]
@@ -2170,13 +1604,11 @@ mod tests {
     fn test_get_install_ids_to_uninstall_with_version() {
         let mut manifest_mock = generate_mock_manifest(vec![("testInstallID", "dotted.package")]);
 
-        if let TypedManifest::Catalog(ref mut catalog) = manifest_mock {
-            if let ManifestPackageDescriptor::Catalog(descriptor) =
-                catalog.install.get_mut("testInstallID").unwrap()
-            {
-                descriptor.version = Some("1.0".to_string());
-            };
-        }
+        if let ManifestPackageDescriptor::Catalog(descriptor) =
+            manifest_mock.install.get_mut("testInstallID").unwrap()
+        {
+            descriptor.version = Some("1.0".to_string());
+        };
 
         let result = CoreEnvironment::get_install_ids_to_uninstall(&manifest_mock, vec![
             "dotted.package@1.0".to_string(),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -44,7 +44,7 @@ use crate::models::environment::copy_dir_recursive;
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner};
 use crate::models::floxmeta::{floxmeta_git_options, FloxMeta, FloxMetaError};
 use crate::models::lockfile::Lockfile;
-use crate::models::manifest::{PackageToInstall, TypedManifestCatalog};
+use crate::models::manifest::{Manifest, PackageToInstall};
 use crate::providers::git::{
     GitCommandBranchHashError,
     GitCommandError,
@@ -374,7 +374,7 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Return the deserialized manifest
-    fn manifest(&self, flox: &Flox) -> Result<TypedManifestCatalog, EnvironmentError> {
+    fn manifest(&self, flox: &Flox) -> Result<Manifest, EnvironmentError> {
         Ok(toml::from_str(&self.manifest_contents(flox)?)
             .map_err(CoreEnvironmentError::DeserializeManifest)?)
     }
@@ -1657,7 +1657,7 @@ mod test {
     use crate::models::floxmeta::floxmeta_dir;
     use crate::models::lockfile::test_helpers::fake_catalog_package_lock;
     use crate::models::lockfile::Lockfile;
-    use crate::models::manifest::{ManifestPackageDescriptorCatalog, TypedManifestCatalog};
+    use crate::models::manifest::{Manifest, ManifestPackageDescriptorCatalog};
     use crate::providers::catalog::{Client, MockClient, GENERATED_DATA};
     use crate::providers::git::tests::commit_file;
     use crate::providers::git::GitCommandProvider;
@@ -2219,8 +2219,7 @@ mod test {
 
         flox.catalog_client = MockClient::new(None::<&str>).unwrap().into();
 
-        let original_manifest =
-            toml_edit::ser::to_string_pretty(&TypedManifestCatalog::default()).unwrap();
+        let original_manifest = toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap();
 
         let managed_env = test_helpers::mock_managed_environment(&flox, &original_manifest, owner);
 
@@ -2266,7 +2265,7 @@ mod test {
 
         let managed_env = test_helpers::mock_managed_environment(
             &flox,
-            &toml_edit::ser::to_string_pretty(&TypedManifestCatalog::default()).unwrap(),
+            &toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap(),
             owner,
         );
 
@@ -2309,7 +2308,7 @@ mod test {
 
         let managed_env = test_helpers::mock_managed_environment(
             &flox,
-            &toml_edit::ser::to_string_pretty(&TypedManifestCatalog::default()).unwrap(),
+            &toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap(),
             owner,
         );
 
@@ -2346,7 +2345,7 @@ mod test {
 
         let mut managed_env = test_helpers::mock_managed_environment(
             &flox,
-            &toml_edit::ser::to_string_pretty(&TypedManifestCatalog::default()).unwrap(),
+            &toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap(),
             owner,
         );
 
@@ -2403,7 +2402,7 @@ mod test {
 
         let mut managed_env = test_helpers::mock_managed_environment(
             &flox,
-            &toml_edit::ser::to_string_pretty(&TypedManifestCatalog::default()).unwrap(),
+            &toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap(),
             owner,
         );
 
@@ -2417,7 +2416,7 @@ mod test {
             panic!("Expected a MockClient");
         }
 
-        let mut new_manifest = TypedManifestCatalog::default();
+        let mut new_manifest = Manifest::default();
         new_manifest.install.insert(
             "hello".to_string(),
             ManifestPackageDescriptorCatalog {
@@ -2460,8 +2459,8 @@ mod test {
     fn test_validate_local_same_manifest() {
         let (flox, _temp_dir_handle) = flox_instance();
 
-        let manifest_a = TypedManifestCatalog::default();
-        let manifest_b = TypedManifestCatalog::default();
+        let manifest_a = Manifest::default();
+        let manifest_b = Manifest::default();
 
         let env_a = new_core_environment(
             &flox,
@@ -2480,8 +2479,8 @@ mod test {
     fn test_validate_local_different_manifest() {
         let (flox, _temp_dir_handle) = flox_instance();
 
-        let mut manifest_a = TypedManifestCatalog::default();
-        let manifest_b = TypedManifestCatalog::default();
+        let mut manifest_a = Manifest::default();
+        let manifest_b = Manifest::default();
 
         let env_a = new_core_environment(
             &flox,
@@ -2510,8 +2509,8 @@ mod test {
     fn test_validate_local_different_binary_content() {
         let (flox, _temp_dir_handle) = flox_instance();
 
-        let manifest_a = TypedManifestCatalog::default();
-        let manifest_b = TypedManifestCatalog::default();
+        let manifest_a = Manifest::default();
+        let manifest_b = Manifest::default();
 
         // Serialize the same manifest to two different environments
         // once with pretty formatting and once without.

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -21,7 +21,6 @@ use super::{
     EnvironmentPointer,
     InstallationAttempt,
     ManagedPointer,
-    MigrationInfo,
     PathPointer,
     UninstallationAttempt,
     CACHE_DIR_NAME,
@@ -44,8 +43,8 @@ use crate::models::env_registry::{
 use crate::models::environment::copy_dir_recursive;
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner};
 use crate::models::floxmeta::{floxmeta_git_options, FloxMeta, FloxMetaError};
-use crate::models::lockfile::LockedManifest;
-use crate::models::manifest::{PackageToInstall, TypedManifest};
+use crate::models::lockfile::LockedManifestCatalog;
+use crate::models::manifest::{PackageToInstall, TypedManifestCatalog};
 use crate::providers::git::{
     GitCommandBranchHashError,
     GitCommandError,
@@ -209,7 +208,7 @@ impl GenerationLock {
 
 impl Environment for ManagedEnvironment {
     /// This will lock if there is an out of sync local checkout
-    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifest, EnvironmentError> {
+    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifestCatalog, EnvironmentError> {
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
         self.ensure_locked(flox, &mut local_checkout)
     }
@@ -375,7 +374,7 @@ impl Environment for ManagedEnvironment {
     }
 
     /// Return the deserialized manifest
-    fn manifest(&self, flox: &Flox) -> Result<TypedManifest, EnvironmentError> {
+    fn manifest(&self, flox: &Flox) -> Result<TypedManifestCatalog, EnvironmentError> {
         Ok(toml::from_str(&self.manifest_contents(flox)?)
             .map_err(CoreEnvironmentError::DeserializeManifest)?)
     }
@@ -485,50 +484,6 @@ impl Environment for ManagedEnvironment {
         Ok(())
     }
 
-    fn migrate_to_v1(
-        &mut self,
-        flox: &Flox,
-        migration_info: MigrationInfo,
-    ) -> Result<(), EnvironmentError> {
-        let mut generations = self
-            .generations()
-            .writable(flox.temp_dir.clone())
-            .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
-
-        let remote = generations
-            .get_current_generation()
-            .map_err(ManagedEnvironmentError::CreateGenerationFiles)?;
-
-        let mut temporary = self.local_env_or_copy_current_generation(flox)?;
-
-        if !Self::validate_checkout(&temporary, &remote)? && migration_info.needs_manifest_migration
-        {
-            Err(EnvironmentError::ManagedEnvironment(
-                ManagedEnvironmentError::CheckoutOutOfSync,
-            ))?
-        }
-
-        let metadata = match (
-            migration_info.needs_manifest_migration,
-            migration_info.needs_upgrade,
-        ) {
-            (true, true) => "Migrated manifest to v1 and upgraded packages",
-            (true, false) => "Migrated manifest to v1", // and locked
-            (false, true) => "Upgraded packages",
-            _ => unreachable!("called with invalid migration metadata"),
-        };
-
-        let store_path = temporary.migrate_to_v1(flox, migration_info)?;
-
-        generations
-            .add_generation(&mut temporary, metadata.to_string())
-            .map_err(ManagedEnvironmentError::CommitGeneration)?;
-        self.lock_pointer()?;
-        self.link(store_path)?;
-
-        Ok(())
-    }
-
     /// Return the path where the process compose socket for an environment
     /// should be created
     fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
@@ -547,7 +502,7 @@ impl ManagedEnvironment {
         &mut self,
         flox: &Flox,
         local_checkout: &mut CoreEnvironment,
-    ) -> Result<LockedManifest, EnvironmentError> {
+    ) -> Result<LockedManifestCatalog, EnvironmentError> {
         // Otherwise, there would be a generation without a lockfile, which is a bad state,
         // and we error.
         if !Self::validate_checkout(local_checkout, &self.get_current_generation(flox)?)? {
@@ -895,47 +850,6 @@ impl ManagedEnvironment {
         if matches!(result, Ok(EditResult::Unchanged)) {
             return Ok(result);
         }
-
-        debug!("Environment changed, create and lock generation");
-
-        generations
-            .add_generation(&mut temporary, "manually edited".to_string())
-            .map_err(ManagedEnvironmentError::CommitGeneration)?;
-        self.lock_pointer()?;
-
-        // don't link, the environment may be broken
-
-        Ok(result)
-    }
-
-    /// Edit the environment while also adding `version = 1` to the provided manifest contents.
-    /// Don't check that the environment builds.
-    ///
-    /// This is used to allow `flox pull` to work with environments
-    /// that don't specify the current system as supported.
-    pub fn migrate_and_edit_unsafe(
-        &mut self,
-        flox: &Flox,
-        contents: String,
-    ) -> Result<Result<PathBuf, CoreEnvironmentError>, EnvironmentError> {
-        let mut generations = self
-            .generations()
-            .writable(flox.temp_dir.clone())
-            .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
-
-        let remote = generations
-            .get_current_generation()
-            .map_err(ManagedEnvironmentError::CreateGenerationFiles)?;
-
-        let mut temporary = self.local_env_or_copy_current_generation(flox)?;
-
-        if !Self::validate_checkout(&temporary, &remote)? {
-            Err(EnvironmentError::ManagedEnvironment(
-                ManagedEnvironmentError::CheckoutOutOfSync,
-            ))?
-        }
-
-        let result = temporary.migrate_and_edit_unsafe(flox, contents)?;
 
         debug!("Environment changed, create and lock generation");
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -43,7 +43,7 @@ use crate::models::env_registry::{
 use crate::models::environment::copy_dir_recursive;
 use crate::models::environment_ref::{EnvironmentName, EnvironmentOwner};
 use crate::models::floxmeta::{floxmeta_git_options, FloxMeta, FloxMetaError};
-use crate::models::lockfile::LockedManifestCatalog;
+use crate::models::lockfile::Lockfile;
 use crate::models::manifest::{PackageToInstall, TypedManifestCatalog};
 use crate::providers::git::{
     GitCommandBranchHashError,
@@ -208,7 +208,7 @@ impl GenerationLock {
 
 impl Environment for ManagedEnvironment {
     /// This will lock if there is an out of sync local checkout
-    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifestCatalog, EnvironmentError> {
+    fn lockfile(&mut self, flox: &Flox) -> Result<Lockfile, EnvironmentError> {
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
         self.ensure_locked(flox, &mut local_checkout)
     }
@@ -502,7 +502,7 @@ impl ManagedEnvironment {
         &mut self,
         flox: &Flox,
         local_checkout: &mut CoreEnvironment,
-    ) -> Result<LockedManifestCatalog, EnvironmentError> {
+    ) -> Result<Lockfile, EnvironmentError> {
         // Otherwise, there would be a generation without a lockfile, which is a bad state,
         // and we error.
         if !Self::validate_checkout(local_checkout, &self.get_current_generation(flox)?)? {
@@ -1656,7 +1656,7 @@ mod test {
     use crate::models::environment::{DOT_FLOX, MANIFEST_FILENAME};
     use crate::models::floxmeta::floxmeta_dir;
     use crate::models::lockfile::test_helpers::fake_catalog_package_lock;
-    use crate::models::lockfile::LockedManifestCatalog;
+    use crate::models::lockfile::Lockfile;
     use crate::models::manifest::{ManifestPackageDescriptorCatalog, TypedManifestCatalog};
     use crate::providers::catalog::{Client, MockClient, GENERATED_DATA};
     use crate::providers::git::tests::commit_file;
@@ -2442,14 +2442,14 @@ mod test {
 
         let lockfile_content =
             fs::read_to_string(managed_env.lockfile_path(&flox).unwrap()).unwrap();
-        let lockfile: LockedManifestCatalog = serde_json::from_str(&lockfile_content).unwrap();
+        let lockfile: Lockfile = serde_json::from_str(&lockfile_content).unwrap();
 
         assert_eq!(lockfile.manifest, new_manifest);
         assert_eq!(lockfile.packages.len(), 4); // 1 x 4 systems
 
         let lockfile_in_generation_content =
             fs::read_to_string(managed_env.lockfile_path(&flox).unwrap()).unwrap();
-        let lockfile_in_generation: LockedManifestCatalog =
+        let lockfile_in_generation: Lockfile =
             serde_json::from_str(&lockfile_in_generation_content).unwrap();
 
         assert_eq!(lockfile_in_generation, lockfile);

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -15,7 +15,7 @@ use self::remote_environment::RemoteEnvironmentError;
 use super::container_builder::ContainerBuilder;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
-use super::lockfile::{LockedManifestCatalog, LockedManifestError};
+use super::lockfile::{LockedManifestError, Lockfile};
 use super::manifest::{ManifestError, PackageToInstall, TypedManifestCatalog};
 use crate::data::{CanonicalPath, CanonicalizeError};
 use crate::flox::{Flox, Floxhub};
@@ -134,7 +134,7 @@ pub trait Environment: Send {
     ///
     /// Some implementations error if the lock does not already exist, while
     /// others call lock.
-    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifestCatalog, EnvironmentError>;
+    fn lockfile(&mut self, flox: &Flox) -> Result<Lockfile, EnvironmentError>;
 
     /// Extract the current content of the manifest
     ///

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -16,7 +16,7 @@ use super::container_builder::ContainerBuilder;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
 use super::lockfile::{LockedManifestError, Lockfile};
-use super::manifest::{ManifestError, PackageToInstall, TypedManifestCatalog};
+use super::manifest::{Manifest, ManifestError, PackageToInstall};
 use crate::data::{CanonicalPath, CanonicalizeError};
 use crate::flox::{Flox, Floxhub};
 use crate::providers::git::{
@@ -143,7 +143,7 @@ pub trait Environment: Send {
     fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError>;
 
     /// Return the deserialized manifest
-    fn manifest(&self, flox: &Flox) -> Result<TypedManifestCatalog, EnvironmentError>;
+    fn manifest(&self, flox: &Flox) -> Result<Manifest, EnvironmentError>;
 
     /// Return a path containing the built environment and its activation script.
     ///

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -47,7 +47,7 @@ use crate::models::container_builder::ContainerBuilder;
 use crate::models::env_registry::{deregister, ensure_registered};
 use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
-use crate::models::lockfile::LockedManifestCatalog;
+use crate::models::lockfile::Lockfile;
 use crate::models::manifest::{
     CatalogPackage,
     PackageToInstall,
@@ -176,7 +176,7 @@ impl PathEnvironment {
 
 impl Environment for PathEnvironment {
     /// This will lock the environment if it is not already locked.
-    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifestCatalog, EnvironmentError> {
+    fn lockfile(&mut self, flox: &Flox) -> Result<Lockfile, EnvironmentError> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         Ok(env_view.ensure_locked(flox)?)
     }

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -48,12 +48,7 @@ use crate::models::env_registry::{deregister, ensure_registered};
 use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::lockfile::Lockfile;
-use crate::models::manifest::{
-    CatalogPackage,
-    PackageToInstall,
-    RawManifest,
-    TypedManifestCatalog,
-};
+use crate::models::manifest::{CatalogPackage, Manifest, PackageToInstall, RawManifest};
 use crate::utils::mtime_of;
 
 /// Struct representing a local environment
@@ -271,7 +266,7 @@ impl Environment for PathEnvironment {
     }
 
     /// Return the deserialized manifest
-    fn manifest(&self, _flox: &Flox) -> Result<TypedManifestCatalog, EnvironmentError> {
+    fn manifest(&self, _flox: &Flox) -> Result<Manifest, EnvironmentError> {
         let env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         env_view.manifest().map_err(EnvironmentError::Core)
     }

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -31,7 +31,6 @@ use super::{
     EnvironmentError,
     EnvironmentPointer,
     InstallationAttempt,
-    MigrationInfo,
     PathPointer,
     UninstallationAttempt,
     CACHE_DIR_NAME,
@@ -48,8 +47,13 @@ use crate::models::container_builder::ContainerBuilder;
 use crate::models::env_registry::{deregister, ensure_registered};
 use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
-use crate::models::lockfile::LockedManifest;
-use crate::models::manifest::{CatalogPackage, PackageToInstall, RawManifest, TypedManifest};
+use crate::models::lockfile::LockedManifestCatalog;
+use crate::models::manifest::{
+    CatalogPackage,
+    PackageToInstall,
+    RawManifest,
+    TypedManifestCatalog,
+};
 use crate::utils::mtime_of;
 
 /// Struct representing a local environment
@@ -172,7 +176,7 @@ impl PathEnvironment {
 
 impl Environment for PathEnvironment {
     /// This will lock the environment if it is not already locked.
-    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifest, EnvironmentError> {
+    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifestCatalog, EnvironmentError> {
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         Ok(env_view.ensure_locked(flox)?)
     }
@@ -267,7 +271,7 @@ impl Environment for PathEnvironment {
     }
 
     /// Return the deserialized manifest
-    fn manifest(&self, _flox: &Flox) -> Result<TypedManifest, EnvironmentError> {
+    fn manifest(&self, _flox: &Flox) -> Result<TypedManifestCatalog, EnvironmentError> {
         let env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
         env_view.manifest().map_err(EnvironmentError::Core)
     }
@@ -349,17 +353,6 @@ impl Environment for PathEnvironment {
     /// Path to the lockfile. The path may not exist.
     fn lockfile_path(&self, _flox: &Flox) -> Result<PathBuf, EnvironmentError> {
         Ok(self.path.join(ENV_DIR_NAME).join(LOCKFILE_FILENAME))
-    }
-
-    fn migrate_to_v1(
-        &mut self,
-        flox: &Flox,
-        migration_info: MigrationInfo,
-    ) -> Result<(), EnvironmentError> {
-        let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
-        let store_path = env_view.migrate_to_v1(flox, migration_info)?;
-        self.link(flox, store_path)?;
-        Ok(())
     }
 
     /// Return the path where the process compose socket for an environment
@@ -572,13 +565,9 @@ pub mod test_helpers {
 #[cfg(test)]
 mod tests {
 
-    use test_helpers::{new_path_environment, new_path_environment_from_env_files};
-
     use super::*;
     use crate::flox::test_helpers::flox_instance;
     use crate::models::env_registry::{env_registry_path, read_environment_registry};
-    use crate::models::environment::CoreEnvironmentError;
-    use crate::providers::catalog::MANUALLY_GENERATED;
 
     #[test]
     fn create_env() {
@@ -707,59 +696,5 @@ mod tests {
         assert!(reg_path.exists());
         let reg = read_environment_registry(&reg_path).unwrap().unwrap();
         assert!(reg.entries.is_empty());
-    }
-    /// It should be possible to build a container for a v0 environment
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn build_container_for_v0_environment() {
-        // We want a catalog client so we know we aren't calling pkgdb lock
-        let (flox, _temp_dir_handle) = flox_instance();
-
-        let mut environment =
-            new_path_environment_from_env_files(&flox, MANUALLY_GENERATED.join("hello_v0"));
-        environment.build_container(&flox, "latest").unwrap();
-    }
-
-    /// Attempting to build a container for a v0 environment without a lockfile should fail
-    #[test]
-    fn build_container_for_v0_environment_fails_without_lockfile() {
-        let (flox, _temp_dir_handle) = flox_instance();
-
-        let manifest_contents =
-            std::fs::read_to_string(MANUALLY_GENERATED.join("hello_v0").join(MANIFEST_FILENAME))
-                .unwrap();
-        let mut environment = new_path_environment(&flox, &manifest_contents);
-        let err = environment.build_container(&flox, "latest").unwrap_err();
-        assert!(matches!(
-            err,
-            EnvironmentError::Core(CoreEnvironmentError::LockingVersion0NotSupported)
-        ));
-    }
-
-    /// It should be possible to build a v0 environment
-    #[test]
-    fn activation_path_for_v0_environment() {
-        // We want a catalog client so we know we aren't calling pkgdb lock
-        let (flox, _temp_dir_handle) = flox_instance();
-
-        let mut environment =
-            new_path_environment_from_env_files(&flox, MANUALLY_GENERATED.join("hello_v0"));
-        environment.activation_path(&flox).unwrap();
-    }
-
-    /// Attempting to build a v0 environment without a lockfile should fail
-    #[test]
-    fn activation_path_for_v0_environment_fails_without_lockfile() {
-        let (flox, _temp_dir_handle) = flox_instance();
-
-        let manifest_contents =
-            std::fs::read_to_string(MANUALLY_GENERATED.join("hello_v0").join(MANIFEST_FILENAME))
-                .unwrap();
-        let mut environment = new_path_environment(&flox, &manifest_contents);
-        let err = environment.activation_path(&flox).unwrap_err();
-        assert!(matches!(
-            err,
-            EnvironmentError::Core(CoreEnvironmentError::LockingVersion0NotSupported)
-        ));
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -26,7 +26,7 @@ use crate::models::container_builder::ContainerBuilder;
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
 use crate::models::lockfile::Lockfile;
-use crate::models::manifest::{PackageToInstall, TypedManifestCatalog};
+use crate::models::manifest::{Manifest, PackageToInstall};
 
 const REMOTE_ENVIRONMENT_BASE_DIR: &str = "remote";
 
@@ -249,7 +249,7 @@ impl Environment for RemoteEnvironment {
     }
 
     /// Return the deserialized manifest
-    fn manifest(&self, flox: &Flox) -> Result<TypedManifestCatalog, EnvironmentError> {
+    fn manifest(&self, flox: &Flox) -> Result<Manifest, EnvironmentError> {
         self.inner.manifest(flox)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -16,7 +16,6 @@ use super::{
     EnvironmentError,
     InstallationAttempt,
     ManagedPointer,
-    MigrationInfo,
     UninstallationAttempt,
     DOT_FLOX,
     ENVIRONMENT_POINTER_FILENAME,
@@ -26,8 +25,8 @@ use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::container_builder::ContainerBuilder;
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
-use crate::models::lockfile::LockedManifest;
-use crate::models::manifest::{PackageToInstall, TypedManifest};
+use crate::models::lockfile::LockedManifestCatalog;
+use crate::models::manifest::{PackageToInstall, TypedManifestCatalog};
 
 const REMOTE_ENVIRONMENT_BASE_DIR: &str = "remote";
 
@@ -173,7 +172,7 @@ impl RemoteEnvironment {
 impl Environment for RemoteEnvironment {
     /// Return the lockfile content,
     /// or error if the lockfile doesn't exist.
-    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifest, EnvironmentError> {
+    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifestCatalog, EnvironmentError> {
         self.inner.lockfile(flox)
     }
 
@@ -250,7 +249,7 @@ impl Environment for RemoteEnvironment {
     }
 
     /// Return the deserialized manifest
-    fn manifest(&self, flox: &Flox) -> Result<TypedManifest, EnvironmentError> {
+    fn manifest(&self, flox: &Flox) -> Result<TypedManifestCatalog, EnvironmentError> {
         self.inner.manifest(flox)
     }
 
@@ -307,20 +306,6 @@ impl Environment for RemoteEnvironment {
     /// When extended to delete upstream environments, this will be more useful.
     fn delete(self, flox: &Flox) -> Result<(), EnvironmentError> {
         self.inner.delete(flox)
-    }
-
-    fn migrate_to_v1(
-        &mut self,
-        flox: &Flox,
-        migration_info: MigrationInfo,
-    ) -> Result<(), EnvironmentError> {
-        self.inner.migrate_to_v1(flox, migration_info)?;
-        self.inner
-            .push(flox, false)
-            .map_err(|e| RemoteEnvironmentError::UpdateUpstream(e).into())
-            .and_then(|_| Self::update_out_link(flox, &self.out_link, &mut self.inner))?;
-
-        Ok(())
     }
 
     fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -25,7 +25,7 @@ use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::container_builder::ContainerBuilder;
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
-use crate::models::lockfile::LockedManifestCatalog;
+use crate::models::lockfile::Lockfile;
 use crate::models::manifest::{PackageToInstall, TypedManifestCatalog};
 
 const REMOTE_ENVIRONMENT_BASE_DIR: &str = "remote";
@@ -172,7 +172,7 @@ impl RemoteEnvironment {
 impl Environment for RemoteEnvironment {
     /// Return the lockfile content,
     /// or error if the lockfile doesn't exist.
-    fn lockfile(&mut self, flox: &Flox) -> Result<LockedManifestCatalog, EnvironmentError> {
+    fn lockfile(&mut self, flox: &Flox) -> Result<Lockfile, EnvironmentError> {
         self.inner.lockfile(flox)
     }
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -21,10 +21,10 @@ use thiserror::Error;
 
 use super::manifest::{
     Allows,
+    Manifest,
     ManifestPackageDescriptor,
     ManifestPackageDescriptorCatalog,
     ManifestPackageDescriptorFlake,
-    TypedManifestCatalog,
     DEFAULT_GROUP_NAME,
     DEFAULT_PRIORITY,
 };
@@ -77,7 +77,7 @@ pub struct Lockfile {
     #[serde(rename = "lockfile-version")]
     pub version: Version<1>,
     /// original manifest that was locked
-    pub manifest: TypedManifestCatalog,
+    pub manifest: Manifest,
     /// locked packages
     pub packages: Vec<LockedPackage>,
 }
@@ -504,7 +504,7 @@ impl Lockfile {
     /// Keeping the locking of each kind separate keeps the existing methods simpler
     /// and allows for potential parallelization in the future.
     pub async fn lock_manifest(
-        manifest: &TypedManifestCatalog,
+        manifest: &Manifest,
         seed_lockfile: Option<&Lockfile>,
         client: &impl catalog::ClientTrait,
         installable_locker: &impl InstallableLocker,
@@ -640,7 +640,7 @@ impl Lockfile {
     /// so we update the priority of already locked packages to match the manifest.
     fn update_priority<'a>(
         already_locked_packages: impl IntoIterator<Item = &'a mut LockedPackage>,
-        manifest: &TypedManifestCatalog,
+        manifest: &Manifest,
     ) {
         for locked_package in already_locked_packages {
             let LockedPackage::Catalog(LockedPackageCatalog {
@@ -704,7 +704,7 @@ impl Lockfile {
     /// fallible conversions like that would be unnecessary,
     /// or would be pushed higher up.
     fn collect_package_groups(
-        manifest: &TypedManifestCatalog,
+        manifest: &Manifest,
         seed_lockfile: Option<&Lockfile>,
     ) -> Result<impl Iterator<Item = PackageGroup>, LockedManifestError> {
         let seed_locked_packages = seed_lockfile.map_or_else(HashMap::new, Self::make_seed_mapping);
@@ -856,7 +856,7 @@ impl Lockfile {
     ///       currently there is no api to request packages from specific pages
     /// TODO: handle json value conversion earlier in the shim (or the upstream spec)
     fn locked_packages_from_resolution<'manifest>(
-        manifest: &'manifest TypedManifestCatalog,
+        manifest: &'manifest Manifest,
         groups: impl IntoIterator<Item = ResolvedPackageGroup> + 'manifest,
     ) -> Result<impl Iterator<Item = LockedPackageCatalog> + 'manifest, LockedManifestError> {
         let groups = groups.into_iter().collect::<Vec<_>>();
@@ -909,7 +909,7 @@ impl Lockfile {
     /// Constructs [ResolutionFailure]s from the failed groups
     fn collect_failures(
         failed_groups: &[ResolvedPackageGroup],
-        manifest: &TypedManifestCatalog,
+        manifest: &Manifest,
     ) -> Result<Vec<ResolutionFailure>, LockedManifestError> {
         let mut failures = Vec::new();
         for group in failed_groups {
@@ -976,7 +976,7 @@ impl Lockfile {
     /// available for
     fn determine_invalid_systems(
         r_msg: &MsgAttrPathNotFoundNotFoundForAllSystems,
-        manifest: &TypedManifestCatalog,
+        manifest: &Manifest,
     ) -> Result<Vec<System>, LockedManifestError> {
         let default_systems = HashSet::<_>::from_iter(DEFAULT_SYSTEMS_STR.iter());
         let valid_systems = HashSet::<_>::from_iter(&r_msg.valid_systems);
@@ -1026,7 +1026,7 @@ impl Lockfile {
     /// [Self::split_locked_flake_installables], based on the descriptor alone,
     /// no additional "marking" is needed.
     fn collect_flake_installables(
-        manifest: &TypedManifestCatalog,
+        manifest: &Manifest,
     ) -> impl Iterator<Item = FlakeInstallableToLock> + '_ {
         manifest
             .install
@@ -1531,7 +1531,7 @@ pub(crate) mod tests {
 
     use self::catalog::PackageResolutionInfo;
     use super::*;
-    use crate::models::manifest::{RawManifest, TypedManifestCatalog};
+    use crate::models::manifest::{Manifest, RawManifest};
     use crate::models::search::{SearchLimit, SearchResults};
     use crate::providers::flox_cpp_utils::{FlakeInstallableError, InstallableLockerMock};
 
@@ -1676,7 +1676,7 @@ pub(crate) mod tests {
         .unwrap()
     });
 
-    static TEST_TYPED_MANIFEST: Lazy<TypedManifestCatalog> =
+    static TEST_TYPED_MANIFEST: Lazy<Manifest> =
         Lazy::new(|| TEST_RAW_MANIFEST.to_typed().unwrap());
 
     static TEST_RESOLUTION_RESPONSE_UNKNOWN_MSG: Lazy<Vec<ResolvedPackageGroup>> =
@@ -1781,42 +1781,41 @@ pub(crate) mod tests {
         }]
     });
 
-    static TEST_LOCKED_MANIFEST: Lazy<Lockfile> =
-        Lazy::new(|| Lockfile {
-            version: Version::<1>,
-            manifest: TEST_TYPED_MANIFEST.clone(),
-            packages: vec![LockedPackageCatalog {
-                attr_path: "hello".to_string(),
-                broken: Some(false),
-                derivation: "derivation".to_string(),
-                description: Some("description".to_string()),
-                install_id: "hello_install_id".to_string(),
-                license: Some("license".to_string()),
-                locked_url: "locked_url".to_string(),
-                name: "hello".to_string(),
-                outputs: [("name".to_string(), "store_path".to_string())]
-                    .into_iter()
-                    .collect(),
+    static TEST_LOCKED_MANIFEST: Lazy<Lockfile> = Lazy::new(|| Lockfile {
+        version: Version::<1>,
+        manifest: TEST_TYPED_MANIFEST.clone(),
+        packages: vec![LockedPackageCatalog {
+            attr_path: "hello".to_string(),
+            broken: Some(false),
+            derivation: "derivation".to_string(),
+            description: Some("description".to_string()),
+            install_id: "hello_install_id".to_string(),
+            license: Some("license".to_string()),
+            locked_url: "locked_url".to_string(),
+            name: "hello".to_string(),
+            outputs: [("name".to_string(), "store_path".to_string())]
+                .into_iter()
+                .collect(),
 
-                outputs_to_install: Some(vec!["name".to_string()]),
-                pname: "pname".to_string(),
-                rev: "rev".to_string(),
-                rev_count: 1,
-                rev_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
-                    .unwrap()
-                    .with_timezone(&chrono::offset::Utc),
-                scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
-                    .unwrap()
-                    .with_timezone(&chrono::offset::Utc),
-                stabilities: Some(vec!["stability".to_string()]),
-                unfree: Some(false),
-                version: "version".to_string(),
-                system: SystemEnum::Aarch64Darwin.to_string(),
-                group: "group".to_string(),
-                priority: 5,
-            }
-            .into()],
-        });
+            outputs_to_install: Some(vec!["name".to_string()]),
+            pname: "pname".to_string(),
+            rev: "rev".to_string(),
+            rev_count: 1,
+            rev_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::offset::Utc),
+            scrape_date: chrono::DateTime::parse_from_rfc3339("2021-08-31T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::offset::Utc),
+            stabilities: Some(vec!["stability".to_string()]),
+            unfree: Some(false),
+            version: "version".to_string(),
+            system: SystemEnum::Aarch64Darwin.to_string(),
+            group: "group".to_string(),
+            priority: 5,
+        }
+        .into()],
+    });
 
     #[test]
     fn make_params_smoke() {
@@ -2126,7 +2125,7 @@ pub(crate) mod tests {
     fn make_params_seeded_unchanged() {
         let (foo_before_iid, foo_before_descriptor, foo_before_locked) =
             fake_catalog_package_lock("foo", None);
-        let mut manifest_before = TypedManifestCatalog::default();
+        let mut manifest_before = Manifest::default();
         manifest_before
             .install
             .insert(foo_before_iid.clone(), foo_before_descriptor.clone());
@@ -2139,10 +2138,9 @@ pub(crate) mod tests {
 
         // ---------------------------------------------------------------------
 
-        let actual_params =
-            Lockfile::collect_package_groups(&manifest_before, Some(&seed))
-                .unwrap()
-                .collect::<Vec<_>>();
+        let actual_params = Lockfile::collect_package_groups(&manifest_before, Some(&seed))
+            .unwrap()
+            .collect::<Vec<_>>();
 
         // the original derivation should be present and unchanged
         assert_eq!(
@@ -2158,7 +2156,7 @@ pub(crate) mod tests {
     fn make_params_seeded_unlock_if_invalidated() {
         let (foo_before_iid, foo_before_descriptor, foo_before_locked) =
             fake_catalog_package_lock("foo", None);
-        let mut manifest_before = TypedManifestCatalog::default();
+        let mut manifest_before = Manifest::default();
         manifest_before
             .install
             .insert(foo_before_iid.clone(), foo_before_descriptor.clone());
@@ -2181,15 +2179,14 @@ pub(crate) mod tests {
 
         assert!(foo_after_descriptor.invalidates_existing_resolution(&foo_before_descriptor));
 
-        let mut manifest_after = TypedManifestCatalog::default();
+        let mut manifest_after = Manifest::default();
         manifest_after
             .install
             .insert(foo_after_iid.clone(), foo_after_descriptor.clone());
 
-        let actual_params =
-            Lockfile::collect_package_groups(&manifest_after, Some(&seed))
-                .unwrap()
-                .collect::<Vec<_>>();
+        let actual_params = Lockfile::collect_package_groups(&manifest_after, Some(&seed))
+            .unwrap()
+            .collect::<Vec<_>>();
 
         // if the package changed, it should be re-resolved
         // i.e. the derivation should be None
@@ -2204,7 +2201,7 @@ pub(crate) mod tests {
     fn make_params_seeded_changed_no_invalidation() {
         let (foo_before_iid, foo_before_descriptor, foo_before_locked) =
             fake_catalog_package_lock("foo", None);
-        let mut manifest_before = TypedManifestCatalog::default();
+        let mut manifest_before = Manifest::default();
         manifest_before
             .install
             .insert(foo_before_iid.clone(), foo_before_descriptor.clone());
@@ -2226,15 +2223,14 @@ pub(crate) mod tests {
 
         assert!(!foo_after_descriptor.invalidates_existing_resolution(&foo_before_descriptor));
 
-        let mut manifest_after = TypedManifestCatalog::default();
+        let mut manifest_after = Manifest::default();
         manifest_after
             .install
             .insert(foo_after_iid.clone(), foo_after_descriptor.clone());
 
-        let actual_params =
-            Lockfile::collect_package_groups(&manifest_after, Some(&seed))
-                .unwrap()
-                .collect::<Vec<_>>();
+        let actual_params = Lockfile::collect_package_groups(&manifest_after, Some(&seed))
+            .unwrap()
+            .collect::<Vec<_>>();
 
         assert_eq!(
             actual_params[0].descriptors[0].derivation.as_ref(),
@@ -2292,7 +2288,7 @@ pub(crate) mod tests {
     /// for each default system.
     #[test]
     fn make_installables_to_lock_for_default_systems() {
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         let (foo_install_id, foo_descriptor, _) = fake_flake_installable_lock("foo");
 
         manifest
@@ -2318,7 +2314,7 @@ pub(crate) mod tests {
     fn make_installables_to_lock_for_manifest_systems() {
         let system = "aarch64-darwin";
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.options.systems = Some(vec![system.to_string()]);
 
         let (foo_install_id, foo_descriptor, _) = fake_flake_installable_lock("foo");
@@ -2343,7 +2339,7 @@ pub(crate) mod tests {
     /// should only return [FlakeInstallableToLock] for the flake installables.
     #[test]
     fn make_installables_to_lock_filter_catalog() {
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         let (foo_install_id, foo_descriptor, _) = fake_flake_installable_lock("foo");
         let (bar_install_id, bar_descriptor, _) = fake_catalog_package_lock("bar", None);
 
@@ -2411,10 +2407,9 @@ pub(crate) mod tests {
 
         let manifest = &*TEST_TYPED_MANIFEST;
 
-        let locked_packages =
-            Lockfile::locked_packages_from_resolution(manifest, groups.clone())
-                .unwrap()
-                .collect::<Vec<_>>();
+        let locked_packages = Lockfile::locked_packages_from_resolution(manifest, groups.clone())
+            .unwrap()
+            .collect::<Vec<_>>();
 
         let descriptor = manifest
             .install
@@ -2437,7 +2432,7 @@ pub(crate) mod tests {
     /// Both catalog packages and flake installables should be removed.
     #[test]
     fn unlock_by_iid() {
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         let (foo_iid, foo_descriptor, foo_locked) = fake_catalog_package_lock("foo", None);
         let (bar_iid, bar_descriptor, bar_locked) = fake_catalog_package_lock("bar", None);
         let (baz_iid, baz_descriptor, baz_locked) = fake_flake_installable_lock("baz");
@@ -2472,7 +2467,7 @@ pub(crate) mod tests {
     /// Unlocking by group should remove all packages in that group
     #[test]
     fn unlock_by_group() {
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         let (foo_iid, foo_descriptor, foo_locked) = fake_catalog_package_lock("foo", Some("group"));
         let (bar_iid, bar_descriptor, bar_locked) = fake_catalog_package_lock("bar", Some("group"));
         manifest.install.insert(foo_iid.clone(), foo_descriptor);
@@ -2492,7 +2487,7 @@ pub(crate) mod tests {
     /// and the package
     #[test]
     fn unlock_by_iid_and_group() {
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         let (foo_iid, foo_descriptor, foo_locked) =
             fake_catalog_package_lock("foo", Some("foo_install_id"));
         let (bar_iid, bar_descriptor, bar_locked) =
@@ -2532,13 +2527,8 @@ pub(crate) mod tests {
             response.first().unwrap().msgs.first().unwrap().clone();
         client.push_resolve_response(response);
 
-        let locked_manifest = Lockfile::lock_manifest(
-            manifest,
-            None,
-            &client,
-            &InstallableLockerMock::new(),
-        )
-        .await;
+        let locked_manifest =
+            Lockfile::lock_manifest(manifest, None, &client, &InstallableLockerMock::new()).await;
         if let Err(LockedManifestError::ResolutionFailed(res_failures)) = locked_manifest {
             if let [ResolutionFailure::UnknownServiceMessage(MsgUnknown { msg, .. })] =
                 res_failures.0.as_slice()
@@ -2570,13 +2560,9 @@ pub(crate) mod tests {
                 response.first().unwrap().msgs.first().unwrap().clone();
             client.push_resolve_response(response);
 
-            let locked_manifest = Lockfile::lock_manifest(
-                manifest,
-                None,
-                &client,
-                &InstallableLockerMock::new(),
-            )
-            .await;
+            let locked_manifest =
+                Lockfile::lock_manifest(manifest, None, &client, &InstallableLockerMock::new())
+                    .await;
             if let Err(LockedManifestError::ResolutionFailed(res_failures)) = locked_manifest {
                 assert_eq!(res_failures.to_string(), response_msg.msg());
             } else {
@@ -2592,14 +2578,10 @@ pub(crate) mod tests {
         let mut client = catalog::MockClient::new(None::<String>).unwrap();
         client.push_resolve_response(TEST_RESOLUTION_RESPONSE.clone());
 
-        let locked_manifest = Lockfile::lock_manifest(
-            manifest,
-            None,
-            &client,
-            &InstallableLockerMock::new(),
-        )
-        .await
-        .unwrap();
+        let locked_manifest =
+            Lockfile::lock_manifest(manifest, None, &client, &InstallableLockerMock::new())
+                .await
+                .unwrap();
         assert_eq!(&locked_manifest, &*TEST_LOCKED_MANIFEST);
     }
 
@@ -2613,7 +2595,7 @@ pub(crate) mod tests {
             [install]
             hello_install_id.pkg-path = "hello"
         "#};
-        let manifest: TypedManifestCatalog = toml::from_str(manifest_str).unwrap();
+        let manifest: Manifest = toml::from_str(manifest_str).unwrap();
         let package_groups: Vec<_> = Lockfile::collect_package_groups(&manifest, None)
             .unwrap()
             .collect();
@@ -2647,7 +2629,7 @@ pub(crate) mod tests {
             fake_catalog_package_lock("baz", Some("group2"));
         let (yeet_iid, yeet_descriptor, _) = fake_catalog_package_lock("yeet", Some("group2"));
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.install.insert(foo_iid, foo_descriptor.clone());
         manifest.install.insert(bar_iid, bar_descriptor.clone());
         manifest
@@ -2666,8 +2648,7 @@ pub(crate) mod tests {
             .install
             .insert(yeet_iid.clone(), yeet_descriptor.clone());
 
-        let groups =
-            Lockfile::collect_package_groups(&manifest, Some(&locked)).unwrap();
+        let groups = Lockfile::collect_package_groups(&manifest, Some(&locked)).unwrap();
 
         let (fully_locked, to_resolve): (Vec<_>, Vec<_>) =
             Lockfile::split_fully_locked_groups(groups, Some(&locked));
@@ -2742,7 +2723,7 @@ pub(crate) mod tests {
             ..foo_locked.clone()
         };
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest
             .install
             .insert(foo_iid.clone(), foo_descriptor_two_systems.clone());
@@ -2799,7 +2780,7 @@ pub(crate) mod tests {
             panic!("Expected a catalog descriptor");
         };
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest
             .install
             .insert(foo_iid.clone(), foo_descriptor_one_system.clone());
@@ -2846,7 +2827,7 @@ pub(crate) mod tests {
         let (foo_iid, foo_descriptor, _) = fake_flake_installable_lock("foo");
         let (bar_iid, bar_descriptor, bar_locked) = fake_flake_installable_lock("bar");
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.options.systems = Some(vec![system.to_string()]);
 
         manifest
@@ -2865,10 +2846,7 @@ pub(crate) mod tests {
         let flake_installables = Lockfile::collect_flake_installables(&manifest);
 
         let (locked, to_resolve): (Vec<_>, Vec<_>) =
-            Lockfile::split_locked_flake_installables(
-                flake_installables,
-                Some(&locked),
-            );
+            Lockfile::split_locked_flake_installables(flake_installables, Some(&locked));
 
         assert_eq!(locked, vec![bar_locked.into()]);
         assert_eq!(&to_resolve, &[FlakeInstallableToLock {
@@ -2885,7 +2863,7 @@ pub(crate) mod tests {
         let system = "aarch64-darwin";
         let (_, _, bar_locked) = fake_flake_installable_lock("bar");
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.options.systems = Some(vec![system.to_string()]);
 
         let locked = Lockfile {
@@ -2897,10 +2875,7 @@ pub(crate) mod tests {
         let flake_installables = Lockfile::collect_flake_installables(&manifest);
 
         let (locked, to_resolve): (Vec<_>, Vec<_>) =
-            Lockfile::split_locked_flake_installables(
-                flake_installables,
-                Some(&locked),
-            );
+            Lockfile::split_locked_flake_installables(flake_installables, Some(&locked));
 
         assert_eq!(locked, vec![]);
         assert_eq!(&to_resolve, &[]);
@@ -2917,7 +2892,7 @@ pub(crate) mod tests {
         let mut foo_locked_system_2 = foo_locked;
         foo_locked_system_2.locked_installable.system = SystemEnum::Aarch64Linux.to_string();
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.options.systems = Some(vec![system.to_string()]);
 
         manifest
@@ -2936,10 +2911,7 @@ pub(crate) mod tests {
         let flake_installables = Lockfile::collect_flake_installables(&manifest);
 
         let (locked, to_resolve): (Vec<_>, Vec<_>) =
-            Lockfile::split_locked_flake_installables(
-                flake_installables,
-                Some(&locked),
-            );
+            Lockfile::split_locked_flake_installables(flake_installables, Some(&locked));
 
         assert_eq!(locked, vec![foo_locked_system_1.into()]);
         assert_eq!(&to_resolve, &[]);
@@ -2952,7 +2924,7 @@ pub(crate) mod tests {
         let system_2 = "aarch64-linux";
         let (foo_iid, foo_descriptor, foo_locked) = fake_flake_installable_lock("foo");
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest
             .install
             .insert(foo_iid.clone(), foo_descriptor.clone().into());
@@ -2970,10 +2942,7 @@ pub(crate) mod tests {
         let flake_installables = Lockfile::collect_flake_installables(&manifest);
 
         let (locked, to_resolve): (Vec<_>, Vec<_>) =
-            Lockfile::split_locked_flake_installables(
-                flake_installables,
-                Some(&locked),
-            );
+            Lockfile::split_locked_flake_installables(flake_installables, Some(&locked));
 
         assert_eq!(locked, vec![]);
         assert_eq!(
@@ -2992,7 +2961,7 @@ pub(crate) mod tests {
         let (foo_iid, foo_descriptor, foo_locked) = fake_catalog_package_lock("foo", None);
         let (bar_iid, bar_descriptor, bar_locked) = fake_flake_installable_lock("bar");
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.options.systems = Some(vec![SystemEnum::Aarch64Darwin.to_string()]);
         manifest
             .install
@@ -3007,14 +2976,10 @@ pub(crate) mod tests {
             packages: vec![foo_locked.into(), bar_locked.into()],
         };
 
-        let locked_manifest = Lockfile::lock_manifest(
-            &manifest,
-            Some(&locked),
-            &PanickingClient,
-            &PanickingLocker,
-        )
-        .await
-        .unwrap();
+        let locked_manifest =
+            Lockfile::lock_manifest(&manifest, Some(&locked), &PanickingClient, &PanickingLocker)
+                .await
+                .unwrap();
 
         assert_eq!(locked_manifest, locked);
     }
@@ -3026,7 +2991,7 @@ pub(crate) mod tests {
         let (foo_iid, foo_descriptor, _) = fake_catalog_package_lock("foo", None);
         let (bar_iid, bar_descriptor, bar_locked) = fake_flake_installable_lock("bar");
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.options.systems = Some(vec![SystemEnum::Aarch64Darwin.to_string()]);
         manifest
             .install
@@ -3077,14 +3042,10 @@ pub(crate) mod tests {
             }),
         }]);
 
-        let locked_manifest = Lockfile::lock_manifest(
-            &manifest,
-            Some(&locked),
-            &client_mock,
-            &PanickingLocker,
-        )
-        .await
-        .unwrap();
+        let locked_manifest =
+            Lockfile::lock_manifest(&manifest, Some(&locked), &client_mock, &PanickingLocker)
+                .await
+                .unwrap();
 
         assert_eq!(locked_manifest.packages.len(), 2, "{:#?}", locked_manifest);
     }
@@ -3096,7 +3057,7 @@ pub(crate) mod tests {
         let (foo_iid, foo_descriptor, foo_locked) = fake_catalog_package_lock("foo", None);
         let (bar_iid, bar_descriptor, bar_locked) = fake_flake_installable_lock("bar");
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.options.systems = Some(vec![SystemEnum::Aarch64Darwin.to_string()]);
         manifest
             .install
@@ -3114,14 +3075,10 @@ pub(crate) mod tests {
         let locker_mock = InstallableLockerMock::new();
         locker_mock.push_lock_result(Ok(bar_locked.locked_installable));
 
-        let locked_manifest = Lockfile::lock_manifest(
-            &manifest,
-            Some(&locked),
-            &PanickingClient,
-            &locker_mock,
-        )
-        .await
-        .unwrap();
+        let locked_manifest =
+            Lockfile::lock_manifest(&manifest, Some(&locked), &PanickingClient, &locker_mock)
+                .await
+                .unwrap();
 
         assert_eq!(locked_manifest.packages.len(), 2, "{:#?}", locked_manifest);
     }
@@ -3132,7 +3089,7 @@ pub(crate) mod tests {
     async fn update_priority_if_fully_locked() {
         let (foo_iid, foo_descriptor, foo_locked) = fake_catalog_package_lock("foo", None);
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest.options.systems = Some(vec![SystemEnum::Aarch64Darwin.to_string()]);
         manifest
             .install
@@ -3180,7 +3137,7 @@ pub(crate) mod tests {
         let (foo_iid, foo_descriptor_one_system, mut foo_locked) =
             fake_catalog_package_lock("foo", None);
         foo_locked.unfree = Some(true);
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest
             .install
             .insert(foo_iid.clone(), foo_descriptor_one_system.clone());
@@ -3215,7 +3172,7 @@ pub(crate) mod tests {
         // Create a manifest with a package foo and `options.allow.unfree = false`
         let (foo_iid, foo_descriptor_one_system, _) =
             fake_catalog_package_lock("foo", Some("toplevel"));
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest
             .install
             .insert(foo_iid.clone(), foo_descriptor_one_system.clone());
@@ -3241,14 +3198,9 @@ pub(crate) mod tests {
             .unfree = Some(true);
         client.push_resolve_response(vec![resolved_group]);
         assert!(matches!(
-            Lockfile::lock_manifest(
-                &manifest,
-                None,
-                &client,
-                &InstallableLockerMock::new()
-            )
-            .await
-            .unwrap_err(),
+            Lockfile::lock_manifest(&manifest, None, &client, &InstallableLockerMock::new())
+                .await
+                .unwrap_err(),
             LockedManifestError::UnfreeNotAllowed { .. }
         ));
     }
@@ -3405,7 +3357,7 @@ pub(crate) mod tests {
         };
         baz_locked.system = SystemEnum::Aarch64Linux.to_string();
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest
             .install
             .insert(foo_iid.clone(), foo_descriptor.clone());
@@ -3481,7 +3433,7 @@ pub(crate) mod tests {
 
         baz_locked.locked_installable.system = SystemEnum::Aarch64Linux.to_string();
 
-        let mut manifest = TypedManifestCatalog::default();
+        let mut manifest = Manifest::default();
         manifest
             .install
             .insert(foo_iid.clone(), foo_descriptor.clone().into());
@@ -3518,8 +3470,7 @@ pub(crate) mod tests {
         systems = ["aarch64-linux", "x86_64-linux"]
         "#};
         let manifest = toml_edit::de::from_str(&manifest_contents).unwrap();
-        let installables =
-            Lockfile::collect_flake_installables(&manifest).collect::<Vec<_>>();
+        let installables = Lockfile::collect_flake_installables(&manifest).collect::<Vec<_>>();
         assert_eq!(installables.len(), 1);
         assert_eq!(installables[0].system.as_str(), "x86_64-linux");
     }

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -240,8 +240,9 @@ impl MockClient {
     /// Clear mock responses and then load responses from a file into the list
     /// of mock responses
     pub fn clear_and_load_responses_from_file(&mut self, relative_path: &str) {
-        let responses = read_mock_responses((*GENERATED_DATA).join(relative_path))
-            .expect("couldn't read mock responses");
+        let data_path = (*GENERATED_DATA).join(relative_path);
+        eprintln!("data path: {}", data_path.display());
+        let responses = read_mock_responses(data_path).expect("couldn't read mock responses");
         let mut locked_mock_responses = self
             .mock_responses
             .lock()

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -272,6 +272,7 @@ pub fn service_config_write_location(temp_dir: impl AsRef<Path>) -> Result<PathB
     Ok(path)
 }
 
+/// Generate the YAML config file for services if the lockfile contains services.
 pub fn maybe_make_service_config_file(
     flox: &Flox,
     lockfile: &LockedManifestCatalog,

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -22,7 +22,7 @@ use tempfile::NamedTempFile;
 use tracing::debug;
 
 use crate::flox::Flox;
-use crate::models::lockfile::LockedManifestCatalog;
+use crate::models::lockfile::Lockfile;
 use crate::models::manifest::{ManifestServiceShutdown, ManifestServices};
 use crate::utils::{traceable_path, CommandExt};
 
@@ -275,7 +275,7 @@ pub fn service_config_write_location(temp_dir: impl AsRef<Path>) -> Result<PathB
 /// Generate the YAML config file for services if the lockfile contains services.
 pub fn maybe_make_service_config_file(
     flox: &Flox,
-    lockfile: &LockedManifestCatalog,
+    lockfile: &Lockfile,
 ) -> Result<Option<PathBuf>, ServiceError> {
     let service_config_path = if !lockfile.manifest.services.is_empty() {
         let config_path = service_config_write_location(&flox.temp_dir)?;

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -27,7 +27,6 @@ use flox_rust_sdk::models::environment::{
     FLOX_PROMPT_ENVIRONMENTS_VAR,
     FLOX_SERVICES_SOCKET_VAR,
 };
-use flox_rust_sdk::models::manifest::TypedManifest;
 use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
 use flox_rust_sdk::providers::services::shutdown_process_compose_if_all_processes_stopped;
 use indexmap::IndexSet;
@@ -322,63 +321,62 @@ impl Activate {
         }
 
         let socket_path = environment.services_socket_path(&flox)?;
-        if let TypedManifest::Catalog(manifest) = environment.manifest(&flox)? {
-            exports.insert(
-                "_FLOX_ENV_CUDA_DETECTION",
-                match manifest.options.cuda_detection {
-                    Some(false) => "0", // manifest opts-out
-                    _ => "1",           // default to enabling CUDA
-                }
-                .to_string(),
-            );
-
-            if in_place && self.start_services {
-                debug!("not starting services for in-place activation");
-                message::warning("Skipped starting services. Services are not yet supported for in place activations.");
+        let manifest = environment.manifest(&flox)?;
+        exports.insert(
+            "_FLOX_ENV_CUDA_DETECTION",
+            match manifest.options.cuda_detection {
+                Some(false) => "0", // manifest opts-out
+                _ => "1",           // default to enabling CUDA
             }
+            .to_string(),
+        );
 
-            // We should error for remote environments even if they don't have
-            // services so that the user doesn't assume we're actually starting
-            // services.
-            if self.start_services {
-                // Error for remote envs and envs with v0 manifests, since they don't support services
-                ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+        if in_place && self.start_services {
+            debug!("not starting services for in-place activation");
+            message::warning("Skipped starting services. Services are not yet supported for in place activations.");
+        }
 
-                if manifest.services.is_empty() {
-                    message::warning(ServicesCommandsError::NoDefinedServices);
-                } else if manifest.services.copy_for_system(&flox.system).is_empty() {
-                    message::warning(ServicesCommandsError::NoDefinedServicesForSystem {
-                        system: flox.system.clone(),
-                    });
-                }
+        // We should error for remote environments even if they don't have
+        // services so that the user doesn't assume we're actually starting
+        // services.
+        if self.start_services {
+            // Error for remote envs, since they don't support services
+            ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+
+            if manifest.services.is_empty() {
+                message::warning(ServicesCommandsError::NoDefinedServices);
+            } else if manifest.services.copy_for_system(&flox.system).is_empty() {
+                message::warning(ServicesCommandsError::NoDefinedServicesForSystem {
+                    system: flox.system.clone(),
+                });
             }
+        }
 
-            let should_have_services = self.start_services
-                && !manifest.services.copy_for_system(&flox.system).is_empty()
-                && !in_place;
-            let start_new_process_compose = should_have_services
-                && if socket_path.exists() {
-                    // Returns `Ok(true)` if `process-compose` was shutdown
-                    shutdown_process_compose_if_all_processes_stopped(&socket_path)?
-                } else {
-                    true
-                };
-            tracing::debug!(
-                should_have_services,
-                start_new_process_compose,
-                "setting service variables"
-            );
-            exports.insert(
-                FLOX_ACTIVATE_START_SERVICES_VAR,
-                start_new_process_compose.to_string(),
-            );
-            exports.insert(
-                FLOX_SERVICES_SOCKET_VAR,
-                socket_path.to_string_lossy().to_string(),
-            );
-            if should_have_services && !start_new_process_compose {
-                message::warning("Skipped starting services, services are already running");
-            }
+        let should_have_services = self.start_services
+            && !manifest.services.copy_for_system(&flox.system).is_empty()
+            && !in_place;
+        let start_new_process_compose = should_have_services
+            && if socket_path.exists() {
+                // Returns `Ok(true)` if `process-compose` was shutdown
+                shutdown_process_compose_if_all_processes_stopped(&socket_path)?
+            } else {
+                true
+            };
+        tracing::debug!(
+            should_have_services,
+            start_new_process_compose,
+            "setting service variables"
+        );
+        exports.insert(
+            FLOX_ACTIVATE_START_SERVICES_VAR,
+            start_new_process_compose.to_string(),
+        );
+        exports.insert(
+            FLOX_SERVICES_SOCKET_VAR,
+            socket_path.to_string_lossy().to_string(),
+        );
+        if should_have_services && !start_new_process_compose {
+            message::warning("Skipped starting services, services are already running");
         }
 
         exports.extend(default_nix_env_vars());

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::lockfile::LockedManifest;
+use flox_rust_sdk::models::lockfile::LockedManifestCatalog;
 use flox_rust_sdk::providers::build::{FloxBuildMk, ManifestBuilder, Output};
 use indoc::indoc;
 use tracing::instrument;
@@ -133,11 +133,10 @@ impl Build {
     }
 }
 
-fn available_packages(lockfile: &LockedManifest, packages: Vec<String>) -> Result<Vec<String>> {
-    let LockedManifest::Catalog(lockfile) = lockfile else {
-        bail!("Build requires a v1 lockfile");
-    };
-
+fn available_packages(
+    lockfile: &LockedManifestCatalog,
+    packages: Vec<String>,
+) -> Result<Vec<String>> {
     let environment_packages = &lockfile.manifest.build;
 
     if environment_packages.is_empty() {

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::lockfile::LockedManifestCatalog;
+use flox_rust_sdk::models::lockfile::Lockfile;
 use flox_rust_sdk::providers::build::{FloxBuildMk, ManifestBuilder, Output};
 use indoc::indoc;
 use tracing::instrument;
@@ -134,7 +134,7 @@ impl Build {
 }
 
 fn available_packages(
-    lockfile: &LockedManifestCatalog,
+    lockfile: &Lockfile,
     packages: Vec<String>,
 ) -> Result<Vec<String>> {
     let environment_packages = &lockfile.manifest.build;

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -133,10 +133,7 @@ impl Build {
     }
 }
 
-fn available_packages(
-    lockfile: &Lockfile,
-    packages: Vec<String>,
-) -> Result<Vec<String>> {
+fn available_packages(lockfile: &Lockfile, packages: Vec<String>) -> Result<Vec<String>> {
     let environment_packages = &lockfile.manifest.build;
 
     if environment_packages.is_empty() {

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -12,7 +12,7 @@ use flox_rust_sdk::models::environment::{
     InstallationAttempt,
 };
 use flox_rust_sdk::models::lockfile::{
-    LockedManifest,
+    LockedManifestCatalog,
     LockedManifestError,
     LockedPackage,
     ResolutionFailure,
@@ -34,12 +34,7 @@ use tracing::{instrument, warn};
 
 use super::services::warn_manifest_changes_for_services;
 use super::{environment_select, EnvironmentSelect};
-use crate::commands::{
-    ensure_floxhub_token,
-    environment_description,
-    maybe_migrate_environment_to_v1,
-    EnvironmentSelectError,
-};
+use crate::commands::{ensure_floxhub_token, environment_description, EnvironmentSelectError};
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::didyoumean::{DidYouMean, InstallSuggestion};
@@ -96,7 +91,7 @@ impl Install {
             ensure_floxhub_token(&mut flox).await?;
         }
 
-        let mut concrete_environment = match self
+        let concrete_environment = match self
             .environment
             .detect_concrete_environment(&flox, "Install to")
         {
@@ -123,7 +118,6 @@ impl Install {
         };
         let description = environment_description(&concrete_environment)?;
 
-        maybe_migrate_environment_to_v1(&flox, &mut concrete_environment).await?;
         let mut environment = concrete_environment.into_dyn_environment();
 
         let mut packages_to_install = self
@@ -170,23 +164,15 @@ impl Install {
         let lockfile_content = std::fs::read_to_string(&lockfile_path)?;
 
         // Check for warnings in the lockfile
-        let lockfile: LockedManifest = serde_json::from_str(&lockfile_content)?;
-
-        match lockfile {
-            // TODO: move this behind the `installation.new_manifest.is_some()`
-            // check below so we don't warn when we don't even install anything
-            LockedManifest::Catalog(locked_manifest) => {
-                for warning in Self::generate_warnings(
-                    &locked_manifest.packages,
-                    &catalog_packages_to_install(&packages_to_install),
-                ) {
-                    message::warning(warning);
-                }
-            },
-            LockedManifest::Pkgdb(_) => {
-                unreachable!("We only support installing from the catalog now");
-            },
-        };
+        let lockfile: LockedManifestCatalog = serde_json::from_str(&lockfile_content)?;
+        // TODO: move this behind the `installation.new_manifest.is_some()`
+        // check below so we don't warn when we don't even install anything
+        for warning in Self::generate_warnings(
+            &lockfile.packages,
+            &catalog_packages_to_install(&packages_to_install),
+        ) {
+            message::warning(warning);
+        }
 
         // Print which new packages were installed
         for pkg in packages_to_install.iter() {

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -12,9 +12,9 @@ use flox_rust_sdk::models::environment::{
     InstallationAttempt,
 };
 use flox_rust_sdk::models::lockfile::{
-    Lockfile,
     LockedManifestError,
     LockedPackage,
+    Lockfile,
     ResolutionFailure,
     ResolutionFailures,
 };

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -12,7 +12,7 @@ use flox_rust_sdk::models::environment::{
     InstallationAttempt,
 };
 use flox_rust_sdk::models::lockfile::{
-    LockedManifestCatalog,
+    Lockfile,
     LockedManifestError,
     LockedPackage,
     ResolutionFailure,
@@ -164,7 +164,7 @@ impl Install {
         let lockfile_content = std::fs::read_to_string(&lockfile_path)?;
 
         // Check for warnings in the lockfile
-        let lockfile: LockedManifestCatalog = serde_json::from_str(&lockfile_content)?;
+        let lockfile: Lockfile = serde_json::from_str(&lockfile_content)?;
         // TODO: move this behind the `installation.new_manifest.is_some()`
         // check below so we don't warn when we don't even install anything
         for warning in Self::generate_warnings(

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -7,8 +7,8 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::models::lockfile::{
     InstalledPackage,
-    Lockfile,
     LockedPackageFlake,
+    Lockfile,
     PackageInfo,
     PackageToList,
 };

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -7,11 +7,10 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::models::lockfile::{
     InstalledPackage,
-    LockedManifest,
+    LockedManifestCatalog,
     LockedPackageFlake,
     PackageInfo,
     PackageToList,
-    TypedLockedManifestPkgdb,
 };
 use flox_rust_sdk::models::manifest::DEFAULT_PRIORITY;
 use flox_rust_sdk::providers::flox_cpp_utils::LockedInstallable;
@@ -73,12 +72,7 @@ impl List {
 
         let system = &flox.system;
         let lockfile = Self::get_lockfile(&flox, &mut *env)?;
-        let packages = match lockfile {
-            LockedManifest::Pkgdb(pkgdb_lockfile) => {
-                TypedLockedManifestPkgdb::try_from(pkgdb_lockfile)?.list_packages(system)
-            },
-            LockedManifest::Catalog(catalog_lockfile) => catalog_lockfile.list_packages(system)?,
-        };
+        let packages = lockfile.list_packages(system)?;
 
         if packages.is_empty() {
             let message = formatdoc! {"
@@ -261,7 +255,7 @@ impl List {
     ///
     /// Check the implementation docs of [Environment::lockfile] for more
     /// information.
-    fn get_lockfile(flox: &Flox, env: &mut dyn Environment) -> Result<LockedManifest> {
+    fn get_lockfile(flox: &Flox, env: &mut dyn Environment) -> Result<LockedManifestCatalog> {
         let lockfile = Dialog {
                 message: "No lockfile found for environment, building...",
                 help_message: None,
@@ -275,21 +269,11 @@ impl List {
 
 #[cfg(test)]
 mod tests {
-    use flox_rust_sdk::flox::test_helpers::flox_instance;
-    use flox_rust_sdk::models::environment::path_environment::test_helpers::{
-        new_path_environment,
-        new_path_environment_from_env_files,
-    };
-    use flox_rust_sdk::models::environment::{
-        CoreEnvironmentError,
-        EnvironmentError,
-        MANIFEST_FILENAME,
-    };
+
     use flox_rust_sdk::models::lockfile::test_helpers::{
         nix_eval_jobs_descriptor,
         LOCKED_NIX_EVAL_JOBS,
     };
-    use flox_rust_sdk::providers::catalog::MANUALLY_GENERATED;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -578,45 +562,5 @@ mod tests {
               Unfree:   N/A
               Broken:   N/A
         "})
-    }
-
-    /// Listing a v0 environment should succeed (without having to call pkgdb lock)
-    #[tokio::test]
-    async fn list_v0_environment() {
-        // We want a catalog client so we know we aren't calling pkgdb lock
-        let (flox, _temp_dir_handle) = flox_instance();
-
-        let environment =
-            new_path_environment_from_env_files(&flox, MANUALLY_GENERATED.join("hello_v0"));
-        List {
-            environment: EnvironmentSelect::Dir(environment.path.parent().unwrap().to_path_buf()),
-            list_mode: ListMode::Extended,
-        }
-        .handle(flox)
-        .await
-        .unwrap();
-    }
-
-    /// Attempting to `flox list` on a v0 environment without a lockfile should fail
-    #[tokio::test]
-    async fn list_v0_environment_fails_without_lockfile() {
-        let (flox, _temp_dir_handle) = flox_instance();
-
-        let manifest_contents =
-            std::fs::read_to_string(MANUALLY_GENERATED.join("hello_v0").join(MANIFEST_FILENAME))
-                .unwrap();
-        let environment = new_path_environment(&flox, &manifest_contents);
-        let err = List {
-            environment: EnvironmentSelect::Dir(environment.path.parent().unwrap().to_path_buf()),
-            list_mode: ListMode::Extended,
-        }
-        .handle(flox)
-        .await
-        .unwrap_err();
-        let core_err = err.downcast_ref::<EnvironmentError>().unwrap();
-        assert!(matches!(
-            core_err,
-            EnvironmentError::Core(CoreEnvironmentError::LockingVersion0NotSupported)
-        ));
     }
 }

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -7,7 +7,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::models::lockfile::{
     InstalledPackage,
-    LockedManifestCatalog,
+    Lockfile,
     LockedPackageFlake,
     PackageInfo,
     PackageToList,
@@ -255,7 +255,7 @@ impl List {
     ///
     /// Check the implementation docs of [Environment::lockfile] for more
     /// information.
-    fn get_lockfile(flox: &Flox, env: &mut dyn Environment) -> Result<LockedManifestCatalog> {
+    fn get_lockfile(flox: &Flox, env: &mut dyn Environment) -> Result<Lockfile> {
         let lockfile = Dialog {
                 message: "No lockfile found for environment, building...",
                 help_message: None,

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -41,10 +41,7 @@ use flox_rust_sdk::flox::{
     FLOX_VERSION,
 };
 use flox_rust_sdk::models::env_registry::{EnvRegistry, ENV_REGISTRY_FILENAME};
-use flox_rust_sdk::models::environment::managed_environment::{
-    ManagedEnvironment,
-    ManagedEnvironmentError,
-};
+use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
 use flox_rust_sdk::models::environment::path_environment::PathEnvironment;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
 use flox_rust_sdk::models::environment::{
@@ -72,7 +69,7 @@ use url::Url;
 use self::envs::DisplayEnvironments;
 use crate::commands::general::update_config;
 use crate::config::{Config, EnvironmentTrust, FLOX_CONFIG_FILE};
-use crate::utils::dialog::{Confirm, Dialog, Select, Spinner};
+use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::display_chain;
 use crate::utils::init::{
     init_catalog_client,
@@ -246,7 +243,9 @@ impl FloxArgs {
             Hub::global().set_client(client);
         } else {
             debug!("Metrics collection disabled");
-            env::set_var("FLOX_DISABLE_METRICS", "true");
+            unsafe {
+                env::set_var("FLOX_DISABLE_METRICS", "true");
+            }
         }
 
         let git_url_override = {
@@ -1658,137 +1657,12 @@ pub fn environment_description(environment: &ConcreteEnvironment) -> Result<Stri
     UninitializedEnvironment::from_concrete_environment(environment)?.message_description()
 }
 
-#[derive(Debug, Error)]
-pub enum MigrationError {
-    #[error("Migration cancelled. Run 'flox upgrade' to migrate the environment.")]
-    MigrationCancelled,
-    #[error("upgrade failed")]
-    ConfirmedUpgradeFailed(#[source] EnvironmentError),
-    #[error(transparent)]
-    Environment(#[from] EnvironmentError),
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-}
-
 /// Check if the environment needs to be migrated to version 1.
-/// If doing so requires an upgrade, prompt the user for whether to proceed.
-async fn maybe_migrate_environment_to_v1(
-    flox: &Flox,
-    environment: &mut ConcreteEnvironment,
-) -> Result<(), MigrationError> {
-    maybe_migrate_environment_to_v1_inner(
-        flox,
-        environment,
-        Dialog::can_prompt().then_some(confirm_migration_upgrade(&environment_description(
-            environment,
-        )?)),
-    )
-    .await
-}
-/// Check if the environment needs to be migrated to version 1.
-/// If doing so requires an upgrade, prompt the user for whether to proceed.
-///
-/// If confirm_upgrade_future is None, the user can't be prompted to confirm an upgrade.
-async fn maybe_migrate_environment_to_v1_inner(
-    flox: &Flox,
-    concrete_environment: &mut ConcreteEnvironment,
-    confirm_upgrade_future: Option<impl Future<Output = Result<bool>>>,
-) -> Result<(), MigrationError> {
-    let description = environment_description(concrete_environment)?;
-
-    // The user answered the prompt to upgrade the environment
-    let mut confirmed_upgrade = false;
-    if let Some(migration_info) = concrete_environment
-        .dyn_environment_ref_mut()
-        .needs_migration_to_v1(flox)?
-    {
-        // If the migration requires changes to a manifest, check if the environment is in sync
-        // before asking whether to migrate
-        // (which would subsequently fail due to changes in the manifest).
-        if migration_info.needs_manifest_migration {
-            if let ConcreteEnvironment::Managed(ref environment) = concrete_environment {
-                if environment
-                    .has_local_changes(flox)
-                    .map_err(EnvironmentError::ManagedEnvironment)?
-                {
-                    Err(EnvironmentError::ManagedEnvironment(
-                        ManagedEnvironmentError::CheckoutOutOfSync,
-                    ))?;
-                }
-            }
-        }
-
-        if migration_info.needs_upgrade {
-            // We could be a bit more sophisticated and check if there are packages installed.
-            // But we'll be re-writing the lock, so call it an upgrade.
-            match confirm_upgrade_future {
-                None => {
-                    Err(anyhow!(formatdoc! {"
-                    To edit environment {description}, you must upgrade to environment version 1.
-                    Run 'flox upgrade' to migrate the environment."
-                    }))?;
-                },
-                Some(confirm_upgrade_future) => {
-                    if !confirm_upgrade_future.await? {
-                        Err(MigrationError::MigrationCancelled)?;
-                    }
-                    confirmed_upgrade = true;
-                },
-            };
-        } else {
-            message::warning("Detected an old environment manifest.")
-        }
-        let result = Dialog {
-            message: "Migrating to version 1.",
-            help_message: None,
-            typed: Spinner::new(|| {
-                concrete_environment
-                    .dyn_environment_ref_mut()
-                    .migrate_to_v1(flox, migration_info)
-            }),
-        }
-        .spin();
-
-        if confirmed_upgrade {
-            result.map_err(MigrationError::ConfirmedUpgradeFailed)?;
-        } else {
-            result?
-        }
-
-        message::plain(format!(
-            "⬆️  Migrated environment {description} to version 1."
-        ));
-    }
-    Ok(())
-}
-
-async fn confirm_migration_upgrade(description: &str) -> Result<bool> {
-    Ok(Dialog {
-        message: &formatdoc! {"
-                    To edit environment {description}, you must upgrade to environment version 1.
-                    Do you want to upgrade now?"},
-        help_message: None,
-        typed: Confirm {
-            default: Some(false),
-        },
-    }
-    .prompt()
-    .await?)
-}
-
 #[cfg(test)]
 mod tests {
 
-    use flox_rust_sdk::flox::test_helpers::flox_instance_with_optional_floxhub;
     use flox_rust_sdk::flox::EnvironmentName;
-    use flox_rust_sdk::models::environment::managed_environment::test_helpers::{
-        mock_managed_environment,
-        mock_managed_environment_from_env_files,
-    };
-    use flox_rust_sdk::models::environment::test_helpers::MANIFEST_V0_FIELDS;
-    use flox_rust_sdk::models::environment::{CoreEnvironmentError, PathPointer};
-    use flox_rust_sdk::models::lockfile::LockedManifest;
-    use flox_rust_sdk::providers::catalog::MANUALLY_GENERATED;
+    use flox_rust_sdk::models::environment::PathPointer;
     use sentry::test::with_captured_events;
     use tempfile::tempdir;
 
@@ -2096,252 +1970,5 @@ mod tests {
         let message =
             UpdateNotification::update_instructions(update_instructions_file.to_str().unwrap());
         assert!(message.contains(custom_message));
-    }
-
-    /// maybe_migrate_environment_to_v1_inner migrates a v0 manifest without
-    /// prompting
-    ///
-    /// This also gives some coverage for managed environments
-    #[tokio::test]
-    async fn maybe_migrate_managed_environment_manifest() {
-        let owner = "owner".parse().unwrap();
-        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-
-        let mut environment =
-            ConcreteEnvironment::Managed(mock_managed_environment(&flox, "", owner));
-
-        // TODO: use None::<???> instead of false.then
-        maybe_migrate_environment_to_v1_inner(
-            &flox,
-            &mut environment,
-            false.then(|| confirm_migration_upgrade("")),
-        )
-        .await
-        .unwrap();
-
-        assert!(environment
-            .dyn_environment_ref_mut()
-            .manifest_contents(&flox)
-            .unwrap()
-            .contains("version = 1"));
-    }
-
-    /// maybe_migrate_environment_to_v1_inner bails if the environment has a
-    /// lock and the prompt function returns false
-    ///
-    /// This also gives some coverage for managed environments
-    #[tokio::test]
-    async fn maybe_migrate_managed_environment_bails() {
-        let owner = "owner".parse().unwrap();
-        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-
-        let mut environment =
-            ConcreteEnvironment::Managed(mock_managed_environment_from_env_files(
-                &flox,
-                MANUALLY_GENERATED.join("empty_v0"),
-                owner,
-            ));
-
-        let err = maybe_migrate_environment_to_v1_inner(
-            &flox,
-            &mut environment,
-            Some(async { Ok(false) }),
-        )
-        .await
-        .unwrap_err();
-        assert!(err.to_string().contains("Migration cancelled"));
-
-        assert!(!environment
-            .dyn_environment_ref_mut()
-            .manifest_contents(&flox)
-            .unwrap()
-            .contains("version = 1"));
-    }
-
-    /// maybe_migrate_environment_to_v1_inner migrates the manifest and lock if
-    /// the environment has a lock and the prompt function returns true
-    ///
-    /// This also gives some coverage for managed environments
-    #[tokio::test]
-    async fn maybe_migrate_managed_environment_lock() {
-        let owner = "owner".parse().unwrap();
-        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-
-        let mut environment =
-            ConcreteEnvironment::Managed(mock_managed_environment_from_env_files(
-                &flox,
-                MANUALLY_GENERATED.join("empty_v0"),
-                owner,
-            ));
-
-        maybe_migrate_environment_to_v1_inner(&flox, &mut environment, Some(async { Ok(true) }))
-            .await
-            .unwrap();
-
-        assert!(environment
-            .dyn_environment_ref_mut()
-            .manifest_contents(&flox)
-            .unwrap()
-            .contains("version = 1"));
-
-        assert!(matches!(
-            LockedManifest::read_from_file(
-                &CanonicalPath::new(
-                    environment
-                        .dyn_environment_ref_mut()
-                        .lockfile_path(&flox)
-                        .unwrap()
-                )
-                .unwrap(),
-            )
-            .unwrap(),
-            LockedManifest::Catalog(_)
-        ));
-    }
-
-    /// maybe_migrate_environment_to_v1_inner returns MigrationCancelled if the
-    /// environment has a lock and the prompt function returns false
-    ///
-    /// This also gives some coverage for managed environments
-    #[tokio::test]
-    async fn maybe_migrate_managed_environment_migration_cancelled() {
-        let owner = "owner".parse().unwrap();
-        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-
-        let mut environment =
-            ConcreteEnvironment::Managed(mock_managed_environment_from_env_files(
-                &flox,
-                MANUALLY_GENERATED.join("empty_v0"),
-                owner,
-            ));
-
-        let err = maybe_migrate_environment_to_v1_inner(
-            &flox,
-            &mut environment,
-            Some(async { Ok(false) }),
-        )
-        .await
-        .unwrap_err();
-
-        assert!(matches!(err, MigrationError::MigrationCancelled));
-    }
-
-    /// maybe_migrate_environment_to_v1_inner returns ConfirmedUpgradeFailed if
-    /// the environment has a manifest with v0 only fields, a lock, and the
-    /// prompt function returns true
-    ///
-    /// This also gives some coverage for managed environments
-    #[tokio::test]
-    async fn maybe_migrate_managed_environment_failed_upgrade() {
-        let owner = "owner".parse().unwrap();
-        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-
-        let mut environment =
-            ConcreteEnvironment::Managed(mock_managed_environment_from_env_files(
-                &flox,
-                MANUALLY_GENERATED.join("v0_fields"),
-                owner,
-            ));
-
-        let err = maybe_migrate_environment_to_v1_inner(
-            &flox,
-            &mut environment,
-            Some(async { Ok(true) }),
-        )
-        .await
-        .unwrap_err();
-
-        assert!(matches!(
-            err,
-            MigrationError::ConfirmedUpgradeFailed(EnvironmentError::Core(
-                CoreEnvironmentError::MigrateManifest(_)
-            ))
-        ));
-    }
-
-    /// maybe_migrate_environment_to_v1 fails if a managed environment has local changes
-    #[tokio::test]
-    async fn maybe_migrate_managed_environment_blocked() {
-        let owner = "owner".parse().unwrap();
-        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-
-        let mut environment = ConcreteEnvironment::Managed(mock_managed_environment(
-            &flox,
-            &formatdoc! {"
-                # before
-                {MANIFEST_V0_FIELDS}
-            "},
-            owner,
-        ));
-
-        // modify the lockfile
-        {
-            let manifest_path = environment
-                .dyn_environment_ref_mut()
-                .manifest_path(&flox)
-                .unwrap();
-
-            fs::write(manifest_path, formatdoc! {"
-                # after
-                {MANIFEST_V0_FIELDS}
-            "})
-            .unwrap();
-        }
-
-        let err = maybe_migrate_environment_to_v1_inner(
-            &flox,
-            &mut environment,
-            Some(async { unreachable!() }),
-        )
-        .await
-        .unwrap_err();
-
-        assert!(matches!(
-            err,
-            MigrationError::Environment(EnvironmentError::ManagedEnvironment(
-                ManagedEnvironmentError::CheckoutOutOfSync
-            ))
-        ));
-    }
-
-    /// [maybe_migrate_environment_to_v1] succeeds
-    /// even if a managed environment has local changes when no migration is needed
-    #[tokio::test]
-    async fn maybe_migrate_managed_environment_blocked_only_if_migration_needed() {
-        let owner = "owner".parse().unwrap();
-        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-
-        let mut environment = ConcreteEnvironment::Managed(mock_managed_environment(
-            &flox,
-            &formatdoc! {"
-                # before
-                version = 1
-            "},
-            owner,
-        ));
-
-        // modify the lockfile
-        {
-            let manifest_path = environment
-                .dyn_environment_ref_mut()
-                .manifest_path(&flox)
-                .unwrap();
-
-            fs::write(manifest_path, formatdoc! {"
-                # after
-                version = 1
-            "})
-            .unwrap();
-        }
-
-        maybe_migrate_environment_to_v1_inner(
-            &flox,
-            &mut environment,
-            Some(async { unreachable!() }),
-        )
-        .await
-        .expect(
-            "maybe_migrate_environment_to_v1_inner _should not_ fail, since no migration is needed",
-        );
     }
 }

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::data::System;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::{CoreEnvironmentError, Environment};
-use flox_rust_sdk::models::lockfile::LockedManifest;
-use flox_rust_sdk::models::manifest::{ManifestServices, TypedManifest, TypedManifestCatalog};
+use flox_rust_sdk::models::environment::Environment;
+use flox_rust_sdk::models::manifest::{ManifestServices, TypedManifestCatalog};
 use flox_rust_sdk::providers::services::{new_services_to_start, ProcessState, ProcessStates};
 use tracing::{debug, instrument};
 
@@ -114,12 +113,7 @@ impl ServicesEnvironment {
             .dyn_environment_ref()
             .services_socket_path(flox)?;
 
-        let TypedManifest::Catalog(manifest) = environment.dyn_environment_ref().manifest(flox)?
-        else {
-            return Err(CoreEnvironmentError::ServicesWithV0.into());
-        };
-
-        let manifest = *manifest;
+        let manifest = environment.dyn_environment_ref().manifest(flox)?;
 
         Ok(Self {
             environment,
@@ -284,11 +278,6 @@ pub async fn start_with_new_process_compose(
 ) -> Result<Vec<String>> {
     let environment = concrete_environment.dyn_environment_ref_mut();
     let lockfile = environment.lockfile(&flox)?;
-    let LockedManifest::Catalog(lockfile) = lockfile else {
-        // Checks for supported environments within the commands should prevent
-        // us ever getting here, but just in case.
-        return Err(CoreEnvironmentError::ServicesWithV0.into());
-    };
     let system = flox.system.clone();
 
     for name in names {

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -5,7 +5,7 @@ use bpaf::Bpaf;
 use flox_rust_sdk::data::System;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
-use flox_rust_sdk::models::manifest::{ManifestServices, TypedManifestCatalog};
+use flox_rust_sdk::models::manifest::{Manifest, ManifestServices};
 use flox_rust_sdk::providers::services::{new_services_to_start, ProcessState, ProcessStates};
 use tracing::{debug, instrument};
 
@@ -98,7 +98,7 @@ impl ServicesCommands {
 pub struct ServicesEnvironment {
     environment: ConcreteEnvironment,
     socket: PathBuf,
-    manifest: TypedManifestCatalog,
+    manifest: Manifest,
 }
 
 impl ServicesEnvironment {

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -9,12 +9,7 @@ use tracing::instrument;
 
 use super::services::warn_manifest_changes_for_services;
 use super::{environment_select, EnvironmentSelect};
-use crate::commands::{
-    ensure_floxhub_token,
-    environment_description,
-    maybe_migrate_environment_to_v1,
-    EnvironmentSelectError,
-};
+use crate::commands::{ensure_floxhub_token, environment_description, EnvironmentSelectError};
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::message;
@@ -48,7 +43,7 @@ impl Uninstall {
             ensure_floxhub_token(&mut flox).await?;
         };
 
-        let mut concrete_environment = match self
+        let concrete_environment = match self
             .environment
             .detect_concrete_environment(&flox, "Uninstall from")
         {
@@ -72,8 +67,6 @@ impl Uninstall {
             },
             Err(e) => Err(e)?,
         };
-
-        maybe_migrate_environment_to_v1(&flox, &mut concrete_environment).await?;
 
         let description = environment_description(&concrete_environment)?;
         let mut environment = concrete_environment.into_dyn_environment();

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -42,40 +42,6 @@ impl Upgrade {
 
         let mut environment = concrete_environment.into_dyn_environment();
 
-        if let Some(migration_info) = environment.needs_migration_to_v1(&flox)? {
-            if migration_info.needs_upgrade {
-                message::warning(
-                        "Detected an old environment version. Attempting to migrate to version 1 and upgrade packages.",
-                    );
-                Dialog {
-                    message: "Upgrading packages...",
-                    help_message: None,
-                    typed: Spinner::new(|| environment.migrate_to_v1(&flox, migration_info)),
-                }
-                .spin()?;
-                message::plain(format!(
-                    "⬆️  Migrated environment to version 1 and upgraded all packages for environment {description}."
-                ));
-            } else {
-                message::warning(
-                    "Detected an old environment version. Attempting to migrate to version 1.",
-                );
-                Dialog {
-                    message: "Migrating environment...",
-                    help_message: None,
-                    typed: Spinner::new(|| environment.migrate_to_v1(&flox, migration_info)),
-                }
-                .spin()?;
-                message::plain(format!(
-                    "⬆️  Migrated environment {description} to version 1."
-                ));
-                message::plain(format!(
-                    "ℹ️  No packages need to be upgraded in environment {description}."
-                ));
-            }
-            return Ok(());
-        }
-
         let result = Dialog {
             message: "Upgrading packages...",
             help_message: None,

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use bpaf::{Args, Parser};
-use commands::{EnvironmentSelectError, FloxArgs, FloxCli, MigrationError, Prefix, Version};
+use commands::{EnvironmentSelectError, FloxArgs, FloxCli, Prefix, Version};
 use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironmentError;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentError;
@@ -19,7 +19,6 @@ use crate::utils::errors::{
     format_environment_select_error,
     format_error,
     format_managed_error,
-    format_migration_error,
     format_remote_error,
 };
 use crate::utils::metrics::Hub;
@@ -95,10 +94,12 @@ fn main() -> ExitCode {
     let _metrics_guard = Hub::global().try_guard().ok();
 
     // Pass down the verbosity level to all pkgdb calls
-    std::env::set_var(
-        "_FLOX_PKGDB_VERBOSITY",
-        format!("{}", verbosity.to_pkgdb_verbosity_level()),
-    );
+    unsafe {
+        std::env::set_var(
+            "_FLOX_PKGDB_VERBOSITY",
+            format!("{}", verbosity.to_pkgdb_verbosity_level()),
+        );
+    }
     debug!(
         "set _FLOX_PKGDB_VERBOSITY={}",
         verbosity.to_pkgdb_verbosity_level()
@@ -161,10 +162,6 @@ fn main() -> ExitCode {
                     e.downcast_ref::<EnvironmentSelectError>()
                         .map(format_environment_select_error)
                 })
-                .or_else(|| {
-                    e.downcast_ref::<MigrationError>()
-                        .map(format_migration_error)
-                })
                 .or_else(|| e.downcast_ref::<ServiceError>().map(format_service_error));
 
             if let Some(message) = message {
@@ -211,8 +208,10 @@ fn set_user() -> Result<()> {
         if let Some(effective_user) = nix::unistd::User::from_uid(nix::unistd::geteuid())? {
             // TODO: warn if variable is empty?
             if env::var("USER").unwrap_or_default() != effective_user.name {
-                env::set_var("USER", effective_user.name);
-                env::set_var("HOME", effective_user.dir);
+                unsafe {
+                    env::set_var("USER", effective_user.name);
+                    env::set_var("HOME", effective_user.dir);
+                }
             }
         } else {
             // Corporate LDAP environments rely on finding nss_ldap in
@@ -239,7 +238,9 @@ fn set_user() -> Result<()> {
 /// keep running their chosen shell.
 fn set_parent_process_id() {
     let ppid = nix::unistd::getppid();
-    env::set_var("FLOX_PARENT_PID", ppid.to_string());
+    unsafe {
+        env::set_var("FLOX_PARENT_PID", ppid.to_string());
+    }
 }
 
 /// Avoid SIGPIPE from killing the process

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -18,7 +18,7 @@ use flox_rust_sdk::providers::services::{LoggedError, ServiceError};
 use indoc::{formatdoc, indoc};
 use log::{debug, trace};
 
-use crate::commands::{EnvironmentSelectError, MigrationError};
+use crate::commands::EnvironmentSelectError;
 
 /// Convert to an error variant that directs the user to the docs if the provided error is
 /// due to a package not being supported on the current system.
@@ -414,13 +414,7 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
             "},
         },
         // User facing
-        CoreEnvironmentError::Version0NotSupported => display_chain(err),
-        // User facing
-        CoreEnvironmentError::LockingVersion0NotSupported => display_chain(err),
         CoreEnvironmentError::Services(err) => display_chain(err),
-        CoreEnvironmentError::ServicesWithV0 => {
-            format_core_error(&CoreEnvironmentError::ServicesWithV0)
-        },
     }
 }
 
@@ -705,34 +699,6 @@ pub fn format_environment_select_error(err: &EnvironmentSelectError) -> String {
             .chain()
             .skip(1)
             .fold(err.to_string(), |acc, cause| format!("{}: {}", acc, cause)),
-    }
-}
-
-pub fn format_migration_error(err: &MigrationError) -> String {
-    trace!("formatting migration_error: {err:?}");
-
-    match err {
-        MigrationError::Environment(EnvironmentError::ManagedEnvironment(
-            ManagedEnvironmentError::CheckoutOutOfSync,
-        ))
-        | MigrationError::ConfirmedUpgradeFailed(EnvironmentError::ManagedEnvironment(
-            ManagedEnvironmentError::CheckoutOutOfSync,
-        )) => formatdoc! {"
-            Cannot automatically migrate environment:
-            The environment has changes that are not yet synced to a generation.
-
-            Migrate the environment manually by setting 'version = 1'
-            in the manifest file or reset the local manifest to the current generation using
-
-                $ flox edit --reset
-        "},
-        MigrationError::Environment(err) | MigrationError::ConfirmedUpgradeFailed(err) => {
-            formatdoc! {"
-                Failed to migrate environment:
-                {err}
-            ", err = format_error(err).trim_end()}
-        },
-        _ => display_chain(err),
     }
 }
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -90,17 +90,6 @@ project_setup() {
   "$FLOX_BIN" init -d "$PROJECT_DIR"
 }
 
-# project setup with pkgdb
-project_setup_pkgdb() {
-  project_setup_common
-  mkdir -p "$PROJECT_DIR/.flox/env"
-  cp --no-preserve=mode "$MANUALLY_GENERATED"/hello_v0/* "$PROJECT_DIR/.flox/env"
-  echo '{
-    "name": "'$PROJECT_NAME'",
-    "version": 1
-  }' >>"$PROJECT_DIR/.flox/env.json"
-}
-
 project_teardown() {
   popd >/dev/null || return
   rm -rf "${PROJECT_DIR?}"

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -218,7 +218,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:path,activate:path:bash
-@test "catalog: bash: interactive activate puts package in path" {
+@test "bash: interactive activate puts package in path" {
   project_setup
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -230,7 +230,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:fish
-@test "catalog: fish: interactive activate puts package in path" {
+@test "fish: interactive activate puts package in path" {
   project_setup
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -241,7 +241,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:tcsh
-@test "catalog: tcsh: interactive activate puts package in path" {
+@test "tcsh: interactive activate puts package in path" {
   project_setup
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -253,7 +253,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:zsh
-@test "catalog: zsh: interactive activate puts package in path" {
+@test "zsh: interactive activate puts package in path" {
   project_setup
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
@@ -1118,7 +1118,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:path,activate:path:bash
-@test "catalog: 'flox activate' modifies path (bash)" {
+@test "'flox activate' modifies path (bash)" {
   project_setup
   original_path="$PATH"
   FLOX_SHELL="bash" run "$FLOX_BIN" activate -- echo '$PATH'
@@ -1138,7 +1138,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:fish
-@test "catalog: 'flox activate' modifies path (fish)" {
+@test "'flox activate' modifies path (fish)" {
   project_setup
   original_path="$PATH"
   FLOX_SHELL="fish" run "$FLOX_BIN" activate -- echo '$PATH'
@@ -1158,7 +1158,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:tcsh
-@test "catalog: 'flox activate' modifies path (tcsh)" {
+@test "'flox activate' modifies path (tcsh)" {
   project_setup
   original_path="$PATH"
   FLOX_SHELL="tcsh" run "$FLOX_BIN" activate -- echo '$PATH'
@@ -1178,7 +1178,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:path,activate:path:zsh
-@test "catalog: 'flox activate' modifies path (zsh)" {
+@test "'flox activate' modifies path (zsh)" {
   project_setup
   original_path="$PATH"
   FLOX_SHELL="zsh" run "$FLOX_BIN" activate -- echo '$PATH'
@@ -1246,7 +1246,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:bash
-@test "catalog: 'flox activate' modifies the current shell (bash)" {
+@test "'flox activate' modifies the current shell (bash)" {
   project_setup
   # set profile scripts
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
@@ -1268,7 +1268,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:fish
-@test "catalog: 'flox activate' modifies the current shell (fish)" {
+@test "'flox activate' modifies the current shell (fish)" {
   project_setup
   # set profile scripts
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
@@ -1292,7 +1292,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:tcsh
-@test "catalog: 'flox activate' modifies the current shell (tcsh)" {
+@test "'flox activate' modifies the current shell (tcsh)" {
   project_setup
   # set profile scripts
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
@@ -1316,7 +1316,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:zsh
-@test "catalog: 'flox activate' modifies the current shell (zsh)" {
+@test "'flox activate' modifies the current shell (zsh)" {
   project_setup
   # set profile scripts
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
@@ -1391,7 +1391,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:python-detects-installed-python
-@test "catalog: 'flox activate' sets python vars if python is installed" {
+@test "'flox activate' sets python vars if python is installed" {
   project_setup
   # unset python vars if any
   unset PYTHONPATH
@@ -1431,7 +1431,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate:flox-uses-default-env
-@test "catalog: 'flox *' uses local environment over 'default' environment" {
+@test "'flox *' uses local environment over 'default' environment" {
   project_setup # TODO: we need PROJECT_DIR, but not flox init
   "$FLOX_BIN" delete -f
   mkdir default

--- a/cli/tests/catalog-live.bats
+++ b/cli/tests/catalog-live.bats
@@ -43,7 +43,6 @@ teardown_file() {
 
   run "$FLOX_BIN" install hello -vvv
   assert_success
-  assert_output --partial "using catalog client to lock"
 
   run "$FLOX_BIN" activate -- hello
   assert_success

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -106,7 +106,7 @@ function skip_if_linux() {
 }
 
 # bats test_tags=containerize:default-to-file
-@test "catalog: container is written to a file by default" {
+@test "container is written to a file by default" {
   skip_if_not_linux
 
   env_setup_catalog
@@ -124,7 +124,7 @@ function skip_if_linux() {
 }
 
 # bats test_tags=containerize:container-tag
-@test "catalog: container is tagged with specified tag" {
+@test "container is tagged with specified tag" {
   skip_if_not_linux
 
   env_setup_catalog
@@ -142,7 +142,7 @@ function skip_if_linux() {
 }
 
 # bats test_tags=containerize:piped-to-stdout
-@test "catalog: container is written to stdout when '-o -' is passed" {
+@test "container is written to stdout when '-o -' is passed" {
   skip "duplicate of next test"
   skip_if_not_linux
 
@@ -154,7 +154,7 @@ function skip_if_linux() {
 }
 
 # bats test_tags=containerize:run-container-i
-@test "catalog: container can be run with 'podman/docker run' with/without -i'" {
+@test "container can be run with 'podman/docker run' with/without -i'" {
   skip_if_not_linux
 
   env_setup_catalog

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -288,7 +288,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=managed,activate,managed:activate
-@test "catalog: m9: activate works in managed environment" {
+@test "m9: activate works in managed environment" {
   make_empty_remote_env
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     "$FLOX_BIN" install hello

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -61,7 +61,7 @@ function make_empty_remote_env() {
 # create path env from pre-generated locked manifest v0
 function make_remote_env_with_hello() {
   mkdir -p "$PROJECT_DIR/.flox/env"
-  cp "$MANUALLY_GENERATED"/hello_v0/* "$PROJECT_DIR/.flox/env"
+  cp "$GENERATED_DATA"/envs/hello/* "$PROJECT_DIR/.flox/env"
   echo '{
     "name": "'$PROJECT_NAME'",
     "version": 1
@@ -286,16 +286,6 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
-
-# Make sure we haven't activate
-# bats test_tags=managed,activate,managed:activate
-@test "m9: activate works in managed environment" {
-  make_remote_env_with_hello
-
-  run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- command -v hello
-  assert_success
-  assert_output --regexp "${FLOX_CACHE_DIR}/run/owner/${PROJECT_NAME}\..+/bin/hello"
-}
 
 # bats test_tags=managed,activate,managed:activate
 @test "catalog: m9: activate works in managed environment" {

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -58,17 +58,6 @@ function make_empty_remote_env() {
   "$FLOX_BIN" push --owner "$OWNER"
 }
 
-# create path env from pre-generated locked manifest v0
-function make_remote_env_with_hello() {
-  mkdir -p "$PROJECT_DIR/.flox/env"
-  cp "$GENERATED_DATA"/envs/hello/* "$PROJECT_DIR/.flox/env"
-  echo '{
-    "name": "'$PROJECT_NAME'",
-    "version": 1
-  }' >>"$PROJECT_DIR/.flox/env.json"
-  "$FLOX_BIN" push --owner "$OWNER"
-}
-
 # ---------------------------------------------------------------------------- #
 
 dot_flox_exists() {

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -100,7 +100,7 @@ make_remote_pkgdb_env_with_hello() {
 }
 
 # bats test_tags=hermetic,remote,remote:outlink
-@test "catalog: r0: building a remote environment creates outlink" {
+@test "r0: building a remote environment creates outlink" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   make_empty_remote_env
 
@@ -140,7 +140,7 @@ make_remote_pkgdb_env_with_hello() {
 }
 
 # bats test_tags=edit,remote,remote:edit
-@test "catalog: m3: edit a package from a managed environment" {
+@test "m3: edit a package from a managed environment" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   make_empty_remote_env
 
@@ -165,7 +165,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=remote,activate,remote:activate
-@test "catalog: m9: activate works in remote environment" {
+@test "m9: activate works in remote environment" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   make_empty_remote_env
   "$FLOX_BIN" install hello --remote "$OWNER/test"

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -65,25 +65,6 @@ function make_empty_remote_env() {
   rm -rf local
 }
 
-# create remote a pkgdb environment with hello installed
-# from pre-generated lock
-make_remote_pkgdb_env_with_hello() {
-  mkdir local
-  pushd local
-
-  # init path environment and push to remote
-  mkdir -p .flox/env
-  cp "$MANUALLY_GENERATED"/hello_v0/* .flox/env
-  echo '{
-    "name": "test",
-    "version": 1
-  }' >.flox/env.json
-  "$FLOX_BIN" push --owner "$OWNER"
-  "$FLOX_BIN" delete -f
-  popd
-  rm -rf local
-}
-
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=hermetic,remote,remote:hermetic

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -165,15 +165,6 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=remote,activate,remote:activate
-@test "m9: activate works in remote environment" {
-  make_remote_pkgdb_env_with_hello
-
-  run "$FLOX_BIN" activate --trust --remote "$OWNER/test" -- command -v hello
-  assert_success
-  assert_output --partial "$FLOX_CACHE_DIR/remote/owner/test/.flox/run/bin/hello"
-}
-
-# bats test_tags=remote,activate,remote:activate
 @test "catalog: m9: activate works in remote environment" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   make_empty_remote_env

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -206,7 +206,7 @@ EOF
 }
 
 # bats test_tags=init:catalog
-@test "catalog: init creates manifest with all 4 systems" {
+@test "init creates manifest with all 4 systems" {
   "$FLOX_BIN" init
   systems=$(tomlq -r -c '.options.systems' .flox/env/manifest.toml)
   assert_equal "$systems" '["aarch64-darwin","aarch64-linux","x86_64-darwin","x86_64-linux"]'

--- a/cli/tests/lang-node.bats
+++ b/cli/tests/lang-node.bats
@@ -51,7 +51,7 @@ teardown() {
 # catalog tests
 
 # bats test_tags=catalog
-@test "catalog: flox activate works with npm" {
+@test "flox activate works with npm" {
   cp -r "$INPUT_DATA/init/node/common/." .
   cp -r "$INPUT_DATA/init/node/npm/." .
   # Files copied from the store are read-only
@@ -65,7 +65,7 @@ teardown() {
 }
 
 # bats test_tags=catalog
-@test "catalog: flox activate works with yarn" {
+@test "flox activate works with yarn" {
   cp -r "$INPUT_DATA/init/node/common/." .
   cp -r "$INPUT_DATA/init/node/yarn/." .
   # Files copied from the store are read-only
@@ -80,7 +80,7 @@ teardown() {
 }
 
 # bats test_tags=catalog
-@test "catalog: install krb5 with node" {
+@test "install krb5 with node" {
   "$FLOX_BIN" init
 
   cat "$GENERATED_DATA/envs/krb5_prereqs/manifest.toml" | _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/envs/krb5_prereqs/krb5_prereqs.json" "$FLOX_BIN" edit -f -

--- a/cli/tests/lang-python.bats
+++ b/cli/tests/lang-python.bats
@@ -52,7 +52,7 @@ teardown() {
 # catalog tests
 
 # bats test_tags=catalog
-@test "catalog: install requests with pip" {
+@test "install requests with pip" {
   "$FLOX_BIN" init
 
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/python3_pip.json" \
@@ -66,7 +66,7 @@ teardown() {
 }
 
 # bats test_tags=python:activate:poetry,catalog
-@test "catalog: flox activate works with poetry" {
+@test "flox activate works with poetry" {
   cp -r "$INPUT_DATA"/init/python/common/* "$PROJECT_DIR/"
   cp -r "$INPUT_DATA"/init/python/poetry/* "$PROJECT_DIR/"
   # Files copied from the store are read-only
@@ -86,7 +86,7 @@ teardown() {
 }
 
 # bats test_tags=python:activate:pyproject:pip,catalog
-@test "catalog: flox activate works with pyproject and pip" {
+@test "flox activate works with pyproject and pip" {
   cp -r "$INPUT_DATA"/init/python/common/* "$PROJECT_DIR/"
   cp -r "$INPUT_DATA"/init/python/pyproject-pip/* "$PROJECT_DIR/"
   # Files copied from the store are read-only
@@ -105,7 +105,7 @@ teardown() {
 }
 
 # bats test_tags=python:activate:requirements,catalog
-@test "catalog: flox activate works with requirements.txt and pip" {
+@test "flox activate works with requirements.txt and pip" {
   cp -r "$INPUT_DATA"/init/python/common/* "$PROJECT_DIR/"
   cp -r "$INPUT_DATA"/init/python/requirements/* "$PROJECT_DIR/"
   # Files copied from the store are read-only
@@ -124,7 +124,7 @@ teardown() {
 }
 
 # bats test_tags=init:python:auto-setup,init:python:auto-setup:bash,catalog
-@test "catalog: verify auto-setup Python venv activation: bash" {
+@test "verify auto-setup Python venv activation: bash" {
   OWNER="owner"
   NAME="name"
   echo "requests" > requirements.txt
@@ -137,7 +137,7 @@ teardown() {
 }
 
 # bats test_tags=init:python:auto-setup,init:python:auto-setup:zsh,catalog
-@test "catalog: verify auto-setup Python venv activation: zsh" {
+@test "verify auto-setup Python venv activation: zsh" {
   OWNER="owner"
   NAME="name"
   echo "requests" > requirements.txt
@@ -150,7 +150,7 @@ teardown() {
 }
 
 # bats test_tags=init:python:auto-setup,init:python:auto-setup:fish,catalog
-@test "catalog: verify auto-setup Python venv activation: fish" {
+@test "verify auto-setup Python venv activation: fish" {
   OWNER="owner"
   NAME="name"
   echo "requests" > requirements.txt
@@ -163,7 +163,7 @@ teardown() {
 }
 
 # bats test_tags=init:python:auto-setup,init:python:auto-setup:tcsh,catalog
-@test "catalog: verify auto-setup Python venv activation: tcsh" {
+@test "verify auto-setup Python venv activation: tcsh" {
   OWNER="owner"
   NAME="name"
   echo "requests" > requirements.txt

--- a/cli/tests/ld-floxlib.bats
+++ b/cli/tests/ld-floxlib.bats
@@ -49,15 +49,6 @@ project_setup_common() {
   pushd "$PROJECT_DIR" > /dev/null || return
 }
 
-project_setup_pkgdb() {
-  mkdir -p "$PROJECT_DIR/.flox/env"
-  cp "$MANUALLY_GENERATED"/ld_floxlib_test_deps_v0/* "$PROJECT_DIR/.flox/env"
-  echo '{
-    "name": "env",
-    "version": 1
-  }' >>"$PROJECT_DIR/.flox/env.json"
-}
-
 project_setup_catalog() {
   $FLOX_BIN init
 

--- a/cli/tests/ld-floxlib.bats
+++ b/cli/tests/ld-floxlib.bats
@@ -100,7 +100,7 @@ teardown() {
 
 # ---------------------------------------------------------------------------- #
 
-@test "catalog: test ld-floxlib.so on Linux only" {
+@test "test ld-floxlib.so on Linux only" {
   project_setup_catalog
 
   # Revision PKGDB_NIXPKGS_REV_OLDER is expected to provide glibc 2.34.

--- a/cli/tests/ld-floxlib.bats
+++ b/cli/tests/ld-floxlib.bats
@@ -99,42 +99,6 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------- #
-#
-@test "test ld-floxlib.so on Linux only" {
-  project_setup_pkgdb
-
-  # Revision PKGDB_NIXPKGS_REV_OLDER is expected to provide glibc 2.34.
-  # Assert that here before going any further.
-  run "$FLOX_BIN" list
-  assert_success
-  assert_output --partial "glibc: glibc (2.34)"
-  # Also assert the environment's loader points to the expected package.
-  run "$FLOX_BIN" activate -- bash -exc 'realpath $FLOX_ENV/lib/ld-linux-*.so.*'
-  assert_success
-  assert_output --partial -- "-glibc-2.34-210/lib/ld-linux-"
-
-  ### Test 1: load libraries found in $FLOX_ENV_LIB_DIRS last
-  run "$FLOX_BIN" activate -- bash ./test-load-library-last.sh
-  assert_success
-
-  ### Test 2: confirm LD_AUDIT can find missing libraries
-  # Link against nixmain because that's a library that won't be present on any host system.
-  # Build print-nix-version, remove RUNPATH & interpreter
-  run "$FLOX_BIN" activate -- bash -exc ' \
-    g++ -std=c++17 -o get-nix-version ./get-nix-version.cc -I"$FLOX_ENV"/include -L"$FLOX_ENV"/lib -lnixmain && \
-    patchelf --remove-rpath ./get-nix-version && \
-    LD_FLOXLIB_AUDIT=1 ./get-nix-version'
-  assert_success
-  assert_output --partial "testing (Nix) 2.10.3"
-
-  ### Test 3: confirm binary cannot find missing libraries without LD_AUDIT
-  # Note run with "run -127" to silence the 127 "Command not found" error code
-  # warning that bats will display by default when it attempts to launch a
-  # command that fails to run because it cannot load its libraries.
-  run -127 "$FLOX_BIN" activate -- bash -exc \
-    'env -i LD_DEBUG=libs ./get-nix-version'
-  assert_failure
-}
 
 @test "catalog: test ld-floxlib.so on Linux only" {
   project_setup_catalog

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -125,7 +125,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=list,list:catalog
-@test "catalog: 'flox list' lists packages of environment in the current dir; One package from nixpkgs" {
+@test "'flox list' lists packages of environment in the current dir; One package from nixpkgs" {
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     "$FLOX_BIN" install hello
@@ -136,7 +136,7 @@ EOF
 }
 
 # bats test_tags=list,list:catalog,list:config
-@test "catalog: 'flox list --config' shows manifest content" {
+@test "'flox list --config' shows manifest content" {
   "$FLOX_BIN" init
   MANIFEST_CONTENTS="$(
     cat <<-EOF

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -233,7 +233,7 @@ function add_incompatible_package() {
 }
 
 # bats test_tags=pull:l2,pull:l2:a,pull:l4
-@test "catalog: l2.a/l4: flox pull accepts a floxhub namespace/environment, creates .flox if it does not exist" {
+@test "l2.a/l4: flox pull accepts a floxhub namespace/environment, creates .flox if it does not exist" {
   make_dummy_env "owner" "name"
 
   # dummy environment has no packages to resolve
@@ -249,7 +249,7 @@ function add_incompatible_package() {
 }
 
 # bats test_tags=pull:l2,pull:l2:b
-@test "catalog: l2.b: flox pull with --remote fails if an env is already present" {
+@test "l2.b: flox pull with --remote fails if an env is already present" {
   make_dummy_env "owner" "name"
 
   # dummy environment has no packages to resolve
@@ -262,7 +262,7 @@ function add_incompatible_package() {
 }
 
 # bats test_tags=pull:l2,pull:l2:c
-@test "catalog: l2.c: flox pull with --remote and --dir pulls into the specified directory" {
+@test "l2.c: flox pull with --remote and --dir pulls into the specified directory" {
   make_dummy_env "owner" "name"
 
   # dummy environment has no packages to resolve
@@ -277,7 +277,7 @@ function add_incompatible_package() {
 }
 
 # bats test_tags=pull:l3,pull:l3:a
-@test "catalog: l3.a: pulling without namespace/environment" {
+@test "l3.a: pulling without namespace/environment" {
   make_dummy_env "owner" "name"
 
   # dummy environment has no packages to resolve
@@ -299,7 +299,7 @@ function add_incompatible_package() {
 }
 
 # bats test_tags=pull:l3,pull:l3:b
-@test "catalog: l3.b: pulling without namespace/environment respects --dir" {
+@test "l3.b: pulling without namespace/environment respects --dir" {
   make_dummy_env "owner" "name"
 
   # dummy environment has no packages to resolve
@@ -320,7 +320,7 @@ function add_incompatible_package() {
 }
 
 # bats test_tags=pull:l6,pull:l6:a
-@test "catalog: l6.a: pulling the same remote environment in multiple directories creates unique copies of the environment" {
+@test "l6.a: pulling the same remote environment in multiple directories creates unique copies of the environment" {
   make_dummy_env "owner" "name"
 
   mkdir first second
@@ -352,7 +352,7 @@ function add_incompatible_package() {
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=pull:twice:no-force
-@test "catalog: pull environment inside the same environment without the '--force' flag" {
+@test "pull environment inside the same environment without the '--force' flag" {
   make_dummy_env "owner" "name"
   update_dummy_env "owner" "name"
 
@@ -366,7 +366,7 @@ function add_incompatible_package() {
 }
 
 # bats test_tags=pull:twice:force
-@test "catalog: pull environment inside the same environment with '--force' flag" {
+@test "pull environment inside the same environment with '--force' flag" {
   make_dummy_env "owner" "name"
   update_dummy_env "owner" "name"
 
@@ -386,7 +386,7 @@ function add_incompatible_package() {
 # due to the current system missing <system> in `option.systems`
 # AND a package that is indeed not able to be built for the current system
 # should show a warning, but otherwise succeed to pull
-@test "catalog: pull unsupported environment succeeds with '--force' flag but shows warning if unable to build still" {
+@test "pull unsupported environment succeeds with '--force' flag but shows warning if unable to build still" {
   make_dummy_env "owner" "name"
   remove_extra_systems "owner" "name"
   update_dummy_env "owner" "name"
@@ -485,7 +485,7 @@ function add_incompatible_package() {
 
 # bats test_tags=activate:remote:incompatible
 # activating an incompatible environment should fail gracefully
-@test "catalog: activate incompatible environment fails gracefully" {
+@test "activate incompatible environment fails gracefully" {
 
   make_dummy_env "owner" "name"
   remove_extra_systems "owner" "name"

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -216,122 +216,6 @@ function add_incompatible_package() {
 
 # ---------------------------------------------------------------------------- #
 
-# bats test_tags=pull:unsupported:warning
-# An environment that is not compatible with the current ssystem
-# due to the current system missing <system> in `option.systems`
-# AND a package that is indeed not able to be built for the current system
-# should show a warning, but otherwise succeed to pull
-@test "pull v0 unsupported environment succeeds with '--force' flag but shows warning if unable to build still" {
-  make_dummy_env "owner" "name"
-  update_dummy_env "owner" "name"
-  if [ -z "${NIX_SYSTEM##*-linux}" ]; then
-    ENV_FILES_DIR="$MANUALLY_GENERATED/ps_v0_aarch64-darwin"
-    # This response might not be precisely correct if we regenerate because it's
-    # for x86_64-darwin and aarch64-linux, but currently it's the same
-    CATALOG_RESPONSE="$GENERATED_DATA/resolve/darwin_ps_incompatible.json"
-    # TODO: flox uses attr path in errors, while pkgdb uses install ID
-    PACKAGE="darwin.ps"
-  elif [ -z "${NIX_SYSTEM#*-darwin}" ]; then
-    ENV_FILES_DIR="$MANUALLY_GENERATED/glibc_v0_x86_64-linux"
-    # This response might not be precisely correct if we regenerate because it's
-    # for x86_64-linux and aarch64-darwin, but currently it's the same
-    CATALOG_RESPONSE="$GENERATED_DATA/resolve/glibc_incompatible.json"
-    PACKAGE="glibc"
-  else
-    echo "unknown system: '$NIX_SYSTEM'"
-    exit 1
-  fi
-
-  copy_manifest_and_lockfile_to_remote "owner" "name" "$ENV_FILES_DIR"
-
-  _FLOX_USE_CATALOG_MOCK="$CATALOG_RESPONSE" \
-    run "$FLOX_BIN" pull --remote owner/name --force
-  assert_success
-  assert_line --partial "resolution failed: package '$PACKAGE' not available for"
-  assert_line --partial "Migrated the environment to version 1 and included your system"
-
-  run "$FLOX_BIN" list
-  assert_success
-}
-
-# ---------------------------------------------------------------------------- #
-
-# bats test_tags=activate:remote:incompatible
-# activating an incompatible environment should fail gracefully
-@test "activate incompatible environment fails gracefully" {
-  make_dummy_env "owner" "name"
-  update_dummy_env "owner" "name"
-
-  if [ -z "${NIX_SYSTEM##*-linux}" ]; then
-    ENV_FILES_DIR="$MANUALLY_GENERATED/ps_v0_aarch64-darwin"
-  elif [ -z "${NIX_SYSTEM#*-darwin}" ]; then
-    ENV_FILES_DIR="$MANUALLY_GENERATED/glibc_v0_x86_64-linux"
-  else
-    echo "unknown system: '$NIX_SYSTEM'"
-    exit 1
-  fi
-
-  copy_manifest_and_lockfile_to_remote "owner" "name" "$ENV_FILES_DIR"
-
-  run "$FLOX_BIN" activate --remote owner/name --trust
-  assert_failure
-  assert_output --partial "This environment is not yet compatible with your system ($NIX_SYSTEM)"
-}
-
-# ---------------------------------------------------------------------------- #
-
-# bats test_tags=pull:unsupported-package
-# pulling an environment with a package that is not available for the current platform
-# should fail with an error
-@test "pull v0 environment with package not available for the current platform fails" {
-  make_dummy_env "owner" "name"
-  update_dummy_env "owner" "name"
-
-  if [ -z "${NIX_SYSTEM##*-linux}" ]; then
-    ENV_FILES_DIR="$MANUALLY_GENERATED/ps_incompatible_v0_both_linux"
-    # This response might not be precisely correct if we regenerate because it's
-    # for x86_64-darwin and aarch64-linux, but currently it's the same
-    CATALOG_RESPONSE="$GENERATED_DATA/resolve/darwin_ps_incompatible.json"
-    # TODO: pkgdb uses install ID in errors, while flox uses attr path
-    PACKAGE="ps"
-  elif [ -z "${NIX_SYSTEM#*-darwin}" ]; then
-    ENV_FILES_DIR="$MANUALLY_GENERATED/glibc_incompatible_v0_both_darwin"
-    # This response might not be precisely correct if we regenerate because it's
-    # for x86_64-linux and aarch64-darwin, but currently it's the same
-    CATALOG_RESPONSE="$GENERATED_DATA/resolve/glibc_incompatible.json"
-    PACKAGE="glibc"
-  else
-    echo "unknown system: '$NIX_SYSTEM'"
-    exit 1
-  fi
-
-  copy_manifest_and_lockfile_to_remote "owner" "name" "$ENV_FILES_DIR"
-
-  _FLOX_USE_CATALOG_MOCK="$CATALOG_RESPONSE" \
-    run "$FLOX_BIN" pull --remote owner/name
-
-  assert_failure
-  assert_line --partial "package '$PACKAGE' is not available for this system ('$NIX_SYSTEM')"
-}
-
-# ---------------------------------------------------------------------------- #
-
-# bats test_tags=pull:eval-failure
-# pulling an environment with a package that fails to evaluate
-# should fail with an error
-@test "pull v0 environment with insecure package fails to evaluate" {
-  make_dummy_env "owner" "name"
-  update_dummy_env "owner" "name"
-  copy_manifest_and_lockfile_to_remote "owner" "name" "$MANUALLY_GENERATED/python2_insecure_v0"
-
-  run "$FLOX_BIN" pull --remote owner/name
-
-  assert_failure
-  assert_line --partial "package 'python2' failed to evaluate:"
-}
-
-# ---------------------------------------------------------------------------- #
-
 # bats test_tags=pull:up-to-date
 # updating an up-to-date environment should return with an info message
 @test "pull up-to-date env returns info message" {
@@ -347,33 +231,6 @@ function add_incompatible_package() {
   assert_success
   assert_line --partial "already up to date."
 }
-
-# pull a pkgdb based environment to ensure we didn't break compatibility
-# bats test_tags=pull:deprecated-pkgdb
-@test "flox pull of deprecated pkgdb based environment succeeds" {
-  # single test for pulling pkgdb based environments, so do the setup inline once
-  mkdir -p "$PROJECT_DIR/.flox/env"
-  cp -r "$MANUALLY_GENERATED"/hello_v0/* "$PROJECT_DIR/.flox/env"
-  echo '{
-    "name": "name",
-    "version": 1
-  }' >>"$PROJECT_DIR/.flox/env.json"
-  "$FLOX_BIN" push --owner owner
-  "$FLOX_BIN" delete --force
-
-  run "$FLOX_BIN" pull --remote owner/name
-  assert_success
-  assert [ -e ".flox/env.json" ]
-  assert [ -e ".flox/env.lock" ]
-  assert [ $(cat .flox/env.json | jq -r '.name') == "name" ]
-  assert [ $(cat .flox/env.json | jq -r '.owner') == "owner" ]
-
-  # v0 manifest does not have a version field
-  assert [ $(cat .flox/env/manifest.toml | tomlq -r '.version') == "null" ]
-}
-
-# ----------------------------- Catalog Tests -------------------------------- #
-# ---------------------------------------------------------------------------- #
 
 # bats test_tags=pull:l2,pull:l2:a,pull:l4
 @test "catalog: l2.a/l4: flox pull accepts a floxhub namespace/environment, creates .flox if it does not exist" {
@@ -525,7 +382,7 @@ function add_incompatible_package() {
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=pull:catalog:unsupported:warning
-# An environment that is not compatible with the current ssystem
+# An environment that is not compatible with the current system
 # due to the current system missing <system> in `option.systems`
 # AND a package that is indeed not able to be built for the current system
 # should show a warning, but otherwise succeed to pull

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -232,37 +232,3 @@ EOF
   assert_success
   assert_output "⬆️  Upgraded 'hello' in environment 'test'."
 }
-
-# bats test_tags=upgrade:migrate:manifest
-@test "upgrade performs manifest migration" {
-  NAME="name"
-
-  setup_pkgdb_env "$NAME"
-  # Updating an locked environment produces a different message.
-  # Here we want to test the migration message for migrating manifests only.
-  rm -f "$PROJECT_DIR/.flox/env/manifest.lock"
-
-  run "$FLOX_BIN" upgrade
-  assert_output --partial "Detected an old environment version. Attempting to migrate to version 1."
-  assert_output --partial "ℹ️  No packages need to be upgraded in environment '$NAME'"
-  assert_output --partial "⬆️  Migrated environment '$NAME' to version 1."
-}
-
-# bats test_tags=upgrade:migrate:lockfile
-@test "upgrade performs lockfile migration" {
-  NAME="name"
-  setup_pkgdb_env "$NAME"
-
-  run "$FLOX_BIN" upgrade
-  assert_output --partial "Detected an old environment version. Attempting to migrate to version 1 and upgrade packages."
-  assert_output --partial "⬆️  Migrated environment to version 1 and upgraded all packages for environment '$NAME'."
-}
-
-@test "catalog: package names and systems are deduped" {
-  "$FLOX_BIN" init
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" \
-    "$FLOX_BIN" install hello
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
-    run "$FLOX_BIN" upgrade hello
-  assert_output "⬆️  Upgraded 'hello' in environment 'test'."
-}

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -180,7 +180,7 @@ setup_pkgdb_env() {
   assert_output "ℹ️  No packages need to be upgraded in environment 'test'."
 }
 
-@test "catalog: page changes should not be considered an upgrade" {
+@test "page changes should not be considered an upgrade" {
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" \
     "$FLOX_BIN" install curl hello

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -81,6 +81,10 @@ cmd = '''
 '''
 ignore_cmd_errors = true # build will fail on macos, thats fine
 
+[resolve.influxdb2]
+pre_cmd = "flox init"
+cmd = "flox install influxdb2"
+
 [resolve.darwin_ps]
 pre_cmd = '''
     flox init
@@ -160,6 +164,11 @@ cmd = "flox install overmind"
 pre_cmd = "flox init"
 cmd = "flox install package"
 ignore_cmd_errors = true
+
+# This is useful for testing insecure packages
+[resolve.python2]
+pre_cmd = "flox init"
+cmd = "flox install python2"
 
 [resolve.python3]
 pre_cmd = "flox init"
@@ -343,6 +352,96 @@ cmd = "flox edit -f manifest.toml"
 post_cmd = '''
     envs_output_dir="$(dirname $RESPONSE_FILE)"
     env_dir="$envs_output_dir/krb5_prereqs"
+    mkdir -p "$env_dir"
+    cp manifest.toml "$env_dir/manifest.toml"
+    cp .flox/env/manifest.lock "$env_dir/manifest.lock"
+    mv "$RESPONSE_FILE" "$env_dir/$(basename $RESPONSE_FILE)"
+'''
+
+# Used as an environment with a macOS-only package
+[envs.darwin_ps]
+skip_if_output_exists = "envs/darwin_ps"
+files = ["envs/darwin_ps/manifest.toml"]
+pre_cmd = "flox init"
+cmd = "flox edit -f manifest.toml"
+post_cmd = '''
+    envs_output_dir="$(dirname $RESPONSE_FILE)"
+    env_dir="$envs_output_dir/darwin_ps"
+    mkdir -p "$env_dir"
+    cp manifest.toml "$env_dir/manifest.toml"
+    cp .flox/env/manifest.lock "$env_dir/manifest.lock"
+    mv "$RESPONSE_FILE" "$env_dir/$(basename $RESPONSE_FILE)"
+'''
+
+# Used as an environment with a Linux-only package
+[envs.bpftrace]
+skip_if_output_exists = "envs/bpftrace"
+files = ["envs/bpftrace/manifest.toml"]
+pre_cmd = "flox init"
+cmd = "flox edit -f manifest.toml"
+post_cmd = '''
+    envs_output_dir="$(dirname $RESPONSE_FILE)"
+    env_dir="$envs_output_dir/bpftrace"
+    mkdir -p "$env_dir"
+    cp manifest.toml "$env_dir/manifest.toml"
+    cp .flox/env/manifest.lock "$env_dir/manifest.lock"
+    mv "$RESPONSE_FILE" "$env_dir/$(basename $RESPONSE_FILE)"
+'''
+
+# Used in list tests for packages whose install IDs != pkg-path
+[envs.hello_as_greeting]
+skip_if_output_exists = "envs/hello_as_greeting"
+files = ["envs/hello_as_greeting/manifest.toml"]
+pre_cmd = "flox init"
+cmd = "flox edit -f manifest.toml"
+post_cmd = '''
+    envs_output_dir="$(dirname $RESPONSE_FILE)"
+    env_dir="$envs_output_dir/hello_as_greeting"
+    mkdir -p "$env_dir"
+    cp manifest.toml "$env_dir/manifest.toml"
+    cp .flox/env/manifest.lock "$env_dir/manifest.lock"
+    mv "$RESPONSE_FILE" "$env_dir/$(basename $RESPONSE_FILE)"
+'''
+
+# Used for list tests that only display packages for the current system
+[envs.hello_and_htop_for_no_system]
+skip_if_output_exists = "envs/hello_and_htop_for_no_system"
+files = ["envs/hello_and_htop_for_no_system/manifest.toml"]
+pre_cmd = "flox init"
+cmd = "flox edit -f manifest.toml"
+post_cmd = '''
+    envs_output_dir="$(dirname $RESPONSE_FILE)"
+    env_dir="$envs_output_dir/hello_and_htop_for_no_system"
+    mkdir -p "$env_dir"
+    cp manifest.toml "$env_dir/manifest.toml"
+    cp .flox/env/manifest.lock "$env_dir/manifest.lock"
+    mv "$RESPONSE_FILE" "$env_dir/$(basename $RESPONSE_FILE)"
+'''
+
+# This is used as a package that doesn't have a version
+[envs.influxdb2]
+skip_if_output_exists = "envs/influxdb2"
+files = ["envs/influxdb2/manifest.toml"]
+pre_cmd = "flox init"
+cmd = "flox edit -f manifest.toml"
+post_cmd = '''
+    envs_output_dir="$(dirname $RESPONSE_FILE)"
+    env_dir="$envs_output_dir/influxdb2"
+    mkdir -p "$env_dir"
+    cp manifest.toml "$env_dir/manifest.toml"
+    cp .flox/env/manifest.lock "$env_dir/manifest.lock"
+    mv "$RESPONSE_FILE" "$env_dir/$(basename $RESPONSE_FILE)"
+'''
+
+# Used in list tests to show the full pkg-path (pip)
+[envs.pip]
+skip_if_output_exists = "envs/pip"
+files = ["envs/pip/manifest.toml"]
+pre_cmd = "flox init"
+cmd = "flox edit -f manifest.toml"
+post_cmd = '''
+    envs_output_dir="$(dirname $RESPONSE_FILE)"
+    env_dir="$envs_output_dir/pip"
     mkdir -p "$env_dir"
     cp manifest.toml "$env_dir/manifest.toml"
     cp .flox/env/manifest.lock "$env_dir/manifest.lock"

--- a/test_data/generated/envs/bpftrace/bpftrace.json
+++ b/test_data/generated/envs/bpftrace/bpftrace.json
@@ -1,0 +1,88 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "bpftrace",
+            "broken": false,
+            "derivation": "/nix/store/iskf0w9ijnpswyd6jh1yc0aba164alj4-bpftrace-0.21.2.drv",
+            "description": "High-level tracing language for Linux eBPF",
+            "install_id": "bpftrace",
+            "license": "Apache-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "bpftrace-0.21.2",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/7x4y4vdjdqq5vw6m4v06k41wrwsvckqp-bpftrace-0.21.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/nsxhqzrcpy1r3a0f0z06bjy3mkck5vyc-bpftrace-0.21.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "bpftrace",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "0.21.2"
+          },
+          {
+            "attr_path": "bpftrace",
+            "broken": false,
+            "derivation": "/nix/store/32cmsz189h00nkgjg874v78qiniya6dn-bpftrace-0.21.2.drv",
+            "description": "High-level tracing language for Linux eBPF",
+            "install_id": "bpftrace",
+            "license": "Apache-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "bpftrace-0.21.2",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/4zsnhbragvvyf9qksk84wqswd9xb8lcw-bpftrace-0.21.2-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/k56kgsknbvis83wgviacg3j3rp85p8fk-bpftrace-0.21.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "bpftrace",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "0.21.2"
+          }
+        ],
+        "page": 690827,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/envs/bpftrace/manifest.lock
+++ b/test_data/generated/envs/bpftrace/manifest.lock
@@ -1,0 +1,92 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "bpftrace": {
+        "pkg-path": "bpftrace"
+      }
+    },
+    "vars": {},
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-linux",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    },
+    "services": {},
+    "build": {}
+  },
+  "packages": [
+    {
+      "attr_path": "bpftrace",
+      "broken": false,
+      "derivation": "/nix/store/iskf0w9ijnpswyd6jh1yc0aba164alj4-bpftrace-0.21.2.drv",
+      "description": "High-level tracing language for Linux eBPF",
+      "install_id": "bpftrace",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "bpftrace-0.21.2",
+      "pname": "bpftrace",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.21.2",
+      "outputs_to_install": [
+        "out",
+        "man"
+      ],
+      "outputs": {
+        "man": "/nix/store/7x4y4vdjdqq5vw6m4v06k41wrwsvckqp-bpftrace-0.21.2-man",
+        "out": "/nix/store/nsxhqzrcpy1r3a0f0z06bjy3mkck5vyc-bpftrace-0.21.2"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "bpftrace",
+      "broken": false,
+      "derivation": "/nix/store/32cmsz189h00nkgjg874v78qiniya6dn-bpftrace-0.21.2.drv",
+      "description": "High-level tracing language for Linux eBPF",
+      "install_id": "bpftrace",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "bpftrace-0.21.2",
+      "pname": "bpftrace",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.21.2",
+      "outputs_to_install": [
+        "out",
+        "man"
+      ],
+      "outputs": {
+        "man": "/nix/store/4zsnhbragvvyf9qksk84wqswd9xb8lcw-bpftrace-0.21.2-man",
+        "out": "/nix/store/k56kgsknbvis83wgviacg3j3rp85p8fk-bpftrace-0.21.2"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/generated/envs/bpftrace/manifest.toml
+++ b/test_data/generated/envs/bpftrace/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+bpftrace.pkg-path = "bpftrace"
+
+[options]
+systems = ["aarch64-linux", "x86_64-linux"] 

--- a/test_data/generated/envs/darwin_ps/darwin_ps.json
+++ b/test_data/generated/envs/darwin_ps/darwin_ps.json
@@ -1,0 +1,94 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "darwin.ps",
+            "broken": false,
+            "derivation": "/nix/store/vgy095hf2rppg1nwmwim4s7h8m9w19w0-adv_cmds-119.drv",
+            "description": null,
+            "insecure": false,
+            "install_id": "darwin_ps",
+            "license": "APSL-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "name": "adv_cmds-119",
+            "outputs": [
+              {
+                "name": "ps",
+                "store_path": "/nix/store/hc486lb42as766pp5pmssqdvnmnykf9g-adv_cmds-119-ps"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/9c96l3zmf4354s0kfplwikw0g60azfw2-adv_cmds-119"
+              },
+              {
+                "name": "locale",
+                "store_path": "/nix/store/bmck4ngcqj5az94rggv599ydgd6ls482-adv_cmds-119-locale"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "ps",
+            "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "rev_count": 689866,
+            "rev_date": "2024-10-06T19:07:05Z",
+            "scrape_date": "2024-10-09T03:51:54Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "adv_cmds-119"
+          },
+          {
+            "attr_path": "darwin.ps",
+            "broken": false,
+            "derivation": "/nix/store/kjajqsdmcylczdhm3xnzc3wxzdqachga-adv_cmds-119.drv",
+            "description": null,
+            "insecure": false,
+            "install_id": "darwin_ps",
+            "license": "APSL-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "name": "adv_cmds-119",
+            "outputs": [
+              {
+                "name": "ps",
+                "store_path": "/nix/store/2ia2pa46s6nyrywg1rz5qvmh0n0mh4k4-adv_cmds-119-ps"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/rxpdvnidcg24yz7xca5jyd9w39zvwscj-adv_cmds-119"
+              },
+              {
+                "name": "locale",
+                "store_path": "/nix/store/fzamsb5ilcrmrvyjxgw8c0dq27bqd74f-adv_cmds-119-locale"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "ps",
+            "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+            "rev_count": 689866,
+            "rev_date": "2024-10-06T19:07:05Z",
+            "scrape_date": "2024-10-09T03:51:54Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "adv_cmds-119"
+          }
+        ],
+        "page": 689866,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/envs/darwin_ps/manifest.lock
+++ b/test_data/generated/envs/darwin_ps/manifest.lock
@@ -1,0 +1,85 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "darwin_ps": {
+        "pkg-path": "darwin.ps"
+      }
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "x86_64-darwin"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "darwin.ps",
+      "broken": false,
+      "derivation": "/nix/store/vgy095hf2rppg1nwmwim4s7h8m9w19w0-adv_cmds-119.drv",
+      "install_id": "darwin_ps",
+      "license": "APSL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "name": "adv_cmds-119",
+      "pname": "ps",
+      "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "rev_count": 689866,
+      "rev_date": "2024-10-06T19:07:05Z",
+      "scrape_date": "2024-10-09T03:51:54Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "adv_cmds-119",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "locale": "/nix/store/bmck4ngcqj5az94rggv599ydgd6ls482-adv_cmds-119-locale",
+        "out": "/nix/store/9c96l3zmf4354s0kfplwikw0g60azfw2-adv_cmds-119",
+        "ps": "/nix/store/hc486lb42as766pp5pmssqdvnmnykf9g-adv_cmds-119-ps"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "darwin.ps",
+      "broken": false,
+      "derivation": "/nix/store/kjajqsdmcylczdhm3xnzc3wxzdqachga-adv_cmds-119.drv",
+      "install_id": "darwin_ps",
+      "license": "APSL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "name": "adv_cmds-119",
+      "pname": "ps",
+      "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "rev_count": 689866,
+      "rev_date": "2024-10-06T19:07:05Z",
+      "scrape_date": "2024-10-09T03:51:54Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "adv_cmds-119",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "locale": "/nix/store/fzamsb5ilcrmrvyjxgw8c0dq27bqd74f-adv_cmds-119-locale",
+        "out": "/nix/store/rxpdvnidcg24yz7xca5jyd9w39zvwscj-adv_cmds-119",
+        "ps": "/nix/store/2ia2pa46s6nyrywg1rz5qvmh0n0mh4k4-adv_cmds-119-ps"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/generated/envs/darwin_ps/manifest.toml
+++ b/test_data/generated/envs/darwin_ps/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+darwin_ps.pkg-path = "darwin.ps"
+
+[options]
+systems = ["aarch64-darwin", "x86_64-darwin"] 

--- a/test_data/generated/envs/hello_and_htop_for_no_system/hello_and_htop_for_no_system.json
+++ b/test_data/generated/envs/hello_and_htop_for_no_system/hello_and_htop_for_no_system.json
@@ -1,0 +1,140 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "hello",
+            "broken": false,
+            "derivation": "/nix/store/2xclkmh62nvh11fz839lnnfp0fvdmars-hello-2.12.1.drv",
+            "description": "Program that produces a familiar, friendly greeting",
+            "insecure": false,
+            "install_id": "hello",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "hello-2.12.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/p3vrcf0z38979rclg1923vwi4vcrpgq1-hello-2.12.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "2.12.1"
+          },
+          {
+            "attr_path": "hello",
+            "broken": false,
+            "derivation": "/nix/store/gm4sf3dwjyw1zslv4b1l020m1p3122a0-hello-2.12.1.drv",
+            "description": "Program that produces a familiar, friendly greeting",
+            "insecure": false,
+            "install_id": "hello",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "hello-2.12.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/b9nxjjjpnv5npiwqxw882x4z7wxmvwm5-hello-2.12.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "2.12.1"
+          },
+          {
+            "attr_path": "hello",
+            "broken": false,
+            "derivation": "/nix/store/07iwdbb4j4r2daaja5fancdh1wq4r0lj-hello-2.12.1.drv",
+            "description": "Program that produces a familiar, friendly greeting",
+            "insecure": false,
+            "install_id": "hello",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "hello-2.12.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/7lml1vf30kmg4lppnjjf0sqpgvvafp40-hello-2.12.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "2.12.1"
+          },
+          {
+            "attr_path": "hello",
+            "broken": false,
+            "derivation": "/nix/store/af3rc6phyv80h7aq4y3d08awnq2ja8fp-hello-2.12.1.drv",
+            "description": "Program that produces a familiar, friendly greeting",
+            "insecure": false,
+            "install_id": "hello",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "hello-2.12.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/yb84nwgvixzi9sx9nxssq581pc0cc8p3-hello-2.12.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "2.12.1"
+          }
+        ],
+        "page": 690827,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/envs/hello_and_htop_for_no_system/manifest.lock
+++ b/test_data/generated/envs/hello_and_htop_for_no_system/manifest.lock
@@ -1,0 +1,147 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "hello": {
+        "pkg-path": "hello"
+      },
+      "htop": {
+        "pkg-path": "htop",
+        "systems": []
+      }
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "x86_64-darwin",
+        "aarch64-linux",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/2xclkmh62nvh11fz839lnnfp0fvdmars-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "hello",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/p3vrcf0z38979rclg1923vwi4vcrpgq1-hello-2.12.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/gm4sf3dwjyw1zslv4b1l020m1p3122a0-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "hello",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/b9nxjjjpnv5npiwqxw882x4z7wxmvwm5-hello-2.12.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/07iwdbb4j4r2daaja5fancdh1wq4r0lj-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "hello",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/7lml1vf30kmg4lppnjjf0sqpgvvafp40-hello-2.12.1"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/af3rc6phyv80h7aq4y3d08awnq2ja8fp-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "hello",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/yb84nwgvixzi9sx9nxssq581pc0cc8p3-hello-2.12.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/generated/envs/hello_and_htop_for_no_system/manifest.toml
+++ b/test_data/generated/envs/hello_and_htop_for_no_system/manifest.toml
@@ -1,0 +1,9 @@
+version = 1
+
+[install]
+hello.pkg-path = "hello"
+htop.pkg-path = "htop"
+htop.systems = []
+
+[options]
+systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]

--- a/test_data/generated/envs/hello_as_greeting/hello_as_greeting.json
+++ b/test_data/generated/envs/hello_as_greeting/hello_as_greeting.json
@@ -1,0 +1,140 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "hello",
+            "broken": false,
+            "derivation": "/nix/store/2xclkmh62nvh11fz839lnnfp0fvdmars-hello-2.12.1.drv",
+            "description": "Program that produces a familiar, friendly greeting",
+            "insecure": false,
+            "install_id": "greeting",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "hello-2.12.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/p3vrcf0z38979rclg1923vwi4vcrpgq1-hello-2.12.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "2.12.1"
+          },
+          {
+            "attr_path": "hello",
+            "broken": false,
+            "derivation": "/nix/store/07iwdbb4j4r2daaja5fancdh1wq4r0lj-hello-2.12.1.drv",
+            "description": "Program that produces a familiar, friendly greeting",
+            "insecure": false,
+            "install_id": "greeting",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "hello-2.12.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/7lml1vf30kmg4lppnjjf0sqpgvvafp40-hello-2.12.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "2.12.1"
+          },
+          {
+            "attr_path": "hello",
+            "broken": false,
+            "derivation": "/nix/store/gm4sf3dwjyw1zslv4b1l020m1p3122a0-hello-2.12.1.drv",
+            "description": "Program that produces a familiar, friendly greeting",
+            "insecure": false,
+            "install_id": "greeting",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "hello-2.12.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/b9nxjjjpnv5npiwqxw882x4z7wxmvwm5-hello-2.12.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "2.12.1"
+          },
+          {
+            "attr_path": "hello",
+            "broken": false,
+            "derivation": "/nix/store/af3rc6phyv80h7aq4y3d08awnq2ja8fp-hello-2.12.1.drv",
+            "description": "Program that produces a familiar, friendly greeting",
+            "insecure": false,
+            "install_id": "greeting",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "hello-2.12.1",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/yb84nwgvixzi9sx9nxssq581pc0cc8p3-hello-2.12.1"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "hello",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "2.12.1"
+          }
+        ],
+        "page": 690827,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/envs/hello_as_greeting/manifest.lock
+++ b/test_data/generated/envs/hello_as_greeting/manifest.lock
@@ -1,0 +1,143 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "greeting": {
+        "pkg-path": "hello"
+      }
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/2xclkmh62nvh11fz839lnnfp0fvdmars-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "greeting",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/p3vrcf0z38979rclg1923vwi4vcrpgq1-hello-2.12.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/07iwdbb4j4r2daaja5fancdh1wq4r0lj-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "greeting",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/7lml1vf30kmg4lppnjjf0sqpgvvafp40-hello-2.12.1"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/gm4sf3dwjyw1zslv4b1l020m1p3122a0-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "greeting",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/b9nxjjjpnv5npiwqxw882x4z7wxmvwm5-hello-2.12.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/af3rc6phyv80h7aq4y3d08awnq2ja8fp-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "greeting",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/yb84nwgvixzi9sx9nxssq581pc0cc8p3-hello-2.12.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/generated/envs/hello_as_greeting/manifest.toml
+++ b/test_data/generated/envs/hello_as_greeting/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+greeting.pkg-path = "hello"
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/generated/envs/influxdb2/influxdb2.json
+++ b/test_data/generated/envs/influxdb2/influxdb2.json
@@ -1,0 +1,140 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "influxdb2",
+            "broken": false,
+            "derivation": "/nix/store/s9ia095xi14qjy7rrf336lhbl53zrgjp-influxdb2.drv",
+            "description": null,
+            "insecure": false,
+            "install_id": "influxdb2",
+            "license": null,
+            "locked_url": "https://github.com/flox/nixpkgs?rev=a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+            "name": "influxdb2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/sja8nimqff7ycj6vy6mb4y4cs5qfwlm2-influxdb2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "influxdb2",
+            "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+            "rev_count": 692963,
+            "rev_date": "2024-10-14T06:48:30Z",
+            "scrape_date": "2024-10-16T03:55:11Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "influxdb2"
+          },
+          {
+            "attr_path": "influxdb2",
+            "broken": false,
+            "derivation": "/nix/store/fcxl46qgc41p74m6krmv3c1603llskaf-influxdb2.drv",
+            "description": null,
+            "insecure": false,
+            "install_id": "influxdb2",
+            "license": null,
+            "locked_url": "https://github.com/flox/nixpkgs?rev=a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+            "name": "influxdb2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/a50y0nnfdm4gmm6gjw2wb249zikf3bgh-influxdb2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "influxdb2",
+            "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+            "rev_count": 692963,
+            "rev_date": "2024-10-14T06:48:30Z",
+            "scrape_date": "2024-10-16T03:55:11Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "influxdb2"
+          },
+          {
+            "attr_path": "influxdb2",
+            "broken": false,
+            "derivation": "/nix/store/sb9w8kw4jjjh7wn9ibx03dw9r5vzsny7-influxdb2.drv",
+            "description": null,
+            "insecure": false,
+            "install_id": "influxdb2",
+            "license": null,
+            "locked_url": "https://github.com/flox/nixpkgs?rev=a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+            "name": "influxdb2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/i09smhkkmyzh5q24n3qd5fip2kq5pxgd-influxdb2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "influxdb2",
+            "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+            "rev_count": 692963,
+            "rev_date": "2024-10-14T06:48:30Z",
+            "scrape_date": "2024-10-16T03:55:11Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "influxdb2"
+          },
+          {
+            "attr_path": "influxdb2",
+            "broken": false,
+            "derivation": "/nix/store/dj4m4li2zrk7cqr3zb8sqny7rxy2g6al-influxdb2.drv",
+            "description": null,
+            "insecure": false,
+            "install_id": "influxdb2",
+            "license": null,
+            "locked_url": "https://github.com/flox/nixpkgs?rev=a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+            "name": "influxdb2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/9p3i3k2x5ppvmfkibhig000w4lxbp963-influxdb2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "influxdb2",
+            "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+            "rev_count": 692963,
+            "rev_date": "2024-10-14T06:48:30Z",
+            "scrape_date": "2024-10-16T03:55:11Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "influxdb2"
+          }
+        ],
+        "page": 692963,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/envs/influxdb2/manifest.lock
+++ b/test_data/generated/envs/influxdb2/manifest.lock
@@ -1,0 +1,135 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "influxdb2": {
+        "pkg-path": "influxdb2"
+      }
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "influxdb2",
+      "broken": false,
+      "derivation": "/nix/store/s9ia095xi14qjy7rrf336lhbl53zrgjp-influxdb2.drv",
+      "install_id": "influxdb2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+      "name": "influxdb2",
+      "pname": "influxdb2",
+      "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+      "rev_count": 692963,
+      "rev_date": "2024-10-14T06:48:30Z",
+      "scrape_date": "2024-10-16T03:55:11Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "influxdb2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/sja8nimqff7ycj6vy6mb4y4cs5qfwlm2-influxdb2"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "influxdb2",
+      "broken": false,
+      "derivation": "/nix/store/fcxl46qgc41p74m6krmv3c1603llskaf-influxdb2.drv",
+      "install_id": "influxdb2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+      "name": "influxdb2",
+      "pname": "influxdb2",
+      "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+      "rev_count": 692963,
+      "rev_date": "2024-10-14T06:48:30Z",
+      "scrape_date": "2024-10-16T03:55:11Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "influxdb2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/a50y0nnfdm4gmm6gjw2wb249zikf3bgh-influxdb2"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "influxdb2",
+      "broken": false,
+      "derivation": "/nix/store/sb9w8kw4jjjh7wn9ibx03dw9r5vzsny7-influxdb2.drv",
+      "install_id": "influxdb2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+      "name": "influxdb2",
+      "pname": "influxdb2",
+      "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+      "rev_count": 692963,
+      "rev_date": "2024-10-14T06:48:30Z",
+      "scrape_date": "2024-10-16T03:55:11Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "influxdb2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/i09smhkkmyzh5q24n3qd5fip2kq5pxgd-influxdb2"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "influxdb2",
+      "broken": false,
+      "derivation": "/nix/store/dj4m4li2zrk7cqr3zb8sqny7rxy2g6al-influxdb2.drv",
+      "install_id": "influxdb2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+      "name": "influxdb2",
+      "pname": "influxdb2",
+      "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+      "rev_count": 692963,
+      "rev_date": "2024-10-14T06:48:30Z",
+      "scrape_date": "2024-10-16T03:55:11Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "influxdb2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/9p3i3k2x5ppvmfkibhig000w4lxbp963-influxdb2"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/generated/envs/influxdb2/manifest.toml
+++ b/test_data/generated/envs/influxdb2/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+influxdb2.pkg-path = "influxdb2"
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/generated/envs/pip/manifest.lock
+++ b/test_data/generated/envs/pip/manifest.lock
@@ -1,0 +1,159 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "pip": {
+        "pkg-path": "python312Packages.pip"
+      }
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "x86_64-darwin",
+        "aarch64-linux",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "python312Packages.pip",
+      "broken": false,
+      "derivation": "/nix/store/3v2dbqnlcbiv775cmy70qhsd6vswxpxl-python3.12-pip-24.0.drv",
+      "description": "PyPA recommended tool for installing Python packages",
+      "install_id": "pip",
+      "license": "[ MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "python3.12-pip-24.0",
+      "pname": "pip",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "python3.12-pip-24.0",
+      "outputs_to_install": [
+        "out",
+        "man"
+      ],
+      "outputs": {
+        "dist": "/nix/store/3yb7n0g2g3ilgg8lqxjra7xwfk8gvx8b-python3.12-pip-24.0-dist",
+        "man": "/nix/store/pigrf6jikna1akz7wh540y7dawcbhba2-python3.12-pip-24.0-man",
+        "out": "/nix/store/gqwsjs8lb2qncb7nq2pcnbrfm7xn86ry-python3.12-pip-24.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "python312Packages.pip",
+      "broken": false,
+      "derivation": "/nix/store/7rpvlg66lppmmn90fa8c588kagfiw2ln-python3.12-pip-24.0.drv",
+      "description": "PyPA recommended tool for installing Python packages",
+      "install_id": "pip",
+      "license": "[ MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "python3.12-pip-24.0",
+      "pname": "pip",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "python3.12-pip-24.0",
+      "outputs_to_install": [
+        "out",
+        "man"
+      ],
+      "outputs": {
+        "dist": "/nix/store/050bshc1sdfq9lmvmgqrj1iihklw8bpv-python3.12-pip-24.0-dist",
+        "man": "/nix/store/wd5gpcw3nh94fljzh4ycdhh4mqdp1dhs-python3.12-pip-24.0-man",
+        "out": "/nix/store/g24k5pcsml27wrdbg0cnv4z43sg1x2j0-python3.12-pip-24.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "python312Packages.pip",
+      "broken": false,
+      "derivation": "/nix/store/7cfp4xa189j5idaswfhkjgaj2ws8rvrn-python3.12-pip-24.0.drv",
+      "description": "PyPA recommended tool for installing Python packages",
+      "install_id": "pip",
+      "license": "[ MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "python3.12-pip-24.0",
+      "pname": "pip",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "python3.12-pip-24.0",
+      "outputs_to_install": [
+        "out",
+        "man"
+      ],
+      "outputs": {
+        "dist": "/nix/store/pra4rbs2v1j2q765sb9i57i3vh3i3m47-python3.12-pip-24.0-dist",
+        "man": "/nix/store/d1w6bk9kzabml495qnyq3401l1nv5z2k-python3.12-pip-24.0-man",
+        "out": "/nix/store/ripynigkvg7cyb5c4vwnff0x9wg3g11s-python3.12-pip-24.0"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "python312Packages.pip",
+      "broken": false,
+      "derivation": "/nix/store/qbmkaf15dr962yjn0l84nl442zz9vk1h-python3.12-pip-24.0.drv",
+      "description": "PyPA recommended tool for installing Python packages",
+      "install_id": "pip",
+      "license": "[ MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "name": "python3.12-pip-24.0",
+      "pname": "pip",
+      "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+      "rev_count": 690827,
+      "rev_date": "2024-10-09T16:51:18Z",
+      "scrape_date": "2024-10-11T03:53:01Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "python3.12-pip-24.0",
+      "outputs_to_install": [
+        "out",
+        "man"
+      ],
+      "outputs": {
+        "dist": "/nix/store/dsvflc0qwkji07q5s1wcdkmjnlvn6pcn-python3.12-pip-24.0-dist",
+        "man": "/nix/store/qd68nvc1jj0bqv47v2zbv8p2ghhqw6hi-python3.12-pip-24.0-man",
+        "out": "/nix/store/gam79wgc54sn8yyw2xkrqkf93v5lwaz1-python3.12-pip-24.0"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/generated/envs/pip/manifest.toml
+++ b/test_data/generated/envs/pip/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+pip.pkg-path = "python312Packages.pip"
+
+[options]
+systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]

--- a/test_data/generated/envs/pip/pip.json
+++ b/test_data/generated/envs/pip/pip.json
@@ -1,0 +1,180 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "python312Packages.pip",
+            "broken": false,
+            "derivation": "/nix/store/3v2dbqnlcbiv775cmy70qhsd6vswxpxl-python3.12-pip-24.0.drv",
+            "description": "PyPA recommended tool for installing Python packages",
+            "insecure": false,
+            "install_id": "pip",
+            "license": "[ MIT ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "python3.12-pip-24.0",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/pigrf6jikna1akz7wh540y7dawcbhba2-python3.12-pip-24.0-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/gqwsjs8lb2qncb7nq2pcnbrfm7xn86ry-python3.12-pip-24.0"
+              },
+              {
+                "name": "dist",
+                "store_path": "/nix/store/3yb7n0g2g3ilgg8lqxjra7xwfk8gvx8b-python3.12-pip-24.0-dist"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "pip",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "python3.12-pip-24.0"
+          },
+          {
+            "attr_path": "python312Packages.pip",
+            "broken": false,
+            "derivation": "/nix/store/7rpvlg66lppmmn90fa8c588kagfiw2ln-python3.12-pip-24.0.drv",
+            "description": "PyPA recommended tool for installing Python packages",
+            "insecure": false,
+            "install_id": "pip",
+            "license": "[ MIT ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "python3.12-pip-24.0",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/wd5gpcw3nh94fljzh4ycdhh4mqdp1dhs-python3.12-pip-24.0-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/g24k5pcsml27wrdbg0cnv4z43sg1x2j0-python3.12-pip-24.0"
+              },
+              {
+                "name": "dist",
+                "store_path": "/nix/store/050bshc1sdfq9lmvmgqrj1iihklw8bpv-python3.12-pip-24.0-dist"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "pip",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "python3.12-pip-24.0"
+          },
+          {
+            "attr_path": "python312Packages.pip",
+            "broken": false,
+            "derivation": "/nix/store/7cfp4xa189j5idaswfhkjgaj2ws8rvrn-python3.12-pip-24.0.drv",
+            "description": "PyPA recommended tool for installing Python packages",
+            "insecure": false,
+            "install_id": "pip",
+            "license": "[ MIT ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "python3.12-pip-24.0",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/d1w6bk9kzabml495qnyq3401l1nv5z2k-python3.12-pip-24.0-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/ripynigkvg7cyb5c4vwnff0x9wg3g11s-python3.12-pip-24.0"
+              },
+              {
+                "name": "dist",
+                "store_path": "/nix/store/pra4rbs2v1j2q765sb9i57i3vh3i3m47-python3.12-pip-24.0-dist"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "pip",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "python3.12-pip-24.0"
+          },
+          {
+            "attr_path": "python312Packages.pip",
+            "broken": false,
+            "derivation": "/nix/store/qbmkaf15dr962yjn0l84nl442zz9vk1h-python3.12-pip-24.0.drv",
+            "description": "PyPA recommended tool for installing Python packages",
+            "insecure": false,
+            "install_id": "pip",
+            "license": "[ MIT ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "python3.12-pip-24.0",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/qd68nvc1jj0bqv47v2zbv8p2ghhqw6hi-python3.12-pip-24.0-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/gam79wgc54sn8yyw2xkrqkf93v5lwaz1-python3.12-pip-24.0"
+              },
+              {
+                "name": "dist",
+                "store_path": "/nix/store/dsvflc0qwkji07q5s1wcdkmjnlvn6pcn-python3.12-pip-24.0-dist"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "pip",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "python3.12-pip-24.0"
+          }
+        ],
+        "page": 690827,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/resolve/influxdb2.json
+++ b/test_data/generated/resolve/influxdb2.json
@@ -1,0 +1,140 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "influxdb2",
+            "broken": false,
+            "derivation": "/nix/store/3rnzn9c4krzv9n0fl31mm69arsbgih2f-influxdb2.drv",
+            "description": null,
+            "install_id": "influxdb2",
+            "license": null,
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "influxdb2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/8rh00yksll0mawx6zlqlvbawn10fa2cb-influxdb2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "influxdb2",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "influxdb2"
+          },
+          {
+            "attr_path": "influxdb2",
+            "broken": false,
+            "derivation": "/nix/store/s7zfjjxwsyjrfrwadvdg9f7cp7lx0s2c-influxdb2.drv",
+            "description": null,
+            "install_id": "influxdb2",
+            "license": null,
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "influxdb2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/dagj92sifp3i4ql1sd06dh15dkg0fjf5-influxdb2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "influxdb2",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "influxdb2"
+          },
+          {
+            "attr_path": "influxdb2",
+            "broken": false,
+            "derivation": "/nix/store/9b5bshvqv7nvayylcm8nldb8m2db5hx9-influxdb2.drv",
+            "description": null,
+            "install_id": "influxdb2",
+            "license": null,
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "influxdb2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/kvmvrbikz1cx5phmyj9yfcpjs0wym6w8-influxdb2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "influxdb2",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "influxdb2"
+          },
+          {
+            "attr_path": "influxdb2",
+            "broken": false,
+            "derivation": "/nix/store/0di9p9dfhck3jcim350lqyak2adf4bh3-influxdb2.drv",
+            "description": null,
+            "install_id": "influxdb2",
+            "license": null,
+            "locked_url": "https://github.com/flox/nixpkgs?rev=5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "name": "influxdb2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/rgakzi7i4impvx2xdj7ks0hiajn2ppsr-influxdb2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "influxdb2",
+            "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+            "rev_count": 690827,
+            "rev_date": "2024-10-09T16:51:18Z",
+            "scrape_date": "2024-10-11T03:53:01Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "influxdb2"
+          }
+        ],
+        "page": 690827,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/resolve/python2.json
+++ b/test_data/generated/resolve/python2.json
@@ -1,0 +1,144 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "python2",
+            "broken": false,
+            "derivation": "/nix/store/14chck670ca005mxvml26sk46b3m7r2l-python-2.7.18.5.drv",
+            "description": "A high-level dynamically-typed programming language",
+            "insecure": false,
+            "install_id": "python2",
+            "license": "Python-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+            "name": "python-2.7.18.5",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/cw29cg9jzgi6qz8c4zjxjmgc1dprj8il-python-2.7.18.5"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "python2",
+            "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+            "rev_count": 439146,
+            "rev_date": "2023-01-02T00:06:23Z",
+            "scrape_date": "2024-08-16T02:13:46Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "python-2.7.18.5"
+          },
+          {
+            "attr_path": "python2",
+            "broken": false,
+            "derivation": "/nix/store/caszjvk5h4lrg34n4j7xxlcska4c0ig5-python-2.7.18.5.drv",
+            "description": "A high-level dynamically-typed programming language",
+            "insecure": false,
+            "install_id": "python2",
+            "license": "Python-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+            "name": "python-2.7.18.5",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/85xdnvslacp1x9kxwijn4kyp88s88696-python-2.7.18.5"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "python2",
+            "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+            "rev_count": 439146,
+            "rev_date": "2023-01-02T00:06:23Z",
+            "scrape_date": "2024-08-16T02:13:46Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "python-2.7.18.5"
+          },
+          {
+            "attr_path": "python2",
+            "broken": false,
+            "derivation": "/nix/store/kv5zal9yx6s16mknixcscsss1drw75zg-python-2.7.18.5.drv",
+            "description": "A high-level dynamically-typed programming language",
+            "insecure": false,
+            "install_id": "python2",
+            "license": "Python-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+            "name": "python-2.7.18.5",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/bv88b3gvqkzrwgflbnr463m608pmw1pq-python-2.7.18.5"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "python2",
+            "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+            "rev_count": 439146,
+            "rev_date": "2023-01-02T00:06:23Z",
+            "scrape_date": "2024-08-16T02:13:46Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "python-2.7.18.5"
+          },
+          {
+            "attr_path": "python2",
+            "broken": false,
+            "derivation": "/nix/store/9xv6pv3fqipca3ndw4g311mx4a23pnyr-python-2.7.18.5.drv",
+            "description": "A high-level dynamically-typed programming language",
+            "insecure": false,
+            "install_id": "python2",
+            "license": "Python-2.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+            "name": "python-2.7.18.5",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/vyd0a3w8csnbwivm9hrcz49cvfhryjaa-python-2.7.18.5"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "python2",
+            "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+            "rev_count": 439146,
+            "rev_date": "2023-01-02T00:06:23Z",
+            "scrape_date": "2024-08-16T02:13:46Z",
+            "stabilities": [
+              "staging",
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "python-2.7.18.5"
+          }
+        ],
+        "page": 439146,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/input_data/envs/bpftrace/manifest.toml
+++ b/test_data/input_data/envs/bpftrace/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+bpftrace.pkg-path = "bpftrace"
+
+[options]
+systems = ["aarch64-linux", "x86_64-linux"] 

--- a/test_data/input_data/envs/darwin_ps/manifest.toml
+++ b/test_data/input_data/envs/darwin_ps/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+darwin_ps.pkg-path = "darwin.ps"
+
+[options]
+systems = ["aarch64-darwin", "x86_64-darwin"] 

--- a/test_data/input_data/envs/hello_and_htop_for_no_system/manifest.toml
+++ b/test_data/input_data/envs/hello_and_htop_for_no_system/manifest.toml
@@ -1,0 +1,9 @@
+version = 1
+
+[install]
+hello.pkg-path = "hello"
+htop.pkg-path = "htop"
+htop.systems = []
+
+[options]
+systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]

--- a/test_data/input_data/envs/hello_as_greeting/manifest.toml
+++ b/test_data/input_data/envs/hello_as_greeting/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+greeting.pkg-path = "hello"
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/input_data/envs/influxdb2/manifest.toml
+++ b/test_data/input_data/envs/influxdb2/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+influxdb2.pkg-path = "influxdb2"
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/test_data/input_data/envs/pip/manifest.toml
+++ b/test_data/input_data/envs/pip/manifest.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[install]
+pip.pkg-path = "python312Packages.pip"
+
+[options]
+systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]

--- a/test_data/manually_generated/hello_and_htop_for_no_system/manifest.lock
+++ b/test_data/manually_generated/hello_and_htop_for_no_system/manifest.lock
@@ -1,0 +1,147 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "hello": {
+        "pkg-path": "hello"
+      },
+      "htop": {
+        "pkg-path": "htop",
+        "systems": []
+      }
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/2xclkmh62nvh11fz839lnnfp0fvdmars-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "hello",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "rev_count": 689866,
+      "rev_date": "2024-10-06T19:07:05Z",
+      "scrape_date": "2024-10-09T03:51:54Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/p3vrcf0z38979rclg1923vwi4vcrpgq1-hello-2.12.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/07iwdbb4j4r2daaja5fancdh1wq4r0lj-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "hello",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "rev_count": 689866,
+      "rev_date": "2024-10-06T19:07:05Z",
+      "scrape_date": "2024-10-09T03:51:54Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/7lml1vf30kmg4lppnjjf0sqpgvvafp40-hello-2.12.1"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/gm4sf3dwjyw1zslv4b1l020m1p3122a0-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "hello",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "rev_count": 689866,
+      "rev_date": "2024-10-06T19:07:05Z",
+      "scrape_date": "2024-10-09T03:51:54Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/b9nxjjjpnv5npiwqxw882x4z7wxmvwm5-hello-2.12.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "hello",
+      "broken": false,
+      "derivation": "/nix/store/af3rc6phyv80h7aq4y3d08awnq2ja8fp-hello-2.12.1.drv",
+      "description": "Program that produces a familiar, friendly greeting",
+      "install_id": "hello",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "name": "hello-2.12.1",
+      "pname": "hello",
+      "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+      "rev_count": 689866,
+      "rev_date": "2024-10-06T19:07:05Z",
+      "scrape_date": "2024-10-09T03:51:54Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.12.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/yb84nwgvixzi9sx9nxssq581pc0cc8p3-hello-2.12.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/manually_generated/hello_and_htop_for_no_system/manifest.toml
+++ b/test_data/manually_generated/hello_and_htop_for_no_system/manifest.toml
@@ -1,0 +1,19 @@
+#
+# This is a Flox environment manifest.
+# Visit flox.dev/docs/concepts/manifest/
+# or see flox-edit(1), manifest.toml(5) for more information.
+#
+# Flox manifest version managed by Flox CLI
+version = 1
+
+# List packages you wish to install in your environment inside
+# the `[install]` section.
+[install]
+hello.pkg-path = "hello"
+htop.pkg-path = "htop"
+htop.systems = []
+
+[options]
+systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]
+# Uncomment to disable CUDA detection.
+# cuda-detection = false


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Removes support in the Rust code for v0 manifests. Note that there is still support in pkgdb itself.
This removes all of the tests that solely tested v0 functionality, and updated any more general tests to use generated test data.

This also refactors the manifest and lockfile enums into structs now that we don't have to match on the version.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
