### PR TITLE
chore(push): Generalise FloxHub editing message

### DIFF
--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -212,7 +212,7 @@ impl Push {
             Use 'flox pull {owner}/{name}' to get this environment in any other location.
 
             This environment is public.
-            You can change this by editing settings at https://hub.flox.dev/{owner}/{name}/settings
+            You can view and edit the environment at https://hub.flox.dev/{owner}/{name}
         "}
     }
 }


### PR DESCRIPTION
## Proposed Changes

State that new environments are public by default and give a URL where they can navigate to settings (as well as promoting other view/edit options) whilst still giving us us the flexibility to change in FloxHub which environments can be made private, both now and again in future.

I briefly looked at converting these to use `env.floxhub_url` but then got lost in a rabbit hole of what to print when `join()` fails and whether we should promote the URL for all messages, so I've deferred that for now.

## Release Notes

N/A
