### PR TITLE
fix: only get info for parent process

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1504,7 +1504,7 @@ checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
  "cfg-if",
  "libc",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1718,7 +1718,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3714,17 +3714,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "e3b5ae3f4f7d64646c46c4cae4e3f01d1c5d255c7406fdd7c7f999a94e488791"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
  "rayon",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -4401,7 +4400,17 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -4415,13 +4424,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -4440,7 +4492,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -58,7 +58,7 @@ serde_yaml = "0.9"
 shell-escape = "0.1.5"
 supports-color = "3.0.1"
 # provides process tools for shell detection
-sysinfo = "0.30.13"
+sysinfo = "0.32.0"
 # provide system version information for metric
 # TODO: review if we need this
 sys-info = "0.9"

--- a/pkgs/rust-external-deps/default.nix
+++ b/pkgs/rust-external-deps/default.nix
@@ -35,6 +35,7 @@ let
       ]
       ++ lib.optional hostPlatform.isDarwin [
         darwin.libiconv
+        darwin.libobjc
         darwin.apple_sdk.frameworks.SystemConfiguration
       ];
 


### PR DESCRIPTION
We're currently refreshing sysinfo for all processes instead of just one in get_parent_process_exe(). Update our sysinfo crate and get process info for just the parent process we're interested in.

Updating sysinfo required adding darwin.libobjc since a dependency on objc was added upstream in https://github.com/GuillaumeGomez/sysinfo/commit/5f78295b50c3e604d71f18fb45b5013b7b0d9f5f

Before this change, get_parent_process_exe() benchmarks were:
Duration: 9.639049208s
Duration: 64.236333ms
Duration: 8.124838292s
Duration: 676.244542ms
Duration: 6.660007916s
avg duration: 5.032875258s
min duration: 64.236333ms
max duration: 9.639049208s

I killed a bunch of processes I had running, and then benchmarks were:
Duration: 11.099875ms
Duration: 6.176417ms
Duration: 5.539125ms
Duration: 10.232542ms
Duration: 7.185416ms
avg duration: 8.046675ms
min duration: 5.539125ms
max duration: 11.099875ms

After this change (and killing processes), benchmarks were:
Duration: 720.75µs
Duration: 615.792µs
Duration: 170.625µs
Duration: 144µs
Duration: 212.625µs
avg duration: 372.758µs
min duration: 144µs
max duration: 720.75µs

The benchmarks are from the following test:
```
    #[test]
    fn test_detect_from_parent_process() {
        use std::time::{Duration, Instant};

        let mut avg = Duration::from_millis(0);
        let mut min = Duration::from_secs(1000);
        let mut max = Duration::from_millis(0);

        let iterations = 5;
        for _loop in 1..=iterations {
            let start = Instant::now();
            get_parent_process_exe().unwrap();
            let duration = start.elapsed();
            avg += duration;
            min = min.min(duration);
            max = max.max(duration);

            println!("Duration: {:?}", duration);
        }

        println!("avg duration: {:?}", avg / iterations);
        println!("min duration: {:?}", min);
        println!("max duration: {:?}", max);
    }
```

## Release Notes

Fixed performance issue for in-place activations