### PR TITLE
fix(activate): nested activations for zsh

### DIFF
--- a/assets/activation-scripts/activate.d/zdotdir/.zlogin
+++ b/assets/activation-scripts/activate.d/zdotdir/.zlogin
@@ -6,6 +6,28 @@
 # Save and restore the current tracelevel in the event that sourcing
 # bashrc launches an inner nested activation which unsets it.
 _save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+_save_FLOX_ACTIVATION_STATE_DIR="$_FLOX_ACTIVATION_STATE_DIR"
+_save_FLOX_ENV="$FLOX_ENV"
+_save_FLOX_ORIG_ZDOTDIR="$FLOX_ORIG_ZDOTDIR"
+_save_ZDOTDIR="$ZDOTDIR"
+_save_activate_d="$_activate_d"
+_save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
+_save_FLOX_RESTORE_PATH="$_FLOX_RESTORE_PATH"
+_save_FLOX_RESTORE_MANPATH="$_FLOX_RESTORE_MANPATH"
+_save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
+
+restore_saved_vars() {
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    export FLOX_ENV="$_save_FLOX_ENV"
+    export FLOX_ORIG_ZDOTDIR="$_save_FLOX_ORIG_ZDOTDIR"
+    export ZDOTDIR="$_save_ZDOTDIR"
+    export _activate_d="$_save_activate_d"
+    export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
+    export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
+    export _FLOX_RESTORE_PATH="$_save_FLOX_RESTORE_PATH"
+    export _FLOX_RESTORE_MANPATH="$_save_FLOX_RESTORE_MANPATH"
+    export _FLOX_ACTIVATION_PROFILE_ONLY="$_save_FLOX_ACTIVATION_PROFILE_ONLY"
+}
 
 if [ -f /etc/zlogin ]
 then
@@ -15,7 +37,7 @@ then
     else
         ZDOTDIR= source /etc/zlogin
     fi
-    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    restore_saved_vars
 fi
 
 zlogin="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zlogin"
@@ -27,7 +49,7 @@ then
     else
         ZDOTDIR= source "$zlogin"
     fi
-    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    restore_saved_vars
 fi
 
 # Bring in the Nix and Flox environment customizations.

--- a/assets/activation-scripts/activate.d/zdotdir/.zprofile
+++ b/assets/activation-scripts/activate.d/zdotdir/.zprofile
@@ -5,6 +5,28 @@
 # Save and restore the current tracelevel in the event that sourcing
 # bashrc launches an inner nested activation which unsets it.
 _save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+_save_FLOX_ACTIVATION_STATE_DIR="$_FLOX_ACTIVATION_STATE_DIR"
+_save_FLOX_ENV="$FLOX_ENV"
+_save_FLOX_ORIG_ZDOTDIR="$FLOX_ORIG_ZDOTDIR"
+_save_ZDOTDIR="$ZDOTDIR"
+_save_activate_d="$_activate_d"
+_save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
+_save_FLOX_RESTORE_PATH="$_FLOX_RESTORE_PATH"
+_save_FLOX_RESTORE_MANPATH="$_FLOX_RESTORE_MANPATH"
+_save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
+
+restore_saved_vars() {
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    export FLOX_ENV="$_save_FLOX_ENV"
+    export FLOX_ORIG_ZDOTDIR="$_save_FLOX_ORIG_ZDOTDIR"
+    export ZDOTDIR="$_save_ZDOTDIR"
+    export _activate_d="$_save_activate_d"
+    export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
+    export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
+    export _FLOX_RESTORE_PATH="$_save_FLOX_RESTORE_PATH"
+    export _FLOX_RESTORE_MANPATH="$_save_FLOX_RESTORE_MANPATH"
+    export _FLOX_ACTIVATION_PROFILE_ONLY="$_save_FLOX_ACTIVATION_PROFILE_ONLY"
+}
 
 if [ -f /etc/zprofile ]
 then
@@ -14,7 +36,7 @@ then
     else
         ZDOTDIR= source /etc/zprofile
     fi
-    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    restore_saved_vars
 fi
 
 zprofile="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zprofile"
@@ -26,7 +48,7 @@ then
     else
         ZDOTDIR= source "$zprofile"
     fi
-    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    restore_saved_vars
 fi
 
 # Do not bring in the Nix and Flox environment customizations from this file

