### PR TITLE
feat: Upload published packages to specified cache

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -5,6 +5,7 @@ use catalog_api_v1::types::{Output, Outputs, SystemEnum};
 use chrono::{DateTime, Utc};
 use log::debug;
 use thiserror::Error;
+use url::Url;
 
 use super::build::{build_symlink_path, ManifestBuilder};
 use super::catalog::{Client, ClientTrait, UserBuildInfo, UserDerivationInfo};
@@ -91,6 +92,7 @@ pub struct CheckedBuildMetadata {
 pub struct PublishProvider<Builder> {
     pub env_metadata: CheckedEnvironmentMetadata,
     pub build_metadata: CheckedBuildMetadata,
+    pub cache: Option<Url>,
 
     pub _builder: Option<Builder>,
 }
@@ -155,7 +157,7 @@ where
             rev: self.env_metadata.build_repo_ref.rev.clone(),
             rev_count: self.env_metadata.build_repo_ref.rev_count as i64,
             rev_date: self.env_metadata.build_repo_ref.rev_date,
-            cache_uri: None,
+            cache_uri: self.cache.clone().map(|u| u.to_string()),
         };
         debug!("Publishing build in catalog...");
         client
@@ -416,6 +418,7 @@ pub mod tests {
         let publish_provider = PublishProvider::<&FloxBuildMk> {
             build_metadata,
             env_metadata,
+            cache: None,
             _builder: None,
         };
 


### PR DESCRIPTION
`flox publish` now accepts an optional `--cache` flag to specify a cache location for published artifacts, as well as a `--key-file` flag to specify a signing key. If `--cache` is specified, artifacts are signed with the given key and  `nix copy`'d to the cache. The cache location is also sent to catalog-server along with the rest of the build metadata, so that later installs of the package will know where to retrieve it.

This introduces a new `BinaryCache` trait to encapsulate the cache behavior and allow for easy mocking during testing.