### PR TITLE
test(activate): Capture watchdog logs

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3319,7 +3319,10 @@ EOF
   ACTIVATIONS_JSON=$(cat activations_json)
 
   # Wait for the "start" to exit.
+  # Add some output to the buffer to debug later assertion failures.
+  echo "$(date -u +'%FT%T.%6NZ'): Initial activation finished."
   wait_for_watchdogs "$PROJECT_DIR"
+  cat "${PROJECT_DIR}"/.flox/log/watchdog.*
 
   # Old version should still be recorded.
   jq --exit-status '.version == 0' "$ACTIVATIONS_JSON"


### PR DESCRIPTION
## Proposed Changes

To help debug this failing test where the existing activation hadn't exited:

- https://github.com/flox/flox/actions/runs/11956889846/job/33332714048#step:8:256

I haven't been able to reproduce this locally or with 100 runs in CI:

- https://github.com/flox/flox/actions/runs/12029821849/job/33535905317

My hunch is that the watchdog hadn't started by the time that `wait_for_watchdogs` was called, which allows it to proceed immediately, but it could also be that there was an error during cleanup. This should give us information about either case.

Unfortunately we don't currently distinguish between tests that use `wait_for_watchdogs` to guard against the suite failing vs tests that depend on the watchdog being started and/or finished.

## Release Notes

N/A