### PR TITLE
debug: run strace on process-compose in tests

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -35,6 +35,7 @@ export _gnused="@gnused@"
 export _jq="@jq@"
 export _process_compose="@process-compose@"
 export _setsid="@setsid@"
+export _strace="@strace@"
 
 # Top-level Flox environment activation script.
 

--- a/assets/activation-scripts/activate.d/start-services.bash
+++ b/assets/activation-scripts/activate.d/start-services.bash
@@ -45,11 +45,12 @@ start_services_blocking() {
 
   # flox services start [service...] needs to be able to start some but not all
   # services
+  mkdir -p "$HOME/strace_debugging"
   if [ -n "${_FLOX_SERVICES_TO_START:-}" ]; then
     readarray -t services_to_start < <(echo "$_FLOX_SERVICES_TO_START" | "$_jq" -r '.[]')
-    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up "${services_to_start[@]}" -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
+    COMPOSE_SHELL="$_bash" "$_strace" -f -o "$HOME/strace_debugging/log_$BATS_TEST_NAME.txt" "$_setsid" "$_setsid" "$_process_compose" up "${services_to_start[@]}" -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
   else
-    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
+    COMPOSE_SHELL="$_bash" "$_strace" -f -o "$HOME/strace_debugging/log_$BATS_TEST_NAME.txt" "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
   fi
   # Make these functions available in subshells so that `timeout` can call them
   export -f wait_for_services_socket poll_services_status

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -17,6 +17,7 @@
   flox-activations,
   shfmt,
   daemonize,
+  strace,
 }:
 let
   ld-floxlib_so = if stdenv.isLinux then "${ld-floxlib}/lib/ld-floxlib.so" else "__LINUX_ONLY__";
@@ -26,6 +27,13 @@ let
     name = "editorconfig";
     path = ../../.editorconfig;
   };
+  addStrace =
+    if stdenv.isLinux then
+      ''
+        substituteInPlace $out/activate --replace "@strace@" "${strace}/bin/strace"
+      ''
+    else
+      "";
 in
 runCommand "flox-activation-scripts"
   {
@@ -51,6 +59,8 @@ runCommand "flox-activation-scripts"
       --replace "@setsid@" "${util-linux}/bin/setsid" \
       --replace "@daemonize@" "${daemonize}/bin/daemonize" \
       --replace "/usr/bin/env bash" "${bash}/bin/bash"
+
+    ${addStrace}
 
     substituteInPlace $out/activate.d/bash \
       --replace "@gnused@" "${gnused}"


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
When this patch is applied, `strace` will be run on Linux on each invocation of `process-compose`, and the output will be put in `$HOME/strace_debugging/log_$BATS_TEST_NAME.txt`. Note that this is only useful for debugging because it will likely fail on macOS entirely (because `strace` is only available on Linux), and multiple runs will clobber the files in that directory.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
