### PR TITLE
chore(ci): Verify remote builder system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,15 @@ jobs:
           REMOTE_BUILDERS:        "${{    vars.MANAGED_REMOTE_BUILDERS }}"
           SYSTEM:                 "${{ matrix.system }}"
 
+      - name: Verify remote builder system
+        run: |
+          REMOTE_SYSTEM=$(ssh github@$REMOTE_SERVER_ADDRESS \
+            -oLogLevel=ERROR \
+            -oUserKnownHostsFile=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE \
+            nix eval --experimental-features "nix-command" \
+            --impure --raw --expr builtins.currentSystem)
+          [[ "${REMOTE_SYSTEM}" == "${{ matrix.system }}" ]]
+
       - name: "Run Bats Tests (./#flox-cli-tests)"
         timeout-minutes: 30
         run: |


### PR DESCRIPTION
## Proposed Changes

This `x86_64-darwin` job has an `aarch64-darwin` hostname:

- https://github.com/flox/flox/actions/runs/12630953181/job/35191830459?pr=2565#step:5:134

## Release Notes

N/A