### PR TITLE
feat: prep Bash changes needed for run mode

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -33,6 +33,7 @@ export _flox_activations="@flox_activations@"
 export _getopt="@getopt@"
 export _gnused="@gnused@"
 export _jq="@jq@"
+export _nawk="@nawk@"
 export _process_compose="@process-compose@"
 export _setsid="@setsid@"
 
@@ -48,9 +49,9 @@ export FLOX_PROMPT_COLOR_1="${FLOX_PROMPT_COLOR_1:-99}"
 export FLOX_PROMPT_COLOR_2="${FLOX_PROMPT_COLOR_2:-141}"
 
 # Parse command-line arguments.
-OPTIONS=c:
-LONGOPTS=command:,noprofile,turbo
-USAGE="Usage: $0 [-c \"<cmd> <args>\"] [--turbo] [--noprofile]"
+OPTIONS="c:"
+LONGOPTS="command:,noprofile,turbo,mode:"
+USAGE="Usage: $0 [-c \"<cmd> <args>\"] [--turbo] [--noprofile] [--mode (dev|run)]"
 
 PARSED=$("$_getopt/bin/getopt" --options="$OPTIONS" --longoptions="$LONGOPTS" --name "$0" -- "$@")
 # shellcheck disable=SC2181
@@ -66,16 +67,27 @@ eval set -- "$PARSED"
 FLOX_CMD=""
 FLOX_TURBO="${FLOX_TURBO:-}"
 FLOX_NOPROFILE="${FLOX_NOPROFILE:-}"
+_FLOX_ENV_ACTIVATION_MODE="dev"
 while true; do
   case "$1" in
     -c | --command)
       shift
-      if [ -z "$1" ]; then
+      if [ -z "${1:-}" ]; then
         echo "Option -c requires an argument." >&2
         echo "$USAGE" >&2
         exit 1
       fi
       FLOX_CMD="$1"
+      shift
+      ;;
+    --mode)
+      shift
+      if [ -z "${1:-}" ] || ! { [ "$1" == "run" ] || [ "$1" == "dev" ]; }; then
+        echo "Option --mode requires 'dev' or 'run' as an argument." >&2
+        echo "$USAGE" >&2
+        exit 1
+      fi
+      _FLOX_ENV_ACTIVATION_MODE="$1"
       shift
       ;;
     --turbo)
@@ -162,6 +174,77 @@ to_eval="$($_flox_activations \
   --pid "$$" --flox-env "$FLOX_ENV" --store-path "$_FLOX_ACTIVATE_STORE_PATH")"
 eval "$to_eval"
 export _FLOX_ACTIVATION_STATE_DIR _FLOX_ACTIVATION_ID
+
+# Now that we support attaching to an environment we can no longer rely on
+# the environment variable replay for setting the PATH and MANPATH variables,
+# and must instead infer them from the FLOX_ENV_DIRS variable maintained for
+# us by the flox CLI.
+
+# Set IFS=: for this portion of the script.
+_save_IFS="$IFS"
+IFS=":"
+
+# Get an iterable array of FLOX_ENV_DIRS.
+declare -a _FLOX_ENV_DIRS
+# If there's an outer activation with the CLI followed by an inner activation
+# with just the activate script (this could happen e.g. for a build),
+# we need to combine $FLOX_ENV and $FLOX_ENV_DIRS.
+# If $FLOX_ENV is already in $FLOX_ENV_DIRS, the deduplication logic below will
+# handle that
+# shellcheck disable=SC2206
+_FLOX_ENV_DIRS=($FLOX_ENV $FLOX_ENV_DIRS)
+
+# Set the PATH environment variable.
+declare _prepend_path=""
+for i in "${_FLOX_ENV_DIRS[@]}"; do
+    _prepend_path="$_prepend_path${_prepend_path:+:}$i/bin:$i/sbin"
+done
+PATH="$_prepend_path${PATH:+:$PATH}"
+
+# Set the man(1) search path.
+# The search path for manual pages is determined
+# from the MANPATH environment variable in a non-standard way:
+#
+# 1) If MANPATH begins with a colon, it is appended to the default list;
+# 2) if it ends with a colon, it is prepended to the default list;
+# 3) or if it contains two adjacent colons,
+#    the standard search path is inserted between the colons.
+# 4) If none of these conditions are met, it overrides the standard search path.
+#
+# In order for man(1) to find manual pages not defined in the flox environment,
+# we ensure that we prepend the flox search path _with_ a colon in all cases.
+#
+# Thus, the man pages defined in the flox environment are searched first,
+# and default search paths still apply.
+# Additionally, decisions made by the user by setting the MANPATH variable
+# are not overridden by the flox environment:
+# - If MANPATH starts with `:` we now have `::` -> rule 1/3,
+#   the defaults are inserted in between,
+#   i.e. in front of MANPATH, but FLOXENV will take precedence in any case
+# - If MANPATH ends with `:` we end with `:` -> rule 2,
+#   the defaults are appended (no change)
+# - If MANPATH does not start or end with `:`, -> rule 4,
+#   FLOX_ENV:MANPATH replaces the defaults (no change)
+declare _prepend_manpath=""
+for i in "${_FLOX_ENV_DIRS[@]}"; do
+    _prepend_manpath="$_prepend_manpath${_prepend_manpath:+:}$i/share/man"
+done
+MANPATH="$_prepend_manpath:${MANPATH:+$MANPATH}"
+
+# Restore IFS.
+IFS="$_save_IFS"
+unset _save_IFS
+
+# Remove duplicates from PATH and MANPATH. We use echo -n in the command
+# below to remove trailing newline characters from the input that might
+# otherwise cause a [trailing] duplicate entry to be missed.
+declare _awkScript _nodup_PATH _nodup_MANPATH
+# shellcheck disable=SC2016
+_awkScript='BEGIN { RS = ":"; } { if (A[$0]) {} else { A[$0]=1; printf(((NR==1) ? "" : ":") $0); } }'
+_nodup_PATH="$(echo -n "$PATH" | "$_nawk/bin/nawk" "$_awkScript")"
+_nodup_MANPATH="$(echo -n "$MANPATH" | "$_nawk/bin/nawk" "$_awkScript")"
+export PATH="${_nodup_PATH}"
+export MANPATH="${_nodup_MANPATH}"
 
 if [ "$_FLOX_ATTACH" == true ]; then
   # shellcheck source-path=SCRIPTDIR/activate.d

