### PR TITLE
feat(build): print paths to build outputs

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -534,15 +534,21 @@ pub mod test_helpers {
 
     use super::*;
 
-    pub fn new_path_environment(flox: &Flox, contents: &str) -> PathEnvironment {
+    pub fn new_path_environment_in(
+        flox: &Flox,
+        contents: &str,
+        path: impl AsRef<Path>,
+    ) -> PathEnvironment {
         let pointer = PathPointer::new("name".parse().unwrap());
-        PathEnvironment::write_new_unchecked(
+        PathEnvironment::write_new_unchecked(flox, pointer, path, contents).unwrap()
+    }
+
+    pub fn new_path_environment(flox: &Flox, contents: &str) -> PathEnvironment {
+        new_path_environment_in(
             flox,
-            pointer,
-            tempdir_in(&flox.temp_dir).unwrap().into_path(),
             contents,
+            tempdir_in(&flox.temp_dir).unwrap().into_path(),
         )
-        .unwrap()
     }
 
     pub fn new_path_environment_from_env_files(

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use tracing::{debug, warn};
 
 use crate::flox::Flox;
+use crate::models::environment::{Environment, EnvironmentError};
 use crate::utils::CommandExt;
 
 pub const FLOX_RUNTIME_DIR_VAR: &str = "FLOX_RUNTIME_DIR";
@@ -265,6 +266,13 @@ fn read_output_to_channel(
             break;
         };
     }
+}
+
+pub fn build_symlink_path(
+    environment: &impl Environment,
+    package: &str,
+) -> Result<PathBuf, EnvironmentError> {
+    Ok(environment.parent_path()?.join(format!("result-{package}")))
 }
 
 pub mod test_helpers {

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 use crate::models::pkgdb::{call_pkgdb, CallPkgDbError, PkgDbError, PKGDB_BIN};
 use crate::utils::CommandExt;
 
-static NIX_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
+pub static NIX_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
     std::env::var("NIX_BIN")
         .unwrap_or_else(|_| env!("NIX_BIN").to_string())
         .into()


### PR DESCRIPTION
Check if the expected symlinks have been created by the manifest
builder, and if they do, print them to the user. Shorten current
directory to `.`.

Example output:
```
✨ Build completed successfully. Output created: ./result-hello
```

Example with multiple packages not in current dir:
```
✨ Builds completed successfully.
Outputs created: /private/tmp/result-hello, /private/tmp/result-hello2
```

## Release Notes

All changes behind a feature flag