### PR TITLE
feat: print messages via `tracing`

### DIFF
--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::io::Write;
 
 use flox_rust_sdk::models::manifest::PackageToInstall;
+use tracing::info;
 /// Write a message to stderr.
 ///
 /// This is a wrapper around `eprintln!` that can be further extended
@@ -13,7 +14,7 @@ fn print_message(v: impl Display) {
         history.push_message(format!("{v}"));
     }
 
-    eprintln!("{v}");
+    info!("{v}");
 }
 
 fn print_message_to_buffer(out: &mut impl Write, v: impl Display) {


### PR DESCRIPTION
Dan found that for some commands the spinners would not be completely cleared before the command would print a message.

This issue appeared especially with `Span::in_scope` constructs:

```rust
let span: Span = ...;
span.in_scope(||{ ... });
```

While the "spinning status" correctly matches the scope, the spinner is not cleared, as the scope ends,
but on `Drop` of the span.
Dropping the span explicitly resolves this.
However, keeping span lifetimes in mind is easy to miss,
both in this PR as well as in future additions of spinners.

Alternatively, we can use an `IndicatifWriter`,
which will clear spinners for us to print logs or messages.
The most well integrated way to do so is by setting an `IndicatifWriter`
as the writer for the `fmt` logger, which is advisable in either way,
to avoid clobbering the terminal output.

Currently, our `messages` module prints out to stderr directly without indirection,
which means it does not honor the writer of the `fmt` logger.

Getting hold of the indicatif writers outside of the logging proved tricky (panics ensued).
Besides not being integrated with `tracing` pipeline,
means that `messages` do not respect the `--quiet` flag either (https://github.com/flox/flox/issues/2396).

This commit brings `messages` (back) into the tracing pipeline,
by defining a special `fmt` layer, that prints events from `flox::utils::message`
without additional "log" decoration such as timestamps or structured fields.
The writer is set to an `IndicatifWriter` to avoid clobbering spinners and clear stale spinners.
Further, it applies a common filter to both the log layer and the new message layer,
such that `--quiet` now affects messages as well.

Finally, the filtering presets were adjusted to be more intuitive (and in line with how we pass verbosity on to child processes)

    -q | --quiet          -> show error logs only
    <no flags>            -> show warnings and messages
    -v | --verbose        -> show informational logs for all flox crates 
                             (e.g. subcommand stderr?)
                             -- we haven't used this level effectively yet
    -vv | --verbose x 2   -> show debug logs for all flox crates
    -vvv | --verbose x 3  -> show trace logs for all flox crates
    -vvvv | --verbose x 4 -> show trace logs for all crates -
                             -- very loud
                                usually better handled by setting RUST_LOG="<crate>=trace>"