--- a/assets/activation-scripts/activate.d/attach-command.bash
+++ b/assets/activation-scripts/activate.d/attach-command.bash
@@ -15,6 +15,10 @@ if [ -n "$FLOX_TURBO" ]; then
   fi
 fi
 
+# Export PATH and MANPATH to restore in shell-specific activate scripts.
+export _FLOX_RESTORE_PATH="$PATH"
+export _FLOX_RESTORE_MANPATH="$MANPATH"
+
 # "-c" command mode: pass both [2] arguments unaltered to shell invocation
 case "$_flox_shell" in
   *bash)

--- a/assets/activation-scripts/activate.d/attach-inplace.bash
+++ b/assets/activation-scripts/activate.d/attach-inplace.bash
@@ -15,6 +15,8 @@ expiring_pid="$$"
 # script fragment when represented on a single line.
 case "$_flox_shell" in
   *bash)
+    echo "export _FLOX_RESTORE_PATH=\"$PATH\";"
+    echo "export _FLOX_RESTORE_MANPATH=\"$MANPATH\";"
     echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$\$ --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
     echo "export _flox_activate_tracelevel=\"$_flox_activate_tracelevel\";"
     echo "export FLOX_ENV=\"$FLOX_ENV\";"
@@ -23,6 +25,8 @@ case "$_flox_shell" in
     echo "source '$_activate_d/bash';"
     ;;
   *fish)
+    echo "set -gx _FLOX_RESTORE_PATH \"$PATH\";"
+    echo "set -gx _FLOX_RESTORE_MANPATH \"$MANPATH\";"
     echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$fish_pid --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
     echo "set -gx _flox_activate_tracelevel \"$_flox_activate_tracelevel\";"
     echo "set -gx FLOX_ENV \"$FLOX_ENV\";"
@@ -31,6 +35,8 @@ case "$_flox_shell" in
     echo "source '$_activate_d/fish';"
     ;;
   *tcsh)
+    echo "setenv _FLOX_RESTORE_PATH \"$PATH\";"
+    echo "setenv _FLOX_RESTORE_MANPATH \"$MANPATH\";"
     echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$\$ --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
     echo "setenv _flox_activate_tracelevel \"$_flox_activate_tracelevel\";"
     echo "setenv FLOX_ENV \"$FLOX_ENV\";"
@@ -40,6 +46,8 @@ case "$_flox_shell" in
     ;;
   # Any additions should probably be restored in zdotdir/* scripts
   *zsh)
+    echo "export _FLOX_RESTORE_PATH=\"$PATH\";"
+    echo "export _FLOX_RESTORE_MANPATH=\"$MANPATH\";"
     echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$\$ --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
     echo "export _flox_activate_tracelevel=\"$_flox_activate_tracelevel\";"
     echo "export FLOX_ENV=\"$FLOX_ENV\";"

