### PR TITLE
ci: fix git commit message checks

### DIFF
--- a/.github/workflows/nix-managed-lints.yml
+++ b/.github/workflows/nix-managed-lints.yml
@@ -47,17 +47,23 @@ jobs:
         # prepend `refs/heads/` to match the format of
         # `github.event.merge_group.base_ref`.
         run: |
-          echo 'TARGET_BRANCH=refs/heads/${{ github.base_ref }}' >> "$GITHUB_ENV";
+          echo 'TARGET_REF=refs/heads/${{ github.base_ref }}' >> "$GITHUB_ENV";
+          echo 'HEAD_REF=refs/heads/${{ github.head_ref }}' >> "$GITHUB_ENV";
 
       - name: "Fetch target branch ( Merge Queue )"
         if: ${{ github.event_name == 'merge_group' }}
         run: |
-          echo 'TARGET_BRANCH=${{ github.event.merge_group.base_ref }}' >> "$GITHUB_ENV";
+          echo 'TARGET_REF=${{ github.event.merge_group.base_ref }}' >> "$GITHUB_ENV";
+          echo 'HEAD_REF=${{ github.event.merge_group.head_ref }}' >> "$GITHUB_ENV";
 
-      # Fetch the target branch and create a local reference to it.
-      - name: "Fetch target branch"
+      # Fetch the head and target branch and create a local reference to it.
+      # Apparently git does not like fetching into the current branch,
+      # so we fetch into temporary branches `target` and `head`.
+      - name: "Fetch branches"
         run: |
-          git fetch origin "$TARGET_BRANCH:$TARGET_BRANCH";
+          git fetch --atomic origin \
+            "$TARGET_REF:target" \
+            "$HEAD_REF:head";
 
       # avoid the next step being filled with nix substitution logs
       # and ensure that `pre-commit` can run cargo with the `--offline` flag
@@ -73,11 +79,14 @@ jobs:
       # `git rev-parse`.
       - name: "Run Nix Git Hooks"
         run: |
+          echo "TARGET_REF: $TARGET_REF ($( git rev-parse "target" ))"
+          echo "HEAD_REF: $HEAD_REF ($( git rev-parse "head" ))"
+
           nix develop -L --no-update-lock-file --command \
             pre-commit run \
               --hook-stage manual \
-              --from-ref "$( git rev-parse "$TARGET_BRANCH" )" \
-              --to-ref   "$( git rev-parse HEAD )";
+              --from-ref "$( git rev-parse "target" )" \
+              --to-ref   "$( git rev-parse "head" )";
 
 # ---------------------------------------------------------------------------- #
 #


### PR DESCRIPTION
Incorrectly formatted commit messages (i.e. commit messages
that are not complying with conventional commits' format,
will now _actually_ cause failures of the "Project Lints / Nix Git Hooks" Job.
These failures will look as the one below.

Previously we checked the commit range `<PR target branch>..HEAD`.
However, in `pull_request` events `HEAD` will point to a _detached merge commit_,
or otherwise independent history,
such that commitizen never actually got to checked the correct git history.

This commit changes the action to instead use `github.head_ref` (`pull_request` events)
or `github.events.merge_group.head_ref` (`merge_group` events).

```
TARGET_REF: refs/heads/main (abe3a55d415974cedaa014d13a588cfbadba3417)
HEAD_REF: refs/heads/ci/message-lints-2 (21e6f3a5dc9b35e24688d2de64917d7808fd3642)
evaluation warning: `rust.toRustTarget platform` is deprecated. Use `platform.rust.rustcTarget` instead.
clang-format.........................................(no files to check)Skipped
clippy...............................................(no files to check)Skipped
commitizen-in-ci.........................................................Failed
- hook id: commitizen-in-ci
- exit code: 14

commit validation: failed!
please enter a commit message in the commitizen format.
commit "a2b983c2b62b7d453b719733237cd3bfa04d81": "not compliant"
pattern: (?s)(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)(\(\S+\))?!?:( [^\n\r]+)((\n\n.*)|(\s*))?$

nixfmt-rfc-style.....................................(no files to check)Skipped
rustfmt..............................................(no files to check)Skipped
```