### PR TITLE
feat: activate in runtime mode

### DIFF
--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -475,9 +475,9 @@ fn prompt_to_modify_rc_file() -> Result<bool, anyhow::Error> {
         // There are unicode quoting issues with the current form
         // We can't use <() for zsh because it blocks input which can make it
         // impossible to Ctrl-C
-        Shell::Bash(_) | Shell::Zsh(_) => r#"eval "$(flox activate -d ~)""#,
-        Shell::Tcsh(_) => r#"eval "`flox activate -d ~`""#,
-        Shell::Fish(_) => "flox activate -d ~ | source",
+        Shell::Bash(_) | Shell::Zsh(_) => r#"eval "$(flox activate -d ~ -m run)""#,
+        Shell::Tcsh(_) => r#"eval "`flox activate -d ~ -m run`""#,
+        Shell::Fish(_) => "flox activate -d ~ -m run | source",
     };
     let rc_file_name = match shell {
         Shell::Bash(_) => ".bashrc",

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -306,7 +306,7 @@ pub async fn start_services_with_new_process_compose(
         print_script: false,
         start_services: true,
         use_fallback_interpreter: false,
-        _mode: Some(Mode::Dev),
+        mode: Some(Mode::Dev),
         run_args: vec!["true".to_string()],
     }
     .activate(

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3455,3 +3455,92 @@ EOF
   assert_success
   assert_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/bin/emacs"
 }
+
+# ---------------------------------------------------------------------------- #
+
+@test "runtime: dev dependencies aren't added to PATH" {
+  project_setup
+  "$FLOX_BIN" edit -n "runtime_project" # give it a stable name
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install almonds
+  # `almonds` brings in Python as a development dependency, and we don't want
+  # that in runtime mode
+  run "$FLOX_BIN" activate -m run -- bash <(cat <<'EOF'
+    [ -e "$FLOX_ENV/bin/almonds" ]
+    [ ! -e "$FLOX_ENV/bin/python3" ]
+EOF
+)
+  assert_success
+}
+
+@test "runtime: packages still added to PATH" {
+  project_setup
+  "$FLOX_BIN" edit -n "runtime_project" # give it a stable name
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install almonds
+  run "$FLOX_BIN" activate -m run -- which almonds
+  assert_output --partial ".flox/run/$NIX_SYSTEM.runtime_project.run/bin/almonds"
+}
+
+@test "runtime: remains in runtime mode as bottom layer" {
+  # Prepare two environments that we're going to layer
+  export bottom_layer_dir="$BATS_TEST_TMPDIR/bottom_layer"
+  mkdir "$bottom_layer_dir"
+  "$FLOX_BIN" init -d "$bottom_layer_dir"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install -d "$bottom_layer_dir" almonds
+  export top_layer_dir="$BATS_TEST_TMPDIR/top_layer"
+  mkdir "$top_layer_dir"
+  "$FLOX_BIN" init -d "$top_layer_dir"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install -d "$top_layer_dir" hello
+
+  run "$FLOX_BIN" activate -m run -d "$bottom_layer_dir" -- bash <(cat <<'EOF'
+    # This is where we *would* find `python3` if it was present
+    python_path_bottom="$FLOX_ENV/bin/python3"
+    if [ "$(command -v python3)" = "$python_path_bottom" ]; then
+      exit 1
+    fi
+
+    # Layer another environment on top
+    source <("$FLOX_BIN" activate -d "$top_layer_dir")
+
+    # Ensure that we don't find Python from the bottom environment
+    if [ "$(command -v python3)" = "$python_path_bottom" ]; then
+      exit 1
+    fi
+EOF
+)
+  assert_success
+}
+
+@test "runtime: remains in runtime mode as top layer" {
+  # Prepare two environments that we're going to layer
+  export bottom_layer_dir="$BATS_TEST_TMPDIR/bottom_layer"
+  mkdir "$bottom_layer_dir"
+  "$FLOX_BIN" init -d "$bottom_layer_dir"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install -d "$bottom_layer_dir" hello
+  export top_layer_dir="$BATS_TEST_TMPDIR/top_layer"
+  mkdir "$top_layer_dir"
+  "$FLOX_BIN" init -d "$top_layer_dir"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install -d "$top_layer_dir" almonds
+
+  run "$FLOX_BIN" activate -d "$bottom_layer_dir" -m run  -- bash <(cat <<'EOF'
+    # Layer another environment on top
+    source <("$FLOX_BIN" activate -m run -d "$top_layer_dir")
+
+    # Ensure that we don't find Python from the bottom environment
+    if [ "$(command -v python3)" = "$FLOX_ENV/bin/python3" ]; then
+      exit 1
+    fi
+EOF
+)
+  assert_success
+}
+
+@test "runtime: doesn't set CPATH" {
+  project_setup
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install hello
+  export outer_cpath="$CPATH"
+  run "$FLOX_BIN" activate -m run -- bash <(cat <<'EOF'
+    [ "$CPATH" = "$outer_cpath" ]
+EOF
+)
+  assert_success
+}

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -17,6 +17,12 @@ pre_cmd = '''
 cmd = "flox install definitely-not-a-package"
 ignore_cmd_errors = true
 
+[resolve.almonds]
+pre_cmd = '''
+  flox init  
+'''
+cmd = "flox install almonds"
+
 # Install a package that doesn't exist and that doesn't have suggestions
 [resolve.badpkg]
 pre_cmd = "flox init"

--- a/test_data/generated/resolve/almonds.json
+++ b/test_data/generated/resolve/almonds.json
@@ -1,0 +1,156 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "almonds",
+            "broken": false,
+            "derivation": "/nix/store/nk2bb1zvnlqal5czwpbjklb4jnfhl7sy-almonds-1.25b.drv",
+            "description": "Terminal Mandelbrot fractal viewer",
+            "insecure": false,
+            "install_id": "almonds",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+            "name": "almonds-1.25b",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/nw79gw3gfazf5dy8swcpw3c3wiq1b7b9-almonds-1.25b"
+              },
+              {
+                "name": "dist",
+                "store_path": "/nix/store/r5qfxxb66d8jv74j338fsw2bk2k39b3d-almonds-1.25b-dist"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "almonds",
+            "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+            "rev_count": 703931,
+            "rev_date": "2024-11-05T05:43:48Z",
+            "scrape_date": "2024-11-07T03:55:45Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "1.25b"
+          },
+          {
+            "attr_path": "almonds",
+            "broken": false,
+            "derivation": "/nix/store/q3bc9a3a6wrz15phhhyjsci6hbsflvgb-almonds-1.25b.drv",
+            "description": "Terminal Mandelbrot fractal viewer",
+            "insecure": false,
+            "install_id": "almonds",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+            "name": "almonds-1.25b",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/ngsyqgk3b8sir9y6nfxynacn7mfv419d-almonds-1.25b"
+              },
+              {
+                "name": "dist",
+                "store_path": "/nix/store/xaxhddr0ky3l3wlgkjrvqr4shq2c2z53-almonds-1.25b-dist"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "almonds",
+            "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+            "rev_count": 703931,
+            "rev_date": "2024-11-05T05:43:48Z",
+            "scrape_date": "2024-11-07T03:55:45Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "1.25b"
+          },
+          {
+            "attr_path": "almonds",
+            "broken": false,
+            "derivation": "/nix/store/wvvwwqj1rhmcd3h1xdwvh175icqdl9bd-almonds-1.25b.drv",
+            "description": "Terminal Mandelbrot fractal viewer",
+            "insecure": false,
+            "install_id": "almonds",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+            "name": "almonds-1.25b",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/dpr51icxmjfiz8sxxvsrmiiq0amm2qml-almonds-1.25b"
+              },
+              {
+                "name": "dist",
+                "store_path": "/nix/store/s1yr5vp1kazy9m5ij42735lc8ig52rn1-almonds-1.25b-dist"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "almonds",
+            "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+            "rev_count": 703931,
+            "rev_date": "2024-11-05T05:43:48Z",
+            "scrape_date": "2024-11-07T03:55:45Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "1.25b"
+          },
+          {
+            "attr_path": "almonds",
+            "broken": false,
+            "derivation": "/nix/store/q3gl7lwxyac0gf2pzyda3hl3nv7xli88-almonds-1.25b.drv",
+            "description": "Terminal Mandelbrot fractal viewer",
+            "insecure": false,
+            "install_id": "almonds",
+            "license": "MIT",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+            "name": "almonds-1.25b",
+            "outputs": [
+              {
+                "name": "out",
+                "store_path": "/nix/store/912av8n5sd1sr9lmp5xlka71i4l8bf2a-almonds-1.25b"
+              },
+              {
+                "name": "dist",
+                "store_path": "/nix/store/zfsy887j66dmlkaynqdia4vi85hhb0ld-almonds-1.25b-dist"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pname": "almonds",
+            "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+            "rev_count": 703931,
+            "rev_date": "2024-11-05T05:43:48Z",
+            "scrape_date": "2024-11-07T03:55:45Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "1.25b"
+          }
+        ],
+        "page": 703931,
+        "url": ""
+      }
+    }
+  ]
+]


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This makes the `--mode` flag actually change which environment closure
is used to activate the environment.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users can now pass the `--mode/-m (dev|run)` flag to `flox activate`, which will choose how an environment is activated. The default is `dev` and is the same as the previous behavior. The new behavior is used when `-m run` is used. This mode will only put the manifest's package in `PATH` (and not their development dependencies), and won't set certain environment variables that are necessary for development.

<!-- Many thanks! -->
