### PR TITLE
chore: nix flake update

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -112,7 +112,7 @@ setup_start_counter_services() {
 @test "can call process-compose" {
   run "$PROCESS_COMPOSE_BIN" version
   assert_success
-  assert_output --partial "v1.27.0"
+  assert_output --partial "v1.34.0"
 }
 
 @test "process-compose can run generated config file" {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1725125250,
-        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
+        "lastModified": 1730652660,
+        "narHash": "sha256-+XVYfmVXAiYA0FZT7ijHf555dxCe+AoAT5A6RU+6vSo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
+        "rev": "a4ca93905455c07cb7e3aca95d4faf7601cba458",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1725258763,
-        "narHash": "sha256-7s5RfYlTljWnKGkK4hOMJCJ0sNQoLYjMxezX3Vijy/0=",
+        "lastModified": 1730702146,
+        "narHash": "sha256-a657FU8MS5m0Y4pQvcmQPfvXYOPpxih7u2hU57Bn2i4=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "0774f58cf1025bbb713971deecc7f07c856be6ed",
+        "rev": "fa3610f841725c8e20fc0fab070ee60609fdd5ee",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727122398,
-        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
+        "lastModified": 1729665710,
+        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
+        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725191098,
-        "narHash": "sha256-YH0kH5CSOnAuPUB1BUzUqvnKiv5SgDhfMNjrkki9Ahk=",
+        "lastModified": 1730645367,
+        "narHash": "sha256-RnmBO+9zmZ3NpU6+NfYUDRg31dsPZ17xUqXVw/ZOKZ8=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "779d9eee2ea403da447278a7007c9627c8878856",
+        "rev": "e44691a60443f1246a077df659607ca89f2ddc58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Notably this includes a newer version of nixpkgs that has https://github.com/flox/nixpkgs/commit/d0b33648223427e635df7336097f8732764d3419

• Updated input 'crane':
    'github:ipetkov/crane/96fd12c7100e9e05fa1a0a5bd108525600ce282f' (2024-08-31)
  → 'github:ipetkov/crane/a4ca93905455c07cb7e3aca95d4faf7601cba458' (2024-11-03)
• Updated input 'fenix':
    'github:nix-community/fenix/0774f58cf1025bbb713971deecc7f07c856be6ed' (2024-09-02)
  → 'github:nix-community/fenix/fa3610f841725c8e20fc0fab070ee60609fdd5ee' (2024-11-04)
• Updated input 'fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/779d9eee2ea403da447278a7007c9627c8878856' (2024-09-01)
  → 'github:rust-lang/rust-analyzer/e44691a60443f1246a077df659607ca89f2ddc58' (2024-11-03)
• Updated input 'nixpkgs':
    'github:flox/nixpkgs/30439d93eb8b19861ccbe3e581abf97bdc91b093' (2024-09-23)
  → 'github:flox/nixpkgs/2768c7d042a37de65bb1b5b3268fc987e534c49d' (2024-10-23)

## Release Notes

NA