### PR TITLE
fix(activate): zsh interactive force rehash

### DIFF
--- a/assets/activation-scripts/activate.d/zsh
+++ b/assets/activation-scripts/activate.d/zsh
@@ -94,6 +94,19 @@ done
 setopt nohashcmds
 setopt nohashdirs
 
+# Undo the hashing that plugins like `vcs_info` perform as a side-effect of
+# checking `$commands` from `precmd` hooks in interactive shells. We should have
+# loaded all user config by now so our hook will come near-to-last. Setting
+# `nohashlistall` will prevent them from finding VCS commands altogether.
+if [[ -o interactive ]]; then
+  # Underscore prefix to prevent it polluting auto-complete.
+  function _flox_rehash() {
+    hash -r
+  }
+  autoload -Uz add-zsh-hook
+  add-zsh-hook precmd _flox_rehash
+fi
+
 # Disable tracing before potentially launching into user shell.
 if [ "$_flox_activate_tracelevel" -ge 2 ]; then
   set +x


### PR DESCRIPTION
## Proposed Changes

Add a `precmd` hook for interactive zsh shells that calls `hash -r` to undo the effect of `vcs_info` and other plugins that inadvertently populate the hash table by accessing `$commands`.

This prevented newly installed packages from being picked up if they were already on PATH from outside the environment and were then installed within an activation.

Calling `vcs_info` populates the hash table despite `nohashcmds` and `nohashdirs` being set:

    % zsh -o NO_GLOBAL_RCS -o NO_RCS -o nohashcmds -o nohashdirs
    mba15% hash | wc -l
    0
    mba15% autoload -Uz vcs_info
    mba15% vcs_info
    mba15% hash | wc -l
    1412

Narrowing it down to what a function like `VCS_INFO_detect_git` does:

    % zsh -o NO_GLOBAL_RCS -o NO_RCS -o nohashcmds -o nohashdirs
    mba15% hash | wc -l
    0
    mba15% echo "$commands[git]"
    /Users/dcarley/projects/dcarley/flox-envs/shell/.flox/run/aarch64-darwin.shell.run/bin/git
    mba15% hash | wc -l
    1412

Disabling `nohashlistall` prevents it from happening but it also breaks anything that depends on `$commands` so `vcs_info` no longer detects `git` or sets a prompt variable:

    % zsh -o NO_GLOBAL_RCS -o NO_RCS -o nohashcmds -o nohashdirs -o nohashlistall
    mba15% autoload -Uz vcs_info
    mba15% vcs_info
    mba15% hash | wc -l
    0
    mba15% echo "vcs_info: ${vcs_info_msg_0_}"
    vcs_info:

I couldn't see any other way to configure this in `zsh` so I've added our own `precmd` hook which will clear the hash table after all of the other hooks are done. This is only added for interactive shells where `precmd` would be run. I don't expect it to have any negative effect on performance or functionality since clearing the hash table is fast and it's equivalent to what we were doing in the absence of these plugins anyway.

I'm not happy about needing to use `expect` in the test, not least because it clobbers the output so that we need to use `assert_line --partial`, but it gives us the most realistic test to demonstrate the issue and prevent future regressions. The only thing I'm not doing is setting the prompt because it's a pain to check from the `expect` output.

## Release Notes

Fixed a bug with interactive `zsh` shells not finding newly installed packages if they were already available from `PATH` and VCS plugins were in use.