### PR TITLE
build: consume internal dependencies by dynamic path in devshells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.flox
 /autom4te.cache/
 /cli/target
+/build/*
 compile_commands.json
 result
 result-*

--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,7 @@ build-cdb:
     @make -C pkgdb -j 8 -s cdb
 
 # Build only pkgdb
-@build-pkgdb:
+@build-pkgdb: build-activation-scripts
     make -C pkgdb -j 8;
 
 # Build pkgdb with debug symbols

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 _dirname="@coreutils@/bin/dirname"
-_flox_activations="@flox_activations@/bin/flox-activations"
 _getopt="@getopt@/bin/getopt"
 _nawk="@nawk@/bin/nawk"
 _readlink="@coreutils@/bin/readlink"
+_flox_activations="@flox_activations@"
 
 set -euo pipefail
 

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -1,6 +1,6 @@
 _comm="@coreutils@/bin/comm"
 _daemonize="@daemonize@/bin/daemonize"
-_flox_activations="@flox_activations@/bin/flox-activations"
+_flox_activations="@flox_activations@"
 _sed="@gnused@/bin/sed"
 _sort="@coreutils@/bin/sort"
 

--- a/buildenv/buildenv.bash
+++ b/buildenv/buildenv.bash
@@ -62,7 +62,7 @@ fi
 
 # Binaries required for the script.
 declare _nix="@nix@/bin/nix --extra-experimental-features flakes --extra-experimental-features nix-command"
-declare _pkgdb="@floxPkgdb@/bin/pkgdb"
+declare _pkgdb="@pkgdb@"
 
 # Nicer name for referring to the manifest.
 declare manifestLock="$1"

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,7 @@
             flox-buildenv = null;
             flox-package-builder = null;
             flox-pkgdb = null;
+            flox-mk-container = null;
           };
 
           flox-cli = prev.flox-cli.override {

--- a/pkgdb/Makefile
+++ b/pkgdb/Makefile
@@ -154,8 +154,7 @@ VERSION := $(file < $(PKGDB_ROOT)/.version)
 CONTAINER_BUILDER_PATH ?= $(shell \
   $(NIX) store add-path -n mkContainer.nix src/libexec/mkContainer.nix)
 
-COMMON_NIXPKGS_URL ?= $(shell \
-  $(NIX) eval --raw .\#flox-pkgdb.envs.COMMON_NIXPKGS_URL)
+COMMON_NIXPKGS_URL ?= $(COMMON_NIXPKGS_URL)
 
 # ---------------------------------------------------------------------------- #
 
@@ -354,26 +353,11 @@ endif # ifeq (Linux,$(OS))
 # Save path for most recent build of flox-activation-scripts package
 # in a file, and automatically rebuild that file when assets change,
 # or overwrite it with the value from the environment if defined.
-CLEANFILES += .ACTIVATION_SCRIPTS_PACKAGE_DIR
-ifdef ACTIVATION_SCRIPTS_PACKAGE_DIR
-  .ACTIVATION_SCRIPTS_PACKAGE_DIR: FORCE
-	@# Only update the file if the value has changed.
-	-rm -f $@.new
-	echo '$(ACTIVATION_SCRIPTS_PACKAGE_DIR)' > $@.new
-	( cmp $@ $@.new && rm $@.new ) || mv -f $@.new $@
-else
-  _rebuild_paths = ../flake.nix ../flake.lock \
-    ../assets/activation-scripts ../pkgs/flox-activation-scripts \
-		../cli/flox-activations
-  .ACTIVATION_SCRIPTS_PACKAGE_DIR: $(shell find $(_rebuild_paths) -type f)
-	$(NIX) build --print-out-paths .#flox-activation-scripts > $@
-endif
 
-# Rebuild realise.o whenever the activation scripts package changes.
-src/buildenv/realise.o: .ACTIVATION_SCRIPTS_PACKAGE_DIR
+ACTIVATION_SCRIPTS_PACKAGE_DIR ?= $(FLOX_INTERPRETER)
 
 src/buildenv/realise.o: CXXFLAGS +=               \
-	'-DACTIVATION_SCRIPTS_PACKAGE_DIR="$(file <.ACTIVATION_SCRIPTS_PACKAGE_DIR)"'
+	'-DACTIVATION_SCRIPTS_PACKAGE_DIR="$(ACTIVATION_SCRIPTS_PACKAGE_DIR)"'
 
 src/buildenv/realise.o: CXXFLAGS +=               \
 	'-DCONTAINER_BUILDER_PATH="$(CONTAINER_BUILDER_PATH)"'

--- a/pkgdb/src/buildenv/realise.cc
+++ b/pkgdb/src/buildenv/realise.cc
@@ -794,7 +794,8 @@ makeActivationScripts( nix::EvalState &         state,
   auto            references = nix::StorePathSet();
   references.insert( activationStorePath );
   references.insert(
-    state.store->parseStorePath( ACTIVATION_SCRIPTS_PACKAGE_DIR ) );
+    state.store->addToStore( "activation-scripts",
+                             ACTIVATION_SCRIPTS_PACKAGE_DIR ) );
   references.insert( state.store->parseStorePath( FLOX_BASH_PKG ) );
   references.insert( state.store->parseStorePath( FLOX_CACERT_PKG ) );
 
@@ -868,8 +869,8 @@ makeActivationScriptsPackageDir( nix::EvalState & state )
   debugLog( nix::fmt( "adding activation scripts to store, path=%s",
                       ACTIVATION_SCRIPTS_PACKAGE_DIR ) );
   auto profileScriptsPath
-    = state.store->parseStorePath( ACTIVATION_SCRIPTS_PACKAGE_DIR );
-  state.store->ensurePath( profileScriptsPath );
+    = state.store->addToStore( "activation-scripts",
+                               ACTIVATION_SCRIPTS_PACKAGE_DIR );
   RealisedPackage realised( state.store->printStorePath( profileScriptsPath ),
                             true,
                             buildenv::Priority() );

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -38,7 +38,11 @@ let
     # Note that substitution doesn't work with variables containing "-"
     # so we need to create and use alternative names.
     process_compose = process-compose;
-    flox_activations = flox-activations;
+    flox_activations =
+      if flox-activations != null then
+        "${flox-activations}/bin/flox-activations"
+      else
+        "$FLOX_ACTIVATIONS_BIN";
     util_linux = util-linux;
     # Make clear when packages are not available on Darwin.
     ld_floxlib = if stdenv.isLinux then ld-floxlib else "__LINUX_ONLY__";

--- a/pkgs/flox-activations/default.nix
+++ b/pkgs/flox-activations/default.nix
@@ -1,6 +1,5 @@
 {
   inputs,
-  gnused,
   lib,
   pkgsFor,
   rust-toolchain,
@@ -76,7 +75,6 @@ craneLib.buildPackage ({
         PATH="$( git rev-parse --show-toplevel; )/cli/target/debug":$PATH;
         REPO_ROOT="$( git rev-parse --show-toplevel; )";
       fi
-
     '';
   };
 })

--- a/pkgs/flox-buildenv/default.nix
+++ b/pkgs/flox-buildenv/default.nix
@@ -53,7 +53,7 @@ runCommandNoCC "${pname}-${version}"
     # Substitutions for builder.pl.
     inherit (builtins) storeDir;
     perl = perl + "/bin/perl";
-    floxPkgdb = flox-pkgdb;
+    pkgdb = if flox-pkgdb != null then "${flox-pkgdb}/bin/pkgdb" else "$PKGDB_BIN";
   }
   ''
     mkdir -p "$out/bin" "$out/lib"

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -158,7 +158,7 @@ writeShellScriptBin PROJECT_NAME ''
   ${if NIX_BIN == null then "export NIX_BIN='nix';" else "export NIX_BIN='${NIX_BIN}';"}
   ${
     if BUILDENV_BIN == null then
-      ''export BUILDENV_BIN="$(command -v buildenv)";''
+      ''export BUILDENV_BIN="$PROJECT_ROOT_DIR/build/flox-buildenv/bin/buildenv";''
     else
       "export BUILDENV_BIN='${BUILDENV_BIN}';"
   }
@@ -177,7 +177,7 @@ writeShellScriptBin PROJECT_NAME ''
   }
   ${
     if FLOX_ACTIVATIONS_BIN == null then
-      "export FLOX_ACTIVATIONS_BIN='flox-activations';"
+      ''export FLOX_ACTIVATIONS_BIN="$(command -v flox-activations)";''
     else
       "export FLOX_ACTIVATIONS_BIN='${FLOX_ACTIVATIONS_BIN}';"
   }
@@ -185,7 +185,12 @@ writeShellScriptBin PROJECT_NAME ''
   # which "$FLOX_BIN" in user_dotfiles_setup
   ${if FLOX_BIN == null then "export FLOX_BIN='flox';" else "export FLOX_BIN='${FLOX_BIN}';"}
   export PROCESS_COMPOSE_BIN='${process-compose}/bin/process-compose';
-  export FLOX_INTERPRETER='${flox-activation-scripts}';
+  ${
+    if flox-activation-scripts == null then
+      ''export FLOX_INTERPRETER="$PROJECT_ROOT_DIR/build/flox-activation-scripts";''
+    else
+      ''export FLOX_INTERPRETER='${flox-activation-scripts}';''
+  }
 
   usage() {
         cat << EOF

--- a/pkgs/flox-package-builder/default.nix
+++ b/pkgs/flox-package-builder/default.nix
@@ -39,12 +39,4 @@ stdenv.mkDerivation {
   # install the packages to $out/libexec/*
   makeFlags = [ "PREFIX=$(out)" ];
   doCheck = true;
-
-  passthru.devShellHook = ''
-    # Find the project root and set FLOX_BUILD_MK.
-    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-      REPO_ROOT="$( git rev-parse --show-toplevel; )";
-      FLOX_BUILD_MK="$REPO_ROOT/package-builder/flox-build.mk";
-    fi
-  '';
 }

--- a/pkgs/flox-watchdog/default.nix
+++ b/pkgs/flox-watchdog/default.nix
@@ -82,7 +82,6 @@ craneLib.buildPackage (
         if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
           PATH="$( git rev-parse --show-toplevel; )/cli/target/debug":$PATH;
           REPO_ROOT="$( git rev-parse --show-toplevel; )";
-          WATCHDOG_BIN="$REPO_ROOT/cli/target/debug/flox-watchdog";
         fi
 
       '';

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -15,30 +15,15 @@
   cargo-nextest,
   flox-cli,
   flox-cli-tests,
+  flox-activations,
   flox-watchdog,
   flox-pkgdb,
-  flox-manpages,
-  flox-package-builder,
   stdenv,
   ci ? false,
-  GENERATED_DATA ? ./../../test_data/generated,
-  MANUALLY_GENERATED ? ./../../test_data/manually_generated,
 }:
 let
   # For use in GitHub Actions and local development.
-  ciPackages =
-    flox-pkgdb.ciPackages
-    ++ flox-watchdog.ciPackages
-    ++ flox-pkgdb.ciPackages
-    ++ flox-cli.ciPackages
-    ++ [
-      (flox-cli-tests.override {
-        PROJECT_TESTS_DIR = "/cli/tests";
-        PKGDB_BIN = null;
-        FLOX_BIN = null;
-        WATCHDOG_BIN = null;
-      })
-    ];
+  ciPackages = [ ] ++ flox-pkgdb.ciPackages;
 
   devPackages =
     flox-pkgdb.devPackages
@@ -54,6 +39,7 @@ let
       cargo-nextest
       procps
       pstree
+      flox-cli-tests
     ]
     ++ lib.optionals stdenv.isLinux [
       # The python3Packages.mitmproxy-macos package is broken on mac:
@@ -67,28 +53,75 @@ mkShell (
   {
     name = "flox-dev";
 
+    # Artifacts not build by nix, i.e. cargo builds
+    # generally all cargo builds should have the same inputs
+    # but in case we add specific ones,
+    # it's good to have them here already.
     inputsFrom = [
       flox-pkgdb
-      (flox-cli.override {
-        flox-pkgdb = null;
-        flox-watchdog = null;
-      })
+      flox-cli
+      flox-watchdog
+      flox-activations
     ];
 
     packages = ciPackages ++ lib.optionals (!ci) devPackages;
 
     shellHook =
-      flox-pkgdb.devShellHook
-      + flox-watchdog.devShellHook
-      + flox-cli.devShellHook
-      + pre-commit-check.shellHook
-      + flox-package-builder.devShellHook
+      pre-commit-check.shellHook
       + ''
-        export MANPATH=${flox-manpages}/share/man:$MANPATH
-      '';
+        function define_dev_env_var() {
+          local USAGE="Usage: define_dev_env_var <name> <value>";
 
-    inherit GENERATED_DATA;
-    inherit MANUALLY_GENERATED;
+          local name=''${1?$USAGE};
+          local value=''${2?$USAGE};
+
+          export $name="$value";
+          echo "$name => $(printenv "$name")";
+        }
+
+        # Find the project root.
+        REPO_ROOT="$( git rev-parse --show-toplevel; )";
+
+        # Setup mutable paths to all internal subsystems,
+        # so that they can be changed and built without restarting the shell.
+
+        # cargo built binaries
+        define_dev_env_var FLOX_BIN "''${REPO_ROOT}/cli/target/debug/flox";
+        define_dev_env_var WATCHDOG_BIN "''${REPO_ROOT}/cli/target/debug/flox-watchdog";
+        define_dev_env_var FLOX_ACTIVATIONS_BIN "''${REPO_ROOT}/cli/target/debug/flox-activations";
+
+        # make built binaries
+        define_dev_env_var PKGDB_BIN "''${REPO_ROOT}/pkgdb/bin/pkgdb";
+
+        # static nix files
+        define_dev_env_var FLOX_MK_CONTAINER_NIX "''${REPO_ROOT}/mkContainer/mkContainer.nix";
+
+        # Nix built subsystems
+        define_dev_env_var FLOX_INTERPRETER "''${REPO_ROOT}/build/flox-activation-scripts";
+        define_dev_env_var FLOX_BUILDENV "''${REPO_ROOT}/build/flox-buildenv";
+        define_dev_env_var FLOX_BUILDENV_NIX "''${FLOX_BUILDENV}/lib/buildenv.nix";
+        define_dev_env_var FLOX_PACKAGE_BUILDER "''${REPO_ROOT}/build/flox-package-builder";
+        define_dev_env_var FLOX_BUILD_MK "''$FLOX_PACKAGE_BUILDER/libexec/flox-build.mk";
+        define_dev_env_var FLOX_MANPAGES "''${REPO_ROOT}/build/flox-manpages";
+
+        # test data
+        define_dev_env_var GENERATED_DATA "''${REPO_ROOT}/test_data/generated";
+        define_dev_env_var MANUALLY_GENERATED "''${REPO_ROOT}/test_data/manually_generated";
+
+        # Add all internal rust crates to the path.
+        # That's `flox` itself as well as the `flox-watchdog`
+        # and `flox-activations` subsystems.
+        export PATH="''${REPO_ROOT}/cli/target/debug":$PATH;
+
+        # Add the pkgdb binary to the path
+        export PATH="''${REPO_ROOT}/pkgdb/bin":$PATH;
+
+        # Add the flox-manpages to the manpath
+        export MANPATH="''${FLOX_MANPAGES}/share/man:$MANPATH"
+
+        echo;
+        echo "run 'just build' to build flox and all its subsystems";
+      '';
   }
   // flox-pkgdb.devEnvs
   // flox-watchdog.devEnvs


### PR DESCRIPTION
## Background

Out codebase has grown multiple subsystems that are depended on by flox or depend on other subsystems themselves.
E.g. `flox -> pkgdb -> flox-activation-scripts -> flox-activations` for one of the worse ones. On the one hand it is important to be able to build final artefacts of each individual subsystem with nix to allow for better build caching if nothing else. Nix also makes defining these dependencies relatively easy through e.g. string contexts.

However, since our devshell is derived from _the inputs of the toplevel binaries_, the naive approach results in
1. all dependencies being built upon entering the devshell
2. the devshell being in accessible while any dependency fails to build
3. the devshell being stale as soon as any dependency changes -- requiring us to reenter the devshell

Until not too long ago, most of the now standalone subsystems were consolidated in pkgdb (i.e. buildenv and associated functionality).
In order to avoid the 3 pitfalls above, for development, we would set `PKGDB_BIN` to `pkgdb`, instead of `${flox-pkgdb}/bin/pkgdb`, in turn removing the dependency on pkgdb form the build closure, as well as the dev shell closure.
`Pkgdb` now needed to be built separately from the `flox` binary, which we ensured would happen through via the central Justfile. As we added internal (nix built) dependencies to `pkgdb`, we amended the pkgdb Makefile to build these dependencies as requisites of the `pkgdb` binary and provide their path to the C++ preprocessor, when they were unspecified in dev mode.

While `flox` only depended on binaries this worked out relatively well, except occasionally we would still find internal dependencies in the closure of the devshell. That was because we

1. forgot to add "dev mode" overrides,
2. depend on a package by both `flox` and `pkgdb`,
3. required absolute paths which broke our heuristic of adding binaries to PATH,
4. etc.

As we are phasing out pkgdb as a binary, and move more functionality into independent packages orchestrated by the `flox` binary, we are losing some of the dynamic setup we had implemented via the `pkgdb` Makefile.
For example, most recently we have experienced issues wrt `flox-activation-scripts`, which made its way into the devshell (alongside, flox-buildenv and transitively `pkgdb` ...).

This commit is trying to consolidate the dependency management for `flox` and the remains of pkgdb, by applying a similar strategy at an earlier stage.


## Proposed Changes

1. packages **only** provide build environment variables that reference dependencies iff the dependency is provided, i.e. not overridden to `null`
2. within the `floxDevelopmentPackages` scope, all internal dependencies of internal packages are overridden to `null.
3. define all environment variables that point to internal dependencies within the `shellHook` of the devshell and point them to a local directory. `cargo` built dependencies become: `FLOX_ACTIVATIONS_BIN="''${REPO_ROOT}/cli/target/debug/flox-activations"` `nix` built dependencies become `FLOX_BUILDENV="''${REPO_ROOT}/build/flox-buildenv"`
4. define Justfile targets that build dependencies with either `cargo` or `nix` thereby populating the directories previously defined in the environment.

Compared to the previous Makefile implementation this avoids requiring to rebuild binaries as the dependencies change, because everything will depend on stable paths that are updated in place.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
