### PR TITLE
Fix remote environment flakey tests

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::LazyLock;
@@ -99,6 +100,9 @@ impl BuildEnv for BuildEnvNix {
         lockfile_path: &Path,
         service_config_path: Option<PathBuf>,
     ) -> Result<BuildEnvOutputs, BuildEnvError> {
+        if env::var("_FLOX_TESTING_NO_BUILD").is_ok() {
+            panic!("Can't build when _FLOX_TESTING_NO_BUILD is set");
+        }
         // todo: use `stat` or `nix path-info` to filter out pre-existing store paths
 
         // Realise the packages in the lockfile

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -343,7 +343,8 @@ EOF
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
   mkfifo "$TEARDOWN_FIFO"
 
-  "$FLOX_BIN" activate --trust -r "$OWNER/test" -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
+  ensure_remote_environment_built "$OWNER/test"
+  _FLOX_TESTING_NO_BUILD=true "$FLOX_BIN" activate --trust -r "$OWNER/test" -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
   timeout 8 cat started
   run cat output
   assert_success

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1079,8 +1079,9 @@ EOF
   assert_success
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
 
+  ensure_remote_environment_built "$OWNER/$PROJECT_NAME"
   mkfifo started "$TEARDOWN_FIFO"
-  "$FLOX_BIN" activate --start-services -r "${OWNER}/${PROJECT_NAME}" -- bash <(cat <<'EOF'
+  _FLOX_TESTING_NO_BUILD=true "$FLOX_BIN" activate --start-services -r "${OWNER}/${PROJECT_NAME}" -- bash <(cat <<'EOF'
     echo > started
     echo > finished
 EOF
@@ -1098,8 +1099,9 @@ EOF
   "$FLOX_BIN" push --owner "$OWNER"
   assert_success
 
+  ensure_remote_environment_built "$OWNER/$PROJECT_NAME"
   mkfifo started finished
-  "$FLOX_BIN" activate --start-services -r "${OWNER}/${PROJECT_NAME}" -- bash <(cat <<'EOF'
+  _FLOX_TESTING_NO_BUILD=true "$FLOX_BIN" activate --start-services -r "${OWNER}/${PROJECT_NAME}" -- bash <(cat <<'EOF'
     echo > started
     timeout 8 cat finished
 EOF

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -267,6 +267,12 @@ cat_teardown_fifo() {
 
 }
 
+ensure_remote_environment_built() {
+  envRef="${1?}"
+  "$FLOX_BIN" list -c -r "$envRef" | sed -e '1i\' > edited-manifest.toml
+  "$FLOX_BIN" edit -r "$envRef" -f edited-manifest.toml
+}
+
 # ---------------------------------------------------------------------------- #
 #
 #


### PR DESCRIPTION
[fix: don't always rebuild remote environments](https://github.com/flox/flox/commit/810421f09940686be64690927e4614a8a96f3504)

Currently every `flox activate -r` triggers a rebuild of the
environment, which is slow.

This is happening because RemoteEnvironment::new_in runs a force pull of
the underlying ManagedEnvironment.

There's currently a logic error in pull where force pulls don't check if
an environment is up to date, so a force pull returns
PullResult::Updated even when it should return PullResult::UpToDate.

Coincidentally, this leads to calling
reset_local_env_to_current_generation(), which changes the mtime of the
manifest, which causes ManagedEnvironment::rendered_env_links to call
build().

To fix this, check if the environment is up to date for force pulls in
the same way as normal pulls.


[test: ensure Nix daemon doesn't cause timeouts](https://github.com/flox/flox/commit/6d953d8be28297db8fd5a517949ab2316b879cbe)

We've seen tests that activate a remote environment followed by a
timeout failing.

remote: only have a single instance of services
https://github.com/flox/flox/actions/runs/11631840091/job/32394762606#step:5:562

remote: can interact with services from outside the activation
https://github.com/flox/flox/actions/runs/11631840091/job/32394762606#step:5:599

We've bumped the timeout to 8 seconds but have still seen failures, such
as:

remote environments can attach
https://github.com/flox/flox/actions/runs/11756006460/job/32751843685#step:5:359

When the runner is under load, sometimes the Nix daemon will hang for
multiple seconds for even simple operations like `nix-store -r`.

To ensure the Nix daemon hanging isn't causing us to hit the timeouts,
build remote environments before the activation that is hitting the
timeout.

Add an env var `_FLOX_TESTING_NO_BUILD` that will cause a panic if a
build is run to guarantee we aren't running one and prevent us from
regressing that behavior.

To reproduce the timeout, I did the following on our x86_64-linux
runner:

I dropped the timeout 8 to timeout 2.

I created a script add-root.sh:
```
while true; do nix-store -r /nix/store/2nhrwv91g6ycpyxvhmvc0xs8p92wp4bk-nix-2.24.9 --add-root /tmp/test-link; done
```

I then ran that x64 in parallel to swamp the Nix daemon:
```
parallel -n0 -j 64 sh add-root.sh ::: {1..64}
```

When running the test `remote: can interact with services from outside
the activation` in a loop, I then saw failures on run 4, run 1, and run
4.

After the fix, the test has passed 50 times in a row under the same
conditions.

## Release Notes

Makes repeated commands with remote environments slightly faster