### PR TITLE
feat(edit): Show spinner for edit -f

### DIFF
--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -141,7 +141,7 @@ impl Edit {
                 environment.reset_local_env_to_current_generation(&flox)?;
 
                 Dialog {
-                    message: "Building environment",
+                    message: "Building environment...",
                     help_message: None,
                     typed: Spinner::new(|| {
                         // The current generation already has a lock,

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -248,7 +248,7 @@ impl Edit {
             let new_manifest = Edit::edited_manifest_contents(&tmp_manifest, &editor, &args)?;
 
             let result = Dialog {
-                message: "Building environment to validate edit...",
+                message: "Building environment...",
                 help_message: None,
                 typed: Spinner::new(|| environment.edit(flox, new_manifest.clone())),
             }


### PR DESCRIPTION
## Proposed Changes

From ticket:

> If you copy a manifest from one environment to the other and it
> happens to be sizeable, building that environment could take a
> non-trivial amount of time. We're missing a spinner for this
> operation, and there's otherwise no output at all during this
> operation, so a user would reasonably expect that Flox has frozen.

Implemented by refactoring the existing spinner that used by
`interactive_edit` into a separate function and calling that for the
"non-interactive" case to make it clear that they share the same actions
and use a spinner.

Since we can't test interactive spinners (and despite asciinema stripping the rotating part)..

Before:
![2394-before](https://github.com/user-attachments/assets/7791ea34-7fdd-4962-847d-8e52e87d05d1)

After:
![2394-after](https://github.com/user-attachments/assets/d62c3795-b349-4040-a115-994a4196b75c)

## Release Notes

`flox edit -f` now shows a spinner to indicate when it's building an environment.