### PR TITLE
feat: add FLOX_ACTIVATE_TRACE debugging feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,51 @@ section refers to settings from that plugin.
    "shellformat.useEditorConfig": true,
   ```
 
+### Activation scripts
+
+Flox activations invoke a series of scripts
+which begins with the `activate` script
+as maintained in the `assets/activation-scripts` subdirectory.
+The process of developing these scripts is highly iterative,
+and it can be challenging to follow the sequence of scripts
+as invoked in different contexts.
+
+To make debugging easier
+we have added invocations of a "tracer" script
+to the top and bottom of each file to be sourced.
+This script then prints to STDERR
+the full path of the file and one of "START" or "END"
+depending on its position in the file.
+We invoke the "tracer" script in this way
+so as to remain compatible with all shells.
+
+The default "tracer" script is "true",
+which under normal circumstances will do nothing,
+but it can be set to a Flox or user-provided script
+by way of the following:
+
+1. set `FLOX_ACTIVATE_TRACE` to a non-empty value
+
+    If `FLOX_ACTIVATE_TRACE` is defined
+    but does _not_ refer to the path of an executable file
+    then tracing will be performed using the standard
+    `activate.d/trace` script included in the Flox environment.
+
+1. set `FLOX_ACTIVATE_TRACE` to the path of a program of your choosing
+
+    Otherwise, if `FLOX_ACTIVATE_TRACE` contains the path of an executable file
+    then that will be the program invoked
+    at the start and end of each activation script.
+    This is useful when studying the effects of activation scripts
+    on certain environment variables and shell settings.
+
+To use the tracing facility when testing changes to the activation scripts,
+the canonical/authoritative method is to build and activate the full `flox` package:
+```
+nix build
+FLOX_ACTIVATE_TRACE=1 result/bin/flox activate [args]
+```
+
 ## Testing
 
 ### Unit tests

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-_dirname="@coreutils@/bin/dirname"
-_getopt="@getopt@/bin/getopt"
-_nawk="@nawk@/bin/nawk"
-_readlink="@coreutils@/bin/readlink"
-_flox_activations="@flox_activations@"
-
-set -euo pipefail
 
 # Trace levels supported by activation scripts:
 #   1. (-v) top-level activate script
@@ -14,6 +7,30 @@ set -euo pipefail
 #   3. (-vvv) zsh `autoload -U compinit` (very verbose)
 export _flox_activate_tracelevel="${_FLOX_PKGDB_VERBOSITY:-0}"
 [ "$_flox_activate_tracelevel" -eq 0 ] || set -x
+
+# Ensure that $_flox_activate_tracer is defined as an executable.
+if [ -z "${FLOX_ACTIVATE_TRACE-}" ]; then
+  # If FLOX_ACTIVATE_TRACE is empty or not set, set _flox_activate_tracer to
+  # `true` which can always be invoked with any arguments without error.
+  export _flox_activate_tracer=true
+else
+  # If FLOX_ACTIVATE_TRACE is set but does not refer to an executable, then
+  # set _flox_activate_tracer to the default trace script.
+  if [ -x "${FLOX_ACTIVATE_TRACE:-}" ]; then
+    export _flox_activate_tracer="$FLOX_ACTIVATE_TRACE"
+  else
+    export _flox_activate_tracer="__OUT__/activate.d/trace"
+  fi
+fi
+"$_flox_activate_tracer" "__OUT__/activate" START
+
+_dirname="@coreutils@/bin/dirname"
+_getopt="@getopt@/bin/getopt"
+_nawk="@nawk@/bin/nawk"
+_readlink="@coreutils@/bin/readlink"
+_flox_activations="@flox_activations@"
+
+set -euo pipefail
 
 # These all derive from the `flox-interpreter` package.
 # FIXME This is wrong; the profile.d scripts in particular should be
@@ -208,3 +225,5 @@ else
   # shellcheck source-path=SCRIPTDIR/activate.d
   source "${_activate_d}/attach-inplace.bash"
 fi
+
+"$_flox_activate_tracer" "__OUT__/activate" END

--- a/assets/activation-scripts/activate.d/attach-command.bash
+++ b/assets/activation-scripts/activate.d/attach-command.bash
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/attach-command.bash" START
+
 # "command" mode(s): invoke the user's shell with args that:
 #   a. defeat the shell's normal startup scripts
 #   b. source the relevant activation script
@@ -87,3 +89,5 @@ case "$_flox_shell" in
     exit 1
     ;;
 esac
+
+"$_flox_activate_tracer" "$_activate_d/attach-command.bash" END

--- a/assets/activation-scripts/activate.d/attach-inplace.bash
+++ b/assets/activation-scripts/activate.d/attach-inplace.bash
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/attach-inplace.bash" START
+
 expiring_pid="$$"
 # Put a 5 second timeout on the activation
 "$_flox_activations" \
@@ -40,6 +42,7 @@ case "$_flox_shell" in
     echo "export _FLOX_ACTIVATION_STATE_DIR=\"$_FLOX_ACTIVATION_STATE_DIR\";"
     echo "export FLOX_ZSH_INIT_SCRIPT=\"$_activate_d/zsh\";"
     echo "export _activate_d=\"$_activate_d\";"
+    echo "export _flox_activate_tracer=\"$_flox_activate_tracer\";"
     echo "source '$_activate_d/zsh';"
     ;;
   *)
@@ -47,3 +50,5 @@ case "$_flox_shell" in
     exit 1
     ;;
 esac
+
+"$_flox_activate_tracer" "$_activate_d/attach-inplace.bash" END

--- a/assets/activation-scripts/activate.d/attach-interactive.bash
+++ b/assets/activation-scripts/activate.d/attach-interactive.bash
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/attach-interactive.bash" START
+
 # Export PATH and MANPATH to restore in shell-specific activate scripts.
 export _FLOX_RESTORE_PATH="$PATH"
 export _FLOX_RESTORE_MANPATH="$MANPATH"
@@ -77,3 +79,5 @@ case "$_flox_shell" in
     exit 1
     ;;
 esac
+
+"$_flox_activate_tracer" "$_activate_d/attach-interactive.bash" END

--- a/assets/activation-scripts/activate.d/attach.bash
+++ b/assets/activation-scripts/activate.d/attach.bash
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/attach.bash" START
+
 _sed="@gnused@/bin/sed"
 
 # If interactive and a command has not been passed, this is an interactive
@@ -14,3 +16,5 @@ fi
 # Replay the environment for the benefit of this shell.
 eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
 eval "$($_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
+
+"$_flox_activate_tracer" "$_activate_d/attach.bash" END

--- a/assets/activation-scripts/activate.d/generate-bash-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-bash-startup-commands.bash
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2154
 
 _sed="@gnused@/bin/sed"
 
@@ -48,6 +49,11 @@ generate_bash_startup_commands() {
     if [ -n "$_FLOX_RESTORE_MANPATH" ]; then
       echo "export MANPATH='$_FLOX_RESTORE_MANPATH';"
     fi
+
+    # Propagate $_activate_d to the environment.
+    echo "export _activate_d='$_activate_d';"
+    # Propagate $_flox_activate_tracer to the environment.
+    echo "export _flox_activate_tracer='$_flox_activate_tracer';"
   fi
 
   # Set the prompt if we're in an interactive shell.
@@ -56,7 +62,11 @@ generate_bash_startup_commands() {
   # Source user-specified profile scripts if they exist.
   for i in profile-common profile-bash hook-script; do
     if [ -e "$FLOX_ENV/activate.d/$i" ]; then
+      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" START
       echo "source '$FLOX_ENV/activate.d/$i';"
+      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" END
+    else
+      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" NOT FOUND
     fi
   done
 

--- a/assets/activation-scripts/activate.d/generate-fish-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-fish-startup-commands.bash
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2154
+
 _sed="@gnused@/bin/sed"
 
 # N.B. the output of
@@ -41,6 +43,11 @@ generate_fish_startup_commands() {
     if [ -n "$_FLOX_RESTORE_MANPATH" ]; then
       echo "set -gx MANPATH $_FLOX_RESTORE_MANPATH;"
     fi
+
+    # Propagate $_activate_d to the environment.
+    echo "set -gx _activate_d $_activate_d;"
+    # Propagate $_flox_activate_tracer to the environment.
+    echo "set -gx _flox_activate_tracer $_flox_activate_tracer;"
   fi
 
   # Set the prompt if we're in an interactive shell.
@@ -49,7 +56,11 @@ generate_fish_startup_commands() {
   # Source user-specified profile scripts if they exist.
   for i in profile-common profile-fish hook-script; do
     if [ -e "$FLOX_ENV/activate.d/$i" ]; then
+      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" START
       echo "source '$FLOX_ENV/activate.d/$i';"
+      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" END
+    else
+      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" NOT FOUND
     fi
   done
 

--- a/assets/activation-scripts/activate.d/generate-tcsh-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-tcsh-startup-commands.bash
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2154
 
 _sed="@gnused@/bin/sed"
 
@@ -44,6 +45,11 @@ generate_tcsh_startup_commands() {
     if [ -n "$_FLOX_RESTORE_MANPATH" ]; then
       echo "setenv MANPATH '$_FLOX_RESTORE_MANPATH';"
     fi
+
+    # Propagate $_activate_d to the environment.
+    echo "setenv _activate_d '$_activate_d';"
+    # Propagate $_flox_activate_tracer to the environment.
+    echo "setenv _flox_activate_tracer '$_flox_activate_tracer';"
   fi
 
   # Set the prompt if we're in an interactive shell.

--- a/assets/activation-scripts/activate.d/set-prompt.bash
+++ b/assets/activation-scripts/activate.d/set-prompt.bash
@@ -1,4 +1,7 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2154
+"$_flox_activate_tracer" "$_activate_d/set-prompt.bash" START
+
 # Tweak the (already customized) prompt: add a flox indicator.
 
 _esc="\x1b["
@@ -40,3 +43,5 @@ if [ -n "$_flox" ] && [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != 
 fi
 
 unset _flox
+
+"$_flox_activate_tracer" "$_activate_d/set-prompt.bash" END

--- a/assets/activation-scripts/activate.d/set-prompt.fish
+++ b/assets/activation-scripts/activate.d/set-prompt.fish
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/set-prompt.fish" START
+
 if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS" && [ "$_FLOX_SET_PROMPT" != false ]
     if not set -q FLOX_PROMPT
         set FLOX_PROMPT "flox"
@@ -22,3 +24,5 @@ if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS" && [ "
         flox_saved_fish_prompt
     end
 end
+
+"$_flox_activate_tracer" "$_activate_d/set-prompt.fish" END

--- a/assets/activation-scripts/activate.d/set-prompt.tcsh
+++ b/assets/activation-scripts/activate.d/set-prompt.tcsh
@@ -1,3 +1,5 @@
+$_flox_activate_tracer $_activate_d/set-prompt.tcsh START
+
 # Tweak the (already customized) prompt: add a flox indicator.
 if ( ! $?FLOX_PROMPT ) then
     set FLOX_PROMPT = "flox"
@@ -27,3 +29,5 @@ if ( $?prompt && "$FLOX_PROMPT_ENVIRONMENTS" != "" && "$_FLOX_SET_PROMPT" != "fa
 endif
 
 unset _flox
+
+$_flox_activate_tracer $_activate_d/set-prompt.tcsh END

--- a/assets/activation-scripts/activate.d/set-prompt.zsh
+++ b/assets/activation-scripts/activate.d/set-prompt.zsh
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/set-prompt.zsh" START
+
 # Tweak the (already customized) prompt: add a flox indicator.
 
 _floxPrompt1="${FLOX_PROMPT-flox}"
@@ -30,3 +32,5 @@ if [ -n "$_flox" -a -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" -a "$
 fi
 
 unset _flox _floxPrompt1 _floxPrompt2
+
+"$_flox_activate_tracer" "$_activate_d/set-prompt.zsh" END

--- a/assets/activation-scripts/activate.d/set-run-variables.bash
+++ b/assets/activation-scripts/activate.d/set-run-variables.bash
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/set-run-variables.bash" START
+
 # Now that we support attaching to an environment we can no longer rely on
 # the environment variable replay for setting the PATH and MANPATH variables,
 # and must instead infer them from the FLOX_ENV_DIRS variable maintained for
@@ -68,3 +70,5 @@ _nodup_PATH="$(echo "$PATH" | "$_nawk" "$_awkScript")"
 _nodup_MANPATH="$(echo "$MANPATH" | "$_nawk" "$_awkScript")"
 export PATH="${_nodup_PATH}"
 export MANPATH="${_nodup_MANPATH}"
+
+"$_flox_activate_tracer" "$_activate_d/set-run-variables.bash" END

--- a/assets/activation-scripts/activate.d/start-services.bash
+++ b/assets/activation-scripts/activate.d/start-services.bash
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/start-services.bash" START
+
 NOT_READY="SOCKET_NOT_READY"
 
 poll_services_status() {
@@ -89,3 +91,5 @@ start_services_blocking() {
 
 config_file="$FLOX_ENV/service-config.yaml"
 start_services_blocking "$config_file" "$_FLOX_SERVICES_SOCKET" "$_FLOX_ENV_LOG_DIR"
+
+"$_flox_activate_tracer" "$_activate_d/start-services.bash" START

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/start.bash" START
+
 _comm="@coreutils@/bin/comm"
 _daemonize="@daemonize@/bin/daemonize"
 _flox_activations="@flox_activations@"
@@ -79,9 +81,13 @@ if [ -e "$FLOX_ENV/activate.d/hook-on-activate" ]; then
   # as configuration statements by the "in-place" activation
   # mode. So, we'll redirect stdout to stderr.
   set +euo pipefail
+  "$_flox_activate_tracer" "$FLOX_ENV/activate.d/hook-on-activate" START
   # shellcheck disable=SC1091 # from rendered environment
   source "$FLOX_ENV/activate.d/hook-on-activate" 1>&2
+  "$_flox_activate_tracer" "$FLOX_ENV/activate.d/hook-on-activate" END
   set -euo pipefail
+else
+  "$_flox_activate_tracer" "$FLOX_ENV/activate.d/hook-on-activate" NOT FOUND
 fi
 
 # Capture ending environment.
@@ -113,3 +119,5 @@ LC_ALL=C $_comm -23 "$_start_env" "$_end_env" \
   --runtime-dir "$FLOX_RUNTIME_DIR" \
   set-ready \
   --flox-env "$FLOX_ENV" --id "$_FLOX_ACTIVATION_ID"
+
+"$_flox_activate_tracer" "$_activate_d/start.bash" END

--- a/assets/activation-scripts/activate.d/trace.bash
+++ b/assets/activation-scripts/activate.d/trace.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -o pipefail
+path0=$(echo "$PATH" | cut -d: -f1)
+if realpath "$path0" | grep -q "^/nix/store/"; then
+  echo "FLOX_ACTIVATE_TRACE:" "$*" ✅ PATH 1>&2
+else
+  echo "FLOX_ACTIVATE_TRACE:" "$*" "❌ path[0] = $path0" 1>&2
+fi

--- a/assets/activation-scripts/activate.d/zdotdir/.zlogin
+++ b/assets/activation-scripts/activate.d/zdotdir/.zlogin
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$activate_d/zdotdir/.zlogin" START
+
 # Source /etc/zlogin and "${FLOX_ORIG_ZDOTDIR:-$HOME}/.zlogin" if they exist
 # prior to performing Flox-specific initialization.
 #
@@ -54,3 +56,5 @@ fi
 
 # Bring in the Nix and Flox environment customizations.
 [ -z "$FLOX_ZSH_INIT_SCRIPT" ] || source "$FLOX_ZSH_INIT_SCRIPT"
+
+"$_flox_activate_tracer" "$activate_d/zdotdir/.zlogin" END

--- a/assets/activation-scripts/activate.d/zdotdir/.zprofile
+++ b/assets/activation-scripts/activate.d/zdotdir/.zprofile
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/zdotdir/.zprofile" START
+
 # Source /etc/zprofile and "${FLOX_ORIG_ZDOTDIR:-$HOME}/.zprofile" if they exist.
 #
 # See README.md for more information on the initialization process.
@@ -54,3 +56,5 @@ fi
 # Do not bring in the Nix and Flox environment customizations from this file
 # because one of the neighbouring .zshrc or .zlogin files will always be
 # sourced after this one.
+
+"$_flox_activate_tracer" "$_activate_d/zdotdir/.zprofile" END

--- a/assets/activation-scripts/activate.d/zdotdir/.zshenv
+++ b/assets/activation-scripts/activate.d/zdotdir/.zshenv
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/zdotdir/.zshenv" START
+
 # Source /etc/zshenv and "${FLOX_ORIG_ZDOTDIR:-$HOME}/.zshenv" if they exist
 # prior to performing Flox-specific initialization.
 #
@@ -60,3 +62,5 @@ fi
 # after we've set it up.
 [[ -o interactive ]] || [[ -o login ]] || \
   [ -z "$FLOX_ZSH_INIT_SCRIPT" ] || source "$FLOX_ZSH_INIT_SCRIPT"
+
+"$_flox_activate_tracer" "$_activate_d/zdotdir/.zshenv" END

--- a/assets/activation-scripts/activate.d/zdotdir/.zshrc
+++ b/assets/activation-scripts/activate.d/zdotdir/.zshrc
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/zdotdir/.zshrc" START
+
 # Source /etc/zshrc and "${FLOX_ORIG_ZDOTDIR:-$HOME}/.zshrc" if they exist
 # prior to performing Flox-specific initialization.
 #
@@ -59,3 +61,5 @@ fi
 # opportunity to perturb the environment after we've set it up.
 [[ -o login ]] || \
   [ -z "$FLOX_ZSH_INIT_SCRIPT" ] || source "$FLOX_ZSH_INIT_SCRIPT"
+
+"$_flox_activate_tracer" "$_activate_d/zdotdir/.zshrc" END

--- a/assets/activation-scripts/activate.d/zsh
+++ b/assets/activation-scripts/activate.d/zsh
@@ -1,3 +1,5 @@
+"$_flox_activate_tracer" "$_activate_d/zsh" START
+
 _sed="@gnused@/bin/sed"
 
 # Confirm _flox_activate_tracelevel is defined before proceeding.
@@ -82,7 +84,11 @@ fi
 # Source user-specified profile scripts if they exist.
 for i in profile-common profile-zsh hook-script; do
   if [ -e "$FLOX_ENV/activate.d/$i" ]; then
+    "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" START
     source "$FLOX_ENV/activate.d/$i"
+    "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" END
+  else
+    "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" NOT FOUND
   fi
 done
 
@@ -98,3 +104,5 @@ if [ "$_flox_activate_tracelevel" -ge 2 ]; then
   set +x
 fi
 unset _flox_activate_tracelevel
+
+"$_flox_activate_tracer" "$_activate_d/zsh" END

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -75,16 +75,18 @@ runCommandNoCC "flox-activation-scripts"
   ''
     # Create the "out" output.
     cp -R ${activation-scripts} $out
-    chmod +x $out/activate
     chmod -R +w $out
+    chmod +x $out/activate
     patchShebangs $out/activate
-    substituteInPlace $out/activate --replace-fail "__OUT__" "$out"
+    mv $out/activate.d/trace.bash $out/activate.d/trace
+    chmod +x $out/activate.d/trace
+    patchShebangs $out/activate.d/trace
 
     # Next create the (lesser) "build_wrapper" output.
-    cp -R ${activation-scripts} $build_wrapper
-    chmod +x $build_wrapper/activate
-    chmod -R +w $build_wrapper
-    patchShebangs $build_wrapper/activate
+    cp -R $out $build_wrapper
+
+    # Replace __OUT__ with the output path for both outputs.
+    substituteInPlace $out/activate --replace-fail "__OUT__" "$out"
     substituteInPlace $build_wrapper/activate --replace-fail "__OUT__" "$build_wrapper"
 
     # TODO: come up with neater way to master activate script for build_wrapper case.


### PR DESCRIPTION
## Proposed Changes

With the myriad of activation scripts I was finding it challenging to track environment variable changes happening in the different files, so I added invocations of a $FLOX_ACTIVATE_TRACE script at the beginning and end of each file in order to trace their various entry/exit points. While this PR includes a default trace script, it also provides the ability for people to provide their own, making it a convenient hook for inspecting the changes that can happen to arbitrary variables.

The full instructions for using this variable have been added to the CONTRIBUTING.md document.

## Release Notes

* added new FLOX_ACTIVATE_TRACE feature for use debugging activation scripts