### PR TITLE
Upgrade tailscale/github-action

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: "Setup Tailscale"
-      uses: "tailscale/github-action@v2"
+      uses: "tailscale/github-action@v3"
       if: ${{ inputs.TAILSCALE_URL && inputs.TAILSCALE_AUTH_KEY }}
       with:
         args: "--timeout 30s --login-server ${{ inputs.TAILSCALE_URL }}"


### PR DESCRIPTION
A major release including faster failing if curl fails and a newer tailscale version gets installed by default.

Refs: https://github.com/tailscale/github-action/releases/tag/v3
