### PR TITLE
feat: recommend .profile for default env

### DIFF
--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -482,7 +482,7 @@ fn prompt_to_modify_rc_file() -> Result<bool, anyhow::Error> {
     };
     let rc_file_names = match shell {
         Shell::Bash(_) => vec![".bashrc", ".profile"],
-        Shell::Zsh(_) => vec![".zshrc"],
+        Shell::Zsh(_) => vec![".zshenv"],
         Shell::Tcsh(_) => vec![".tcshrc"],
         Shell::Fish(_) => vec!["config.fish"],
     };


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

On macOS every shell is started as a login shell, which is different from many Linux distributions. This means that the recommendation to put the default environment activation in `.bashrc` will not activate the default environment since Bash only loads `.profile` for login shells, not `.bashrc`. To address this we put the activation line in both scripts.

No tests were added because we already have tests for verifying that individual RC files were modified, but the new functionality and messaging was verified interactively.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
On macOS when you're prompted to create a `default` environment if you're using Bash then you will be prompted to modify both `.profile` and `.bashrc`. On macOS new shells are created as login shells, and therefore Bash doesn't load `.bashrc` in that case. This fix ensures that the `default` environment is activated for all Bash shells on macOS.

<!-- Many thanks! -->
