### PR TITLE
feat: wrap manifest build executables with build-specific env

### DIFF
--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -1,5 +1,6 @@
 {
-  activationScripts_storePath ? "@activationScripts@",
+  activationScripts_out_storePath ? "@activationScripts_out@",
+  activationScripts_build_wrapper_storePath ? "@activationScripts_build_wrapper@",
   defaultEnvrc_storePath ? "@defaultEnvrc@",
   coreutils_storePath ? "@coreutils@",
   floxBuildenv_storePath ? "@out@",
@@ -18,7 +19,8 @@ let
   # and returns a string with the path added to its string context[1].
   #
   # [1]: <https://nix.dev/manual/nix/2.24/language/string-context>
-  activationScripts = builtins.storePath activationScripts_storePath;
+  activationScripts_out = builtins.storePath activationScripts_out_storePath;
+  activationScripts_build_wrapper = builtins.storePath activationScripts_build_wrapper_storePath;
   defaultEnvrc = builtins.storePath defaultEnvrc_storePath;
   floxBuildEnv = builtins.storePath floxBuildenv_storePath;
   coreutils = builtins.storePath coreutils_storePath;
@@ -245,7 +247,8 @@ builtins.derivation {
 
   # Pull in external attributes and those calculated above.
   inherit
-    activationScripts
+    activationScripts_out
+    activationScripts_build_wrapper
     inputSrcs
     manifestPackage
     system
@@ -312,7 +315,8 @@ builtins.derivation {
   # The `builder.pl` script is responsible for parsing this when computing
   # the contents of requisites.txt for each output.
   exportReferencesGraph.graph = inputSrcs ++ [
-    activationScripts
+    activationScripts_out
+    activationScripts_build_wrapper
     manifestPackage
   ];
 }

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -408,6 +408,13 @@ impl Environment for ManagedEnvironment {
         Ok(self.rendered_env_links.clone())
     }
 
+    fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError> {
+        let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
+        // todo: ensure lockfile exists?
+
+        Ok(local_checkout.build(flox)?)
+    }
+
     /// Returns .flox/cache
     fn cache_path(&self) -> Result<CanonicalPath, EnvironmentError> {
         let cache_dir = self.path.join(CACHE_DIR_NAME);
@@ -510,12 +517,6 @@ impl ManagedEnvironment {
             let content = local_checkout.existing_lockfile()?;
             content.ok_or(EnvironmentError::MissingLockfile)
         }
-    }
-
-    pub fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError> {
-        let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
-
-        Ok(local_checkout.build(flox)?)
     }
 
     pub fn link(&mut self, store_paths: &BuildEnvOutputs) -> Result<(), EnvironmentError> {

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -161,6 +161,13 @@ pub trait Environment: Send {
         flox: &Flox,
     ) -> Result<RenderedEnvironmentLinks, EnvironmentError>;
 
+    /// Build the environment and return the built store paths
+    /// for the development and runtime variants,
+    /// as well as runtime environments of the manifest builds defined in this environment.
+    ///
+    /// This does not link the environment, but may lock the environment, if necessary.
+    fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError>;
+
     /// Return a path that environment hooks should use to store transient data.
     ///
     /// The returned path will exist.

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -299,13 +299,20 @@ impl Environment for PathEnvironment {
         let out_paths = self.rendered_env_links.clone();
 
         if self.needs_rebuild(flox)? {
-            let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
-            env_view.ensure_locked(flox)?;
-            let store_paths = env_view.build(flox)?;
+            let store_paths = self.build(flox)?;
             self.link(flox, &store_paths)?;
         }
 
         Ok(out_paths)
+    }
+
+    /// Build the environment
+    /// This will lock the environment if it is not already locked.
+    fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError> {
+        let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
+        env_view.lock(flox)?;
+        let store_paths = env_view.build(flox)?;
+        Ok(store_paths)
     }
 
     /// Returns .flox/cache

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -328,6 +328,13 @@ impl Environment for RemoteEnvironment {
         Ok(self.rendered_env_links.clone())
     }
 
+    fn build(
+        &mut self,
+        flox: &Flox,
+    ) -> Result<crate::providers::buildenv::BuildEnvOutputs, EnvironmentError> {
+        self.inner.build(flox)
+    }
+
     /// Return a path that environment hooks should use to store transient data.
     ///
     /// Remote environments shouldn't have state of any kind, so this just

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -737,7 +737,7 @@ mod tests {
     fn build_uses_package_from_manifest() {
         let package_name = String::from("foo");
         let file_name = String::from("bar");
-        let file_content = String::from("environment-develop/bin/hello\n");
+        let file_content = String::from("environment-build-foo/bin/hello\n");
 
         let manifest = formatdoc! {r#"
             version = 1

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::LazyLock;
 
 use indoc::indoc;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::debug;
 
@@ -59,14 +60,21 @@ pub enum BuildEnvError {
     ReadOutputs(#[source] serde_json::Error),
 }
 
-#[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct BuildEnvOutputs {
     pub develop: BuiltStorePath,
     pub runtime: BuiltStorePath,
-    // todo: add more build runtime outputs
+    /// A map of additional built store paths.
+    /// These are the runtime environments for each manifest build.
+    /// The main consumer of this is [super::build::FloxBuildMk].
+    // todo: nest additional built paths for manifest builds
+    #[serde(flatten)]
+    pub manifest_build_runtimes: HashMap<String, BuiltStorePath>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq, derive_more::Deref, derive_more::AsRef)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, derive_more::Deref, derive_more::AsRef,
+)]
 pub struct BuiltStorePath(PathBuf);
 
 pub trait BuildEnv {

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -110,7 +110,7 @@ impl Build {
         };
 
         let base_dir = env.parent_path()?;
-        let flox_env = env.rendered_env_links(&flox)?;
+        let built_environments = env.build(&flox)?;
 
         let packages_to_build = available_packages(&env.lockfile(&flox)?, packages)?;
 
@@ -118,7 +118,7 @@ impl Build {
         let output = builder.build(
             &flox,
             &base_dir,
-            &flox_env.development,
+            &built_environments,
             &FLOX_INTERPRETER,
             &packages_to_build,
         )?;

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -80,13 +80,7 @@ runCommandNoCC "flox-activation-scripts"
 
     # Remove start-services.bash.
     rm $build_wrapper/activate.d/start-services.bash
-    sed -i 's/source ".*start-services.bash"/: no services in build_wrapper script/' $build_wrapper/activate
-
-    # Remove references to flox-activations.
-    rm $build_wrapper/activate.d/attach-*.bash
-    sed -i 's/source ".*attach-.*.bash"/: no attaching in build_wrapper script/' $build_wrapper/activate
-    sed -i 's/_flox_activations=.*/_flox_activations=true/' \
-        $build_wrapper/activate $build_wrapper/activate.d/start.bash
+    sed -i 's/source ".*start-services.bash"/echo no services in build_wrapper script >\&2; false/' $build_wrapper/activate
 
     # That's the build done, now shellcheck the results.
     ${shellcheck}/bin/shellcheck --external-sources --check-sourced \

--- a/pkgs/flox-buildenv/default.nix
+++ b/pkgs/flox-buildenv/default.nix
@@ -19,7 +19,8 @@ let
   buildenv = (writers.writeBash "buildenv" (builtins.readFile ../../buildenv/buildenv.bash));
   buildenv_nix = ../../buildenv/buildenv.nix;
   builder_pl = ../../buildenv/builder.pl;
-  activationScripts = flox-activation-scripts;
+  activationScripts_out = flox-activation-scripts.out;
+  activationScripts_build_wrapper = flox-activation-scripts.build_wrapper;
   defaultEnvrc = writeText "default.envrc" (
     ''
       # Default environment variables
@@ -45,7 +46,8 @@ runCommandNoCC "${pname}-${version}"
       nix
       pname
       version
-      activationScripts
+      activationScripts_out
+      activationScripts_build_wrapper
       defaultEnvrc
       ;
     # Substitutions for builder.pl.


### PR DESCRIPTION
## Proposed Changes

Following the recent buildenv replacement we now build dedicated closures for each manifest build package. This patch updates the builder to wrap files in bin and sbin with this new closure instead of the original $FLOX_ENV closure used to perform the actual build.

## Release Notes

N/A (manifest builds not yet a published feature)