--- a/assets/activation-scripts/activate.d/attach-interactive.bash
+++ b/assets/activation-scripts/activate.d/attach-interactive.bash
@@ -1,3 +1,7 @@
+# Export PATH and MANPATH to restore in shell-specific activate scripts.
+export _FLOX_RESTORE_PATH="$PATH"
+export _FLOX_RESTORE_MANPATH="$MANPATH"
+
 # "interactive" mode: invoke the user's shell with args that:
 #   a. defeat the shell's normal startup scripts
 #   b. source the relevant activation script

--- a/assets/activation-scripts/activate.d/bash
+++ b/assets/activation-scripts/activate.d/bash
@@ -32,6 +32,16 @@ fi
 eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
 eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
 
+# Restore PATH and MANPATH if set in one of the attach scripts.
+if [ -n "$_FLOX_RESTORE_PATH" ]; then
+  export PATH="$_FLOX_RESTORE_PATH"
+  unset _FLOX_RESTORE_PATH
+fi
+if [ -n "$_FLOX_RESTORE_MANPATH" ]; then
+  export MANPATH="$_FLOX_RESTORE_MANPATH"
+  unset _FLOX_RESTORE_MANPATH
+fi
+
 # Set the prompt if we're in an interactive shell.
 if [ -t 1 ]; then
   # shellcheck disable=SC1091 # from rendered environment

--- a/assets/activation-scripts/activate.d/fish
+++ b/assets/activation-scripts/activate.d/fish
@@ -20,6 +20,16 @@ end
 $_gnused/bin/sed -e 's/^/set -e /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env" | source
 $_gnused/bin/sed -e 's/^/set -gx /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env" | source
 
+# Restore PATH and MANPATH if set in one of the attach scripts.
+if set -q _FLOX_RESTORE_PATH
+  set -gx PATH $_FLOX_RESTORE_PATH
+  set -e _FLOX_RESTORE_PATH
+end
+if set -q _FLOX_RESTORE_MANPATH
+  set -gx MANPATH $_FLOX_RESTORE_MANPATH
+  set -e _FLOX_RESTORE_MANPATH
+end
+
 # Set the prompt if we're in an interactive shell.
 if isatty 1
     source "$_activate_d/set-prompt.fish"

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -16,7 +16,7 @@ export | LC_ALL=C $_coreutils/bin/sort > "$_start_env"
 # Process the flox environment customizations, which includes (amongst
 # other things) prepending this environment's bin directory to the PATH.
 # shellcheck disable=SC2154 # set in the main `activate` script
-if [ -d "$_profile_d" ]; then
+if [ "$_FLOX_ENV_ACTIVATION_MODE" = "dev" ] && [ -d "$_profile_d" ]; then
   declare -a _profile_scripts
   # TODO: figure out why this is needed
   set +e

--- a/assets/activation-scripts/activate.d/tcsh
+++ b/assets/activation-scripts/activate.d/tcsh
@@ -14,6 +14,16 @@ endif
 eval `$_gnused/bin/sed -e 's/^/unsetenv /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"`
 eval `$_gnused/bin/sed -e 's/^/setenv /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"`
 
+# Restore PATH and MANPATH if set in one of the attach scripts.
+if ( $?_FLOX_RESTORE_PATH ) then
+  setenv PATH "$_FLOX_RESTORE_PATH"
+  unset _FLOX_RESTORE_PATH
+endif
+if ( $?_FLOX_RESTORE_MANPATH ) then
+  setenv MANPATH "$_FLOX_RESTORE_MANPATH"
+  unset _FLOX_RESTORE_MANPATH
+endif
+
 # Set the prompt if we're in an interactive shell.
 if ( $?tty ) then
   source "$_activate_d/set-prompt.tcsh"

--- a/assets/activation-scripts/activate.d/zsh
+++ b/assets/activation-scripts/activate.d/zsh
@@ -62,6 +62,16 @@ unset fpath_prepend
 eval "$($_gnused/bin/sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
 eval "$($_gnused/bin/sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
 
+# Restore PATH and MANPATH if set in one of the attach scripts.
+if [ -n "$_FLOX_RESTORE_PATH" ]; then
+  export PATH="$_FLOX_RESTORE_PATH"
+  unset _FLOX_RESTORE_PATH
+fi
+if [ -n "$_FLOX_RESTORE_MANPATH" ]; then
+  export MANPATH="$_FLOX_RESTORE_MANPATH"
+  unset _FLOX_RESTORE_MANPATH
+fi
+
 # Set the prompt if we're in an interactive shell.
 if [[ -o interactive ]]; then
   source "$_activate_d/set-prompt.zsh"

