### PR TITLE
feat(activate): upgrade notifications

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "toml 0.8.19",
  "toml_edit",

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -32,6 +32,7 @@ shell-escape.workspace = true
 temp-env.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tokio.workspace = true
 toml_edit.workspace = true
 toml.workspace = true

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 
 use itertools::Itertools;
 use pollster::FutureExt;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::debug;
 
@@ -857,10 +858,10 @@ impl EditResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct UpgradeResult {
-    old_lockfile: Option<Lockfile>,
-    new_lockfile: Lockfile,
+    pub old_lockfile: Option<Lockfile>,
+    pub new_lockfile: Lockfile,
     pub store_path: Option<BuildEnvOutputs>,
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -170,7 +170,9 @@ pub trait Environment: Send {
     /// This does not link the environment, but may lock the environment, if necessary.
     fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError>;
 
-    /// Return a path that environment hooks should use to store transient data.
+    /// Return a path to store transient data,
+    /// such as temporary files created by the environment hooks or the environment itself,
+    /// including reproducible data about the environment.
     ///
     /// The returned path will exist.
     fn cache_path(&self) -> Result<CanonicalPath, EnvironmentError>;

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use core_environment::UpgradeResult;
 use enum_dispatch::enum_dispatch;
 pub use flox_core::{path_hash, Version};
 use log::debug;
@@ -32,7 +31,13 @@ use crate::providers::git::{
 use crate::utils::copy_file_without_permissions;
 
 mod core_environment;
-pub use core_environment::{test_helpers, CoreEnvironment, CoreEnvironmentError, EditResult};
+pub use core_environment::{
+    test_helpers,
+    CoreEnvironment,
+    CoreEnvironmentError,
+    EditResult,
+    UpgradeResult,
+};
 
 pub mod generations;
 pub mod managed_environment;
@@ -228,6 +233,7 @@ pub trait Environment: Send {
 
 /// The various ways in which an environment can be referred to
 #[enum_dispatch(Environment)]
+#[derive(Debug)]
 pub enum ConcreteEnvironment {
     /// Container for [PathEnvironment]
     Path(PathEnvironment),

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use tempfile::TempDir;
 use thiserror::Error;
 use tracing::{debug, instrument};
 
@@ -335,13 +334,8 @@ impl Environment for RemoteEnvironment {
         self.inner.build(flox)
     }
 
-    /// Return a path that environment hooks should use to store transient data.
-    ///
-    /// Remote environments shouldn't have state of any kind, so this just
-    /// returns a temporary directory.
     fn cache_path(&self) -> Result<CanonicalPath, EnvironmentError> {
-        let tempdir = TempDir::new().map_err(EnvironmentError::CreateTempDir)?;
-        CanonicalPath::new(tempdir.into_path()).map_err(EnvironmentError::Canonicalize)
+        self.inner.cache_path()
     }
 
     fn log_path(&self) -> Result<CanonicalPath, EnvironmentError> {

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -159,6 +159,14 @@ impl LockedPackage {
             LockedPackage::StorePath(_) => None,
         }
     }
+
+    pub fn version(&self) -> Option<&str> {
+        match self {
+            LockedPackage::Catalog(pkg) => Some(&pkg.version),
+            LockedPackage::Flake(pkg) => pkg.locked_installable.version.as_deref(),
+            LockedPackage::StorePath(_) => None,
+        }
+    }
 }
 
 #[skip_serializing_none]

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1051,7 +1051,11 @@ mod realise_flakes_tests {
         );
 
         let result = buildenv.realise_flakes(&locked_package);
-        assert!(result.is_ok());
+        assert!(
+            result.is_ok(),
+            "failed to build flake: {}",
+            result.unwrap_err()
+        );
         assert!(buildenv
             .check_store_path(locked_package.locked_installable.outputs.values())
             .unwrap());

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -6,3 +6,4 @@ pub mod flox_cpp_utils;
 pub mod git;
 pub mod publish;
 pub mod services;
+pub mod upgrade_checks;

--- a/cli/flox-rust-sdk/src/providers/upgrade_checks.rs
+++ b/cli/flox-rust-sdk/src/providers/upgrade_checks.rs
@@ -1,10 +1,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 
 use fslock::LockFile;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use time::OffsetDateTime;
 use tracing::debug;
 
 use crate::models::environment::UpgradeResult;
@@ -26,7 +26,8 @@ pub enum UpgradeChecksError {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct UpgradeInformation {
     /// The last time the upgrade check was performed
-    pub last_checked: SystemTime,
+    #[serde(with = "time::serde::iso8601")]
+    pub last_checked: OffsetDateTime,
     /// The result of the last upgrade check
     pub result: UpgradeResult,
 }
@@ -262,7 +263,7 @@ mod tests {
         let mut locked = guard.lock_if_unlocked().unwrap().unwrap();
 
         *locked.info_mut() = Some(UpgradeInformation {
-            last_checked: SystemTime::now(),
+            last_checked: OffsetDateTime::now_utc(),
             result: UpgradeResult {
                 old_lockfile: None,
                 new_lockfile: Lockfile::default(),
@@ -283,7 +284,7 @@ mod tests {
         let guard = UpgradeInformationGuard::read_in(temp_dir.path()).unwrap();
         let mut locked = guard.lock_if_unlocked().unwrap().unwrap();
         let info = UpgradeInformation {
-            last_checked: SystemTime::now(),
+            last_checked: OffsetDateTime::now_utc(),
             result: UpgradeResult {
                 old_lockfile: None,
                 new_lockfile: Lockfile::default(),

--- a/cli/flox-rust-sdk/src/providers/upgrade_checks.rs
+++ b/cli/flox-rust-sdk/src/providers/upgrade_checks.rs
@@ -1,0 +1,317 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use flox_core::path_hash;
+use fslock::LockFile;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::debug;
+
+use crate::models::environment::UpgradeResult;
+
+#[derive(Debug, Error)]
+pub enum UpgradeChecksError {
+    #[error("Failed to acquire lock")]
+    Lock(#[source] fslock::Error),
+    #[error("Failed to read upgrade information")]
+    Read(#[source] std::io::Error),
+    #[error("Failed to write upgrade information")]
+    Write(#[source] std::io::Error),
+    #[error("Failed to parse upgrade information")]
+    Deserialize(#[source] serde_json::Error),
+    #[error("Failed to serialize upgrade information")]
+    Serialize(#[source] serde_json::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct UpgradeInformation {
+    /// The last time the upgrade check was performed
+    pub last_checked: SystemTime,
+    /// The result of the last upgrade check
+    pub result: UpgradeResult,
+}
+
+/// A guard for a file containing upgrade information,
+/// located at [Self::upgrade_information_path].
+/// A guard is created in an [Unlocked] state,
+/// in which the upgrade information can be read but not written.
+/// The guard can be locked to gain exclusive access to the file
+/// via a [LockFile] file lock,
+/// allowing the upgrade information to be mutated
+/// and [Self::commit]ed back to the file.
+#[derive(Debug)]
+pub struct UpgradeInformationGuard<LockState> {
+    /// The upgrade information found at [Self::upgrade_information_path]
+    /// or [None] if no information was found.
+    ///
+    /// This field can be mutated iff the guard is [Locked].
+    info: Option<UpgradeInformation>,
+    upgrade_information_path: PathBuf,
+    _lock: LockState,
+}
+
+/// The state marker for an unlocked guard.
+#[derive(Debug)]
+pub struct Unlocked;
+
+/// The state marker for a locked guard.
+/// This holds a file lock which prevents concurrent writes
+/// to the underlying locked upgrade information file.
+#[derive(Debug)]
+pub struct Locked {
+    _lock: LockFile,
+}
+
+/// Operations valid for a guard of any state.
+impl<L> UpgradeInformationGuard<L> {
+    /// Returns the upgrade information found at [Self::upgrade_information_path]
+    /// or [None] if no information was found.
+    pub fn info(&self) -> &Option<UpgradeInformation> {
+        &self.info
+    }
+}
+
+/// Operations valid for an [Unlocked] guard.
+impl UpgradeInformationGuard<Unlocked> {
+    /// Reads the upgrade information for an environment located at `dot_flox_path`
+    /// and returns an unlocked guard.
+    ///
+    /// The upgrade information is stored in a file located at the path
+    /// provided by [upgrade_information_path].
+    /// If no information is found, this methods succeeds
+    /// and returns a guard with [None] as the upgrade information.
+    /// This guard can then be locked and mutated to store new information.
+    pub fn for_environment(
+        cache_dir: impl AsRef<Path>,
+        dot_flox_path: impl AsRef<Path>,
+    ) -> Result<UpgradeInformationGuard<Unlocked>, UpgradeChecksError> {
+        let upgrade_information_path = upgrade_information_path(cache_dir, dot_flox_path);
+        let info = read_upgrade_information(&upgrade_information_path)?;
+
+        debug!(
+            ?upgrade_information_path,
+            ?info,
+            "created unlocked upgrade information guard"
+        );
+
+        Ok(UpgradeInformationGuard {
+            info,
+            upgrade_information_path,
+            _lock: Unlocked,
+        })
+    }
+
+    /// Attempts to lock the guard and return a locked guard.
+    ///
+    /// If the guard is already locked, this method returns `Ok(Err(self))`
+    /// without waiting.
+    pub fn lock_if_unlocked(
+        self,
+    ) -> Result<Result<UpgradeInformationGuard<Locked>, Self>, UpgradeChecksError> {
+        let Some(lock) = try_acquire_lock(&self.upgrade_information_path)? else {
+            debug!(upgrade_information_path=?self.upgrade_information_path, "lock already taken");
+            return Ok(Err(self));
+        };
+
+        debug!(upgrade_information_path=?self.upgrade_information_path, "lock acquired");
+        Ok(Ok(UpgradeInformationGuard {
+            info: self.info,
+            upgrade_information_path: self.upgrade_information_path,
+            _lock: Locked { _lock: lock },
+        }))
+    }
+}
+
+/// Operations valid for a [Locked] guard.
+/// While locked, this guard has exclusive access to the underlying upgrade information file.
+/// When the guard is dropped, the lock is released.
+impl UpgradeInformationGuard<Locked> {
+    /// Returns a mutable reference to the upgrade information.
+    ///
+    /// This method is used to set or update the stored upgrade information.
+    pub fn info_mut(&mut self) -> &mut Option<UpgradeInformation> {
+        &mut self.info
+    }
+
+    /// Commits the upgrade information to the file system.
+    ///
+    /// Updates the file at [Self::upgrade_information_path] to the current state of the guard.
+    /// If the guard has no upgrade information, and a file exists at [Self::upgrade_information_path],
+    /// the file is deleted.
+    /// Otherwise, [Self::info] is serialized to json and written to the file.
+    pub fn commit(&self) -> Result<(), UpgradeChecksError> {
+        if self.info.is_none() && self.upgrade_information_path.exists() {
+            debug!(upgrade_information_path=?self.upgrade_information_path, "deleting upgrade information");
+            fs::remove_file(&self.upgrade_information_path).map_err(UpgradeChecksError::Write)?;
+            return Ok(());
+        }
+
+        if self.info.is_none() {
+            debug!("no upgrade information to write");
+            return Ok(());
+        }
+
+        let info_str = serde_json::to_string(&self.info).map_err(UpgradeChecksError::Serialize)?;
+        fs::write(&self.upgrade_information_path, info_str).map_err(UpgradeChecksError::Write)?;
+
+        debug!(upgrade_information_path=?self.upgrade_information_path, "wrote upgrade information");
+        Ok(())
+    }
+}
+
+/// Returns the path to the upgrade information file
+/// for an environment located at `dot_flox_path`.
+///
+/// The upgrade information is stored in a file located at the path
+/// ```text
+/// cache_dir/upgrade-checks-{path_hash(dot_flox_path)}.json
+/// ```
+fn upgrade_information_path(
+    cache_dir: impl AsRef<Path>,
+    dot_flox_path: impl AsRef<Path>,
+) -> PathBuf {
+    let path_hash = path_hash(&dot_flox_path);
+    cache_dir
+        .as_ref()
+        .join(format!("upgrade-checks-{}.json", path_hash))
+}
+
+/// Tries to acquire a lock on the upgrade information file.
+/// Returns [None] if the lock is already taken, without waiting.
+fn try_acquire_lock(
+    upgrade_information_path: impl AsRef<Path>,
+) -> Result<Option<LockFile>, UpgradeChecksError> {
+    let lock_path = upgrade_information_path.as_ref().with_extension("lock");
+
+    let mut lock = LockFile::open(&lock_path).map_err(UpgradeChecksError::Lock)?;
+
+    if !lock.try_lock().map_err(UpgradeChecksError::Lock)? {
+        return Ok(None);
+    };
+
+    Ok(Some(lock))
+}
+
+/// Reads an [UpgradeInformation] from a file at `upgrade_information_path`.
+fn read_upgrade_information(
+    upgrade_information_path: impl AsRef<Path>,
+) -> Result<Option<UpgradeInformation>, UpgradeChecksError> {
+    if !upgrade_information_path.as_ref().exists() {
+        return Ok(None);
+    }
+
+    let info_str =
+        fs::read_to_string(upgrade_information_path).map_err(UpgradeChecksError::Read)?;
+
+    // todo: should we ignore deserialize errors and just return none here,
+    // so the file may just get overriden with a good one later?
+    let info = serde_json::from_str(&info_str).map_err(UpgradeChecksError::Deserialize)?;
+    Ok(Some(info))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::models::lockfile::Lockfile;
+
+    #[test]
+    fn try_acquire_lock_does_not_wait_for_lock() {
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+
+        std::thread::scope(|scope| {
+            let (wait_for_first_lock_sender, wait_for_first_lock_receiver) = mpsc::sync_channel(0);
+            let (wait_for_second_lock_sender, wait_for_second_lock_receiver) =
+                mpsc::sync_channel(0);
+
+            // first lock
+            scope.spawn(move || {
+                // acquire the lock and hold it while another process attempts to acquire it
+                let lock = try_acquire_lock(path).unwrap();
+                assert!(lock.is_some());
+
+                // syncronize second attempt to acquire the lock,
+                // to run after the first lock.
+                wait_for_first_lock_sender.send(()).unwrap();
+
+                // fail the test if the second attempt to acquire the lock blocks
+                wait_for_second_lock_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .unwrap()
+            });
+
+            // second lock
+            scope.spawn(move || {
+                let _ = wait_for_first_lock_receiver.recv();
+                let lock = try_acquire_lock(path).unwrap();
+                assert!(lock.is_none());
+                wait_for_second_lock_sender.send(()).unwrap();
+            });
+        });
+    }
+
+    #[test]
+    fn upgrade_information_is_none_if_absent() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dot_flox_path = temp_dir.path().join("flox.toml");
+
+        let guard =
+            UpgradeInformationGuard::for_environment(temp_dir.path(), dot_flox_path).unwrap();
+        assert_eq!(guard.info(), &None);
+    }
+
+    #[test]
+    fn upgrade_information_is_discarded_if_not_committed() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dot_flox_path = temp_dir.path().join("flox.toml");
+
+        let guard =
+            UpgradeInformationGuard::for_environment(temp_dir.path(), &dot_flox_path).unwrap();
+        let mut locked = guard.lock_if_unlocked().unwrap().unwrap();
+
+        *locked.info_mut() = Some(UpgradeInformation {
+            last_checked: SystemTime::now(),
+            result: UpgradeResult {
+                old_lockfile: None,
+                new_lockfile: Lockfile::default(),
+                store_path: None,
+            },
+        });
+
+        drop(locked);
+
+        let guard =
+            UpgradeInformationGuard::for_environment(temp_dir.path(), dot_flox_path).unwrap();
+        assert_eq!(guard.info(), &None);
+    }
+
+    #[test]
+    fn upgrade_information_is_written_if_committed() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dot_flox_path = temp_dir.path().join("flox.toml");
+
+        let guard =
+            UpgradeInformationGuard::for_environment(temp_dir.path(), &dot_flox_path).unwrap();
+        let mut locked = guard.lock_if_unlocked().unwrap().unwrap();
+        let info = UpgradeInformation {
+            last_checked: SystemTime::now(),
+            result: UpgradeResult {
+                old_lockfile: None,
+                new_lockfile: Lockfile::default(),
+                store_path: None,
+            },
+        };
+        let _ = locked.info_mut().insert(info.clone());
+        locked.commit().unwrap();
+
+        drop(locked);
+
+        let guard =
+            UpgradeInformationGuard::for_environment(temp_dir.path(), dot_flox_path).unwrap();
+        assert_eq!(guard.info(), &Some(info));
+    }
+}

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -131,7 +131,7 @@ pub fn mtime_of(path: impl AsRef<Path>) -> SystemTime {
 }
 
 /// An extension trait for [std::process::Command]
-pub(crate) trait CommandExt {
+pub trait CommandExt {
     /// Provide a [DisplayCommand] that can be used to display
     /// POSIX like formatting of the command.
     fn display(&self) -> DisplayCommand;
@@ -143,7 +143,7 @@ impl CommandExt for std::process::Command {
     }
 }
 
-pub(crate) struct DisplayCommand<'a>(&'a std::process::Command);
+pub struct DisplayCommand<'a>(&'a std::process::Command);
 
 impl Display for DisplayCommand<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -699,8 +699,7 @@ impl Activate {
 /// Future activations will be able to read the upgrade information from a file
 /// and notify the user if there are any upgrades available using this function.
 fn notify_upgrade_if_available(flox: &Flox, environment: &mut ConcreteEnvironment) -> Result<()> {
-    let upgrade_guard =
-        UpgradeInformationGuard::for_environment(&flox.cache_dir, environment.dot_flox_path())?;
+    let upgrade_guard = UpgradeInformationGuard::read_in(environment.cache_path()?)?;
 
     let Some(info) = upgrade_guard.info() else {
         debug!("Not notifying user of upgrade, no upgrade information available");
@@ -972,11 +971,8 @@ mod upgrade_notification_tests {
         let mut environment = ConcreteEnvironment::Path(environment);
 
         {
-            let upgrade_information = UpgradeInformationGuard::for_environment(
-                &flox.cache_dir,
-                environment.dot_flox_path(),
-            )
-            .unwrap();
+            let upgrade_information =
+                UpgradeInformationGuard::read_in(environment.cache_path().unwrap()).unwrap();
             let mut locked = upgrade_information.lock_if_unlocked().unwrap().unwrap();
 
             let mut new_lockfile = environment.lockfile(&flox).unwrap();
@@ -1032,11 +1028,8 @@ mod upgrade_notification_tests {
         let mut environment = ConcreteEnvironment::Path(environment);
 
         {
-            let upgrade_information = UpgradeInformationGuard::for_environment(
-                &flox.cache_dir,
-                environment.dot_flox_path(),
-            )
-            .unwrap();
+            let upgrade_information =
+                UpgradeInformationGuard::read_in(environment.cache_path().unwrap()).unwrap();
             let mut locked = upgrade_information.lock_if_unlocked().unwrap().unwrap();
 
             // cause old_lockfile to evaluate as non-equal to the current lockfile
@@ -1074,11 +1067,8 @@ mod upgrade_notification_tests {
         let mut environment = ConcreteEnvironment::Path(environment);
 
         {
-            let upgrade_information = UpgradeInformationGuard::for_environment(
-                &flox.cache_dir,
-                environment.dot_flox_path(),
-            )
-            .unwrap();
+            let upgrade_information =
+                UpgradeInformationGuard::read_in(environment.cache_path().unwrap()).unwrap();
 
             let result = UpgradeResult {
                 old_lockfile: Some(environment.lockfile(&flox).unwrap()),

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -881,7 +881,6 @@ mod tests {
 mod upgrade_notification_tests {
     use std::io::Write;
     use std::sync::{Arc, Mutex};
-    use std::time::SystemTime;
 
     use flox_rust_sdk::flox::test_helpers::flox_instance;
     use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment_from_env_files;
@@ -889,6 +888,7 @@ mod upgrade_notification_tests {
     use flox_rust_sdk::models::lockfile::LockedPackage;
     use flox_rust_sdk::providers::catalog::GENERATED_DATA;
     use flox_rust_sdk::providers::upgrade_checks::UpgradeInformation;
+    use time::OffsetDateTime;
     use tracing::Subscriber;
     use tracing_subscriber::filter::FilterFn;
     use tracing_subscriber::layer::SubscriberExt;
@@ -983,7 +983,7 @@ mod upgrade_notification_tests {
             }
 
             let _ = locked.info_mut().insert(UpgradeInformation {
-                last_checked: SystemTime::now(),
+                last_checked: OffsetDateTime::now_utc(),
                 result: UpgradeResult {
                     old_lockfile: Some(environment.lockfile(&flox).unwrap()),
                     new_lockfile,
@@ -1027,7 +1027,7 @@ mod upgrade_notification_tests {
             old_lockfile.packages.clear();
 
             let _ = locked.info_mut().insert(UpgradeInformation {
-                last_checked: SystemTime::now(),
+                last_checked: OffsetDateTime::now_utc(),
                 result: UpgradeResult {
                     old_lockfile: Some(old_lockfile),
                     new_lockfile: environment.lockfile(&flox).unwrap(),
@@ -1072,7 +1072,7 @@ mod upgrade_notification_tests {
             let mut locked = upgrade_information.lock_if_unlocked().unwrap().unwrap();
 
             let _ = locked.info_mut().insert(UpgradeInformation {
-                last_checked: SystemTime::now(),
+                last_checked: OffsetDateTime::now_utc(),
                 result,
             });
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -884,3 +884,226 @@ mod tests {
         assert_eq!(prompt, "wichtig".to_string());
     }
 }
+
+#[cfg(test)]
+mod upgrade_notification_tests {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use std::time::SystemTime;
+
+    use flox_rust_sdk::flox::test_helpers::flox_instance;
+    use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment_from_env_files;
+    use flox_rust_sdk::models::environment::UpgradeResult;
+    use flox_rust_sdk::providers::catalog::GENERATED_DATA;
+    use flox_rust_sdk::providers::upgrade_checks::UpgradeInformation;
+    use tracing::Subscriber;
+    use tracing_subscriber::filter::FilterFn;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct CollectingWriter {
+        buffer: Mutex<Vec<u8>>,
+    }
+
+    impl Display for CollectingWriter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let buffer = self.buffer.lock().unwrap();
+            let str_content = String::from_utf8_lossy(&buffer);
+            write!(f, "{str_content}")
+        }
+    }
+    impl Write for &CollectingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.buffer.lock().unwrap().write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.buffer.lock().unwrap().flush()
+        }
+    }
+
+    // For now this is a POC of using tracing for output tests,
+    // evenatually we should probably move that to the tracing utils or `message` module.
+    fn test_subscriber() -> (impl Subscriber, Arc<CollectingWriter>) {
+        let writer = Arc::new(CollectingWriter::default());
+
+        // TODO: also tee to test output?
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .compact()
+            .without_time()
+            .with_level(false)
+            .with_target(false)
+            .finish()
+            .with(FilterFn::new(|metadata| {
+                metadata.target() == "flox::utils::message"
+            }));
+
+        (subscriber, writer)
+    }
+
+    #[test]
+    fn no_notification_printed_if_absent() {
+        let (flox, _tempdir) = flox_instance();
+        let (subscriber, writer) = test_subscriber();
+
+        let environment =
+            new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
+        let mut environment = ConcreteEnvironment::Path(environment);
+
+        tracing::subscriber::with_default(subscriber, || {
+            notify_upgrade_if_available(&flox, &mut environment).unwrap();
+        });
+
+        let printed = writer.to_string();
+
+        assert!(printed.is_empty(), "printed: {printed}");
+    }
+
+    #[test]
+    fn notification_printed_if_present() {
+        let (flox, _tempdir) = flox_instance();
+        let (subscriber, writer) = test_subscriber();
+
+        let environment =
+            new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
+        let mut environment = ConcreteEnvironment::Path(environment);
+
+        {
+            let upgrade_information = UpgradeInformationGuard::for_environment(
+                &flox.cache_dir,
+                environment.dot_flox_path(),
+            )
+            .unwrap();
+            let mut locked = upgrade_information.lock_if_unlocked().unwrap().unwrap();
+
+            let mut new_lockfile = environment.lockfile(&flox).unwrap();
+            for locked_package in new_lockfile.packages.iter_mut() {
+                match locked_package {
+                    LockedPackage::Catalog(locked_package_catalog) => {
+                        locked_package_catalog.derivation = "upgraded".to_string()
+                    },
+                    LockedPackage::Flake(locked_package_flake) => {
+                        locked_package_flake.locked_installable.derivation = "upgraded".to_string()
+                    },
+                    LockedPackage::StorePath(_) => {},
+                }
+            }
+
+            let _ = locked.info_mut().insert(UpgradeInformation {
+                last_checked: SystemTime::now(),
+                result: UpgradeResult {
+                    old_lockfile: Some(environment.lockfile(&flox).unwrap()),
+                    new_lockfile,
+
+                    store_path: None,
+                },
+            });
+
+            locked.commit().unwrap();
+        }
+
+        tracing::subscriber::with_default(subscriber, || {
+            notify_upgrade_if_available(&flox, &mut environment).unwrap();
+        });
+
+        let printed = writer.to_string();
+
+        assert!(
+            printed.contains("The following packages can be upgraded"),
+            "printed: {printed}"
+        );
+        assert!(printed.contains("- hello: "), "printed: {printed}");
+        assert!(
+            printed.contains("Run 'flox upgrade' to apply these changes."),
+            "printed: {printed}"
+        );
+    }
+
+    #[test]
+    fn no_notification_printed_if_outdated() {
+        let (flox, _tempdir) = flox_instance();
+        let (subscriber, writer) = test_subscriber();
+
+        let environment =
+            new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
+        let mut environment = ConcreteEnvironment::Path(environment);
+
+        {
+            let upgrade_information = UpgradeInformationGuard::for_environment(
+                &flox.cache_dir,
+                environment.dot_flox_path(),
+            )
+            .unwrap();
+            let mut locked = upgrade_information.lock_if_unlocked().unwrap().unwrap();
+
+            // cause old_lockfile to evaluate as non-equal to the current lockfile
+            let mut old_lockfile = environment.lockfile(&flox).unwrap();
+            old_lockfile.packages.clear();
+
+            let _ = locked.info_mut().insert(UpgradeInformation {
+                last_checked: SystemTime::now(),
+                result: UpgradeResult {
+                    old_lockfile: Some(old_lockfile),
+                    new_lockfile: environment.lockfile(&flox).unwrap(),
+
+                    store_path: None,
+                },
+            });
+
+            locked.commit().unwrap();
+        }
+
+        tracing::subscriber::with_default(subscriber, || {
+            notify_upgrade_if_available(&flox, &mut environment).unwrap();
+        });
+
+        let printed = writer.to_string();
+        assert!(printed.is_empty(), "printed: {printed}");
+    }
+
+    #[test]
+    fn no_notification_printed_if_no_diff() {
+        let (flox, _tempdir) = flox_instance();
+        let (subscriber, writer) = test_subscriber();
+
+        let environment =
+            new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
+        let mut environment = ConcreteEnvironment::Path(environment);
+
+        {
+            let upgrade_information = UpgradeInformationGuard::for_environment(
+                &flox.cache_dir,
+                environment.dot_flox_path(),
+            )
+            .unwrap();
+
+            let result = UpgradeResult {
+                old_lockfile: Some(environment.lockfile(&flox).unwrap()),
+                new_lockfile: environment.lockfile(&flox).unwrap(),
+
+                store_path: None,
+            };
+
+            assert_eq!(result.diff(), vec![]);
+
+            let mut locked = upgrade_information.lock_if_unlocked().unwrap().unwrap();
+
+            let _ = locked.info_mut().insert(UpgradeInformation {
+                last_checked: SystemTime::now(),
+                result,
+            });
+
+            locked.commit().unwrap();
+        }
+
+        tracing::subscriber::with_default(subscriber, || {
+            notify_upgrade_if_available(&flox, &mut environment).unwrap();
+        });
+
+        let printed = writer.to_string();
+        assert!(printed.is_empty(), "printed: {printed}");
+    }
+}

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -696,6 +696,21 @@ impl Activate {
 /// Upon activation flox will start a detached process to check for upgrades.
 /// Future activations will be able to read the upgrade information from a file
 /// and notify the user if there are any upgrades available using this function.
+/// See [spawn_detached_check_for_upgrades_process] for more information
+/// on the upgrade check process.
+///
+/// This function reads the upgrade information for a given environment,
+/// and prints a message to the user if the upgrade information is still applicable
+/// to the current environment -- based on the same lockfile
+/// and indicating that upgrades are available.
+/// There is no refractory period for upgrade notifications,
+/// i.e. we message _every_ time this function is called by `flox activate`.
+/// The motivation for this is to provide deterministic behavior,
+/// compared to comparatively random display of upgrade messages every hour or so.
+/// For example, when a user activates an environment and sees a message,
+/// but doesn't act on it, they should see the message again next time they activate,
+/// so they are not wondering whether upgrades may have been applied automatically.
+/// To make this less annoying, we tried to make the message as unobtrusive as possible.
 fn notify_upgrade_if_available(flox: &Flox, environment: &mut ConcreteEnvironment) -> Result<()> {
     let upgrade_guard = UpgradeInformationGuard::read_in(environment.cache_path()?)?;
 

--- a/cli/flox/src/commands/check_for_upgrades.rs
+++ b/cli/flox/src/commands/check_for_upgrades.rs
@@ -65,7 +65,7 @@ impl CheckForUpgrades {
             let is_information_for_current_lockfile =
                 info.result.old_lockfile == Some(environment_lockfile);
             let is_checked_recently =
-                info.last_checked.elapsed().unwrap().as_secs() <= self.check_timeout;
+                info.last_checked.elapsed().unwrap().as_secs() < self.check_timeout;
 
             if is_information_for_current_lockfile && is_checked_recently {
                 debug!("Recently checked for upgrades. Skipping.");

--- a/cli/flox/src/commands/check_for_upgrades.rs
+++ b/cli/flox/src/commands/check_for_upgrades.rs
@@ -1,0 +1,91 @@
+use std::time::SystemTime;
+
+use anyhow::Result;
+use bpaf::{Bpaf, Parser};
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::Environment;
+use flox_rust_sdk::providers::upgrade_checks::{UpgradeInformation, UpgradeInformationGuard};
+use serde::de::DeserializeOwned;
+use tracing::{debug, info_span, instrument};
+
+use super::UninitializedEnvironment;
+use crate::subcommand_metric;
+
+/// By default check once a day
+const DEFAULT_TIMEOUT_SECONDS: u64 = 24 * 60 * 60;
+
+#[derive(Bpaf, Clone)]
+pub struct CheckForUpgrades {
+    /// Skip checking for upgrade if checked less <timeout> seconds ago
+    #[bpaf(long, argument("seconds"), fallback(DEFAULT_TIMEOUT_SECONDS))]
+    check_timeout: u64,
+
+    #[bpaf(external(parse_uninitialized_environment_json))]
+    environment: UninitializedEnvironment,
+}
+
+fn parse_uninitialized_environment_json<T: DeserializeOwned>() -> impl Parser<T> {
+    bpaf::positional("environment")
+        .help("JSON representation of an uninitialized environment to be checked")
+        .parse(|string: String| serde_json::from_str::<T>(&string))
+}
+
+impl CheckForUpgrades {
+    #[instrument(name = "check-upgrade", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("check-upgrade");
+
+        let mut environment = self.environment.into_concrete_environment(&flox)?;
+
+        let upgrade_information =
+            UpgradeInformationGuard::for_environment(&flox.cache_dir, environment.dot_flox_path())?;
+
+        // Return if previous information
+        // - exists &&
+        // - targets the current lockfile &&
+        // - has recently been fetched
+        // Otherwise, dry-upgrade the environment and store the new information
+        if let Some(info) = upgrade_information.info() {
+            let environment_lockfile = environment.lockfile(&flox)?;
+            if Some(environment_lockfile) == info.result.old_lockfile
+                && info.last_checked.elapsed().unwrap().as_secs() < self.check_timeout
+            {
+                debug!("Recently checked for upgrades. Skipping.");
+                return Ok(());
+            }
+        }
+
+        let Ok(mut locked) = upgrade_information.lock_if_unlocked()? else {
+            debug!("Lock already taken. Skipping.");
+            return Ok(());
+        };
+
+        let result = info_span!("check-upgrade", progress = "Performing dry upgrade")
+            .entered()
+            .in_scope(|| environment.dry_upgrade(&flox, &[]))?;
+
+        let info = locked.info_mut();
+
+        match info.as_mut() {
+            // Check if the resolution didn't change,
+            // only update the last checked timestamp
+            Some(old_info) if old_info.result.new_lockfile == result.new_lockfile => {
+                debug!("Resolution didn't change. Updating last checked timestamp.");
+                old_info.last_checked = SystemTime::now()
+            },
+            Some(_) | None => {
+                debug!(diff = ?result.diff(), "Upgrading information with new result.");
+
+                let new_info = UpgradeInformation {
+                    last_checked: SystemTime::now(),
+                    result,
+                };
+                let _ = info.insert(new_info);
+            },
+        };
+
+        locked.commit()?;
+
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1,6 +1,7 @@
 mod activate;
 mod auth;
 mod build;
+mod check_for_upgrades;
 mod containerize;
 mod delete;
 mod edit;
@@ -927,6 +928,12 @@ enum InternalCommands {
     /// Lock a manifest file
     #[bpaf(command, hide)]
     LockManifest(#[bpaf(external(lock_manifest::lock_manifest))] lock_manifest::LockManifest),
+    /// Check for environmet upgrades
+    #[bpaf(command, hide)]
+    CheckForUpgrades(
+        #[bpaf(external(check_for_upgrades::check_for_upgrades))]
+        check_for_upgrades::CheckForUpgrades,
+    ),
 }
 
 impl InternalCommands {
@@ -938,6 +945,7 @@ impl InternalCommands {
             InternalCommands::Publish(args) => args.handle(config, flox).await?,
             InternalCommands::Upload(args) => args.handle(config, flox).await?,
             InternalCommands::LockManifest(args) => args.handle(flox).await?,
+            InternalCommands::CheckForUpgrades(args) => args.handle(flox).await?,
         }
         Ok(())
     }

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -94,7 +94,7 @@ pub struct FloxConfig {
     /// Hide environments named 'default' from the shell prompt
     pub hide_default_prompt: Option<bool>,
 
-    /// Check for upgrades on `flox activate` (default: true)
+    /// Print notification if upgrades are available on `flox activate` (default: true)
     pub upgrade_notifications: Option<bool>,
 }
 

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -93,6 +93,9 @@ pub struct FloxConfig {
 
     /// Hide environments named 'default' from the shell prompt
     pub hide_default_prompt: Option<bool>,
+
+    /// Check for upgrades on `flox activate` (default: true)
+    pub upgrade_notifications: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Following this PR, `flox activate` will perform a dry upgrade of the activated environment, in the background.
If upgrades are available, upon the next activation `flox` will notify the user that upgrades are available.

```shell
$ flox activate 
ℹ️  Upgrades are available for packages in 'name'.
Use 'flox upgrade' to get the latest.

✅ You are now using the environment 'environmentname'.
To stop using this environment, type 'exit'
```

## Proposed Changes

## [feat: add provider for upgrade checks](https://github.com/flox/flox/commit/0da326bed3b6717550a6aa259089a6c67dd2365f)
Add an access layer for an `UpgradeInformation` file.
An `UpgradeInformationGuard<Unlocked>` is used to access a possibly absent file.
The guard can attempt to acquire a file lock to gain exclusive access to the `UpgradeInformation` on disk.
`UpgradeInformationGuard::try_lock` will _not_ block, but instead return early
without changing state.

## [feat: add hidden check-for-upgrades command](https://github.com/flox/flox/commit/4ba6688646c5f1424a1574499094066505427199) 
A simple subcommand that opens a provided `UninitializedEnvironment` and attempts a `dry_upgrade`.
The result is written to an `UpgradeInformation` file.
Concurrent writes to the file are prevented by first acquiring a lock.
If there already is an UpgradeInformation file, which has been checked less than `<check-timeout>` seconds (default 1 day) ago,
or any other process currently owns a lock,
the process exits early without attempting another upgrade, or touching the file.

## [feat: add helper function for spawning an async upgrade check](https://github.com/flox/flox/commit/1c04d42557c5e5debf7d858171d6a7a2cb427b5b) 

Spawn a new `flox check-for-upgrades` process in the background,
and redirect its logs to a log file.

The process will live on after the parent process exits.
When multiple processes are spawned, e.g. due to multiple successive activations,
one (usually the first) process will grab a lock on the upgrade information file,
and the others will exit early.

## [feat(activate): notify users applicable upgrade information was found](https://github.com/flox/flox/commit/6501509c56f92966fd6bf5ea04c9b7e5154a762d) 

Before activation, read the result of a previous `check-for-upgrade`.
If an UpgradeInfo file exists, corresponds to the activated lockfile,
and suggests that upgrades are available,
compile a report of what packages could be upgraded.

feat: spawn async check for upgrades before executing the activation

feat: add config option to disable upgrade notifications