### PR TITLE
feat: install by store paths

### DIFF
--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -197,7 +197,13 @@ let
     package:
     if package.system == system then
       (
-        if (builtins.hasAttr "outputs" package) then
+        if builtins.hasAttr "store_path" package then
+          let
+            storePath = builtins.getAttr "store_path" package;
+            registeredStorePath = builtins.storePath storePath;
+          in
+          [ registeredStorePath ]
+        else if (builtins.hasAttr "outputs" package) then
           (
             # Important: report storePaths rather than strings because
             # the updated string context populates `inputSrcs` for the

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1248,7 +1248,7 @@ pub struct UpdateResult {
 /// **DEPRECATED**: pkgdb lockfiles are being phased out
 /// in favor of catalog lockfiles.
 /// Since catalog backed lockfiles are managed within the CLI,
-/// [LockedManifestCatalog] provides a typed interface directly,
+/// [Lockfile] provides a typed interface directly,
 /// hence there is no catalog equivalent of this type.
 ///
 /// This struct is meant **for reading only**.
@@ -2365,7 +2365,7 @@ pub(crate) mod tests {
     }
 
     /// If flake installables and catalog packages are mixed,
-    /// [LockedManifestCatalog::collect_package_groups]
+    /// [Lockfile::collect_package_groups]
     /// should only return [PackageGroup]s for the catalog descriptors.
     #[test]
     fn make_params_filters_installables() {
@@ -2410,7 +2410,7 @@ pub(crate) mod tests {
         assert_eq!(actual_params, expected_params);
     }
 
-    /// [LockedManifestCatalog::collect_package_groups] generates [FlakeInstallableToLock]
+    /// [Lockfile::collect_package_groups] generates [FlakeInstallableToLock]
     /// for each default system.
     #[test]
     fn make_installables_to_lock_for_default_systems() {
@@ -2434,7 +2434,7 @@ pub(crate) mod tests {
         assert_eq!(actual, expected);
     }
 
-    /// [LockedManifestCatalog::collect_package_groups] generates [FlakeInstallableToLock]
+    /// [Lockfile::collect_package_groups] generates [FlakeInstallableToLock]
     /// for each system in the manifest.
     #[test]
     fn make_installables_to_lock_for_manifest_systems() {
@@ -2461,7 +2461,7 @@ pub(crate) mod tests {
     }
 
     /// If flake installables and catalog packages are mixed,
-    /// [LockedManifestCatalog::collect_flake_installables]
+    /// [Lockfile::collect_flake_installables]
     /// should only return [FlakeInstallableToLock] for the flake installables.
     #[test]
     fn make_installables_to_lock_filter_catalog() {
@@ -3280,7 +3280,7 @@ pub(crate) mod tests {
         ]);
     }
 
-    /// [LockedManifestCatalog::lock_manifest] returns an error if an already
+    /// [Lockfile::lock_manifest] returns an error if an already
     /// locked package is no longer allowed
     #[tokio::test]
     async fn lock_manifest_catches_not_allowed_package() {
@@ -3317,7 +3317,7 @@ pub(crate) mod tests {
         ));
     }
 
-    /// [LockedManifestCatalog::lock_manifest] returns an error if the server
+    /// [Lockfile::lock_manifest] returns an error if the server
     /// returns a package that is not allowed.
     #[tokio::test]
     async fn lock_manifest_catches_not_allowed_package_from_server() {
@@ -3357,7 +3357,7 @@ pub(crate) mod tests {
         ));
     }
 
-    /// [LockedManifestCatalog::check_packages_are_allowed] returns an error
+    /// [Lockfile::check_packages_are_allowed] returns an error
     /// when it finds a disallowed license
     #[test]
     fn check_packages_are_allowed_disallowed_license() {
@@ -3374,7 +3374,7 @@ pub(crate) mod tests {
         ));
     }
 
-    /// [LockedManifestCatalog::check_packages_are_allowed] does not error when
+    /// [Lockfile::check_packages_are_allowed] does not error when
     /// a package's license is allowed
     #[test]
     fn check_packages_are_allowed_allowed_license() {
@@ -3391,7 +3391,7 @@ pub(crate) mod tests {
         );
     }
 
-    /// [LockedManifestCatalog::check_packages_are_allowed] returns an error
+    /// [Lockfile::check_packages_are_allowed] returns an error
     /// when a package is broken even if `allow.broken` is unset
     #[test]
     fn check_packages_are_allowed_broken_default() {
@@ -3408,7 +3408,7 @@ pub(crate) mod tests {
         ));
     }
 
-    /// [LockedManifestCatalog::check_packages_are_allowed] does not error for a
+    /// [Lockfile::check_packages_are_allowed] does not error for a
     /// broken package when `allow.broken = true`
     #[test]
     fn check_packages_are_allowed_broken_true() {
@@ -3425,7 +3425,7 @@ pub(crate) mod tests {
         );
     }
 
-    /// [LockedManifestCatalog::check_packages_are_allowed] returns an error
+    /// [Lockfile::check_packages_are_allowed] returns an error
     /// when a package is broken and `allow.broken = false`
     #[test]
     fn check_packages_are_allowed_broken_false() {
@@ -3442,7 +3442,7 @@ pub(crate) mod tests {
         ));
     }
 