--- a/assets/activation-scripts/etc/profile.d/0100_common-paths.sh
+++ b/assets/activation-scripts/etc/profile.d/0100_common-paths.sh
@@ -25,41 +25,6 @@ export \
 
 # ---------------------------------------------------------------------------- #
 
-# Set the PATH environment variable.
-PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin${PATH:+:$PATH}"
-export PATH
-
-# ---------------------------------------------------------------------------- #
-
-# Set the man(1) search path.
-# The search path for manual pages is determined
-# from the MANPATH environment variable in a non-standard way:
-#
-# 1) If MANPATH begins with a colon, it is appended to the default list;
-# 2) if it ends with a colon, it is prepended to the default list;
-# 3) or if it contains two adjacent colons,
-#    the standard search path is inserted between the colons.
-# 4) If none of these conditions are met, it overrides the standard search path.
-#
-# In order for man(1) to find manual pages not definded in the flox environment,
-# we ensure that we prepend the flox search path _with_ a colon in all cases.
-#
-# Thus, the man pages defined in the flox environment are searched first,
-# and default search paths still apply.
-# Additionally, decisions made by the user by setting the MANPATH variable
-# are not overridden by the flox environment:
-# - If MANPATH starts with `:` we now have `::` -> rule 1/3,
-#   the defaults are inserted in between,
-#   i.e. in front of MANPATH, but FLOXENV will take precedence in any case
-# - If MANPATH ends with `:` we end with `:` -> rule 2,
-#   the defaults are appended (no change)
-# - If MANPATH does not start or end with `:`, -> rule 4,
-#   FLOX_ENV:MANPATH replaces the defaults (no change)
-MANPATH="$FLOX_ENV/share/man:${MANPATH:+$MANPATH}"
-export MANPATH
-
-# ---------------------------------------------------------------------------- #
-
 if [ -n "${FLOX_ENV_LIB_DIRS:-}" ]; then
   case "$($_coreutils/bin/uname -s)" in
     Linux*)

--- a/cli/tests/activate/verify_PATH.bash
+++ b/cli/tests/activate/verify_PATH.bash
@@ -20,13 +20,21 @@ IFS=: read -ra path_array <<< "$PATH"
   exit 1;
 }
 # 3) contains neither of the above more than once
-declare -A seen
+declare seen_bin=""
+declare seen_sbin=""
 for p in "${path_array[@]}"; do
-    if [ "$p" = "$FLOX_ENV/bin" ] || [ "$p" = "$FLOX_ENV/sbin" ]; then
-        if [ -n "${seen[$p]}" ]; then
+    if [ "$p" = "$FLOX_ENV/bin" ]; then
+        if [ -n "$seen_bin" ]; then
             exit 1
         else
-            seen["$p"]=1
+            seen_bin=1
+        fi
+    fi
+    if [ "$p" = "$FLOX_ENV/sbin" ]; then
+        if [ -n "$seen_sbin" ]; then
+            exit 1
+        else
+            seen_sbin=1
         fi
     fi
 done

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -46,6 +46,7 @@ runCommand "flox-activation-scripts"
       --replace "@getopt@" "${getopt}" \
       --replace "@gnused@" "${gnused}" \
       --replace "@jq@" "${jq}/bin/jq" \
+      --replace "@nawk@" "${nawk}" \
       --replace "@out@" "$out" \
       --replace "@process-compose@" "${process-compose}/bin/process-compose" \
       --replace "@setsid@" "${util-linux}/bin/setsid" \

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -28,6 +28,7 @@
   gnused,
   gnutar,
   jq,
+  man,
   nix,
   yq,
   openssh,
@@ -78,6 +79,7 @@ let
       gnused
       gnutar
       jq
+      man
       nix
       openssh
       parallel


### PR DESCRIPTION
Make changes needed in Bash activation scripts to support run mode. This
commit adds a `[ --mode (run|dev) ]` option. It is never used and
defaults to `dev` which is the current behavior.

Run mode only modifies PATH and MANPATH. The method for setting PATH and
MANPATH was changed to always prepend all items in FLOX_ENV_DIRS to
MANPATH and PATH rather than using add.env and del.env. This is to allow
nested activations; without this change `flox activate -d 1` in one
shell followed by `flox activate -d 2 && flox activate -d 1` in another
would blow away the changes to PATH made by the `flox activate -d 2`
command.

## Release Notes

Run mode now supports nested activations