### PR TITLE
feat: prompt to create default environment

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -2561,7 +2561,7 @@ mod test {
         };
         let reg_path = env_registry_path(&flox);
         let lock = LockFile::open(&env_registry_lock_path(reg_path)).unwrap();
-        write_environment_registry(&reg, &env_registry_path(&flox), lock).unwrap();
+        write_environment_registry(&reg, env_registry_path(&flox), lock).unwrap();
         let branch_name = branch_name(&pointer, &path);
         let decoded_path = ManagedEnvironment::decode(&flox, &branch_name).unwrap();
         let canonicalized_decoded_path = std::fs::canonicalize(decoded_path).unwrap();

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -359,7 +359,7 @@ impl DotFlox {
 #[derive(Debug, Error)]
 pub enum EnvironmentError {
     // todo: candidate for impl specific error
-    // * only path and managed env are defined in .Flox
+    // * only path and managed env are defined in .flox
     // region: path env open
     /// The `.flox` directory was not found
     /// This error is thrown by calling [DotFlox::open_default_in]

--- a/cli/flox-rust-sdk/src/models/mod.rs
+++ b/cli/flox-rust-sdk/src/models/mod.rs
@@ -8,3 +8,4 @@ pub mod lockfile;
 pub mod manifest;
 pub mod pkgdb;
 pub mod search;
+pub mod user_state;

--- a/cli/flox-rust-sdk/src/models/user_state.rs
+++ b/cli/flox-rust-sdk/src/models/user_state.rs
@@ -1,0 +1,94 @@
+use std::path::{Path, PathBuf};
+
+use flox_core::{serialize_atomically, traceable_path, SerializeError};
+use fslock::LockFile;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::flox::Flox;
+
+pub const USER_STATE_FILENAME: &str = "user_state.json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum UserStateError {
+    #[error("couldn't acquire user state file lock")]
+    AcquireLock(#[source] fslock::Error),
+    #[error("couldn't read user state file")]
+    ReadFile(#[source] std::io::Error),
+    #[error("couldn't parse user state file")]
+    Parse(#[source] serde_json::Error),
+    #[error("failed to write user state file")]
+    WriteFile(#[source] SerializeError),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserState {
+    pub confirmed_create_default_env: Option<bool>,
+}
+
+// TODO: These functions are very close to their counterparts in
+// `env_registry.rs` and `activations.rs`.
+//       The main differences are error types. We could share a common set of functionality
+//       by creating a trait that uses associated types/constants to identify the error types
+//       that are used at the different steps, then provide default implementations for the
+//       operations since they're essentially identical.
+
+/// Returns the path to the user's state file.
+pub fn user_state_path(flox: &Flox) -> PathBuf {
+    flox.cache_dir.join(USER_STATE_FILENAME)
+}
+
+/// Returns the path to the user state lock file. The presensce
+/// of the lock file does not indicate an active lock because the file isn't
+/// removed after use. This is a separate file because we replace the state file
+/// on write.
+pub(crate) fn user_state_lock_path(state_file_path: impl AsRef<Path>) -> PathBuf {
+    state_file_path.as_ref().with_extension("lock")
+}
+
+/// Returns the parsed state file or `None` if it doesn't yet exist.
+pub fn read_user_state_file(path: impl AsRef<Path>) -> Result<Option<UserState>, UserStateError> {
+    let path = path.as_ref();
+    if !path.exists() {
+        debug!(path = traceable_path(&path), "user state file not found");
+        return Ok(None);
+    }
+    let contents = std::fs::read_to_string(path).map_err(UserStateError::ReadFile)?;
+    let parsed: UserState = serde_json::from_str(&contents).map_err(UserStateError::Parse)?;
+    Ok(Some(parsed))
+}
+
+/// Acquires the filesystem-based lock on the user state file
+pub fn acquire_user_state_lock(
+    state_file_path: impl AsRef<Path>,
+) -> Result<LockFile, UserStateError> {
+    let lock_path = user_state_lock_path(state_file_path);
+    let mut lock = LockFile::open(lock_path.as_os_str()).map_err(UserStateError::AcquireLock)?;
+    lock.lock().map_err(UserStateError::AcquireLock)?;
+    Ok(lock)
+}
+
+/// Writes the user state file to disk.
+///
+/// First the registry is written to a temporary file and then it is renamed so the write appears
+/// atomic. This also takes a [LockFile] argument to ensure that the write can only be performed
+/// when the lock is acquired. It is a bug if you pass a [LockFile] that doesn't correspond to the
+/// user state file, as that is essentially bypassing the lock.
+pub fn write_user_state_file(
+    state: &UserState,
+    path: impl AsRef<Path>,
+    lock: LockFile,
+) -> Result<(), UserStateError> {
+    serialize_atomically(state, &path, lock).map_err(UserStateError::WriteFile)
+}
+
+/// Acquires the lock on the user state file before reading it, returning
+/// both the lock and the parsed file contents.
+pub fn lock_and_read_user_state_file(
+    path: impl AsRef<Path>,
+) -> Result<(LockFile, UserState), UserStateError> {
+    debug!(path = traceable_path(&path), "reading user state file");
+    let lock = acquire_user_state_lock(&path)?;
+    let state = read_user_state_file(&path)?.unwrap_or_default();
+    Ok((lock, state))
+}

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -96,7 +96,7 @@ impl Install {
             .detect_concrete_environment(&flox, "Install to")
         {
             Ok(concrete_environment) => concrete_environment,
-            Err(EnvironmentSelectError::Environment(
+            Err(EnvironmentSelectError::EnvironmentError(
                 ref e @ EnvironmentError::DotFloxNotFound(ref dir),
             )) => {
                 let parent = dir.parent().unwrap_or(dir).display();

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -81,7 +81,7 @@ impl Install {
         subcommand_metric!("install");
 
         debug!(
-            "installing packages [{}] to {:?}",
+            "attempting to install packages [{}] to {:?}",
             self.packages.as_slice().join(", "),
             self.environment
         );

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -107,6 +107,7 @@ impl Install {
                 })
             },
             Err(e @ EnvironmentSelectError::EnvNotFoundInCurrentDirectory) => {
+                // TODO: prompt for initialization here
                 bail!(formatdoc! {"
                 {e}
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -986,7 +986,7 @@ pub enum EnvironmentSelect {
 #[derive(Debug, Error)]
 pub enum EnvironmentSelectError {
     #[error(transparent)]
-    Environment(#[from] EnvironmentError),
+    EnvironmentError(#[from] EnvironmentError),
     #[error("Did not find an environment in the current directory.")]
     EnvNotFoundInCurrentDirectory,
     #[error(transparent)]

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -48,7 +48,7 @@ impl Uninstall {
             .detect_concrete_environment(&flox, "Uninstall from")
         {
             Ok(concrete_environment) => concrete_environment,
-            Err(EnvironmentSelectError::Environment(
+            Err(EnvironmentSelectError::EnvironmentError(
                 ref e @ EnvironmentError::DotFloxNotFound(ref dir),
             )) => {
                 let parent = dir.parent().unwrap_or(dir).display();

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -691,7 +691,7 @@ pub fn format_environment_select_error(err: &EnvironmentSelectError) -> String {
     trace!("formatting environment_select_error: {err:?}");
 
     match err {
-        EnvironmentSelectError::Environment(err) => format_error(err),
+        EnvironmentSelectError::EnvironmentError(err) => format_error(err),
         EnvironmentSelectError::EnvNotFoundInCurrentDirectory => formatdoc! {"
             Did not find an environment in the current directory.
         "},

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -275,7 +275,7 @@ EOF
 
 # bats test_tags=remote,remote:not-found
 @test "install --remote fails on a non existent environment" {
-  run "$FLOX_BIN" install -r "$OWNER/i-dont-exist"
+  run "$FLOX_BIN" install hello -r "$OWNER/i-dont-exist"
   assert_failure
   assert_output --partial "Environment not found in FloxHub."
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


**feat: prompt to create default environment**

This prompts the user to create a default environment the first time
that they attempt to install a package without an activated environment
and without an environment in the current directory. This choice is
persisted in a new file called `user_state.json`. The field for this
choice is an Option<bool> so we can represent "unprompted" as None, and
the user's choice as Some(value). If the user cancels the operation, no
choice is persisted.

**chore: address clippy lints**

The paperclip was complaining.

**refactor: rename error variant**

The previous name was unclear at the call site. The new name makes it
clear that it's simply a wrapped `EnvironmentError`.

**chore: clarify language in debug msg**

Makes it clear that the packages have not yet been installed.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users will now be prompted to create a `default` environment when attempting to install a package where no other environment is active or present in the current directory. This removes friction when using Flox as a Homebrew replacement.

<!-- Many thanks! -->
