### PR TITLE
feat(activate): Warn on incompatible activations

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -188,7 +188,7 @@ declare -a _FLOX_ENV_DIRS
 # If $FLOX_ENV is already in $FLOX_ENV_DIRS, the deduplication logic below will
 # handle that
 # shellcheck disable=SC2206
-_FLOX_ENV_DIRS=($FLOX_ENV $FLOX_ENV_DIRS)
+_FLOX_ENV_DIRS=($FLOX_ENV ${FLOX_ENV_DIRS:-})
 
 # Set the PATH environment variable.
 declare _prepend_path=""

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -6,16 +6,7 @@ _getopt="@getopt@/bin/getopt"
 _nawk="@nawk@/bin/nawk"
 _readlink="@coreutils@/bin/readlink"
 
-# Disabled for now.
-# - The etc/profile.d/0800_cuda.sh script relies on a failure filling out
-#   SYSTEM_LIBS to provide a fallback behavior on NixOS. This meant that
-#   with this line enabled activation was broken on NixOS.
-# - This is a behavior change that was unexpected and not caught by CI,
-#   so it's possible that there are other behavior changes caused by this,
-#   so we've decided to disable it for now.
-# - Furthermore, this was breakage that affected a user that didn't need
-#   CUDA support, so it's unnecessary breakage.
-# set -euo pipefail
+set -euo pipefail
 
 # Trace levels supported by activation scripts:
 #   1. (-v) top-level activate script

