### PR TITLE
refactor: simplify update_watchlist logic

### DIFF
--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -436,7 +436,7 @@ pub fn deregister_activation(
     Ok(current_activations)
 }
 
-/// Returns the list of activation PIDs for a given activation.
+/// Returns the list of all activation PIDs for a given activation.
 pub fn activation_pids(
     reg_path: impl AsRef<Path>,
     path_hash: impl AsRef<str>,
@@ -446,7 +446,6 @@ pub fn activation_pids(
     let entry = reg
         .entry_for_hash_mut(path_hash.as_ref())
         .ok_or(EnvRegistryError::EnvNotRegistered)?;
-    entry.remove_stale_activations();
     let remaining_pids = entry.activations.clone();
     Ok(remaining_pids)
 }


### PR DESCRIPTION
Our current update_watchlist logic calls 3 different functions which all check if a PID is still running:
- activation_pids() calls remove_stale_activations()
- prune_terminations()
- watch_new_pids()

The logic to determine if a PID is about to get more complicated (since we'll need to check if an attached PID has expired), so it's preferable to have to update just one thing instead of 3.

Change the algorithm in update_watchlist() such that PIDs are checked to be running just once.


## Release Notes

NA