### PR TITLE
chore: improve message for missing `$out`

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -465,8 +465,9 @@ mod tests {
         assert!(output.stdout.contains(
             r#"
        > ❌ ERROR: Build command did not copy outputs to '$out'.
-       > - copy a single file with 'cp bin $out'
-       > - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
+       > - copy a single file with 'mkdir -p $out/bin && cp file $out/bin'
+       > - copy a bin directory with 'mkdir $out && cp -r bin $out'
+       > - copy multiple files with 'mkdir -p $out/bin && cp bin/* $out/bin'
        > - copy files from an Autotools project with 'make install PREFIX=$out'"#
         ));
     }
@@ -494,8 +495,9 @@ mod tests {
         assert!(output.stdout.contains(
             r#"
        > ❌ ERROR: Build command did not copy outputs to '$out'.
-       > - copy a single file with 'cp bin $out'
-       > - copy multiple files with 'mkdir -p $out && cp bin/* $out/'
+       > - copy a single file with 'mkdir -p $out/bin && cp file $out/bin'
+       > - copy a bin directory with 'mkdir $out && cp -r bin $out'
+       > - copy multiple files with 'mkdir -p $out/bin && cp bin/* $out/bin'
        > - copy files from an Autotools project with 'make install PREFIX=$out'"#
         ));
         assert!(

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -29,8 +29,9 @@ let
   buildCache-tar-contents = if (buildCache == null) then null else (/. + buildCache);
   dollar_out_error_and_exit = ''
     echo "❌ ERROR: Build command did not copy outputs to '\$out'." 1>&2
-    echo "- copy a single file with 'cp bin \$out'" 1>&2
-    echo "- copy multiple files with 'mkdir -p \$out && cp bin/* \$out/'" 1>&2
+    echo "- copy a single file with 'mkdir -p \$out/bin && cp file \$out/bin'" 1>&2
+    echo "- copy a bin directory with 'mkdir \$out && cp -r bin \$out'" 1>&2
+    echo "- copy multiple files with 'mkdir -p \$out/bin && cp bin/* \$out/bin'" 1>&2
     echo "- copy files from an Autotools project with 'make install PREFIX=\$out'" 1>&2
     exit 1
   '';


### PR DESCRIPTION
since we only wrap binaries in `$out/bin` and only expose those on the PATH, the hint message used to be somewhat misleading,
asking users to copy binaries to `$out`.

This changes the hint to direct users to create and copy to `$out/bin` instead.
