### PR TITLE
fix(tests): Default SHELL to bashInteractive

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2682,7 +2682,7 @@ EOF
   run bash <(cat <<'EOF'
     eval "$("$FLOX_BIN" activate)"
 
-    FLOX_SHELL="bash" expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+    expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
 EOF
 )
   assert_failure
@@ -2707,7 +2707,7 @@ attach_runs_hooks_once() {
   TEARDOWN_FIFO="$PROJECT_DIR/teardown_activate"
   mkfifo "$TEARDOWN_FIFO"
 
-  FLOX_SHELL=bash "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" 2> output &
+  "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" 2> output &
 
   cat activate_finished
   run cat output
@@ -2716,10 +2716,10 @@ attach_runs_hooks_once() {
 
   case "$mode" in
     interactive)
-      FLOX_SHELL=bash NO_COLOR=1 run expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" true
+      NO_COLOR=1 run expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" true
       ;;
     command)
-      FLOX_SHELL=bash run "$FLOX_BIN" activate -- true
+      run "$FLOX_BIN" activate -- true
       ;;
     in-place)
       run bash -c 'eval "$("$FLOX_BIN" activate)"'
@@ -3273,7 +3273,7 @@ EOF
   unset RUST_BACKTRACE
 
   export -f jq_edit
