### PR TITLE
fix: zshenv -> zshrc zprofile

### DIFF
--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -482,7 +482,7 @@ fn prompt_to_modify_rc_file() -> Result<bool, anyhow::Error> {
     };
     let rc_file_names = match shell {
         Shell::Bash(_) => vec![".bashrc", ".profile"],
-        Shell::Zsh(_) => vec![".zshenv"],
+        Shell::Zsh(_) => vec![".zshrc", ".zprofile"],
         Shell::Tcsh(_) => vec![".tcshrc"],
         Shell::Fish(_) => vec!["config.fish"],
     };


### PR DESCRIPTION
## Proposed Changes
Bug:
- We put the eval .. line in ~/.zshenv
- path_helper on macOS runs after that, so /usr/loca/bin isn't even in PATH yet
- flox isn't found
- Even if it was found, all of the stuff flox adds to PATH would be put at the end of PATH by path_helper

Solution:
- Put the `eval` line in both `.zshrc` and `.zprofile`
- This doesn't cover the case of a non-login non-interactive shell (which is only possible on Linux).
- We acknowledge that case and hope that a user running a command this way will already have
   the default environment active in the shell running the command.

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
