### PR TITLE
feat: Show catalog name in search results

### DIFF
--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -298,6 +298,8 @@ pub struct SearchResult {
     ///
     /// TODO: rename this attr_path or pkg_path
     pub rel_path: Vec<String>,
+    /// The package path including catalog name
+    pub pkg_path: String,
     /// The package name
     pub pname: Option<String>,
     /// The package version
@@ -330,6 +332,7 @@ mod test {
         "relPath": [
             "hello"
         ],
+        "pkgPath": "hello",
         "subtree": "legacyPackages",
         "system": "aarch64-darwin",
         "stability": null,

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1261,7 +1261,7 @@ impl TryFrom<PackageInfoSearch> for SearchResult {
 
     fn try_from(package_info: PackageInfoSearch) -> Result<Self, SearchError> {
         Ok(Self {
-            input: NIXPKGS_CATALOG.to_string(),
+            input: package_info.catalog.unwrap_or(NIXPKGS_CATALOG.to_string()),
             system: package_info.system.to_string(),
             // The server does not include legacyPackages.<system> in attr_path
             rel_path: package_info
@@ -1273,6 +1273,7 @@ impl TryFrom<PackageInfoSearch> for SearchResult {
             version: None,
             description: package_info.description,
             license: None,
+            pkg_path: package_info.pkg_path,
         })
     }
 }
@@ -1281,8 +1282,13 @@ impl TryFrom<api_types::PackageResolutionInfo> for SearchResult {
     type Error = VersionsError;
 
     fn try_from(package_info: api_types::PackageResolutionInfo) -> Result<Self, VersionsError> {
+        let pkg_path = match &package_info.catalog {
+            Some(catalog) => format!("{}/{}", catalog, package_info.attr_path),
+            None => package_info.attr_path.clone(),
+        };
+
         Ok(Self {
-            input: NIXPKGS_CATALOG.to_string(),
+            input: package_info.catalog.unwrap_or(NIXPKGS_CATALOG.to_string()),
             system: package_info.system.to_string(),
             // The server does not include legacyPackages.<system> in attr_path
             rel_path: package_info
@@ -1294,6 +1300,7 @@ impl TryFrom<api_types::PackageResolutionInfo> for SearchResult {
             version: Some(package_info.version),
             description: package_info.description,
             license: package_info.license,
+            pkg_path,
         })
     }
 }

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -15,6 +15,8 @@ pub const DEFAULT_DESCRIPTION: &'_ str = "<no description provided>";
 pub struct DisplayItem {
     /// The input that the package came from
     input: String,
+    /// The package path of the package, including catalog name
+    pkg_path: String,
     /// The attribute path of the package, excluding subtree and system
     rel_path: Vec<String>,
     /// The package description
@@ -38,7 +40,7 @@ impl Display for DisplayItem {
         if self.render_with_input {
             write!(f, "{}{SEARCH_INPUT_SEPARATOR}", self.input)?;
         }
-        write!(f, "{}", self.rel_path.join("."))
+        write!(f, "{}", self.pkg_path)
     }
 }
 
@@ -90,6 +92,7 @@ impl From<Vec<SearchResult>> for DisplayItems {
             .into_iter()
             .map(|r| DisplayItem {
                 input: r.input,
+                pkg_path: r.pkg_path,
                 rel_path: r.rel_path,
                 description: r.description.map(|s| s.replace('\n', " ")),
                 render_with_input: false,

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -173,7 +173,11 @@ impl Display for DisplaySearchResults {
         let mut items = self.display_items.iter().peekable();
 
         while let Some(d) = items.next() {
-            let desc = d.description.as_deref().unwrap_or(DEFAULT_DESCRIPTION);
+            let desc = if d.description.as_deref().is_none_or(|s| s.is_empty()) {
+                DEFAULT_DESCRIPTION
+            } else {
+                d.description.as_deref().unwrap()
+            };
             let name = format_name(&d.to_string());
 
             // The two spaces here provide visual breathing room.

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -115,7 +115,7 @@ impl Display for DisplaySearchResults {
         let column_width = self
             .display_items
             .iter()
-            .map(|d| format_name(&d.to_string()).len())
+            .map(|d| d.to_string().len())
             .max()
             .unwrap_or_default();
 
@@ -129,9 +129,10 @@ impl Display for DisplaySearchResults {
                 d.description.as_deref().unwrap()
             };
             let name = format_name(&d.to_string());
+            let width = column_width + (name.len() - d.to_string().len());
 
             // The two spaces here provide visual breathing room.
-            write!(f, "{name:<column_width$}  {desc}")?;
+            write!(f, "{name:<width$}  {desc}")?;
             // Only print a newline if there are more items to print
             if items.peek().is_some() {
                 writeln!(f)?;

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -158,3 +158,73 @@ impl DisplaySearchResults {
             ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use flox_rust_sdk::models::search::SearchResult;
+    use indoc::indoc;
+
+    use super::*;
+
+    #[test]
+    fn test_display_search_result() {
+        let search_results = vec![
+            SearchResult {
+                input: "nixpkgs".to_string(),
+                pkg_path: "pkg1".to_string(),
+                description: Some("description of pkg1".to_string()),
+                ..Default::default()
+            },
+            SearchResult {
+                input: "mycatalog".to_string(),
+                pkg_path: "mycatalog/pkg1".to_string(),
+                description: Some("description of mycatalog/pkg1".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let display = DisplaySearchResults {
+            search_term: "pkg1".to_string(),
+            count: Some(search_results.len() as u64),
+            display_items: search_results.into(),
+            n_results: 2,
+            use_bold: false,
+        };
+
+        let expected = indoc! {"
+            pkg1            description of pkg1
+            mycatalog/pkg1  description of mycatalog/pkg1
+            "};
+        assert_eq!(expected, format!("{}\n", display));
+    }
+
+    #[test]
+    fn test_display_empty_description() {
+        let search_results = vec![
+            SearchResult {
+                pkg_path: "pkg1".to_string(),
+                description: None,
+                ..Default::default()
+            },
+            SearchResult {
+                pkg_path: "pkg2".to_string(),
+                description: Some("".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let display = DisplaySearchResults {
+            search_term: "pkg".to_string(),
+            count: Some(search_results.len() as u64),
+            display_items: search_results.into(),
+            n_results: 2,
+            use_bold: false,
+        };
+
+        let expected = indoc! {"
+            pkg1  <no description provided>
+            pkg2  <no description provided>
+            "};
+        assert_eq!(expected, format!("{}\n", display));
+    }
+}

--- a/test_data/generated/resolve/node_suggestions.json
+++ b/test_data/generated/resolve/node_suggestions.json
@@ -16,12 +16,13 @@
     }
   ],
   {
-    "count": 67,
+    "count": 68,
     "results": [
       {
         "description": "Event-driven I/O framework for the V8 JavaScript engine",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "nodejs",
         "pname": "nodejs",
         "relPath": [
           "nodejs"
@@ -33,6 +34,7 @@
         "description": "Event-driven I/O framework for the V8 JavaScript engine",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "nodejs_14",
         "pname": "nodejs_14",
         "relPath": [
           "nodejs_14"
@@ -44,6 +46,7 @@
         "description": "Event-driven I/O framework for the V8 JavaScript engine",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "nodejs_16",
         "pname": "nodejs_16",
         "relPath": [
           "nodejs_16"

--- a/test_data/generated/resolve/package_suggestions.json
+++ b/test_data/generated/resolve/package_suggestions.json
@@ -16,12 +16,13 @@
     }
   ],
   {
-    "count": 3180,
+    "count": 3203,
     "results": [
       {
         "description": "System to facilitate installing and updating packages",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "packagekit",
         "pname": "packagekit",
         "relPath": [
           "packagekit"
@@ -33,6 +34,7 @@
         "description": "Package manager for PureScript based on package sets",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "psc-package",
         "pname": "psc-package",
         "relPath": [
           "psc-package"
@@ -44,6 +46,7 @@
         "description": "Fix broken node modules instantly",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "patch-package",
         "pname": "patch-package",
         "relPath": [
           "patch-package"

--- a/test_data/generated/search/ello_all.json
+++ b/test_data/generated/search/ello_all.json
@@ -1,11 +1,12 @@
 [
   {
-    "count": 63,
+    "count": 64,
     "results": [
       {
         "description": "Program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -17,6 +18,7 @@
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "jello",
         "pname": "jello",
         "relPath": [
           "jello"
@@ -28,6 +30,7 @@
         "description": "Simple program printing hello world in Go",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello-go",
         "pname": "hello-go",
         "relPath": [
           "hello-go"
@@ -39,6 +42,7 @@
         "description": "Higher level programming in C",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "libcello",
         "pname": "libcello",
         "relPath": [
           "libcello"
@@ -50,6 +54,7 @@
         "description": "Basic sanity check that C++ and cmake infrastructure are working",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello-cpp",
         "pname": "hello-cpp",
         "relPath": [
           "hello-cpp"
@@ -61,6 +66,7 @@
         "description": "GTK3-based greeter for the greetd daemon, written in python",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "nwg-hello",
         "pname": "nwg-hello",
         "relPath": [
           "nwg-hello"
@@ -72,6 +78,7 @@
         "description": "SocketCAN over Ethernet tunnel",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "cannelloni",
         "pname": "cannelloni",
         "relPath": [
           "cannelloni"
@@ -83,6 +90,7 @@
         "description": "Example package with unfree license (for testing)",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello-unfree",
         "pname": "hello-unfree",
         "relPath": [
           "hello-unfree"
@@ -94,6 +102,7 @@
         "description": "Cloud music integration for your desktop",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "mellowplayer",
         "pname": "mellowplayer",
         "relPath": [
           "mellowplayer"
@@ -105,6 +114,7 @@
         "description": "Hello world Wayland client",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello-wayland",
         "pname": "hello-wayland",
         "relPath": [
           "hello-wayland"
@@ -116,6 +126,7 @@
         "description": "Marwaita GTK theme with Pop_os Linux style",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "marwaita-yellow",
         "pname": "marwaita-yellow",
         "relPath": [
           "marwaita-yellow"
@@ -127,6 +138,7 @@
         "description": "Unified Modelling Language (UML) diagram program",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "libsForQt5.umbrello",
         "pname": "umbrello",
         "relPath": [
           "libsForQt5",
@@ -136,9 +148,22 @@
         "version": null
       },
       {
+        "description": "Aesthetic, modern fcitx5 theme featuring rounded rectangle design",
+        "input": "nixpkgs",
+        "license": null,
+        "pkgPath": "fcitx5-mellow-themes",
+        "pname": "fcitx5-mellow-themes",
+        "relPath": [
+          "fcitx5-mellow-themes"
+        ],
+        "system": "aarch64-darwin",
+        "version": null
+      },
+      {
         "description": "GUI for diagramming Unified Modelling Language (UML)",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "kdePackages.umbrello",
         "pname": "umbrello",
         "relPath": [
           "kdePackages",
@@ -151,6 +176,7 @@
         "description": "A Unified Modelling Language (UML) diagram program",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "libsForQt512.umbrello",
         "pname": "umbrello",
         "relPath": [
           "libsForQt512",
@@ -163,6 +189,7 @@
         "description": "A Unified Modelling Language (UML) diagram program",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "libsForQt514.umbrello",
         "pname": "umbrello",
         "relPath": [
           "libsForQt514",
@@ -175,6 +202,7 @@
         "description": "A Unified Modelling Language (UML) diagram program",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "libsForQt515.umbrello",
         "pname": "umbrello",
         "relPath": [
           "libsForQt515",
@@ -187,6 +215,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "emacsPackages.ellocate",
         "pname": "ellocate",
         "relPath": [
           "emacsPackages",
@@ -199,6 +228,7 @@
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python310Packages.jello",
         "pname": "jello",
         "relPath": [
           "python310Packages",
@@ -211,6 +241,7 @@
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python311Packages.jello",
         "pname": "jello",
         "relPath": [
           "python311Packages",
@@ -223,6 +254,7 @@
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python312Packages.jello",
         "pname": "jello",
         "relPath": [
           "python312Packages",
@@ -235,6 +267,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "sbclPackages.hello-clog",
         "pname": "hello-clog",
         "relPath": [
           "sbclPackages",
@@ -247,6 +280,7 @@
         "description": "Modification of a Go package to create othello boards",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "texlivePackages.othello",
         "pname": "othello",
         "relPath": [
           "texlivePackages",
@@ -259,6 +293,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "emacsPackages.org-trello",
         "pname": "org-trello",
         "relPath": [
           "emacsPackages",
@@ -271,6 +306,7 @@
         "description": "Unified Modelling Language (UML) diagram program",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "plasma5Packages.umbrello",
         "pname": "umbrello",
         "relPath": [
           "plasma5Packages",
@@ -283,6 +319,7 @@
         "description": "A Python 3 project to implement EZSP for EmberZNet devices",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python37Packages.bellows",
         "pname": "bellows",
         "relPath": [
           "python37Packages",
@@ -295,6 +332,7 @@
         "description": "Python module to implement EZSP for EmberZNet devices",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python38Packages.bellows",
         "pname": "bellows",
         "relPath": [
           "python38Packages",
@@ -307,6 +345,7 @@
         "description": "Python library for nello.io intercoms",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python38Packages.pynello",
         "pname": "pynello",
         "relPath": [
           "python38Packages",
@@ -319,6 +358,7 @@
         "description": "Python module to implement EZSP for EmberZNet devices",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python39Packages.bellows",
         "pname": "bellows",
         "relPath": [
           "python39Packages",
@@ -331,6 +371,7 @@
         "description": "Python library for nello.io intercoms",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python39Packages.pynello",
         "pname": "pynello",
         "relPath": [
           "python39Packages",
@@ -343,6 +384,7 @@
         "description": "Python module to implement EZSP for EmberZNet devices",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python310Packages.bellows",
         "pname": "bellows",
         "relPath": [
           "python310Packages",
@@ -355,6 +397,7 @@
         "description": "Python library for nello.io intercoms",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python310Packages.pynello",
         "pname": "pynello",
         "relPath": [
           "python310Packages",
@@ -367,6 +410,7 @@
         "description": "Python module to implement EZSP for EmberZNet devices",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python311Packages.bellows",
         "pname": "bellows",
         "relPath": [
           "python311Packages",
@@ -379,6 +423,7 @@
         "description": "Python library for nello.io intercoms",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python311Packages.pynello",
         "pname": "pynello",
         "relPath": [
           "python311Packages",
@@ -391,6 +436,7 @@
         "description": "Python module to implement EZSP for EmberZNet devices",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python312Packages.bellows",
         "pname": "bellows",
         "relPath": [
           "python312Packages",
@@ -403,6 +449,7 @@
         "description": "Python library for nello.io intercoms",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python312Packages.pynello",
         "pname": "pynello",
         "relPath": [
           "python312Packages",
@@ -415,6 +462,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "emacsPackages.mellow-theme",
         "pname": "mellow-theme",
         "relPath": [
           "emacsPackages",
@@ -427,6 +475,7 @@
         "description": "Execute loops using parallel forked subprocesses",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "perlPackages.ParallelLoops",
         "pname": "ParallelLoops",
         "relPath": [
           "perlPackages",
@@ -439,6 +488,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "sbclPackages.hello-builder",
         "pname": "hello-builder",
         "relPath": [
           "sbclPackages",
@@ -451,6 +501,7 @@
         "description": "Maven Hello World",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "javaPackages.mavenHello_1_0",
         "pname": "mavenHello_1_0",
         "relPath": [
           "javaPackages",
@@ -463,6 +514,7 @@
         "description": "Maven Hello World",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "javaPackages.mavenHello_1_1",
         "pname": "mavenHello_1_1",
         "relPath": [
           "javaPackages",
@@ -475,6 +527,7 @@
         "description": "Typeset Othello (Reversi) diagrams of any size, with annotations",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "texlivePackages.othelloboard",
         "pname": "othelloboard",
         "relPath": [
           "texlivePackages",
@@ -487,6 +540,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "emacsPackages.sly-hello-world",
         "pname": "sly-hello-world",
         "relPath": [
           "emacsPackages",
@@ -499,6 +553,7 @@
         "description": "Execute loops using parallel forked subprocesses",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "perl536Packages.ParallelLoops",
         "pname": "ParallelLoops",
         "relPath": [
           "perl536Packages",
@@ -511,6 +566,7 @@
         "description": "Execute loops using parallel forked subprocesses",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "perl538Packages.ParallelLoops",
         "pname": "ParallelLoops",
         "relPath": [
           "perl538Packages",
@@ -523,6 +579,7 @@
         "description": "Execute loops using parallel forked subprocesses",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "perl540Packages.ParallelLoops",
         "pname": "ParallelLoops",
         "relPath": [
           "perl540Packages",
@@ -535,6 +592,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "sbclPackages.qtools-helloworld",
         "pname": "qtools-helloworld",
         "relPath": [
           "sbclPackages",
@@ -547,6 +605,7 @@
         "description": "A Unified Modelling Language (UML) diagram program",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "libsForQt5_openssl_1_1.umbrello",
         "pname": "umbrello",
         "relPath": [
           "libsForQt5_openssl_1_1",
@@ -559,6 +618,7 @@
         "description": "Apache module with a simple SAML 2.0 service provider",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "apacheHttpdPackages.mod_auth_mellon",
         "pname": "mod_auth_mellon",
         "relPath": [
           "apacheHttpdPackages",
@@ -571,6 +631,7 @@
         "description": "Apache module with a simple SAML 2.0 service provider",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "apacheHttpdPackages_2_4.mod_auth_mellon",
         "pname": "mod_auth_mellon",
         "relPath": [
           "apacheHttpdPackages_2_4",
@@ -583,6 +644,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "lispPackages_new.sbclPackages.hello-clog",
         "pname": "hello-clog",
         "relPath": [
           "lispPackages_new",
@@ -596,6 +658,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "lispPackages_new.sbclPackages.hello-builder",
         "pname": "hello-builder",
         "relPath": [
           "lispPackages_new",
@@ -609,6 +672,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "lispPackages_new.sbclPackages.qtools-helloworld",
         "pname": "qtools-helloworld",
         "relPath": [
           "lispPackages_new",
@@ -622,6 +686,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "sbclPackages.cl-mw_dot_examples_dot_hello-world",
         "pname": "cl-mw_dot_examples_dot_hello-world",
         "relPath": [
           "sbclPackages",
@@ -634,6 +699,7 @@
         "description": "Open source home automation that puts local control and privacy first",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "home-assistant-component-tests.homeassistant_yellow",
         "pname": "homeassistant_yellow",
         "relPath": [
           "home-assistant-component-tests",
@@ -646,6 +712,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "lispPackages_new.sbclPackages.cl-mw_dot_examples_dot_hello-world",
         "pname": "cl-mw_dot_examples_dot_hello-world",
         "relPath": [
           "lispPackages_new",
@@ -659,6 +726,7 @@
         "description": "Trello interactive CLI on terminal",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "_3llo",
         "pname": "_3llo",
         "relPath": [
           "_3llo"
@@ -670,6 +738,7 @@
         "description": "Computer version of the game Reversi, more popularly called Othello",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "iagno",
         "pname": "iagno",
         "relPath": [
           "iagno"
@@ -681,6 +750,7 @@
         "description": "Directly render SVG overlays into Gerber and Excellon files",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "gerbolyze",
         "pname": "gerbolyze",
         "relPath": [
           "gerbolyze"
@@ -692,6 +762,7 @@
         "description": "Computer version of the game Reversi, more popularly called Othello",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "gnome.iagno",
         "pname": "iagno",
         "relPath": [
           "gnome",
@@ -704,6 +775,7 @@
         "description": "Computer version of the game Reversi, more popularly called Othello",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "gnome3.iagno",
         "pname": "iagno",
         "relPath": [
           "gnome3",
@@ -716,6 +788,7 @@
         "description": "Produce song books for church or fellowship",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "texlivePackages.songs",
         "pname": "songs",
         "relPath": [
           "texlivePackages",
@@ -728,6 +801,7 @@
         "description": "Pythonic library for reading/modifying/writing Gerber/Excellon/IPC-356 files",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python311Packages.gerbonara",
         "pname": "gerbonara",
         "relPath": [
           "python311Packages",
@@ -740,6 +814,7 @@
         "description": "Pythonic library for reading/modifying/writing Gerber/Excellon/IPC-356 files",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python312Packages.gerbonara",
         "pname": "gerbonara",
         "relPath": [
           "python312Packages",

--- a/test_data/generated/search/exactly_ten.json
+++ b/test_data/generated/search/exactly_ten.json
@@ -6,6 +6,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python",
         "pname": "python",
         "relPath": [
           "python"
@@ -17,6 +18,7 @@
         "description": "Python interpreter written in Go",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "gpython",
         "pname": "gpython",
         "relPath": [
           "gpython"
@@ -28,6 +30,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python2",
         "pname": "python2",
         "relPath": [
           "python2"
@@ -39,6 +42,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python3",
         "pname": "python3",
         "relPath": [
           "python3"
@@ -50,6 +54,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python27",
         "pname": "python27",
         "relPath": [
           "python27"
@@ -61,6 +66,7 @@
         "description": "A high-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python36",
         "pname": "python36",
         "relPath": [
           "python36"
@@ -72,6 +78,7 @@
         "description": "A high-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python37",
         "pname": "python37",
         "relPath": [
           "python37"
@@ -83,6 +90,7 @@
         "description": "A high-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python38",
         "pname": "python38",
         "relPath": [
           "python38"
@@ -94,6 +102,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python39",
         "pname": "python39",
         "relPath": [
           "python39"
@@ -105,6 +114,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python310",
         "pname": "python310",
         "relPath": [
           "python310"

--- a/test_data/generated/search/hello.json
+++ b/test_data/generated/search/hello.json
@@ -6,6 +6,7 @@
         "description": "Program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -17,6 +18,7 @@
         "description": "Simple program printing hello world in Go",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello-go",
         "pname": "hello-go",
         "relPath": [
           "hello-go"
@@ -28,6 +30,7 @@
         "description": "Basic sanity check that C++ and cmake infrastructure are working",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello-cpp",
         "pname": "hello-cpp",
         "relPath": [
           "hello-cpp"
@@ -39,6 +42,7 @@
         "description": "GTK3-based greeter for the greetd daemon, written in python",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "nwg-hello",
         "pname": "nwg-hello",
         "relPath": [
           "nwg-hello"
@@ -50,6 +54,7 @@
         "description": "Example package with unfree license (for testing)",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello-unfree",
         "pname": "hello-unfree",
         "relPath": [
           "hello-unfree"
@@ -61,6 +66,7 @@
         "description": "Hello world Wayland client",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hello-wayland",
         "pname": "hello-wayland",
         "relPath": [
           "hello-wayland"
@@ -72,6 +78,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "sbclPackages.hello-clog",
         "pname": "hello-clog",
         "relPath": [
           "sbclPackages",
@@ -84,6 +91,7 @@
         "description": "Modification of a Go package to create othello boards",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "texlivePackages.othello",
         "pname": "othello",
         "relPath": [
           "texlivePackages",
@@ -96,6 +104,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "sbclPackages.hello-builder",
         "pname": "hello-builder",
         "relPath": [
           "sbclPackages",
@@ -108,6 +117,7 @@
         "description": "Maven Hello World",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "javaPackages.mavenHello_1_0",
         "pname": "mavenHello_1_0",
         "relPath": [
           "javaPackages",

--- a/test_data/generated/search/java_suggestions.json
+++ b/test_data/generated/search/java_suggestions.json
@@ -1,11 +1,12 @@
 [
   {
-    "count": 818,
+    "count": 819,
     "results": [
       {
         "description": "Parser generator for building parsers from grammars",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "javacc",
         "pname": "javacc",
         "relPath": [
           "javacc"
@@ -17,6 +18,7 @@
         "description": "LALR parser generator for Java",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "javaCup",
         "pname": "javaCup",
         "relPath": [
           "javaCup"
@@ -28,6 +30,7 @@
         "description": "A Java package that implements HDF4 and HDF5 data objects in an object-oriented form",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "hdf_java",
         "pname": "hdf_java",
         "relPath": [
           "hdf_java"
@@ -39,6 +42,7 @@
         "description": null,
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "dbus_java",
         "pname": "dbus_java",
         "relPath": [
           "dbus_java"
@@ -50,6 +54,7 @@
         "description": "GeoIP Java API",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "geoipjava",
         "pname": "geoipjava",
         "relPath": [
           "geoipjava"
@@ -61,6 +66,7 @@
         "description": "Library for extracting tables from PDF files",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "tabula-java",
         "pname": "tabula-java",
         "relPath": [
           "tabula-java"
@@ -72,6 +78,7 @@
         "description": "Programming language used for massively scalable soft real-time systems",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "erlang_javac",
         "pname": "erlang_javac",
         "relPath": [
           "erlang_javac"
@@ -83,6 +90,7 @@
         "description": "Interface compiler that connects C/C++ code to higher-level languages",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "swigWithJava",
         "pname": "swigWithJava",
         "relPath": [
           "swigWithJava"
@@ -94,6 +102,7 @@
         "description": "Award winning, fully featured low overhead profiler for Java EE and Java SE platforms",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "yourkit-java",
         "pname": "yourkit-java",
         "relPath": [
           "yourkit-java"
@@ -102,12 +111,13 @@
         "version": null
       },
       {
-        "description": "Cap'n Proto codegen plugin for Java",
+        "description": "Java library containing matchers that can be combined to create flexible expressions of intent",
         "input": "nixpkgs",
         "license": null,
-        "pname": "capnproto-java",
+        "pkgPath": "java-hamcrest",
+        "pname": "java-hamcrest",
         "relPath": [
-          "capnproto-java"
+          "java-hamcrest"
         ],
         "system": "aarch64-darwin",
         "version": null
@@ -118,9 +128,10 @@
     "count": 142,
     "results": [
       {
-        "description": "Open-source Java Development Kit",
+        "description": "Certified builds of OpenJDK",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "jdk",
         "pname": "jdk",
         "relPath": [
           "jdk"
@@ -129,9 +140,10 @@
         "version": null
       },
       {
-        "description": "Open-source Java Development Kit",
+        "description": "Certified builds of OpenJDK",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "jdk8",
         "pname": "jdk8",
         "relPath": [
           "jdk8"
@@ -143,6 +155,7 @@
         "description": "Open-source Java Development Kit",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "jdk11",
         "pname": "jdk11",
         "relPath": [
           "jdk11"

--- a/test_data/generated/search/python.json
+++ b/test_data/generated/search/python.json
@@ -1,11 +1,12 @@
 [
   {
-    "count": 17465,
+    "count": 17530,
     "results": [
       {
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python",
         "pname": "python",
         "relPath": [
           "python"
@@ -17,6 +18,7 @@
         "description": "Python interpreter written in Go",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "gpython",
         "pname": "gpython",
         "relPath": [
           "gpython"
@@ -28,6 +30,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python2",
         "pname": "python2",
         "relPath": [
           "python2"
@@ -39,6 +42,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python3",
         "pname": "python3",
         "relPath": [
           "python3"
@@ -50,6 +54,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python27",
         "pname": "python27",
         "relPath": [
           "python27"
@@ -61,6 +66,7 @@
         "description": "A high-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python36",
         "pname": "python36",
         "relPath": [
           "python36"
@@ -72,6 +78,7 @@
         "description": "A high-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python37",
         "pname": "python37",
         "relPath": [
           "python37"
@@ -83,6 +90,7 @@
         "description": "A high-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python38",
         "pname": "python38",
         "relPath": [
           "python38"
@@ -94,6 +102,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python39",
         "pname": "python39",
         "relPath": [
           "python39"
@@ -105,6 +114,7 @@
         "description": "High-level dynamically-typed programming language",
         "input": "nixpkgs",
         "license": null,
+        "pkgPath": "python310",
         "pname": "python310",
         "relPath": [
           "python310"

--- a/test_data/generated/show/flask.json
+++ b/test_data/generated/show/flask.json
@@ -6,6 +6,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -18,6 +19,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -30,6 +32,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -42,6 +45,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -54,6 +58,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -66,6 +71,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -78,6 +84,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -90,6 +97,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -102,6 +110,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -114,6 +123,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -126,6 +136,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -138,6 +149,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -150,6 +162,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -162,6 +175,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -174,6 +188,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -186,6 +201,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -198,6 +214,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -210,6 +227,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -222,6 +240,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -234,6 +253,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -246,6 +266,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -258,6 +279,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -270,6 +292,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -282,6 +305,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -294,6 +318,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -306,6 +331,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -318,6 +344,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -330,6 +357,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -342,6 +370,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -354,6 +383,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -366,6 +396,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",
@@ -378,6 +409,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
+        "pkgPath": "nixpkgs/python310Packages.flask",
         "pname": "flask",
         "relPath": [
           "python310Packages",

--- a/test_data/generated/show/hello.json
+++ b/test_data/generated/show/hello.json
@@ -6,6 +6,7 @@
         "description": "Program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -17,6 +18,7 @@
         "description": "Program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -25,9 +27,10 @@
         "version": "2.12.1"
       },
       {
-        "description": "A program that produces a familiar, friendly greeting",
+        "description": "Program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -39,6 +42,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -50,6 +54,19 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
+        "pname": "hello",
+        "relPath": [
+          "hello"
+        ],
+        "system": "aarch64-linux",
+        "version": "2.12"
+      },
+      {
+        "description": "A program that produces a familiar, friendly greeting",
+        "input": "nixpkgs",
+        "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -61,6 +78,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -72,6 +90,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -83,17 +102,19 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
         ],
         "system": "aarch64-linux",
-        "version": "2.12"
+        "version": "2.10"
       },
       {
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -105,6 +126,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
@@ -116,22 +138,12 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
+        "pkgPath": "nixpkgs/hello",
         "pname": "hello",
         "relPath": [
           "hello"
         ],
         "system": "x86_64-darwin",
-        "version": "2.10"
-      },
-      {
-        "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
-        "license": "GPL-3.0-or-later",
-        "pname": "hello",
-        "relPath": [
-          "hello"
-        ],
-        "system": "aarch64-linux",
         "version": "2.10"
       }
     ]


### PR DESCRIPTION
We now include the catalog name for custom catalog packages when listing
search results. Where possible, this uses the recently introduced pkg-path
field, rather than attempting to construct it from catalog name and
attr-path.

This also includes a fix for an alignment bug in the case where some package
names matched the search term and were highlighted and others were not.

It also removes the unnecessary disambiguation code that was previously
intended to handle the case where multiple catalogs could provide a package
with the same name.

Closes #2472.