### PR TITLE
fix: Recursive walkReferences runs forever and eats all your CPU/RAM

### DIFF
--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -334,6 +334,9 @@ if ($manifest) {
 # <flox>
 } else {
 
+    # For each reference being walked, make sure we don't trip over cyclic links.
+    my %seen;
+
     sub parseJSONFile($) {
         my $json_file = shift;
         # Read the JSON file.
@@ -681,11 +684,12 @@ if ($manifest) {
         my $references = shift @_;
         my $pkg = shift @_;
         my @retarray = ( $pkg );
-        if (defined $references->{$pkg}) {
+        if (defined $references->{$pkg} and not defined $seen{$pkg}) {
             foreach my $reference (@{$references->{$pkg}}) {
                 next if $reference eq $pkg;
                 push @retarray, walkReferences($references, $reference);
             }
+            $seen{$pkg} = 1;
         } else {
             warn "references for package $pkg not found\n";
         }
@@ -709,6 +713,7 @@ if ($manifest) {
         %done = ();
         %postponed = ();
         %symlinks = ();
+        %seen = ();
         my $envName = $output->{"name"};
 
         my $path = $nix_attrs->{"outputs"}{$envName};


### PR DESCRIPTION
We didn't notice the slowness sooner since most of the closures small enough to be "good enough". But using the haskell ecosystem (with many packages in closure) you notice this right way.

But the issue that brought this up is `slack` package (the version at the time of commiting this), has some loop. Since loops are not possible within a single package output, I assume the loop happens between different package outputs.

Also a very nice side benefit is also that this fix should also speed up other Flox environments. The bigger the closure the more the speed up we'll see, which usually means bigger Flox environments will see most of the speed up.

