### PR TITLE
fix: update behaviour of hide_default_prompt to match documentation

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -292,7 +292,7 @@ impl Activate {
             "}),
             (set_prompt, hide_default_prompt, _) => (
                 set_prompt.unwrap_or(true),
-                hide_default_prompt.unwrap_or(true),
+                hide_default_prompt.unwrap_or(false),
             ),
         };
 


### PR DESCRIPTION
## Proposed Changes

Update the `hide_default_prompt` configuration default to match the behaviour as documented in flox-config.md:
```
hide_default_prompt
Hide environments named ‘default’ from the shell prompt, and don’t add
environments named ‘default’ to $FLOX_PROMPT_ENVIRONMENTS (default: false).
                                                                    ^^^^^
```
## Release Notes

N/A .. this addresses a regression only just introduced in the recent pre-release so shouldn't represent a change in behaviour to any current users.