### PR TITLE
feat: selectable activation-scripts "interpreter" package

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -104,10 +104,7 @@ fi
 #       container invocations, and it would have the incorrect value for
 #       nested flox activations.
 _FLOX_ENV="$($_coreutils/bin/dirname -- "${BASH_SOURCE[0]}")"
-if [ -n "$FLOX_ENV" ] && [ "$FLOX_ENV" != "$_FLOX_ENV" ]; then
-  echo "WARN: detected change in FLOX_ENV: $FLOX_ENV -> $_FLOX_ENV" >&2
-fi
-export FLOX_ENV="$_FLOX_ENV"
+export FLOX_ENV="${FLOX_ENV:-$_FLOX_ENV}"
 
 # The rust CLI contains sophisticated logic to set $FLOX_SHELL based on the
 # process listening on STDOUT, but that won't happen when activating from

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -304,6 +304,7 @@ pub async fn start_with_new_process_compose(
         trust: false,
         print_script: false,
         start_services: true,
+        use_old_interpreter: false,
         run_args: vec!["true".to_string()],
     }
     .activate(

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -44,6 +44,9 @@ let
 
       FLOX_ZDOTDIR = flox-activation-scripts + "/activate.d/zdotdir";
 
+      # Path to the flox interpreter package.
+      FLOX_INTERPRETER = flox-activation-scripts;
+
       # [sic] nix handles `BASH_` variables specially,
       # so we need to use a different name.
       INTERACTIVE_BASH_BIN = "${bashInteractive}/bin/bash";


### PR DESCRIPTION
## Proposed Changes

_DRAFT: for discussion_

Going forward we will refer to the files in the flox-activation-scripts package as the "flox interpreter", because it acts like an interpreter as it "activates" the contents of a $FLOX_ENV. It is also like an interpreter in the classic UNIX sense because it can be both included with the environment (just like the "shebang" statement in a script) or used from outside a previously-rendered environment to provide updated functionality without having to re-render the environment (just like you can run a script with `/path/to/interp <script>`).

This patch adds the ability to select at runtime whether to activate environments with:

* the latest interpreter as bundled with the flox CLI (default), or
* the interpreter installed to the environment as it was built

By offering both interpreters to the user at activation time we get the maximum flexibility, providing the ability to move forward with updated activation features over time by default while preserving the ability to revert to the "original" features as installed to the environment at build time. This patch introduces the new `--use-old-interpreter` flag for controlling this behavior.

## Release Notes

* TBD