### PR TITLE
feat: define flox-build.mk verbosity macros based on $_FLOX_PKGDB_VERBOSITY

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -88,6 +88,16 @@ TMPDIR ?= /tmp
 # Use the wildcard operator to identify builds in the provided $FLOX_ENV.
 BUILDS := $(wildcard $(FLOX_ENV)/package-builds.d/*)
 
+# Set makefile verbosity based on the value of _FLOX_PKGDB_VERBOSITY [sic]
+# as set in the environment by the flox CLI. First set it to 0 if not defined.
+ifeq (,$(_FLOX_PKGDB_VERBOSITY))
+  _FLOX_PKGDB_VERBOSITY = 0
+endif
+# Then set them to empty string or "@" based on being greater than 0, 1, or 2.
+$(eval _V_ = $(intcmp 0,$(_FLOX_PKGDB_VERBOSITY),,@))
+$(eval _VV_ = $(intcmp 1,$(_FLOX_PKGDB_VERBOSITY),,@))
+$(eval _VVV_ = $(intcmp 2,$(_FLOX_PKGDB_VERBOSITY),,@))
+
 # Define a usage target to provide a helpful message when no target is specified.
 .PHONY: usage
 usage:


### PR DESCRIPTION
## Proposed Changes

It is really useful to be able to tune makefile verbosity in response to the `flox -v` verbose flag, and this commit introduces 3 new macros for this purpose, defined as in this pseudo-code:
```
  _V_ = $_FLOX_PKGDB_VERBOSITY > 0 ? "" : "@"
 _VV_ = $_FLOX_PKGDB_VERBOSITY > 1 ? "" : "@"
_VVV_ = $_FLOX_PKGDB_VERBOSITY > 2 ? "" : "@"
```
The end result is that we can preface any line in a makefile stanza with `$(_V_)` and make will only report that invocation if flox has been invoked with `-v`. Similarly a line starting with `$(_VVV_)` will only be reported if flox has been invoked with `-vvv` (or more).

## Release Notes

N/A