### PR TITLE
test: enable macos containerize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
           - "containerize"
           - "catalog"
           - "!activate,!containerize,!catalog"
+        exclude:
+          # Skip containerize tests on the macOS runner because we can't double nest virtualization
+          - os: "macos-14-xlarge"
+            test-tags: "containerize"
 
     steps:
       - name: "Checkout"
@@ -158,6 +162,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           AUTH0_FLOX_DEV_CLIENT_SECRET: "${{ secrets.MANAGED_AUTH0_FLOX_DEV_CLIENT_SECRET }}"
+          FLOX_CI_RUNNER: "github-${{ matrix.os }}"
         run: |
           nix develop -L --no-update-lock-file --command just integ-tests --\
             --filter-tags '"${{ matrix.test-tags }}"'
@@ -365,6 +370,10 @@ jobs:
         test-tags:
           - "containerize"
           - "!containerize"
+        exclude:
+          # Skip containerize tests on this runner because it's actually Rosetta on aarch64-darwin
+          - system: "x86_64-darwin"
+            test-tags: "containerize"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -393,6 +402,8 @@ jobs:
 
       - name: "Run Bats Tests (./#flox-cli-tests)"
         timeout-minutes: 30
+        env:
+          FLOX_CI_RUNNER: "flox-${{ matrix.system }}"
         run: |
           git clean -xfd
           ssh github@$REMOTE_SERVER_ADDRESS \

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -43,19 +43,109 @@ podman_cache_reset() {
   true
 }
 
