### PR TITLE
refactor(catalog): Move reset mocks to test_helper

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1162,7 +1162,8 @@ pub mod test_helpers {
 mod tests {
     use std::os::unix::fs::PermissionsExt;
 
-    use catalog::{Client, GENERATED_DATA, MANUALLY_GENERATED};
+    use catalog::test_helpers::reset_mocks_from_file;
+    use catalog::{GENERATED_DATA, MANUALLY_GENERATED};
     use catalog_api_v1::types::{ResolvedPackageDescriptor, SystemEnum};
     use chrono::{DateTime, Utc};
     use flox_core::Version;
@@ -1207,12 +1208,7 @@ mod tests {
         hello.pkg-path = "hello"
         "#;
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/hello.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
         env_view.edit(&flox, new_env_str.to_string()).unwrap();
 
         assert_eq!(env_view.manifest_contents().unwrap(), new_env_str);
@@ -1283,12 +1279,7 @@ mod tests {
         hello.pkg-path = "hello"
         "#;
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/hello.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
         let result = env_view.edit(&flox, new_env_str.to_string()).unwrap();
 
         assert!(matches!(result, EditResult::Success { store_path: _ }));
@@ -1446,12 +1437,7 @@ mod tests {
 
         let mut env_view = CoreEnvironment::new(&env_path);
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/hello.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
         env_view.lock(&flox).expect("locking should succeed");
         let store_path = env_view.build(&flox).expect("build should succeed");
         CoreEnvironment::link(env_path.path().with_extension("out-link"), store_path)

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1658,7 +1658,8 @@ mod test {
     use crate::models::lockfile::test_helpers::fake_catalog_package_lock;
     use crate::models::lockfile::Lockfile;
     use crate::models::manifest::{Manifest, ManifestPackageDescriptorCatalog};
-    use crate::providers::catalog::{Client, MockClient, GENERATED_DATA};
+    use crate::providers::catalog::test_helpers::reset_mocks_from_file;
+    use crate::providers::catalog::{MockClient, GENERATED_DATA};
     use crate::providers::git::tests::commit_file;
     use crate::providers::git::GitCommandProvider;
 
@@ -2410,11 +2411,7 @@ mod test {
             .local_env_or_copy_current_generation(&flox)
             .unwrap();
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/hello.json");
-        } else {
-            panic!("Expected a MockClient");
-        }
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
 
         let mut new_manifest = Manifest::default();
         new_manifest.install.insert(

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -272,7 +272,8 @@ mod tests {
     };
     use crate::models::environment::path_environment::PathEnvironment;
     use crate::models::environment::Environment;
-    use crate::providers::catalog::{Client, GENERATED_DATA};
+    use crate::providers::catalog::test_helpers::reset_mocks_from_file;
+    use crate::providers::catalog::GENERATED_DATA;
 
     fn result_dir(parent: &Path, package: &str) -> PathBuf {
         parent.join(format!("result-{package}"))
@@ -704,12 +705,7 @@ mod tests {
         let mut env = new_path_environment(&flox, &manifest);
         let env_path = env.parent_path().unwrap();
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/hello.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
         assert_build_status(&flox, &mut env, &package_name, true);
         assert_build_file(&env_path, &package_name, &file_name, &file_content);
     }
@@ -740,12 +736,7 @@ mod tests {
         let mut env = new_path_environment(&flox, &manifest);
         let env_path = env.parent_path().unwrap();
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/hello.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
         assert_build_status(&flox, &mut env, &package_name, true);
 
         let result_path = result_dir(&env_path, &package_name)
@@ -930,12 +921,7 @@ mod tests {
         "#};
         fs::write(env_path.join("main.go"), arg0_code).unwrap();
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/go.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/go.json");
         assert_build_status(&flox, &mut env, &package_name, true);
         let result_path = result_dir(&env_path, &package_name)
             .join("bin")
@@ -1042,12 +1028,7 @@ mod tests {
         "#};
         fs::write(env_path.join("main.go"), exe_code).unwrap();
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("resolve/go.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/go.json");
         assert_build_status(&flox, &mut env, &package_name, true);
         let result_path = result_dir(&env_path, &package_name)
             .join("bin")
@@ -1119,12 +1100,7 @@ mod tests {
         "#};
         fs::write(env_path.join(source_name), source_code).unwrap();
 
-        if let Client::Mock(ref mut client) = flox.catalog_client {
-            client.clear_and_load_responses_from_file("envs/go_gcc.json");
-        } else {
-            panic!("expected Mock client")
-        };
-
+        reset_mocks_from_file(&mut flox.catalog_client, "envs/go_gcc.json");
         assert_build_status(&flox, &mut env, &package_name, true);
 
         let result_path = result_dir(&env_path, &package_name)


### PR DESCRIPTION
## Proposed Changes

So that we don't need to repeat the `if panic` dance everywhere.

Currently based on https://github.com/flox/flox/pull/2268 which adds another one of these.

## Release Notes

N/A