### PR TITLE
feat: use flox-activations to store env files

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -112,6 +112,13 @@ if [ -n "${FLOX_ENV:-}" ] && [ "$FLOX_ENV" != "$_FLOX_ENV" ]; then
 fi
 export FLOX_ENV="$_FLOX_ENV"
 
+# Set a default for _FLOX_ACTIVATE_STORE_PATH for container and build
+# invocations
+if [ -z "${_FLOX_ACTIVATE_STORE_PATH:-}" ]; then
+  _FLOX_ACTIVATE_STORE_PATH="$("$_coreutils/bin/readlink" -f "$FLOX_ENV")"
+fi
+
+
 # The rust CLI contains sophisticated logic to set $FLOX_SHELL based on the
 # process listening on STDOUT, but that won't happen when activating from
 # the top-level activation script, so fall back to $SHELL as a default.
@@ -131,31 +138,23 @@ case "$_flox_shell" in
     ;;
 esac
 
-# Set all other variables derived from FLOX_ENV. We previously did this
-# from within the rust CLI but we've moved it to this top-level activation
-# script so that it can be invoked without using the flox CLI, e.g. as
-# required when invoking the environment from a container entrypoint.
+# The CLI is responsible for erroring if the environment is already active.
+# We can start-or-attach no matter what
 
-# Identify if this environment has been activated before. If it has,
-# then it will appear as an element in the colon-separated FLOX_ENV_DIRS
-# variable, and if it hasn't then we'll prepend it to the list and set
-# all the other related env variables.
-declare -a flox_env_dirs
-IFS=: read -ra flox_env_dirs <<< "${FLOX_ENV_DIRS_activate}"
-declare -i flox_env_found=0
-for d in "${flox_env_dirs[@]}"; do
-  if [ "$d" = "$FLOX_ENV" ]; then
-    flox_env_found=1
-    break
-  fi
-done
+# TODO: we could restore _start_env from the prior activation when performing an ephemeral activation
 
-if [ $flox_env_found -eq 0 ] || [ "$_FLOX_ACTIVATE_FORCE_REACTIVATE" == true ]; then
-  # shellcheck source-path=SCRIPTDIR/activate.d
-  source "${_activate_d}/start.bash"
-else
+# sets _FLOX_ATTACH, _FLOX_ACTIVATION_STATE_DIR, _FLOX_ACTIVATION_ID
+# Don't eval on one line so that we exit if flox-activations fails
+to_eval="$($_flox_activations start-or-attach --pid "$$" --flox-env "$FLOX_ENV" --store-path "$_FLOX_ACTIVATE_STORE_PATH")"
+eval "$to_eval"
+export _FLOX_ACTIVATION_STATE_DIR _FLOX_ACTIVATION_ID
+
+if [ "$_FLOX_ATTACH" == true ]; then
   # shellcheck source-path=SCRIPTDIR/activate.d
   source "${_activate_d}/attach.bash"
+else
+  # shellcheck source-path=SCRIPTDIR/activate.d
+  source "${_activate_d}/start.bash"
 fi
 
 # Start services before the shell or command is invoked

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
+
+set -euo pipefail
+
 export _activate_d="@out@/activate.d"
 export _bash="@bash@"
 export _coreutils="@coreutils@"
@@ -104,7 +107,7 @@ fi
 #       container invocations, and it would have the incorrect value for
 #       nested flox activations.
 _FLOX_ENV="$($_coreutils/bin/dirname -- "${BASH_SOURCE[0]}")"
-if [ -n "$FLOX_ENV" ] && [ "$FLOX_ENV" != "$_FLOX_ENV" ]; then
+if [ -n "${FLOX_ENV:-}" ] && [ "$FLOX_ENV" != "$_FLOX_ENV" ]; then
   echo "WARN: detected change in FLOX_ENV: $FLOX_ENV -> $_FLOX_ENV" >&2
 fi
 export FLOX_ENV="$_FLOX_ENV"
@@ -156,7 +159,7 @@ else
 fi
 
 # Start services before the shell or command is invoked
-if [ "$FLOX_ACTIVATE_START_SERVICES" == "true" ]; then
+if [ "${FLOX_ACTIVATE_START_SERVICES:-}" == "true" ]; then
   # shellcheck source-path=SCRIPTDIR/activate.d
   source "${_activate_d}/start-services.bash"
 fi
