### PR TITLE
feat: add `lock-manifest` command

### DIFF
--- a/cli/flox/src/commands/lock_manifest.rs
+++ b/cli/flox/src/commands/lock_manifest.rs
@@ -1,0 +1,64 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::lockfile::Lockfile;
+use tracing::instrument;
+
+use crate::subcommand_metric;
+
+/// Lock a manifest file read from the path specified or stdin if `-`.
+/// If provided, uses the lockfile from the path specified by `--lockfile`
+/// as the base lockfile.
+/// Returns the lockfile as JSON to stdout.
+#[derive(Bpaf, Clone)]
+pub struct LockManifest {
+    /// The previous lockfile to use as a base.
+    #[bpaf(long, short, argument("path"))]
+    lockfile: Option<PathBuf>,
+
+    /// The manifest file to lock. (default: stdin)
+    #[bpaf(positional("path to manifest"))]
+    manifest: PathBuf,
+}
+
+impl LockManifest {
+    #[instrument(name = "lock", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("lock");
+
+        let manifest_path = if self.manifest == PathBuf::from("-") {
+            Path::new("/dev/stdin")
+        } else {
+            &self.manifest
+        };
+
+        let input_manifest =
+            fs::read_to_string(manifest_path).context("Failed to read manifest file")?;
+
+        let input_manifest =
+            toml::from_str(&input_manifest).context("Failed to parse manifest file")?;
+
+        let input_lockfile = if let Some(lockfile_path) = self.lockfile {
+            let lockfile = fs::read_to_string(lockfile_path).context("Failed to read lockfile")?;
+            Some(serde_json::from_str(&lockfile).context("Failed to parse lockfile")?)
+        } else {
+            None
+        };
+
+        let lockfile = Lockfile::lock_manifest(
+            &input_manifest,
+            input_lockfile.as_ref(),
+            &flox.catalog_client,
+            &flox.installable_locker,
+        )
+        .await
+        .context("Failed to lock the manifest")?;
+
+        serde_json::to_writer_pretty(std::io::stdout(), &lockfile)
+            .context("failed to write lockfile to stdout")?;
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod general;
 mod init;
 mod install;
 mod list;
+mod lock_manifest;
 mod publish;
 mod pull;
 mod push;
@@ -909,6 +910,9 @@ enum InternalCommands {
     /// Publish packages
     #[bpaf(command, hide, footer("Run 'man flox-publish' for more details."))]
     Publish(#[bpaf(external(publish::publish))] publish::Publish),
+    /// Lock a manifest file
+    #[bpaf(command, hide)]
+    LockManifest(#[bpaf(external(lock_manifest::lock_manifest))] lock_manifest::LockManifest),
 }
 
 impl InternalCommands {
@@ -918,6 +922,7 @@ impl InternalCommands {
             InternalCommands::Auth(args) => args.handle(config, flox).await?,
             InternalCommands::Build(args) => args.handle(config, flox).await?,
             InternalCommands::Publish(args) => args.handle(config, flox).await?,
+            InternalCommands::LockManifest(args) => args.handle(flox).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
Adds a new hidden and strictly internal command `flox lock-manifest`,
that allows locking of a manifest, separately from an environment.
With `--lockfile` allows to specify a base lockfile. This command _only_ locks
and never builds the resulting lockfile, which makes it useful for generating test data,
in particular for the use with the environment building subsystem.