### PR TITLE
docs: update link to default environment tutorial

### DIFF
--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -510,7 +510,7 @@ fn prompt_to_modify_rc_file() -> Result<bool, anyhow::Error> {
 
     let read_more_msg = formatdoc! {"
         -> Read more about the 'default' environment at:
-           https://flox.dev/docs/tutorials/layering-multiple-environments/#create-your-default-home-environment"};
+           https://flox.dev/docs/tutorials/default-environment/"};
     let restart_msg = formatdoc! {"
         The 'default' environment will be activated for every new shell.
         -> Restart your shell to continue using the default environment."};


### PR DESCRIPTION
We've added a full tutorial with more information about the default environment and want to link that page in the prompt about the default environment.

Closes https://github.com/flox/flox/issues/2510

## Release Notes

Minor: updated a link to point at a new docs page