@@ -165,7 +168,7 @@ fi
 if [ $# -gt 0 ]; then
   # shellcheck source-path=SCRIPTDIR/activate.d
   source "${_activate_d}/attach-command.bash"
-elif [ -t 1 ] || [ -n "$_FLOX_FORCE_INTERACTIVE" ]; then
+elif [ -t 1 ] || [ -n "${_FLOX_FORCE_INTERACTIVE:-}" ]; then
   # shellcheck source-path=SCRIPTDIR/activate.d
   source "${_activate_d}/attach-interactive.bash"
 else

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -145,7 +145,11 @@ esac
 
 # sets _FLOX_ATTACH, _FLOX_ACTIVATION_STATE_DIR, _FLOX_ACTIVATION_ID
 # Don't eval on one line so that we exit if flox-activations fails
-to_eval="$($_flox_activations start-or-attach --pid "$$" --flox-env "$FLOX_ENV" --store-path "$_FLOX_ACTIVATE_STORE_PATH")"
+if [ -n "${FLOX_RUNTIME_DIR:-}" ]; then
+  to_eval="$($_flox_activations --runtime-dir "$FLOX_RUNTIME_DIR" start-or-attach --pid "$$" --flox-env "$FLOX_ENV" --store-path "$_FLOX_ACTIVATE_STORE_PATH")"
+else
+  to_eval="$($_flox_activations start-or-attach --pid "$$" --flox-env "$FLOX_ENV" --store-path "$_FLOX_ACTIVATE_STORE_PATH")"
+fi
 eval "$to_eval"
 export _FLOX_ACTIVATION_STATE_DIR _FLOX_ACTIVATION_ID
 

--- a/assets/activation-scripts/activate.d/attach-command.bash
+++ b/assets/activation-scripts/activate.d/attach-command.bash
@@ -5,7 +5,7 @@
 if [ -n "$FLOX_TURBO" ]; then
   # "turbo command" mode: simply invoke the provided command and args
   # from *this shell* without paying the cost of invoking the userShell.
-  if [ -n "$FLOX_SET_ARG0" ]; then
+  if [ -n "${FLOX_SET_ARG0:-}" ]; then
     # Wrapped binary from `flox build`.
     exec -a "$FLOX_SET_ARG0" "$@"
   else
@@ -52,7 +52,9 @@ case "$_flox_shell" in
     if [ -n "$FLOX_NOPROFILE" ]; then
       exec "$_flox_shell" -o NO_GLOBAL_RCS -o NO_RCS -c "$*"
     else
-      export FLOX_ORIG_ZDOTDIR="$ZDOTDIR"
+      if [ -n "${ZDOTDIR:-}" ]; then
+        export FLOX_ORIG_ZDOTDIR="$ZDOTDIR"
+      fi
       export ZDOTDIR="$_zdotdir"
       export FLOX_ZSH_INIT_SCRIPT="$FLOX_ENV/activate.d/zsh"
       # The "NO_GLOBAL_RCS" option is necessary to prevent zsh from

--- a/assets/activation-scripts/activate.d/attach-inplace.bash
+++ b/assets/activation-scripts/activate.d/attach-inplace.bash
@@ -29,7 +29,9 @@ case "$_flox_shell" in
   *zsh)
     echo "export _flox_activate_tracelevel=\"$_flox_activate_tracelevel\";"
     echo "export FLOX_ENV=\"$FLOX_ENV\";"
-    echo "export FLOX_ORIG_ZDOTDIR=\"$ZDOTDIR\";"
+    if [ -n "${ZDOTDIR:-}" ]; then
+      echo "export FLOX_ORIG_ZDOTDIR=\"$ZDOTDIR\";"
+    fi
     echo "export ZDOTDIR=\"$_zdotdir\";"
     echo "export FLOX_ZSH_INIT_SCRIPT=\"$FLOX_ENV/activate.d/zsh\";"
     echo "export _add_env=\"$_add_env\";"

--- a/assets/activation-scripts/activate.d/attach-inplace.bash
+++ b/assets/activation-scripts/activate.d/attach-inplace.bash
@@ -7,22 +7,19 @@ case "$_flox_shell" in
   *bash)
     echo "export _flox_activate_tracelevel=\"$_flox_activate_tracelevel\";"
     echo "export FLOX_ENV=\"$FLOX_ENV\";"
-    echo "export _add_env=\"$_add_env\";"
-    echo "export _del_env=\"$_del_env\";"
+    echo "export _FLOX_ACTIVATION_STATE_DIR=\"$_FLOX_ACTIVATION_STATE_DIR\";"
     echo "source '$FLOX_ENV/activate.d/bash';"
     ;;
   *fish)
     echo "set -gx _flox_activate_tracelevel \"$_flox_activate_tracelevel\";"
     echo "set -gx FLOX_ENV \"$FLOX_ENV\";"
