### PR TITLE
fix: remove $out when building in local mode

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -203,6 +203,7 @@ define BUILD_local_template =
   $(_pname)_local_build: $($(_pvarname)_buildScript)
 	@# $(if $(FLOX_INTERPRETER),,$$(error FLOX_INTERPRETER not defined))
 	@echo "Building $(_name) in local mode"
+	@$(_rm) -rf $(_out)
 	$(if $(_virtualSandbox),$(PRELOAD_ARGS) FLOX_SRC_DIR=$$$$($(_pwd)) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
 	MAKEFLAGS= out=$(_out) $(FLOX_INTERPRETER)/activate --turbo -- $(_bash) -e $($(_pvarname)_buildScript)
 	set -o pipefail && $(_nix) build -L --file $(_libexec_dir)/build-manifest.nix \


### PR DESCRIPTION
## Proposed Changes

When performing a local manifest build we create a /tmp/store_* path which is recorded in the environment as the $out used for the build.

The next step is to copy the contents of $out into the store, rewriting the /tmp/store_* paths to /nix/store_* in the process.  By all rights we could remove this directory immediately after performing this step, but we instead leave it in place because it makes it possible to use compilation artefacts that are sitting in the user's build directory that make reference to that /tmp/store_* path.

But that is where the usefulness ends, and in particular when performing a manifest build it can be problematic to slurp up the contents of a previous build when copying $out to the store. This patch addresses this problem by explicitly removing the contents of $out prior to kicking off a local build, ensuring that any subsequent packages won't contain files from old builds.

## Release Notes

N/A