### PR TITLE
fix(build): Don't check FLOX_INTERPRETER for clean

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -201,6 +201,7 @@ define BUILD_local_template =
 
   .INTERMEDIATE: $(_pname)_local_build
   $(_pname)_local_build: $($(_pvarname)_buildScript)
+	@# $(if $(FLOX_INTERPRETER),,$$(error FLOX_INTERPRETER not defined))
 	@echo "Building $(_name) in local mode"
 	$(if $(_virtualSandbox),$(PRELOAD_ARGS) FLOX_SRC_DIR=$$$$($(_pwd)) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
 	MAKEFLAGS= out=$(_out) $(FLOX_INTERPRETER)/activate --turbo -- $(_bash) -e $($(_pvarname)_buildScript)
@@ -289,11 +290,6 @@ define BUILD_nix_sandbox_template =
 endef
 
 define BUILD_template =
-  # Ensure the FLOX_INTERPRETER variable is set
-  ifeq (,$(FLOX_INTERPRETER))
-    $$(error FLOX_INTERPRETER not defined)
-  endif
-
   # build mode passed as $(1)
   $(eval _build_mode = $(1))
   # We want to create build-specific variables, and variable names cannot


### PR DESCRIPTION
## Proposed Changes

Move the check for `FLOX_INTERPRETER` to the local build template
because we don't need an intepreter for clean and it was causing it to
fail as follows.

This wasn't caught by the unit tests and is hard to test the unhappy
path because we inherit `FLOX_INTERPRETER` set by the `devShell`.

    [0] stahnma@floxbox01 ~/go/src/github.com/stahnma/vhs[main] > flox --version
    1.3.3-212-gad7d08c7
    [0] stahnma@floxbox01 ~/go/src/github.com/stahnma/vhs[main] > flox build
    make: Entering directory '/Users/stahnma/go/src/github.com/stahnma/vhs'
    Rendering vhs build script to /var/folders/sc/rddkr3kd2vg1k1qmy_cx1q900000gn/T//c807b616-vhs-build.bash
    Building vhs-0.0.0 in local mode
    MAKEFLAGS= out=/tmp/store_c807b616551b1981b89b913162867434-vhs-0.0.0 /nix/store/2ba0172z86znj5jp28rnl3i5gm7x7izl-flox-activation-scripts/activate --turbo -- /nix/store/jin4ifpw4bvi554g02phy668gvaylqn1-bash-interactive-5.2p32/bin/bash -e /var/folders/sc/rddkr3kd2vg1k1qmy_cx1q900000gn/T//c807b616-vhs-build.bash
    set -o pipefail && /nix/store/7wr913d7zdn899ggl9p48gas243znipa-nix-2.18.8/bin/nix --extra-experimental-features "flakes nix-command" build -L --file /nix/store/fajwdjvp1yri33wln69gdfkc15yrm6ns-package-builder-1.0.0/libexec/build-manifest.nix --argstr name "vhs-0.0.0" --argstr flox-env "/Users/stahnma/go/src/github.com/stahnma/vhs/.flox/run/aarch64-darwin.vhs" --argstr install-prefix "/tmp/store_c807b616551b1981b89b913162867434-vhs-0.0.0" --argstr nixpkgs-url "path:/nix/store/lsy6c2f9alj2gkjj36h754kk63x6701l-source" --out-link "result-vhs" 2>&1 | /nix/store/b7j95xd7yccclshfln10k843q2qf20yg-coreutils-9.5/bin/tee /var/folders/sc/rddkr3kd2vg1k1qmy_cx1q900000gn/T/tmp.aNOdDPMrJB-build-vhs.log
    make: Leaving directory '/Users/stahnma/go/src/github.com/stahnma/vhs'
    ✨ Build completed successfully
    [0] stahnma@floxbox01 ~/go/src/github.com/stahnma/vhs[main] > flox build clean
    ❌ ERROR: failed to clean up build artifacts
    [1] stahnma@floxbox01 ~/go/src/github.com/stahnma/vhs[main] > flox build clean -vvv --debug
    2024-11-08T18:49:36.301190Z DEBUG flox: set _FLOX_PKGDB_VERBOSITY=3
    2024-11-08T18:49:36.301706Z DEBUG flox::config: reading raw config (initialized: true, reload: false)
    2024-11-08T18:49:36.302093Z DEBUG flox::commands: Metrics collection disabled
    2024-11-08T18:49:36.302152Z DEBUG flox::utils::init::catalog_client: using catalog client with url: https://api.flox.dev
    2024-11-08T18:49:36.303629Z DEBUG flox::utils::init::metrics: Attempting to read own UUID from file
    2024-11-08T18:49:36.303758Z DEBUG flox_rust_sdk::models::environment: looking for .flox: starting_path=/Users/stahnma/go/src/github.com/stahnma/vhs/.flox
    2024-11-08T18:49:36.303805Z DEBUG flox_rust_sdk::models::environment: .flox found: path=/Users/stahnma/go/src/github.com/stahnma/vhs/.flox
    2024-11-08T18:49:36.303824Z DEBUG flox::commands: detected concrete environment type: path
    2024-11-08T18:49:36.304006Z TRACE build::clean: flox_command: subcommand="build::clean"
    2024-11-08T18:49:36.304013Z DEBUG build::clean: flox::utils::metrics: No metrics client setup, skipping record
    2024-11-08T18:49:36.304032Z DEBUG build::clean: flox_rust_sdk::models::environment::path_environment: manifest_modified_at: SystemTime { tv_sec: 1731084306, tv_nsec: 886153338 },
                 out_link_modified_at: SystemTime { tv_sec: 1731084310, tv_nsec: 727521803 }
    2024-11-08T18:49:36.304336Z DEBUG build::clean: flox_rust_sdk::providers::build: running manifest clean target command=/nix/store/xqd18p6bfh63xgy6r27ryj43m05sygfd-gnumake-4.4.1/bin/make --file /nix/store/fajwdjvp1yri33wln69gdfkc15yrm6ns-package-builder-1.0.0/libexec/flox-build.mk --directory /Users/stahnma/go/src/github.com/stahnma/vhs FLOX_ENV=/Users/stahnma/go/src/github.com/stahnma/vhs/.flox/run/aarch64-darwin.vhs 'BUILDTIME_NIXPKGS_URL=path:/nix/store/lsy6c2f9alj2gkjj36h754kk63x6701l-source' clean/vhs
    2024-11-08T18:49:36.338386Z DEBUG build::clean: flox_rust_sdk::providers::build: failed to clean build artifacts status=exit status: 2 stderr=/nix/store/fajwdjvp1yri33wln69gdfkc15yrm6ns-package-builder-1.0.0/libexec/flox-build.mk:373: *** FLOX_INTERPRETER not defined.  Stop.
     stdout=make: Entering directory '/Users/stahnma/go/src/github.com/stahnma/vhs'
    make: Leaving directory '/Users/stahnma/go/src/github.com/stahnma/vhs'

    ❌ ERROR: failed to clean up build artifacts
    2024-11-08T18:49:36.338667Z DEBUG flox::utils::metrics: No metrics client setup, skipping flush

## Release Notes

N/A if it goes into 1.3.4