### PR TITLE
test: wait_for_watchdogs capture logs

### DIFF
--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -212,8 +212,11 @@ wait_for_watchdogs() {
         break
       else
         if [[ $tries -gt 1000 ]]; then
-          echo "ERROR: flox-watchdog processes did not finish after 10 seconds, logs:" >&3
+          echo "ERROR: flox-watchdog processes did not finish after 10 seconds" >&3
+          echo "Watchdog logs:" >&3
           cat "${project_dir}"/.flox/log/watchdog.* >&3
+          echo "Bats processes:" >&3
+          pstree -ws "$BATS_RUN_TMPDIR" >&3
           # This will fail the test giving us a better idea of which watchdog
           # didn't get cleaned up
           exit 1

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -35,6 +35,7 @@
   parallel,
   podman,
   procps,
+  pstree,
   unixtools,
   which,
   writeShellScriptBin,
@@ -83,6 +84,7 @@ let
       nix
       openssh
       parallel
+      pstree
       unixtools.util-linux
       which
       yq


### PR DESCRIPTION
## Proposed Changes

**test: wait_for_watchdogs capture logs**

Output logs from a project's watchdog if it fails to exit with the 10s threshold. This may help us debug failures like:

- https://github.com/flox/flox/actions/runs/11631840091/job/32393789961#step:5:593
- https://github.com/flox/flox/actions/runs/11631840091/job/32393789961#step:5:595
- https://github.com/flox/flox/actions/runs/11937837306/job/33275476937?pr=2406#step:5:539

**test: wait_for_watchdogs capture processes**

Capture the process tree for the current Bats run (by tmp dir) when
`wait_for_watchdogs` fails to help debug which process it's still
waiting for. This works because the processes are still parented to
`bats-exec-test` when it fails.

Demonstrated with:

    @test "wip" {
      project_setup
      run "$FLOX_BIN" activate -- sleep infinity &
      run "$FLOX_BIN" activate -- echo foo
      assert_success
      assert_line "foo"
    }

Which produces this output:

    …
    Bats processes:
    -+= 00001 root (launchd)
     |-+= 19164 dcarley /Applications/flox-kitty.app/Contents/MacOS/applet
     | \-+- 19166 dcarley /Users/dcarley/projects/dcarley/flox-envs/shell/.flox/run/aarch64-darwin.shell.run/bin/kitty
     |   \-+= 17878 root (login)
     |     \-+= 17885 dcarley -zsh
     |       \-+= 23623 dcarley just integ-tests activate.bats -- -f wip
     |         \-+- 23835 dcarley /nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32/bin/bash /nix/store/1ixd0p0d1vcmwkwwcp9z8pg4k3nabjn0-flox-cli-tests/bin/flox-cli-tests --pkgdb /Users/dcarley/projects/flox/flox/pkgdb/bin/pkgdb --flox /Users/dcarley/projects/flox/flox/cli/target/debug/flox --watchdog /Users/dcarley/projects/flox/flox/cli/target/debug/flox-watchdog --input-data /Users/dcarley/projects/flox/flox/test_data/input_data --generated-data /Users/dcarley/projects/flox/flox/test_data/generated activate.bats -- -f wip
     |           \-+- 23858 dcarley /nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32/bin/bash /nix/store/zk4mlqhnhz7jj8yjm8fd2fzlgkrsslfz-bats-1.11.0/libexec/bats-core/bats --print-output-on-failure --verbose-run --timing --jobs 4 --no-parallelize-across-files -f wip activate.bats
     |             \-+- 23867 dcarley /nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32/bin/bash /nix/store/zk4mlqhnhz7jj8yjm8fd2fzlgkrsslfz-bats-1.11.0/libexec/bats-core/bats-exec-suite --dummy-flag --print-output-on-failure --verbose-run -T -j 4 --no-parallelize-across-files -f wip -x --setup-suite-file /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/flox-cli-tests-ACFXKC/setup_suite.bash /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/flox-cli-tests-ACFXKC/activate.bats
     |               \-+- 24101 dcarley /nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32/bin/bash /nix/store/zk4mlqhnhz7jj8yjm8fd2fzlgkrsslfz-bats-1.11.0/libexec/bats-core/bats-exec-file --dummy-flag --print-output-on-failure --verbose-run -T -j 4 -x /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/flox-cli-tests-ACFXKC/activate.bats /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/bats-run-9JtaAe/test_list_file.txt
     |                 \-+- 24226 dcarley /nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32/bin/bash /nix/store/zk4mlqhnhz7jj8yjm8fd2fzlgkrsslfz-bats-1.11.0/libexec/bats-core/bats-exec-file --dummy-flag --print-output-on-failure --verbose-run -T -j 4 -x /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/flox-cli-tests-ACFXKC/activate.bats /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/bats-run-9JtaAe/test_list_file.txt
     |                   \-+- 24230 dcarley /nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32/bin/bash /nix/store/zk4mlqhnhz7jj8yjm8fd2fzlgkrsslfz-bats-1.11.0/libexec/bats-core/bats-exec-test --dummy-flag --print-output-on-failure --verbose-run -T -x /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/flox-cli-tests-ACFXKC/activate.bats test_wip 1 1 1
     |                     |-+- 24401 dcarley /nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32/bin/bash /nix/store/zk4mlqhnhz7jj8yjm8fd2fzlgkrsslfz-bats-1.11.0/libexec/bats-core/bats-exec-test --dummy-flag --print-output-on-failure --verbose-run -T -x /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/flox-cli-tests-ACFXKC/activate.bats test_wip 1 1 1
     |                     | \-+- 24404 dcarley /nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32/bin/bash /nix/store/zk4mlqhnhz7jj8yjm8fd2fzlgkrsslfz-bats-1.11.0/libexec/bats-core/bats-exec-test --dummy-flag --print-output-on-failure --verbose-run -T -x /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/flox-cli-tests-ACFXKC/activate.bats test_wip 1 1 1
     |                     |   \-+- 24405 dcarley /nix/store/jin4ifpw4bvi554g02phy668gvaylqn1-bash-interactive-5.2p32/bin/bash --noprofile --norc -s
     |                     |     \--- 24534 dcarley sleep infinity
     |                     \-+- 27533 dcarley pstree -ws /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/bats-run-9JtaAe
     |                       \--- 27534 dcarley ps -axwwo user,pid,ppid,pgid,command
     \--= 24519 dcarley /Users/dcarley/projects/flox/flox/cli/target/debug/flox-watchdog --disable-metrics --log-dir /private/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/bats-run-9JtaAe/test/1/project-1/.flox/log --socket /tmp/flox.tests.pp7vrO/tmp.4Q2L0K6RXD/run/flox.fd4c66da.sock --flox-env /private/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.tlWNqS/bats-run-9JtaAe/test/1/project-1/.flox/run/aarch64-darwin.project-1.dev --activation-id d41b2a7f --runtime-dir /tmp/flox.tests.pp7vrO/tmp.4Q2L0K6RXD/run
       tags: activate
       (from function `wait_for_watchdogs' in file test_support.bash, line 222,
        from function `teardown' in test file activate.bats, line 119)
         `wait_for_watchdogs "$PROJECT_DIR"' failed
       ✨ Created environment 'project-1' (aarch64-darwin)

       Next:
         $ flox search <package>    <- Search for a package
         $ flox install <package>   <- Install a package into an environment
         $ flox activate            <- Enter the environment
         $ flox edit                <- Add environment variables and shell hooks

       Sourcing .bashrc
       Setting PATH from .bashrc
       foo
       Last output:
       Sourcing .bashrc
       Setting PATH from .bashrc
       foo

    1 test, 1 failure in 23 seconds



## Release Notes

N/A