### PR TITLE
refactor(watchdog): Move watchdog to start.bash

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -145,11 +145,10 @@ esac
 
 # sets _FLOX_ATTACH, _FLOX_ACTIVATION_STATE_DIR, _FLOX_ACTIVATION_ID
 # Don't eval on one line so that we exit if flox-activations fails
-if [ -n "${FLOX_RUNTIME_DIR:-}" ]; then
-  to_eval="$($_flox_activations --runtime-dir "$FLOX_RUNTIME_DIR" start-or-attach --pid "$$" --flox-env "$FLOX_ENV" --store-path "$_FLOX_ACTIVATE_STORE_PATH")"
-else
-  to_eval="$($_flox_activations start-or-attach --pid "$$" --flox-env "$FLOX_ENV" --store-path "$_FLOX_ACTIVATE_STORE_PATH")"
-fi
+to_eval="$($_flox_activations \
+  ${FLOX_RUNTIME_DIR:+--runtime-dir "$FLOX_RUNTIME_DIR"} \
+  start-or-attach \
+  --pid "$$" --flox-env "$FLOX_ENV" --store-path "$_FLOX_ACTIVATE_STORE_PATH")"
 eval "$to_eval"
 export _FLOX_ACTIVATION_STATE_DIR _FLOX_ACTIVATION_ID
 

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -6,6 +6,7 @@ set -euo pipefail
 export _activate_d="@out@/activate.d"
 export _bash="@bash@"
 export _coreutils="@coreutils@"
+export _daemonize="@daemonize@"
 export _flox_activations="@flox_activations@"
 export _getopt="@getopt@"
 export _gnused="@gnused@"

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -79,8 +79,7 @@ LC_ALL=C $_coreutils/bin/comm -13 "$_start_env" "$_end_env" \
 LC_ALL=C $_coreutils/bin/comm -23 "$_start_env" "$_end_env" \
   | $_gnused/bin/sed -e 's/^declare -x //' -e 's/=.*//' > "$_del_env"
 
-if [ -n "${FLOX_RUNTIME_DIR:-}" ]; then
-  "$_flox_activations" --runtime-dir "$FLOX_RUNTIME_DIR" set-ready --flox-env "$FLOX_ENV" --id "$_FLOX_ACTIVATION_ID"
-else
-  "$_flox_activations" set-ready --flox-env "$FLOX_ENV" --id "$_FLOX_ACTIVATION_ID"
-fi
+"$_flox_activations" \
+  ${FLOX_RUNTIME_DIR:+--runtime-dir "$FLOX_RUNTIME_DIR"} \
+  set-ready \
+  --flox-env "$FLOX_ENV" --id "$_FLOX_ACTIVATION_ID"

