### PR TITLE
feat: skip eval if storepaths exist

### DIFF
--- a/cli/catalog-api-v1/openapi.json
+++ b/cli/catalog-api-v1/openapi.json
@@ -1412,6 +1412,11 @@
       },
       "PackageResolutionInfo": {
         "properties": {
+          "catalog": {
+            "title": "Catalog",
+            "nullable": true,
+            "type": "string"
+          },
           "attr_path": {
             "type": "string",
             "title": "Attr Path"
@@ -1671,6 +1676,11 @@
       },
       "ResolvedPackageDescriptor": {
         "properties": {
+          "catalog": {
+            "title": "Catalog",
+            "nullable": true,
+            "type": "string"
+          },
           "attr_path": {
             "type": "string",
             "title": "Attr Path"
@@ -1995,9 +2005,22 @@
       },
       "UserBuild-Input": {
         "properties": {
-          "locked_url": {
+          "url": {
             "type": "string",
-            "title": "Locked Url"
+            "title": "Url"
+          },
+          "rev": {
+            "type": "string",
+            "title": "Rev"
+          },
+          "rev_count": {
+            "type": "integer",
+            "title": "Rev Count"
+          },
+          "rev_date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Rev Date"
           },
           "locked_base_catalog_url": {
             "title": "Locked Base Catalog Url",
@@ -2010,7 +2033,10 @@
         },
         "type": "object",
         "required": [
-          "locked_url",
+          "url",
+          "rev",
+          "rev_count",
+          "rev_date",
           "derivation"
         ],
         "title": "UserBuild",
@@ -2031,14 +2057,30 @@
             "version": "1.0"
           },
           "locked_base_catalog_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
-          "locked_url": "http://example.com?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172"
+          "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+          "rev_count": 1,
+          "rev_date": "2021-09-01T00:00:00",
+          "url": "http://example.com"
         }
       },
       "UserBuild-Output": {
         "properties": {
-          "locked_url": {
+          "url": {
             "type": "string",
-            "title": "Locked Url"
+            "title": "Url"
+          },
+          "rev": {
+            "type": "string",
+            "title": "Rev"
+          },
+          "rev_count": {
+            "type": "integer",
+            "title": "Rev Count"
+          },
+          "rev_date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Rev Date"
           },
           "locked_base_catalog_url": {
             "title": "Locked Base Catalog Url",
@@ -2051,7 +2093,10 @@
         },
         "type": "object",
         "required": [
-          "locked_url",
+          "url",
+          "rev",
+          "rev_count",
+          "rev_date",
           "derivation"
         ],
         "title": "UserBuild",
@@ -2072,7 +2117,10 @@
             "version": "1.0"
           },
           "locked_base_catalog_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
-          "locked_url": "http://example.com?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172"
+          "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+          "rev_count": 1,
+          "rev_date": "2021-09-01T00:00:00",
+          "url": "http://example.com"
         }
       },
       "UserBuildCreationResponse": {

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -1089,6 +1089,13 @@ pub mod types {
     ///        "null"
     ///      ]
     ///    },
+    ///    "catalog": {
+    ///      "title": "Catalog",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
     ///    "derivation": {
     ///      "title": "Derivation",
     ///      "type": "string"
@@ -1193,6 +1200,8 @@ pub mod types {
     pub struct PackageResolutionInfo {
         pub attr_path: String,
         pub broken: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub catalog: Option<String>,
         pub derivation: String,
         pub description: Option<String>,
         pub insecure: Option<bool>,
@@ -1489,6 +1498,13 @@ pub mod types {
     ///        "null"
     ///      ]
     ///    },
+    ///    "catalog": {
+    ///      "title": "Catalog",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
     ///    "derivation": {
     ///      "title": "Derivation",
     ///      "type": "string"
@@ -1597,6 +1613,8 @@ pub mod types {
     pub struct ResolvedPackageDescriptor {
         pub attr_path: String,
         pub broken: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub catalog: Option<String>,
         pub derivation: String,
         pub description: Option<String>,
         pub insecure: Option<bool>,
@@ -2151,13 +2169,19 @@ pub mod types {
     ///        "version": "1.0"
     ///      },
     ///      "locked_base_catalog_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
-    ///      "locked_url": "http://example.com?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172"
+    ///      "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+    ///      "rev_count": 1,
+    ///      "rev_date": "2021-09-01T00:00:00",
+    ///      "url": "http://example.com"
     ///    }
     ///  ],
     ///  "type": "object",
     ///  "required": [
     ///    "derivation",
-    ///    "locked_url"
+    ///    "rev",
+    ///    "rev_count",
+    ///    "rev_date",
+    ///    "url"
     ///  ],
     ///  "properties": {
     ///    "derivation": {
@@ -2170,8 +2194,21 @@ pub mod types {
     ///        "null"
     ///      ]
     ///    },
-    ///    "locked_url": {
-    ///      "title": "Locked Url",
+    ///    "rev": {
+    ///      "title": "Rev",
+    ///      "type": "string"
+    ///    },
+    ///    "rev_count": {
+    ///      "title": "Rev Count",
+    ///      "type": "integer"
+    ///    },
+    ///    "rev_date": {
+    ///      "title": "Rev Date",
+    ///      "type": "string",
+    ///      "format": "date-time"
+    ///    },
+    ///    "url": {
+    ///      "title": "Url",
     ///      "type": "string"
     ///    }
     ///  }
@@ -2183,7 +2220,10 @@ pub mod types {
         pub derivation: UserDerivationInput,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub locked_base_catalog_url: Option<String>,
-        pub locked_url: String,
+        pub rev: String,
+        pub rev_count: i64,
+        pub rev_date: chrono::DateTime<chrono::offset::Utc>,
+        pub url: String,
     }
     impl From<&UserBuildInput> for UserBuildInput {
         fn from(value: &UserBuildInput) -> Self {
@@ -2279,13 +2319,19 @@ pub mod types {
     ///        "version": "1.0"
     ///      },
     ///      "locked_base_catalog_url": "https://github.com/flox/nixpkgs?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
-    ///      "locked_url": "http://example.com?rev=99dc8785f6a0adac95f5e2ab05cc2e1bf666d172"
+    ///      "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+    ///      "rev_count": 1,
+    ///      "rev_date": "2021-09-01T00:00:00",
+    ///      "url": "http://example.com"
     ///    }
     ///  ],
     ///  "type": "object",
     ///  "required": [
     ///    "derivation",
-    ///    "locked_url"
+    ///    "rev",
+    ///    "rev_count",
+    ///    "rev_date",
+    ///    "url"
     ///  ],
     ///  "properties": {
     ///    "derivation": {
@@ -2298,8 +2344,21 @@ pub mod types {
     ///        "null"
     ///      ]
     ///    },
-    ///    "locked_url": {
-    ///      "title": "Locked Url",
+    ///    "rev": {
+    ///      "title": "Rev",
+    ///      "type": "string"
+    ///    },
+    ///    "rev_count": {
+    ///      "title": "Rev Count",
+    ///      "type": "integer"
+    ///    },
+    ///    "rev_date": {
+    ///      "title": "Rev Date",
+    ///      "type": "string",
+    ///      "format": "date-time"
+    ///    },
+    ///    "url": {
+    ///      "title": "Url",
     ///      "type": "string"
     ///    }
     ///  }
@@ -2311,7 +2370,10 @@ pub mod types {
         pub derivation: UserDerivationOutput,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub locked_base_catalog_url: Option<String>,
-        pub locked_url: String,
+        pub rev: String,
+        pub rev_count: i64,
+        pub rev_date: chrono::DateTime<chrono::offset::Utc>,
+        pub url: String,
     }
     impl From<&UserBuildOutput> for UserBuildOutput {
         fn from(value: &UserBuildOutput) -> Self {

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -66,6 +66,8 @@ pub struct Features {
     pub search_strategy: SearchStrategy,
     #[serde(default)]
     pub build: bool,
+    #[serde(default)]
+    pub publish: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, derive_more::Deref)]

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1412,6 +1412,7 @@ mod tests {
             name: DEFAULT_GROUP_NAME.to_string(),
             page: Some(CatalogPage {
                 packages: Some(vec![ResolvedPackageDescriptor {
+                    catalog: None,
                     attr_path: "foo".to_string(),
                     broken: Some(false),
                     derivation: "new derivation".to_string(),

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1574,6 +1574,7 @@ pub(crate) mod tests {
             &self,
             _catalog_name: impl AsRef<str> + Send + Sync,
             _package_name: impl AsRef<str> + Send + Sync,
+            _original_url: impl AsRef<str> + Send + Sync,
         ) -> Result<(), CatalogClientError> {
             unreachable!("catalog service should not be called");
         }

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -203,6 +203,7 @@ impl LockedPackageCatalog {
     ) -> Self {
         // unpack package to avoid missing new fields
         let catalog::PackageResolutionInfo {
+            catalog: _,
             attr_path,
             broken,
             derivation,
@@ -1773,6 +1774,7 @@ pub(crate) mod tests {
                 page: 1,
                 url: "url".to_string(),
                 packages: Some(vec![PackageResolutionInfo {
+                    catalog: None,
                     attr_path: "hello".to_string(),
                     broken: Some(false),
                     derivation: "derivation".to_string(),
@@ -2398,6 +2400,7 @@ pub(crate) mod tests {
                 complete: true,
                 url: "url".to_string(),
                 packages: Some(vec![PackageResolutionInfo {
+                    catalog: None,
                     attr_path: "hello".to_string(),
                     broken: Some(false),
                     derivation: "derivation".to_string(),
@@ -3042,6 +3045,7 @@ pub(crate) mod tests {
             page: Some(CatalogPage {
                 complete: true,
                 packages: Some(vec![ResolvedPackageDescriptor {
+                    catalog: None,
                     attr_path: foo_catalog_descriptor.pkg_path.clone(),
                     broken: Default::default(),
                     derivation: "derivation".to_string(),

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1567,7 +1567,7 @@ pub(crate) mod tests {
             &self,
             _catalog_name: impl AsRef<str> + Send + Sync,
         ) -> Result<(), CatalogClientError> {
-            unreachable!("catalog service should not be called");
+            unreachable!("create_catalog should not be called");
         }
 
         async fn create_package(
@@ -1576,7 +1576,7 @@ pub(crate) mod tests {
             _package_name: impl AsRef<str> + Send + Sync,
             _original_url: impl AsRef<str> + Send + Sync,
         ) -> Result<(), CatalogClientError> {
-            unreachable!("catalog service should not be called");
+            unreachable!("create_package should not be called");
         }
 
         async fn publish_build(
@@ -1585,7 +1585,7 @@ pub(crate) mod tests {
             _package_name: impl AsRef<str> + Send + Sync,
             _build_info: &UserBuildInfo,
         ) -> Result<(), CatalogClientError> {
-            unreachable!("catalog service should not be called");
+            unreachable!("publish_build should not be called");
         }
     }
 

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1250,6 +1250,7 @@ pub mod test_helpers {
         version: &str,
     ) -> ResolvedPackageGroup {
         let pkg = PackageResolutionInfo {
+            catalog: None,
             attr_path: pkg_path.to_string(),
             broken: Some(false),
             derivation: String::new(),

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -247,9 +247,13 @@ fn gather_base_repo_meta(
         .into_iter()
         .map(|(pkg, _desc)| pkg);
 
-    // Require a lockfile, but don't require anything in the top level group.
+    // We should not need this, and allow for no base catalog page dependency.
+    // But for now, requireing it simplifies resolution and model updates
+    // significantly.
     if install_ids_in_toplevel_group.clone().count() == 0 {
-        return Ok(None);
+        return Err(PublishError::UnsupportEnvironmentState(
+            "No packages in toplevel group".to_string(),
+        ));
     }
 
     let top_level_locked_descs = lockfile.packages.iter().filter(|pkg| {

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -154,7 +154,6 @@ where
                 unfree: None,
                 version: None,
             },
-            // TODO - make this optional in the API
             locked_base_catalog_url: self
                 .env_metadata
                 .base_catalog_ref

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod general;
 mod init;
 mod install;
 mod list;
+mod publish;
 mod pull;
 mod push;
 mod search;
@@ -910,6 +911,9 @@ enum InternalCommands {
     /// Build packages for Flox
     #[bpaf(command, hide, footer("Run 'man flox-build' for more details."))]
     Build(#[bpaf(external(build::build))] build::Build),
+    /// Publish packages
+    #[bpaf(command, hide, footer("Run 'man flox-publish' for more details."))]
+    Publish(#[bpaf(external(publish::publish_cmd))] publish::PublishCmd),
 }
 
 impl InternalCommands {
@@ -918,6 +922,7 @@ impl InternalCommands {
             InternalCommands::ResetMetrics(args) => args.handle(config, flox).await?,
             InternalCommands::Auth(args) => args.handle(config, flox).await?,
             InternalCommands::Build(args) => args.handle(config, flox).await?,
+            InternalCommands::Publish(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -913,7 +913,7 @@ enum InternalCommands {
     Build(#[bpaf(external(build::build))] build::Build),
     /// Publish packages
     #[bpaf(command, hide, footer("Run 'man flox-publish' for more details."))]
-    Publish(#[bpaf(external(publish::publish_cmd))] publish::Publish),
+    Publish(#[bpaf(external(publish::publish))] publish::Publish),
 }
 
 impl InternalCommands {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -913,7 +913,7 @@ enum InternalCommands {
     Build(#[bpaf(external(build::build))] build::Build),
     /// Publish packages
     #[bpaf(command, hide, footer("Run 'man flox-publish' for more details."))]
-    Publish(#[bpaf(external(publish::publish_cmd))] publish::PublishCmd),
+    Publish(#[bpaf(external(publish::publish_cmd))] publish::Publish),
 }
 
 impl InternalCommands {

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -66,7 +66,7 @@ impl Publish {
             bail!("Package '{}' not found in environment", package);
         }
 
-        let env_metadata = match &env {
+        let env_metadata = match &mut env {
             ConcreteEnvironment::Managed(environment) => {
                 check_environment_metadata(&flox, environment)
             },

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -1,0 +1,137 @@
+use anyhow::{bail, Result};
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::lockfile::Lockfile;
+use flox_rust_sdk::providers::build::FloxBuildMk;
+use flox_rust_sdk::providers::publish::{
+    check_build_metadata,
+    check_environment_metadata,
+    Publish,
+    PublishProvider,
+};
+use indoc::indoc;
+use log::debug;
+use tracing::instrument;
+
+use super::{environment_select, EnvironmentSelect};
+use crate::commands::{ensure_floxhub_token, ConcreteEnvironment};
+use crate::config::Config;
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[allow(unused)] // remove when we implement the command
+#[derive(Bpaf, Clone)]
+pub struct PublishCmd {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+
+    #[bpaf(external(subcommand_or_build_targets))]
+    subcommand_or_targets: SubcommandOrBuildTargets,
+}
+
+#[derive(Debug, Bpaf, Clone)]
+enum SubcommandOrBuildTargets {
+    BuildTarget {
+        /// The package to build.
+        /// Corresponds to entries in the 'build' table in the environment's manifest.toml.
+        /// If not specified, all packages are built.
+        #[bpaf(positional("package"))]
+        target: String,
+    },
+}
+
+impl PublishCmd {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        if !config.features.unwrap_or_default().publish {
+            message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
+            bail!("'publish' feature is not enabled.");
+        }
+
+        match self.subcommand_or_targets {
+            SubcommandOrBuildTargets::BuildTarget { target } => {
+                let env = self
+                    .environment
+                    .detect_concrete_environment(&flox, "Clean build files of")?;
+
+                Self::publish(flox, env, target).await
+            },
+        }
+    }
+
+    #[instrument(name = "publish", skip_all, fields(package))]
+    async fn publish(mut flox: Flox, env: ConcreteEnvironment, package: String) -> Result<()> {
+        subcommand_metric!("publish");
+
+        if let ConcreteEnvironment::Remote(_) = &env {
+            bail!("Cannot publish from a remote environment");
+        };
+
+        let mut env = env.into_dyn_environment();
+
+        if !check_package(&env.lockfile(&flox)?, &package)? {
+            bail!("Package '{}' not found in environment", package);
+        }
+
+        let (env_meta, build_meta) = (
+            check_environment_metadata(&flox, &*env).unwrap(),
+            check_build_metadata(&*env, &package, &flox.system).unwrap(),
+        );
+
+        let publish_provider = PublishProvider::<&FloxBuildMk> {
+            build_meta,
+            env_meta,
+            _builder: None,
+        };
+
+        ensure_floxhub_token(&mut flox).await?;
+        let token = flox.floxhub_token.as_ref().unwrap();
+
+        debug!("publishing package: {}", &package);
+        match publish_provider.publish(&flox.catalog_client, token).await {
+            Ok(_) => message::created("Package published successfully"),
+            Err(e) => bail!("Failed to publish package: {}", e.to_string()),
+        }
+
+        // let base_dir = env.parent_path()?;
+        // let flox_env = env.activation_path(&flox)?;
+
+        // let packages_to_build = available_packages(&env.lockfile(&flox)?, package)?;
+
+        // let builder = FloxBuildMk;
+        // let output = builder.build(&flox, &base_dir, &flox_env, &packages_to_build)?;
+
+        // for message in output {
+        //     match message {
+        //         Output::Stdout(line) => println!("{line}"),
+        //         Output::Stderr(line) => eprintln!("{line}"),
+        //         Output::Exit(status) if status.success() => {
+        //             message::created("Build completed successfully");
+        //             break;
+        //         },
+        //         Output::Exit(status) => {
+        //             bail!("Build failed with status: {status}");
+        //         },
+        //     }
+        // }
+
+        Ok(())
+    }
+}
+
+fn check_package(lockfile: &Lockfile, package: &str) -> Result<bool> {
+    let environment_packages = &lockfile.manifest.build;
+
+    if environment_packages.is_empty() {
+        bail!(indoc! {"
+        No builds found.
+
+        Add a build by modifying the '[build]' section of the manifest with 'flox edit'
+        "});
+    }
+
+    if !environment_packages.contains_key(package) {
+        bail!("Package '{}' not found in environment", package);
+    }
+
+    Ok(true)
+}

--- a/cli/flox/src/utils/init/catalog_client.rs
+++ b/cli/flox/src/utils/init/catalog_client.rs
@@ -52,6 +52,11 @@ pub fn init_catalog_client(config: &Config) -> Result<Client, anyhow::Error> {
             }
         };
 
+        // Authenticated requests (for custom catalogs) require a token.
+        if let Some(token) = config.flox.floxhub_token.as_ref() {
+            extra_headers.insert("Authorization".to_string(), format!("Bearer {}", token));
+        };
+
         // Pass in a bool if we are running in CI, so requests can reflect this in the headers
         if std::env::var("CI").is_ok() {
             extra_headers.insert("flox-ci".to_string(), "true".to_string());

--- a/pkgdb/include/flox/realisepkgs/realisepkgs-lockfile.hh
+++ b/pkgdb/include/flox/realisepkgs/realisepkgs-lockfile.hh
@@ -29,10 +29,10 @@ struct RealisepkgsLockedPackage
   std::string system;
   std::string installId;
   // TODO: this could probably just be attrs
-  resolver::LockedInputRaw input;
-  AttrPath                 attrPath;
-  unsigned                 priority;
-  OutputsToOutpaths        outputsToOutpaths;
+  resolver::LockedInputRaw           input;
+  AttrPath                           attrPath;
+  unsigned                           priority;
+  std::shared_ptr<OutputsToOutpaths> outputsToOutpaths;
 };
 
 

--- a/pkgdb/include/flox/realisepkgs/realisepkgs-lockfile.hh
+++ b/pkgdb/include/flox/realisepkgs/realisepkgs-lockfile.hh
@@ -19,6 +19,10 @@ namespace flox::realisepkgs {
 
 /* -------------------------------------------------------------------------- */
 
+
+/** @brief A mapping of output name to outpath. */
+typedef std::unordered_map<std::string, std::string> OutputsToOutpaths;
+
 /** @brief The components of a package that realisepkgs needs to realise it. */
 struct RealisepkgsLockedPackage
 {
@@ -28,6 +32,7 @@ struct RealisepkgsLockedPackage
   resolver::LockedInputRaw input;
   AttrPath                 attrPath;
   unsigned                 priority;
+  OutputsToOutpaths        outputsToOutpaths;
 };
 
 

--- a/pkgdb/src/realisepkgs/realise.cc
+++ b/pkgdb/src/realisepkgs/realise.cc
@@ -375,7 +375,6 @@ getRealisedOutputs( nix::ref<nix::EvalState> &       state,
         }
       catch ( const nix::Error & e )
         {
-          debugLog( "failed to ensure path: " + std::string( e.what() ) );
           allValid = false;
           break;  // no need to check the rest if any output is not
                   // substitutable

--- a/pkgdb/src/realisepkgs/realisepkgs-lockfile.cc
+++ b/pkgdb/src/realisepkgs/realisepkgs-lockfile.cc
@@ -55,12 +55,14 @@ RealisepkgsLockfile::from_v0_content( const nlohmann::json & jfrom )
                 lockedPackage->input.attrs );
               input.url = nix::FlakeRef::fromAttrs( input.attrs ).to_string();
 
-              this->packages.emplace_back(
-                RealisepkgsLockedPackage { system,
-                                           installId,
-                                           input,
-                                           lockedPackage->attrPath,
-                                           lockedPackage->priority } );
+              this->packages.emplace_back( RealisepkgsLockedPackage {
+                system,
+                installId,
+                input,
+                lockedPackage->attrPath,
+                lockedPackage->priority,
+                // TODO - this is a hack, not supported in V0?
+                OutputsToOutpaths() } );
             }
         }
     }
@@ -179,6 +181,11 @@ realisepkgsPackageFromV1Descriptor( const nlohmann::json &     jfrom,
           traceLog(
             nix::fmt( "locked_url is not nixpkgs... skipping input for %s ",
                       attrPath ) );
+        }
+
+      for ( auto [output, outpath] : jfrom["outputs"].items() )
+        {
+          pkg.outputsToOutpaths[output] = outpath;
         }
     }
 }

--- a/pkgdb/src/realisepkgs/realisepkgs-lockfile.cc
+++ b/pkgdb/src/realisepkgs/realisepkgs-lockfile.cc
@@ -55,14 +55,13 @@ RealisepkgsLockfile::from_v0_content( const nlohmann::json & jfrom )
                 lockedPackage->input.attrs );
               input.url = nix::FlakeRef::fromAttrs( input.attrs ).to_string();
 
-              this->packages.emplace_back( RealisepkgsLockedPackage {
-                system,
-                installId,
-                input,
-                lockedPackage->attrPath,
-                lockedPackage->priority,
-                // TODO - this is a hack, not supported in V0?
-                OutputsToOutpaths() } );
+              this->packages.emplace_back(
+                RealisepkgsLockedPackage { system,
+                                           installId,
+                                           input,
+                                           lockedPackage->attrPath,
+                                           lockedPackage->priority,
+                                           nullptr } );
             }
         }
     }
@@ -183,9 +182,10 @@ realisepkgsPackageFromV1Descriptor( const nlohmann::json &     jfrom,
                       attrPath ) );
         }
 
+      pkg.outputsToOutpaths = std::make_shared<OutputsToOutpaths>();
       for ( auto [output, outpath] : jfrom["outputs"].items() )
         {
-          pkg.outputsToOutpaths[output] = outpath;
+          pkg.outputsToOutpaths.get()->emplace( output, outpath );
         }
     }
 }


### PR DESCRIPTION
The first cutline of publish is without re-production, so we need to check if the storepath exists and if it does, then we are all set.  If it does not, we should error out.  The current code performs an eval to get the outpaths rather than using the info in the lockfile that we already have.

This change adds loading of the outpaths from the lockfile and using them, rather than eval'ing again.

To be rebased and merged after https://github.com/flox/flox/pull/2324