### PR TITLE
Publish unit test followups

### DIFF
--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -1238,14 +1238,13 @@ pub mod tests {
 
     #[test]
     fn test_rev_count() {
-        let (_, tempdir_handle) = init_temp_repo(false);
-        let path = tempdir_handle.path().canonicalize().unwrap();
-        let repo = GitCommandProvider::discover(&path).unwrap();
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
         let ct = repo.rev_count("HEAD");
         assert!(ct.is_err());
 
         commit_file(&repo, "dummy");
-        let hash_1 = repo.branch_hash("master").unwrap();
+        let hash_1 = repo.branch_hash("branch_1").unwrap();
         let ct = repo.rev_count("HEAD").unwrap();
         assert_eq!(ct, 1);
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -280,7 +280,7 @@ pub mod tests {
     fn example_remote() -> (tempfile::TempDir, GitCommandProvider, String) {
         let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
 
-        let repo = GitCommandProvider::init(tempdir_handle.path(), false).unwrap();
+        let repo = GitCommandProvider::init(tempdir_handle.path(), true).unwrap();
 
         let remote_uri = format!("file://{}", tempdir_handle.path().display());
 
@@ -307,17 +307,16 @@ pub mod tests {
         remote: Option<&String>,
     ) -> (PathEnvironment, GitCommandProvider) {
         let env =
-            new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/publish-simple"));
+            new_path_environment_from_env_files(flox, GENERATED_DATA.join("envs/publish-simple"));
 
         let git = GitCommandProvider::init(
-            &env.parent_path().expect("Parent path must be accessible"),
+            env.parent_path().expect("Parent path must be accessible"),
             false,
         )
         .unwrap();
 
         git.checkout("main", true).expect("checkout main branch");
-        git.add(&[&env.dot_flox_path().to_path_buf()])
-            .expect("adding flox files");
+        git.add(&[&env.dot_flox_path()]).expect("adding flox files");
         git.commit("Initial commit").expect("be able to commit");
 
         if let Some(uri) = remote {


### PR DESCRIPTION
[test: fix test_rev_count](https://github.com/flox/flox/commit/41dd6c89688bb0444bdd25c0c4cad961b41f1802)

test_rev_count is failing for me with:
```
thread 'providers::git::tests::test_rev_count' panicked at flox-rust-sdk/src/providers/git.rs:1248:49:
called `Result::unwrap()` on an `Err` value: DoesNotExist
```

I think this is due to my git defaulting to `main` instead of `master`.
Use `branch_1` for consistency with other tests instead.

Also use the repo returned by `init_temp_repo()`

[test: use bare repo for example_remote()](https://github.com/flox/flox/commit/0e57ec24333d8d67624886ad34eed6de78c57ded)

test_check_env_meta_nominal is currently failing for me with:
```
thread 'providers::publish::tests::test_check_env_meta_nominal' panicked at flox-rust-sdk/src/providers/publish.rs:325:38:
push to origin: Command(BadExit(1, "To file:///var/folders/2w/r9qm37r12qs4xn3sjn4cv2ym0000gn/T/nix-shell.J0LAzk/.tmpvA9J2M\n!\tHEAD:refs/heads/main\t[remote rejected] (branch is currently checked out)\nDone\n", "remote: error: refusing to update checked out branch: refs/heads/main        \nremote: error: By default, updating the current branch in a non-bare repository        \nremote: is denied, because it will make the index and work tree inconsistent        \nremote: with what you pushed, and will require 'git reset --hard' to match        \nremote: the work tree to HEAD.        \nremote: \nremote: You can set the 'receive.denyCurrentBranch' configuration variable        \nremote: to 'ignore' or 'warn' in the remote repository to al
low pushing into        \nremote: its current branch; however, this is not recommended unless you        \nremote: arranged to update its work tree to match what you pushed in some        \nremote: other way.        \nremote: \nremote: To squelch this message and still keep the default behaviour, set        \nremote: 'receive.denyCurrentBranch' configuration variable to 'refuse'.        \nerror: failed to push some refs to 'file:///var/folders/2w/r9qm37r12qs4xn3sjn4cv2ym0000gn/T/nix-shell.J0LAzk/.tmpvA9J2M'\n"))
```

I'm not sure why this would only be failing for me locally, but it makes
sense to use a bare repo.

Fix some clippy lints as well.

## Release Notes
NA