-  FLOX_SHELL="bash" run "$FLOX_BIN" activate -- bash <(
+  run "$FLOX_BIN" activate -- bash <(
     cat << 'EOF'
       echo "$PPID" > activation_pid
 
@@ -3304,7 +3304,7 @@ PIDs of the running activations: ${ACTIVATION_PID}"
   LATEST_VERSION=1
 
   export -f jq_edit
-  FLOX_SHELL="bash" run "$FLOX_BIN" activate -- bash <(
+  run "$FLOX_BIN" activate -- bash <(
     cat << 'EOF'
       ACTIVATIONS_DIR=$(dirname "$_FLOX_ACTIVATION_STATE_DIR")
       ACTIVATIONS_JSON="${ACTIVATIONS_DIR}/activations.json"
@@ -3449,14 +3449,14 @@ EOF
       refute_output "$EMACS_MAN"
 
       # vim gets added to MANPATH
-      FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -- bash -c "man --path vim > output; echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
+      "$FLOX_BIN" activate -d vim -- bash -c "man --path vim > output; echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
       cat activate_finished
       run cat output
       assert_success
       assert_output "$VIM_MAN"
 
       # emacs gets added to MANPATH, and then a nested attach also adds vim
-      FLOX_SHELL=bash "$FLOX_BIN" activate -d emacs -- \
+      "$FLOX_BIN" activate -d emacs -- \
         bash -c 'man --path emacs > output_emacs_1 && "$FLOX_BIN" activate -d vim -- bash -c "man --path vim > output_vim && man --path emacs > output_emacs_2"'
       run cat output_emacs_1
       assert_output "$EMACS_MAN"
@@ -3474,7 +3474,7 @@ EOF
       refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man.*"
 
       # vim gets added to MANPATH
-      FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -- bash -c "/usr/bin/manpath > output && echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
+      "$FLOX_BIN" activate -d vim -- bash -c "/usr/bin/manpath > output && echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
       cat activate_finished
       run cat output
       assert_success
@@ -3482,7 +3482,7 @@ EOF
       refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man.*"
 
       # emacs gets added to MANPATH, and then a nested attach also adds vim
-      FLOX_SHELL=bash "$FLOX_BIN" activate -d emacs -- \
+      "$FLOX_BIN" activate -d emacs -- \
         bash -c '/usr/bin/manpath > output_1 && "$FLOX_BIN" activate -d vim -- bash -c "/usr/bin/manpath > output_2"'
       run cat output_1
       refute_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
@@ -3521,14 +3521,14 @@ EOF
   run command -v emacs
   refute_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/bin/emacs"
 
-  FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -- bash -c "command -v vim > output; echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
+  "$FLOX_BIN" activate -d vim -- bash -c "command -v vim > output; echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
   cat activate_finished
 
   run cat output
   assert_success
   assert_output "$(realpath "$PROJECT_DIR")/vim/.flox/run/$NIX_SYSTEM.vim.dev/bin/vim"
 
-  FLOX_SHELL=bash "$FLOX_BIN" activate -d emacs -- \
+  "$FLOX_BIN" activate -d emacs -- \
     bash -c 'command -v emacs > output_emacs_1; "$FLOX_BIN" activate -d vim -- bash -c "command -v vim > output_vim && command -v emacs > output_emacs_2 || true"'
   run cat output_emacs_1
   assert_success

--- a/cli/tests/cuda.bats
+++ b/cli/tests/cuda.bats
@@ -58,7 +58,7 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 #
 @test "cuda disabled when nvidia device absent and libcuda present" {
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+  run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-disabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "${TESTS_DIR}/cuda/ldconfig-mock-present.sh"
@@ -68,7 +68,7 @@ teardown() {
 @test "cuda disabled when nvidia0 device present but libcuba absent" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+  run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-disabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "${TESTS_DIR}/cuda/ldconfig-mock-absent.sh"
@@ -78,7 +78,7 @@ teardown() {
 @test "cuda disabled when nvidia0 device present but libcuba absent on NixOS" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+  run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-disabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "${TESTS_DIR}/cuda/ldconfig-mock-error.sh"
@@ -88,13 +88,13 @@ teardown() {
 @test "cuda disabled when not on Linux" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+  run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-disabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "__LINUX_ONLY__"
   assert_success
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+  run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-disabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "invalid_ldconfig_path"
@@ -105,7 +105,7 @@ teardown() {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
   tomlq --in-place -t '.options."cuda-detection" = false' .flox/env/manifest.toml
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+  run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-disabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "${TESTS_DIR}/cuda/ldconfig-mock-present.sh"
@@ -115,7 +115,7 @@ teardown() {
 @test "cuda enabled when nvidia0 device present and libcuda present" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+  run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-enabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "${TESTS_DIR}/cuda/ldconfig-mock-present.sh"
@@ -133,7 +133,7 @@ teardown() {
   touch "${FAKE_FHS_ROOT}/run/opengl-driver/libnvidia-nvvm.so"
   touch "${FAKE_FHS_ROOT}/run/opengl-driver/libnvidia-nvvm.so.4"
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -- bash \
+  run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-enabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "${TESTS_DIR}/cuda/ldconfig-mock-error.sh"
@@ -148,7 +148,7 @@ teardown() {
   NESTED_PROJECT_DIR="${PROJECT_NAME}-nested"
   "$FLOX_BIN" init -d "$NESTED_PROJECT_DIR"
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -d "$NESTED_PROJECT_DIR" -- bash \
+  run "$FLOX_BIN" activate -d "$NESTED_PROJECT_DIR" -- bash \
     "$TESTS_DIR/cuda/cuda-enabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "${TESTS_DIR}/cuda/ldconfig-mock-present.sh"
@@ -162,7 +162,7 @@ teardown() {
   "$FLOX_BIN" init -d "$NESTED_PROJECT_DIR"
   tomlq --in-place -t '.options."cuda-detection" = false' "${NESTED_PROJECT_DIR}/.flox/env/manifest.toml"
 
-  FLOX_SHELL=bash run "$FLOX_BIN" activate -d "$NESTED_PROJECT_DIR" -- bash \
+  run "$FLOX_BIN" activate -d "$NESTED_PROJECT_DIR" -- bash \
     "$TESTS_DIR/cuda/cuda-disabled.sh" \
     "${FAKE_FHS_ROOT}" \
     "${TESTS_DIR}/cuda/ldconfig-mock-present.sh"

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -514,7 +514,7 @@ EOF
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
   mkfifo "$TEARDOWN_FIFO"
 
-  FLOX_SHELL=bash "$FLOX_BIN" activate -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
+  "$FLOX_BIN" activate -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
   timeout 2 cat started
   run cat output
   assert_success

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -343,7 +343,7 @@ EOF
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
   mkfifo "$TEARDOWN_FIFO"
 
-  FLOX_SHELL=bash "$FLOX_BIN" activate --trust -r "$OWNER/test" -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
+  "$FLOX_BIN" activate --trust -r "$OWNER/test" -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
   timeout 8 cat started
   run cat output
   assert_success

--- a/cli/tests/lang-python.bats
+++ b/cli/tests/lang-python.bats
@@ -62,7 +62,7 @@ teardown() {
   assert_output --partial "✅ 'pip' installed to environment"
   assert_output --partial "✅ 'python3' installed to environment"
 
-  FLOX_SHELL=bash "$FLOX_BIN" activate -- bash "$INPUT_DATA/init/python/requests-with-pip.sh"
+  "$FLOX_BIN" activate -- bash "$INPUT_DATA/init/python/requests-with-pip.sh"
 }
 
 # bats test_tags=python:activate:poetry,catalog

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -610,7 +610,7 @@ EOF
   commands=("start" "restart")
   for command in "${commands[@]}"; do
     echo "Testing: flox services $command"
-    FLOX_SHELL="bash" command="$command" run "$FLOX_BIN" activate -- bash <(
+    command="$command" run "$FLOX_BIN" activate -- bash <(
       cat << 'EOF'
         echo "$PPID" > activation_pid
 

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -159,6 +159,11 @@ misc_vars_setup() {
   # rc files from getting loaded.
   unset ZDOTDIR
 
+  # Ignore the user shell and assume bash as the default.
+  SHELL="$(which bash)"
+  export SHELL
+  unset FLOX_SHELL
+
   # Used to check if metrics are coming form the CI
   export CI=true
 }

--- a/cli/tests/suite.bats
+++ b/cli/tests/suite.bats
@@ -1,0 +1,25 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test setup of the test suite.
+#
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=suite
+
+# ---------------------------------------------------------------------------- #
+
+@test "suite: SHELL should default to bashInteractive from Nix" {
+  run printenv SHELL
+  assert_success
+  assert_output --regexp "^/nix/store/.*-bash-interactive-.*/bin/bash$"
+}
+
+@test "suite: FLOX_SHELL should not leak from outer user shell" {
+  run printenv FLOX_SHELL
+  assert_failure
+}


### PR DESCRIPTION
## Proposed Changes

Use `bashInteractive` from `flox-cli-tests` rather than leaking `SHELL` from the user running the tests.  This surprised me when writing a `flox activate` test that made use of `export -f` because it was defaulting to my `zsh` shell. Without the change to `setup_suite.bash` the new test fails for me with:

    ✗ suite: should default to bashInteractive [1006]
       tags: activate
       (from function `assert_output' in file /nix/store/h7inz07x6739s38i02532g5pj6dlnx8k-bats-with-libraries-1.11.0/share/bats/bats-assert/src/assert_output.bash, line 178,
        in test file activate.bats, line 200)
         `assert_output --regexp "$EXPECTED_OUTPUT"' failed
       ✨ Created environment 'project-1' (aarch64-darwin)

       Next:
         $ flox search <package>    <- Search for a package
         $ flox install <package>   <- Install a package into an environment
         $ flox activate            <- Enter the environment
         $ flox edit                <- Add environment variables and shell hooks

       /bin/zsh

       -- regular expression does not match output --
       regexp : ^/nix/store/.*-bash-interactive-.*/bin/bash$
       output : /bin/zsh
       --

       Last output:
       /bin/zsh

    1 test, 1 failure in 3 seconds

## Release Notes

N/A
