### PR TITLE
build(buildenv): drop dependency on flox-interpreter in dev builds

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -56,8 +56,11 @@ build-cdb:
     nix {{nix_options}} build .#flox-manpages -o build/flox-manpages
 
 # Build the activation scripts
+# `pure-eval` is disabled because `FLOX_ACTIVATIONS_BIN`
+# is read from the environment.
 @build-activation-scripts: build-activations
     nix {{nix_options}} build \
+        --option pure-eval false \
         '.#floxDevelopmentPackages.flox-activation-scripts^*' \
         -o $FLOX_INTERPRETER
 
@@ -68,8 +71,11 @@ build-cdb:
         -o "$FLOX_PACKAGE_BUILDER"
 
 # Build the flox buildenv
+# `pure-eval` is disabled because `FLOX_INTERPRETER`
+# is read from the environment.
 @build-buildenv:
     nix {{nix_options}} build \
+        --option pure-eval false \
         ".#floxDevelopmentPackages.flox-buildenv" \
         -o "$FLOX_BUILDENV"
 

--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,7 @@
           };
           flox-package-builder = prev.flox-package-builder.override { };
           flox-buildenv = prev.flox-buildenv.override {
+            flox-activation-scripts = null;
             flox-pkgdb = null;
           };
           checksFor = checks.${prev.system};

--- a/pkgs/flox-buildenv/default.nix
+++ b/pkgs/flox-buildenv/default.nix
@@ -13,14 +13,28 @@
   writers,
   writeText,
 }:
+# We need to ensure that the flox-activation-scripts package is available.
+# If it's not, we'll use the binary from the environment.
+# Build or evaluate this package with `--option pure-eval false`.
+assert (flox-activation-scripts == null) -> builtins.getEnv "FLOX_INTERPRETER" != null;
 let
   pname = "flox-buildenv";
   version = "0.0.1";
   buildenv = (writers.writeBash "buildenv" (builtins.readFile ../../buildenv/buildenv.bash));
   buildenv_nix = ../../buildenv/buildenv.nix;
   builder_pl = ../../buildenv/builder.pl;
-  activationScripts_out = flox-activation-scripts.out;
-  activationScripts_build_wrapper = flox-activation-scripts.build_wrapper;
+  activationScripts_fallback = builtins.getEnv "FLOX_INTERPRETER";
+  activationScripts_out =
+    if flox-activation-scripts != null then
+      flox-activation-scripts.out
+    else
+      "${activationScripts_fallback}";
+  activationScripts_build_wrapper =
+    if flox-activation-scripts != null then
+      flox-activation-scripts.build_wrapper
+    else
+      "${activationScripts_fallback}-build_wrapper";
+
   defaultEnvrc = writeText "default.envrc" (
     ''
       # Default environment variables


### PR DESCRIPTION
Even in dev builds building `flox-buildenv` resulted in a nix build of the `flox-activation-scripts` package, which we aim to avoid.
This commit removes the dependency on `flox-activation-scripts` in builds of the `floxDevelopmentPackages.flox-buildenv`, in which case `flox-buildenv` will depend on `$FLOX_INTERPRETER` at runtime.

This is achieved by "baking in" an absolute path to `flox-activation-scripts` into `buildenv.nix` as well as `flox-activations` into `flox-activation-scripts`.
It's no coincidence that both used to be meant to be loaded from the environment _at runtime_.
However, `flox-activation-scripts` is also a part of manifest builds, in which case the `FLOX_ACTIVATION_SCRIPTS` or respectively the `FLOX_INTERPRETER` variables would be unavailable (particularly when sandboxed).
Further we have to copy `FLOX_INTERPRETER` to the store to allow builds to access it, as well as to produce valid containers that do not reference "outside" binaries.


