### PR TITLE
fix: hide default prompt by default

### DIFF
--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -99,7 +99,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 
 `hide_default_prompt`
 :   Hide environments named 'default' from the shell prompt,
-    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: false).
+    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: true).
 
 `search_limit`
 :   How many items `flox search` should show by default.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -264,7 +264,7 @@ impl Activate {
             "}),
             (set_prompt, hide_default_prompt, _) => (
                 set_prompt.unwrap_or(true),
-                hide_default_prompt.unwrap_or(false),
+                hide_default_prompt.unwrap_or(true),
             ),
         };
 


### PR DESCRIPTION
This more closely matches the behavior of a system package manager

## Release Notes

- Hide default environments from shell prompts by default