-    echo "set -gx _add_env \"$_add_env\";"
-    echo "set -gx _del_env \"$_del_env\";"
+    echo "set -gx _FLOX_ACTIVATION_STATE_DIR \"$_FLOX_ACTIVATION_STATE_DIR\";"
     echo "source '$FLOX_ENV/activate.d/fish';"
     ;;
   *tcsh)
     echo "setenv _flox_activate_tracelevel \"$_flox_activate_tracelevel\";"
     echo "setenv FLOX_ENV \"$FLOX_ENV\";"
-    echo "setenv _add_env \"$_add_env\";"
-    echo "setenv _del_env \"$_del_env\";"
+    echo "setenv _FLOX_ACTIVATION_STATE_DIR \"$_FLOX_ACTIVATION_STATE_DIR\";"
     echo "source '$FLOX_ENV/activate.d/tcsh';"
     ;;
   # Any additions should probably be restored in zdotdir/* scripts
@@ -34,8 +31,7 @@ case "$_flox_shell" in
     fi
     echo "export ZDOTDIR=\"$_zdotdir\";"
     echo "export FLOX_ZSH_INIT_SCRIPT=\"$FLOX_ENV/activate.d/zsh\";"
-    echo "export _add_env=\"$_add_env\";"
-    echo "export _del_env=\"$_del_env\";"
+    echo "export _FLOX_ACTIVATION_STATE_DIR=\"$_FLOX_ACTIVATION_STATE_DIR\";"
     echo "source '$FLOX_ENV/activate.d/zsh';"
     ;;
   *)

--- a/assets/activation-scripts/activate.d/attach-interactive.bash
+++ b/assets/activation-scripts/activate.d/attach-interactive.bash
@@ -42,7 +42,9 @@ case "$_flox_shell" in
     if [ -n "$FLOX_NOPROFILE" ]; then
       exec "$_flox_shell" -o NO_GLOBAL_RCS -o NO_RCS
     else
-      export FLOX_ORIG_ZDOTDIR="$ZDOTDIR"
+      if [ -n "${ZDOTDIR:-}" ]; then
+        export FLOX_ORIG_ZDOTDIR="$ZDOTDIR"
+      fi
       export ZDOTDIR="$_zdotdir"
       export FLOX_ZSH_INIT_SCRIPT="$FLOX_ENV/activate.d/zsh"
       # The "NO_GLOBAL_RCS" option is necessary to prevent zsh from

