### PR TITLE
fix: local test failure

### DIFF
--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -152,7 +152,8 @@ writeShellScriptBin PROJECT_NAME ''
   }
   ${
     if WATCHDOG_BIN == null then
-      "export WATCHDOG_BIN='flox-watchdog';"
+      # We pass this to daemonize which requires an absolute path
+      "export WATCHDOG_BIN=\"$(which flox-watchdog)\";"
     else
       "export WATCHDOG_BIN='${WATCHDOG_BIN}';"
   }


### PR DESCRIPTION
When running the test `kills daemon process` locally it fails. This is because flox-cli-tests sets FLOX_WATCHDOG to `flox-watchdog` instead of an absolute path. Our daemonize call in the activation scripts then fails with `The 'path' parameter must be an absolute path name.`

Use `which flox-watchdog` to set an absolute path instead.

## Release Notes

NA