### PR TITLE
fix: more visually obvious build error

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -416,7 +416,7 @@ mod tests {
         // Weird string formatting because indoc strips leading whitespace
         assert!(output.stdout.contains(
             r#"
-       > ERROR: Build command did not copy outputs to '$out'.
+       > ❌ ERROR: Build command did not copy outputs to '$out'.
        > - copy a single file with 'cp bin $out'
        > - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
        > - copy files from an Autotools project with 'make install PREFIX=$out'"#
@@ -442,7 +442,7 @@ mod tests {
         // Weird string formatting because indoc strips leading whitespace
         assert!(output.stdout.contains(
             r#"
-       > ERROR: Build command did not copy outputs to '$out'.
+       > ❌ ERROR: Build command did not copy outputs to '$out'.
        > - copy a single file with 'cp bin $out'
        > - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
        > - copy files from an Autotools project with 'make install PREFIX=$out'"#

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -22,7 +22,7 @@ let
   buildScript-contents = /. + buildScript;
   buildCache-tar-contents = if (buildCache == null) then null else (/. + buildCache);
   dollar_out_error_and_exit = ''
-    echo "ERROR: Build command did not copy outputs to '\$out'." 1>&2
+    echo "❌ ERROR: Build command did not copy outputs to '\$out'." 1>&2
     echo "- copy a single file with 'cp bin \$out'" 1>&2
     echo "- copy multiple files with 'mkdir -p \$out && cp bin/* \$out/'" 1>&2
     echo "- copy files from an Autotools project with 'make install PREFIX=\$out'" 1>&2


### PR DESCRIPTION
## Proposed Changes

Makes the "Build command did not copy outputs to '$out'" error more visually distinct and conform to CLI style guide


## Release Notes

N/A


<!-- Many thanks! -->
