### PR TITLE
Review suggestions for 2410

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -62,6 +62,8 @@ pub struct Flox {
 
     /// Feature flags
     pub features: Features,
+
+    pub verbosity: i32,
 }
 
 impl Flox {}
@@ -306,6 +308,7 @@ pub mod test_helpers {
             catalog_client: MockClient::default().into(),
             installable_locker: Default::default(),
             features: Default::default(),
+            verbosity: 0,
         };
 
         (flox, tempdir_handle)

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -94,7 +94,7 @@ impl Build {
         let packages_to_clean = available_packages(&env.lockfile(&flox)?, packages)?;
 
         let builder = FloxBuildMk;
-        builder.clean(&base_dir, &flox_env.development, &packages_to_clean)?;
+        builder.clean(&flox, &base_dir, &flox_env.development, &packages_to_clean)?;
 
         message::created("Clean completed successfully");
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -338,6 +338,7 @@ impl FloxArgs {
             catalog_client,
             installable_locker: Default::default(),
             features: config.features.clone().unwrap_or_default(),
+            verbosity: self.verbosity.to_i32(),
         };
 
         // in debug mode keep the tempdir to reproduce nix commands

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -127,10 +127,12 @@ pub enum Verbosity {
 }
 
 impl Verbosity {
-    pub fn to_pkgdb_verbosity_level(self) -> usize {
+    pub fn to_i32(self) -> i32 {
         match self {
-            Verbosity::Quiet => 0,
-            Verbosity::Verbose(n) => n,
+            Verbosity::Quiet => -1,
+            Verbosity::Verbose(n) => n
+                .try_into()
+                .expect("If you passed -v enough times to overflow an i32, I'm impressed"),
         }
     }
 }

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -95,15 +95,9 @@ fn main() -> ExitCode {
 
     // Pass down the verbosity level to all pkgdb calls
     unsafe {
-        std::env::set_var(
-            "_FLOX_PKGDB_VERBOSITY",
-            format!("{}", verbosity.to_pkgdb_verbosity_level()),
-        );
+        std::env::set_var("_FLOX_PKGDB_VERBOSITY", format!("{}", verbosity.to_i32()));
     }
-    debug!(
-        "set _FLOX_PKGDB_VERBOSITY={}",
-        verbosity.to_pkgdb_verbosity_level()
-    );
+    debug!("set _FLOX_PKGDB_VERBOSITY={}", verbosity.to_i32());
 
     // Run the argument parser
     //

--- a/pkgdb/src/main.cc
+++ b/pkgdb/src/main.cc
@@ -76,7 +76,10 @@ setVerbosityFromEnv()
   auto * valueChars = std::getenv( "_FLOX_PKGDB_VERBOSITY" );
   if ( valueChars == nullptr ) { return; }
   std::string value( valueChars );
-  if ( value == std::string( "0" ) ) { nix::verbosity = nix::lvlError; }
+  if ( value == std::string( "-1" ) || value == std::string( "0" ) )
+    {
+      nix::verbosity = nix::lvlError;
+    }
   else if ( value == std::string( "1" ) ) { nix::verbosity = nix::lvlInfo; }
   else if ( value == std::string( "2" ) ) { nix::verbosity = nix::lvlDebug; }
   else if ( value == std::string( "3" ) ) { nix::verbosity = nix::lvlChatty; }


### PR DESCRIPTION
[fix: don't conflate --quiet with no verbosity flag](https://github.com/flox/flox/commit/11507c1124745166b36872dd7c493a15f4c58782)

Currently Verbosity::to_pkgdb_verbosity_level() returns 0 for both Quiet
and Verbosity(0), which correspond to `flox --quiet` and `flox` which
should actually be treated differently.

Return -1 instead for Quiet and update pkgdb accordingly.

Also to_pkgdb_verbosity_level -> to_i32 since this will be used in the
build module in Rust.

[style: review suggestions](https://github.com/flox/flox/commit/1ce2df26b142f1ea44b1599916b20284d87af686)

Thread verbosity through to build module rather than using the PKGDB env
var