### PR TITLE
feat: reduce log output

### DIFF
--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -62,7 +62,7 @@ fi
 if [ -n "${_FLOX_WATCHDOG_BIN:-}" ]; then
   # TODO: Some of these args can be removed after https://github.com/flox/flox/issues/2206
   "$_daemonize" \
-    -E _FLOX_WATCHDOG_LOG_LEVEL="debug" \
+    -E _FLOX_WATCHDOG_LOG_LEVEL="${_FLOX_WATCHDOG_LOG_LEVEL:-debug}" \
     "$_FLOX_WATCHDOG_BIN" \
     ${FLOX_DISABLE_METRICS:+--disable-metrics} \
     --log-dir "$_FLOX_ENV_LOG_DIR" \

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -704,6 +704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1219,7 @@ dependencies = [
  "tempfile",
  "time",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -3983,6 +3993,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -70,6 +70,7 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
 toml_edit = { version = "0.22", features = ["serde"] }
 tracing = "0.1"
+tracing-appender = "0.2"
 tracing-log = { version = "0.2", features = [] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.5", features = ["serde"] }

--- a/cli/flox-watchdog/Cargo.toml
+++ b/cli/flox-watchdog/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 signal-hook.workspace = true
 time.workspace = true
 tracing.workspace = true
+tracing-appender.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/cli/flox-watchdog/src/process.rs
+++ b/cli/flox-watchdog/src/process.rs
@@ -20,7 +20,7 @@ use anyhow::{bail, Result};
 use flox_core::activations::{read_activations_json, Activations, AttachedPid};
 use fslock::LockFile;
 use time::OffsetDateTime;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 /// How long to wait between watcher updates.
 pub const WATCHER_SLEEP_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -133,7 +133,7 @@ impl PidWatcher {
         let stat = match read_to_string(path) {
             Ok(stat) => stat,
             Err(err) => {
-                warn!(
+                trace!(
                     %err,
                     pid,
                     "failed to parse /proc/<pid>/stat, treating as not running"
@@ -262,7 +262,7 @@ impl Watcher for PidWatcher {
     fn should_clean_up(&self) -> Result<bool, super::Error> {
         let should_clean_up = self.pids_watching.is_empty();
         if !should_clean_up {
-            debug!("still watching PIDs {:?}", self.pids_watching);
+            trace!("still watching PIDs {:?}", self.pids_watching);
         }
         Ok(should_clean_up)
     }

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3199,10 +3199,10 @@ EOF
   # Start a first_activation which sets FOO=first_activation
   case "$mode" in
     command)
-      injected="first_activation" "$FLOX_BIN" activate -- bash -c "echo \$FOO > output && echo > activate_finished && echo > $TEARDOWN_FIFO" &
+      injected="first_activation" _FLOX_WATCHDOG_LOG_LEVEL=trace "$FLOX_BIN" activate -- bash -c "echo \$FOO > output && echo > activate_finished && echo > $TEARDOWN_FIFO" &
       ;;
     in-place)
-      TEARDOWN_FIFO="$TEARDOWN_FIFO" injected="first_activation" bash -c 'eval "$("$FLOX_BIN" activate)" && echo $FOO > output && echo > activate_finished && echo > "$TEARDOWN_FIFO"' &
+      TEARDOWN_FIFO="$TEARDOWN_FIFO" injected="first_activation" bash -c 'eval "$(_FLOX_WATCHDOG_LOG_LEVEL=trace "$FLOX_BIN" activate)" && echo $FOO > output && echo > activate_finished && echo > "$TEARDOWN_FIFO"' &
       ;;
   esac
 
@@ -3217,11 +3217,11 @@ EOF
 
   # First wait for the logfile to appear
   timeout 1s bash -c '
-    while ! ls $PROJECT_DIR/.flox/log/watchdog.*.log; do
+    while ! ls $PROJECT_DIR/.flox/log/watchdog.*.log.*; do
       sleep .1
     done
   '
-  watchdog_1_log="$(echo $PROJECT_DIR/.flox/log/watchdog.*.log)"
+  watchdog_1_log="$(echo $PROJECT_DIR/.flox/log/watchdog.*.log.*)"
   initial_number_of_polls="$(cat "$watchdog_1_log" | grep "still watching PIDs" | wc -l)"
   watchdog_1_log="$watchdog_1_log" initial_number_of_polls="$initial_number_of_polls" \
     timeout 1s bash -c '

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -902,7 +902,7 @@ EOF
 
   # Poll because watchdog may not have started by the time the activation finishes.
   run timeout 1s bash -c "
-    while ! grep 'flox_watchdog: starting' \"$PROJECT_DIR\"/.flox/log/watchdog.*.log; do
+    while ! grep 'flox_watchdog: starting' \"$PROJECT_DIR\"/.flox/log/watchdog.*.log*; do
       sleep 0.1
     done
   "
@@ -1406,7 +1406,7 @@ EOF
 
   # Check that services and watchdog are both running
   "${TESTS_DIR}"/services/wait_for_service_status.sh one:Running
-  watchdog_1_log="$(echo $PROJECT_DIR/.flox/log/watchdog.*.log)"
+  watchdog_1_log="$(echo $PROJECT_DIR/.flox/log/watchdog.*.log.*)"
   run cat "$watchdog_1_log"
   assert_success
   assert_output --partial "woof"
@@ -1445,7 +1445,7 @@ EOF
   rm "$watchdog_1_log"
 
   # Check that watchdog 2 is running
-  watchdog_2_log="$(echo $PROJECT_DIR/.flox/log/watchdog.*.log)"
+  watchdog_2_log="$(echo $PROJECT_DIR/.flox/log/watchdog.*.log.*)"
   run cat "$watchdog_2_log"
   assert_output --partial "woof"
   refute_output "finished cleanup"

--- a/cli/tests/watchdog.bats
+++ b/cli/tests/watchdog.bats
@@ -155,12 +155,13 @@ EOF
     --socket does_not_exist 3>&- &
 
   watchdog_pid="$!"
-  log_file="$BATS_TEST_TMPDIR/watchdog.${_FLOX_ACTIVATION_ID}.log"
+  log_file="$BATS_TEST_TMPDIR/watchdog.${_FLOX_ACTIVATION_ID}.log.*"
 
   # Wait for initial log entry. Other entries will be printed later but we don't
   # want to wait that long.
   timeout 1s bash -c "
-    while ! grep -qs 'still watching, woof woof' \"$log_file\"; do
+    # $log_file is intentionally unquoted here so that the glob is expanded
+    while ! grep -qs 'still watching, woof woof' $log_file; do
       sleep 0.1
     done
   "
@@ -244,11 +245,12 @@ EOF
     --socket does_not_exist &
 
   watchdog_pid="$!"
-  log_file="$BATS_TEST_TMPDIR/watchdog.${_FLOX_ACTIVATION_ID}.log"
+  log_file="$BATS_TEST_TMPDIR/watchdog.${_FLOX_ACTIVATION_ID}.log.*"
 
   # Wait for start.
   timeout 1s bash -c "
-    while ! grep -qs 'watchdog is on duty' \"$log_file\"; do
+    # $log_file is intentionally unquoted here so that the glob is expanded
+    while ! grep -qs 'watchdog is on duty' $log_file; do
       sleep 0.1
     done
   "
@@ -295,11 +297,12 @@ EOF
     --socket does_not_exist &
 
   watchdog_pid="$!"
-  log_file="$BATS_TEST_TMPDIR/watchdog.${_FLOX_ACTIVATION_ID}.log"
+  log_file="$BATS_TEST_TMPDIR/watchdog.${_FLOX_ACTIVATION_ID}.log.*"
 
   # Wait for start.
   timeout 1s bash -c "
-    while ! grep -qs 'starting' \"$log_file\"; do
+    # $log_file is intentionally unquoted here so that the glob is expanded
+    while ! grep -qs 'starting' $log_file; do
       sleep 0.1
     done
   "


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
The watchdog was emitting log lines at a rate of 10Hz in some cases, which quickly generates enormous log files. This reduces the log level of the two offending lines and allows a user to override the log level of the watchdog (mostly for testing purposes).

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Flox will use less disk space for log files.

<!-- Many thanks! -->