-    /// [LockedManifestCatalog::check_packages_are_allowed] does not error for
+    /// [Lockfile::check_packages_are_allowed] does not error for
     /// an unfree package when `allow.unfree` is unset
     #[test]
     fn check_packages_are_allowed_unfree_default() {
@@ -3459,7 +3459,7 @@ pub(crate) mod tests {
         );
     }
 
-    /// [LockedManifestCatalog::check_packages_are_allowed] does not error for a
+    /// [Lockfile::check_packages_are_allowed] does not error for a
     /// an unfree package when `allow.unfree = true`
     #[test]
     fn check_packages_are_allowed_unfree_true() {
@@ -3476,7 +3476,7 @@ pub(crate) mod tests {
         );
     }
 
-    /// [LockedManifestCatalog::check_packages_are_allowed] returns an error
+    /// [Lockfile::check_packages_are_allowed] returns an error
     /// when a package is unfree and `allow.unfree = false`
     #[test]
     fn check_packages_are_allowed_unfree_false() {

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -315,7 +315,7 @@ pub struct LockedPackageStorePath {
     /// Store path to add to the environment
     pub store_path: String,
     pub system: System,
-    pub priority: Option<u64>,
+    pub priority: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1202,7 +1202,7 @@ impl Lockfile {
                     install_id: install_id.clone(),
                     store_path: descriptor.store_path.clone(),
                     system: system.clone(),
-                    priority: descriptor.priority,
+                    priority: descriptor.priority.unwrap_or(DEFAULT_PRIORITY),
                 })
             })
             .collect()
@@ -1530,7 +1530,7 @@ pub mod test_helpers {
                 licenses: None,
                 broken: None,
                 unfree: None,
-                priority: None,
+                priority: DEFAULT_PRIORITY,
             },
         };
         (install_id, descriptor, locked)

--- a/cli/flox/doc/flox-install.md
+++ b/cli/flox/doc/flox-install.md
@@ -77,7 +77,8 @@ reference.
 :   The pkg-path of the package to install as shown by 'flox search'
     Append `@<version>` to specify a version requirement.
 
-    Alternatively, an arbitrary Nix flake installable may be specified.
+    Alternatively, an arbitrary Nix flake installable,
+    or store path may be specified.
     See [`manfifest-toml(1)`](./manifest.toml.md) for more details.
 
 

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -230,6 +230,42 @@ and `flake` is described below:
     If an attrpath is specified, it is checked whether
     `packages.$system.$attrpath` or `legacyPackages.$system.$attrpath` exist.
 
