### PR TITLE
feat: use nix to get derivation info for publish

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -578,8 +578,8 @@ pub mod tests {
         let (flox, _temp_dir_handle) = flox_instance();
         // Some of this found heuristically, and _probably_ won't change
         assert_eq!(meta.name.starts_with("nix-"), true);
-        assert_eq!(meta.outputs.len(), 5);
-        assert_eq!(meta.outputs_to_install.len(), 5);
+        assert!(meta.outputs.len() >= 4);
+        assert_eq!(meta.outputs_to_install.len(), meta.outputs.len());
         assert_eq!(meta.outputs[0].store_path.starts_with("/nix/store/"), true);
         assert_eq!(meta.drv_path.starts_with("/nix/store/"), true);
         assert_eq!(meta.version.is_none(), true);

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -89,7 +89,7 @@ impl Publish {
             check_environment_metadata(&flox, &mut env).or_else(|e| bail!(e.to_string()))?;
 
         let build_metadata =
-            check_build_metadata(&env, &package, &flox.system).or_else(|e| bail!(e.to_string()))?;
+            check_build_metadata(&env, &package).or_else(|e| bail!(e.to_string()))?;
 
         let cache = cache_args.map(|args| NixCopyCache {
             url: args.url,

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -85,11 +85,9 @@ impl Publish {
             bail!("Unsupported environment type");
         }
 
-        let env_metadata =
-            check_environment_metadata(&flox, &mut env).or_else(|e| bail!(e.to_string()))?;
+        let env_metadata = check_environment_metadata(&flox, &mut env)?;
 
-        let build_metadata =
-            check_build_metadata(&env, &package).or_else(|e| bail!(e.to_string()))?;
+        let build_metadata = check_build_metadata(&env, &package)?;
 
         let cache = cache_args.map(|args| NixCopyCache {
             url: args.url,


### PR DESCRIPTION
Refactor code for publish to use `nix derivation show` on the `realpath` of the output link from the build to gather all the info used to publish to the catalog.