### PR TITLE
fix: add missing outputs_to_install

### DIFF
--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -370,6 +370,9 @@ if ($manifest) {
                      defined $package->{"outputs_to_install"} ) {
                     $package->{"outputs_to_install"} = $package->{"outputs-to-install"};
                 }
+                unless ( defined $package->{"outputs_to_install"} ) {
+                    $package->{"outputs_to_install"} = keys %{$package->{"outputs"}};
+                }
                 foreach my $output (keys %{$package->{"outputs"}}) {
                     # Unfortunately, due to pkgdb limitations in the 1.0 release we
                     # adopted the convention of installing all outputs for every

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -1289,7 +1289,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_rev() {
+    fn test_rev_date() {
         let (repo, _tempdir_handle) = init_temp_repo(false);
         repo.checkout("branch_1", true).unwrap();
         let date = repo.rev_date("HEAD");
@@ -1298,7 +1298,7 @@ pub mod tests {
         commit_file(&repo, "dummy");
         let hash_1 = repo.branch_hash("branch_1").unwrap();
         let date = repo.rev_date(&hash_1).unwrap();
-        assert!(Utc::now().signed_duration_since(date) < chrono::Duration::seconds(1));
+        assert!(Utc::now().signed_duration_since(date) < chrono::Duration::seconds(5));
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -124,6 +124,14 @@ where
                 })
                 .collect(),
         );
+        let outputs_to_install = Some(
+            self.build_metadata
+                .outputs
+                .clone()
+                .into_iter()
+                .map(|o| o.name.clone())
+                .collect(),
+        );
 
         let build_info = UserBuildInfo {
             derivation: UserDerivationInfo {
@@ -133,7 +141,7 @@ where
                 license: None,
                 name: self.build_metadata.package.to_string().to_owned(),
                 outputs,
-                outputs_to_install: None,
+                outputs_to_install,
                 pname: Some(self.build_metadata.package.to_string()),
                 system: self.build_metadata.system,
                 unfree: None,


### PR DESCRIPTION
And a fix for a regression in builder.pl to default to all the outputs if outputs_to_install is missing at that level.
