### PR TITLE
chore(watchdog): Move from bin to libexec

### DIFF
--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -42,7 +42,7 @@
   NIX_BIN ? "${nix}/bin/nix",
   PKGDB_BIN ? "${flox-pkgdb}/bin/pkgdb",
   FLOX_BIN ? "${flox-cli}/bin/flox",
-  WATCHDOG_BIN ? "${flox-watchdog}/bin/flox-watchdog",
+  WATCHDOG_BIN ? "${flox-watchdog}/libexec/flox-watchdog",
 }:
 let
   batsWith = bats.withLibraries (p: [

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -40,7 +40,7 @@ let
       GIT_PKG = gitMinimal;
 
       WATCHDOG_BIN =
-        if flox-watchdog == null then "flox-watchdog" else "${flox-watchdog}/bin/flox-watchdog";
+        if flox-watchdog == null then "flox-watchdog" else "${flox-watchdog}/libexec/flox-watchdog";
 
       FLOX_ZDOTDIR = flox-activation-scripts + "/activate.d/zdotdir";
 

--- a/pkgs/flox-watchdog/default.nix
+++ b/pkgs/flox-watchdog/default.nix
@@ -53,12 +53,15 @@ craneLib.buildPackage (
 
     # bundle manpages and completion scripts
     #
+    # mv: Moves to libexec to prevent it leaking onto PATH.
+    #
     # sed: Removes rust-toolchain from binary. Likely due to toolchain overriding.
     #   unclear about the root cause, so this is a hotfix.
     postInstall = ''
-      rm -f $out/bin/crane-*
+      mv $out/bin $out/libexec
+      rm -f $out/libexec/crane-*
       for target in "$(basename ${rust-toolchain.rust.outPath} | cut -f1 -d- )" ; do
-        sed -i -e "s|$target|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee|g" $out/bin/flox-watchdog
+        sed -i -e "s|$target|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee|g" $out/libexec/flox-watchdog
       done
     '';
 

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -44,7 +44,7 @@ symlinkJoin {
       ${lib.optionalString (SENTRY_ENV != null) "--set FLOX_SENTRY_ENV \"${SENTRY_ENV}\" "} \
       --set PKGDB_BIN       "${flox-pkgdb}/bin/pkgdb" \
       --set FLOX_BIN        "${flox-cli}/bin/flox" \
-      --set WATCHDOG_BIN    "${flox-watchdog}/bin/flox-watchdog" \
+      --set WATCHDOG_BIN    "${flox-watchdog}/libexec/flox-watchdog" \
       --set PROCESS_COMPOSE_BIN "${process-compose}/bin/process-compose" \
       --set FLOX_VERSION    "${version}"
   '';


### PR DESCRIPTION
## Proposed Changes

So that it doesn't get installed to `/usr/local/bin` on MacOS and end up leaking onto `$PATH`. We don't want to expose this to users because they never need to interface with it directly.

My understanding is that `flox-installers` collects up these packages and puts them into `/usr/local`, so that moving it within these packages will have the desired outcome.

⚠️ 

I extrapolated the intent and solution from #2101 but feel free to correct if I've misinterpreted. I'm on leave from the end of today so someone else will need to respond to any feedback and merge in my absence.


## Release Notes

N/A, don't think it's worth mentioning.
