### PR TITLE
feat: publish collected package metadata

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -226,16 +226,10 @@ pub mod test_helpers {
     use crate::providers::git::{GitCommandProvider, GitProvider};
 
     pub fn create_test_token(handle: &str) -> Result<FloxhubToken, FloxhubTokenError> {
-        #[derive(Debug, Clone, Deserialize, Serialize)]
-        struct MyClaims {
-            #[serde(rename = "https://flox.dev/handle")]
-            handle: String,
-            exp: usize,
-        }
-        let my_claims = MyClaims {
-            handle: handle.to_owned(),
-            exp: 9999999999,
-        };
+        let my_claims = serde_json::json!({
+            "https://flox.dev/handle": {handle},
+            "exp": 9999999999,
+        });
 
         // my_claims is a struct that implements Serialize
         // This will create a JWT using HS256 as algorithm

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -225,6 +225,30 @@ pub mod test_helpers {
     use super::*;
     use crate::providers::git::{GitCommandProvider, GitProvider};
 
+    pub fn create_test_token(handle: &str) -> Result<FloxhubToken, FloxhubTokenError> {
+        #[derive(Debug, Clone, Deserialize, Serialize)]
+        struct MyClaims {
+            #[serde(rename = "https://flox.dev/handle")]
+            handle: String,
+            exp: usize,
+        }
+        let my_claims = MyClaims {
+            handle: handle.to_owned(),
+            exp: 9999999999,
+        };
+
+        // my_claims is a struct that implements Serialize
+        // This will create a JWT using HS256 as algorithm
+        let token = jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &my_claims,
+            &jsonwebtoken::EncodingKey::from_secret("secret".as_ref()),
+        )
+        .unwrap();
+
+        FloxhubToken::from_str(&token)
+    }
+
     pub fn flox_instance() -> (Flox, TempDir) {
         flox_instance_with_optional_floxhub(None)
     }

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -225,10 +225,10 @@ pub mod test_helpers {
     use super::*;
     use crate::providers::git::{GitCommandProvider, GitProvider};
 
-    pub fn create_test_token(handle: &str) -> Result<FloxhubToken, FloxhubTokenError> {
+    pub fn create_test_token(handle: &str) -> FloxhubToken {
         let my_claims = serde_json::json!({
-            "https://flox.dev/handle": {handle},
-            "exp": 9999999999,
+        "https://flox.dev/handle": handle,
+        "exp": 9999999999_i64
         });
 
         // my_claims is a struct that implements Serialize
@@ -240,7 +240,7 @@ pub mod test_helpers {
         )
         .unwrap();
 
-        FloxhubToken::from_str(&token)
+        FloxhubToken::from_str(&token).unwrap()
     }
 
     pub fn flox_instance() -> (Flox, TempDir) {

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1515,12 +1515,14 @@ pub(crate) mod tests {
 
     use catalog::test_helpers::resolved_pkg_group_with_dummy_package;
     use catalog::{
+        CatalogClientError,
         MsgAttrPathNotFoundSystemsNotOnSamePage,
         MsgGeneral,
         MsgUnknown,
         ResolutionMessage,
         ResolveError,
         SearchError,
+        UserBuildInfo,
         VersionsError,
     };
     use catalog_api_v1::types::{Output, ResolvedPackageDescriptor};
@@ -1559,6 +1561,30 @@ pub(crate) mod tests {
             _: impl AsRef<str> + Send + Sync,
         ) -> Result<SearchResults, VersionsError> {
             unreachable!("package_versions should not be called");
+        }
+
+        async fn create_catalog(
+            &self,
+            _catalog_name: impl AsRef<str> + Send + Sync,
+        ) -> Result<(), CatalogClientError> {
+            unreachable!("catalog service should not be called");
+        }
+
+        async fn create_package(
+            &self,
+            _catalog_name: impl AsRef<str> + Send + Sync,
+            _package_name: impl AsRef<str> + Send + Sync,
+        ) -> Result<(), CatalogClientError> {
+            unreachable!("catalog service should not be called");
+        }
+
+        async fn publish_build(
+            &self,
+            _catalog_name: impl AsRef<str> + Send + Sync,
+            _package_name: impl AsRef<str> + Send + Sync,
+            _build_info: &UserBuildInfo,
+        ) -> Result<(), CatalogClientError> {
+            unreachable!("catalog service should not be called");
         }
     }
 

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -280,6 +280,9 @@ impl MockClient {
     }
 }
 
+pub type UserBuildInfo = api_types::UserBuildInput;
+pub type UserDerivationInfo = api_types::UserDerivationInput;
+
 #[enum_dispatch]
 #[allow(async_fn_in_trait)]
 pub trait ClientTrait {
@@ -303,6 +306,27 @@ pub trait ClientTrait {
         &self,
         attr_path: impl AsRef<str> + Send + Sync,
     ) -> Result<SearchResults, VersionsError>;
+
+    /// Create a user catalog
+    async fn create_catalog(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+    ) -> Result<(), CatalogClientError>;
+
+    /// Create a package within a user catalog
+    async fn create_package(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+        _package_name: impl AsRef<str> + Send + Sync,
+    ) -> Result<(), CatalogClientError>;
+
+    /// Publish a build of a user package
+    async fn publish_build(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+        _package_name: impl AsRef<str> + Send + Sync,
+        _build_info: &UserBuildInfo,
+    ) -> Result<(), CatalogClientError>;
 }
 
 impl ClientTrait for CatalogClient {
@@ -455,6 +479,30 @@ impl ClientTrait for CatalogClient {
         Self::maybe_dump_shim_response(&search_results);
 
         Ok(search_results)
+    }
+
+    async fn create_catalog(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+    ) -> Result<(), CatalogClientError> {
+        Ok(())
+    }
+
+    async fn create_package(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+        _package_name: impl AsRef<str> + Send + Sync,
+    ) -> Result<(), CatalogClientError> {
+        Ok(())
+    }
+
+    async fn publish_build(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+        _package_name: impl AsRef<str> + Send + Sync,
+        _build_info: &UserBuildInfo,
+    ) -> Result<(), CatalogClientError> {
+        Ok(())
     }
 }
 
@@ -619,6 +667,30 @@ impl ClientTrait for MockClient {
                 panic!("expected mock response, found nothing");
             },
         }
+    }
+
+    async fn create_catalog(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+    ) -> Result<(), CatalogClientError> {
+        Ok(())
+    }
+
+    async fn create_package(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+        _package_name: impl AsRef<str> + Send + Sync,
+    ) -> Result<(), CatalogClientError> {
+        Ok(())
+    }
+
+    async fn publish_build(
+        &self,
+        _catalog_name: impl AsRef<str> + Send + Sync,
+        _package_name: impl AsRef<str> + Send + Sync,
+        _build_info: &UserBuildInfo,
+    ) -> Result<(), CatalogClientError> {
+        Ok(())
     }
 }
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -413,7 +413,7 @@ pub mod tests {
         assert_build_status(&flox, &mut env, EXAMPLE_PACKAGE_NAME, true);
 
         let client = Client::Mock(MockClient::new(None::<String>).unwrap());
-        let token = create_test_token("test").unwrap();
+        let token = create_test_token("test");
 
         let (env_meta, build_meta) = (
             check_environment_metadata(&flox, &env).unwrap(),


### PR DESCRIPTION
This is an incremental update to the publish workflow, and only makes the calls into the catalog provider.  The actual calls to the service are not yet implemented, nor is there any CLI command to invoke any of this code.  There are separate PRs in progress for wiring up a new `flox publish` to this code, and to implement the calls to the catalog service (with it's own PRs and updates).