+#### Store paths
+
+
+Store path descriptors allow installing software from an arbitrary Nix store path.
+
+The full list of store path descriptor options is:
+```
+Descriptor ::= {
+  store-path         = STRING
+, systems            = null | [<STRING>, ...]
+, priority           = null | <INT>
+}
+```
+
+Only `store-path` is required.
+`priority` behaves the same as described above for catalog
+descriptors and flake installables, and `store-path` is described below:
+
+
+`store-path`
+:   Specifies a nix store path, i.e. a nix built package in `/nix/store`. This
+    can be the result of a native Nix operations such as `nix build`, `nix
+    copy`, etc.
+    The store path has to be available on the current system in order to build
+    the environment. The environment will fail to build on other systems without
+    first distributing the store path via Nix tooling.
+    As such, this feature is most suitable for local experiments and ad-hoc
+    interoperability with Nix.
+
+`system`
+:   Behaves equally to the system attribute of catalog descriptors
+    and flakes installables.
+    Unlike the former, users are encouraged to specify it,
+    because store paths are generally system dependent.
+
+
 ## `[vars]`
 
 The `[vars]` section allows you to define environment variables for your

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -110,13 +110,13 @@ impl Install {
         let mut packages_to_install = self
             .packages
             .iter()
-            .map(|p| PackageToInstall::from_str(p))
+            .map(|p| PackageToInstall::parse(&flox.system, p))
             .collect::<Result<Vec<_>, _>>()?;
         let pkgs_with_ids = self
             .id
             .iter()
             .map(|p| {
-                let mut pkg = PackageToInstall::from_str(&p.pkg);
+                let mut pkg = PackageToInstall::parse(&flox.system, &p.pkg);
                 if let Ok(ref mut pkg) = pkg {
                     pkg.set_id(&p.id);
                 }
@@ -255,6 +255,7 @@ impl Install {
             .map(|p| match p {
                 PackageToInstall::Catalog(pkg) => pkg.pkg_path.clone(),
                 PackageToInstall::Flake(pkg) => pkg.url.to_string(),
+                PackageToInstall::StorePath(pkg) => pkg.store_path.display().to_string(),
             })
             .join(",")
     }
@@ -569,8 +570,6 @@ fn add_activation_to_rc_file(
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use flox_rust_sdk::models::lockfile::test_helpers::fake_catalog_package_lock;
     use flox_rust_sdk::models::lockfile::LockedPackageCatalog;
     use flox_rust_sdk::models::manifest::{CatalogPackage, PackageToInstall};
@@ -689,9 +688,9 @@ mod tests {
     #[test]
     fn package_list_for_prompt_is_formatted_correctly() {
         let packages = vec![
-            PackageToInstall::from_str("hello").unwrap(),
-            PackageToInstall::from_str("ripgrep").unwrap(),
-            PackageToInstall::from_str("bpftrace").unwrap(),
+            PackageToInstall::parse(&"dummy-system".to_string(), "hello").unwrap(),
+            PackageToInstall::parse(&"dummy-system".to_string(), "ripgrep").unwrap(),
+            PackageToInstall::parse(&"dummy-system".to_string(), "bpftrace").unwrap(),
         ];
         assert_eq!(
             format!("'hello'"),

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -479,3 +479,41 @@ EOF
   installed_flake=$(tomlq -r -c -t ".install.hello" "$MANIFEST_PATH")
   assert_equal "$installed_flake" "flake = \"$input_flake\""
 }
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=install:install-store-path
+@test "'flox install' install-store-path" {
+  "$FLOX_BIN" init
+  hello_store_path="$(nix build "github:nixos/nixpkgs/$PKGDB_NIXPKGS_REV_NEW#hello^out" --no-link --print-out-paths)"
+
+  PROJECT_DIR="$(realpath "$PROJECT_DIR")"
+  run "$FLOX_BIN" install "$hello_store_path"
+  assert_success
+
+  run "$FLOX_BIN" activate -- bash -c 'command -v hello'
+  assert_success
+  assert_output "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}.dev/bin/hello"
+
+  run "$FLOX_BIN" activate -- bash -c 'realpath "$(command -v hello)"'
+  assert_success
+  assert_output "$hello_store_path/bin/hello"
+}
+
+# bats test_tags=install:install-store-path
+@test "'flox install' install-store-path from link" {
+ "$FLOX_BIN" init
+  vim_store_path="$(nix build "github:nixos/nixpkgs/$PKGDB_NIXPKGS_REV_NEW#vim^out" --out-link ./result-vim --print-out-paths)"
+
+  PROJECT_DIR="$(realpath "$PROJECT_DIR")"
+  run "$FLOX_BIN" install "./result-vim"
+  assert_success
+
+  run "$FLOX_BIN" activate -- bash -c 'command -v vim'
+  assert_success
+  assert_output "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}.dev/bin/vim"
+
+  run "$FLOX_BIN" activate -- bash -c 'realpath "$(command -v vim)"'
+  assert_success
+  assert_output "$vim_store_path/bin/vim"
+}

--- a/pkgdb/include/flox/realisepkgs/realisepkgs-lockfile.hh
+++ b/pkgdb/include/flox/realisepkgs/realisepkgs-lockfile.hh
@@ -28,6 +28,13 @@ struct RealisepkgsLockedPackage
 {
   std::string system;
   std::string installId;
+  // TODO: `storePath` is technically mutually exclusive
+  // with `input` and `attrPath`
+  // but we hope this wont be around for much longer to warrant the effort
+  // of representing this as a variant.
+  // <https://github.com/flox/flox/issues/2423>
+  std::optional<std::string> storePath;
+
   // TODO: this could probably just be attrs
   resolver::LockedInputRaw           input;
   AttrPath                           attrPath;

--- a/pkgdb/src/realisepkgs/realise.cc
+++ b/pkgdb/src/realisepkgs/realise.cc
@@ -363,6 +363,17 @@ std::vector<std::pair<realisepkgs::RealisedPackage, nix::StorePath>>
 getRealisedOutputs( nix::ref<nix::EvalState> &       state,
                     const RealisepkgsLockedPackage & lockedPackage )
 {
+
+  if ( lockedPackage.storePath.has_value() )
+    {
+      auto storePath = state->store->parseStorePath( *lockedPackage.storePath );
+      state->store->ensurePath( storePath );
+      auto realisedPackage = realisepkgs::RealisedPackage(
+        state->store->printStorePath( storePath ),
+        true );
+      return { { realisedPackage, storePath } };
+    }
+
   auto timeEvalStart = std::chrono::high_resolution_clock::now();
   /**
    * Collect the store paths for each output of the package.

--- a/pkgdb/src/realisepkgs/realisepkgs-lockfile.cc
+++ b/pkgdb/src/realisepkgs/realisepkgs-lockfile.cc
@@ -55,9 +55,11 @@ RealisepkgsLockfile::from_v0_content( const nlohmann::json & jfrom )
                 lockedPackage->input.attrs );
               input.url = nix::FlakeRef::fromAttrs( input.attrs ).to_string();
 
+              auto store_path = std::nullopt;
               this->packages.emplace_back(
                 RealisepkgsLockedPackage { system,
                                            installId,
+                                           store_path,
                                            input,
                                            lockedPackage->attrPath,
                                            lockedPackage->priority,
@@ -135,10 +137,16 @@ realisepkgsPackageFromV1Descriptor( const nlohmann::json &     jfrom,
   pkg.installId = installId;
   pkg.system    = system;
 
+
+  if ( jfrom.contains( "store_path" ) )
+    {
+      pkg.storePath = jfrom["store_path"];
+      pkg.priority  = jfrom["priority"];
+    }
   // Catalog packages don't come from a flake context so only have attr-path.
   // Flake packages will always have locked-flake-attr-path.
   // For now, use this to differentiate between the two.
-  if ( jfrom.contains( "locked-flake-attr-path" ) )
+  else if ( jfrom.contains( "locked-flake-attr-path" ) )
     {
       LockedInstallable lockedInstallable = LockedInstallable();
       jfrom.get_to( lockedInstallable );


### PR DESCRIPTION
## Proposed Changes

### [feat: add store path descriptor to manifest](https://github.com/flox/flox/commit/92270a502b43c28fdd196d81dc28f8e980c43cd6) 

* Add `ManifestPackageDescriptorStorePath` to the supported `ManifestPackageDescriptor` enum.

### [feat: lock store path descriptors](https://github.com/flox/flox/commit/efc785de5c1b76eec84c9490efeecfda1eabcc34) 

* add `LockedPackageStorePath` type and declare it as a `LockedPackage` variant
* locking: collect StorePath descriptors, and map to `LockedPackageStorePath`
  Since store paths are locked by definition,
  collection can directly map the descriptor to a locked package.

### [refactor: make priority non-optional](https://github.com/flox/flox/commit/b5bcb7d0d45504bbd091aee87ec0abff374fdbef) 

Establish a concrete priority when locking packages, such that `buildenv`
can expect priority to be set.

### [feat(realise): realise manifest installed store paths](https://github.com/flox/flox/commit/549674b28967facd927170a3e9c55e353e84b9fc) 

* parse and validate locked store paths

### [feat(buildenv): link installed store paths](https://github.com/flox/flox/commit/797590f68dc78e43aeab687bc7a09b0ef89c5779) 

Test that manifests with a nix build store path build into an environment

### [feat(list): list installed store paths](https://github.com/flox/flox/commit/4abc044d87b1501876222334352a06756f5ddc75)

### [feat(install): parse store path arguments](https://github.com/flox/flox/pull/2413/commits/177ecacc7320c96d7cada58d954540c7781f1e72) 

* Add a `StorePath` variant to `PackageToInstall`
* implement `StorePath::parse`
  Parse a path doing minimal validation that the path is in `/nix/store` or a symlinked path in `/nix/store`.
  Remove extraneous path components.
  Extract the Id from the store path, by reimplementing the `DrvName` constructor in `nix`:

  > The `name' part of a derivation name is everything up to
  > but not including the first dash *not* followed by a letter.
  > The `version' part is the rest (excluding the separating dash).
  > E.g., `apache-httpd-2.0.48' is parsed to (`apache-httpd', '2.0.48').
  >
  > <https://github.com/NixOS/nix/blob/fa17927d9d75b6feec38a3fbc8b6e34e17c71b52/src/libstore/names.cc#L22-L38>

  Add a provided `system` to restrict the `[install]` descriptor to the current system
* Replace `impl FromStr for PackageToInstall` with `PackageToInstall::parse`
  which takes an extra `system` argument.

## Changelog

Allows to install store paths in the manifest via 

```
[install]
foo.store-path = <store path>
foo.systems = [<system>]       // optional
```

or via `flox install <store path>`.




> [!NOTE]
> TDOD: docs







