### PR TITLE
feat(containerize): Add support for macOS

### DIFF
--- a/cli/flox-rust-sdk/src/data/flox_version.rs
+++ b/cli/flox-rust-sdk/src/data/flox_version.rs
@@ -86,6 +86,14 @@ impl From<ParseIntError> for VersionParseError {
     }
 }
 
+impl FloxVersion {
+    /// Returns the base semantic version string (major.minor.patch) without any
+    /// suffixes (release candidate, commit ref, etc).
+    pub fn base_semver(&self) -> String {
+        format!("{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
 impl FromStr for FloxVersion {
     type Err = VersionParseError;
 
@@ -205,7 +213,7 @@ impl PartialOrd for FloxVersion {
 impl fmt::Display for FloxVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Start with the mandatory major.minor.patch part
-        let mut version_str = format!("{}.{}.{}", self.major, self.minor, self.patch);
+        let mut version_str = self.base_semver();
 
         // If there is a pre-release name (e.g., "rc"), include it
         if let Some(ref pre_name) = self.pre_name {
@@ -241,6 +249,22 @@ impl fmt::Display for FloxVersion {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn base_semver_omits_suffixes() {
+        let version = FloxVersion {
+            major: 1,
+            minor: 2,
+            patch: 3,
+            pre_name: Some(PreReleaseName::RC),
+            pre_number: Some(1),
+            num_of_commits: Some(10),
+            commit_vcs: Some('g'),
+            commit_sha: Some("b91c3f1".to_string()),
+            is_dirty: true,
+        };
+        assert_eq!(version.base_semver(), "1.2.3");
+    }
 
     #[test]
     fn test_parse_standard_version() {

--- a/cli/flox-rust-sdk/src/data/flox_version.rs
+++ b/cli/flox-rust-sdk/src/data/flox_version.rs
@@ -92,6 +92,11 @@ impl FloxVersion {
     pub fn base_semver(&self) -> String {
         format!("{}.{}.{}", self.major, self.minor, self.patch)
     }
+
+    /// Returns the commit SHA only.
+    pub fn commit_sha(&self) -> Option<String> {
+        self.commit_sha.clone()
+    }
 }
 
 impl FromStr for FloxVersion {

--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -32,6 +32,10 @@ the container is loaded into a supported runtime,
 If no supported runtime is found,
 the container is written to `./<env name>-container.tar` instead.
 
+**Note**: Exporting a container from macOS requires a supported runtime to be
+found because a proxy container is used to build the environment and image. You
+may be prompted for permissions to share files into the proxy container.
+
 Running the container will behave like running `flox activate`.
 Running the container interactively with `docker run -it <container id>`,
 will launch a bash subshell in the container
@@ -41,10 +45,6 @@ This is akin to `flox activate`.
 Running the container non-interactively with `docker run <container id>`
 allows you to run a command within the container without launching a subshell,
 similar to `flox activate --`.
-
-**Note**:
-The `containerize` command is currently **only available on Linux**.
-The produced container however can also run on macOS.
 
 # OPTIONS
 

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -6,6 +6,7 @@ use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::providers::container_builder::{ContainerBuilder, ContainerSource};
 
 use super::Runtime;
+use crate::config::FLOX_DISABLE_METRICS_VAR;
 
 const FLOX_FLAKE: &str = "github:flox/flox";
 const FLOX_PROXY_IMAGE: &str = "ghcr.io/flox/flox";
@@ -67,6 +68,17 @@ impl ContainerBuilder for ContainerizeProxy {
                     home_dir.to_string_lossy(),
                     MOUNT_HOME
                 ),
+            ]);
+        }
+
+        // Honour `FLOX_DISABLE_METRICS` if set. Aside from being set by the
+        // user, it may also be set at runtime by  [Flox::Commands::FloxArgs]
+        // from another config path like `/etc/flox.toml` which isn't mounted
+        // into the proxy container.
+        if let Ok(disable_metrics) = std::env::var(FLOX_DISABLE_METRICS_VAR) {
+            command.args([
+                "--env",
+                &format!("{}={}", FLOX_DISABLE_METRICS_VAR, disable_metrics),
             ]);
         }
 

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -1,21 +1,100 @@
 use std::convert::Infallible;
 use std::path::PathBuf;
 
+use dirs::home_dir;
+use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::providers::container_builder::{ContainerBuilder, ContainerSource};
 
-#[allow(unused)]
-struct ContainerizeProxy {
+use super::Runtime;
+
+const FLOX_FLAKE: &str = "github:flox/flox";
+const FLOX_PROXY_IMAGE: &str = "ghcr.io/flox/flox";
+
+const MOUNT_ENV: &str = "/flox_env";
+const MOUNT_HOME: &str = "/flox_home";
+
+/// An implementation of [ContainerBuilder] for macOS that uses `flox
+/// containerize` within a proxy container of a given [Runtime].
+#[derive(Debug, Clone)]
+pub(crate) struct ContainerizeProxy {
     environment_path: PathBuf,
+    container_runtime: Runtime,
+}
+
+impl ContainerizeProxy {
+    pub(crate) fn new(environment_path: PathBuf, container_runtime: Runtime) -> Self {
+        Self {
+            environment_path,
+            container_runtime,
+        }
+    }
 }
 
 impl ContainerBuilder for ContainerizeProxy {
     type Error = Infallible;
 
+    /// Create a [ContainerSource] for macOS that streams the output via:
+    /// 1. `<container> run`
+    /// 2. `nix run`
+    /// 3. `flox containerize`
     fn create_container_source(
         &self,
+        // Inferred from `self.environment_path` by flox _inside_ the container.
         _name: impl AsRef<str>,
-        _tag: impl AsRef<str>,
+        tag: impl AsRef<str>,
     ) -> Result<ContainerSource, Self::Error> {
-        todo!("🚧 MacOS container builder in construction 🚧")
+        // Inception L1: Container runtime args.
+        let mut command = self.container_runtime.to_command();
+        command.arg("run");
+        command.arg("--rm");
+        command.args([
+            "--mount",
+            &format!(
+                "type=bind,source={},target={}",
+                self.environment_path.to_string_lossy(),
+                MOUNT_ENV
+            ),
+        ]);
+
+        // Honour config from the user's home directory on their host machine if
+        // available.
+        if let Some(home_dir) = home_dir() {
+            command.args(["--env", &format!("HOME={}", MOUNT_HOME)]);
+            command.args([
+                "--mount",
+                &format!(
+                    "type=bind,source={},target={}",
+                    home_dir.to_string_lossy(),
+                    MOUNT_HOME
+                ),
+            ]);
+        }
+
+        let flox_version = &*FLOX_VERSION;
+        let flox_version_tag = format!("v{}", flox_version.base_semver());
+
+        // Use a released Flox container of the same semantic version as a base
+        // because it already has:
+        //
+        // - most of the dependency store paths
+        // - substitutors configured
+        // - correct version of nix
+        let flox_container = format!("{}:{}", FLOX_PROXY_IMAGE, flox_version_tag);
+        command.arg(flox_container);
+
+        // Inception L2: Nix args.
+        command.arg("nix");
+        command.args(["--extra-experimental-features", "nix-command flakes"]);
+        let flox_flake = format!("{}/{}", FLOX_FLAKE, flox_version_tag);
+        command.args(["run", &flox_flake, "--"]);
+
+        // Inception L3: Flox args.
+        command.arg("containerize");
+        command.args(["--dir", MOUNT_ENV]);
+        command.args(["--tag", tag.as_ref()]);
+        command.args(["--file", "-"]);
+
+        let container_source = ContainerSource::new(command);
+        Ok(container_source)
     }
 }

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -97,7 +97,13 @@ impl ContainerBuilder for ContainerizeProxy {
         // Inception L2: Nix args.
         command.arg("nix");
         command.args(["--extra-experimental-features", "nix-command flakes"]);
-        let flox_flake = format!("{}/{}", FLOX_FLAKE, flox_version_tag);
+        let flox_flake = format!(
+            "{}/{}",
+            FLOX_FLAKE,
+            // Use a more specific commit if available, e.g. pushed to GitHub.
+            // TODO: Doesn't always work: https://github.com/flox/flox/issues/2502
+            flox_version.commit_sha().unwrap_or(flox_version_tag)
+        );
         command.args(["run", &flox_flake, "--"]);
 
         // Inception L3: Flox args.

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -73,7 +73,13 @@ use xdg::BaseDirectories;
 
 use self::envs::DisplayEnvironments;
 use crate::commands::general::update_config;
-use crate::config::{Config, EnvironmentTrust, FLOX_CONFIG_FILE, FLOX_DIR_NAME};
+use crate::config::{
+    Config,
+    EnvironmentTrust,
+    FLOX_CONFIG_FILE,
+    FLOX_DIR_NAME,
+    FLOX_DISABLE_METRICS_VAR,
+};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::display_chain;
 use crate::utils::init::{
@@ -260,7 +266,7 @@ impl FloxArgs {
         } else {
             debug!("Metrics collection disabled");
             unsafe {
-                env::set_var("FLOX_DISABLE_METRICS", "true");
+                env::set_var(FLOX_DISABLE_METRICS_VAR, "true");
             }
         }
 

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -23,6 +23,8 @@ pub const FLOX_DIR_NAME: &str = "flox";
 const FLOX_CONFIG_DIR_VAR: &str = "FLOX_CONFIG_DIR";
 pub const FLOX_CONFIG_FILE: &str = "flox.toml";
 
+pub const FLOX_DISABLE_METRICS_VAR: &str = "FLOX_DISABLE_METRICS";
+
 #[derive(Clone, Debug, Deserialize, Default, Serialize)]
 pub struct Config {
     /// flox configuration options

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -200,18 +200,6 @@ function skip_if_linux() {
   assert_line --partial "Failed to call runtime"
 }
 
-# bats test_tags=containerize:piped-to-stdout
-@test "container is written to stdout when '-f -' is passed" {
-  skip "duplicate of next test"
-  skip_if_not_linux
-
-  env_setup_catalog
-
-  run bash -c '"$FLOX_BIN" containerize -f - | podman load'
-  assert_success
-  assert_line --partial "Loaded image:"
-}
-
 function assert_container_output() {
   # check:
   # (1) if the variable `foo = bar` is set in the container
@@ -243,6 +231,7 @@ function assert_container_output() {
 
   env_setup_catalog
 
+  # Also tests writing to STDOUT with `-f -`
   CONTAINER_ID="$("$FLOX_BIN" containerize -f - | podman load | sed -nr 's/^Loaded image: (.*)$/\1/p')"
 
   run --separate-stderr podman run -q -i "$CONTAINER_ID" -c 'echo $foo'

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -128,16 +128,20 @@ function skip_if_linux() {
 
 # ---------------------------------------------------------------------------- #
 
-# bats test_tags=containerize:unsupported
-@test "building a container fails on macos" {
+# TODO: Implement happy path tests for macOS in
+# https://github.com/flox/flox/issues/2466
 
+# bats test_tags=containerize:macos
+@test "runtime is required for proxy container on macos" {
   skip_if_linux
 
   "$FLOX_BIN" init
 
-  run "$FLOX_BIN" containerize
+  run bash -c 'PATH= "$FLOX_BIN" containerize' 3>&-
   assert_failure
-  assert_output --partial "🚧 MacOS container builder in construction 🚧"
+  assert_output "❌ ERROR: No container runtime found in PATH.
+
+Exporting a container on macOS requires Docker or Podman to be installed."
 }
 
 # bats test_tags=containerize:default-to-file


### PR DESCRIPTION
## Proposed Changes

By using the proxy container approach from:

- https://www.notion.so/floxdev/012-Containerize-cross-platform-14a744c8e3168090b508dafd1fc9f37d0

This has some rough edges which we'll polish later..

The proxy container has to fetch/build store paths on every run. We can
reduce this time by caching/persisting the proxy container in #2469. It
may also be desirable to separate the build of the Flox flake from the
build of the environment for better feedback, but it's not worth doing
that until we refactor for caching.

Testing has only been done manually so far because we don't have a
functioning Docker or Podman in CI. This will be covered in #2466.

Output from `nix run` interleaves the "Writing container" spinner but it
does give some useful feedback about why it might be slow and is
consistent with the existing behaviour when writing layers. I've created
#2498 to put this all behind a verbose flag.

I've tested that it also works for remote environments.

Creating a `ContainerSource` for macOS doesn't require a spinner because
it doesn't execute anything until `stream_container()`.

Example output: https://gist.github.com/dcarley/99705356f0060920972dbf11ff5df812

## Release Notes

`flox containerize` now supports running from macOS!