### PR TITLE
Symlink extra buildenv outputs into ".flox" directory

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -10,24 +10,7 @@ use super::core_environment::{CoreEnvironment, UpgradeResult};
 use super::generations::{Generations, GenerationsError};
 use super::path_environment::PathEnvironment;
 use super::{
-    gcroots_dir,
-    path_hash,
-    services_socket_path,
-    CanonicalizeError,
-    CoreEnvironmentError,
-    EditResult,
-    Environment,
-    EnvironmentError,
-    EnvironmentPointer,
-    InstallationAttempt,
-    ManagedPointer,
-    PathPointer,
-    UninstallationAttempt,
-    CACHE_DIR_NAME,
-    ENVIRONMENT_POINTER_FILENAME,
-    ENV_DIR_NAME,
-    LOG_DIR_NAME,
-    N_HASH_CHARS,
+    gcroots_dir, path_hash, services_socket_path, CanonicalizeError, CoreEnvironmentError, EditResult, Environment, EnvironmentError, EnvironmentPointer, InstallationAttempt, ManagedPointer, PathPointer, RenderedEnvironmentLinks, UninstallationAttempt, CACHE_DIR_NAME, ENVIRONMENT_POINTER_FILENAME, ENV_DIR_NAME, LOG_DIR_NAME, N_HASH_CHARS
 };
 use crate::data::CanonicalPath;
 use crate::flox::{EnvironmentRef, Flox};
@@ -381,7 +364,7 @@ impl Environment for ManagedEnvironment {
     }
 
     /// This will lock if there is an out of sync local checkout
