### PR TITLE
chore: use findutils in preference to fd

### DIFF
--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -2,7 +2,6 @@
   bash,
   coreutils,
   daemonize,
-  fd,
   findutils,
   flox-activations,
   getopt,
@@ -32,7 +31,6 @@ let
       bash
       coreutils
       daemonize
-      fd
       findutils
       getopt
       gnused

--- a/pkgs/flox-manpages/default.nix
+++ b/pkgs/flox-manpages/default.nix
@@ -3,14 +3,16 @@
   writeShellScript,
   runCommand,
   pandoc,
-  fd,
+  findutils,
   installShellFiles,
 }:
 let
   compileManPageBin = writeShellScript "compile" ''
     source="$1"
     shift
-    dest="$1"
+    destdir="$1"
+    shift
+    section="$1"
     shift
 
     # tools
@@ -30,7 +32,7 @@ let
       --from markdown                          \
       --to man                                 \
        $source                                 \
-    > "$dest"
+    > "$destdir/$(basename $source .md).$section"
   '';
 in
 runCommand "flox-manpages"
@@ -40,7 +42,7 @@ runCommand "flox-manpages"
       path = "${./../../cli/flox/doc}";
     };
     buildInputs = [
-      fd
+      findutils
       installShellFiles
     ];
   }
@@ -51,8 +53,7 @@ runCommand "flox-manpages"
     mkdir "$buildDir"
     pushd "$src"
 
-
-    fd ".*\.md" -d 1 ./ -x ${compileManPageBin} {} $buildDir/{/.}.1
+    find . -name "*.md" -exec ${compileManPageBin} {} $buildDir 1 \;
     mv $buildDir/manifest.toml.1 $buildDir/manifest.toml.5
 
     ls $buildDir


### PR DESCRIPTION
## Proposed Changes

Replace uses of `fd` with `find` in the two places where it is currently being used, and remove `fd` from the build and runtime closures.

Closes #2544 

## Release Notes

N/A