### PR TITLE
Ensure catalog client uses the new token after ensure_floxhub_token

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 dependencies = [
  "backtrace",
 ]
@@ -3684,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -3705,9 +3705,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3725,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 dependencies = [
  "backtrace",
 ]
@@ -3684,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3705,9 +3705,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3725,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -185,7 +185,7 @@ impl CatalogClient {
         if let Some(token) = &config.floxhub_token {
             header_map.insert(
                 header::HeaderName::from_static("authorization"),
-                header::HeaderValue::from_str(&format!("bearer {}", token.clone())).unwrap(),
+                header::HeaderValue::from_str(&format!("bearer {token}")).unwrap(),
             );
         };
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -6,6 +6,7 @@ use bpaf::Bpaf;
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
 use flox_rust_sdk::flox::{Flox, FloxhubToken};
+use flox_rust_sdk::providers::catalog::{CatalogClient, Client};
 use indoc::formatdoc;
 use log::debug;
 use oauth2::basic::BasicClient;
@@ -260,6 +261,14 @@ pub async fn login_flox(flox: &mut Flox) -> Result<()> {
         Some(token.clone()),
     )
     .context("Could not write token to config")?;
+
+    // If the catalog client is catalog (not a mock), update the token by
+    // creating a new client based on the old config with the updated token
+    if let Client::Catalog(client) = &flox.catalog_client {
+        let mut current_config = client.config.clone();
+        current_config.floxhub_token = Some(token.secret().to_string());
+        flox.catalog_client = CatalogClient::new(current_config).into()
+    }
 
     message::updated("Authentication complete");
     message::updated(format!("Logged in as {handle}"));

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1611,10 +1611,11 @@ pub(super) async fn ensure_environment_trust(
 ///
 /// If the token is not present and we can prompt the user,
 /// run the login flow ([auth::login_flox]).
-pub(super) async fn ensure_floxhub_token(flox: &mut Flox) -> Result<Option<FloxhubToken>> {
+pub(super) async fn ensure_floxhub_token(flox: &mut Flox) -> Result<&FloxhubToken> {
     match flox.floxhub_token {
         Some(ref token) => {
             log::debug!("floxhub token is present; logged in as {}", token.handle());
+            Ok(token)
         },
         None if !Dialog::can_prompt() => {
             log::debug!("floxhub token is not present; can not prompt user");
@@ -1634,11 +1635,10 @@ pub(super) async fn ensure_floxhub_token(flox: &mut Flox) -> Result<Option<Floxh
             log::debug!("floxhub token is not present; prompting user");
 
             message::plain("You are not logged in to FloxHub. Logging in...");
-            auth::login_flox(flox).await?;
+            let token = auth::login_flox(flox).await?;
+            Ok(token)
         },
-    };
-
-    Ok(flox.floxhub_token.clone())
+    }
 }
 
 pub fn environment_description(environment: &ConcreteEnvironment) -> Result<String> {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1611,7 +1611,7 @@ pub(super) async fn ensure_environment_trust(
 ///
 /// If the token is not present and we can prompt the user,
 /// run the login flow ([auth::login_flox]).
-pub(super) async fn ensure_floxhub_token(flox: &mut Flox) -> Result<()> {
+pub(super) async fn ensure_floxhub_token(flox: &mut Flox) -> Result<Option<FloxhubToken>> {
     match flox.floxhub_token {
         Some(ref token) => {
             log::debug!("floxhub token is present; logged in as {}", token.handle());
@@ -1638,7 +1638,7 @@ pub(super) async fn ensure_floxhub_token(flox: &mut Flox) -> Result<()> {
         },
     };
 
-    Ok(())
+    Ok(flox.floxhub_token.clone())
 }
 
 pub fn environment_description(environment: &ConcreteEnvironment) -> Result<String> {

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -103,24 +103,23 @@ impl Publish {
             _builder: None,
         };
 
-        ensure_floxhub_token(&mut flox).await?;
-        let token = flox
-            .floxhub_token
-            .as_ref()
-            .expect("should be authenticated to FloxHub");
-        let catalog_name = token.handle().to_string();
+        if let Some(token) = ensure_floxhub_token(&mut flox).await? {
+            let catalog_name = token.handle().to_string();
 
-        debug!("publishing package: {}", &package);
-        match publish_provider
-            .publish(&flox.catalog_client, &catalog_name)
-            .await
-        {
-            Ok(_) => message::updated(formatdoc! {"
-                Package published successfully.
+            debug!("publishing package: {}", &package);
+            match publish_provider
+                .publish(&flox.catalog_client, &catalog_name)
+                .await
+            {
+                Ok(_) => message::updated(formatdoc! {"
+                    Package published successfully.
 
-                Use 'flox install {catalog_name}/{package}' to install it.
-                "}),
-            Err(e) => bail!("Failed to publish package: {}", e.to_string()),
+                    Use 'flox install {catalog_name}/{package}' to install it.
+                    "}),
+                Err(e) => bail!("Failed to publish package: {}", e.to_string()),
+            }
+        } else {
+            bail!("Failed to get FloxHub token");
         }
 
         Ok(())

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -103,23 +103,21 @@ impl Publish {
             _builder: None,
         };
 
-        if let Some(token) = ensure_floxhub_token(&mut flox).await? {
-            let catalog_name = token.handle().to_string();
+        let token = ensure_floxhub_token(&mut flox).await?;
 
-            debug!("publishing package: {}", &package);
-            match publish_provider
-                .publish(&flox.catalog_client, &catalog_name)
-                .await
-            {
-                Ok(_) => message::updated(formatdoc! {"
-                    Package published successfully.
+        let catalog_name = token.handle().to_string();
 
-                    Use 'flox install {catalog_name}/{package}' to install it.
-                    "}),
-                Err(e) => bail!("Failed to publish package: {}", e.to_string()),
-            }
-        } else {
-            bail!("Failed to get FloxHub token");
+        debug!("publishing package: {}", &package);
+        match publish_provider
+            .publish(&flox.catalog_client, &catalog_name)
+            .await
+        {
+            Ok(_) => message::updated(formatdoc! {"
+                Package published successfully.
+
+                Use 'flox install {catalog_name}/{package}' to install it.
+                "}),
+            Err(e) => bail!("Failed to publish package: {}", e.to_string()),
         }
 
         Ok(())


### PR DESCRIPTION
The first commit refactors the `init_catalog_client` code to use a configuration struct.  This is passed to the catalog client new function to actually create the client, and also saves the config along side the client.  This allows a new client to be created with the config adjusted based on the original config without requiring the global `Config` object to be around.
The second commit creates a new client in the `login_flox` function with the new token.