### PR TITLE
feat: use activations.json in flox-watchdog

### DIFF
--- a/assets/activation-scripts/activate.d/attach-inplace.bash
+++ b/assets/activation-scripts/activate.d/attach-inplace.bash
@@ -1,3 +1,13 @@
+expiring_pid="$$"
+# Put a 5 second timeout on the activation
+"$_flox_activations" \
+  --runtime-dir "$FLOX_RUNTIME_DIR" \
+  attach \
+  --pid "$expiring_pid" \
+  --flox-env "$FLOX_ENV" \
+  --id "$_FLOX_ACTIVATION_ID" \
+  --timeout-ms 5000
+
 # "in-place" mode: emit activation commands in correct shell dialect by echoing
 # the contents of the shell-specific activation script.  N.B. the output of
 # these scripts may be eval'd with backticks which have the effect of removing
@@ -5,6 +15,7 @@
 # script fragment when represented on a single line.
 case "$_flox_shell" in
   *bash)
+    echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$\$ --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
     echo "export _flox_activate_tracelevel=\"$_flox_activate_tracelevel\";"
     echo "export FLOX_ENV=\"$FLOX_ENV\";"
     echo "export _FLOX_ACTIVATION_STATE_DIR=\"$_FLOX_ACTIVATION_STATE_DIR\";"
@@ -12,6 +23,7 @@ case "$_flox_shell" in
     echo "source '$_activate_d/bash';"
     ;;
   *fish)
+    echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$fish_pid --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
     echo "set -gx _flox_activate_tracelevel \"$_flox_activate_tracelevel\";"
     echo "set -gx FLOX_ENV \"$FLOX_ENV\";"
     echo "set -gx _FLOX_ACTIVATION_STATE_DIR \"$_FLOX_ACTIVATION_STATE_DIR\";"
@@ -19,6 +31,7 @@ case "$_flox_shell" in
     echo "source '$_activate_d/fish';"
     ;;
   *tcsh)
+    echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$\$ --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
     echo "setenv _flox_activate_tracelevel \"$_flox_activate_tracelevel\";"
     echo "setenv FLOX_ENV \"$FLOX_ENV\";"
     echo "setenv _FLOX_ACTIVATION_STATE_DIR \"$_FLOX_ACTIVATION_STATE_DIR\";"
@@ -27,6 +40,7 @@ case "$_flox_shell" in
     ;;
   # Any additions should probably be restored in zdotdir/* scripts
   *zsh)
+    echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$\$ --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
     echo "export _flox_activate_tracelevel=\"$_flox_activate_tracelevel\";"
     echo "export FLOX_ENV=\"$FLOX_ENV\";"
     if [ -n "${ZDOTDIR:-}" ]; then

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -96,9 +96,9 @@ if [ -n "${_FLOX_WATCHDOG_BIN:-}" ]; then
     ${FLOX_DISABLE_METRICS:+--disable-metrics} \
     --log-dir "$_FLOX_ENV_LOG_DIR" \
     --socket "$_FLOX_SERVICES_SOCKET" \
-    --pid "$$" \
-    --registry "$_FLOX_REGISTRY_PATH" \
-    --hash "$_FLOX_DOTFLOX_HASH"
+    --flox-env "$FLOX_ENV" \
+    --activation-id "$_FLOX_ACTIVATION_ID" \
+    --runtime-dir "$FLOX_RUNTIME_DIR"
 fi
 
 # Finally mark the environment as ready to use for attachments.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1194,6 +1194,7 @@ dependencies = [
  "clap",
  "clap_derive",
  "filetime",
+ "flox-activations",
  "flox-core",
  "flox-rust-sdk",
  "glob",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "flox-activations",
  "flox-core",
  "flox-rust-sdk",