-    fn rendered_env_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
+    fn rendered_env_path(&mut self, flox: &Flox) -> Result<RenderedEnvironmentLinks, EnvironmentError> {
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
 
         self.ensure_locked(flox, &mut local_checkout)?;

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1564,6 +1564,7 @@ pub mod test_helpers {
     use crate::flox::{Floxhub, DEFAULT_FLOXHUB_URL};
     use crate::models::environment::core_environment::test_helpers::new_core_environment;
     use crate::models::environment::test_helpers::new_core_environment_from_env_files;
+    use crate::models::environment::DOT_FLOX;
     use crate::models::floxmeta::test_helpers::unusable_mock_floxmeta;
 
     /// Get a [ManagedEnvironment] that is invalid but can be used in tests
@@ -1628,12 +1629,21 @@ pub mod test_helpers {
         env_files_dir: impl AsRef<Path>,
         owner: EnvironmentOwner,
     ) -> ManagedEnvironment {
+        // TODO: `RemoteEnvironment::new_in` still expects a .flox directory
+        // We create a temporary .flox directory here,
+        // but it would be better if we wouldn't depend on the existence of a literal `.flox` directory.
+        let dot_flox_path = tempdir_in(&flox.temp_dir)
+            .unwrap()
+            .into_path()
+            .join(DOT_FLOX);
+        fs::create_dir(&dot_flox_path).unwrap();
+
         ManagedEnvironment::push_new_without_building(
             flox,
             owner,
             "name".parse().unwrap(),
             false,
-            CanonicalPath::new(tempdir_in(&flox.temp_dir).unwrap().into_path()).unwrap(),
+            CanonicalPath::new(dot_flox_path).unwrap(),
             new_core_environment_from_env_files(flox, env_files_dir),
         )
         .unwrap()

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -151,7 +151,10 @@ pub trait Environment: Send {
     /// This should be a link to a store path so that it can be swapped
     /// dynamically, i.e. so that install/edit can modify the environment
     /// without requiring reactivation.
-    fn rendered_env_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError>;
+    fn rendered_env_links(
+        &mut self,
+        flox: &Flox,
+    ) -> Result<RenderedEnvironmentLinks, EnvironmentError>;
 
     /// Return a path that environment hooks should use to store transient data.
     ///

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -19,6 +19,7 @@ use super::lockfile::{LockedManifestError, Lockfile};
 use super::manifest::{Manifest, ManifestError, PackageToInstall};
 use crate::data::{CanonicalPath, CanonicalizeError};
 use crate::flox::{Flox, Floxhub};
+use crate::providers::buildenv::BuildEnvOutputs;
 use crate::providers::git::{
     GitCommandDiscoverError,
     GitCommandProvider,
@@ -84,9 +85,9 @@ pub use flox_core::N_HASH_CHARS;
 pub struct InstallationAttempt {
     pub new_manifest: Option<String>,
     pub already_installed: HashMap<String, bool>,
-    /// The store path of environment that was built to validate the install.
+    /// The store paths of environment that was built to validate the install.
     /// This is used as an optimization to skip builds that we've already done.
-    pub store_path: Option<PathBuf>,
+    pub built_environments: Option<BuildEnvOutputs>,
 }
 
 /// The result of an uninstallation attempt
@@ -95,7 +96,7 @@ pub struct UninstallationAttempt {
     pub new_manifest: Option<String>,
     /// The store path of environment that was built to validate the uninstall.
     /// This is used as an optimization to skip builds that we've already done.
-    pub store_path: Option<PathBuf>,
+    pub built_environment_store_paths: Option<BuildEnvOutputs>,
 }
 
 pub trait Environment: Send {

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -23,23 +23,7 @@ use log::debug;
 
 use super::core_environment::{CoreEnvironment, UpgradeResult};
 use super::{
-    path_hash,
-    services_socket_path,
-    DotFlox,
-    EditResult,
-    Environment,
-    EnvironmentError,
-    EnvironmentPointer,
-    InstallationAttempt,
-    PathPointer,
-    UninstallationAttempt,
-    CACHE_DIR_NAME,
-    DOT_FLOX,
-    ENVIRONMENT_POINTER_FILENAME,
-    GCROOTS_DIR_NAME,
-    LIB_DIR_NAME,
-    LOCKFILE_FILENAME,
-    LOG_DIR_NAME,
+    path_hash, services_socket_path, DotFlox, EditResult, Environment, EnvironmentError, EnvironmentPointer, InstallationAttempt, PathPointer, RenderedEnvironmentLinks, UninstallationAttempt, CACHE_DIR_NAME, DOT_FLOX, ENVIRONMENT_POINTER_FILENAME, GCROOTS_DIR_NAME, LIB_DIR_NAME, LOCKFILE_FILENAME, LOG_DIR_NAME
 };
 use crate::data::{CanonicalPath, System};
 use crate::flox::Flox;
@@ -290,7 +274,7 @@ impl Environment for PathEnvironment {
     }
 
     /// This will lock the environment if it is not already locked.
-    fn rendered_env_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
+    fn rendered_env_path(&mut self, flox: &Flox) -> Result<RenderedEnvironmentLinks, EnvironmentError> {
         let out_link = self.out_link(&flox.system)?;
 
         if self.needs_rebuild(flox)? {

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -8,18 +8,7 @@ use thiserror::Error;
 use super::core_environment::UpgradeResult;
 use super::managed_environment::{remote_branch_name, ManagedEnvironment, ManagedEnvironmentError};
 use super::{
-    gcroots_dir,
-    CanonicalPath,
-    CanonicalizeError,
-    EditResult,
-    Environment,
-    EnvironmentError,
-    InstallationAttempt,
-    ManagedPointer,
-    UninstallationAttempt,
-    DOT_FLOX,
-    ENVIRONMENT_POINTER_FILENAME,
-    GCROOTS_DIR_NAME,
+    gcroots_dir, CanonicalPath, CanonicalizeError, EditResult, Environment, EnvironmentError, InstallationAttempt, ManagedPointer, RenderedEnvironmentLinks, UninstallationAttempt, DOT_FLOX, ENVIRONMENT_POINTER_FILENAME, GCROOTS_DIR_NAME
 };
 use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::container_builder::ContainerBuilder;
@@ -253,7 +242,7 @@ impl Environment for RemoteEnvironment {
         self.inner.manifest(flox)
     }
 
-    fn rendered_env_path(&mut self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
+    fn rendered_env_path(&mut self, flox: &Flox) -> Result<RenderedEnvironmentLinks, EnvironmentError> {
         Self::update_out_link(flox, &self.out_link, &mut self.inner)?;
         Ok(self.out_link.clone())
     }

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -303,8 +303,8 @@ pub mod test_helpers {
             .build(
                 flox,
                 &env.parent_path().unwrap(),
-                &env.rendered_env_path(flox).unwrap(),
-                &env.rendered_env_path(flox).unwrap(),
+                &env.rendered_env_links(flox).unwrap().development,
+                &env.rendered_env_links(flox).unwrap().development,
                 &[package_name.to_owned()],
             )
             .unwrap();
@@ -337,7 +337,7 @@ pub mod test_helpers {
         let err = builder
             .clean(
                 &env.parent_path().unwrap(),
-                &env.rendered_env_path(flox).unwrap(),
+                &env.rendered_env_links(flox).unwrap().development,
                 &package_names
                     .iter()
                     .map(|s| s.to_string())

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1,0 +1,203 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::LazyLock;
+
+use indoc::indoc;
+use serde::Deserialize;
+use thiserror::Error;
+use tracing::debug;
+
+use crate::models::pkgdb::{call_pkgdb, CallPkgDbError, PkgDbError, PKGDB_BIN};
+use crate::utils::CommandExt;
+
+static NIX_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
+    std::env::var("NIX_BIN")
+        .unwrap_or_else(|_| env!("NIX_BIN").to_string())
+        .into()
+});
+
+static BUILDENV_NIX: LazyLock<PathBuf> = LazyLock::new(|| {
+    std::env::var("FLOX_BUILDENV_NIX")
+        .unwrap_or_else(|_| env!("FLOX_BUILDENV_NIX").to_string())
+        .into()
+});
+
+#[derive(Debug, Error)]
+pub enum BuildEnvError {
+    /// An error that occurred while realising the packages in the lockfile.
+    /// Those are Nix errors pkgdb forwards to us as well as detection of
+    /// disallowed packages.
+    #[error("Failed to realise packages in lockfile")]
+    Realise(#[source] PkgDbError),
+
+    /// Other errors arising from calling pkgdb and interpreting its output.
+    #[error(transparent)]
+    CallPkgDb(CallPkgDbError),
+
+    /// An error that occurred while composing the environment.
+    /// I.e. `nix build` returned with a non-zero exit code.
+    /// The error message is the stderr of the `nix build` command.
+    // TODO: this requires to capture the stderr of the `nix build` command
+    // or essentially "tee" it if we also want to foward the logs to the user.
+    // At the moment the "interesting" logs
+    // are emitted by the `pkgdb realise` portion of the build.
+    // So in the interest of initial simplicity
+    // we can defer forwarding the nix build logs and capture output with [Command::output].
+    #[error("Failed to constructed environment: {0}")]
+    Build(String),
+
+    /// An error that occurred while linking a store path.
+    #[error("Failed to link environment: {0}")]
+    Link(String),
+
+    /// An error that occurred while calling nix build.
+    #[error("Failed to call 'nix build'")]
+    CallNixBuild(#[source] std::io::Error),
+
+    /// An error that occurred while deserializing the output of the `nix build` command.
+    #[error("Failed to deserialize 'nix build' output")]
+    ReadOutputs(#[source] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BuildEnvOutputs {
+    pub develop: PathBuf,
+    pub runtime: PathBuf,
+    // todo: add more build runtime outputs
+}
+
+pub type BuildEnvResult = BuildEnvOutputs;
+
+pub trait BuildEnv {
+    fn build(
+        &self,
+        lockfile: &Path,
+        service_config_path: Option<PathBuf>,
+    ) -> Result<BuildEnvOutputs, BuildEnvError>;
+
+    fn link(
+        &self,
+        store_path: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
+    ) -> Result<(), BuildEnvError>;
+}
+
+pub struct BuildEnvNix;
+
+impl BuildEnv for BuildEnvNix {
+    fn build(
+        &self,
+        lockfile_path: &Path,
+        service_config_path: Option<PathBuf>,
+    ) -> Result<BuildEnvOutputs, BuildEnvError> {
+        // todo: use `stat` or `nix path-info` to filter out pre-existing store paths
+
+        // Realise the packages in the lockfile
+        //
+        // Locking flakes may require using `ssh` for private flakes,
+        // so don't clear PATH
+        // We don't have tests for private flakes,
+        // so make sure private flakes work after touching this.
+        let mut pkgdb_realise_cmd = Command::new(Path::new(&*PKGDB_BIN));
+        pkgdb_realise_cmd.arg("realise").arg(lockfile_path);
+
+        debug!(cmd=%pkgdb_realise_cmd.display(), "realising packages");
+        match call_pkgdb(pkgdb_realise_cmd, false) {
+            Ok(_) => {},
+            Err(CallPkgDbError::PkgDbError(err)) => return Err(BuildEnvError::Realise(err)),
+            Err(err) => return Err(BuildEnvError::CallPkgDb(err)),
+        }
+
+        // build the environment
+        let mut nix_build_command = self.base_command();
+
+        nix_build_command.args(["build", "--no-link", "--offline", "--json"]);
+        // build the derivation produced by evaluating the `buildenv.nix` file
+        nix_build_command.arg("--file").arg(&*BUILDENV_NIX);
+        // pass the lockfile path as an argument to the `buildenv.nix` file
+        nix_build_command
+            .arg("--argstr")
+            .arg("manifestLock")
+            .arg(lockfile_path);
+        // pass the service config path as an argument to the `buildenv.nix` file
+        // if it is provided
+        if let Some(service_config_path) = &service_config_path {
+            nix_build_command
+                .arg("--argstr")
+                .arg("serviceConfigYaml")
+                .arg(service_config_path);
+        }
+        // ... use default values for the remaining arguments of the `buildenv.nix` function.
+
+        debug!(cmd=%nix_build_command.display(), "building environment");
+
+        let output = nix_build_command
+            .output()
+            .map_err(BuildEnvError::CallNixBuild)?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(BuildEnvError::Build(stderr.to_string()));
+        }
+
+        // defined inline as an implementation detail
+        #[derive(Debug, Clone, Deserialize)]
+        struct BuildEnvResultRaw {
+            outputs: BuildEnvOutputs,
+        }
+
+        let [build_env_result]: [BuildEnvResultRaw; 1] =
+            serde_json::from_slice(&output.stdout).map_err(BuildEnvError::ReadOutputs)?;
+
+        let outputs = build_env_result.outputs;
+        Ok(outputs)
+    }
+
+    fn link(
+        &self,
+        destination: impl AsRef<Path>,
+        store_path: impl AsRef<Path>,
+    ) -> Result<(), BuildEnvError> {
+        let mut nix_build_command = self.base_command();
+
+        nix_build_command.arg("build").arg(store_path.as_ref());
+        nix_build_command
+            .arg("--out-link")
+            .arg(destination.as_ref());
+
+        debug!(cmd=%nix_build_command.display(), "linking store path");
+
+        let output = nix_build_command
+            .output()
+            .map_err(BuildEnvError::CallNixBuild)?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(BuildEnvError::Link(stderr.to_string()));
+        }
+
+        Ok(())
+    }
+}
+
+impl BuildEnvNix {
+    fn base_command(&self) -> Command {
+        let mut nix_build_command = Command::new(&*NIX_BIN);
+        // Override nix config to use flake commands,
+        // allow impure language features such as `builtins.storePath`,
+        // and use the auto store (which is used by the preceding `pkgdb realise` command)
+        // TODO: formalize this in a config file,
+        // and potentially disable other user configs (allowing specific overrides)
+        let nix_config = indoc! {"
+            experimental-features = nix-command flakes
+            pure-eval = false
+            store = auto
+        "};
+
+        nix_build_command.env("NIX_CONFIG", nix_config);
+        // we generally want to see more logs (we can always filter them out)
+        nix_build_command.arg("--print-build-logs");
+
+        nix_build_command
+    }
+}

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod buildenv;
 pub mod catalog;
 pub mod flox_cpp_utils;
 pub mod git;

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -153,6 +153,28 @@ impl Display for DisplayCommand<'_> {
             .get_args()
             .map(|a| shell_escape::escape(a.to_string_lossy()));
 
+        let mut envs = command
+            .get_envs()
+            .map(|(k, v)| {
+                let Some(v) = v else {
+                    return format!("-u {}", k.to_string_lossy());
+                };
+
+                format!(
+                    "{k}={v}",
+                    k = k.to_string_lossy(),
+                    v = shell_escape::escape(v.to_string_lossy())
+                )
+            })
+            .peekable();
+
+        if envs.peek().is_some() {
+            write!(f, "env ")?;
+            for env in envs {
+                write!(f, "{} ", env)?;
+            }
+        }
+
         write!(f, "{}", command.get_program().to_string_lossy())?;
         for arg in args {
             write!(f, " {}", arg)?;

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -14,7 +14,6 @@ use flox_rust_sdk::flox::{Flox, DEFAULT_NAME};
 use flox_rust_sdk::models::env_registry::env_registry_path;
 use flox_rust_sdk::models::environment::{
     path_hash,
-    CoreEnvironmentError,
     Environment,
     EnvironmentError,
     FLOX_ACTIVE_ENVIRONMENTS_VAR,
@@ -28,7 +27,6 @@ use flox_rust_sdk::models::environment::{
     FLOX_PROMPT_ENVIRONMENTS_VAR,
     FLOX_SERVICES_SOCKET_VAR,
 };
-use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
 use flox_rust_sdk::providers::build::FLOX_RUNTIME_DIR_VAR;
 use flox_rust_sdk::providers::services::shutdown_process_compose_if_all_processes_stopped;
 use flox_rust_sdk::utils::traceable_path;
@@ -190,12 +188,7 @@ impl Activate {
         };
 
         let rendered_env_path = match rendered_env_path_result {
-            Err(EnvironmentError::Core(CoreEnvironmentError::BuildEnv(
-                CallPkgDbError::PkgDbError(PkgDbError {
-                    exit_code: error_codes::LOCKFILE_INCOMPATIBLE_SYSTEM,
-                    ..
-                }),
-            ))) => {
+            Err(EnvironmentError::Core(err)) if err.is_incompatible_system_error() => {
                 let mut message = format!(
                     "This environment is not yet compatible with your system ({system}).",
                     system = flox.system

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -86,12 +86,12 @@ impl Build {
         let mut env = env.into_dyn_environment();
 
         let base_dir = env.parent_path()?;
-        let flox_env = env.rendered_env_path(&flox)?;
+        let flox_env = env.rendered_env_links(&flox)?;
 
         let packages_to_clean = available_packages(&env.lockfile(&flox)?, packages)?;
 
         let builder = FloxBuildMk;
-        builder.clean(&base_dir, &flox_env, &packages_to_clean)?;
+        builder.clean(&base_dir, &flox_env.development, &packages_to_clean)?;
 
         message::created("Clean completed successfully");
 
@@ -109,7 +109,7 @@ impl Build {
         let mut env = env.into_dyn_environment();
 
         let base_dir = env.parent_path()?;
-        let flox_env = env.rendered_env_path(&flox)?;
+        let flox_env = env.rendered_env_links(&flox)?;
 
         let packages_to_build = available_packages(&env.lockfile(&flox)?, packages)?;
 
@@ -117,7 +117,7 @@ impl Build {
         let output = builder.build(
             &flox,
             &base_dir,
-            &flox_env,
+            &flox_env.development,
             &FLOX_INTERPRETER,
             &packages_to_build,
         )?;

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -146,7 +146,7 @@ impl Edit {
                         // The current generation already has a lock,
                         // so we can skip locking.
                         let store_path = environment.build(&flox)?;
-                        environment.link(store_path)
+                        environment.link(&store_path)
                     }),
                 }
                 .spin()?;

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -17,7 +17,6 @@ use flox_rust_sdk::models::environment::{
     Environment,
     EnvironmentError,
 };
-use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
 use flox_rust_sdk::providers::services::ServiceError;
 use itertools::Itertools;
 use log::debug;
@@ -280,12 +279,15 @@ impl Edit {
         match result {
             Err(EnvironmentError::Core(e @ CoreEnvironmentError::LockedManifest(_)))
             | Err(EnvironmentError::Core(e @ CoreEnvironmentError::DeserializeManifest(_)))
-            | Err(EnvironmentError::Core(
-                e @ CoreEnvironmentError::BuildEnv(CallPkgDbError::PkgDbError(PkgDbError {
-                    exit_code: error_codes::BUILDENV_CONFLICT,
-                    ..
-                })),
-            )) => Ok(Err(e)),
+            // TODO: detect path conflict with in builenv.nix output!
+            //
+            // | Err(EnvironmentError::Core(
+            //     e @ CoreEnvironmentError::BuildEnv(CallPkgDbError::PkgDbError(PkgDbError {
+            //         exit_code: error_codes::BUILDENV_CONFLICT,
+            //         ..
+            //     })),
+            // ))
+            => Ok(Err(e)),
             Err(EnvironmentError::Core(
                 e @ CoreEnvironmentError::Services(ServiceError::InvalidConfig(_)),
             )) => Ok(Err(e)),

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -608,14 +608,15 @@ mod tests {
     };
     use flox_rust_sdk::models::environment::test_helpers::MANIFEST_INCOMPATIBLE_SYSTEM;
     use flox_rust_sdk::models::pkgdb::error_codes::PACKAGE_BUILD_FAILURE;
-    use flox_rust_sdk::models::pkgdb::{error_codes, CallPkgDbError, PkgDbError};
+    use flox_rust_sdk::models::pkgdb::{error_codes, PkgDbError};
+    use flox_rust_sdk::providers::buildenv::BuildEnvError;
     use tempfile::tempdir_in;
 
     use super::*;
 
     fn incompatible_system_result() -> Result<(), EnvironmentError> {
         Err(EnvironmentError::Core(CoreEnvironmentError::BuildEnv(
-            CallPkgDbError::PkgDbError(PkgDbError {
+            BuildEnvError::Realise(PkgDbError {
                 exit_code: error_codes::LOCKFILE_INCOMPATIBLE_SYSTEM,
                 category_message: "category_message".to_string(),
                 context_message: None,
@@ -625,7 +626,7 @@ mod tests {
 
     fn incompatible_package_result() -> Result<(), EnvironmentError> {
         Err(EnvironmentError::Core(CoreEnvironmentError::BuildEnv(
-            CallPkgDbError::PkgDbError(PkgDbError {
+            BuildEnvError::Realise(PkgDbError {
                 exit_code: PACKAGE_BUILD_FAILURE,
                 category_message: "category_message".to_string(),
                 context_message: None,

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -192,8 +192,8 @@ impl Pull {
                     typed: Spinner::new(|| {
                         // The pulled generation already has a lock,
                         // so we can skip locking.
-                        let store_path = env.build(flox)?;
-                        env.link(store_path)
+                        let store_paths = env.build(flox)?;
+                        env.link(&store_paths)
                     }),
                 }
                 .spin()?;
@@ -303,8 +303,8 @@ impl Pull {
             typed: Spinner::new(|| {
                 // The pulled generation already has a lock,
                 // so we can skip locking.
-                let store_path = env.build(flox)?;
-                env.link(store_path)
+                let store_paths = env.build(flox)?;
+                env.link(&store_paths)
             }),
         }
         .spin();

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -685,6 +685,7 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
         RemoteEnvironmentError::ReadInternalOutLink(_) => display_chain(err),
         RemoteEnvironmentError::DeleteOldOutLink(_) => display_chain(err),
         RemoteEnvironmentError::WriteNewOutlink(_) => display_chain(err),
+        RemoteEnvironmentError::CreateGcRootDir(_) => display_chain(err),
     }
 }
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -360,14 +360,14 @@ EOF
   assert_success
 }
 
-# bats test_tags=activate
+# bats test_tags=activate:standalone
 @test "bash: activation script can be run directly" {
   project_setup
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly in various forms.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.run/activate -c :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -375,19 +375,19 @@ EOF
   refute_output --partial "sourcing profile.fish"
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --command :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -c true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --command true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -- :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -- true
   assert_success
 }
 
@@ -398,7 +398,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly with --noprofile.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --noprofile :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --noprofile :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -415,7 +415,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly with --turbo.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --turbo :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="bash" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --turbo :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -500,7 +500,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly in various forms.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -c :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -508,19 +508,19 @@ EOF
   assert_output --partial "sourcing profile.fish"
   refute_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --command :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -c true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --command true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -- :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -- true
   assert_success
 }
 
@@ -531,7 +531,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly with --noprofile.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --noprofile :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --noprofile :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -548,7 +548,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly with --turbo.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --turbo :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="fish" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --turbo :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -632,7 +632,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly in various forms.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -c :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -640,19 +640,19 @@ EOF
   refute_output --partial "sourcing profile.fish"
   assert_output --partial "sourcing profile.tcsh"
   refute_output --partial "sourcing profile.zsh"
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --command :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -c true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --command true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -- :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -- true
   assert_success
 }
 
@@ -663,7 +663,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly with --noprofile.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --noprofile :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --noprofile :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -680,7 +680,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly with --turbo.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --turbo :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="tcsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --turbo :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -765,7 +765,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly in various forms.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -c :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -773,19 +773,19 @@ EOF
   refute_output --partial "sourcing profile.fish"
   refute_output --partial "sourcing profile.tcsh"
   assert_output --partial "sourcing profile.zsh"
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --command :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -c true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -c true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --command true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --command true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -- :
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate true
   assert_success
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate -- true
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate -- true
   assert_success
 }
 
@@ -796,7 +796,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly with --noprofile.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --noprofile :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --noprofile :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -813,7 +813,7 @@ EOF
   sed -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml" | "$FLOX_BIN" edit -f -
 
   # Test running the activate script directly with --turbo.
-  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/activate --turbo :
+  FLOX_RUNTIME_DIR="$FLOX_CACHE_DIR" FLOX_SHELL="zsh" NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --turbo :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   refute_output --partial "sourcing profile.common"
@@ -1602,7 +1602,7 @@ EOF
 
   run -- "$FLOX_BIN" activate -- echo PYTHONPATH is '$PYTHONPATH'
   assert_success
-  assert_line "PYTHONPATH is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/lib/python3.11/site-packages"
+  assert_line "PYTHONPATH is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/lib/python3.11/site-packages"
 
   run -- "$FLOX_BIN" activate -- echo PIP_CONFIG_FILE is '$PIP_CONFIG_FILE'
   assert_success
@@ -2641,7 +2641,7 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/fish_3_2_2.json" \
     "$FLOX_BIN" install fish@3.2.2
 
-  FLOX_SHELL="./.flox/run/$NIX_SYSTEM.$PROJECT_NAME/bin/fish" run "$FLOX_BIN" activate -- echo "\$FISH_VERSION"
+  FLOX_SHELL="./.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/fish" run "$FLOX_BIN" activate -- echo "\$FISH_VERSION"
   assert_success
   # fish doesn't have the equivalent of set -e, so refute "Error"
   refute_output --partial Error
@@ -3295,7 +3295,7 @@ EOF
   "$FLOX_BIN" edit -n bad_interpreter
 
   # Install something to the environment so the out-link exists
-  link_name="$NIX_SYSTEM.bad_interpreter"
+  link_name="$NIX_SYSTEM.bad_interpreter.dev"
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install hello
   hello_path="$(realpath ".flox/run/$link_name/bin/hello")"
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -278,9 +278,10 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     "$FLOX_BIN" install hello
 
+  export PROJECT_DIR="$(realpath "$PROJECT_DIR")"
   run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- command -v hello
   assert_success
-  assert_output --regexp "${FLOX_CACHE_DIR}/run/owner/${PROJECT_NAME}\..+/bin/hello"
+  assert_output --regexp "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}.dev/bin/hello"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -80,7 +80,9 @@ function make_empty_remote_env() {
   run --separate-stderr "$FLOX_BIN" install hello --remote "$OWNER/test"
   assert_success
 
-  assert [ -h "$FLOX_CACHE_DIR/run/$OWNER/test" ]
+  assert [ -h "$FLOX_CACHE_DIR/run/$OWNER/$NIX_SYSTEM.test.dev" ]
+  assert [ -h "$FLOX_CACHE_DIR/run/$OWNER/$NIX_SYSTEM.test.run" ]
+
 }
 
 # bats test_tags=install,remote,remote:install
@@ -143,9 +145,10 @@ EOF
   make_empty_remote_env
   "$FLOX_BIN" install hello --remote "$OWNER/test"
 
+  export FLOX_CACHE_DIR="$(realpath $FLOX_CACHE_DIR)"
   run "$FLOX_BIN" activate --trust --remote "$OWNER/test" -- command -v hello
   assert_success
-  assert_output --partial "$FLOX_CACHE_DIR/remote/owner/test/.flox/run/bin/hello"
+  assert_output --partial "$FLOX_CACHE_DIR/run/owner/$NIX_SYSTEM.test.dev/bin/hello"
 }
 
 # We need to trust the remote environment before we can activate it.

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -165,7 +165,8 @@ EOF
   run "$FLOX_BIN" install hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/bin/hello" ]
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello" ]
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.run/bin/hello" ]
   assert_success
 }
 
@@ -175,11 +176,11 @@ EOF
   run "$FLOX_BIN" install hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/bin/hello" ]
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello" ]
   assert_success
   run "$FLOX_BIN" uninstall hello
   assert_success
-  run [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME/bin/hello" ]
+  run [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello" ]
   assert_success
 }
 


### PR DESCRIPTION
Using `DisplayCommand` can be used to print a copy-pastable shell command.
So far this only included arguments.
However some commands _also_ set or unset environment variables,
which is currently not visible in the logs.
This commit makes `DisplayCommand` print an invocation in the form of

    [env (-u VAR | VAR=VALUE) ... ] CMD ARGS...

if either `Command::{env,envs}`,  or `Command::env_remove` was used on the printed command.## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->



