### PR TITLE
chore(upgrade): pretty print upgraded lockfile

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -577,8 +577,11 @@ impl CoreEnvironment<ReadOnly> {
             (lockfile, upgraded)
         };
 
-        let store_path =
-            self.transact_with_lockfile_contents(serde_json::json!(&lockfile).to_string(), flox)?;
+        // SAFETY: serde_json::to_string_pretty is only documented to fail if
+        // the "Serialize decides to fail, or if T contains a map with non-string keys",
+        // neither of which should happen here.
+        let lockfile_contents = serde_json::to_string_pretty(&lockfile).unwrap();
+        let store_path = self.transact_with_lockfile_contents(lockfile_contents, flox)?;
 
         Ok(UpgradeResult {
             packages: upgraded,


### PR DESCRIPTION
## Proposed Changes

Only `CoreEnvironment::lock` and `upgrade` write lockfiles at all.

`lock` is already using `to_string_pretty`, while `upgrade` uses `json!(...).to_string()` [1] which will write the condensed format.

Change `CoreEnvironment::upgrade` to write a formatted json document instead.

[1]
https://github.com/flox/flox/blob/e54d776d24764d358e381f02d9ef80127ac99f02/cli/flox-rust-sdk/src/models/environment/core_environment.rs#L679-L681

## Release Notes

Lockfiles are now always pretty printed for better visibility in git diffs.