+ "fslock",
  "glob",
  "kqueue",
  "nix",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1194,6 +1194,7 @@ dependencies = [
  "clap",
  "clap_derive",
  "filetime",
+ "flox-core",
  "flox-rust-sdk",
  "glob",
  "kqueue",
@@ -1204,6 +1205,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "tempfile",
+ "time",
  "tracing",
  "tracing-subscriber",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ crossterm = "0.27"
 derive_more = "0.99.18"
 dirs = "5.0.0"
 enum_dispatch = "0.3.13"
+flox-activations = { path = "flox-activations" }
 flox-core = { path = "flox-core" }
 flox-rust-sdk = { path = "flox-rust-sdk" }
 fslock = "0.2.1"

--- a/cli/flox-activations/src/cli/mod.rs
+++ b/cli/flox-activations/src/cli/mod.rs
@@ -1,12 +1,12 @@
 use std::path::PathBuf;
 
+use attach::AttachArgs;
 use clap::{Parser, Subcommand};
 
-mod attach;
+pub mod attach;
 mod set_ready;
 mod start_or_attach;
 
-pub use attach::AttachArgs;
 pub use set_ready::SetReadyArgs;
 pub use start_or_attach::StartOrAttachArgs;
 

--- a/cli/flox-activations/src/cli/set_ready.rs
+++ b/cli/flox-activations/src/cli/set_ready.rs
@@ -10,14 +10,14 @@ type Error = anyhow::Error;
 pub struct SetReadyArgs {
     #[arg(help = "The path to the activation symlink for the environment.")]
     #[arg(short, long, value_name = "PATH")]
-    flox_env: PathBuf,
+    pub flox_env: PathBuf,
     #[arg(help = "The ID for this particular activation of this environment.")]
     #[arg(short, long, value_name = "ID")]
-    id: String,
+    pub id: String,
 }
 
 impl SetReadyArgs {
-    pub(crate) fn handle(self, runtime_dir: &Path) -> Result<(), Error> {
+    pub fn handle(self, runtime_dir: &Path) -> Result<(), Error> {
         let activations_json_path = activations::activations_json_path(runtime_dir, &self.flox_env);
 
         let (activations, lock) = activations::read_activations_json(&activations_json_path)?;

--- a/cli/flox-activations/src/lib.rs
+++ b/cli/flox-activations/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod cli;
+
+pub type Error = anyhow::Error;

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -1,10 +1,7 @@
 use clap::Parser;
-use cli::Cli;
+use flox_activations::cli::Cli;
+use flox_activations::{cli, Error};
 use log::debug;
-
-mod cli;
-
-pub type Error = anyhow::Error;
 
 fn main() -> Result<(), Error> {
     env_logger::init();
@@ -15,7 +12,9 @@ fn main() -> Result<(), Error> {
     let runtime_dir = &args.runtime_dir;
 
     match args.command {
-        cli::Command::StartOrAttach(args) => args.handle(runtime_dir)?,
+        cli::Command::StartOrAttach(args) => {
+            args.handle(runtime_dir)?;
+        },
         cli::Command::SetReady(args) => args.handle(runtime_dir)?,
         cli::Command::Attach(args) => args.handle(runtime_dir)?,
     }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -28,7 +28,7 @@ type Error = anyhow::Error;
 ///
 /// Notably, the [Activations] does not feature methods to remove activations.
 /// Removing actiavtions falls onto the watchdog, which is responsible for cleaning up activations.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Activations {
     version: Version<1>,
     activations: Vec<Activation>,
@@ -112,7 +112,7 @@ impl Activations {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Activation {
     /// Unique identifier for this activation
     ///
@@ -225,7 +225,7 @@ impl AttachedPid {
 
 /// Acquires the filesystem-based lock on activations.json
 #[allow(unused)]
-fn acquire_activations_json_lock(
+pub fn acquire_activations_json_lock(
     activations_json_path: impl AsRef<Path>,
 ) -> Result<LockFile, Error> {
     let lock_path = activations_json_lock_path(activations_json_path);

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -101,6 +101,15 @@ impl Activations {
 
         Ok(self.activations.last_mut().unwrap())
     }
+
+    pub fn remove_activation(&mut self, id: impl AsRef<str>) {
+        self.activations
+            .retain(|activation| activation.id != id.as_ref());
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.activations.is_empty()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -186,7 +195,7 @@ impl Activation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct AttachedPid {
     pub pid: i32,
     /// If Some, the time after which the activation can be cleaned up

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -8,7 +8,7 @@ use nix::sys::signal::kill;
 use nix::unistd::Pid;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use time::{Duration, OffsetDateTime};
+use time::OffsetDateTime;
 
 use crate::{path_hash, Version};
 
@@ -174,8 +174,7 @@ impl Activation {
     /// Register another PID that runs the same activation of an environment.
     /// Registered PIDs are used by the watchdog,
     /// to determine when an activation can be cleaned up.
-    pub fn attach_pid(&mut self, pid: i32, timeout: Option<Duration>) {
-        let expiration = timeout.map(|timeout| OffsetDateTime::now_utc() + timeout);
+    pub fn attach_pid(&mut self, pid: i32, expiration: Option<OffsetDateTime>) {
         let attached_pid = AttachedPid { pid, expiration };
 
         self.attached_pids.push(attached_pid);

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -424,20 +424,6 @@ pub fn deregister_activation(
     Ok(current_activations)
 }
 
-/// Returns the list of all activation PIDs for a given activation.
-pub fn activation_pids(
-    reg_path: impl AsRef<Path>,
-    path_hash: impl AsRef<str>,
-) -> Result<HashSet<ActivationPid>, EnvRegistryError> {
-    let _lock = acquire_env_registry_lock(&reg_path)?;
-    let mut reg = read_environment_registry(&reg_path)?.ok_or(EnvRegistryError::NoEnvRegistry)?;
-    let entry = reg
-        .entry_for_hash_mut(path_hash.as_ref())
-        .ok_or(EnvRegistryError::EnvNotRegistered)?;
-    let remaining_pids = entry.activations.clone();
-    Ok(remaining_pids)
-}
-
 #[cfg(test)]
 mod test {
     use std::fs::OpenOptions;

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -1,13 +1,8 @@
-use std::collections::HashSet;
-use std::fmt;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use flox_core::{serialize_atomically, SerializeError, Version};
 use fslock::LockFile;
-use nix::errno::Errno;
-use nix::sys::signal::kill;
-use nix::unistd::Pid as NixPid;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -91,7 +86,6 @@ impl EnvRegistry {
                 self.entries.push(RegistryEntry {
                     path_hash: hash.to_string(),
                     path: dot_flox_path.as_ref().to_path_buf(),
-                    activations: HashSet::new(),
                     envs: vec![],
                 });
                 self.entries
@@ -135,9 +129,6 @@ pub struct RegistryEntry {
     /// The list of environments that have existed at this path
     /// since the last time environments were garbage collected.
     pub envs: Vec<RegisteredEnv>,
-    /// The PIDs of current activations
-    #[serde(default)]
-    pub activations: HashSet<ActivationPid>,
 }
 
 impl RegistryEntry {
@@ -195,32 +186,6 @@ impl RegistryEntry {
         }
         None
     }
-
-    /// Register an activation for an existing enviroment.
-    fn register_activation(&mut self, pid: ActivationPid) {
-        tracing::debug!(%pid, hash = self.path_hash, "registering activation");
-        self.activations.insert(pid);
-    }
-
-    /// Deregister an activation for an existing enviroment.
-    ///
-    /// Doesn't error if the activation wasn't found, because another watchdog
-    /// may have already cleaned it up as stale.
-    fn deregister_activation(&mut self, pid: ActivationPid) {
-        tracing::debug!(%pid, hash = self.path_hash, "deregistering activation");
-        self.activations.remove(&pid);
-    }
-
-    /// Remove any activation PIDs that are no longer running and weren't explicitly deregistered.
-    fn remove_stale_activations(&mut self) {
-        self.activations.retain(|pid| {
-            let running = pid.is_running();
-            if !running {
-                tracing::debug!(%pid, "removing stale activation");
-            }
-            running
-        })
-    }
 }
 
 /// Metadata about an environment that has been registered.
@@ -232,57 +197,6 @@ pub struct RegisteredEnv {
     /// The metadata about the owner and name of the environment if this environment is a
     /// managed environment.
     pub pointer: EnvironmentPointer,
-}
-
-/// PID of an environment's activation. This is a simpler variation of
-/// `nix::unistd::Pid`.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub struct ActivationPid(i32);
-
-impl ActivationPid {
-    /// Check whether an activation is still running.
-    pub fn is_running(&self) -> bool {
-        // TODO: Compare name or check for watchdog child to see if it's a real activation?
-        let pid = NixPid::from(*self);
-        match kill(pid, None) {
-            // These semantics come from kill(2).
-            Ok(_) => true,              // Process received the signal and is running.
-            Err(Errno::EPERM) => true,  // No permission to send a signal but we know it's running.
-            Err(Errno::ESRCH) => false, // No process running to receive the signal.
-            Err(_) => false,            // Unknown error, assume no running process.
-        }
-    }
-}
-
-impl From<i32> for ActivationPid {
-    fn from(value: i32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<ActivationPid> for i32 {
-    fn from(value: ActivationPid) -> Self {
-        value.0
-    }
-}
-
-impl From<ActivationPid> for NixPid {
-    fn from(pid: ActivationPid) -> Self {
-        NixPid::from_raw(pid.0)
-    }
-}
-
-impl From<NixPid> for ActivationPid {
-    fn from(pid: NixPid) -> Self {
-        ActivationPid(pid.as_raw())
-    }
-}
-
-impl fmt::Display for ActivationPid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
 }
 
 /// Returns the path to the user's environment registry file.
@@ -380,58 +294,13 @@ pub fn deregister(
     Ok(())
 }
 
-/// Register an activation for an existing enviroment.
-pub fn register_activation(
-    reg_path: impl AsRef<Path>,
-    path_hash: &str,
-    pid: ActivationPid,
-) -> Result<(), EnvRegistryError> {
-    // Acquire the lock before reading the registry so that we know there are no modifications while
-    // we're editing it.
-    let lock = acquire_env_registry_lock(&reg_path)?;
-    let mut reg = read_environment_registry(&reg_path)?.unwrap_or_default();
-    let entry = reg
-        .entry_for_hash_mut(path_hash)
-        .ok_or(EnvRegistryError::UnknownKey(path_hash.to_string()))?;
-
-    entry.remove_stale_activations();
-    entry.register_activation(pid);
-
-    write_environment_registry(&reg, &reg_path, lock)?;
-    Ok(())
-}
-
-/// Deregister an activation for an existing enviroment, returning the number of activations
-/// remaining after deregistering.
-pub fn deregister_activation(
-    reg_path: impl AsRef<Path>,
-    path_hash: &str,
-    pid: ActivationPid,
-) -> Result<usize, EnvRegistryError> {
-    // Acquire the lock before reading the registry so that we know there are no modifications while
-    // we're editing it.
-    let lock = acquire_env_registry_lock(&reg_path)?;
-    let mut reg = read_environment_registry(&reg_path)?.unwrap_or_default();
-    let entry = reg
-        .entry_for_hash_mut(path_hash)
-        .ok_or(EnvRegistryError::UnknownKey(path_hash.to_string()))?;
-
-    entry.deregister_activation(pid);
-    entry.remove_stale_activations();
-    let current_activations = entry.activations.len();
-
-    write_environment_registry(&reg, &reg_path, lock)?;
-    Ok(current_activations)
-}
-
 #[cfg(test)]
 mod test {
     use std::fs::OpenOptions;
     use std::io::BufWriter;
-    use std::process::{Child, Command};
 
     use proptest::arbitrary::{any, Arbitrary};
-    use proptest::collection::{hash_set, vec};
+    use proptest::collection::vec;
     use proptest::path::PathParams;
     use proptest::strategy::{BoxedStrategy, Just, Strategy};
     use proptest::{prop_assert, prop_assert_eq, prop_assume, proptest};
@@ -451,22 +320,19 @@ mod test {
             //   be in reality.
             (
                 PathBuf::arbitrary_with(PathParams::default().with_components(1..3)),
-                hash_set((1i32..=65535).prop_map(ActivationPid), 0..20),
                 vec(any::<RegisteredEnv>(), 0..=3),
             )
-                .prop_flat_map(|(path, activation_pids, mut registered_envs)| {
+                .prop_flat_map(|(path, mut registered_envs)| {
                     registered_envs.sort_by_cached_key(|e| e.created_at);
                     (
                         Just(path.clone()),
                         Just(path_hash(&path)),
-                        Just(activation_pids),
                         Just(registered_envs),
                     )
                 })
-                .prop_map(|(path, hash, activation_pids, envs)| RegistryEntry {
+                .prop_map(|(path, hash, envs)| RegistryEntry {
                     path_hash: hash.to_string(),
                     path,
-                    activations: activation_pids,
                     envs,
                 })
                 .boxed()
@@ -595,83 +461,5 @@ mod test {
             // Empty entries should be removed
             prop_assert!(reg.entry_for_hash(&hash).is_none());
         }
-
-        #[test]
-        fn entries_register_activation(mut entry: RegistryEntry, activation: ActivationPid) {
-            entry.register_activation(activation);
-            prop_assert!(entry.activations.contains(&activation));
-        }
-
-        #[test]
-        fn entries_deregister_activation(mut entry: RegistryEntry) {
-            prop_assume!(!entry.activations.is_empty());
-            let activations = entry.activations.clone();
-            let activation = activations.iter().next().unwrap();
-            entry.deregister_activation(*activation);
-            prop_assert!(!entry.activations.contains(activation));
-        }
-    }
-
-    /// Start a shortlived process that we can check the PID is running.
-    fn start_process() -> Child {
-        Command::new("sleep")
-            .arg("2")
-            .spawn()
-            .expect("failed to start")
-    }
-
-    /// Stop a shortlived process that we can check the PID is not running. It's
-    /// unlikely, but not impossible, that the kernel will have not re-used the
-    /// PID by the time we check it.
-    fn stop_process(mut child: Child) {
-        child.kill().expect("failed to kill");
-        child.wait().expect("failed to wait");
-    }
-
-    impl From<&Child> for ActivationPid {
-        fn from(child: &Child) -> Self {
-            Self(child.id() as i32)
-        }
-    }
-
-    #[test]
-    fn test_pid_is_running_lifecycle() {
-        let child = start_process();
-
-        let pid = ActivationPid::from(&child);
-        assert!(pid.is_running());
-
-        stop_process(child);
-        assert!(!pid.is_running());
-    }
-
-    #[test]
-    fn test_pid_is_running_pid1() {
-        // PID 1 is always running on Linux and MacOS but we don't have perms to send signals.
-        assert!(ActivationPid(1).is_running());
-    }
-
-    #[test]
-    fn test_remove_stale_activations() {
-        let child1 = start_process();
-        let child2 = start_process();
-        let activations_before = HashSet::from([
-            ActivationPid(1),
-            ActivationPid::from(&child1),
-            ActivationPid::from(&child2),
-        ]);
-        let mut entry = RegistryEntry {
-            path: PathBuf::from("foo"),
-            path_hash: String::from("foo"),
-            envs: vec![],
-            activations: activations_before.clone(),
-        };
-        entry.remove_stale_activations();
-        assert_eq!(entry.activations, activations_before);
-
-        stop_process(child1);
-        stop_process(child2);
-        entry.remove_stale_activations();
-        assert_eq!(entry.activations, HashSet::from([ActivationPid(1)]));
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1631,7 +1631,6 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
     use std::str::FromStr;
 
     use fslock::LockFile;
@@ -2556,7 +2555,6 @@ mod test {
                     created_at: 0,
                     pointer: EnvironmentPointer::Managed(pointer.clone()),
                 }],
-                activations: HashSet::new(),
             }],
         };
         let reg_path = env_registry_path(&flox);

--- a/cli/flox-watchdog/Cargo.toml
+++ b/cli/flox-watchdog/Cargo.toml
@@ -28,3 +28,4 @@ kqueue.workspace = true
 filetime = "0.2.25"
 tempfile.workspace = true
 serde_json.workspace = true
+flox-activations.workspace = true

--- a/cli/flox-watchdog/Cargo.toml
+++ b/cli/flox-watchdog/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow.workspace = true
 clap.workspace = true
 clap_derive.workspace = true
+flox-core.workspace = true
 flox-rust-sdk.workspace = true
 glob = "0.3.1"
 nix.workspace = true
@@ -16,6 +17,7 @@ once_cell.workspace = true
 sentry.workspace = true
 serde.workspace = true
 signal-hook.workspace = true
+time.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/cli/flox-watchdog/Cargo.toml
+++ b/cli/flox-watchdog/Cargo.toml
@@ -11,6 +11,7 @@ clap.workspace = true
 clap_derive.workspace = true
 flox-core.workspace = true
 flox-rust-sdk.workspace = true
+fslock.workspace = true
 glob = "0.3.1"
 nix.workspace = true
 once_cell.workspace = true

--- a/cli/flox-watchdog/src/process.rs
+++ b/cli/flox-watchdog/src/process.rs
@@ -226,7 +226,7 @@ impl Watcher for PidWatcher {
     fn should_clean_up(&self) -> Result<bool, super::Error> {
         let should_clean_up = self.pids_watching.is_empty();
         if !should_clean_up {
-            debug!("still watching {:?}", self.pids_watching);
+            debug!("still watching PIDs {:?}", self.pids_watching);
         }
         Ok(should_clean_up)
     }

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -114,8 +114,11 @@ teardown() {
   # Cleaning up the `BATS_TEST_TMPDIR` occasionally fails,
   # because of an 'env-registry.json' that gets concurrently written
   # by the watchdog as the activation terminates.
-  wait_for_watchdogs
-  project_teardown
+  if [ -n "${PROJECT_DIR:-}" ]; then
+    # Not all tests call project_setup
+    wait_for_watchdogs "$PROJECT_DIR"
+    project_teardown
+  fi
   common_test_teardown
 }
 
@@ -2593,6 +2596,10 @@ EOF
 }
 
 @test "profile: JUPYTER_PATH is modified when Jupyter is installed" {
+  # Although we don't actually use the environment this creates, we need to call
+  # it so wait_for_watchdogs has a PROJECT_DIR to look for
+  project_setup
+
   # Mock contains both extensions but only one is used in each install.
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/jupyter_with_extensions.json"
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -45,7 +45,7 @@ setup() {
 }
 
 teardown() {
-  wait_for_watchdogs
+  wait_for_watchdogs "$PROJECT_DIR"
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -47,7 +47,7 @@ setup() {
 }
 
 teardown() {
-  wait_for_watchdogs
+  wait_for_watchdogs "$PROJECT_DIR"
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -37,7 +37,7 @@ setup() {
 }
 
 teardown() {
-  wait_for_watchdogs
+  wait_for_watchdogs "$PROJECT_DIR"
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -42,7 +42,7 @@ setup() {
 
 teardown() {
   unset _FLOX_FLOXHUB_GIT_URL
-  wait_for_watchdogs
+  wait_for_watchdogs "$PROJECT_DIR"
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -74,7 +74,7 @@ teardown() {
   # Within the `services` tests, we call `setup_isolated_flox` during `setup()`,
   # which sets the data dir to a unique value for every test,
   # thus avoiding waiting for unrelated watchdog processes.
-  wait_for_watchdogs
+  wait_for_watchdogs "$PROJECT_DIR"
   project_teardown
   common_test_teardown
 }
@@ -581,7 +581,7 @@ EOF
     assert_success
 
     # give the watchdog a chance to clean up the services before the next iteration
-    wait_for_watchdogs
+    wait_for_watchdogs "$PROJECT_DIR"
   done
 }
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1015,7 +1015,7 @@ EOF
     timeout 2 cat finished
 EOF
   ) &
-  timeout 2 cat started
+  timeout 4 cat started
 
   run "$FLOX_BIN" activate --start-services -r "${OWNER}/${PROJECT_NAME}" -- bash -c \
     'echo > finished'
@@ -1035,7 +1035,7 @@ EOF
     timeout 2 cat finished
 EOF
   ) &
-  timeout 2 cat started
+  timeout 4 cat started
 
   run "$FLOX_BIN" services status -r "${OWNER}/${PROJECT_NAME}"
   assert_success

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -258,33 +258,6 @@ jq_edit() {
   mv "$_tmp" "$_file"
 }
 
-dummy_registry() {
-  local path="$1"; shift
-  local hash="$1"
-  REGISTRY_CONTENT="$(cat << EOF
-  {
-    "version": 1,
-    "entries": [
-      {
-        "hash": "$hash",
-        "path": "$path",
-        "envs": [
-          {
-            "created_at": 123,
-            "pointer": {
-              "name": "dummy_env",
-              "version": 1
-            }
-          }
-        ]
-      }
-    ]
-  }
-EOF
-)"
-  echo "$REGISTRY_CONTENT"
-}
-
 cat_teardown_fifo() {
   if [ -n "${TEARDOWN_FIFO:-}" ]; then
     timeout 1 cat "$TEARDOWN_FIFO"

--- a/cli/tests/watchdog.bats
+++ b/cli/tests/watchdog.bats
@@ -39,7 +39,7 @@ setup() {
 }
 
 teardown() {
-  wait_for_watchdogs
+  wait_for_watchdogs "$PROJECT_DIR"
   project_teardown
   common_test_teardown
 }

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,7 @@
                 PKGDB_BIN = null;
                 FLOX_BIN = null;
                 WATCHDOG_BIN = null;
+                FLOX_ACTIVATIONS_BIN = null;
               };
               flox-cli = prev.flox-cli.override {
                 flox-pkgdb = null;

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -167,7 +167,7 @@ writeShellScriptBin PROJECT_NAME ''
   ${
     if WATCHDOG_BIN == null then
       # We pass this to daemonize which requires an absolute path
-      "export WATCHDOG_BIN=\"$(which flox-watchdog)\";"
+      "export WATCHDOG_BIN=\"$(command -v flox-watchdog)\";"
     else
       "export WATCHDOG_BIN='${WATCHDOG_BIN}';"
   }

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -15,6 +15,7 @@
   entr,
   expect,
   findutils,
+  flox-activations,
   flox-buildenv,
   flox-pkgdb,
   flox-watchdog,
@@ -47,6 +48,7 @@
   PKGDB_BIN ? "${flox-pkgdb}/bin/pkgdb",
   FLOX_BIN ? "${flox-cli}/bin/flox",
   WATCHDOG_BIN ? "${flox-watchdog}/libexec/flox-watchdog",
+  FLOX_ACTIVATIONS_BIN ? "${flox-activations}/bin/flox-activations",
 }:
 let
   batsWith = bats.withLibraries (p: [
@@ -169,6 +171,12 @@ writeShellScriptBin PROJECT_NAME ''
     else
       "export WATCHDOG_BIN='${WATCHDOG_BIN}';"
   }
+  ${
+    if FLOX_ACTIVATIONS_BIN == null then
+      "export FLOX_ACTIVATIONS_BIN='flox-activations';"
+    else
+      "export FLOX_ACTIVATIONS_BIN='${FLOX_ACTIVATIONS_BIN}';"
+  }
   ${if FLOX_BIN == null then "export FLOX_BIN='flox';" else "export FLOX_BIN='${FLOX_BIN}';"}
   export PROCESS_COMPOSE_BIN='${process-compose}/bin/process-compose';
   export FLOX_INTERPRETER='${flox-activation-scripts}';
@@ -177,6 +185,7 @@ writeShellScriptBin PROJECT_NAME ''
         cat << EOF
   Usage: $0 [--flox <FLOX BINARY>| -F <FLOX BINARY>] \
             [--watchdog <WATCHDOG BINARY | -K <WATCHDOG BINARY>] \
+            [--flox-activations <FLOX ACTIVATIONS BINARY>] \
             [--pkgdb <PKGDB BINARY>| -P <PKGDB BINARY>] \
             [--nix <NIX BINARY>| -N <NIX BINARY>] \
             [--input-data <INPUT DATA> | -I <INPUT DATA>] \
@@ -208,6 +217,7 @@ writeShellScriptBin PROJECT_NAME ''
       -[fF]|--flox)           export FLOX_BIN="''${2?}"; shift; ;;
       -[kK]|--watchdog)       export WATCHDOG_BIN="''${2?}"; shift; ;;
       -[bB]|--buildenv)       export BUILDENV_BIN="''${2?}"; shift; ;;
+      --flox-activations)     export FLOX_ACTIVATIONS_BIN="''${2?}"; shift; ;;
       -[pP]|--pkgdb)          export PKGDB_BIN="''${2?}"; shift; ;;
       -[nN]|--nix)            export NIX_BIN="''${2?}"; shift; ;;
       -[iI]|--input-data)     export INPUT_DATA="''${2?}"; shift; ;;
@@ -263,6 +273,7 @@ writeShellScriptBin PROJECT_NAME ''
     echo "  FLOX_BIN:                 $FLOX_BIN";
     echo "  WATCHDOG_BIN:             $WATCHDOG_BIN";
     echo "  BUILDENV_BIN:             $BUILDENV_BIN";
+    echo "  FLOX_ACTIVATIONS_BIN:     $FLOX_ACTIVATIONS_BIN";
     echo "  PKGDB_BIN:                $PKGDB_BIN";
     echo "  NIX_BIN:                  $NIX_BIN";
     echo "  FLOX_INTERPRETER:         $FLOX_INTERPRETER";


### PR DESCRIPTION
Instead of using the environment registry to control when activations
are cleaned up, use activations.json

## Release notes

Removes the `activations` field of registered environments
in the environment registry file.
Effectively, the corresponding information is lost 
when switching back to a previous version of flox.