### PR TITLE
refactor: impl Environment for ConcreteEnvironment

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "crossterm 0.27.0",
  "derive_more",
  "dirs",
+ "enum_dispatch",
  "flox-rust-sdk",
  "fslock",
  "futures",

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -13,6 +13,7 @@ config.workspace = true
 crossterm.workspace = true
 derive_more.workspace = true
 dirs.workspace = true
+enum_dispatch.workspace = true
 flox-rust-sdk.workspace = true
 fslock.workspace = true
 futures.workspace = true

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -15,6 +15,7 @@ use flox_rust_sdk::flox::{Flox, DEFAULT_NAME};
 use flox_rust_sdk::models::env_registry::env_registry_path;
 use flox_rust_sdk::models::environment::{
     path_hash,
+    ConcreteEnvironment,
     Environment,
     EnvironmentError,
     FLOX_ACTIVE_ENVIRONMENTS_VAR,
@@ -45,7 +46,7 @@ use super::{
     UninitializedEnvironment,
 };
 use crate::commands::services::ServicesCommandsError;
-use crate::commands::{ensure_environment_trust, ConcreteEnvironment, EnvironmentSelectError};
+use crate::commands::{ensure_environment_trust, EnvironmentSelectError};
 use crate::config::{Config, EnvironmentPromptConfig};
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::openers::Shell;

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::ConcreteEnvironment;
 use flox_rust_sdk::models::lockfile::Lockfile;
 use flox_rust_sdk::providers::build::{FloxBuildMk, ManifestBuilder, Output};
 use indoc::indoc;
@@ -8,7 +9,6 @@ use tracing::instrument;
 
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::activate::FLOX_INTERPRETER;
-use crate::commands::ConcreteEnvironment;
 use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::message;

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -1,12 +1,12 @@
 use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::Environment;
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use indoc::formatdoc;
 use tracing::instrument;
 
 use super::{environment_select, EnvironmentSelect};
-use crate::commands::{environment_description, ConcreteEnvironment};
+use crate::commands::environment_description;
 use crate::subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::message;

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -12,6 +12,7 @@ use flox_rust_sdk::models::environment::managed_environment::{
     SyncToGenerationResult,
 };
 use flox_rust_sdk::models::environment::{
+    ConcreteEnvironment,
     CoreEnvironmentError,
     EditResult,
     Environment,
@@ -29,7 +30,7 @@ use super::{
     EnvironmentSelect,
     UninitializedEnvironment,
 };
-use crate::commands::{ensure_floxhub_token, ConcreteEnvironment, EnvironmentSelectError};
+use crate::commands::{ensure_floxhub_token, EnvironmentSelectError};
 use crate::subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog, Spinner};
 use crate::utils::errors::{apply_doc_link_for_unsupported_packages, format_core_error};

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -7,7 +7,7 @@ use bpaf::Bpaf;
 use flox_rust_sdk::data::AttrPath;
 use flox_rust_sdk::flox::{EnvironmentName, Flox, DEFAULT_NAME};
 use flox_rust_sdk::models::environment::path_environment::{InitCustomization, PathEnvironment};
-use flox_rust_sdk::models::environment::{Environment, PathPointer};
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, PathPointer};
 use flox_rust_sdk::models::manifest::{insert_packages, CatalogPackage, PackageToInstall};
 use flox_rust_sdk::models::search::SearchResult;
 use flox_rust_sdk::providers::catalog::{
@@ -22,7 +22,7 @@ use path_dedot::ParseDot;
 use toml_edit::{DocumentMut, Formatted, Item, Table, Value};
 use tracing::instrument;
 
-use crate::commands::{environment_description, ConcreteEnvironment};
+use crate::commands::environment_description;
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Spinner};
 use crate::utils::message;

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -47,6 +47,7 @@ use flox_rust_sdk::models::environment::path_environment::PathEnvironment;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
 use flox_rust_sdk::models::environment::{
     find_dot_flox,
+    ConcreteEnvironment,
     DotFlox,
     Environment,
     EnvironmentError,
@@ -1160,44 +1161,6 @@ fn open_path(flox: &Flox, path: &PathBuf) -> Result<ConcreteEnvironment, Environ
     DotFlox::open_in(path)
         .map(UninitializedEnvironment::DotFlox)?
         .into_concrete_environment(flox)
-}
-
-/// The various ways in which an environment can be referred to
-pub enum ConcreteEnvironment {
-    /// Container for [PathEnvironment]
-    Path(PathEnvironment),
-    /// Container for [ManagedEnvironment]
-    #[allow(unused)] // pending implementation of ManagedEnvironment
-    Managed(ManagedEnvironment),
-    /// Container for [RemoteEnvironment]
-    #[allow(unused)] // pending implementation of RemoteEnvironment
-    Remote(RemoteEnvironment),
-}
-
-impl ConcreteEnvironment {
-    pub fn into_dyn_environment(self) -> Box<dyn Environment> {
-        match self {
-            ConcreteEnvironment::Path(path_env) => Box::new(path_env),
-            ConcreteEnvironment::Managed(managed_env) => Box::new(managed_env),
-            ConcreteEnvironment::Remote(remote_env) => Box::new(remote_env),
-        }
-    }
-
-    pub fn dyn_environment_ref(&self) -> &dyn Environment {
-        match self {
-            ConcreteEnvironment::Path(path_env) => path_env,
-            ConcreteEnvironment::Managed(managed_env) => managed_env,
-            ConcreteEnvironment::Remote(remote_env) => remote_env,
-        }
-    }
-
-    pub fn dyn_environment_ref_mut(&mut self) -> &mut dyn Environment {
-        match self {
-            ConcreteEnvironment::Path(path_env) => path_env,
-            ConcreteEnvironment::Managed(managed_env) => managed_env,
-            ConcreteEnvironment::Remote(remote_env) => remote_env,
-        }
-    }
 }
 
 /// An environment descriptor of an environment that can be (re)opened,


### PR DESCRIPTION
Use enum_dispatch to implement Environment for ConcreteEnvironment. It makes sense for us to use enum_dispatch rather than trait objects since:
- We have a limited number of types that implement Environment (3)
- Sometimes we want to preserve a concrete type
- There are some limitations on how trait objects can be used in combination with generics

## Release Notes
NA