### PR TITLE
fix: preserve trailing colon in MANPATH when removing duplicates

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -235,14 +235,14 @@ MANPATH="$_prepend_manpath:${MANPATH:+$MANPATH}"
 IFS="$_save_IFS"
 unset _save_IFS
 
-# Remove duplicates from PATH and MANPATH. We use echo -n in the command
-# below to remove trailing newline characters from the input that might
-# otherwise cause a [trailing] duplicate entry to be missed.
+# Remove duplicates from PATH and MANPATH. Note we must use `echo` and not
+# `echo -n` in the command below so that trailing ":" characters are followed
+# by a newline and treated by awk as an empty field.
 declare _awkScript _nodup_PATH _nodup_MANPATH
 # shellcheck disable=SC2016
 _awkScript='BEGIN { RS = ":"; } { if (A[$0]) {} else { A[$0]=1; printf(((NR==1) ? "" : ":") $0); } }'
-_nodup_PATH="$(echo -n "$PATH" | "$_nawk/bin/nawk" "$_awkScript")"
-_nodup_MANPATH="$(echo -n "$MANPATH" | "$_nawk/bin/nawk" "$_awkScript")"
+_nodup_PATH="$(echo "$PATH" | "$_nawk/bin/nawk" "$_awkScript")"
+_nodup_MANPATH="$(echo "$MANPATH" | "$_nawk/bin/nawk" "$_awkScript")"
 export PATH="${_nodup_PATH}"
 export MANPATH="${_nodup_MANPATH}"
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3336,9 +3336,13 @@ EOF
 
 # bats test_tags=activate,activate:attach
 @test "attach doesn't break MANPATH" {
-  # We don't need an environment, but we do need wait_for_watchdogs to have a
-  # PROJECT_DIR to look for
-  project_setup_common
+  project_setup
+
+  # Ensure that an empty MANPATH is replaced with something with a trailing
+  # colon so that the default list is honoured as a fallback.
+  MANPATH= run "$FLOX_BIN" activate -- sh -c 'echo $MANPATH'
+  assert_success
+  assert_output --regexp ".*:$"
 
   "$FLOX_BIN" init -d vim
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/vim.json" "$FLOX_BIN" install -d vim vim


### PR DESCRIPTION
## Proposed Changes

PR #2342 implemented code to remove duplicates in the PATH and MANPATH variables which had the effect of dropping the trailing ":" character from the MANPATH. This patch fixes that by updating the deduplication logic to ensure that a newline is appended following a trailing colon and recognised as a valid [otherwise empty] array element.

## Release Notes

N/A - just a bugfix of a release candidate