### PR TITLE
chore: fix development rebuild of flox-activations

### DIFF
--- a/pkgdb/.gitignore
+++ b/pkgdb/.gitignore
@@ -49,5 +49,5 @@ gmon.out
 *.tmp
 /build/
 
-# Records storePath of last known build of activation scripts package.
-.ACTIVATION_SCRIPTS_PACKAGE_DIR
+# Links storePath of last known build of activation scripts package.
+.ACTIVATION_SCRIPTS_PACKAGE

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -354,26 +354,29 @@ endif # ifeq (Linux,$(OS))
 # Save path for most recent build of flox-activation-scripts package
 # in a file, and automatically rebuild that file when assets change,
 # or overwrite it with the value from the environment if defined.
-CLEANFILES += .ACTIVATION_SCRIPTS_PACKAGE_DIR
-ifdef ACTIVATION_SCRIPTS_PACKAGE_DIR
-  .ACTIVATION_SCRIPTS_PACKAGE_DIR: FORCE
+CLEANFILES += .ACTIVATION_SCRIPTS_PACKAGE
+ifdef ACTIVATION_SCRIPTS_PACKAGE
+  .ACTIVATION_SCRIPTS_PACKAGE: FORCE
 	@# Only update the file if the value has changed.
-	-rm -f $@.new
-	echo '$(ACTIVATION_SCRIPTS_PACKAGE_DIR)' > $@.new
-	( cmp $@ $@.new && rm $@.new ) || mv -f $@.new $@
+	ifneq ($(readlink <.ACTIVATION_SCRIPTS_PACKAGE),$(ACTIVATION_SCRIPTS_PACKAGE))
+		@echo update
+	  ln -sf '$(ACTIVATION_SCRIPTS_PACKAGE)' $@
+	else
+	  @echo noop
+	endif
 else
   _rebuild_paths = ../flake.nix ../flake.lock \
     ../assets/activation-scripts ../pkgs/flox-activation-scripts \
 		../cli/flox-activations
-  .ACTIVATION_SCRIPTS_PACKAGE_DIR: $(shell find $(_rebuild_paths) -type f)
-	$(NIX) build --print-out-paths .#flox-activation-scripts > $@
+  .ACTIVATION_SCRIPTS_PACKAGE: $(shell find $(_rebuild_paths) -type f)
+	$(NIX) build .#flox-activation-scripts --out-link $@
 endif
 
 # Rebuild realise.o whenever the activation scripts package changes.
-src/buildenv/realise.o: .ACTIVATION_SCRIPTS_PACKAGE_DIR
+src/buildenv/realise.o: .ACTIVATION_SCRIPTS_PACKAGE
 
 src/buildenv/realise.o: CXXFLAGS +=               \
-	'-DACTIVATION_SCRIPTS_PACKAGE_DIR="$(file <.ACTIVATION_SCRIPTS_PACKAGE_DIR)"'
+	'-DACTIVATION_SCRIPTS_PACKAGE="$(readlink <.ACTIVATION_SCRIPTS_PACKAGE)"'
 
 src/buildenv/realise.o: CXXFLAGS +=               \
 	'-DCONTAINER_BUILDER_PATH="$(CONTAINER_BUILDER_PATH)"'

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -40,8 +40,8 @@ namespace flox::buildenv {
 
 /* -------------------------------------------------------------------------- */
 
-#ifndef ACTIVATION_SCRIPTS_PACKAGE_DIR
-#  error "ACTIVATION_SCRIPTS_PACKAGE_DIR must be set"
+#ifndef ACTIVATION_SCRIPTS_PACKAGE
+#  error "ACTIVATION_SCRIPTS_PACKAGE must be set"
 #endif
 
 #ifndef CONTAINER_BUILDER_PATH
@@ -794,7 +794,7 @@ makeActivationScripts( nix::EvalState &         state,
   auto            references = nix::StorePathSet();
   references.insert( activationStorePath );
   references.insert(
-    state.store->parseStorePath( ACTIVATION_SCRIPTS_PACKAGE_DIR ) );
+    state.store->parseStorePath( ACTIVATION_SCRIPTS_PACKAGE ) );
   references.insert( state.store->parseStorePath( FLOX_BASH_PKG ) );
   references.insert( state.store->parseStorePath( FLOX_CACERT_PKG ) );
 
@@ -864,11 +864,11 @@ makeActivationScriptsPackageDir( nix::EvalState & state )
 {
   /* Insert activation scripts.
    * The store path is provided at compile time via the
-   * `ACTIVATION_SCRIPTS_PACKAGE_DIR' environment variable. */
+   * `ACTIVATION_SCRIPTS_PACKAGE' environment variable. */
   debugLog( nix::fmt( "adding activation scripts to store, path=%s",
-                      ACTIVATION_SCRIPTS_PACKAGE_DIR ) );
+                      ACTIVATION_SCRIPTS_PACKAGE ) );
   auto profileScriptsPath
-    = state.store->parseStorePath( ACTIVATION_SCRIPTS_PACKAGE_DIR );
+    = state.store->parseStorePath( ACTIVATION_SCRIPTS_PACKAGE );
   state.store->ensurePath( profileScriptsPath );
   RealisedPackage realised( state.store->printStorePath( profileScriptsPath ),
                             true,

--- a/pkgs/flox-pkgdb/default.nix
+++ b/pkgs/flox-pkgdb/default.nix
@@ -147,7 +147,7 @@ stdenv.mkDerivation (
     configurePhase = ''
       runHook preConfigure;
       makeFlagsArray+=( "PREFIX=$out" );
-      makeFlagsArray+=( "ACTIVATION_SCRIPTS_PACKAGE_DIR=${flox-activation-scripts}" );
+      makeFlagsArray+=( "ACTIVATION_SCRIPTS_PACKAGE=${flox-activation-scripts}" );
       if [[ "''${enableParallelBuilding:-1}" = 1 ]]; then
         makeFlagsArray+=( "-j''${NIX_BUILD_CORES:?}" );
       fi


### PR DESCRIPTION
While developing, FLOX_INTERPRETER is set to a /nix/store path rather than a path within the repo that gets rebuilt when flox-activations changes.

Instead of storing a /nix/store path in .ACTIVATION_SCRIPTS_PACKAGE_DIR, symlink the /nix/store path at .ACTIVATION_SCRIPTS_PACKAGE so that path can be used by the CLI and picked up dynamically.

## Release Notes

NA
