### PR TITLE
feat: add dry upgrade support to the sdk

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -488,11 +488,15 @@ impl CoreEnvironment<ReadOnly> {
     /// First resolve a new lockfile with upgraded packages using the catalog client.
     /// Then verify the new lockfile by building the environment.
     ///
-    /// Finally replace the existing environment with the new, upgraded one.
+    /// Finally if `write_lockfile` is true,
+    /// replace the existing environment with the new, upgraded one.
+    /// Otherwise, validate the upgrade by writing the new lockfile to a temporary file
+    /// and building it.
     pub fn upgrade(
         &mut self,
         flox: &Flox,
         groups_or_iids: &[&str],
+        write_lockfile: bool,
     ) -> Result<UpgradeResult, CoreEnvironmentError> {
         tracing::debug!(to_upgrade = groups_or_iids.join(","), "upgrading");
         let manifest = self.manifest()?;
@@ -511,8 +515,20 @@ impl CoreEnvironment<ReadOnly> {
         // the "Serialize decides to fail, or if T contains a map with non-string keys",
         // neither of which should happen here.
         let lockfile_contents = serde_json::to_string_pretty(&result.new_lockfile).unwrap();
-        let store_path = self.transact_with_lockfile_contents(lockfile_contents, flox)?;
-        result.store_path = Some(store_path);
+
+        if write_lockfile {
+            let store_path = self.transact_with_lockfile_contents(lockfile_contents, flox)?;
+            result.store_path = Some(store_path);
+        } else {
+            let tmp_lockfile = tempfile::NamedTempFile::new_in(&flox.temp_dir)
+                .map_err(CoreEnvironmentError::WriteLockfile)?;
+            fs::write(&tmp_lockfile, lockfile_contents)
+                .map_err(CoreEnvironmentError::WriteLockfile)?;
+
+            // We are not interested in the store path here, so we ignore the result
+            // Neither do we depend on services, so we pass `None`
+            let _ = BuildEnvNix.build(&flox.catalog_client, tmp_lockfile.path(), None)?;
+        }
 
         Ok(result)
     }

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -336,7 +336,7 @@ impl Environment for ManagedEnvironment {
             ))?
         }
 
-        let result = local_checkout.upgrade(flox, groups_or_iids)?;
+        let result = local_checkout.upgrade(flox, groups_or_iids, true)?;
 
         let metadata = format!("upgraded packages: {}", result.packages().join(", "));
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -313,6 +313,18 @@ impl Environment for ManagedEnvironment {
         Ok(result)
     }
 
+    /// Try to upgrade packages in the current local checkout
+    /// without committing a new generation
+    fn dry_upgrade(
+        &mut self,
+        flox: &Flox,
+        groups_or_iids: &[&str],
+    ) -> Result<UpgradeResult, EnvironmentError> {
+        let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
+        let result = local_checkout.upgrade(flox, groups_or_iids, false)?;
+        Ok(result)
+    }
+
     /// Atomically upgrade packages in this environment
     fn upgrade(
         &mut self,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 use flox_core::Version;
+use itertools::Itertools;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -337,7 +338,7 @@ impl Environment for ManagedEnvironment {
 
         let result = local_checkout.upgrade(flox, groups_or_iids)?;
 
-        let metadata = format!("upgraded packages: {}", result.packages.join(", "));
+        let metadata = format!("upgraded packages: {}", result.packages().join(", "));
 
         generations
             .add_generation(&mut local_checkout, metadata)

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -121,6 +121,13 @@ pub trait Environment: Send {
     /// Atomically edit this environment, ensuring that it still builds
     fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError>;
 
+    /// Upgrade packages in this environment without modifying the environment on disk.
+    fn dry_upgrade(
+        &mut self,
+        flox: &Flox,
+        groups_or_iids: &[&str],
+    ) -> Result<UpgradeResult, EnvironmentError>;
+
     /// Atomically upgrade packages in this environment
     fn upgrade(
         &mut self,

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -239,7 +239,7 @@ impl Environment for PathEnvironment {
     ) -> Result<UpgradeResult, EnvironmentError> {
         tracing::debug!(to_upgrade = groups_or_iids.join(","), "upgrading");
         let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
-        let result = env_view.upgrade(flox, groups_or_iids)?;
+        let result = env_view.upgrade(flox, groups_or_iids, true)?;
         if let Some(ref store_paths) = result.store_path {
             self.link(flox, store_paths)?;
         }

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -231,6 +231,17 @@ impl Environment for PathEnvironment {
         Ok(result)
     }
 
+    /// Upgrade packages in this environment and return the result, but do not
+    fn dry_upgrade(
+        &mut self,
+        flox: &Flox,
+        groups_or_iids: &[&str],
+    ) -> Result<UpgradeResult, EnvironmentError> {
+        let mut env_view = CoreEnvironment::new(self.path.join(ENV_DIR_NAME));
+        let result = env_view.upgrade(flox, groups_or_iids, false)?;
+        Ok(result)
+    }
+
     /// Atomically upgrade packages in this environment
     fn upgrade(
         &mut self,

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -287,6 +287,14 @@ impl Environment for RemoteEnvironment {
         Ok(result)
     }
 
+    fn dry_upgrade(
+        &mut self,
+        flox: &Flox,
+        groups_or_iids: &[&str],
+    ) -> Result<UpgradeResult, EnvironmentError> {
+        self.inner.dry_upgrade(flox, groups_or_iids)
+    }
+
     /// Atomically upgrade packages in this environment
     fn upgrade(
         &mut self,

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -64,7 +64,7 @@ impl Upgrade {
             )
         })?;
 
-        let upgraded = result.packages;
+        let upgraded = result.packages().collect::<Vec<_>>();
 
         if upgraded.is_empty() {
             if self.groups_or_iids.is_empty() {


### PR DESCRIPTION
## [refactor: `upgrade` produce a more general `UpgradeResult`](https://github.com/flox/flox/commit/8e4a3875f9348aabb439c4127964ffdc6abfda0a) 

Track both old and new lockfile in the `UpgradeResult` and diff packages dynamically as needed.

## [feat(Core): make writing an upgraded lockfile optional](https://github.com/flox/flox/commit/9983ed0bba168041fbdae4921253823cf0c92eee) 

If `write_lockfile` is true,
replace the existing environment with the new, upgraded one.
Otherwise, validate the upgrade by writing the new lockfile to a temporary file
and building it.

## [feat: add dry_upgrade method to Environment trait](https://github.com/flox/flox/commit/e549aa990aa27c3d2eee8a770d31d5925490c32c)