--- a/assets/activation-scripts/activate.d/zdotdir/.zshenv
+++ b/assets/activation-scripts/activate.d/zdotdir/.zshenv
@@ -6,6 +6,28 @@
 # Save and restore the current tracelevel in the event that sourcing
 # bashrc launches an inner nested activation which unsets it.
 _save_flox_activate_tracelevel="$_flox_activate_tracelevel"
+_save_FLOX_ACTIVATION_STATE_DIR="$_FLOX_ACTIVATION_STATE_DIR"
+_save_FLOX_ENV="$FLOX_ENV"
+_save_FLOX_ORIG_ZDOTDIR="$FLOX_ORIG_ZDOTDIR"
+_save_ZDOTDIR="$ZDOTDIR"
+_save_activate_d="$_activate_d"
+_save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
+_save_FLOX_RESTORE_PATH="$_FLOX_RESTORE_PATH"
+_save_FLOX_RESTORE_MANPATH="$_FLOX_RESTORE_MANPATH"
+_save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
+
+restore_saved_vars() {
+    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    export FLOX_ENV="$_save_FLOX_ENV"
+    export FLOX_ORIG_ZDOTDIR="$_save_FLOX_ORIG_ZDOTDIR"
+    export ZDOTDIR="$_save_ZDOTDIR"
+    export _activate_d="$_save_activate_d"
+    export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
+    export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
+    export _FLOX_RESTORE_PATH="$_save_FLOX_RESTORE_PATH"
+    export _FLOX_RESTORE_MANPATH="$_save_FLOX_RESTORE_MANPATH"
+    export _FLOX_ACTIVATION_PROFILE_ONLY="$_save_FLOX_ACTIVATION_PROFILE_ONLY"
+}
 
 if [ -f /etc/zshenv ]
 then
@@ -15,7 +37,7 @@ then
     else
         ZDOTDIR= source /etc/zshenv
     fi
-    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    restore_saved_vars
 fi
 
 zshenv="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zshenv"
@@ -27,7 +49,7 @@ then
     else
         ZDOTDIR= source "$zshenv"
     fi
-    export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
+    restore_saved_vars
 fi
 
 # Bring in the Nix and Flox environment customizations, but _not_ if this is

--- a/assets/activation-scripts/activate.d/zdotdir/.zshrc
+++ b/assets/activation-scripts/activate.d/zdotdir/.zshrc
@@ -12,6 +12,9 @@ _save_FLOX_ORIG_ZDOTDIR="$FLOX_ORIG_ZDOTDIR"
 _save_ZDOTDIR="$ZDOTDIR"
 _save_activate_d="$_activate_d"
 _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
+_save_FLOX_RESTORE_PATH="$_FLOX_RESTORE_PATH"
+_save_FLOX_RESTORE_MANPATH="$_FLOX_RESTORE_MANPATH"
+_save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
     export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
@@ -21,6 +24,9 @@ restore_saved_vars() {
     export _activate_d="$_save_activate_d"
     export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
     export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
+    export _FLOX_RESTORE_PATH="$_save_FLOX_RESTORE_PATH"
+    export _FLOX_RESTORE_MANPATH="$_save_FLOX_RESTORE_MANPATH"
+    export _FLOX_ACTIVATION_PROFILE_ONLY="$_save_FLOX_ACTIVATION_PROFILE_ONLY"
 }
 
 if [ -f /etc/zshrc ]

