### PR TITLE
fix: init_logger sooner

### DIFF
--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -49,10 +49,6 @@ fn main() -> ExitCode {
     // Avoid SIGPIPE from killing the process
     reset_sigpipe();
 
-    // initialize logger with "best guess" defaults
-    // updating the logger conf is cheap, so we reinitialize whenever we get more information
-    init_logger(None);
-
     // Quit early if `--prefix` is present
     if Prefix::check() {
         println!(env!("out"));

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -77,6 +77,8 @@ fn main() -> ExitCode {
             .unwrap_or_default()
     };
 
+    init_logger(Some(verbosity));
+
     if let Err(err) = set_user() {
         message::error(err.to_string());
         return ExitCode::from(1);
@@ -87,7 +89,6 @@ fn main() -> ExitCode {
         .flox
         .disable_metrics;
 
-    init_logger(Some(verbosity));
     // Sentry client must be initialized before starting an async runtime or spawning threads
     // https://docs.sentry.io/platforms/rust/#async-main-function
     let _sentry_guard = (!disable_metrics).then(init_sentry);


### PR DESCRIPTION
Currently the logger is initialized after `set_user` which means that
`warn!` in `set_user` doesn't respect `--quiet`.

This meant there was no way to silence the warning:
```
WARN flox: cannot determine effective uid - continuing as user 'floxfan'
```

Move `init_logger` before `set_user` so that `--quiet` is respected.

## Release Notes

Warnings about determining effective uid now respect `flox --quiet`