### PR TITLE
chore: Update client id for floxhub tests

### DIFF
--- a/cli/tests/floxhub-cross-systems.bats
+++ b/cli/tests/floxhub-cross-systems.bats
@@ -28,19 +28,19 @@ setup_file() {
     skip "AUTH0_FLOX_DEV_CLIENT_SECRET is not set"
   fi
 
-  # Get a token for the `floxEM` user on the development FloxHub instance.
+  # Get a token for the `flox` user on the development FloxHub instance.
   export FLOX_FLOXHUB_TOKEN="$(
     curl --request POST \
       --url https://flox-dev.us.auth0.com/oauth/token \
       --header 'content-type: application/x-www-form-urlencoded' \
-      --data "client_id=A77LKKZbtUo7CbeKIeJs4SoqY1v4UZFh" \
+      --data "client_id=eDC34px8XFypyON4NlDbY6aqxfRGgTo8" \
       --data "audience=https://hub.flox.dev/api" \
       --data "grant_type=client_credentials" \
       --data "client_secret=$AUTH0_FLOX_DEV_CLIENT_SECRET" \
       | jq .access_token -r
   )"
 
-  export OWNER="floxEM"
+  export OWNER="flox"
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.json"
 }
 

--- a/cli/tests/floxhub-cross-systems.bats
+++ b/cli/tests/floxhub-cross-systems.bats
@@ -101,16 +101,15 @@ teardown() {
   local pull_system
   case "$NIX_SYSTEM" in
     x86_64-linux)
-      pull_system="x86_64-darwin"
-      ;;
-    x86_64-darwin)
-      pull_system="x86_64-linux"
+      pull_system="aarch64-darwin"
       ;;
     aarch64-darwin)
       pull_system="x86_64-linux"
       ;;
     *)
-      # we only run the above two systems consistently in CI
+      # We only set AUTH0_FLOX_DEV_CLIENT_SECRET in CI on aarch64-darwin and
+      # x86_64-linux, so we only test on those systems and the skip should be
+      # unreachable
       skip "unsupported system: $NIX_SYSTEM"
       ;;
   esac


### PR DESCRIPTION
This was using the FloxEM application and authenticating as the
superuser "floxEM", but now uses a dedicated testing app that
authenticates as "flox", a user with no special permissions.


## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->