### PR TITLE
feat(containerize): add more options

### DIFF
--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -230,3 +230,19 @@ pub fn proptest_btree_map_alphanum_keys<T: proptest::arbitrary::Arbitrary>(
         0..max_keys,
     )
 }
+
+/// Produces maps whose keys are strings that only contain alphanumeric
+/// characters and whose values are empty BTreeMaps
+#[cfg(any(test, feature = "tests"))]
+pub fn proptest_btree_map_alphanum_keys_empty_map(
+    key_max_size: usize,
+    max_keys: usize,
+) -> impl Strategy<Value = BTreeMap<String, BTreeMap<(), ()>>> {
+    use prop::collection::btree_map;
+
+    prop::collection::btree_map(
+        proptest_alphanum_string(key_max_size),
+        btree_map(any::<()>(), any::<()>(), 0),
+        0..max_keys,
+    )
+}

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -64,9 +64,14 @@ impl Containerize {
         let built_environment = env.build(&flox)?;
 
         let source = if std::env::consts::OS == "linux" {
+            let container_config = env
+                .lockfile(&flox)?
+                .manifest
+                .containerize
+                .and_then(|c| c.config);
             // this method is only executed on linux
             #[cfg_attr(not(target_os = "linux"), allow(deprecated))]
-            let builder = MkContainerNix::new(built_environment.develop);
+            let builder = MkContainerNix::new(built_environment.develop, container_config);
 
             builder.create_container_source(&flox, env.name().as_ref(), output_tag)?
         } else {

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -124,7 +124,7 @@ podman_dirs_setup() {
 rosetta = false
 EOF
   fi
-  
+
   podman_home_setup
   podman_xdg_vars_setup "$FLOX_TEST_HOME" "$SHORT_TMP"
   podman_flox_vars_setup
@@ -331,7 +331,7 @@ function assert_container_output() {
 }
 
 # bats test_tags=containerize:run-container-i
-@test "container can be run with 'podman/docker run' with/without -i'" {
+@test "container can be run with 'podman run' with/without -i'" {
   env_setup_catalog
 
   # Also tests writing to STDOUT with `-f -`

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -11,6 +11,7 @@
   containerName ? "flox-env-container",
   containerTag ? null,
   containerCreated ? "now",
+  containerConfig ? null,
 }:
 let
   environment = builtins.storePath environmentOutPath;
@@ -48,7 +49,7 @@ let
       mkdir -m 1777 tmp
       mkdir -p -m 1777 tmp/flox/run
     '';
-    config = {
+    config = (if containerConfig == null then { } else (builtins.fromJSON containerConfig)) // {
       # Use activate script as the [one] entrypoint capable of
       # detecting interactive vs. command activation modes.
       # Usage:


### PR DESCRIPTION
Add options from the OCI spec to a new manifest section [containerize.config]. Add all options except Entrypoint and Env since those conflict with the current implementation of activate. Deprecated and reserved keys are also left out.