### PR TITLE
test(activate): Workaround bashrc_Apple_Terminal

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2370,7 +2370,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:validate_hook_and_dotfile_sourcing
-@test "{bash,fish,tcsh,zsh}: confirm hooks and dotfiles sourced correctly" {
+@test "bash: confirm hooks and dotfiles sourced correctly" {
   project_setup
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2375,6 +2375,13 @@ EOF
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
+  # Prevent `/etc/bashrc_Apple_Terminal` from altering output with:
+  #   Saving session...completed.
+  #   Deleting expired sessions...none found.
+  if [[ "$NIX_SYSTEM" == *"-darwin" ]]; then
+    touch "${HOME}/.bash_sessions_disable"
+  fi
+
   # This test doesn't just confirm that the right things are sourced,
   # but that they are sourced in the correct order and exactly once.
 


### PR DESCRIPTION
## Proposed Changes

Running the tests in `Terminal.app` on Darwin caused this failure
because it loads customisations from `/etc/bashrc_Apple_Terminal` that
affect the output:

    -- values do not equal --
    expected : 7
    actual   : 9
    --

    Last output:
    Sourcing .profile
    Setting PATH from .profile
    sourcing hook.on-activate
    Sourcing .bashrc
    Setting PATH from .bashrc
    sourcing profile.common
    sourcing profile.bash

    Saving session...completed.
    Deleting expired sessions...none found.

Disable it by the means suggested in that file. I tried setting
`SHELL_SESSION_HISTORY=0` but that didn't change this behaviour.

I don't particularly care for `Terminal.app` but I occasionally reach
for it instead of `Kitty.app` when I want to bypass my default Flox
environment because it's causing problems like https://github.com/flox/flox/pull/2369.

## Release Notes

N/A, development