--- a/cli/flox-activations/src/cli/attach.rs
+++ b/cli/flox-activations/src/cli/attach.rs
@@ -12,7 +12,7 @@ pub struct AttachArgs {
     #[arg(help = "The PID of the shell registering interest in the activation.")]
     #[arg(short, long, value_name = "PID")]
     pub pid: i32,
-    #[arg(help = "The path to the .flox directory for the environment.")]
+    #[arg(help = "The path to the activation symlink for the environment.")]
     #[arg(short, long, value_name = "PATH")]
     pub flox_env: PathBuf,
     #[arg(help = "The ID for this particular activation of this environment.")]

--- a/cli/flox-activations/src/cli/set_ready.rs
+++ b/cli/flox-activations/src/cli/set_ready.rs
@@ -8,7 +8,7 @@ type Error = anyhow::Error;
 
 #[derive(Debug, Args)]
 pub struct SetReadyArgs {
-    #[arg(help = "The path to the .flox directory for the environment.")]
+    #[arg(help = "The path to the activation symlink for the environment.")]
     #[arg(short, long, value_name = "PATH")]
     flox_env: PathBuf,
     #[arg(help = "The ID for this particular activation of this environment.")]

--- a/cli/flox-activations/src/cli/start_or_attach.rs
+++ b/cli/flox-activations/src/cli/start_or_attach.rs
@@ -18,7 +18,7 @@ pub struct StartOrAttachArgs {
     #[arg(help = "The PID of the shell registering interest in the activation.")]
     #[arg(short, long, value_name = "PID")]
     pub pid: i32,
-    #[arg(help = "The path to the .flox directory for the environment.")]
+    #[arg(help = "The path to the activation symlink for the environment.")]
     #[arg(short, long, value_name = "PATH")]
     pub flox_env: PathBuf,
     #[arg(help = "The store path of the rendered environment for this activation.")]

--- a/cli/flox-watchdog/src/main.rs
+++ b/cli/flox-watchdog/src/main.rs
@@ -42,7 +42,8 @@ be manually triggered via signal (SIGUSR1), but otherwise runs automatically.";
 #[command(version = Lazy::get(&FLOX_VERSION).map(|v| v.as_str()).unwrap_or("0.0.0"))]
 #[command(about = SHORT_HELP, long_about = LONG_HELP)]
 pub struct Cli {
-    /// The PID of the process to monitor.
+    /// The PID of the initial activation to store in the environment registry
+    // TODO: This can be removed in: https://github.com/flox/flox/issues/2206
     #[arg(short, long, value_name = "PID")]
     pub pid: i32,
 
@@ -134,7 +135,6 @@ fn run(args: Cli) -> Result<(), Error> {
     }
     drop(lock);
     let mut watcher = process::PidWatcher::new(
-        args.pid.into(),
         &args.registry_path,
         &args.dot_flox_hash,
         should_terminate,

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -447,12 +447,8 @@ impl Activate {
             cmd.arg("--disable-metrics");
         }
 
-        // This process may terminate before the watchdog installs its signal handler,
-        // so we pass it the PID of this process unconditionally (note that on Linux passing this
-        // PID doesn't change which process the watchdog waits on to terminate) so that the watchdog
-        // can check that it still exists before installing its signal handler. There's still a
-        // TOCTOU race condition between checking that this process is still running and installing
-        // the signal handler, but doing the PID checking should mitigate it to a degree.
+        // This process may terminate before the watchdog registers the activation in the environment
+        // registry so we pass it the PID of this process unconditionally.
         cmd.arg("--pid");
         cmd.arg(getpid().as_raw().to_string());
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3177,3 +3177,16 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
+
+# Sub-commands like `flox-activations` and `flox-watchdog` depend on this.
+@test "activate: sets FLOX_DISABLE_METRICS from config" {
+  project_setup
+
+  # Set in isolated config.
+  "$FLOX_BIN" config --set-bool disable_metrics true
+  # Unset from test suite.
+  unset FLOX_DISABLE_METRICS
+
+  run "$FLOX_BIN" activate -- printenv FLOX_DISABLE_METRICS
+  assert_output "true"
+}

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -16,6 +16,7 @@
   fd,
   flox-activations,
   shfmt,
+  daemonize,
 }:
 let
   ld-floxlib_so = if stdenv.isLinux then "${ld-floxlib}/lib/ld-floxlib.so" else "__LINUX_ONLY__";
@@ -32,6 +33,7 @@ runCommand "flox-activation-scripts"
       bash
       coreutils
       gnused
+      daemonize
     ];
   }
   ''
@@ -47,6 +49,7 @@ runCommand "flox-activation-scripts"
       --replace "@out@" "$out" \
       --replace "@process-compose@" "${process-compose}/bin/process-compose" \
       --replace "@setsid@" "${util-linux}/bin/setsid" \
+      --replace "@daemonize@" "${daemonize}/bin/daemonize" \
       --replace "/usr/bin/env bash" "${bash}/bin/bash"
 
     substituteInPlace $out/activate.d/bash \


### PR DESCRIPTION
## Proposed Changes

Start the watchdog from `start.bash` just before `set-ready` is called
so that it's only started once for the first "start" activation and not
the subsequent "attach" activations.

I previously wanted to do this within `flox-activations set-ready` so
that we got some type safety on the command/argument handling and it
would be atomic with the `set-ready` operation. However the need to
make this conditional for direct invocations of `${FLOX_ENV}/activate`,
where we don't currently want to start a watchdog and can't easily
compute all of the arguments (e.g. `--log-dir` when we don't have
`.flox` path), later convinced me to just implement it in Bash.

Passing the path to the watchdog binary in at runtime also ensures that
the watchdog isn't unnecessarily bundled into the closure of
environments, including containers which don't need a watchdog because
there is always a single "start" activation for the lifetime of the
container.

The `--pid`, `--registry`, and `--hash` arguments can be removed when
the watchdog is subsequently changed  from using the environment
registry to `activations.json`.

We no longer explicitly skip starting a watchdog for "ephemeral"
activations, where we call `${FLOX_ENV}/activate` for the purpose of
starting `process-compose` from the right environment, mostly because I
don't want this concept to escape the CLI with yet another environment
variable. This is fine though because it will go through the normal
`flox-activations` flow, starting or attaching, and we are going to
configure the watchdog to only cleanup `process-compose` when _all_
activations for a `$FLOX_ENV` have exited.

We also no longer skip for "in-place" activations but they go through
the normal `flox-activations` flow and we intend to support services for
them very shortly.

There are two outstanding issues to still address:

1. Wrapped binaries from `flox build` will "start" an activation without
   starting a watchdog, which could prevent cleanup or hooks being run
   whilst a wrapped binary is being run. This shouldn't be a release
   blocker for the activation work because build isn't generally
   available yet so we will followup in https://github.com/flox/flox/issues/2287

2. We have a new race condition, which I noticed by chance, where
    `process-compose` isn't being cleaned up for for multiple `flox
    services [re]start` commands.

   The watchdog removes the activation from `env-registry.json` and
   stops `process-compose` on the first iteration of the loop but
   nothing removes the activation from `activations.json`, so the second
   iteration of the loop attaches to an existing activation and doesn't
   start a watchdog.

   This will be fixed by https://github.com/flox/flox/issues/2130 and https://github.com/flox/flox/pull/2286

    ```
    % just integ-tests services.bats -- --filter-tags services:permit-stopped-for-start-restart
    …
    services.bats
     ✓ start, restart: do not require active services [11703]
    Waiting for pids: 33511

    1 test, 0 failures in 13 seconds

    % pstree -ws bats
    -+= 00001 root /sbin/launchd
     \-+= 33600 dcarley /nix/store/dxgk503lw2a0slqcvhcvwfa07qf9y8sx-process-compose-1.27.0/bin/process-compose up -f /private/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.9nd2Vl/bats-run-DlcaDa/test/1/test/.flox/run/aarch64-darwin.test/service-config.yaml -u /private/tmp/flox.tests.LgLx2p/tmp.x68yCqYIQZ/run/flox.825e1522.sock -L /private/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.9nd2Vl/bats-run-DlcaDa/test/1/test/.flox/log/services.20241029104728921926.log --tui=false
       |--= 33605 dcarley /nix/store/1l41471x6rlf7l544s1bxkqqgpprd28m-coreutils-9.5/bin/sleep infinity
       |--= 33606 dcarley sleep infinity
       \--= 33607 dcarley sleep infinity
    ```

There's some refactoring in prior commits which can be reviewed individually.

## Release Notes

N/A