### PR TITLE
fix(watchdog): GC old watchdog.*.log pattern

### DIFF
--- a/cli/flox-watchdog/src/logger.rs
+++ b/cli/flox-watchdog/src/logger.rs
@@ -206,7 +206,6 @@ mod tests {
         // Ensure that the old files are selected for GC
         let mut to_gc = watchdog_logs_to_gc(dir.path(), days_old_to_keep).unwrap();
         to_gc.sort();
-        assert_eq!(to_gc.len(), 2);
         assert_eq!(to_gc, should_be_gced);
 
         // Simulate the old files being GCed
@@ -216,7 +215,7 @@ mod tests {
         // Ensure that the younger files aren't selected for GC after the old
         // files are deleted.
         let to_gc = watchdog_logs_to_gc(dir.path(), days_old_to_keep).unwrap();
-        assert!(to_gc.is_empty());
+        assert_eq!(to_gc, vec![] as Vec<PathBuf>);
     }
 
     #[test]


### PR DESCRIPTION
## Proposed Changes

Ensure that old-style logs, from before we introduced log rotation, are
still cleaned up. This is particularly important after the logging
regression in v1.3.4 which caused the logs to grow very large.

I realised this while writing the release notes for v1.3.5

## Release Notes

To include this in the v1.3.5 release (https://github.com/flox/product/issues/819) we'll need to:

- add a note to the existing draft about exiting all activations if you notice previous problems with v1.3.4
- cherry-pick to the `release-1.3.5` branch and replace the `v1.3.5` tag which hasn't been "fully published" yet