### PR TITLE
feat: auto add activation for default env

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -755,7 +755,7 @@ impl Activate {
     /// 2. SHELL environment variable
     /// 3. Parent process shell
     /// 4. Default to bash bundled with flox
-    fn detect_shell_for_subshell() -> Shell {
+    pub(crate) fn detect_shell_for_subshell() -> Shell {
         Self::detect_shell_for_subshell_with(Shell::detect_from_parent_process)
     }
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -755,7 +755,7 @@ impl Activate {
     /// 2. SHELL environment variable
     /// 3. Parent process shell
     /// 4. Default to bash bundled with flox
-    pub(crate) fn detect_shell_for_subshell() -> Shell {
+    fn detect_shell_for_subshell() -> Shell {
         Self::detect_shell_for_subshell_with(Shell::detect_from_parent_process)
     }
 
@@ -782,8 +782,10 @@ impl Activate {
 
     /// Detect the shell to use for in-place activation
     ///
-    /// Used to determine shell for `eval "$(flox activate)"` / `flox activate --print-script`
-    fn detect_shell_for_in_place() -> Result<Shell> {
+    /// Used to determine shell for `eval "$(flox activate)"`,
+    /// `flox activate --print-script`, and
+    /// when adding activation of a default environment to RC files.
+    pub(crate) fn detect_shell_for_in_place() -> Result<Shell> {
         Self::detect_shell_for_in_place_with(Shell::detect_from_parent_process)
     }
 

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -577,6 +577,7 @@ mod tests {
     use flox_rust_sdk::models::manifest::{CatalogPackage, PackageToInstall};
     use flox_rust_sdk::providers::catalog::SystemEnum;
 
+    use super::{add_activation_to_rc_file, ensure_rc_file_exists};
     use crate::commands::install::{package_list_for_prompt, Install};
 
     /// [Install::generate_warnings] shouldn't warn for packages not in packages_to_install
@@ -708,5 +709,29 @@ mod tests {
     }
 
     #[test]
-    fn foo() {}
+    fn creates_rc_file_if_parent_doesnt_exist() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let parent = tmpdir.path().join("foo");
+        let rc_file_path = parent.join(".bashrc");
+        ensure_rc_file_exists(&rc_file_path).unwrap();
+        assert!(rc_file_path.exists());
+    }
+
+    #[test]
+    fn creates_rc_file_if_doesnt_exist() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let rc_file_path = tmpdir.path().join(".bashrc");
+        ensure_rc_file_exists(&rc_file_path).unwrap();
+        assert!(rc_file_path.exists());
+    }
+
+    #[test]
+    fn creates_rc_file_backup() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let rc_file_path = tmpdir.path().join(".bashrc");
+        ensure_rc_file_exists(&rc_file_path).unwrap();
+        let backup = rc_file_path.with_extension(".pre_flox");
+        add_activation_to_rc_file(&rc_file_path, "be activated").unwrap();
+        assert!(backup.exists());
+    }
 }

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -142,9 +142,9 @@ fn main() -> ExitCode {
         Ok(()) => ExitCode::from(0),
 
         Err(e) => {
-            // Do not print any error if caused by wrapped flox (sh)
-            if e.is::<FloxShellErrorCode>() {
-                return e.downcast_ref::<FloxShellErrorCode>().unwrap().0;
+            // Do not print any error
+            if e.is::<Exit>() {
+                return e.downcast_ref::<Exit>().unwrap().0;
             }
 
             let message = e
@@ -189,14 +189,15 @@ fn main() -> ExitCode {
     // drop(runtime) should implicilty be last
 }
 
+/// Error to exit without printing an error message
 #[derive(Debug)]
-struct FloxShellErrorCode(ExitCode);
-impl Display for FloxShellErrorCode {
+struct Exit(ExitCode);
+impl Display for Exit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         <Self as Debug>::fmt(self, f)
     }
 }
-impl std::error::Error for FloxShellErrorCode {}
+impl std::error::Error for Exit {}
 
 /// Resets the `$USER`/`HOME` variables to match `euid`
 ///


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This prompts the user whether they would like us to add an automatic activation of the default environment to their shell's RC file. We look in the standard locations for the RC files, creating one if it doesn't exist, making a backup before writing to it, and finally append an in-place activation line to their RC file.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
When users are prompted whether they'd like Flox to create a `default` environment for them, they are also asked whether they'd like Flox to append a line to their shell's RC file to automatically activate the `default` environment in every new shell.

<!-- Many thanks! -->
