### PR TITLE
fix(Justfile): gen-data depend on build-cli

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -105,7 +105,7 @@ clean-builds:
     pushd cli; cargo build -p mk_data; popd
 
 # Generate test data
-@gen-data +mk_data_args="": build-data-gen
+@gen-data +mk_data_args="": build-data-gen build-cli
     mkdata="$PWD/cli/target/debug/mk_data"; pushd test_data; "$mkdata" {{mk_data_args}} config.toml; popd
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

It depends on `flox` to generate and manipulate environments. So it wouldn't work on a fresh checkout or, in the case where I noticed, everything wasn't rebuilt after 083abecb:

    % just gen-data -f
    ~/projects/flox/flox/cli ~/projects/flox/flox
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
    ~/projects/flox/flox
    ~/projects/flox/flox/test_data ~/projects/flox/flox
    Error: failed while executing jobs

    Caused by:
        0: failed to execute job: node_yarn
        1: cmd failed
        2: ❌ ERROR: Failed to build environment:

           Failed to constructed environment: error: getting status of '/Users/dcarley/projects/flox/flox/build/flox-buildenv/buildenv.nix': No such file or directory

## Release Notes

N/A, development only.