### PR TITLE
fix: minor bugs in cli/tests/activate.bats

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -860,7 +860,7 @@ EOF
   # Don't use run or assert_output because we can't use them for
   # shells other than bash.
   cat <<'EOF' | tcsh
-    eval "`$FLOX_BIN activate`" >& "$PROJECT_DIR/stderr_1"
+    eval "`$FLOX_BIN activate`" |& tee "$PROJECT_DIR/stderr_1"
     grep -q "sourcing hook.on-activate" "$PROJECT_DIR/stderr_1"
     "$FLOX_BIN" activate | grep -q "sourcing hook.on-activate"
     if ($? == 0) then
@@ -3746,7 +3746,7 @@ EOF
   # Instead `eval "$(flox activate -d default)"` manually to simulate sourcing
   # .bashrc
 
-  echo "eval \`$FLOX_BIN activate -d '$PROJECT_DIR/default'\`" > "$HOME/.tcshrc.extra"
+  echo "eval \"\`$FLOX_BIN activate -d '$PROJECT_DIR/default'\`\"" > "$HOME/.tcshrc.extra"
 
 
   export TCSH="$(which tcsh)"


### PR DESCRIPTION
## Proposed Changes

Minor changes to `cli/tests/activate.bats` to fix bugs encountered while working on #2552:

- use `tee` to display output to stdout as well as stderr so that you can see what goes wrong when the `activate:hook:tcsh` test fails
- properly quote`flox activate` output in the "tcsh: repeat activation in .tcshrc creates correct PATH ordering" test 

## Release Notes

N/A