--- a/assets/activation-scripts/activate.d/attach.bash
+++ b/assets/activation-scripts/activate.d/attach.bash
@@ -1,15 +1,14 @@
-# "Reactivation" of this environment.
-
-# Assert that the expected _{add,del}_env variables are present.
-if [ -z "$_add_env" ] || [ -z "$_del_env" ]; then
-  echo "ERROR (activate): \$_add_env and \$_del_env not found in environment" >&2
-  if [ -h "$FLOX_ENV" ]; then
-    echo "moving $FLOX_ENV link to $FLOX_ENV.$$ - please try again" >&2
-    $_coreutils/bin/mv "$FLOX_ENV" "$FLOX_ENV.$$"
-  fi
-  exit 1
+# If interactive and a command has not been passed, this is an interactive
+# activate,
+# and we print a message to the user
+# If inside a container, FLOX_ENV_DESCRIPTION won't be set, and we don't need to
+# print a message (although attach isn't reachable anyways)
+if [ -t 1 ] && [ $# -eq 0 ] && [ -n "${FLOX_ENV_DESCRIPTION:-}" ]; then
+  echo "✅ Attached to existing activation of environment '$FLOX_ENV_DESCRIPTION'" >&2
+  echo "To stop using this environment, type 'exit'" >&2
+  echo >&2
 fi
 
 # Replay the environment for the benefit of this shell.
-eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' "$_del_env")"
-eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' "$_add_env")"
+eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
+eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"

--- a/assets/activation-scripts/activate.d/bash
+++ b/assets/activation-scripts/activate.d/bash
@@ -6,13 +6,6 @@ if [ "$_flox_activate_tracelevel" -ge 2 ]; then
   set -x
 fi
 
-# Assert that the expected _{add,del}_env variables are present.
-if [ -z "$_add_env" ] || [ -z "$_del_env" ]
-then
-  echo "ERROR (bash): \$_add_env and \$_del_env not found in environment" >&2;
-  exit 1;
-fi
-
 # We use --rcfile to activate using bash which skips sourcing ~/.bashrc,
 # so source that here, but not if we're already in the process of sourcing
 # bashrc in a parent process.
@@ -36,8 +29,8 @@ if [ -z "${_flox_activate_tracelevel:=}" ]; then
 fi
 
 # Restore environment variables set in the previous bash initialization.
-eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' "$_del_env")"
-eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' "$_add_env")"
+eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
+eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
 
 # Set the prompt if we're in an interactive shell.
 if [ -t 1 ]; then

--- a/assets/activation-scripts/activate.d/fish
+++ b/assets/activation-scripts/activate.d/fish
@@ -11,20 +11,14 @@ if test $_flox_activate_tracelevel -ge 2
   set -gx fish_trace 1
 end
 
-# Assert that the expected _{add,del}_env variables are present.
-if test -z "$_add_env" -o -z "$_del_env"
-  echo 'ERROR (fish): $_add_env and $_del_env not found in environment' >&2
-  exit 1
-end
-
 # The fish --init-command option allows us to source our startup
 # file after the normal configuration has been processed, so there
 # is no requirement to go back and source the user's own config
 # as we do in bash.
 
 # Restore environment variables set in the previous bash initialization.
-$_gnused/bin/sed -e 's/^/set -e /' -e 's/$/;/' $_del_env | source
-$_gnused/bin/sed -e 's/^/set -gx /' -e 's/=/ /' -e 's/$/;/' $_add_env | source
+$_gnused/bin/sed -e 's/^/set -e /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env" | source
+$_gnused/bin/sed -e 's/^/set -gx /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env" | source
 
 # Set the prompt if we're in an interactive shell.
 if isatty 1

--- a/assets/activation-scripts/activate.d/start-services.bash
+++ b/assets/activation-scripts/activate.d/start-services.bash
@@ -45,7 +45,7 @@ start_services_blocking() {
 
   # flox services start [service...] needs to be able to start some but not all
   # services
-  if [ -n "$_FLOX_SERVICES_TO_START" ]; then
+  if [ -n "${_FLOX_SERVICES_TO_START:-}" ]; then
     readarray -t services_to_start < <(echo "$_FLOX_SERVICES_TO_START" | "$_jq" -r '.[]')
     COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up "${services_to_start[@]}" -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
   else

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -13,18 +13,6 @@ fi
 _start_env="$_FLOX_ACTIVATION_STATE_DIR/bare.env"
 export | $_coreutils/bin/sort > "$_start_env"
 
-# Set environment variables which represent the cumulative layering
-# of flox environments. For the most part this involves prepending
-# to the existing variables of the same name.
-# TODO: reconcile with CLI which should be setting these. Setting
-#       "*_activate" variables to indicate the ones we've seen and
-#       processed on the activate script side, and ultimately also
-#       for testing/comparison against the CLI-maintained equivalents.
-FLOX_ENV_DIRS_activate="$FLOX_ENV${FLOX_ENV_DIRS_activate:+:$FLOX_ENV_DIRS_activate}"
-FLOX_ENV_LIB_DIRS_activate="$FLOX_ENV/lib${FLOX_ENV_LIB_DIRS_activate:+:$FLOX_ENV_LIB_DIRS_activate}"
-FLOX_PROMPT_ENVIRONMENTS_activate="$FLOX_ENV_DESCRIPTION${FLOX_PROMPT_ENVIRONMENTS_activate:+ $FLOX_PROMPT_ENVIRONMENTS_activate}"
-export FLOX_ENV_DIRS_activate FLOX_ENV_LIB_DIRS_activate FLOX_PROMPT_ENVIRONMENTS_activate
-
 # Process the flox environment customizations, which includes (amongst
 # other things) prepending this environment's bin directory to the PATH.
 if [ -d "$FLOX_ENV/etc/profile.d" ]; then

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -11,7 +11,7 @@ fi
 
 # First activation of this environment. Snapshot environment to start.
 _start_env="$_FLOX_ACTIVATION_STATE_DIR/bare.env"
-export | $_coreutils/bin/sort > "$_start_env"
+export | LC_ALL=C $_coreutils/bin/sort > "$_start_env"
 
 # Process the flox environment customizations, which includes (amongst
 # other things) prepending this environment's bin directory to the PATH.
@@ -35,7 +35,7 @@ fi
 # Capture post-etc-profiles.env.
 # This is currently unused but could be useful for runtime only environment in
 # the future.
-export | $_coreutils/bin/sort > "$_FLOX_ACTIVATION_STATE_DIR/post-etc-profiles.env"
+export | LC_ALL=C $_coreutils/bin/sort > "$_FLOX_ACTIVATION_STATE_DIR/post-etc-profiles.env"
 
 # Set static environment variables from the manifest.
 if [ -f "$FLOX_ENV/activate.d/envrc" ]; then
@@ -57,7 +57,7 @@ fi
 
 # Capture ending environment.
 _end_env="$_FLOX_ACTIVATION_STATE_DIR/post-hook.env"
-export | $_coreutils/bin/sort > "$_end_env"
+export | LC_ALL=C $_coreutils/bin/sort > "$_end_env"
 
 # The userShell initialization scripts that follow have the potential to undo
 # the environment modifications performed above, so we must first calculate
@@ -71,12 +71,12 @@ _del_env="$_FLOX_ACTIVATION_STATE_DIR/del.env"
 
 # Capture environment variables to _set_ as "key=value" pairs.
 # comm -13: only env declarations unique to `$_end_env` (new declarations)
-$_coreutils/bin/comm -13 "$_start_env" "$_end_env" \
+LC_ALL=C $_coreutils/bin/comm -13 "$_start_env" "$_end_env" \
   | $_gnused/bin/sed -e 's/^declare -x //' > "$_add_env"
 
 # Capture environment variables to _unset_ as a list of keys.
 # TODO: remove from $_del_env keys set in $_add_env
-$_coreutils/bin/comm -23 "$_start_env" "$_end_env" \
+LC_ALL=C $_coreutils/bin/comm -23 "$_start_env" "$_end_env" \
   | $_gnused/bin/sed -e 's/^declare -x //' -e 's/=.*//' > "$_del_env"
 
 if [ -n "${FLOX_RUNTIME_DIR:-}" ]; then

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -39,11 +39,14 @@ export FLOX_ENV_DIRS_activate FLOX_ENV_LIB_DIRS_activate FLOX_PROMPT_ENVIRONMENT
 # other things) prepending this environment's bin directory to the PATH.
 if [ -d "$FLOX_ENV/etc/profile.d" ]; then
   declare -a _profile_scripts
+  # TODO: figure out why this is needed
+  set +e
   read -r -d '' -a _profile_scripts < <(
     cd "$FLOX_ENV/etc/profile.d" || exit
     shopt -s nullglob
     echo *.sh
   )
+  set -e
   for profile_script in "${_profile_scripts[@]}"; do
     # shellcheck disable=SC1090 # from rendered environment
     source "$FLOX_ENV/etc/profile.d/$profile_script"
@@ -63,8 +66,10 @@ if [ -e "$FLOX_ENV/activate.d/hook-on-activate" ]; then
   # user-provided hook scripts because these can get interpreted
   # as configuration statements by the "in-place" activation
   # mode. So, we'll redirect stdout to stderr.
+  set +euo pipefail
   # shellcheck disable=SC1091 # from rendered environment
   source "$FLOX_ENV/activate.d/hook-on-activate" 1>&2
+  set -euo pipefail
 fi
 
 # We only need to capture the ending environment when

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -79,4 +79,8 @@ $_coreutils/bin/comm -13 "$_start_env" "$_end_env" \
 $_coreutils/bin/comm -23 "$_start_env" "$_end_env" \
   | $_gnused/bin/sed -e 's/^declare -x //' -e 's/=.*//' > "$_del_env"
 
-"$_flox_activations" set-ready --flox-env "$FLOX_ENV" --id "$_FLOX_ACTIVATION_ID"
+if [ -n "${FLOX_RUNTIME_DIR:-}" ]; then
+  "$_flox_activations" --runtime-dir "$FLOX_RUNTIME_DIR" set-ready --flox-env "$FLOX_ENV" --id "$_FLOX_ACTIVATION_ID"
+else
+  "$_flox_activations" set-ready --flox-env "$FLOX_ENV" --id "$_FLOX_ACTIVATION_ID"
+fi

--- a/assets/activation-scripts/activate.d/tcsh
+++ b/assets/activation-scripts/activate.d/tcsh
@@ -10,15 +10,9 @@ if ( $_flox_activate_tracelevel >= 2 ) then
   set verbose
 endif
 
-# Assert that the expected _{add,del}_env variables are present.
-if ( ! $?_add_env || ! $?_del_env ) then
-  sh -c "echo 'ERROR (tcsh): _add_env and _del_env not found in environment' >&2"
-  exit 1
-endif
-
 # Restore environment variables set in the previous bash initialization.
-eval `$_gnused/bin/sed -e 's/^/unsetenv /' -e 's/$/;/' $_del_env`
-eval `$_gnused/bin/sed -e 's/^/setenv /' -e 's/=/ /' -e 's/$/;/' $_add_env`
+eval `$_gnused/bin/sed -e 's/^/unsetenv /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"`
+eval `$_gnused/bin/sed -e 's/^/setenv /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"`
 
 # Set the prompt if we're in an interactive shell.
 if ( $?tty ) then

--- a/assets/activation-scripts/activate.d/zdotdir/.zshrc
+++ b/assets/activation-scripts/activate.d/zdotdir/.zshrc
@@ -6,12 +6,11 @@
 # Save environment variables that could be set if sourcing zshrc launches an
 # inner nested activation.
 _save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+_save_FLOX_ACTIVATION_STATE_DIR="$_FLOX_ACTIVATION_STATE_DIR"
 _save_FLOX_ENV="$FLOX_ENV"
 _save_FLOX_ORIG_ZDOTDIR="$FLOX_ORIG_ZDOTDIR"
 _save_ZDOTDIR="$ZDOTDIR"
 _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
-_save_add_env="$_add_env"
-_save_del_env="$_del_env"
 
 restore_saved_vars() {
     export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
@@ -19,8 +18,7 @@ restore_saved_vars() {
     export FLOX_ORIG_ZDOTDIR="$_save_FLOX_ORIG_ZDOTDIR"
     export ZDOTDIR="$_save_ZDOTDIR"
     export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
-    export _add_env="$_save_add_env"
-    export _del_env="$_save_del_env"
+    export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
 }
 
 if [ -f /etc/zshrc ]

--- a/assets/activation-scripts/activate.d/zsh
+++ b/assets/activation-scripts/activate.d/zsh
@@ -11,12 +11,6 @@ if [ "$_flox_activate_tracelevel" -ge 2 ]; then
   set -x
 fi
 
-# Assert that the expected _{add,del}_env variables are present.
-[ -n "$_add_env" -a -n "$_del_env" ] || {
-  echo 'ERROR (zsh): $_add_env and $_del_env not found in environment' >&2;
-  exit 1;
-}
-
 # This is the final script to be called in the zsh startup sequence so start
 # by restoring the original value of ZDOTDIR if it was set previously.
 if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
@@ -65,8 +59,8 @@ fi
 unset fpath_prepend
 
 # Restore environment variables set in the previous bash initialization.
-eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' $_del_env)"
-eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' $_add_env)"
+eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
+eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
 
 # Set the prompt if we're in an interactive shell.
 if [[ -o interactive ]]; then

--- a/cli/flox-activations/src/cli/start_or_attach.rs
+++ b/cli/flox-activations/src/cli/start_or_attach.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use clap::Args;
 use fslock::LockFile;
 use indoc::indoc;
+use log::debug;
 use time::{Duration, OffsetDateTime};
 
 use crate::activations::{self, Activations};
@@ -70,6 +71,7 @@ impl StartOrAttachArgs {
         let activations_json_path =
             activations::activations_json_path(runtime_dir, &self.flox_env)?;
 
+        debug!("Reading activations from {:?}", activations_json_path);
         let (activations, lock) = activations::read_activations_json(&activations_json_path)?;
         let activations = activations.unwrap_or_default();
 

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Error> {
             let dirs = BaseDirectories::with_prefix("flox")?;
             match dirs.get_runtime_directory() {
                 Ok(runtime_dir) => runtime_dir.to_path_buf(),
-                Err(_) => dirs.get_cache_home(),
+                Err(_) => dirs.get_cache_home().join("run"),
             }
         },
     };

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -89,8 +89,8 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
    If no services are running, the services from the manifest will be started,
    otherwise a warning will displayed and activation will continue.
 
-   This flag is currently incompatible with "in-place" activations and remote
-   environments, but these features will be added in the future.
+   This flag is currently incompatible with "in-place" activations,
+   but this feature will be added in the future.
 
    The services started with this flag will be cleaned up once the last
    activation of this environment terminates.

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -285,15 +285,17 @@ on-activate = """
 """
 ```
 
-The `on-activate` script is not re-run when activations are nested.
-A nested activation can occur when an environment is already active and either
-`eval "$(flox activate)"` or `flox activate -- CMD` is run.
-In this scenario, `on-activate` is not re-run.
+The `on-activate` script is not re-run when multiple activations are run at the
+same time;
+for instance, if `flox activate` is run in two different shells, the first
+activation will run the hook,
+but the second will not.
+After all activations exit, the next `flox activate` will once again run the hook.
 Currently, environment variables set by the first run of the `on-activate`
-script are captured and then later set by the nested activation,
+script are captured and then set by activations that don't run `on-activate`,
 but this behavior may change.
 
-The `on-activate` script may be re-run by other commands;
+The `on-activate` script may be re-run by other `flox` commands;
 we may create ephemeral activations and thus run the script multiple times for
 commands such as `services start`.
 For this reason, it's best practice to make `on-activate` idempotent.

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2375,8 +2375,7 @@ EOF
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
   # This test doesn't just confirm that the right things are sourced,
-  # but that they are sourced in the correct order and exactly once,
-  # for all supported shells.
+  # but that they are sourced in the correct order and exactly once.
 
   echo "Testing bash"
   run bash -l -c 'eval "$("$FLOX_BIN" activate)"'
@@ -2389,9 +2388,17 @@ EOF
   assert_equal "${lines[4]}" "Setting PATH from .bashrc"
   assert_equal "${lines[5]}" "sourcing profile.common"
   assert_equal "${lines[6]}" "sourcing profile.bash"
-  echo # leave a line between test outputs
+}
 
-  echo "Testing fish"
+# bats test_tags=activate,activate:validate_hook_and_dotfile_sourcing
+@test "fish: confirm hooks and dotfiles sourced correctly" {
+  project_setup
+  sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+  sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+
+  # This test doesn't just confirm that the right things are sourced,
+  # but that they are sourced in the correct order and exactly once.
+
   run fish -c 'eval "$("$FLOX_BIN" activate)"'
   assert_success
   assert_equal "${#lines[@]}" 5
@@ -2400,9 +2407,17 @@ EOF
   assert_equal "${lines[2]}" "sourcing hook.on-activate"
   assert_equal "${lines[3]}" "sourcing profile.common"
   assert_equal "${lines[4]}" "sourcing profile.fish"
-  echo # leave a line between test outputs
+}
 
-  echo "Testing tcsh"
+# bats test_tags=activate,activate:validate_hook_and_dotfile_sourcing
+@test "tcsh: confirm hooks and dotfiles sourced correctly" {
+  project_setup
+  sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+  sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+
+  # This test doesn't just confirm that the right things are sourced,
+  # but that they are sourced in the correct order and exactly once.
+
   run tcsh -c 'eval "`$FLOX_BIN activate`"'
   assert_success
   assert_equal "${#lines[@]}" 5
@@ -2411,9 +2426,17 @@ EOF
   assert_equal "${lines[2]}" "sourcing hook.on-activate"
   assert_equal "${lines[3]}" "sourcing profile.common"
   assert_equal "${lines[4]}" "sourcing profile.tcsh"
-  echo # leave a line between test outputs
+}
 
-  echo "Testing zsh"
+# bats test_tags=activate,activate:validate_hook_and_dotfile_sourcing
+@test "zsh: confirm hooks and dotfiles sourced correctly" {
+  project_setup
+  sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+  sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+
+  # This test doesn't just confirm that the right things are sourced,
+  # but that they are sourced in the correct order and exactly once.
+
   run zsh -i -l -c 'eval "$("$FLOX_BIN" activate)"'
   assert_success
   assert_equal "${#lines[@]}" 13
@@ -2430,8 +2453,6 @@ EOF
   assert_equal "${lines[10]}" "sourcing profile.zsh"
   assert_equal "${lines[11]}" "Sourcing .zlogout"
   assert_equal "${lines[12]}" "Setting PATH from .zlogout"
-  echo # leave a line between test outputs
-
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/activate/attach.exp
+++ b/cli/tests/activate/attach.exp
@@ -1,0 +1,19 @@
+# Attach to a project environment that has already been activated using --dir
+# This expects different output than what activate.exp expects
+
+set dir [lindex $argv 0]
+set command [lindex $argv 1]
+set flox $env(FLOX_BIN)
+set timeout 10
+spawn $flox activate --dir $dir
+expect_after {
+  timeout { exit 1 }
+  eof { exit 2 }
+  "*\n" { exp_continue }
+  "*\r" { exp_continue }
+}
+
+expect "Attached to existing activation"
+
+send "$command && exit\n"
+expect eof

--- a/cli/tests/activate/attach_runs_profile_twice.toml
+++ b/cli/tests/activate/attach_runs_profile_twice.toml
@@ -1,0 +1,18 @@
+version = 1
+
+[profile]
+common = """
+  echo "sourcing profile.common";
+"""
+bash = """
+  echo "sourcing profile.bash";
+"""
+fish = """
+  echo "sourcing profile.fish";
+"""
+tcsh = """
+  echo "sourcing profile.tcsh";
+"""
+zsh = """
+  echo "sourcing profile.zsh";
+"""

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -287,6 +287,13 @@ EOF
   echo "$REGISTRY_CONTENT"
 }
 
+cat_teardown_fifo() {
+  if [ -n "${TEARDOWN_FIFO:-}" ]; then
+    timeout 1 cat "$TEARDOWN_FIFO"
+  fi
+
+}
+
 # ---------------------------------------------------------------------------- #
 #
 #

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -104,7 +104,11 @@ pkgs.runCommandNoCC name
             if buildCache == null then
               ''
                      # When not preserving a cache we just run the build normally.
-                     FLOX_SRC_DIR=$(pwd) ${flox-env-package}/activate --turbo -- \
+
+                     # flox-activations needs runtime dir for activation state dir
+                     # TMP will be set to something like
+                     # /private/tmp/nix-build-file-0.0.0.drv-0
+                     FLOX_SRC_DIR=$(pwd) FLOX_RUNTIME_DIR="$TMP" ${flox-env-package}/activate --turbo -- \
                 bash -e ${buildScript-contents}
               ''
             else
@@ -112,7 +116,11 @@ pkgs.runCommandNoCC name
                      # If the build fails we still want to preserve the build cache, so we
                      # remove $out on failure and allow the Nix build to proceed to write
                      # the result symlink.
-                     FLOX_SRC_DIR=$(pwd) ${flox-env-package}/activate --turbo -- \
+
+                     # flox-activations needs runtime dir for activation state dir
+                     # TMP will be set to something like
+                     # /private/tmp/nix-build-file-0.0.0.drv-0
+                     FLOX_SRC_DIR=$(pwd) FLOX_RUNTIME_DIR="$TMP" ${flox-env-package}/activate --turbo -- \
                 bash -e ${buildScript-contents} || \
                        ( rm -rf $out && echo "flox build failed (caching build dir)" | tee $out 1>&2 )
               ''

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -361,7 +361,8 @@ ifdef ACTIVATION_SCRIPTS_PACKAGE_DIR
 	( cmp $@ $@.new && rm $@.new ) || mv -f $@.new $@
 else
   _rebuild_paths = ../flake.nix ../flake.lock \
-    ../assets/activation-scripts ../pkgs/flox-activation-scripts
+    ../assets/activation-scripts ../pkgs/flox-activation-scripts \
+		../cli/flox-activations
   .ACTIVATION_SCRIPTS_PACKAGE_DIR: $(shell find $(_rebuild_paths) -type f)
 	$(NIX) build --print-out-paths .#flox-activation-scripts > $@
 endif

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -40,7 +40,7 @@ runCommand "flox-activation-scripts"
     substituteInPlace $out/activate \
       --replace "@bash@" "${bash}/bin/bash" \
       --replace "@coreutils@" "${coreutils}" \
-      --replace "@flox_activations@" "${flox-activations}" \
+      --replace "@flox_activations@" "${flox-activations}/bin/flox-activations" \
       --replace "@getopt@" "${getopt}" \
       --replace "@gnused@" "${gnused}" \
       --replace "@jq@" "${jq}/bin/jq" \


### PR DESCRIPTION
Use `flox-activations start-or-attach` and `flox-activations set-ready`
to store environment variable diffs rather than _add_env and _del_env.

This introduces attaching; activations of an environment that are
already active don't re-run hooks.

Notes:
- _FLOX_ACTIVATE_FORCE_REACTIVATE was used to force the activation
  script to re-run start because the activation script couldn't detect
  when the environment store path had changed. Now that start-or-attach
  is aware of the store_path for an environment, this isn't necessary.
- Previously we would run start.bash without capturing _start_env or
  _end_env because we knew nobody would attach. That's no longer true.

## Release Notes

When an environment is activated multiple times before all activations of the environment exit, the environment's hook is only run once by the first activation. Subsequent activations set environment variables set by the hook, but they don't actually re-run commands in the hook.