### PR TITLE
fix: propagate error from process substitution in flox-build.mk

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -401,6 +401,7 @@ mod tests {
     use crate::models::environment::Environment;
     use crate::providers::catalog::test_helpers::reset_mocks_from_file;
     use crate::providers::catalog::GENERATED_DATA;
+    use crate::providers::git::{GitCommandProvider, GitProvider};
 
     #[test]
     fn build_returns_failure_when_package_not_defined() {
@@ -477,6 +478,9 @@ mod tests {
 
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        let _git = GitCommandProvider::init(&env_path, false).unwrap();
 
         let output = assert_build_status(&flox, &mut env, &package_name, false);
         // Weird string formatting because indoc strips leading whitespace
@@ -631,6 +635,8 @@ mod tests {
         let mut env = new_path_environment(&flox, &manifest);
         let env_path = env.parent_path().unwrap();
 
+        let _git = GitCommandProvider::init(&env_path, false).unwrap();
+
         assert_build_status(&flox, &mut env, &package_name, true);
         let file_content = result_content(&env_path, &package_name, &file_name);
 
@@ -667,6 +673,8 @@ mod tests {
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, &manifest);
         let env_path = env.parent_path().unwrap();
+
+        let _git = GitCommandProvider::init(&env_path, false).unwrap();
 
         assert_build_status(&flox, &mut env, &package_name, true);
         let file_content_first_run = result_content(&env_path, &package_name, &file_name);
@@ -741,6 +749,8 @@ mod tests {
         let mut env = new_path_environment(&flox, &manifest);
         let env_path = env.parent_path().unwrap();
 
+        let _git = GitCommandProvider::init(&env_path, false).unwrap();
+
         reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
         assert_build_status(&flox, &mut env, &package_name, true);
         assert_build_file(&env_path, &package_name, &file_name, &file_content);
@@ -771,6 +781,8 @@ mod tests {
         let (mut flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, &manifest);
         let env_path = env.parent_path().unwrap();
+
+        let _git = GitCommandProvider::init(&env_path, false).unwrap();
 
         reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
         assert_build_status(&flox, &mut env, &package_name, true);
@@ -1184,6 +1196,9 @@ mod tests {
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, &manifest);
         let env_path = env.parent_path().unwrap();
+
+        let _git = GitCommandProvider::init(&env_path, false).unwrap();
+
         let result = result_dir(&env_path, &package_name);
         let cache = cache_dir(&env_path, &package_name);
 
@@ -1256,6 +1271,9 @@ mod tests {
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, &manifest);
         let env_path = env.parent_path().unwrap();
+
+        let _git = GitCommandProvider::init(&env_path, false).unwrap();
+
         let result_foo = result_dir(&env_path, &package_foo);
         let cache_foo = cache_dir(&env_path, &package_foo);
         let result_bar = result_dir(&env_path, &package_bar);
@@ -1325,6 +1343,9 @@ mod tests {
 
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        let _git = GitCommandProvider::init(&env_path, false).unwrap();
 
         let output = assert_build_status(&flox, &mut env, &package_name, succeed);
 

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -238,7 +238,10 @@ define BUILD_nix_sandbox_template =
   # instead.
   $(eval $(_pvarname)_src_tar = $($(_pvarname)_tmpBasename)-src.tar)
   $($(_pvarname)_src_tar): FORCE
-	$(_tar) -cf - --no-recursion -T <($(_git) ls-files) > $$@
+	@# TIL that you have to explicitly call `wait` to harvest the exit status
+	@# of a process substitution, and that `set -o pipefail` does nothing here.
+	@# See: https://mywiki.wooledge.org/ProcessSubstitution
+	$(_tar) -cf $$@ --no-recursion -T <($(_git) ls-files) && wait "$$$$!"
 
   # The buildCache value needs to be similarly stable when nothing changes across
   $(eval $(_pvarname)_buildCache = $($(_pvarname)_tmpBasename)-buildCache.tar)


### PR DESCRIPTION
## Proposed Changes

The source tarball target was employing `$(git ls-files)` to get the source manifest, but when this failed the invocation would successfully generate an empty tarball rather than failing. TIL that you need to follow a process substitution with a call to `wait $!` in order to get the desired behaviour!

Having fixed the bug, also needed to add invocations of `GitCommandProvider::init` to the rust build tests so that it doesn't crash when performing a sandbox build from a git-less directory.

## Release Notes

N/A