### PR TITLE
fix(activations): Recover from deadlock

### DIFF
--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -175,7 +175,7 @@ impl<V> Activations<V> {
             .find(|activation| activation.id == activation_id.as_ref())
     }
 
-    /// Remove an activation. Should only be called by `flox-watchdog`.
+    /// Remove an activation.
     pub fn remove_activation(&mut self, id: impl AsRef<str>) {
         self.activations
             .retain(|activation| activation.id != id.as_ref());


### PR DESCRIPTION
## Proposed Changes

Remove an activation that's not ready and the starting process is no longer running so that another loop of `handle_inner()` can recover from the error by starting a new activation.

We introduced the first known occurrence of this happening with `_FLOX_ACTIVATION_PROFILE_ONLY` and fixed it in 2bb050e but the only way to recover existing installations is to manually edit the `activations.json`. Assuming you're able to find it from an existing activation.

We talked about the watchdog being the best place to clean these up as part of #2398, in order to limit the number of state changes to `activations.json`, but I feel differently after realising that we already had the ability to retry in `flox-activations` and a TODO for this class of problem.

Doing it here also means that we don't have to hope that the watchdog synchronises at the right time and hasn't died. Emitting one error message and before proceeding on the next retry will give us some feedback about whether we've introduced other ways for this to occur.

It's awkward to setup the desired state to integration test this change with `handle` so I've just added extra assertions to the existing unit tests.

## Release Notes

We don't need to mention this separately if combined with #2564 in v1.3.9