### PR TITLE
ci: update git-hooks.nix flake and migrate push hook to pre-push

### DIFF
--- a/.github/workflows/nix-managed-lints.yml
+++ b/.github/workflows/nix-managed-lints.yml
@@ -88,6 +88,7 @@ jobs:
 
           nix develop -L --no-update-lock-file --command \
             pre-commit run \
+              --verbose \
               --hook-stage manual \
               --from-ref "$( git rev-parse "target" )" \
               --to-ref   "$( git rev-parse "head" )";

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -739,8 +739,6 @@ fn services_socket_path(id: &str, flox: &Flox) -> Result<PathBuf, EnvironmentErr
 
 #[cfg(test)]
 mod test {
-    #[cfg(target_os = "linux")]
-    use std::os::unix::fs::PermissionsExt;
     use std::str::FromStr;
     use std::time::Duration;
 

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -1320,7 +1320,7 @@ pub mod tests {
         repo.checkout("branch_1", true).unwrap();
 
         let new_filename = "dummy";
-        commit_file(&repo, &new_filename);
+        commit_file(&repo, new_filename);
         let hash_1 = repo.branch_hash("branch_1").unwrap();
         let ct = repo.rev_count("HEAD").unwrap();
         let date = repo.rev_date("HEAD").unwrap();

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -417,7 +417,7 @@ pub mod tests {
             .expect("Should generate key");
         // write the key to the file
         temp_key_file
-            .write(&output.stdout)
+            .write_all(&output.stdout)
             .expect("Should write key to file");
         temp_key_file.flush().expect("Should flush key file");
 
@@ -433,7 +433,7 @@ pub mod tests {
         flox: &Flox,
         remote: Option<&String>,
     ) -> (PathEnvironment, GitCommandProvider) {
-        let env = new_path_environment_from_env_files(&flox, GENERATED_DATA.join(EXAMPLE_MANIFEST));
+        let env = new_path_environment_from_env_files(flox, GENERATED_DATA.join(EXAMPLE_MANIFEST));
 
         let git = GitCommandProvider::init(
             env.parent_path().expect("Parent path must be accessible"),

--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {

--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -54,8 +54,10 @@ pre-commit-hooks.lib.${system}.run {
       enable = true;
       settings = {
         denyWarnings = true;
-        # ensure that #[cfg(test)] is linted as well
-        extraArgs = "--tests";
+        # '--tests': ensure that #[cfg(test)] is linted as well
+        # '--workspace': lint all packages in the workspace
+        # '--no-deps': don't lint dependencies
+        extraArgs = "--tests --workspace --no-deps";
       };
     };
     commitizen = {

--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -14,7 +14,7 @@ pre-commit-hooks.lib.${system}.run {
   src = builtins.path { path = ./.; };
   default_stages = [
     "manual"
-    "push"
+    "pre-push"
   ];
   hooks = {
     nixfmt-rfc-style = {


### PR DESCRIPTION
For a while when we run the git hooks, on push and commit,
the following warning was displayed:

```
[WARNING] hook id `clang-format` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `clippy` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `nixfmt-rfc-style` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `rustfmt` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] top-level `default_stages` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```

tl;dr; the `push` stage was renamed to `pre-push` in pre-commit `4.0.0`.

See also:
- <https://github.com/pre-commit/pre-commit/releases/tag/v4.0.0>
- <https://github.com/pre-commit/pre-commit/issues/2732>
- <https://github.com/pre-commit/pre-commit/pull/3312>

