### PR TITLE
fix(flox-activations): use env_logger

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -961,6 +961,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,9 +1134,11 @@ dependencies = [
  "blake3",
  "clap",
  "clap_derive",
+ "env_logger",
  "flox-core",
  "fslock",
  "indoc",
+ "log",
  "nix",
  "serde",
  "serde_json",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1124,7 +1124,6 @@ dependencies = [
  "temp-env",
  "tempfile",
  "time",
- "tracing",
  "uuid",
  "xdg",
 ]

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -14,7 +14,6 @@ nix.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
-tracing.workspace = true
 uuid.workspace = true
 xdg.workspace = true
 indoc.workspace = true

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -8,8 +8,10 @@ anyhow.workspace = true
 blake3.workspace = true
 clap = { version = "4.5.20", default-features = false, features = ["std","usage", "help", "error-context", "derive"] }
 clap_derive.workspace = true
+env_logger = { version = "0.11.5", default-features = false }
 flox-core.workspace = true
 fslock.workspace = true
+log.workspace = true
 nix.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/cli/flox-activations/src/activations.rs
+++ b/cli/flox-activations/src/activations.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use flox_core::{path_hash, traceable_path, Version};
+use flox_core::{path_hash, Version};
 use fslock::LockFile;
 use nix::errno::Errno;
 use nix::sys::signal::kill;
@@ -9,7 +9,6 @@ use nix::unistd::Pid;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use time::{Duration, OffsetDateTime};
-use tracing::debug;
 
 type Error = anyhow::Error;
 
@@ -276,10 +275,6 @@ pub fn read_activations_json(
     let lock_file = acquire_activations_json_lock(path).context("failed to acquire lockfile")?;
 
     if !path.exists() {
-        debug!(
-            path = traceable_path(&path),
-            "environment registry not found"
-        );
         return Ok((None, lock_file));
     }
 

--- a/cli/flox-activations/src/activations.rs
+++ b/cli/flox-activations/src/activations.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use flox_core::{path_hash, Version};
 use fslock::LockFile;
+use log::debug;
 use nix::errno::Errno;
 use nix::sys::signal::kill;
 use nix::unistd::Pid;
@@ -275,6 +276,10 @@ pub fn read_activations_json(
     let lock_file = acquire_activations_json_lock(path).context("failed to acquire lockfile")?;
 
     if !path.exists() {
+        debug!(
+            "environment registry not found at {}",
+            path.to_string_lossy()
+        );
         return Ok((None, lock_file));
     }
 

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use cli::Cli;
+use log::debug;
 use xdg::BaseDirectories;
 
 mod activations;
@@ -8,8 +9,10 @@ mod cli;
 pub type Error = anyhow::Error;
 
 fn main() -> Result<(), Error> {
+    env_logger::init();
+
     let args = Cli::parse();
-    eprintln!("{args:?}");
+    debug!("{args:?}");
 
     let runtime_dir = match args.runtime_dir {
         Some(runtime_dir) => runtime_dir,


### PR DESCRIPTION
Add env_logger to allow printing debug logs from flox-activations. Set
default-features = false to keep size of flox-activations minimal.

Using `nix build .#flox-activations` and `du -ch` of the
`flox-activations` binary, this increases size from 608K to 624K.

We could write our own logging macros, but that doesn't seem worth it to
save a few KB

`tracing` is more complicated than what we need for `flox-activations`

## Release Notes

N/A