--- a/assets/activation-scripts/activate.d/zsh
+++ b/assets/activation-scripts/activate.d/zsh
@@ -58,18 +58,20 @@ if [ ${#fpath_prepend[@]} -gt 0 ]; then
 fi
 unset fpath_prepend
 
-# Restore environment variables set in the previous bash initialization.
-eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
-eval "$($_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
+if [ "${_FLOX_ACTIVATION_PROFILE_ONLY:-}" != true ]; then
+  # Restore environment variables set in the previous bash initialization.
+  eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
+  eval "$($_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
 
-# Restore PATH and MANPATH if set in one of the attach scripts.
-if [ -n "$_FLOX_RESTORE_PATH" ]; then
-  export PATH="$_FLOX_RESTORE_PATH"
-  unset _FLOX_RESTORE_PATH
-fi
-if [ -n "$_FLOX_RESTORE_MANPATH" ]; then
-  export MANPATH="$_FLOX_RESTORE_MANPATH"
-  unset _FLOX_RESTORE_MANPATH
+  # Restore PATH and MANPATH if set in one of the attach scripts.
+  if [ -n "$_FLOX_RESTORE_PATH" ]; then
+    export PATH="$_FLOX_RESTORE_PATH"
+    unset _FLOX_RESTORE_PATH
+  fi
+  if [ -n "$_FLOX_RESTORE_MANPATH" ]; then
+    export MANPATH="$_FLOX_RESTORE_MANPATH"
+    unset _FLOX_RESTORE_MANPATH
+  fi
 fi
 
 # Set the prompt if we're in an interactive shell.

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -20,6 +20,9 @@ load test_support.bash
 # disrupt flox's attempts to configure the environment. Please append to this
 # growing list of nightmare scenarios as you encounter them in the wild.
 user_dotfiles_setup() {
+  # Make sure FLOX_BIN is set to an absolute PATH so that setting BADPATH
+  # doesn't cause `flox` to be found in e.g. `/usr/local/bin`
+  export FLOX_BIN="$(which "$FLOX_BIN")"
   # N.B. $HOME is set to a test-isolated directory by `common_file_setup`,
   # `home_setup`, and `flox_vars_setup` so none of the files below should exist
   # and we abort if we find otherwise.
@@ -1709,8 +1712,7 @@ EOF
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/on-activate.toml"
 
-  # RC files remove flox from PATH
-  cat <<'EOF' | FLOX_BIN="$(which "$FLOX_BIN")" zsh
+  cat <<'EOF' | zsh
     eval "$("$FLOX_BIN" activate)"
     if [[ "$foo" != "baz" ]]; then
       echo "foo=$foo when it should be foo=baz"
@@ -1832,8 +1834,7 @@ EOF
 
   echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
 
-  # RC files remove flox from PATH
-  cat <<'EOF' | FLOX_BIN="$(which "$FLOX_BIN")" zsh
+  cat <<'EOF' | zsh
     export foo=baz
     eval "$("$FLOX_BIN" activate)"
     if [[ ! -z "${foo:-}" ]]; then
@@ -3832,7 +3833,6 @@ EOF
   )"
   echo "$MANIFEST_CONTENTS_PROJECT" | "$FLOX_BIN" edit -d project -f -
 
-  FLOX_BIN="$(which "$FLOX_BIN")"
   for init_file in "${init_files[@]}"; do
     echo "eval \"\$(\"$FLOX_BIN\" activate -d '$PROJECT_DIR/default')\"" >> "$HOME/$init_file"
   done

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -181,6 +181,8 @@ writeShellScriptBin PROJECT_NAME ''
     else
       "export FLOX_ACTIVATIONS_BIN='${FLOX_ACTIVATIONS_BIN}';"
   }
+  # TODO: we should probably make this an absolute path to avoid having to call
+  # which "$FLOX_BIN" in user_dotfiles_setup
   ${if FLOX_BIN == null then "export FLOX_BIN='flox';" else "export FLOX_BIN='${FLOX_BIN}';"}
   export PROCESS_COMPOSE_BIN='${process-compose}/bin/process-compose';
   export FLOX_INTERPRETER='${flox-activation-scripts}';


### PR DESCRIPTION
## Proposed Changes

Rather than generating a startup script as for Bash in https://github.com/flox/flox/commit/f623518b0a2b912db7cd95f8201b5ecdf941252f, extend
the approach added to .zshrc in https://github.com/flox/flox/commit/52df88e4cc2454d52b78d0aa2f183e779da57f0e that saves and restores
variables used in activation. Extend it to other zsh startup files, and
also add _FLOX_RESTORE_PATH, _FLOX_RESTORE_MANPATH, and
_FLOX_ACTIVATION_PROFILE_ONLY to the save and restore logic.

The current approach could be improved by:
improved by:
- looping over variable names
- sourcing a common file and function from all 4 scripts

Respect _FLOX_ACTIVATION_PROFILE_ONLY in the zsh startup script, similar
to what was added for Bash in https://github.com/flox/flox/commit/fa6601645c5723ce135b366695782d761f0d3795.

## Release Notes

Fix the two bugs fixed by https://github.com/flox/flox/pull/2476 but for zsh