+# We need to handle some directories globally for this file, so we need a
+# different setup routine than the typical `home_setup` function.
+podman_home_setup() {
+  if [[ "${__FT_RAN_HOME_SETUP:-}" = "real" ]]; then
+    export FLOX_TEST_HOME="$REAL_HOME"
+    export HOME="$REAL_HOME"
+  else
+    tmpdir="$(mktemp -d "/tmp/home.XXXXXX")"
+    mkdir -p "$tmpdir"
+    export FLOX_TEST_HOME="$tmpdir"
+    # Force recreation on `home' on every invocation.
+    unset __FT_RAN_HOME_SETUP
+  fi
+  echo "Podman home dir: $FLOX_TEST_HOME" >&3
+  export __FT_RAN_HOME_SETUP="$FLOX_TEST_HOME"
+}
+
+podman_xdg_vars_setup() {
+  home_dir="$1"; shift;
+  short_tmp_dir="$1"; shift;
+
+  xdg_reals_setup
+  # These get unset by the preceding function call and must be restored in order
+  # to use a single podman machine across the test run
+  export XDG_CONFIG_HOME="$short_tmp_dir/.config"
+  export XDG_DATA_HOME="$short_tmp_dir/.local/share"
+  export XDG_RUNTIME_DIR="$short_tmp_dir/run"
+
+  test_cache_dir="${home_dir:?}/.cache"
+  test_state_dir="${home_dir:?}/.local/state"
+
+  # Create all of the directories
+  mkdir -p "$home_dir"
+  mkdir -p "$test_cache_dir"
+  mkdir -p "$test_state_dir"
+  chmod u+w "$home_dir"
+  chmod u+w "$test_cache_dir"
+  chmod u+w "$test_state_dir"
+
+  # Export the vars
+  export XDG_CACHE_HOME="$test_cache_dir"
+  export XDG_STATE_HOME="$test_state_dir"
+}
+
+# This is the same as the global `flox_vars_setup` except it doesn't run
+# `xdg_vars_setup` again.
+podman_flox_vars_setup() {
+  # We store sockets in FLOX_CACHE_DIR,
+  # so create cache in /tmp since TMPDIR may result in too long of a path.
+  FLOX_CACHE_DIR="$(mktemp -d /tmp/flox.tests.XXXXXX)"
+  export FLOX_CACHE_DIR
+  export FLOX_CONFIG_DIR="$XDG_CONFIG_HOME/flox"
+  export FLOX_DATA_HOME="$XDG_DATA_HOME/flox"
+  export FLOX_STATE_HOME="$XDG_STATE_HOME/flox"
+  export FLOX_META="$FLOX_CACHE_DIR/meta"
+  export FLOX_ENVIRONMENTS="$FLOX_DATA_HOME/environments"
+  export HOME="${FLOX_TEST_HOME:-$HOME}"
+}
+
+
+podman_dirs_setup() {
+  # Podman creates deeply nested directories and stores sockets in some of them,
+  # so we need to create locations to store those with shorter paths than what
+  # we'd get nesting them under `/tmp/nix-shell.XXXXXX/bats-run-XXXXXX`.
+  export SHORT_TMP="$(mktemp -d "/tmp/XXXXXX")"
+  export TMPDIR="$SHORT_TMP"
+  export XDG_CONFIG_HOME="$SHORT_TMP/.config"
+  export XDG_DATA_HOME="$SHORT_TMP/.local/share"
+  export XDG_RUNTIME_DIR="$SHORT_TMP/run"
+  echo "Podman XDG root: $SHORT_TMP" >&3
+  mkdir -p "$XDG_CONFIG_HOME/containers"
+  mkdir -p "$XDG_DATA_HOME"
+  mkdir -p "$XDG_RUNTIME_DIR"
+
+  # Don't require Rosetta unless cross-compiling on builders.
+  if [[ "${NIX_SYSTEM}" != "x86_64-darwin" ]]; then
+    cat > "$XDG_CONFIG_HOME/containers/containers.conf" <<'EOF'
+[machine]
+rosetta = false
+EOF
+  fi
+  
+  podman_home_setup
+  podman_xdg_vars_setup "$FLOX_TEST_HOME" "$SHORT_TMP"
+  podman_flox_vars_setup
+}
+
+start_podman_machine() {
+  machine="$(podman machine list -n)"
+  if [ -z "$machine" ]; then
+    echo "Creating podman machine" >&3
+    podman machine init -v /tmp:/tmp -v /Users:/Users -v /private:/private
+  fi
+  echo "Starting podman machine" >&3
+  podman machine start
+}
+
 # ---------------------------------------------------------------------------- #
 
 setup() {
-  common_test_setup
   setup_isolated_flox
   project_setup
 
-  mkdir -p $HOME/.config/containers
-  echo '{ "default": [ {"type": "insecureAcceptAnything"} ] }' > "$HOME/.config/containers/policy.json"
-
-  if ! is_linux; then
-    return
-  fi
   # flox does not allow to set a $HOME
   # that does not correspond to the effective user's,
   # but podman requires the policy.json set in the **test user's** $HOME,
@@ -96,6 +186,15 @@ setup_file() {
   # As a side effect the individual tests will run faster
   # because podman does not need to serialize writes to the cache.
   export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  # Only for macOS, don't force rootless on Linux.
+  if ! is_linux; then
+    podman_dirs_setup
+    start_podman_machine
+  fi
+
+  mkdir -p "$XDG_CONFIG_HOME/containers"
+  echo '{ "default": [ {"type": "insecureAcceptAnything"} ] }' > "$XDG_CONFIG_HOME/containers/policy.json"
 }
 
 teardown() {
@@ -106,6 +205,12 @@ teardown() {
 teardown_file() {
   podman_cache_reset
   common_file_teardown
+
+  if ! is_linux; then
+    podman machine stop
+    rm -rf "$SHORT_TMP"
+    rm -rf "$FLOX_TEST_HOME"
+  fi
 }
 
 # ---------------------------------------------------------------------------- #
@@ -146,7 +251,6 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:default-to-file
 @test "container is written to a runtime by default" {
-  skip_if_not_linux
   env_setup_catalog
 
   # Check that podman is installed
@@ -158,7 +262,7 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 }
 
 # bats test_tags=containerize:default-to-file
-@test "container is written to a file if no runtime is found on PATH" {
+@test "container is written to a file if no runtime is found on PATH on Linux" {
   skip_if_not_linux
   env_setup_catalog
 
@@ -169,8 +273,6 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:container-tag
 @test "container is tagged with specified tag" {
-  skip_if_not_linux
-
   env_setup_catalog
 
   # Check that podman is installed
@@ -183,7 +285,6 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:piped-to-runtime
 @test "container is written to runtime when '--runtime <runtime>' is passed" {
-  skip_if_not_linux
   env_setup_catalog
 
   run bash -c '"$FLOX_BIN" containerize --tag "runtime" --runtime podman' 3>&-
@@ -196,7 +297,7 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:runtime-not-in-path
 @test "error if runtime not in PATH" {
-  skip_if_not_linux
+  skip_if_not_linux # macOS checks for the container runtime earlier.
   env_setup_catalog
 
   run bash -c 'PATH= "$FLOX_BIN" containerize --runtime podman' 3>&-
@@ -231,8 +332,6 @@ function assert_container_output() {
 
 # bats test_tags=containerize:run-container-i
 @test "container can be run with 'podman/docker run' with/without -i'" {
-  skip_if_not_linux
-
   env_setup_catalog
 
   # Also tests writing to STDOUT with `-f -`

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -109,7 +109,7 @@ floxhub_setup() {
 
 # Isolate flox config, data, and cache from the potentially shared
 # xdg directories.
-# This is necessary as other wisemultiple tests contest for the same
+# This is necessary as otherwise multiple tests contest for the same
 # resources, e.g.:
 # * the global manifest and lockfile
 #   + created by multiple processes

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -90,6 +90,7 @@ let
       yq
       process-compose
       procps
+      podman
     ]
     # TODO: this hack is not going to be needed once we test against stuff on system
     ++ lib.optional stdenv.isDarwin (
@@ -108,11 +109,7 @@ let
           mkdir -p "$out/bin"
           echo "$source" | gcc -Wall -o "$out/bin/$name" -xc -
         ''
-    )
-    # Containerize tests need a container runtime.
-    # Since we're building and building only works on linux,
-    # we only include podman on linux.
-    ++ lib.optionals stdenv.isLinux [ podman ];
+    );
 in
 # TODO: we should run tests against different shells
 writeShellScriptBin PROJECT_NAME ''


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Enable macOS tests in CI for `flox containerize`. This starts a `podman` VM for the `containerize.bats` file,
and reuses it for each test. This means that XDG and home dirs are shared for all tests in the file. This is necessary
because `vfkit`, which starts the VM, creates a file under the hard-coded path `$HOME/Library/Application Support/vfkit`.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
