### PR TITLE
feat: allow overriding Nix store

### DIFF
--- a/pkgdb/include/flox/core/nix-state.hh
+++ b/pkgdb/include/flox/core/nix-state.hh
@@ -105,7 +105,16 @@ public:
   nix::ref<nix::Store>
   getStore()
   {
-    if ( this->store == nullptr ) { this->store = nix::openStore(); }
+    if ( this->store == nullptr )
+      {
+        std::string storeURI = "auto";
+        if ( const char * rawStoreURI = std::getenv( "_FLOX_NIX_STORE_URL" ) )
+          {
+            auto providedStoreURI = std::string( rawStoreURI );
+            if ( ! providedStoreURI.empty() ) { storeURI = providedStoreURI; }
+          }
+        this->store = nix::openStore( storeURI );
+      }
     return static_cast<nix::ref<nix::Store>>( this->store );
   }
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This allows a user to override the Nix store via the _FLOX_NIX_STORE_URL variable. This is done in both `pkgdb realise` and on the Rust side. The Rust side happens in `BuildEnvNix::base_command` by reading the environment variable, which we typically don't allow in the SDK. I'm doing it now to unblock another developer and this code will be superseded by another ticket in the very near future.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
