### PR TITLE
Shuffle remote builders

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -65,12 +65,13 @@ runs:
       shell: "bash"
       run: |
         set -eo pipefail
-        export REMOTE_SERVER=$(cat /etc/nix/machines | grep ${{ inputs.SYSTEM }} | cut -f1 -d' ' | cut -f3 -d'/' | head -1 | sed 's/nixbld@//' ; )
+        export REMOTE_SERVER_ENTRY=$(cat /etc/nix/machines | shuf | grep ${{ matrix.system }} | head -1 ; )
+        export REMOTE_SERVER_ADDRESS=$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//' ; )
         export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$(mktemp)
-        export REMOTE_PUBLIC_HOST_KEY=$(cat /etc/nix/machines | grep ${{ inputs.SYSTEM }} | tr -s ' ' | cut -f8 -d' ' | base64 -d ; )
-        printf "%s %s\n" "$REMOTE_SERVER" "$REMOTE_PUBLIC_HOST_KEY" > "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
-        echo "REMOTE_SERVER: $REMOTE_SERVER"
+        export REMOTE_SERVER_PUBLIC_HOST_KEY=$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d ; )
+        printf "%s %s\n" "$REMOTE_SERVER_ADDRESS" "$REMOTE_SERVER_PUBLIC_HOST_KEY" > "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+        echo "REMOTE_SERVER_ADDRESS: $REMOTE_SERVER_ADDRESS"
         echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE: $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
         cat $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE
-        echo "REMOTE_SERVER=$REMOTE_SERVER" >> $GITHUB_ENV
+        echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS" >> $GITHUB_ENV
         echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,7 +453,7 @@ jobs:
         timeout-minutes: 30
         run: |
           git clean -xfd
-          ssh github@$REMOTE_SERVER \
+          ssh github@$REMOTE_SERVER_ADDRESS \
             -oLogLevel=ERROR \
             -oUserKnownHostsFile=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE \
             nix run \


### PR DESCRIPTION
Currently, when selecting a remote builder to run tests on, or build against, we always select the one at top of the list. This isn't really taking full advantage of our infrastructure, since we offer multiple machines for all architectures currently.

This introduces a `shuf` before we select the builder.

Refs: flox/deltaops#375