### PR TITLE
collect build outputs for publish

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -79,7 +79,7 @@ pub struct CheckedEnvironmentMetadata {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedBuildMetadata {
     // Define metadata coming from the build, e.g. outpaths
-    pub outputs: Option<Vec<String>>,
+    pub outputs: Vec<String>,
 
     // This field isn't "pub", so no one outside this module can construct this struct. That helps
     // ensure that we can only make this struct as a result of doing the "right thing."
@@ -138,6 +138,7 @@ where
     }
 }
 
+/// Collect metadata needed for publishing that is obtained from the build output
 fn check_build_metadata(
     env: &PathEnvironment,
     pkg: &str,
@@ -169,7 +170,7 @@ fn check_build_metadata(
     }
 
     Ok(CheckedBuildMetadata {
-        outputs: Some(outputs),
+        outputs,
         _private: (),
     })
 }
@@ -372,8 +373,8 @@ pub mod tests {
         assert_build_status(&flox, &mut env, EXAMPLE_PACKAGE_NAME, true);
 
         let meta = check_build_metadata(&env, EXAMPLE_PACKAGE_NAME).unwrap();
-        assert_eq!(meta.outputs.is_some(), true);
-        assert_eq!(meta.outputs.unwrap()[0].starts_with("/nix/store/"), true);
+        assert_eq!(meta.outputs.len(), 1);
+        assert_eq!(meta.outputs[0].starts_with("/nix/store/"), true);
     }
 
     // Template end to end test

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -143,7 +143,7 @@ fn check_build_metadata(
     pkg: &str,
 ) -> Result<CheckedBuildMetadata, PublishError> {
     // For now assume the build is successful, and present.
-    // look for the outputs from the build at `results-<pkgname>`
+    // look for the outputs from the build at `result-<pkgname>`
     // See tests in build.rs for examples
 
     let result_dir = env

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -117,7 +117,7 @@ where
             PublishEnvironment::Managed(_env) => return Err(PublishError::UnsupportedEnvironment),
             PublishEnvironment::Path(env) => (
                 check_environment_metadata(flox, &env)?,
-                check_builder_metadata(&env, package)?,
+                check_build_metadata(&env, package)?,
             ),
         };
 
@@ -138,7 +138,7 @@ where
     }
 }
 
-fn check_builder_metadata(
+fn check_build_metadata(
     env: &PathEnvironment,
     pkg: &str,
 ) -> Result<CheckedBuildMetadata, PublishError> {
@@ -148,8 +148,7 @@ fn check_builder_metadata(
 
     let result_dir = env
         .parent_path()
-        .map_err(|e| PublishError::UnsupportEnvironmentState(Box::new(e)))
-        .unwrap()
+        .map_err(|e| PublishError::UnsupportEnvironmentState(Box::new(e)))?
         .join(format!("result-{pkg}"));
     let store_dir = result_dir
         .read_link()
@@ -298,12 +297,6 @@ pub mod tests {
         (tempdir_handle, repo, remote_uri)
     }
 
-    // fn example_builder(flox: &Flox, env: &mut PathEnvironment, package_name: &str) -> impl ManifestBuilder {
-    //     let builder = FloxBuildMk;
-
-    //     return builder;
-    // }
-
     fn example_path_environment(
         flox: &Flox,
         remote: Option<&String>,
@@ -378,7 +371,7 @@ pub mod tests {
         // Do the build to ensure it's been run.  We just want to find the outputs
         assert_build_status(&flox, &mut env, EXAMPLE_PACKAGE_NAME, true);
 
-        let meta = check_builder_metadata(&env, EXAMPLE_PACKAGE_NAME).unwrap();
+        let meta = check_build_metadata(&env, EXAMPLE_PACKAGE_NAME).unwrap();
         assert_eq!(meta.outputs.is_some(), true);
         assert_eq!(meta.outputs.unwrap()[0].starts_with("/nix/store/"), true);
     }

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -367,7 +367,7 @@ pub mod tests {
 
         let meta = check_build_metadata(&env, EXAMPLE_PACKAGE_NAME).unwrap();
         assert_eq!(meta.outputs.len(), 1);
-        assert_eq!(meta.outputs[0].starts_with("/nix/store/"), true);
+        assert_eq!(meta.outputs[0].store_path.starts_with("/nix/store/"), true);
     }
 
     // Template end to end test


### PR DESCRIPTION
For a PoC, just collect the out paths present in the results location.  It will be assumed the user has done the build already.  This is working towards having a functional end-to-end publish/consume workflow on the local machine only, using storepaths only.