### PR TITLE
fix(env): Replace dbg! with debug!

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -110,7 +110,7 @@ impl RemoteEnvironment {
             // If we find a symlink, we need to delete it to create a directory
             // with symlinked files in the following step.
             if gcroots_dir.exists() && gcroots_dir.is_symlink() {
-                dbg!("removing symlink");
+                debug!(gcroot=?gcroots_dir, "removing symlink");
                 fs::remove_file(&gcroots_dir).map_err(RemoteEnvironmentError::CreateGcRootDir)?;
             }
 


### PR DESCRIPTION
## Proposed Changes

To suppress this message that I saw when running `flox edit` from a remote env after upgrading past bc3e3120:

    [flox-rust-sdk/src/models/environment/remote_environment.rs:113:17] "removing symlink" = "removing symlink"

`dbg!` sends straight to STDERR whereas `debug!` honours the tracing level. Including the `gcroot` will make it clearer what's being removed.

## Release Notes

N/A, if included in 1.3.4
