### PR TITLE
docs(edit): Clarify docs for --sync and --reset

### DIFF
--- a/cli/flox/doc/flox-edit.md
+++ b/cli/flox/doc/flox-edit.md
@@ -47,13 +47,10 @@ which replaces the contents of the manifest with those of the provided file.
 When using environments that were pushed to or pulled from FloxHub,
 changes to the local manifest in `.flox/env/manifest.toml`
 will block the use of the environment commands
-`flox {install, uninstall, edit, upgrade}`.
-In this case, a new generation has to be created from the local manifest first
-or the changes discarded.
-Run `flox edit --reset` to discard local changes
-and reset to the current latest generation,
-or `flox edit --sync` to create a new generation.
+`flox {install, uninstall, edit, upgrade}`. To proceed, you can run either:
 
+- `flox edit --sync` to commit your local changes to a new generation
+- `flox edit --reset` to discard your local changes and reset to the latest generation
 
 # OPTIONS
 

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -59,13 +59,13 @@ pub enum EditAction {
         name: EnvironmentName,
     },
 
-    /// Create a new generation from the current local environment
+    /// Commit local environment changes to a new generation
     ///
     /// (Only available for managed environments)
     #[bpaf(long, short)]
     Sync,
 
-    /// Reset the environment to the current generation
+    /// Discard local changes and reset to the latest generation
     ///
     /// (Only available for managed environments)
     #[bpaf(long)]

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -500,7 +500,10 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
 
         ManagedEnvironmentError::CheckoutOutOfSync => indoc! {"
             Your environment has changes that are not yet synced to a generation.
-            Use 'flox edit --reset' or 'flox edit --sync' after modifying '.flox/env/manifest.toml'
+
+            To resolve this issue, run either
+            * 'flox edit --sync' to commit your local changes to a new generation
+            * 'flox edit --reset' to discard your local changes and reset to the latest generation
         "}
         .to_string(),
 


### PR DESCRIPTION
It was easier to write the proposed changes than create and refine a ticket for this small change.

## Proposed Changes

The error and the docs confuse me each time I run into them because I'm not immediately sure about which direction the sync or reset are operating and I don't have to interact with the concept of generations very often.

Attempt to clarify this by using the terms "commit" and "discard" from the perspective of local only, which is where the changes have originated from and what the user may lose. This doesn't appear to conflict with the original design in:

- https://github.com/flox/flox/issues/680

I've omitted the "after modifying manifest.toml" part because by definition the manifest has already been modified when you've reached this error and we don't have any notion of conflict resolution until we add diffs in:

- https://github.com/flox/flox/issues/1634

## Release Notes

Clarify documentation and error messages for the use of `flox edit --sync` and `flox edit --reset`.