--- a/assets/activation-scripts/etc/profile.d/0800_cuda.sh
+++ b/assets/activation-scripts/etc/profile.d/0800_cuda.sh
@@ -38,8 +38,10 @@ activate_cuda() {
   fi
 
   # Use system library cache.
-  SYSTEM_LIBS=$("$ldconfig_bin" --print-cache -C /etc/ld.so.cache 2> /dev/null \
-    | "$_nawk" "\$1 ~ /${lib_pattern}/ { print \$4 }")
+  SYSTEM_LIBS=$(
+    { "$ldconfig_bin" --print-cache -C /etc/ld.so.cache 2> /dev/null || echo; } \
+      | "$_nawk" "\$1 ~ /${lib_pattern}/ { print \$4 }"
+  )
 
   # Fallback for NixOS.
   if [ -z "$SYSTEM_LIBS" ]; then

--- a/cli/flox-activations/src/cli/attach.rs
+++ b/cli/flox-activations/src/cli/attach.rs
@@ -42,9 +42,11 @@ impl AttachArgs {
         let activations_json_path = activations::activations_json_path(runtime_dir, &self.flox_env);
 
         let (activations, lock) = activations::read_activations_json(&activations_json_path)?;
-        let Some(mut activations) = activations else {
+        let Some(activations) = activations else {
             anyhow::bail!("Expected an existing activations.json file");
         };
+
+        let mut activations = activations.check_version()?;
 
         let activation = activations
             .activation_for_id_mut(&self.id)

--- a/cli/flox-activations/src/cli/mod.rs
+++ b/cli/flox-activations/src/cli/mod.rs
@@ -51,7 +51,11 @@ mod test {
         let activations_json_path = activations::activations_json_path(runtime_dir, flox_env);
         let (activations, lock) =
             activations::read_activations_json(&activations_json_path).unwrap();
-        let mut activations = activations.unwrap_or_default();
+        let mut activations = activations
+            .map(|a| a.check_version())
+            .transpose()
+            .unwrap()
+            .unwrap_or_default();
 
         let res = f(&mut activations);
 
@@ -67,7 +71,7 @@ mod test {
         let activations_json_path = activations::activations_json_path(runtime_dir, flox_env);
         let (activations, _lock) =
             activations::read_activations_json(&activations_json_path).unwrap();
-        activations.map(|activations| f(&activations))
+        activations.map(|activations| f(&activations.check_version().unwrap()))
     }
 
     #[test]

--- a/cli/flox-activations/src/cli/set_ready.rs
+++ b/cli/flox-activations/src/cli/set_ready.rs
@@ -21,8 +21,12 @@ impl SetReadyArgs {
         let activations_json_path = activations::activations_json_path(runtime_dir, &self.flox_env);
 
         let (activations, lock) = activations::read_activations_json(&activations_json_path)?;
-        let Some(mut activations) = activations else {
+        let Some(activations) = activations else {
             anyhow::bail!("Expected an existing activations.json file");
+        };
+
+        let Ok(mut activations) = activations.check_version() else {
+            anyhow::bail!("Invalid version in activations.json file");
         };
 
         let activation = activations

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -267,7 +267,7 @@ pub fn activation_state_dir_path(
         .join(activation_id.as_ref()))
 }
 
-/// Returns the parsed environment registry file or `None` if it doesn't yet exist.
+/// Returns the parsed `activations.json` file or `None` if it doesn't yet exist.
 ///
 /// The file can be written with [write_activations_json].
 /// This function acquires a lock on the file,
@@ -279,10 +279,7 @@ pub fn read_activations_json(
     let lock_file = acquire_activations_json_lock(path).context("failed to acquire lockfile")?;
 
     if !path.exists() {
-        debug!(
-            "environment registry not found at {}",
-            path.to_string_lossy()
-        );
+        debug!("activations file not found at {}", path.to_string_lossy());
         return Ok((None, lock_file));
     }
 
@@ -291,7 +288,7 @@ pub fn read_activations_json(
     Ok((Some(parsed), lock_file))
 }
 
-/// Writes the environment registry file.
+/// Writes the environment `activations.json` file.
 /// The file is written atomically.
 /// The lock is released after the write.
 ///

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -10,9 +10,24 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use time::OffsetDateTime;
 
-use crate::{path_hash, Version};
+use crate::path_hash;
 
 type Error = anyhow::Error;
+
+/// Simplified alternative to [flox_core::Version] while we don't need to
+/// support multiple schemas.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct Version(u8);
+
+/// Latest supported version for compatibility between:
+/// - `flox` and `flox-activation-scripts`
+/// - `flox-activations` and `flox-watchdog`
+const LATEST_VERSION: Version = Version(1);
+impl Default for Version {
+    fn default() -> Self {
+        LATEST_VERSION
+    }
+}
 
 /// Deserialized contents of activations.json
 ///
@@ -27,7 +42,7 @@ type Error = anyhow::Error;
 /// and global uniqueness in case the that two environments have the same store path.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Activations {
-    version: Version<1>,
+    version: Version,
     activations: Vec<Activation>,
 }
 

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -25,9 +25,6 @@ type Error = anyhow::Error;
 /// being the only way to add an activation.
 /// Activations are identifiable by their [Activation::id], for simpler lookups
 /// and global uniqueness in case the that two environments have the same store path.
-///
-/// Notably, the [Activations] does not feature methods to remove activations.
-/// Removing actiavtions falls onto the watchdog, which is responsible for cleaning up activations.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Activations {
     version: Version<1>,
@@ -102,6 +99,7 @@ impl Activations {
         Ok(self.activations.last_mut().unwrap())
     }
 
+    /// Remove an activation. Should only be called by `flox-watchdog`.
     pub fn remove_activation(&mut self, id: impl AsRef<str>) {
         self.activations
             .retain(|activation| activation.id != id.as_ref());

--- a/cli/flox-watchdog/src/main.rs
+++ b/cli/flox-watchdog/src/main.rs
@@ -295,6 +295,8 @@ mod test {
         let activations_json = read_activations_json(&activations_json_path)
             .unwrap()
             .0
+            .unwrap()
+            .check_version()
             .unwrap();
         assert!(!activations_json.is_empty());
 
@@ -315,6 +317,8 @@ mod test {
         let activations_json = read_activations_json(&activations_json_path)
             .unwrap()
             .0
+            .unwrap()
+            .check_version()
             .unwrap();
         assert!(activations_json.is_empty());
     }

--- a/cli/flox-watchdog/src/process.rs
+++ b/cli/flox-watchdog/src/process.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{bail, Result};
-use flox_core::activations::{read_activations_json, Activations, AttachedPid};
+use flox_core::activations::{read_activations_json, Activations, AttachedPid, UncheckedVersion};
 use fslock::LockFile;
 use time::OffsetDateTime;
 use tracing::{debug, trace, warn};
@@ -29,7 +29,7 @@ type Error = anyhow::Error;
 /// A deserialized activations.json together with a lock preventing it from
 /// being modified
 /// TODO: there's probably a cleaner way to do this
-pub type LockedActivations = (Activations, LockFile);
+pub type LockedActivations = (Activations<UncheckedVersion>, LockFile);
 
 #[derive(Debug)]
 pub enum WaitResult {
@@ -243,6 +243,7 @@ impl Watcher for PidWatcher {
             drop(lock);
             None
         };
+
         let Some(activation) = activations_json.activation_for_id_ref(&self.activation_id) else {
             bail!("watchdog shouldn't be running with ID that isn't in activations.json");
         };

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3290,9 +3290,10 @@ EOF
 
   assert_failure
   refute_line "should fail"
-  assert_output "Error: This environment has already been activated with an older incompatible version of 'flox'
+  assert_output "Error: This environment has already been activated with an incompatible version of 'flox'.
 
-Exit the following activation PIDs and try again: ${ACTIVATION_PID}"
+Exit all activations of the environment and try again.
+PIDs of the running activations: ${ACTIVATION_PID}"
 }
 
 # bats test_tags=activate,activate:attach

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3269,6 +3269,9 @@ EOF
   # TODO: Workaround for https://github.com/flox/flox/issues/2164
   rm "${HOME}/.bashrc"
 
+  # Prevent backtraces from `flox-activations` leaking into output.
+  unset RUST_BACKTRACE
+
   export -f jq_edit
   FLOX_SHELL="bash" run "$FLOX_BIN" activate -- bash <(
     cat << 'EOF'

--- a/cli/tests/cuda.bats
+++ b/cli/tests/cuda.bats
@@ -75,6 +75,16 @@ teardown() {
   assert_success
 }
 
+@test "cuda disabled when nvidia0 device present but libcuba absent on NixOS" {
+  touch "${FAKE_FHS_ROOT}/dev/nvidia0"
+
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+    "$TESTS_DIR/cuda/cuda-disabled.sh" \
+    "${FAKE_FHS_ROOT}" \
+    "${TESTS_DIR}/cuda/ldconfig-mock-error.sh"
+  assert_success
+}
+
 @test "cuda disabled when not on Linux" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
 
@@ -126,7 +136,7 @@ teardown() {
   FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-enabled.sh" \
     "${FAKE_FHS_ROOT}" \
-    "${TESTS_DIR}/cuda/ldconfig-mock-absent.sh"
+    "${TESTS_DIR}/cuda/ldconfig-mock-error.sh"
   assert_success
 }
 

--- a/cli/tests/cuda/ldconfig-mock-error.sh
+++ b/cli/tests/cuda/ldconfig-mock-error.sh
@@ -1,0 +1,6 @@
+# NixOS doesn't ship with any default cache file.
+cat >&2 << EOF
+ldconfig: Can't open cache file /etc/ld.so.cache
+: No such file or directory
+EOF
+exit 1

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -626,9 +626,10 @@ EOF
     ACTIVATION_PID=$(cat activation_pid)
 
     assert_failure
-    assert_output "❌ ERROR: failed to run activation script: Error: This environment has already been activated with an older incompatible version of 'flox'
+    assert_output "❌ ERROR: failed to run activation script: Error: This environment has already been activated with an incompatible version of 'flox'.
 
-Exit the following activation PIDs and try again: ${ACTIVATION_PID}"
+Exit all activations of the environment and try again.
+PIDs of the running activations: ${ACTIVATION_PID}"
 
     # give the watchdog a chance to clean up the services before the next iteration
     wait_for_watchdogs "$PROJECT_DIR"

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -603,6 +603,9 @@ EOF
 @test "start, restart: refuses to attach to an older activations.json version" {
   setup_sleeping_services
 
+  # Prevent backtraces from `flox-activations` leaking into output.
+  unset RUST_BACKTRACE
+
   export -f jq_edit
   commands=("start" "restart")
   for command in "${commands[@]}"; do


### PR DESCRIPTION
## Proposed Changes

Add a mechanism for requiring users to exit existing activations when
using an incompatible version of `flox-activations`. We can bump this
version when making breaking changes to activations, such as introducing
new environment variables between the CLI and interpreter.

By implementing this in `flox-activations` it also prevents services
from being started because they use an ephemeral activation which goes
through the same code path.

It's worth noting that because the version is applied to the root of
`activations.json` that it will catch all activations of all store paths
for an environment. It will not however catch different runmodes of an
environment because they use different `activations.json`, per 2357.

We are not going to add any checks for old non-attach style activations
because we've already shipped that change in v1.3.4 and it would add an
unwanted dependency on the environment registry to `flox-activations`
and `flox-watchdog`.

The error message differs slightly from the original acceptance criteria
in that:

- we don't have access to the environment name without introducing an
  implicit dependency on `FLOX_ENV_DESCRIPTION` but most of our other
  error messages don't include it so I think it's fine to omit

- a list of activation PIDs is included to indicate to the user which
  processes they need to exit, since it was easy to get

Things that I feel uneasy about:

- Inconsistent error formatting; `flox-activations` is getting wrapped
  by `activate` and sometimes `flox activate` so we have limited control
  over how the final error message is formatted, as shown by the tests.

- Using `$PPID` rather than `$$` in the test; possibly because the
  command activation gets wrapped with `FLOX_SHELL` first?

- Maintaining two very similar tests for `activate` and `services`; they
  are different enough and they live in the correct respective places
  but it still sucks to duplicate.

## Release Notes

N/A, since it's not actually in use?