### PR TITLE
cache /nix/store for macOS container builder

### DIFF
--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -9,7 +9,7 @@ _sort="@coreutils@/bin/sort"
 # and we print a message to the user
 # If inside a container, FLOX_ENV_DESCRIPTION won't be set, and we don't need to
 # print a message
-if [ -t 1 ] && [ $# -eq 0 ]; then
+if [ -t 1 ] && [ $# -eq 0 ] && [ -n "${FLOX_ENV_DESCRIPTION:-}" ]; then
   echo "✅ You are now using the environment '$FLOX_ENV_DESCRIPTION'." >&2
   echo "To stop using this environment, type 'exit'" >&2
   echo >&2


### PR DESCRIPTION
See commits

I didn't add tests because that would purely be checking podman and Docker behavior. Since we don't ship a version of podman or Docker there's also not an obvious version to test. But if behavior changes in either of those tools we would regress

Cleaning up the volume (and docs in the manpage) will come in a followup.

## Release Notes

`flox containerize` is now faster on macOS as `/nix/store` is cached across `flox containerize` invocations. Flox now creates a podman or Docker volume named `flox-nix`; it can be removed.