### PR TITLE
test(build): Go with CGO against libc

### DIFF
--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -334,6 +334,19 @@ pre_cmd = '''
 '''
 cmd = "flox init --auto-setup"
 
+[envs.go_gcc]
+skip_if_output_exists = "envs/go_gcc"
+files = ["envs/go_gcc/manifest.toml"]
+pre_cmd = "flox init"
+cmd = "flox edit -f manifest.toml"
+post_cmd = '''
+    envs_output_dir="$(dirname $RESPONSE_FILE)"
+    env_dir="$envs_output_dir/go_gcc"
+    mkdir -p "$env_dir"
+    cp .flox/env/manifest.toml "$env_dir/manifest.toml"
+    cp .flox/env/manifest.lock "$env_dir/manifest.lock"
+'''
+
 [envs.kitchen_sink]
 skip_if_output_exists = "envs/kitchen_sink"
 files = ["envs/kitchen_sink/manifest.toml"]

--- a/test_data/generated/envs/go_gcc.json
+++ b/test_data/generated/envs/go_gcc.json
@@ -1,0 +1,220 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "gcc",
+            "broken": false,
+            "derivation": "/nix/store/wb7cqg9c862zy0kglcapx2rq67fczvsk-gcc-wrapper-13.3.0.drv",
+            "description": "GNU Compiler Collection, version 13.3.0 (wrapper script)",
+            "insecure": false,
+            "install_id": "gcc",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "name": "gcc-wrapper-13.3.0",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/1j6i8cp6m7r6p7hmkh9wwyv7drv1550l-gcc-wrapper-13.3.0-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/z37lqx549cl99dzz12ghsww0zjrifa1y-gcc-wrapper-13.3.0"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/01yyzggvfrw4f0a5izcysj6xnzfmblxh-gcc-wrapper-13.3.0-info"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "gcc",
+            "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "rev_count": 696158,
+            "rev_date": "2024-10-23T06:41:50Z",
+            "scrape_date": "2024-10-25T03:59:03Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "wrapper-13.3.0"
+          },
+          {
+            "attr_path": "gcc",
+            "broken": false,
+            "derivation": "/nix/store/izlcp4pxjhwab669sjq1iy8smp5a7b83-gcc-wrapper-13.3.0.drv",
+            "description": "GNU Compiler Collection, version 13.3.0 (wrapper script)",
+            "insecure": false,
+            "install_id": "gcc",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "name": "gcc-wrapper-13.3.0",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/78ikl7wnjyx1dw6lg1slflv0c60anrs7-gcc-wrapper-13.3.0-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/vh9fsdhgxcnab2qk7vdp2palkkn6j3cp-gcc-wrapper-13.3.0"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/rjhksxfbbrrchf3xsxc8mf7j0k0rwca8-gcc-wrapper-13.3.0-info"
+              }
+            ],
+            "outputs_to_install": [
+              "out",
+              "man"
+            ],
+            "pname": "gcc",
+            "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "rev_count": 696158,
+            "rev_date": "2024-10-23T06:41:50Z",
+            "scrape_date": "2024-10-25T03:59:03Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "wrapper-13.3.0"
+          },
+          {
+            "attr_path": "go",
+            "broken": false,
+            "derivation": "/nix/store/m82cyrgfqssf9aqfas6nhlrppiw21yhl-go-1.23.2.drv",
+            "description": "Go Programming language",
+            "insecure": false,
+            "install_id": "go",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "name": "go-1.23.2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/35jikx2wg5r0qj47sic0p99bqnmwi6cn-go-1.23.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "go",
+            "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "rev_count": 696158,
+            "rev_date": "2024-10-23T06:41:50Z",
+            "scrape_date": "2024-10-25T03:59:03Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "1.23.2"
+          },
+          {
+            "attr_path": "go",
+            "broken": false,
+            "derivation": "/nix/store/fvhf2xd1fis6ris4dviqzvnipc7p5gj0-go-1.23.2.drv",
+            "description": "Go Programming language",
+            "insecure": false,
+            "install_id": "go",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "name": "go-1.23.2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/6bx6d90kpy537yab22wja70ibpp4gkww-go-1.23.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "go",
+            "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "rev_count": 696158,
+            "rev_date": "2024-10-23T06:41:50Z",
+            "scrape_date": "2024-10-25T03:59:03Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "1.23.2"
+          },
+          {
+            "attr_path": "go",
+            "broken": false,
+            "derivation": "/nix/store/a9jji6d0ic7ix8vjw888kmpgcgbkck1a-go-1.23.2.drv",
+            "description": "Go Programming language",
+            "insecure": false,
+            "install_id": "go",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "name": "go-1.23.2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/yi89mimkmw48qhzrll1aaibxbvllpsjv-go-1.23.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "go",
+            "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "rev_count": 696158,
+            "rev_date": "2024-10-23T06:41:50Z",
+            "scrape_date": "2024-10-25T03:59:03Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "1.23.2"
+          },
+          {
+            "attr_path": "go",
+            "broken": false,
+            "derivation": "/nix/store/k4sd1nf7nl549wcyx4z3g59sxd2h8xim-go-1.23.2.drv",
+            "description": "Go Programming language",
+            "insecure": false,
+            "install_id": "go",
+            "license": "BSD-3-Clause",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "name": "go-1.23.2",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/klw1ipjsqx1np7pkk833x7sad7f3ivv9-go-1.23.2"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "go",
+            "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+            "rev_count": 696158,
+            "rev_date": "2024-10-23T06:41:50Z",
+            "scrape_date": "2024-10-25T03:59:03Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "1.23.2"
+          }
+        ],
+        "page": 696158,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/envs/go_gcc/manifest.lock
+++ b/test_data/generated/envs/go_gcc/manifest.lock
@@ -1,0 +1,208 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "gcc": {
+        "pkg-path": "gcc",
+        "systems": [
+          "aarch64-linux",
+          "x86_64-linux"
+        ]
+      },
+      "go": {
+        "pkg-path": "go"
+      }
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "gcc",
+      "broken": false,
+      "derivation": "/nix/store/wb7cqg9c862zy0kglcapx2rq67fczvsk-gcc-wrapper-13.3.0.drv",
+      "description": "GNU Compiler Collection, version 13.3.0 (wrapper script)",
+      "install_id": "gcc",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "name": "gcc-wrapper-13.3.0",
+      "pname": "gcc",
+      "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "rev_count": 696158,
+      "rev_date": "2024-10-23T06:41:50Z",
+      "scrape_date": "2024-10-25T03:59:03Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "wrapper-13.3.0",
+      "outputs_to_install": [
+        "out",
+        "man"
+      ],
+      "outputs": {
+        "info": "/nix/store/01yyzggvfrw4f0a5izcysj6xnzfmblxh-gcc-wrapper-13.3.0-info",
+        "man": "/nix/store/1j6i8cp6m7r6p7hmkh9wwyv7drv1550l-gcc-wrapper-13.3.0-man",
+        "out": "/nix/store/z37lqx549cl99dzz12ghsww0zjrifa1y-gcc-wrapper-13.3.0"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gcc",
+      "broken": false,
+      "derivation": "/nix/store/izlcp4pxjhwab669sjq1iy8smp5a7b83-gcc-wrapper-13.3.0.drv",
+      "description": "GNU Compiler Collection, version 13.3.0 (wrapper script)",
+      "install_id": "gcc",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "name": "gcc-wrapper-13.3.0",
+      "pname": "gcc",
+      "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "rev_count": 696158,
+      "rev_date": "2024-10-23T06:41:50Z",
+      "scrape_date": "2024-10-25T03:59:03Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "wrapper-13.3.0",
+      "outputs_to_install": [
+        "out",
+        "man"
+      ],
+      "outputs": {
+        "info": "/nix/store/rjhksxfbbrrchf3xsxc8mf7j0k0rwca8-gcc-wrapper-13.3.0-info",
+        "man": "/nix/store/78ikl7wnjyx1dw6lg1slflv0c60anrs7-gcc-wrapper-13.3.0-man",
+        "out": "/nix/store/vh9fsdhgxcnab2qk7vdp2palkkn6j3cp-gcc-wrapper-13.3.0"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "go",
+      "broken": false,
+      "derivation": "/nix/store/m82cyrgfqssf9aqfas6nhlrppiw21yhl-go-1.23.2.drv",
+      "description": "Go Programming language",
+      "install_id": "go",
+      "license": "BSD-3-Clause",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "name": "go-1.23.2",
+      "pname": "go",
+      "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "rev_count": 696158,
+      "rev_date": "2024-10-23T06:41:50Z",
+      "scrape_date": "2024-10-25T03:59:03Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.23.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/35jikx2wg5r0qj47sic0p99bqnmwi6cn-go-1.23.2"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "go",
+      "broken": false,
+      "derivation": "/nix/store/fvhf2xd1fis6ris4dviqzvnipc7p5gj0-go-1.23.2.drv",
+      "description": "Go Programming language",
+      "install_id": "go",
+      "license": "BSD-3-Clause",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "name": "go-1.23.2",
+      "pname": "go",
+      "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "rev_count": 696158,
+      "rev_date": "2024-10-23T06:41:50Z",
+      "scrape_date": "2024-10-25T03:59:03Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.23.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/6bx6d90kpy537yab22wja70ibpp4gkww-go-1.23.2"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "go",
+      "broken": false,
+      "derivation": "/nix/store/a9jji6d0ic7ix8vjw888kmpgcgbkck1a-go-1.23.2.drv",
+      "description": "Go Programming language",
+      "install_id": "go",
+      "license": "BSD-3-Clause",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "name": "go-1.23.2",
+      "pname": "go",
+      "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "rev_count": 696158,
+      "rev_date": "2024-10-23T06:41:50Z",
+      "scrape_date": "2024-10-25T03:59:03Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.23.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/yi89mimkmw48qhzrll1aaibxbvllpsjv-go-1.23.2"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "go",
+      "broken": false,
+      "derivation": "/nix/store/k4sd1nf7nl549wcyx4z3g59sxd2h8xim-go-1.23.2.drv",
+      "description": "Go Programming language",
+      "install_id": "go",
+      "license": "BSD-3-Clause",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "name": "go-1.23.2",
+      "pname": "go",
+      "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+      "rev_count": 696158,
+      "rev_date": "2024-10-23T06:41:50Z",
+      "scrape_date": "2024-10-25T03:59:03Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.23.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/klw1ipjsqx1np7pkk833x7sad7f3ivv9-go-1.23.2"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/generated/envs/go_gcc/manifest.toml
+++ b/test_data/generated/envs/go_gcc/manifest.toml
@@ -1,0 +1,9 @@
+version = 1
+
+[install]
+go.pkg-path = "go"
+# CGO builds will fail on Darwin if the environment brings its own `gcc` or `clang`
+# https://go-review.googlesource.com/c/go/+/205457
+# https://go-review.googlesource.com/c/go/+/368634
+gcc.pkg-path = "gcc"
+gcc.systems = ["aarch64-linux", "x86_64-linux"]

--- a/test_data/input_data/envs/go_gcc/manifest.toml
+++ b/test_data/input_data/envs/go_gcc/manifest.toml
@@ -1,0 +1,9 @@
+version = 1
+
+[install]
+go.pkg-path = "go"
+# CGO builds will fail on Darwin if the environment brings its own `gcc` or `clang`
+# https://go-review.googlesource.com/c/go/+/205457
+# https://go-review.googlesource.com/c/go/+/368634
+gcc.pkg-path = "gcc"
+gcc.systems = ["aarch64-linux", "x86_64-linux"]


### PR DESCRIPTION
## Proposed Changes

This supersedes https://github.com/flox/flox/pull/2234

The original hope was that we would use `autoPatchelfHook` to update the interpreter and linked libraries, from system libraries to store paths, wherever possible.

However it's _hard_ to enumerate all of the possible libraries to package names at the appropriate versions and we discovered cases where it would produce non-functioning binaries if the environment brought its own `gcc`. Possibly because of conflicting `nixpkgs` revisions. Here's an `strace` from the "hang" behaviour that's mentioned in the comment:

- https://gist.github.com/dcarley/a5a1e1c6a8cde7fd1d31ecc1f327e384

So instead we have settled on not modifying the binaries at all and adding a test to prevent regressions against the behaviours we saw.

This new test has also highlighted an issue whereby bringing your own `gcc` (or `clang`) on Darwin, rather than using the Xcode provided `gcc`, causes compilations errors. We may need to provide further guidance on this in the future.

## Release Notes

N/A, no functional changes.
