### PR TITLE
build: bundle `nixpkgs` used at build time

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -22,6 +22,10 @@ static GNUMAKE_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
         .into()
 });
 
+static BUILDTIME_NIXPKGS_URL: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("COMMON_NIXPKGS_URL").unwrap_or_else(|_| env!("COMMON_NIXPKGS_URL").to_string())
+});
+
 pub trait ManifestBuilder {
     /// Build the specified packages defined in the environment at `flox_env`.
     /// The build process will start in the background.
@@ -93,6 +97,7 @@ impl FloxBuildMk {
         command.arg("--file").arg(&*FLOX_BUILD_MK);
         command.arg("--directory").arg(base_dir); // Change dir before reading makefile.
         command.arg(format!("FLOX_ENV={}", flox_env.display()));
+        command.arg(format!("BUILDTIME_NIXPKGS_URL={}", &*BUILDTIME_NIXPKGS_URL));
 
         command
     }

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -1,7 +1,8 @@
 {
-  pkgs ?
-    import (builtins.getFlake "github:flox/nixpkgs/dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f")
-      { },
+  # nixpkgs providing `lib` and `stdenv` (`runCommand`)
+  # this is overridden to point to the nixpkgs used to build flox by the caller
+  nixpkgs-url ? "github:flox/nixpkgs/stable",
+  pkgs ? (builtins.getFlake nixpkgs-url).legacyPackages.${builtins.currentSystem},
   name,
   flox-env,
   install-prefix,

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -23,6 +23,10 @@ MANIFEST_LOCK := $(FLOX_ENV)/manifest.lock
 ifeq (,$(wildcard $(MANIFEST_LOCK)))
   $(error $(MANIFEST_LOCK) not found)
 endif
+# Check that the BUILDTIME_NIXPKGS_URL is defined
+ifeq (,$(BUILDTIME_NIXPKGS_URL))
+  $(error BUILDTIME_NIXPKGS_URL not defined)
+endif
 
 # Substitute Nix store paths for packages required by this Makefile.
 __bashInteractive := @bashInteractive@
@@ -204,6 +208,7 @@ define BUILD_local_template =
 	    --argstr name "$(_name)" \
 	    --argstr flox-env "$(FLOX_ENV)" \
 	    --argstr install-prefix "$(_out)" \
+	    --argstr nixpkgs-url "$(BUILDTIME_NIXPKGS_URL)" \
 	    --out-link "result-$(_pname)" \
 	    2>&1 | $(_tee) $($(_pvarname)_logfile)
 
@@ -260,6 +265,7 @@ define BUILD_nix_sandbox_template =
 	    --argstr name "$(_name)" \
 	    --argstr srcTarball "$($(_pvarname)_src_tar)" \
 	    --argstr flox-env "$(FLOX_ENV)" \
+	    --argstr nixpkgs-url "$(BUILDTIME_NIXPKGS_URL)" \
 	    --argstr install-prefix "$(_out)" \
 	    $(if $($(_pvarname)_buildDeps),--arg buildDeps $($(_pvarname)_buildDeps_arg)) \
 	    --argstr buildScript "$($(_pvarname)_buildScript)" \

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -42,6 +42,7 @@
   massif-visualizer ? throw "`massif-visualizer' is required for memory profiling on Linux",
   substituteAll,
   symlinkJoin,
+  inputs,
 }:
 let
   batsWith = bats.withLibraries (p: [
@@ -75,14 +76,8 @@ let
     # they should be
     # a) bundled at buildtime if possible (binaries/packages)
     # b) use this version of nixpkgs i.e. (nix library utils such as `dockerTools`)
-    COMMON_NIXPKGS_URL =
-      let
-        lockfile = builtins.fromJSON (builtins.readFile ./../../flake.lock);
-        root = lockfile.nodes.${lockfile.root};
-        nixpkgs = lockfile.nodes.${root.inputs.nixpkgs}.locked;
-      in
-      # todo: use `builtins.flakerefToString` once flox ships with nix 2.18+
-      "github:NixOS/nixpkgs/${nixpkgs.rev}";
+    COMMON_NIXPKGS_URL = "path:${inputs.nixpkgs.outPath}";
+
   } // lib.optionalAttrs stdenv.isLinux { sentry_PREFIX = sentry-native.outPath; };
 in
 stdenv.mkDerivation (

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -36,6 +36,13 @@ let
 
     PROCESS_COMPOSE_BIN = "${process-compose}/bin/process-compose";
 
+    # Used by `flox build' to access `stdenv` at a known version
+    # When utilities from nixpkgs are used by flox at runtime,
+    # they should be
+    # a) bundled at buildtime if possible (binaries/packages)
+    # b) use this version of nixpkgs i.e. (nix library utils such as `lib` and `runCommand`)
+    COMMON_NIXPKGS_URL = "path:${inputs.nixpkgs.outPath}";
+
     # The current version of flox being built
     inherit FLOX_VERSION;
 


### PR DESCRIPTION
`flox build` should use a known and bundled version of nixpkgs, so that a) build issues related to the nixpkgs used do not depend
   on the user's environment or change from one environment to the other.
b) builds do not require downloading and unpacking nixpkgs at runtime.

With this change, `flox build` now depends on the same **store path** of nixpkgs as the build of flox itself,
i.e. the `nixpkgs` input of the flox crate.

```
  % nix eval --impure
  % nix build .#flox
  % nix path-info --recursive .#flox
  ...
  /nix/store/p2hby44a0qzrnd1vxcpcgfav6160rmcv-source

  % flox build
  ...
  nix build [..] --argstr nixpkgs-url path:/nix/store/p2hby44a0qzrnd1vxcpcgfav6160rmcv-source
```

In addition we updated the pkgdb/default.nix to use the same `path:` url, and make both implementations more similar to each other.

