### PR TITLE
fix: increase catalog client timeout

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -144,10 +144,11 @@ impl CatalogClient {
         }
 
         let client = {
-            let timeout = std::time::Duration::from_secs(15);
+            let conn_timeout = std::time::Duration::from_secs(15);
+            let req_timeout = std::time::Duration::from_secs(60);
             reqwest::ClientBuilder::new()
-                .connect_timeout(timeout)
-                .timeout(timeout)
+                .connect_timeout(conn_timeout)
+                .timeout(req_timeout)
                 .user_agent(format!("flox-cli/{}", &*FLOX_VERSION))
                 .default_headers(header_map)
         };


### PR DESCRIPTION
There was at least one report of a general Catalog Connection Error that was due to a timeout waiting for a resolution response.  Ideally we would improve the performance of the resolution API call, but even then, 15s is somewhat aggressive.

## Proposed Changes

Increase catalog client timeout to 60s.

## Release Notes

Made the timeout for catalog service calls longer to address occasional timeouts
