### PR TITLE
refactor: move user state to state dir

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -35,6 +35,7 @@ pub struct Flox {
     pub config_dir: PathBuf,
     pub cache_dir: PathBuf,
     pub data_dir: PathBuf,
+    pub state_dir: PathBuf,
     pub temp_dir: PathBuf,
     pub runtime_dir: PathBuf,
 
@@ -240,12 +241,14 @@ pub mod test_helpers {
 
         let cache_dir = tempdir_handle.path().join("caches");
         let data_dir = tempdir_handle.path().join(".local/share/flox");
+        let state_dir = tempdir_handle.path().join(".local/state/flox");
         let temp_dir = tempdir_handle.path().join("temp");
         let config_dir = tempdir_handle.path().join("config");
         let runtime_dir = tempdir_handle.path().join("run");
 
         std::fs::create_dir_all(&cache_dir).unwrap();
         std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
         std::fs::create_dir_all(&temp_dir).unwrap();
         std::fs::create_dir_all(&config_dir).unwrap();
         std::fs::create_dir_all(&runtime_dir).unwrap();
@@ -262,6 +265,7 @@ pub mod test_helpers {
             system: env!("NIX_TARGET_SYSTEM").to_string(),
             cache_dir,
             data_dir,
+            state_dir,
             temp_dir,
             config_dir,
             runtime_dir,

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -323,6 +323,7 @@ impl FloxArgs {
         let flox = Flox {
             cache_dir: config.flox.cache_dir.clone(),
             data_dir: config.flox.data_dir.clone(),
+            state_dir: config.flox.state_dir.clone(),
             config_dir: config.flox.config_dir.clone(),
             runtime_dir,
             temp_dir: temp_dir_path.clone(),

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -46,13 +46,17 @@ pub struct FloxConfig {
     #[serde(default)]
     pub disable_metrics: bool,
     /// Directory where flox should store ephemeral data (default:
-    /// `$XDG_CACHE_HOME/flox`)
+    /// `$XDG_CACHE_HOME/flox` e.g. `~/.cache/flox`)
     pub cache_dir: PathBuf,
     /// Directory where flox should store persistent data (default:
-    /// `$XDG_DATA_HOME/flox`)
+    /// `$XDG_DATA_HOME/flox` e.g. `~/.local/share/flox`)
     pub data_dir: PathBuf,
+    /// Directory where flox should store data that's not critical but also
+    /// shouldn't be able to be freely deleted like data in the cache directory.
+    /// (default: `$XDG_STATE_HOME/flox` e.g. `~/.local/state/flox`)
+    pub state_dir: PathBuf,
     /// Directory where flox should load its configuration file (default:
-    /// `$XDG_CONFIG_HOME/flox`)
+    /// `$XDG_CONFIG_HOME/flox` e.g. `~/.config/flox`)
     pub config_dir: PathBuf,
 
     /// Token to authenticate on FloxHub
@@ -153,6 +157,7 @@ impl Config {
 
             let cache_dir = flox_dirs.get_cache_home();
             let data_dir = flox_dirs.get_data_home();
+            let state_dir = flox_dirs.get_state_home();
 
             let config_dir = match env::var(FLOX_CONFIG_DIR_VAR) {
                 Ok(v) => {
@@ -178,6 +183,7 @@ impl Config {
                 .set_default("default_substituter", "https://cache.floxdev.com/")?
                 .set_default("cache_dir", cache_dir.to_str().unwrap())?
                 .set_default("data_dir", data_dir.to_str().unwrap())?
+                .set_default("state_dir", state_dir.to_str().unwrap())?
                 // Config dir is added to the config for completeness;
                 // the config file cannot change the config dir.
                 .set_override("config_dir", config_dir.to_str().unwrap())?;

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -330,7 +330,7 @@ EOF
   mkfifo "$TEARDOWN_FIFO"
 
   FLOX_SHELL=bash "$FLOX_BIN" activate --trust -r "$OWNER/test" -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
-  timeout 2 cat started
+  timeout 8 cat started
   run cat output
   assert_success
   assert_output --partial "sourcing hook.on-activate"

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1032,7 +1032,7 @@ EOF
   mkfifo started finished
   "$FLOX_BIN" activate --start-services -r "${OWNER}/${PROJECT_NAME}" -- bash <(cat <<'EOF'
     echo > started
-    timeout 2 cat finished
+    timeout 8 cat finished
 EOF
   ) &
   timeout 8 cat started

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -126,6 +126,7 @@ floxhub_setup() {
 setup_isolated_flox() {
   export FLOX_CONFIG_DIR="${BATS_TEST_TMPDIR?}/flox-config"
   export FLOX_DATA_DIR="${BATS_TEST_TMPDIR?}/flox-data"
+  export FLOX_STATE_DIR="${BATS_TEST_TMPDIR?}/flox-state"
   # Don't use BATS_TEST_TMPDIR since we store sockets in FLOX_CACHE_DIR,
   # and BATS_TEST_TMPDIR will likely be too long.
   # Create within the existing FLOX_CACHE_DIR so this gets cleaned up by


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**feat: add XDG_STATE_HOME to store user data**

There is data that isn't critical, but that shouldn't be freely deleted
like data in the cache directory. This data belongs in the
XDG_STATE_HOME directory, which is `~/.local/state` on most systems.

**refactor: move user state file to state dir**

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
