### PR TITLE
chore: fix typos and style (rebased)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ $ just test-all;
 
 - [ ] All commits in a Pull Request are
       [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
-      and Verified by Github or via GPG.
+      and Verified by GitHub or via GPG.
 - [ ] As an outside contributor you need to accept the flox
-      [Contributor License Agreement](.github/CLA.md) by adding your Git/Github
+      [Contributor License Agreement](.github/CLA.md) by adding your Git/GitHub
       details in a row at the end of the
       [`CONTRIBUTORS.csv`](.github/CONTRIBUTORS.csv) file by way of the same
       pull request or one done previously.
@@ -41,7 +41,7 @@ This project follows (tries to),
 [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 We employ [commitizen](https://commitizen-tools.github.io/commitizen/)
-to help enforcing those rules.
+to help to enforce those rules.
 
 **Commit messages that explain the content of the commit are appreciated**
 
@@ -113,7 +113,7 @@ This sets up an environment with dependencies, rust toolchain, variable
 and `pre-commit-hooks`.
 
 In the environment, use [`cargo`](https://doc.rust-lang.org/cargo/)
-to build the rust based cli.
+to build the rust based CLI.
 
 **Note:**
 
@@ -190,10 +190,10 @@ section refers to settings from that plugin.
 
 - Install the `rust-analyzer` plugin for your editor
    - See the [official installation instruction](https://rust-analyzer.github.io/manual.html#installation)
-     (in the `nix develop` subshell the toolchain will aready be provided, you
+     (in the `nix develop` subshell the toolchain will already be provided, you
       can skip right to your editor of choice)
 - If you prefer to open your editor at the project root, you'll need to help
-  `rust-analyzer` find the rust workspace by configuing the`linkedProjects`
+  `rust-analyzer` find the rust workspace by configuring the`linkedProjects`
   for `rust-analyzer`.
   In VS Code you can add this: to you `.vscode/settings.json`:
   ```json
@@ -361,7 +361,7 @@ for details.
 ##### Running tests in a Linux container
 
 It's possible to shorten the feedback loop when developing Linux dependent
-features on a MacOS system by running the tests from a container.
+features on a macOS system by running the tests from a container.
 
 Start a container with the code mounted in so that you can continue to use your normal editor:
 
@@ -407,5 +407,5 @@ Development is done on branches and merged back to `main`.  Keep your branch
 updated by rebasing and resolving conflicts regularly to avoid messy merges.
 Merges to `main` should be squashed and *ff-only* back to `main` using GitHub
 PRs.  Or, if they represent multiple bigger changes, squashed into multiple
-distinct change sets.  Also be sure to run all tests before creating a mergable
+distinct change sets.  Also be sure to run all tests before creating a mergeable
 PR (See [above](#testing)).

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ build what’s necessary. However, each new wave of dev tooling
 innovation results in an entirely new set of dependencies that
 need to be managed. What starts as a simple app or microservice
 quickly grows complex, and
-turns into a expanding and fragmented supply
+turns into an expanding and fragmented supply
 chain. Flox brings reproducibility and consistency to complex
-software development lifecycles.
+software development life-cycles.
 
 ## 📘 Origins
 

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -15,7 +15,7 @@ set -euo pipefail
 export _flox_activate_tracelevel="${_FLOX_PKGDB_VERBOSITY:-0}"
 [ "$_flox_activate_tracelevel" -eq 0 ] || set -x
 
-# These all derive from the `flox-interpeter` package.
+# These all derive from the `flox-interpreter` package.
 # FIXME This is wrong; the profile.d scripts in particular should be
 #       sourced from the environment itself so that users can add pkgs
 #       which add additional scripts to the etc/profile.d directory.

--- a/assets/activation-scripts/activate.d/zdotdir/README.md
+++ b/assets/activation-scripts/activate.d/zdotdir/README.md
@@ -28,7 +28,7 @@ The zsh initialization sequence as described in the `zsh(1)` man page is:
 4. if a *login shell*, source `/etc/zlogin` followed by `$ZDOTDIR/.zlogin`
 
 Our goal is to source our own `$FLOX_ZSH_INIT_SCRIPT` last, so we must apply
-conditional logic to figure out which of the first, third or fourth case above
+conditional logic to figure out which of the first, third, or fourth case above
 will be the last to be sourced, then append the sourcing of our script to that.
 This logic can be found at the end of each of the `.{zshenv,zshrc,zlogin}`
 scripts.

--- a/cli/catalog-api-v1/README.md
+++ b/cli/catalog-api-v1/README.md
@@ -6,7 +6,7 @@ using the [progenitor](https://github.com/oxidecomputer/progenitor) crate.
 
 ## Documentation
 
-The types and methods of the client are docuemnted using rustdoc.
+The types and methods of the client are documented using rustdoc.
 [progenitor](https://github.com/oxidecomputer/progenitor) tries it's best
 to enhance the documentation of the generated client based on the spec.
 
@@ -18,7 +18,7 @@ $ cargo doc --open -p catalog-api-v1
 
 Since the client code is generated directly into [the source directory](./src/),
 changes to the [OpenAPI Spec](./openapi.json) are reflected after the next code analysis.
-It may be necessary to updated the shims in [`flox-rust-sdk`](../flox-rust-sdk/)
+It may be necessary to update the shims in [`flox-rust-sdk`](../flox-rust-sdk/)
 after the client was updated.
 
 ```
@@ -26,7 +26,7 @@ after the client was updated.
 $ cargo check -p catalog-api-v1
 ```
 
-Finally, remember to check-in the updated sources.
+Finally, remember to check in the updated sources.
 Mid-term updating the client library and proposing it as a PR will be done by automation.
 
 ## Debugging

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -220,7 +220,7 @@ impl Activation {
 
     /// Whether the activation is ready to be attached to.
     ///
-    /// "Readyness" is a one way state change, set via [Self::set_ready].
+    /// "Readiness" is a one way state change, set via [Self::set_ready].
     pub fn ready(&self) -> bool {
         self.ready
     }

--- a/cli/flox-core/src/version.rs
+++ b/cli/flox-core/src/version.rs
@@ -107,7 +107,7 @@ mod tests {
         serde_json::from_value::<Bla>(json!({
             "foo": "bar",
         }))
-        .expect_err("Should'nt parse implicit V2");
+        .expect_err("Shouldn't parse implicit V2");
 
         serde_json::from_value::<Bla>(json!({
             "foo": "bar",

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1032,7 +1032,7 @@ pub enum CoreEnvironmentError {
     #[error("failed to build container builder")]
     CallContainerBuilder(#[source] std::io::Error),
     // endregion
-    #[error("package is unsupported for this sytem")]
+    #[error("package is unsupported for this system")]
     UnsupportedPackageWithDocLink(#[source] CallPkgDbError),
     #[error("failed to write container builder to sink")]
     WriteContainer(#[source] std::io::Error),

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -54,7 +54,7 @@ pub struct ReadOnly {}
 /// Generations as a checked out branch of a git clone of a [ReadOnly] repo.
 /// In this state files are read and writeable using the filesystem.
 ///
-/// Mutating commands are commited and pushed to the [ReadOnly] branch.
+/// Mutating commands are committed and pushed to the [ReadOnly] branch.
 ///
 /// Instances of this type are created using [Generations::writable].
 ///
@@ -71,7 +71,7 @@ pub struct ReadWrite {}
 pub struct Generations<State = ReadOnly> {
     /// A floxmeta repository/branch that contains the generations of an environment
     ///
-    /// - When [ReadOnly], this is assumend to be bare, but it is not enforced.
+    /// - When [ReadOnly], this is assumed to be bare, but it is not enforced.
     ///   If not bare, updating it using `git push` may fail to update checked out branches.
     /// - When [ReadWrite], this is required to not be bare.
     ///   This is enforced when created using [Self::writable].

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1011,7 +1011,7 @@ impl ManagedEnvironment {
     /// Note:
     /// This is not a method on CoreEnvironment because its currently only relevant
     /// in the context of a ManagedEnvironment.
-    /// A potential future version could provide more detailed comaparison/diff information
+    /// A potential future version could provide more detailed comparison/diff information
     /// that may be more generally useful and see this method changed or moved.
     fn validate_checkout(
         local: &CoreEnvironment,
@@ -1200,7 +1200,7 @@ fn branch_name(pointer: &ManagedPointer, dot_flox_path: &CanonicalPath) -> Strin
 /// within the context of an instance of [ManagedEnvironment].
 ///
 /// [`remote_branch_name`] is primarily used when talking to upstream on FloxHub,
-/// during opening to reconciliate with the upsream repo
+/// during opening to reconciliate with the upstream repo
 /// as well as during [`ManagedEnvironment::pull`].
 pub fn remote_branch_name(pointer: &ManagedPointer) -> String {
     format!("{}", pointer.name)
@@ -2306,7 +2306,7 @@ mod test {
             .join(MANIFEST_FILENAME)
             .exists());
 
-        // dlete env dir to see wheter it is recreated
+        // dlete env dir to see whether it is recreated
         fs::remove_dir_all(managed_env.path.join(ENV_DIR_NAME)).unwrap();
 
         let _ = managed_env
@@ -2395,13 +2395,13 @@ mod test {
         "})
         .unwrap();
 
-        // sanity check that before synching, the manifest is now different
+        // sanity check that before syncing, the manifest is now different
         assert_ne!(
             local_checkout.manifest_contents().unwrap(),
             generation_manifest
         );
 
-        // check that after synching, the manifest is the same
+        // check that after syncing, the manifest is the same
         managed_env.create_generation_from_local_env(&flox).unwrap();
 
         let generation_manifest = managed_env

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -402,7 +402,7 @@ impl PathEnvironment {
         match DotFlox::open_in(dot_flox_parent_path.as_ref()) {
             // continue if the .flox directory does not exist, as it's being created by this method
             Err(EnvironmentError::DotFloxNotFound(_)) => {},
-            // propagate any other error signalling a faulty .flox directory
+            // propagate any other error signaling a faulty .flox directory
             Err(e) => Err(e)?,
             // .flox directory exists, so we can't create a new environment here
             Ok(_) => Err(EnvironmentError::EnvironmentExists(

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -106,7 +106,7 @@ impl RemoteEnvironment {
         let inner_rendered_env_links = {
             let gcroots_dir = dot_flox_path.join(GCROOTS_DIR_NAME);
 
-            // `.flox/run` used to be a link until flox verions 1.3.3!
+            // `.flox/run` used to be a link until flox versions 1.3.3!
             // If we find a symlink, we need to delete it to create a directory
             // with symlinked files in the following step.
             if gcroots_dir.exists() && gcroots_dir.is_symlink() {

--- a/cli/flox-rust-sdk/src/models/floxmeta.rs
+++ b/cli/flox-rust-sdk/src/models/floxmeta.rs
@@ -220,7 +220,7 @@ pub fn floxmeta_git_options(
     };
 
     // Set authentication with the FloxHub token using an inline credential helper.
-    // The credential helper should help avoinding a leak of the token in the process list.
+    // The credential helper should help avoiding a leak of the token in the process list.
     //
     // If no token is provided, we still set the credential helper and pass an empty string as password
     // to enforce authentication failures and avoid fallback to pinentry

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -501,7 +501,7 @@ impl Lockfile {
     /// Already locked flake installables will not be locked again,
     /// and copied from the seed lockfile as is.
     ///
-    /// Catalog and flake installables are locked separately, usinf largely symmetric logic.
+    /// Catalog and flake installables are locked separately, using largely symmetric logic.
     /// Keeping the locking of each kind separate keeps the existing methods simpler
     /// and allows for potential parallelization in the future.
     pub async fn lock_manifest(
@@ -659,7 +659,7 @@ impl Lockfile {
             let new_priority = manifest
                 .install
                 .get(install_id)
-                .and_then(|desciptor| desciptor.as_catalog_descriptor_ref())
+                .and_then(|descriptor| descriptor.as_catalog_descriptor_ref())
                 .and_then(|descriptor| descriptor.priority)
                 .unwrap_or(DEFAULT_PRIORITY);
 

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -2180,7 +2180,7 @@ pub(super) mod test {
                                 AttrPathComponent::Quoted => "\"floxtastic\"",
                                 AttrPathComponent::QuotedWithDots => "\"flox.tastic\"",
                             };
-                            (format!("#legacyPackges.aarch64-darwin.{}", id), id)
+                            (format!("#legacyPackages.aarch64-darwin.{}", id), id)
                         },
                         2 => {
                             let namespace = match attr_path_seeds[0] {

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -146,7 +146,7 @@ impl ManifestBuilder for FloxBuildMk {
         // Add build target arguments by prefixing the package names with "build/".
         // If no packages are specified, build all packages.
         // While the default target is "build", we explicitly specify it here
-        // to avoid unintentional changes in behvaior.
+        // to avoid unintentional changes in behavior.
         if packages.is_empty() {
             let build_all_target = "build";
             command.arg(build_all_target);
@@ -1038,7 +1038,7 @@ mod tests {
         assert_eq!(
             String::from_utf8_lossy(&output.stdout).trim_end(),
             result_wrapped.to_string_lossy(),
-            "intepreted scripts are known to have the wrong arg0"
+            "interpreted scripts are known to have the wrong arg0"
         );
     }
 

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -39,7 +39,7 @@ pub enum BuildEnvError {
     /// I.e. `nix build` returned with a non-zero exit code.
     /// The error message is the stderr of the `nix build` command.
     // TODO: this requires to capture the stderr of the `nix build` command
-    // or essentially "tee" it if we also want to foward the logs to the user.
+    // or essentially "tee" it if we also want to forward the logs to the user.
     // At the moment the "interesting" logs
     // are emitted by the `pkgdb realise` portion of the build.
     // So in the interest of initial simplicity

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -882,7 +882,7 @@ pub struct MsgAttrPathNotFoundNotInCatalog {
 /// A message that is returned by a catalog if the package,
 /// installed as [Self::install_id], cannot be resolved,
 /// because no single page contain a package for all requested systems.
-/// The catalog suggests an alternaive grouping in [Self::system_groupings].
+/// The catalog suggests an alternative grouping in [Self::system_groupings].
 ///
 /// Typically constructed from a [ResolutionMessageGeneral] where
 /// the [ResolutionMessageGeneral::type_] is [MessageType::AttrPathNotFoundSystemsNotOnSamePage].
@@ -936,7 +936,7 @@ pub struct MsgConstraintsTooTight {
     pub msg: String,
 }
 
-/// The content of a yet unkown message.
+/// The content of a yet unknown message.
 ///
 /// Generic messages are typically constructed [MsgGeneral].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/cli/flox-rust-sdk/src/providers/flox_cpp_utils.rs
+++ b/cli/flox-rust-sdk/src/providers/flox_cpp_utils.rs
@@ -284,7 +284,7 @@ mod tests {
             .expect("locking local test flake should succeed");
     }
 
-    // Tests against locking errors thown by pkgdb.
+    // Tests against locking errors thrown by pkgdb.
     //
     // There is currently no coverage of error cases in the pkgdb unit tests,
     // because it's not yet clear how detailed we want tests to be.

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -854,7 +854,7 @@ impl GitProvider for GitCommandProvider {
     /// 3. the upstream branch name
     /// 4. the current revision of the upstream branch
     ///
-    /// This is essentialy
+    /// This is essentially
     ///
     ///   upstream_ref = git rev-parse @{u}
     ///   (remote_name, branch_name) = split_once "/" upstream_ref

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -24,7 +24,7 @@ pub enum PublishError {
     NonexistentOutputs(String),
 
     #[error("The environment is in an unsupported state for publishing: {0}")]
-    UnsupportEnvironmentState(String),
+    UnsupportedEnvironmentState(String),
 
     #[error("There was an error communicating with the catalog")]
     CatalogError(#[source] Box<dyn error::Error>),
@@ -179,7 +179,7 @@ pub fn check_build_metadata(
     // process to feed this.
 
     let system = SystemEnum::from_str(system).map_err(|e| {
-        PublishError::UnsupportEnvironmentState(format!("Unable to identify system: {e}"))
+        PublishError::UnsupportedEnvironmentState(format!("Unable to identify system: {e}"))
     })?;
 
     let result_dir = build_symlink_path(env, pkg)?;
@@ -203,17 +203,17 @@ fn gather_build_repo_meta(environment: &impl Environment) -> Result<LockedUrlInf
     // Gather build repo info
     let git = match environment.parent_path() {
         Ok(env_path) => GitCommandProvider::discover(env_path)
-            .map_err(|e| PublishError::UnsupportEnvironmentState(format!("Git error {e}")))?,
-        Err(e) => return Err(PublishError::UnsupportEnvironmentState(e.to_string())),
+            .map_err(|e| PublishError::UnsupportedEnvironmentState(format!("Git error {e}")))?,
+        Err(e) => return Err(PublishError::UnsupportedEnvironmentState(e.to_string())),
     };
 
     let origin = git
         .get_origin()
-        .map_err(|e| PublishError::UnsupportEnvironmentState(format!("Git error {e}")))?;
+        .map_err(|e| PublishError::UnsupportedEnvironmentState(format!("Git error {e}")))?;
 
     let status = git
         .status()
-        .map_err(|e| PublishError::UnsupportEnvironmentState(e.to_string()))?;
+        .map_err(|e| PublishError::UnsupportedEnvironmentState(e.to_string()))?;
 
     // TODO - check is_dirty and warn?
     // TODO - check if REV is in remote?
@@ -233,7 +233,7 @@ fn gather_base_repo_meta(
     // Gather locked base catalog page info
     let lockfile = environment
         .lockfile(flox)
-        .map_err(|e| PublishError::UnsupportEnvironmentState(e.to_string()))?;
+        .map_err(|e| PublishError::UnsupportedEnvironmentState(e.to_string()))?;
     let install_ids_in_toplevel_group = lockfile
         .manifest
         .pkg_descriptors_in_toplevel_group()
@@ -241,10 +241,10 @@ fn gather_base_repo_meta(
         .map(|(pkg, _desc)| pkg);
 
     // We should not need this, and allow for no base catalog page dependency.
-    // But for now, requireing it simplifies resolution and model updates
+    // But for now, requiring it simplifies resolution and model updates
     // significantly.
     if install_ids_in_toplevel_group.clone().count() == 0 {
-        return Err(PublishError::UnsupportEnvironmentState(
+        return Err(PublishError::UnsupportedEnvironmentState(
             "No packages in toplevel group".to_string(),
         ));
     }
@@ -267,7 +267,7 @@ fn gather_base_repo_meta(
             rev_date: pkg.as_catalog_package_ref().unwrap().rev_date,
         })
     } else {
-        Err(PublishError::UnsupportEnvironmentState(
+        Err(PublishError::UnsupportedEnvironmentState(
             "Unable to find locked descriptor for toplevel package".to_string(),
         ))
     }
@@ -368,7 +368,7 @@ pub mod tests {
 
         let lockfile_path = CanonicalPath::new(env.lockfile_path(&flox).unwrap());
         let lockfile = Lockfile::read_from_file(&lockfile_path.unwrap()).unwrap();
-        // Only the toplevel group in this example, so we can grap the first package
+        // Only the toplevel group in this example, so we can grab the first package
         let locked_base_pkg = lockfile.packages[0].as_catalog_package_ref().unwrap();
         assert_eq!(meta.base_catalog_ref.url, locked_base_pkg.locked_url);
         assert_eq!(meta.base_catalog_ref.rev, locked_base_pkg.rev);

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -360,7 +360,7 @@ impl ProcessStates {
         self.0.iter().find(|state| state.name == name)
     }
 
-    /// Iterater over references to the contained [ProcessState]s.
+    /// Iterate over references to the contained [ProcessState]s.
     pub fn iter(&self) -> impl Iterator<Item = &ProcessState> {
         self.0.iter()
     }
@@ -659,7 +659,7 @@ impl Iterator for ProcessComposeLogStream {
     fn next(&mut self) -> Option<Self::Item> {
         match self.receiver.recv() {
             Ok(line) => Some(Ok(line)),
-            // All senders have been dropped, so we wont't receive any more messages.
+            // All senders have been dropped, so we won't receive any more messages.
             // Drain remaining reader return values.
             Err(_) => {
                 loop {
@@ -964,7 +964,7 @@ pub mod test_helpers {
                 // Processes _may_ have not started yet, or the socket is unresponsive.
                 // We can't really check if the process is running,
                 // as it may have already exited.
-                // We could chek if the socket can be connected to
+                // We could check if the socket can be connected to
                 // or try to read ProcessStates, if the current approach leads to flaking tests.
                 if socket.exists() {
                     break;

--- a/cli/flox-watchdog/src/main.rs
+++ b/cli/flox-watchdog/src/main.rs
@@ -251,7 +251,7 @@ fn ensure_process_group_leader() -> Result<(), Error> {
     // Trivia:
     // You can't create a new session if you're already a session leader, the reason being that
     // the other processes in the group aren't automatically moved to the new session. You're supposed
-    // to have this invariant: all processes in a process group share the same controllling terminal.
+    // to have this invariant: all processes in a process group share the same controlling terminal.
     // If you were able to create a new session as session leader and leave behind the other processes
     // in the group in the old session, it would be possible for processes in this group to be in two
     // different sessions and therefore have two different controlling terminals.

--- a/cli/flox/doc/doc-build/flox-build-clean.md
+++ b/cli/flox/doc/doc-build/flox-build-clean.md
@@ -34,7 +34,7 @@ and build related temporary data.
 :   The package(s) to clean.
     Possible values are all keys under the `build` attribute
     in the environment's `manifest.toml`.
-    If ommitted, will clean all build related data.
+    If omitted, will clean all build related data.
 
 
 ```{.include}

--- a/cli/flox/doc/doc-build/flox-build.md
+++ b/cli/flox/doc/doc-build/flox-build.md
@@ -47,7 +47,7 @@ manual builds, `.env` files containing secrets etc.,
 only files tracked by `git` are available.
 Untracked files, files outside of the repository and notably network access
 will be restricted to encourage "pure" and reproducible builds.
-Builds can opt-out of the sandbox by setting `build.<package>.sandbox = "off"`.
+Builds can opt out of the sandbox by setting `build.<package>.sandbox = "off"`.
 With the sandbox disabled, building is equivalent
 to running the build script manually within a shell created by `flox activate`.
 Any build can access the _results_ of other builds
@@ -109,7 +109,7 @@ echo "hello world" >> $out/hello.txt
 '''
 ```
 
-2. Build the pacakge and verify its contents:
+2. Build the package and verify its contents:
 
 ```
 $ flox build hello
@@ -119,7 +119,7 @@ $ cat ./result-hello/hello.txt
 hello, world
 ```
 
-## Building a simple multi stage app
+## Building a simple multi-stage app
 
 Assume a simple `nodejs` project
 
@@ -140,7 +140,7 @@ Assume a simple `nodejs` project
 $ flox init
 ```
 
-2. Install dependencies and add build instaructions
+2. Install dependencies and add build instructions
 
 ```toml
 # file: .flox/env/manifest.toml

--- a/cli/flox/doc/doc-build/manifest.toml.md
+++ b/cli/flox/doc/doc-build/manifest.toml.md
@@ -151,7 +151,7 @@ Each option is described below:
     pkg-groups and packages interact during upgrades.
 
 `version`
-:   Requires that the package match either an exact version or a semver range.
+:   Requires that the package match either an exact version or a SemVer range.
 
     The semantic version can be specified with the typical qualifiers such as
     `^`, `>=`, etc.
@@ -443,7 +443,7 @@ echo 'Hello, World!' >> $out/hello.txt
 '''
 ```
 
-This would define a package called `hello` that produces a singe file
+This would define a package called `hello` that produces a single file
 `hello.txt` containing the string `Hello, World!".
 Running `flox build hello` would create a symlink `./result-hello`
 in the directory adjacent to the `./flox` directory.

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -34,7 +34,7 @@ and adds `bin` directories to your `$PATH`.
   Executes `CMD` in the same environment as if run inside an interactive shell
   produced by an interactive `flox activate`
   The shell `CMD` is run by is determined by `$FLOX_SHELL` or `$SHELL`.
-* in-place: `flox activate` when invoked from an non-interactive shell
+* in-place: `flox activate` when invoked from a non-interactive shell
   with it's `stdout` redirected e.g. `eval "$(flox activate)"`\
   Produces commands to be sourced by the parent shell.
   Flox will determine the parent shell from `$FLOX_SHELL` or otherwise

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -112,7 +112,7 @@ flox config --set 'trusted_environments."owner/name"' trust
     (default: "show-all").
     This has been deprecated in favor of `set_prompt` and `hide_default_prompt`.
     Possible values are
-    * "show-all": shows all active anvironments
+    * "show-all": shows all active environments
     * "hide-all": disables the modification of the shell prompt
     * "hide-default": filters out environments named 'default' from the shell prompt
 

--- a/cli/flox/doc/flox-delete.md
+++ b/cli/flox/doc/flox-delete.md
@@ -20,10 +20,10 @@ flox [<general options>] delete
 # DESCRIPTION
 
 Deletes all data pertaining to an environment.
-By default only the environment in the current directory is deleted,
+By default, only the environment in the current directory is deleted,
 but environments in other directories may be deleted via the `-d` flag.
 
-By default you will be prompted for a confirmation before deleting the
+By default, you will be prompted for a confirmation before deleting the
 environment.
 The `-f` flag skips the confirmation dialog and is required for non-interactive
 use.

--- a/cli/flox/doc/flox-edit.md
+++ b/cli/flox/doc/flox-edit.md
@@ -21,7 +21,7 @@ flox [<general options>] edit
 
 ## Transactionally edit the environment manifest.
 
-By default invokes an editor with a copy of the local manifest for the user to
+By default, invokes an editor with a copy of the local manifest for the user to
 interactively edit.
 The editor is found by querying `$EDITOR`, `$VISUAL`,
 and then by looking for common editors in `$PATH`.

--- a/cli/flox/doc/flox-init.md
+++ b/cli/flox/doc/flox-init.md
@@ -26,7 +26,7 @@ The name of the environment will be the basename of the current directory
 or `default` if the current directory is `$HOME`.
 The `--name` flag can be used to give the environment a specific name.
 
-By default the environment will be created in the current directory.
+By default, the environment will be created in the current directory.
 Flox will add a directory `$PWD/.flox` containing all relevant environment
 metadata.
 The `--dir` flag can be used to create an environment in another location.

--- a/cli/flox/doc/flox-install.md
+++ b/cli/flox/doc/flox-install.md
@@ -26,7 +26,7 @@ During an installation attempt the environment is built in order to validate
 that the environment isn't broken
 (for example, in rare cases packages may provide files that conflict).
 If building the environment fails,
-including any of the consitituent packages,
+including any of the constituent packages,
 the attempt is discarded and the environment is unmodified.
 If the build succeeds, the environment is atomically updated.
 

--- a/cli/flox/doc/flox-push.md
+++ b/cli/flox/doc/flox-push.md
@@ -53,7 +53,7 @@ FloxHub with local changes to the environment.
 :   FloxHub owner to push environment to (default: current FloxHub user).
 
 `-f`, `--force`
-:   Forceably overwrite the remote copy of the environment.
+:   Forcibly overwrite the remote copy of the environment.
 
 ```{.include}
 ./include/general-options.md

--- a/cli/flox/doc/flox-services-start.md
+++ b/cli/flox/doc/flox-services-start.md
@@ -21,8 +21,8 @@ flox [<general-options>] services start
 Starts the specified services.
 
 If any services are currently running, a warning will be displayed for each
-specified service that is already running but the command will still succeed.
-If a specified service does not exist, an error will displayed and no services
+specified service that is already running, but the command will still succeed.
+If a specified service does not exist, an error will be displayed and no services
 will be started.
 
 If no services are currently running, then the services will be started from an

--- a/cli/flox/doc/include/experimental-warning.md
+++ b/cli/flox/doc/include/experimental-warning.md
@@ -1,2 +1,2 @@
 > **Warning:**
-> This command is **experimental** and its behaviour is subject to change
+> This command is **experimental**, and its behaviour is subject to change

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -719,7 +719,7 @@ impl Activate {
             })
     }
 
-    /// Construct the envrionment list for the shell prompt
+    /// Construct the environment list for the shell prompt
     ///
     /// [`None`] if the prompt is disabled, or filters removed all components.
     fn make_prompt_environments(

--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -47,7 +47,7 @@ impl ResetMetrics {
         }
 
         let notice = indoc! {"
-            Sucessfully reset telemetry ID for this machine!
+            Successfully reset telemetry ID for this machine!
 
             A new ID will be assigned next time you use Flox.
 

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -22,11 +22,11 @@ use crate::utils::dialog::{Dialog, Select};
 use crate::utils::message;
 
 const NPM_HOOK: &str = indoc! {"
-                # Install nodejs depedencies
+                # Install nodejs dependencies
                 npm install"};
 
 const YARN_HOOK: &str = indoc! {"
-                # Install nodejs depedencies
+                # Install nodejs dependencies
                 yarn"};
 
 /// The general flow of the node hook is:
@@ -150,7 +150,7 @@ impl Node {
         // but since npm comes bundled with nodejs, we'll probably cover the most
         // cases by just giving the requested node and hoping for the bundled
         // npm to work.
-        // We could check if our one version of npm with its harcoded nodejs
+        // We could check if our one version of npm with its hardcoded nodejs
         // satisfies all constraints,
         // but that seems unlikely to be as commonly needed.
         let versions = Self::get_package_json_versions(path)?;
@@ -989,7 +989,7 @@ mod tests {
                 "nodejs",
                 "18",
             )]);
-            // Reponse when yarn version 1 is requested
+            // Response when yarn version 1 is requested
             client.push_resolve_response(vec![resolved_pkg_group_with_dummy_package(
                 "yarn_group",
                 &System::from("aarch64-darwin"),

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -364,7 +364,7 @@ impl Install {
                 // with `DidYouMean`.
                 // We use `DidYouMean` to generate the suggestions,
                 // separately from attempting an install,
-                // or other kind of resoluton.
+                // or other kind of resolution.
                 // This is because `DidYouMean` may take an unknown amount of time,
                 // performing a search.
                 // For the same reason `DidYouMean` is also showing a spinner

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1905,7 +1905,7 @@ mod tests {
 
     /// [UpdateNotification::check_for_update_inner] returns
     /// [UpdateCheckResult::MissingNotificationFile] if no update is available
-    ///  but the nitification file is missing
+    ///  but the notification file is missing
     #[tokio::test]
     async fn test_check_for_update_returns_missing_notification_file() {
         let temp_dir = tempdir().unwrap();

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -62,7 +62,7 @@ pub struct Pull {
     #[bpaf(long, short, argument("path"))]
     dir: Option<PathBuf>,
 
-    /// Forceably pull the environment
+    /// Forcibly pull the environment
     /// When pulling a new environment, adds the system to the manifest if the lockfile is incompatible
     /// and ignores eval and build errors.
     /// When pulling an existing environment, overrides local changes.

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -38,7 +38,7 @@ pub struct Push {
     #[bpaf(long, short, argument("owner"))]
     owner: Option<EnvironmentOwner>,
 
-    /// Forceably overwrite the remote copy of the environment
+    /// Forcibly overwrite the remote copy of the environment
     #[bpaf(long, short)]
     force: bool,
 }

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -206,7 +206,7 @@ pub fn guard_is_within_activation(
 }
 
 /// Warn about manifest changes that may require services to be restarted, if
-/// the Environment has a service manager running. It doesn't guarentee that the
+/// the Environment has a service manager running. It doesn't guarantee that the
 /// service manager is working (e.g. hasn't crashed). It is the caller's
 /// responsibility to determine what manifest changes would affect services.
 pub fn warn_manifest_changes_for_services(flox: &Flox, env: &dyn Environment) {

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -32,7 +32,7 @@ pub struct Config {
     /// Feature flags are set from config but more commonly controlled by
     /// `FLOX_FEATURES_` environment variables.
     ///
-    /// Accessing from `flox_rust_sdk::flox::Flox.features` should be prefered
+    /// Accessing from `flox_rust_sdk::flox::Flox.features` should be preferred
     /// over `flox::config::Config.features` if both are available.
     #[serde(default)]
     pub features: Option<Features>,
@@ -264,7 +264,7 @@ impl Config {
 
     /// get a value from the config
     ///
-    /// **intended for human consumtion/intospection of config only**
+    /// **intended for human consumption/intospection of config only**
     ///
     /// Values in the context should be read from the [Config] type instead!
     pub fn get(&self, path: &[Key]) -> Result<String, ReadWriteError> {
@@ -296,7 +296,7 @@ impl Config {
         Ok(value.to_string())
     }
 
-    /// Append or update a key value parin in the toml representation of a partial config
+    /// Append or update a key value paring in the toml representation of a partial config
     ///
     /// Validate using [Self]
     pub fn write_to<V: Serialize>(

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -186,7 +186,7 @@ fn main() -> ExitCode {
 
     exit_code
 
-    // drop(runtime) should implicilty be last
+    // drop(runtime) should implicitly be last
 }
 
 /// Error to exit without printing an error message

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -60,7 +60,7 @@ pub fn format_error(err: &EnvironmentError) -> String {
 
             Try deleting the '.flox' directory and reinitializing the environment.
             If you cloned this environment from a remote repository, verify that
-            `.flox/env/maifest.toml` is commited to the version control system.
+            `.flox/env/maifest.toml` is committed to the version control system.
         "},
         // todo: enrich with a path?
         EnvironmentError::EnvPointerNotFound => formatdoc! {"
@@ -70,7 +70,7 @@ pub fn format_error(err: &EnvironmentError) -> String {
 
             Try deleting the '.flox' directory and reinitializing the environment.
             If you cloned this environment from a remote repository, verify that
-            `.flox/env.json` is commited to the version control system.
+            `.flox/env.json` is committed to the version control system.
         "},
 
         // todo: enrich with a path?
@@ -81,7 +81,7 @@ pub fn format_error(err: &EnvironmentError) -> String {
 
             Try deleting the '.flox' directory and reinitializing the environment.
             If you cloned this environment from a remote repository, verify that
-            `.flox/env/maifest.toml` is commited to the version control system.
+            `.flox/env/maifest.toml` is committed to the version control system.
         "},
 
         // todo: enrich with a path?
@@ -115,7 +115,7 @@ pub fn format_error(err: &EnvironmentError) -> String {
 
             Try deleting the '.flox' directory and reinitializing the environment.
             If you cloned this environment from a remote repository, verify that
-            `.flox/env.json` is commited to the version control system.
+            `.flox/env.json` is committed to the version control system.
         "},
         // todo: enrich with a path?
         // todo: when can this happen:
@@ -123,7 +123,7 @@ pub fn format_error(err: &EnvironmentError) -> String {
         //   * user pushed environment but did not commit the changes to env.json
         //   * new version of the file format and we don't support it yet
         //     or not anymore with the current version of flox
-        //     (this should be catched earlier but you never know...)
+        //     (this should be caught earlier but you never know...)
         EnvironmentError::ParseEnvJson(error) => formatdoc! {"
             Failed to parse environment metadata: {error}
 
@@ -131,7 +131,7 @@ pub fn format_error(err: &EnvironmentError) -> String {
 
             Try deleting the '.flox' directory and reinitializing the environment.
             If you cloned this environment from a remote repository, verify that
-            the latest changes to `.flox/env.json` are commited to the version control system.
+            the latest changes to `.flox/env.json` are committed to the version control system.
         "},
         // this should always never be a problem and if it is, it's a bug
         // the user can likely not do anything about it
@@ -254,7 +254,7 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
             err = format_core_error(err)
         },
         CoreEnvironmentError::MakeSandbox(_) => display_chain(err),
-        // witin transaction, user should not see this and likely can't do anything about it
+        // within transaction, user should not see this and likely can't do anything about it
         CoreEnvironmentError::WriteLockfile(_) => display_chain(err),
         CoreEnvironmentError::MakeTemporaryEnv(_) => display_chain(err),
         CoreEnvironmentError::PriorTransaction(backup) => {
@@ -424,7 +424,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
 
     match err {
         // todo: communicate reasons for this error
-        // git auth errors may be catched separately or reported
+        // git auth errors may be caught separately or reported
         ManagedEnvironmentError::OpenFloxmeta(err) => formatdoc! {"
             Failed to fetch environment: {err}
         "},
@@ -565,7 +565,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
                 message.to_string()
             }
         },
-        // acces denied is catched early as ManagedEnvironmentError::AccessDenied
+        // access denied is caught early as ManagedEnvironmentError::AccessDenied
         ManagedEnvironmentError::Push(_) => display_chain(err),
         ManagedEnvironmentError::DeleteBranch(_) => display_chain(err),
         ManagedEnvironmentError::DeleteEnvironment(path, err) => formatdoc! {"

--- a/cli/flox/src/utils/init/metrics.rs
+++ b/cli/flox/src/utils/init/metrics.rs
@@ -15,7 +15,7 @@ use crate::utils::metrics::{METRICS_LOCK_FILE_NAME, METRICS_UUID_FILE_NAME};
 ///
 /// Check whether the current uuid file is empty.
 ///
-/// An empty metrics uuid file used to signal telemtry opt-out.
+/// An empty metrics uuid file used to signal telemetry opt-out.
 /// We are moving this responsibility to the user configuration file.
 /// This detects whether a migration is necessary.
 pub async fn telemetry_opt_out_needs_migration(

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -94,7 +94,7 @@ pub(crate) fn package_installed(pkg: &PackageToInstall, environment_description:
 ///
 /// Luckily, our CLI surface is largely single threaded.
 /// Threads are mainly spawned for blocking operations either in the library layer,
-/// or to run library funcitons in the background, e.g. to print a progress bar
+/// or to run library functions in the background, e.g. to print a progress bar
 /// on the main thread.
 /// Also, while technically within an async runtime, the CLI is largely synchronous,
 /// and the default [#[tokio::test]] runtime is single threaded.

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -337,7 +337,7 @@ impl Hub {
     /// Flush the metrics to the telemetry backend
     ///
     /// If `force` is true, the metrics are flushed even if the buffer is not expired.
-    /// This methods is jut a convience wrapper around [Client::flush],
+    /// This methods is jut a convenience wrapper around [Client::flush],
     /// that will do nothing if no client is setup.
     fn flush_metrics(&self, force: bool) -> Result<()> {
         self.with_client(|client| {
@@ -352,7 +352,7 @@ impl Hub {
 
     /// Record a metric event
     ///
-    /// This is a convience wrapper around [Client::record_metric],
+    /// This is a convenience wrapper around [Client::record_metric],
     /// that will do nothing if no client is setup.
     pub fn record_metric(&self, event: MetricEvent) -> Result<()> {
         self.with_client(|client| {
@@ -544,7 +544,7 @@ impl Client {
 
     /// Send the metrics to the telemetry backend and clear the buffer file.
     ///
-    /// Any connection errors will bubble up and be catched by the event handler.
+    /// Any connection errors will bubble up and be caught by the event handler.
     /// If the network request failed, the buffer file is _not_ cleared.
     fn flush(&mut self, force: bool) -> Result<()> {
         let mut metrics = MetricsBuffer::read(&self.metrics_dir)?;
@@ -726,7 +726,7 @@ mod tests {
         buffer.push(entry_foo.clone()).unwrap();
         buffer.push(entry_bar.clone()).unwrap();
 
-        // Can't create another bufer object while one is currently locked
+        // Can't create another buffer object while one is currently locked
         drop(buffer);
 
         let buffer = MetricsBuffer::read(tempdir.as_ref()).unwrap();

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -194,7 +194,7 @@ impl DisplaySearchResults {
         // In addition after deduplication we may have fewer results than the limit,
         // but we dont want to show a message like `Showing 5 of 9...`,
         // when the requested number of results is 10.
-        // There is still an issue wit duplicate results where even when called with `--all`
+        // There is still an issue with duplicate results where even when called with `--all`
         // the number of elements in `deduped_display_items` may be less than `count`.
         // That bug will be fixed separately.
         if count == self.n_results {

--- a/cli/mk_data/README.md
+++ b/cli/mk_data/README.md
@@ -68,7 +68,7 @@ Semantics:
 - `files` are relative paths specified relative to the input data directory.
 - `files` are copied from the input data directory into the working directory before anything else happens.
 - `pre_cmd` executes next, but no response file is generated during execution.
-- `cmd` is executed next and a response file is generated.
+- `cmd` is executed next, and a response file is generated.
 - `post_cmd` is executed next, but no response file is generated.
 - `$RESPONSE_FILE` contains the path to the generated response file and is available inside `post_cmd` for post-processing of response files.
 

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -208,7 +208,7 @@ EOF
   assert_success
 
   # applying the same edit again should return early
-  # (simulates quiting the editor without saving)
+  # (simulates quitting the editor without saving)
   run "$FLOX_BIN" edit -f "$TESTS_DIR/edit/manifest.toml"
   assert_success
   assert_output "⚠️  No changes made to environment."

--- a/cli/tests/services/logging_services.toml
+++ b/cli/tests/services/logging_services.toml
@@ -18,7 +18,7 @@ echo 3
 echo >> ./resume-mostly-deterministic.pipe
 
 # Asserting any output past this is prone to race conditions,
-# since we cant guarantee that tests will run before the sleep ends
+# since we can't guarantee that tests will run before the sleep ends
 sleep 3
 
 echo 4

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -241,7 +241,7 @@ gitconfig_setup() {
 
 # deleteEnvForce ENV_NAME
 # ------------------------
-# Force the destruction of an env including any remote metdata.
+# Force the destruction of an env including any remote metadata.
 deleteEnvForce() {
   # TODO delete using Rust
   # { $FLOX_BIN --bash-passthru delete -e "${1?}" --origin -f||:; } >/dev/null 2>&1;

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -64,7 +64,7 @@ setup_test_envname() {
 
 # Build `hello' and root it temporarily so it can be used as an
 # install target in various tests.
-# This symlink is deleteed by `common_teardown'.
+# This symlink is deleted by `common_teardown'.
 hello_pkg_setup() {
   if [[ -n "${__FT_RAN_HELLO_PKG_SETUP:-}" ]]; then return 0; fi
   export HELLO_LINK="$BATS_SUITE_TMPDIR/gc-roots/hello"
@@ -186,7 +186,7 @@ wait_for_watchdogs() {
   # The `ps` prints `<pid> <cmd>`, then we use two separate `grep`s so that the
   # grep command itself doesn't get listed when we search for the data dir.
   # The `sed` removes any leading whitespace,
-  # that is present in the output of `ps` on linux aparently?!.
+  # that is present in the output of `ps` on linux apparently?!.
   # The `cut` just extracts the PID.
 
   local pids

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -113,7 +113,7 @@ usage:
 # and we will presumably want `flox build` to do the same. However,
 # we cannot just mark the various build targets as PHONY because they
 # must be INTERMEDIATE to prevent `flox build foo` from rebuilding
-# `bar` and `baz` as well (unless of course it was a prerequsite).
+# `bar` and `baz` as well (unless of course it was a prerequisite).
 # So we instead derive the packages to be force-rebuilt from the special
 # MAKECMDGOALS variable if defined, and otherwise rebuild them all.
 BUILDGOALS = $(if $(MAKECMDGOALS),$(MAKECMDGOALS),$(notdir $(BUILDS)))

--- a/pkgdb/CONTRIBUTING.md
+++ b/pkgdb/CONTRIBUTING.md
@@ -185,7 +185,7 @@ $ git push origin --tags --force;
 
 Congratulations - you basically cut a release!
 Next you might cruise over to github.com to the repository page and make a new
-release ( under the "Releases" section in the right hand panel ).
+release ( under the "Releases" section in the right-hand panel ).
 When making a release just be sure to select the `v<MAJOR>.<MINOR>.<PATCH>` tag
 as the "release tag", and you're ready to roll!
 

--- a/pkgdb/README.md
+++ b/pkgdb/README.md
@@ -13,14 +13,14 @@ Links to additional documentation may be found at the bottom of this file.
 
 ## Purpose
 
-Evaluating nix expressions for an entire flake is expensive but necessary for
+Evaluating nix expressions for an entire flake is expensive, but necessary for
 features like package search.
 This tool provides a way to scrape the data from a flake once and store it in a
 database for later usage.
 
 The current responsibility of the `pkgdb` tool extends only as far as scraping
 a flake and generating a database.
-The database should be queried using standard sqlite tools and libraries and all
+The database should be queried using standard SQLite tools and libraries and all
 decisions about how and when to generate and update the database are left up to
 the consumer.
 
@@ -100,7 +100,7 @@ $ for subtree in packages legacyPackages; do
 $ sqlite3 "$dbPath" 'SELECT COUNT( * ) FROM Packages';
 ```
 
-In the example above we the caller would passes in a locked ref, this was
+In the example above we the caller would pass in a locked ref, this was
 technically optional, but is strongly recommended.
 What's important is that invocations that intend to append to an existing
 database ABSOLUTELY SHOULD be using locked flake references.
@@ -165,7 +165,7 @@ architectures) by a `Descriptions` table.
 If they are defined explicitly, `pname` and `version` will be read from the
 corresponding attributes.
 Otherwise, they will be parsed from the `name`.
-If `version` can be converted to a semver, it will be.
+If `version` can be converted to a SemVer, it will be.
 
 Note that the `attrName` for a package is the actual name in the tree.
 

--- a/pkgdb/docs/garbage-collection.md
+++ b/pkgdb/docs/garbage-collection.md
@@ -1,6 +1,6 @@
 # Garbage Collection
 
-`pkgdb` has a garbage collector command `pkgdb gc` which uses a 30 day timer to
+`pkgdb` has a garbage collector command `pkgdb gc` which uses a 30-day timer to
 mark existing databases as _stale_ to be removed from the user's system.
 
 In the future we may have additional methods of detecting __staleness_ but for
@@ -9,7 +9,7 @@ now, this simple approach is suitable.
 
 ## Staleness
 
-The 30 day timer can be modified using the option `-a,--min-age AGE` where
+The 30-day timer can be modified using the option `-a,--min-age AGE` where
 `AGE` is _number of days_.
 
 The flag `--dry-run` may be used to list stale databases without actually

--- a/pkgdb/docs/lockfile.md
+++ b/pkgdb/docs/lockfile.md
@@ -55,7 +55,7 @@ Fields:
 
 ## Locking Groups
 
-Currently we enforce compatibility with package groups in a simple manner;
+Currently, we enforce compatibility with package groups in a simple manner;
 in the future we expect to have more sophisticated strategies for ensuring
 compatibility among group members - but for now we enforce that all group
 members come from a single input+rev.
@@ -86,7 +86,7 @@ This has yet to be implemented.
 ### Extending an Existing Locked Group
 
 When locking new members in a group of packages we aim to preserve existing
-resolutions without upgrading other group members; however there's some
+resolutions without upgrading other group members; however there are some
 interesting situations that are worth explicitly specifying:
 
 1. When we can resolve new descriptors in the group's existing input+rev, we

--- a/pkgdb/docs/manifests.md
+++ b/pkgdb/docs/manifests.md
@@ -50,7 +50,7 @@ Fields:
   - `prefer-pre-releases`: Whether to prefer pre-release software over equivalent stable versions for the purpose of search results and installs.
     - Default value is `false`, which would prefer `4.1.9` over `4.2.0-pre`.
 - `Options`
-  - `package-grouping-strategy`: Governs how packages not explicity requested to resolve in a group should be resolved.
+  - `package-grouping-strategy`: Governs how packages not explicitly requested to resolve in a group should be resolved.
     - This field is currently unused.
   - `activation-strategy`: Governs how environments should be activated.
     - This field is currently unused.

--- a/pkgdb/docs/params-to-sql.md
+++ b/pkgdb/docs/params-to-sql.md
@@ -12,7 +12,7 @@ The caller provides filters to the query builder in the form of `PkgQueryArgs`.
 `PkgQuery` can either emit a SQL `SELECT` statement as a string or run that
 query on databases using `PkgQuery::bind( flox::pkgdb::database & )` or
 `PkgQuery::execute( flox::pkgdb::database & )`.
-The difference between `bind` and `execute` will be explain later.
+The difference between `bind` and `execute` will be explained later.
 
 Throughout this codebase you will find various `struct` and `class` definitions
 which essentially exist to hold the parsed user input and convert it into
@@ -59,7 +59,7 @@ stores it on the `SearchCommand` struct.
 `flox::search::SearchParams` contains these components:
 - A `flox::resolver::GlobalManifestRaw`, a path to a global manifest file,
   or nothing.
-- A `flox::resolver::ManfiestRaw`, a path to a manifest file, or nothing.
+- A `flox::resolver::ManifestRaw`, a path to a manifest file, or nothing.
 - A `flox::resolver::LockfileRaw`, a path to a lockfile, or nothing.
 - A `flox::search::SearchQuery`.
 
@@ -123,7 +123,7 @@ The query is constructed when the `PkgQuery` is initialized from
 the `PkgQueryArgs`.
 `PkgQuery` stores an internal list of `SELECT`, `WHERE`, etc clauses that get
 built up as the query arguments are processed.
-The details of query building is covered in a separate section.
+The details of query building are covered in a separate section.
 
 ### The query is executed
 

--- a/pkgdb/docs/registry.md
+++ b/pkgdb/docs/registry.md
@@ -80,7 +80,7 @@ and are often used in the output of `search` and `resolve` invocations.
 
 The `from` fields in each `input` are _flake references_ like those seen in
 `flake.nix` files, being either a URL string or an attribute set representation.
-These _flake references_ may be locked or unlocked but
+These _flake references_ may be locked or unlocked, but
 **locking is strongly recommended** for most use cases.
 
 The `priority` list should contain ONLY keys from `inputs`, and is used to

--- a/pkgdb/docs/testing-private-interfaces.cc
+++ b/pkgdb/docs/testing-private-interfaces.cc
@@ -43,7 +43,7 @@ public:
 /* -------------------------------------------------------------------------- */
 
 /* Approach 2: Using `friend' classes.
- * This does not require changes to visiblity, but does require a forward
+ * This does not require changes to visibility, but does require a forward
  * declaration of `TestClass1' in your public headers. */
 
 class TestClass1;

--- a/pkgdb/docs/valgrind.md
+++ b/pkgdb/docs/valgrind.md
@@ -5,7 +5,7 @@
 `valgrind` is a memory profiling toolkit that is available in our development
 shell on **Linux only**[^1].
 
-[^1]: `valgrind` may work on OSX but I have not personally had success with it
+[^1]: `valgrind` may work on OSX, but I have not personally had success with it
       which is why it has not been included in the Darwin development shell.
 
 While `valgrind` has a variety of tools, we will focus on `memcheck` and 

--- a/pkgdb/include/flox/buildenv/realise.hh
+++ b/pkgdb/include/flox/buildenv/realise.hh
@@ -53,7 +53,7 @@ static constexpr std::string_view REQUISITES_TXT_NAME = "requisites.txt";
 /**
  * @class flox::buildenv::SystemNotSupportedByLockfile
  * @brief An exception thrown when a lockfile is is missing a package.<system>
- * entry fro the requested system.
+ * entry from the requested system.
  * @{
  */
 FLOX_DEFINE_EXCEPTION( SystemNotSupportedByLockfile,

--- a/pkgdb/include/flox/core/util.hh
+++ b/pkgdb/include/flox/core/util.hh
@@ -29,7 +29,7 @@
 
 /* -------------------------------------------------------------------------- */
 
-/* Backported from C++20a for C++20b compatability. */
+/* Backported from C++20a for C++20b compatibility. */
 
 /**
  * @brief Helper type for `std::visit( overloaded { ... }, x );` pattern.
@@ -121,7 +121,7 @@ struct adl_serializer<std::variant<A, B>>
  * will succeed before attempting to parse alternatives.
  *
  * For example, always attempt `bool` first, then `int`, then `float`, and
- * alway attempt `std::string` LAST.
+ * always attempt `std::string` LAST.
  *
  * It's important to note that you must never nest multiple `std::optional`
  * types in a variant, instead make `std::optional<std::variant<...>>`.
@@ -430,7 +430,7 @@ assertIsJSONObject( const nlohmann::json & value,
 
 /**
  * @brief Merge two @a std::vector containers by putting all elements of the
- *        higher prioirty vector first, then appending the deduplicated keys of
+ *        higher priority vector first, then appending the deduplicated keys of
  *        the lower priortity vector.
  * @param lower The lower priority @a std::vector.
  * @param higher The higher priority @a std::vector.

--- a/pkgdb/include/flox/realisepkgs/realise.hh
+++ b/pkgdb/include/flox/realisepkgs/realise.hh
@@ -35,7 +35,7 @@ namespace flox::realisepkgs {
 /**
  * @class flox::realisepkgs::SystemNotSupportedByLockfile
  * @brief An exception thrown when a lockfile is is missing a package.<system>
- * entry fro the requested system.
+ * entry from the requested system.
  * @{
  */
 FLOX_DEFINE_EXCEPTION( SystemNotSupportedByLockfile,

--- a/pkgdb/src/buildenv/buildenv-lockfile.cc
+++ b/pkgdb/src/buildenv/buildenv-lockfile.cc
@@ -32,7 +32,7 @@ BuildenvLockfile::load_from_content( const nlohmann::json & jfrom )
       default:
         throw resolver::InvalidLockfileException(
           "unsupported lockfile version",
-          "only v0 and v1 are supprted" );
+          "only v0 and v1 are supported" );
     }
 }
 

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -356,7 +356,7 @@ tryEvaluatePackageOutPath( nix::ref<nix::EvalState> &              state,
         }
 
       /**
-       * eval errors are cached without the eror trace
+       * eval errors are cached without the error trace
        * force an impure eval to get the full error message
        */
       try
@@ -1040,7 +1040,7 @@ createContainerBuilder( nix::EvalState &         state,
 
   // Access to absolute paths is restricted by default.
   // Instead of disabling restricted evaluation,
-  // we allow access to the bundled store path explictly.
+  // we allow access to the bundled store path explicitly.
   state.allowPath( environmentStorePath );
 
   // the derivation uses `builtins.storePath`

--- a/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
+++ b/pkgdb/src/fetchers/wrapped-nixpkgs-input.cc
@@ -185,7 +185,7 @@ floxNixpkgsAttrsToGithubAttrs( const nix::fetchers::Attrs & attrs )
  * @todo throw a flox exception instead of a nix exception for easier handling?
  * @todo support wrapping of other inputs than `github:nixos/nixpkgs`.
  * This would also require changes to the `WrappedNixpkgsInputScheme` class,
- * as well as existing conversion methods imlemented for it.
+ * as well as existing conversion methods implemented for it.
  */
 nix::fetchers::Attrs
 githubAttrsToFloxNixpkgsAttrs( const nix::fetchers::Attrs & attrs )

--- a/pkgdb/src/lock-flake-installable.cc
+++ b/pkgdb/src/lock-flake-installable.cc
@@ -205,7 +205,7 @@ lockFlakeInstallable( const nix::ref<nix::EvalState> & state,
     // The argument is never stored on the `InstallableFlake` struct
     // or referenced outside of the constructor.
     // We can safely pass a nullptr here, as the constructor performs a null
-    // check before dereferencing the arguement:
+    // check before dereferencing the argument:
     // <https://github.com/NixOS/nix/blob/509be0e77aacd8afcf419526620994cbbbe3708a/src/libcmd/installable-flake.cc#L86-L87>
     static_cast<nix::SourceExprCommand *>( nullptr ),
     state,

--- a/pkgdb/src/logger.cc
+++ b/pkgdb/src/logger.cc
@@ -61,7 +61,7 @@ protected:
   shouldIgnoreWarning( const std::string & str ) const
   {
     /* Ignore warnings about overrides for missing indirect inputs.
-     * These can come up when an indirect input drops a dependendency
+     * These can come up when an indirect input drops a dependency
      * between different revisions and isn't particularly interesting
      * to users. */
     if ( str.find( " has an override for a non-existent input " )

--- a/pkgdb/src/realisepkgs/realise.cc
+++ b/pkgdb/src/realisepkgs/realise.cc
@@ -226,7 +226,7 @@ tryEvaluatePackageOutPath( nix::ref<nix::EvalState> &              state,
         }
 
       /**
-       * eval errors are cached without the eror trace
+       * eval errors are cached without the error trace
        * force an impure eval to get the full error message
        */
       try

--- a/pkgdb/src/realisepkgs/realisepkgs-lockfile.cc
+++ b/pkgdb/src/realisepkgs/realisepkgs-lockfile.cc
@@ -32,7 +32,7 @@ RealisepkgsLockfile::load_from_content( const nlohmann::json & jfrom )
       default:
         throw resolver::InvalidLockfileException(
           "unsupported lockfile version",
-          "only v0 and v1 are supprted" );
+          "only v0 and v1 are supported" );
     }
 }
 

--- a/pkgdb/src/util.cc
+++ b/pkgdb/src/util.cc
@@ -382,7 +382,7 @@ getAvailableSystemMemory()
 
   long long physicalRAM = getSysCtlValue<long long>( "hw.memsize" );
   /* For now use 3/4ths of physical ram.
-   * Simplifed from ((physicalRAM / 1024) / 4) * 3
+   * Simplified from ((physicalRAM / 1024) / 4) * 3
    */
   availableKb = ( physicalRAM / 4096 ) * 3;
 #else

--- a/pkgdb/tests/buildenv-lockfile.cc
+++ b/pkgdb/tests/buildenv-lockfile.cc
@@ -150,7 +150,7 @@ test_LockfileFromV1()
   auto pkg = lockfile.packages[0];
   EXPECT_EQ( pkg.installId, "mycowsay" );
 
-  // The attr path is pre-pended for compatibility reasons
+  // The attr path is prepended for compatibility reasons
   flox::AttrPath attrPath = { "legacyPackages", "x86_64-linux", "cowsay" };
   EXPECT( pkg.attrPath == attrPath );
 

--- a/pkgdb/tests/realisepkgs-lockfile.cc
+++ b/pkgdb/tests/realisepkgs-lockfile.cc
@@ -150,7 +150,7 @@ test_LockfileFromV1()
   auto pkg = lockfile.packages[0];
   EXPECT_EQ( pkg.installId, "mycowsay" );
 
-  // The attr path is pre-pended for compatibility reasons
+  // The attr path is prepended for compatibility reasons
   flox::AttrPath attrPath = { "legacyPackages", "x86_64-linux", "cowsay" };
   EXPECT( pkg.attrPath == attrPath );
 

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -89,7 +89,7 @@ let
       process-compose
       procps
     ]
-    # TODO: this hack is not going to be needed once we test against sutff on system
+    # TODO: this hack is not going to be needed once we test against stuff on system
     ++ lib.optional stdenv.isDarwin (
       runCommandCC "locale"
         {

--- a/pkgs/flox-manpages/pandoc-filters/include-files.lua
+++ b/pkgs/flox-manpages/pandoc-filters/include-files.lua
@@ -77,7 +77,7 @@ function transclude (cb)
     end
   end
 
-  --- keep track of level before recusion
+  --- keep track of level before recursion
   local buffer_last_heading_level = last_heading_level
 
   local blocks = List:new()

--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -77,7 +77,7 @@ pre-commit-hooks.lib.${system}.run {
             by checking the range `"$PRE_COMMIT_FROM_REF".."$PRE_COMMIT_TO_REF"` with commitizen.
             This requires pre-commit to be run with the --from-ref and --to-ref arguments.
             Currently, this hook is called only in the 'Nix Git hooks" CI pipeline,
-            and is reqiored because the commitizen hook does not work with commit ranges.
+            and is required because the commitizen hook does not work with commit ranges.
           '';
 
           stages = [ "manual" ];

--- a/test_data/README.md
+++ b/test_data/README.md
@@ -2,7 +2,7 @@
 
 See [`cli/mk_data/`](cli/mk_data/) for how this is used.
 
-Changes to the mocks won't be picked up by the tests until they are `git` staged and the `nix develop` shell is re-evaluated. Otherwise you'll get errors like this:
+Changes to the mocks won't be picked up by the tests until they are `git` staged and the `nix develop` shell is re-evaluated. Otherwise, you'll get errors like this:
 
 ```console
 ❌ ERROR: path to mock data file doesn't exist: /nix/store/hdlchirs5p2cq5fvsv32j65h90hibn3p-generated/search/java_suggestions.json

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -74,7 +74,7 @@ pre_cmd = '''
     tomlq --in-place --toml-output '.options.systems = [ "x86_64-linux" ]' .flox/env/manifest.toml
 '''
 cmd = "flox install glibc"
-ignore_cmd_errors = true # build will fail on macos, thats fine
+ignore_cmd_errors = true # build will fail on macos, that's fine
 
 [resolve.glibc_incompatible]
 pre_cmd = '''
@@ -85,7 +85,7 @@ cmd = '''
  tomlq --in-place --toml-output '.options.systems = [ "x86_64-linux", "aarch64-darwin" ]' .flox/env/manifest.toml
  flox install glibc || true
 '''
-ignore_cmd_errors = true # build will fail on macos, thats fine
+ignore_cmd_errors = true # build will fail on macos, that's fine
 
 [resolve.influxdb2]
 pre_cmd = "flox init"
@@ -97,7 +97,7 @@ pre_cmd = '''
     tomlq --in-place --toml-output '.options.systems = [ "x86_64-darwin" ]' .flox/env/manifest.toml
 '''
 cmd = "flox install darwin.ps"
-ignore_cmd_errors = true # build will fail on linux, thats fine
+ignore_cmd_errors = true # build will fail on linux, that's fine
 
 [resolve.darwin_ps_incompatible]
 pre_cmd = '''
@@ -107,7 +107,7 @@ cmd = '''
     tomlq --in-place --toml-output '.options.systems = [ "x86_64-darwin", "aarch64-linux" ]' .flox/env/manifest.toml
     flox install darwin.ps
 '''
-ignore_cmd_errors = true # build will fail on linux, thats fine
+ignore_cmd_errors = true # build will fail on linux, that's fine
 
 [resolve.fish_3_2_2]
 pre_cmd = "flox init"
@@ -236,7 +236,7 @@ cmd = "flox install vim"
 [resolve.vim-vim-full-conflict]
 pre_cmd = "flox init"
 cmd = "flox install vim vim-full"
-ignore_cmd_errors = true # pacakges conflict
+ignore_cmd_errors = true # packages conflict
 
 
 [search.hello]


### PR DESCRIPTION
## Proposed Changes

This is a rebase of 468a2cd from the contributor ccoVeille against `origin/main` at 30ec35c6 because we delayed merging it while having problems with CI and I didn't want to ask the contributor rebase again several times.

It fixes merge conflicts and omits `catalog-api-v1/src/client.rs` because it's generated code from another repo. I'll raise a separate PR for that.

I've reviewed all of the changes again, so I just need a stamp to merge and then I'll close 2362 with an update.

## Release Notes

Thanks to contributor ccoVeille for fixing many, many typos!