### PR TITLE
test(services): Fix flakey watchdog tests

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -119,7 +119,7 @@ teardown() {
   # by the watchdog as the activation terminates.
   if [ -n "${PROJECT_DIR:-}" ]; then
     # Not all tests call project_setup
-    wait_for_watchdogs "$PROJECT_DIR"
+    wait_for_watchdogs "$PROJECT_DIR" || return 1
     project_teardown
   fi
   common_test_teardown

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -41,7 +41,7 @@ setup() {
 
 teardown() {
   cat_teardown_fifo
-  wait_for_watchdogs "$PROJECT_DIR"
+  wait_for_watchdogs "$PROJECT_DIR" || return 1
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -39,7 +39,7 @@ setup() {
 
 teardown() {
   cat_teardown_fifo
-  wait_for_watchdogs "$PROJECT_DIR"
+  wait_for_watchdogs "$PROJECT_DIR" || return 1
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -37,7 +37,7 @@ setup() {
 }
 
 teardown() {
-  wait_for_watchdogs "$PROJECT_DIR"
+  wait_for_watchdogs "$PROJECT_DIR" || return 1
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -42,7 +42,7 @@ setup() {
 
 teardown() {
   unset _FLOX_FLOXHUB_GIT_URL
-  wait_for_watchdogs "$PROJECT_DIR"
+  wait_for_watchdogs "$PROJECT_DIR" || return 1
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -902,7 +902,7 @@ EOF
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
   mkfifo "$TEARDOWN_FIFO"
   "$FLOX_BIN" activate -s -- echo \> "$TEARDOWN_FIFO" &
-  activate_pid="$!"
+
   # Make sure the first `process-compose` gets up and running
   "${TESTS_DIR}"/services/wait_for_service_status.sh one:Running
 
@@ -1416,7 +1416,6 @@ EOF
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
   mkfifo "$TEARDOWN_FIFO"
   "$FLOX_BIN" activate -s -- echo \> "$TEARDOWN_FIFO" &
-  activate_pid="$!"
 
   # Since `one` is just an `echo` it will complete almost immediately once it has
   # started, we just need to make we wait until after it has started.

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -898,8 +898,10 @@ EOF
 
 @test "activate services: shows warning when services already running" {
   setup_sleeping_services
-  mkfifo fifo
-  "$FLOX_BIN" activate -s -- echo \> fifo &
+
+  TEARDOWN_FIFO="$PROJECT_DIR/finished"
+  mkfifo "$TEARDOWN_FIFO"
+  "$FLOX_BIN" activate -s -- echo \> "$TEARDOWN_FIFO" &
   activate_pid="$!"
   # Make sure the first `process-compose` gets up and running
   "${TESTS_DIR}"/services/wait_for_service_status.sh one:Running
@@ -907,10 +909,6 @@ EOF
   run "$FLOX_BIN" activate -s -- true
   assert_success
   assert_output --partial "⚠️  Skipped starting services, services are already running"
-
-  # Technically this should be a teardown step
-  # The test will hang forever if it fails and doesn't get here
-  timeout 2 cat fifo
 }
 
 # ---------------------------------------------------------------------------- #
@@ -1415,8 +1413,9 @@ EOF
 
   # Edit the manifest adding a second service and changing the value of FOO.
   # Then start services again.
-  mkfifo fifo
-  "$FLOX_BIN" activate -s -- echo \> fifo &
+  TEARDOWN_FIFO="$PROJECT_DIR/finished"
+  mkfifo "$TEARDOWN_FIFO"
+  "$FLOX_BIN" activate -s -- echo \> "$TEARDOWN_FIFO" &
   activate_pid="$!"
 
   # Since `one` is just an `echo` it will complete almost immediately once it has
@@ -1454,10 +1453,6 @@ EOF
   run "$FLOX_BIN" services logs one
   assert_success
   assert_output "foo_two"
-
-  # Technically this should be a teardown step
-  # The test will hang forever if it fails and doesn't get here
-  timeout 2 cat fifo
 }
 
 @test "services stop after multiple activations of an environment exit" {

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -88,7 +88,7 @@ teardown() {
   # Within the `services` tests, we call `setup_isolated_flox` during `setup()`,
   # which sets the data dir to a unique value for every test,
   # thus avoiding waiting for unrelated watchdog processes.
-  wait_for_watchdogs "$PROJECT_DIR"
+  wait_for_watchdogs "$PROJECT_DIR" || return 1
   project_teardown
   common_test_teardown
 }

--- a/cli/tests/watchdog.bats
+++ b/cli/tests/watchdog.bats
@@ -39,7 +39,7 @@ setup() {
 }
 
 teardown() {
-  wait_for_watchdogs "$PROJECT_DIR"
+  wait_for_watchdogs "$PROJECT_DIR" || return 1
   project_teardown
   common_test_teardown
 }


### PR DESCRIPTION
## Proposed Changes

Prevents `wait_for_watchdogs` from swallowing output and makes an offending test more reliable.

This is best reviewed commit-by-commit because each one contains more detail in the commit message.

## Release Notes

N/A, tests only