### PR TITLE
fix: do not return early with `false` if iid  is not a catalog package

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -504,16 +504,15 @@ fn pkg_or_group_found_in_manifest(
     descriptors: &BTreeMap<String, ManifestPackageDescriptor>,
 ) -> bool {
     descriptors.iter().any(|(id, desc)| {
-        let ManifestPackageDescriptor::Catalog(ManifestPackageDescriptorCatalog {
-            pkg_group, ..
-        }) = desc
-        else {
-            return false;
+        let group = if let ManifestPackageDescriptor::Catalog(catalog) = desc {
+            catalog.pkg_group.as_deref()
+        } else {
+            None
         };
 
         let search_term = search_term.as_ref();
 
-        (search_term == id.as_str()) || (Some(search_term) == pkg_group.as_deref())
+        (search_term == id.as_str()) || (Some(search_term) == group)
     })
 }
 

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -212,15 +212,7 @@ setup_pkgdb_env() {
 @test "upgrade for flake installable" {
   "$FLOX_BIN" init
 
-  MANIFEST_CONTENTS="$(cat << "EOF"
-  version = 1
-
-  [install]
-  hello.flake = "github:NixOS/nixpkgs#hello"
-EOF
-  )"
-
-  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
+  run "$FLOX_BIN" install "github:nixos/nixpkgs/$PKGDB_NIXPKGS_REV_NEW#hello"
 
   run "$FLOX_BIN" upgrade
   assert_success
@@ -231,4 +223,15 @@ EOF
   run "$FLOX_BIN" upgrade
   assert_success
   assert_output "⬆️  Upgraded 'hello' in environment 'test'."
+}
+
+# bats test_tags=upgrade:flake:iid
+@test "upgrade for flake installable by iid" {
+  "$FLOX_BIN" init
+
+  run "$FLOX_BIN" install "github:nixos/nixpkgs/$PKGDB_NIXPKGS_REV_NEW#hello"
+
+  run "$FLOX_BIN" upgrade hello
+  assert_success
+  assert_output "ℹ️  The specified packages do not need to be upgraded in environment 'test'."
 }


### PR DESCRIPTION
When trying to upgrade a single installed flake and addressing it by install id, `flox` insists that the install id does not exist.

```
flox install github:nixos/nixpkgs#hello
flox upgrade hello
```

Expected:
```
ℹ️  No packages need to be upgraded in environment 'test'.
```

Expected (alternative):
```
⬆️  Upgraded 'hello' in environment 'test'.

```

Actual output:
```
❌ ERROR: no package or group named 'hello' in the manifest
```

## Proposed Changes

This was caused by `pkg_or_group_found_in_manifest` returning `false` early for all descriptors but catalog descriptors (assumably due to only them supporting groups and not taking ids into account).

This commit ensures that we still check against ids for other descriptors.


## Release Notes

`flox upgrade` can now upgrade packages installed from flakes by install id. (fixes #2463)

