### PR TITLE
Some cleanup of our PID code

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1144,6 +1144,7 @@ dependencies = [
  "fslock",
  "indoc",
  "log",
+ "nix",
  "serde",
  "serde_json",
  "temp-env",

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -21,5 +21,6 @@ indoc.workspace = true
 
 
 [dev-dependencies]
+nix.workspace = true
 tempfile.workspace = true
 temp-env.workspace = true

--- a/cli/flox-activations/src/cli/attach.rs
+++ b/cli/flox-activations/src/cli/attach.rs
@@ -11,7 +11,7 @@ use crate::Error;
 pub struct AttachArgs {
     #[arg(help = "The PID of the shell registering interest in the activation.")]
     #[arg(short, long, value_name = "PID")]
-    pub pid: u32,
+    pub pid: i32,
     #[arg(help = "The path to the .flox directory for the environment.")]
     #[arg(short, long, value_name = "PATH")]
     pub flox_env: PathBuf,
@@ -30,7 +30,7 @@ pub struct AttachExclusiveArgs {
     pub timeout_ms: Option<u32>,
     #[arg(help = "Remove the specified PID when attaching to this activation.")]
     #[arg(short, long, value_name = "PID")]
-    pub remove_pid: Option<u32>,
+    pub remove_pid: Option<i32>,
 }
 
 impl AttachArgs {

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -77,7 +77,7 @@ impl Activations {
     pub fn create_activation(
         &mut self,
         store_path: &str,
-        pid: u32,
+        pid: i32,
     ) -> Result<&mut Activation, Error> {
         if self.activation_for_store_path(store_path).is_some() {
             anyhow::bail!("activation for store path '{store_path}' already exists");
@@ -165,7 +165,7 @@ impl Activation {
     /// Register another PID that runs the same activation of an environment.
     /// Registered PIDs are used by the watchdog,
     /// to determine when an activation can be cleaned up.
-    pub fn attach_pid(&mut self, pid: u32, timeout: Option<Duration>) {
+    pub fn attach_pid(&mut self, pid: i32, timeout: Option<Duration>) {
         let expiration = timeout.map(|timeout| OffsetDateTime::now_utc() + timeout);
         let attached_pid = AttachedPid { pid, expiration };
 
@@ -180,7 +180,7 @@ impl Activation {
     /// which PID is attached to an activation.
     /// I.e. in in-place activations, the process that started the activation will be flox,
     /// while the process that attaches to the activation will be the `eval`ing shell.
-    pub fn remove_pid(&mut self, pid: u32) {
+    pub fn remove_pid(&mut self, pid: i32) {
         self.attached_pids
             .retain(|attached_pid| attached_pid.pid != pid);
     }
@@ -188,7 +188,7 @@ impl Activation {
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct AttachedPid {
-    pub pid: u32,
+    pub pid: i32,
     /// If Some, the time after which the activation can be cleaned up
     ///
     /// Even if the PID has exited, the activation should not be cleaned up
@@ -204,7 +204,7 @@ pub struct AttachedPid {
 
 impl AttachedPid {
     fn is_running(&self) -> bool {
-        let pid = Pid::from_raw(self.pid as i32);
+        let pid = Pid::from_raw(self.pid);
         match kill(pid, None) {
             // These semantics come from kill(2).
             Ok(_) => true,              // Process received the signal and is running.

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -6,7 +6,6 @@ use std::time::SystemTime;
 use flox_core::{serialize_atomically, SerializeError, Version};
 use fslock::LockFile;
 use nix::errno::Errno;
-use nix::libc::pid_t;
 use nix::sys::signal::kill;
 use nix::unistd::Pid as NixPid;
 use serde::{Deserialize, Serialize};
@@ -239,7 +238,7 @@ pub struct RegisteredEnv {
 /// `nix::unistd::Pid`.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub struct ActivationPid(pid_t);
+pub struct ActivationPid(i32);
 
 impl ActivationPid {
     /// Check whether an activation is still running.
@@ -262,7 +261,7 @@ impl From<i32> for ActivationPid {
     }
 }
 
-impl From<ActivationPid> for pid_t {
+impl From<ActivationPid> for i32 {
     fn from(value: ActivationPid) -> Self {
         value.0
     }

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -242,17 +242,6 @@ pub struct RegisteredEnv {
 pub struct ActivationPid(pid_t);
 
 impl ActivationPid {
-    /// Construct a Pid from the current running process.
-    pub fn from_current_process() -> Self {
-        ActivationPid(nix::unistd::getpid().as_raw())
-    }
-
-    /// Check whether an activation is the parent of the current process.
-    pub fn is_current_process_parent(&self) -> bool {
-        let parent = nix::unistd::getppid();
-        NixPid::from(*self) == parent
-    }
-
     /// Check whether an activation is still running.
     pub fn is_running(&self) -> bool {
         // TODO: Compare name or check for watchdog child to see if it's a real activation?


### PR DESCRIPTION
[refactor: drop dead code](https://github.com/flox/flox/commit/49178bb2295ddd3042788516d0d29683c59e1c04)

ActivationPid::from_current_process and
ActivationPid::is_current_process_parent are unused.

[style: use i32 consistently for PIDs](https://github.com/flox/flox/commit/b624307b5aa69678a8ed9eb2d1917b77d1351427)

We currently use pid_t/i32 for ActivationPid and
PidWatcher::pid_is_running but u32 for AttachedPid. We should be
consistent, and we'll need to use PidWatcher::pid_is_running to check if
an AttachedPid is running.

Use i32 throughout since that's what's used by the libc crate.

Use i32 rather than pid_t since extra imports are annoying.

## Release Notes

NA