### PR TITLE
feat(containerize): Mark non-hidden/experimental

### DIFF
--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -4,10 +4,6 @@ section: 1
 header: "Flox User Manuals"
 ...
 
-```{.include}
-./include/experimental-warning.md
-```
-
 # NAME
 
 flox-containerize - export an environment as a container image

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -814,12 +814,7 @@ enum SharingCommands {
     #[bpaf(command, footer("Run 'man flox-pull' for more details."))]
     Pull(#[bpaf(external(pull::pull))] pull::Pull),
     /// Containerize an environment
-    #[bpaf(
-        command,
-        hide,
-        footer("Run 'man flox-containerize' for more details."),
-        header("This command is experimental and its behaviour is subject to change")
-    )]
+    #[bpaf(command, footer("Run 'man flox-containerize' for more details."))]
     Containerize(#[bpaf(external(containerize::containerize))] containerize::Containerize),
 }
 

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -84,6 +84,8 @@ EOF
   assert_line -n "$line" --regexp '^    push[ ]+[\w .,]+'
   line=$((line + 1))
   assert_line -n "$line" --regexp '^    pull[ ]+[\w .,]+'
+  line=$((line + 1))
+  assert_line -n "$line" --regexp '^    containerize[ ]+[\w .,]+'
 }
 
 @test "f5: command grouping changes 3: move lesser used or not polished commands to 'Additional Commands' section with help tip." {


### PR DESCRIPTION
## Proposed Changes

We're considering this stable after adding `--tag` and `--runtime` support, with macOS support following in #2478.

Accompanying change in https://github.com/flox/floxdocs/pull/99 but this can be merged ahead of time.

## Release Notes

`flox containerize` is no longer marked as experimental.