### PR TITLE
fix: source profile hooks for all active environments

### DIFF
--- a/assets/activation-scripts/activate.d/attach-command.bash
+++ b/assets/activation-scripts/activate.d/attach-command.bash
@@ -24,7 +24,7 @@ case "$_flox_shell" in
       exec "$_flox_shell" --noprofile --norc -c "$*"
     else
       RCFILE="$(@coreutils@/bin/mktemp -p "$_FLOX_ACTIVATION_STATE_DIR")"
-      generate_bash_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$RCFILE"
+      generate_bash_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$RCFILE"
       # self destruct
       echo "@coreutils@/bin/rm '$RCFILE'" >> "$RCFILE"
       if [ -t 1 ]; then
@@ -42,7 +42,7 @@ case "$_flox_shell" in
       exec "$_flox_shell" -c "$*"
     else
       RCFILE="$(@coreutils@/bin/mktemp -p "$_FLOX_ACTIVATION_STATE_DIR")"
-      generate_fish_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$RCFILE"
+      generate_fish_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$RCFILE"
       # self destruct
       echo "@coreutils@/bin/rm '$RCFILE'" >> "$RCFILE"
       exec "$_flox_shell" --init-command "source '$RCFILE'" -c "$*"
@@ -58,7 +58,7 @@ case "$_flox_shell" in
       # The tcsh implementation will source our custom `~/.tcshrc`,
       # which eventually sources $FLOX_TCSH_INIT_SCRIPT after the normal initialization.
       FLOX_TCSH_INIT_SCRIPT="$(@coreutils@/bin/mktemp -p "$_FLOX_ACTIVATION_STATE_DIR")"
-      generate_tcsh_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$FLOX_TCSH_INIT_SCRIPT"
+      generate_tcsh_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$FLOX_TCSH_INIT_SCRIPT"
       # self destruct
       echo "@coreutils@/bin/rm '$FLOX_TCSH_INIT_SCRIPT'" >> "$FLOX_TCSH_INIT_SCRIPT"
       export FLOX_TCSH_INIT_SCRIPT

--- a/assets/activation-scripts/activate.d/attach-inplace.bash
+++ b/assets/activation-scripts/activate.d/attach-inplace.bash
@@ -18,15 +18,15 @@ expiring_pid="$$"
 case "$_flox_shell" in
   *bash)
     echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$\$ --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
-    generate_bash_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}"
+    generate_bash_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}"
     ;;
   *fish)
     echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$fish_pid --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
-    generate_fish_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}"
+    generate_fish_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}"
     ;;
   *tcsh)
     echo "$_flox_activations --runtime-dir \"$FLOX_RUNTIME_DIR\" attach --pid \$\$ --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"
-    generate_tcsh_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}"
+    generate_tcsh_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}"
     ;;
   # Any additions should probably be restored in zdotdir/* scripts
   *zsh)

--- a/assets/activation-scripts/activate.d/attach-interactive.bash
+++ b/assets/activation-scripts/activate.d/attach-interactive.bash
@@ -9,7 +9,7 @@ case "$_flox_shell" in
       exec "$_flox_shell" --noprofile --norc
     else
       RCFILE="$(@coreutils@/bin/mktemp -p "$_FLOX_ACTIVATION_STATE_DIR")"
-      generate_bash_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$RCFILE"
+      generate_bash_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$RCFILE"
       # self destruct
       echo "@coreutils@/bin/rm '$RCFILE'" >> "$RCFILE"
       if [ -t 1 ]; then
@@ -30,7 +30,7 @@ case "$_flox_shell" in
       exec "$_flox_shell"
     else
       RCFILE="$(@coreutils@/bin/mktemp -p "$_FLOX_ACTIVATION_STATE_DIR")"
-      generate_fish_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$RCFILE"
+      generate_fish_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$RCFILE"
       # self destruct
       echo "@coreutils@/bin/rm '$RCFILE'" >> "$RCFILE"
       exec "$_flox_shell" --init-command "source '$RCFILE'"
@@ -46,7 +46,7 @@ case "$_flox_shell" in
       # The tcsh implementation will source our custom `~/.tcshrc`,
       # which eventually sources $FLOX_TCSH_INIT_SCRIPT after the normal initialization.
       FLOX_TCSH_INIT_SCRIPT="$(@coreutils@/bin/mktemp -p "$_FLOX_ACTIVATION_STATE_DIR")"
-      generate_tcsh_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "$FLOX_ENV" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$FLOX_TCSH_INIT_SCRIPT"
+      generate_tcsh_startup_commands "$_flox_activate_tracelevel" "$_FLOX_ACTIVATION_STATE_DIR" "$_activate_d" "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" > "$FLOX_TCSH_INIT_SCRIPT"
       # self destruct
       echo "@coreutils@/bin/rm '$FLOX_TCSH_INIT_SCRIPT'" >> "$FLOX_TCSH_INIT_SCRIPT"
       export FLOX_TCSH_INIT_SCRIPT

--- a/assets/activation-scripts/activate.d/generate-bash-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-bash-startup-commands.bash
@@ -16,8 +16,6 @@ generate_bash_startup_commands() {
   shift
   _activate_d="${1?}"
   shift
-  FLOX_ENV="${1?}"
-  shift
   _FLOX_ACTIVATION_PROFILE_ONLY="${1?}"
   shift
 
@@ -55,15 +53,25 @@ generate_bash_startup_commands() {
   # dotfiles may have changed them, so finish by doing this again.
   echo "eval \"\$($_flox_env_helper bash)\";"
 
-  # Source user-specified profile scripts if they exist.
-  for i in profile-common profile-bash hook-script; do
-    if [ -e "$FLOX_ENV/activate.d/$i" ]; then
-      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" START
-      echo "source '$FLOX_ENV/activate.d/$i';"
-      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" END
-    else
-      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" NOT FOUND
-    fi
+  # Iterate over $FLOX_ENV_DIRS in reverse order and
+  # source user-specified profile scripts if they exist.
+  local -a _flox_env_dirs
+  # The `source ~/.bashrc` above may modify FLOX_ENV_DIRS,
+  # and then _flox_env_helper may fix it up.
+  # If this happens, we want to respect those modifications,
+  # so we use FLOX_ENV_DIRS from the environment
+  IFS=':' read -r -a _flox_env_dirs <<< "$FLOX_ENV_DIRS"
+  for ((x = ${#_flox_env_dirs[@]} - 1; x >= 0; x--)); do
+    local _flox_env="${_flox_env_dirs["$x"]}"
+    for i in profile-common profile-bash hook-script; do
+      if [ -e "$_flox_env/activate.d/$i" ]; then
+        "$_flox_activate_tracer" "$_flox_env/activate.d/$i" START
+        echo "source '$_flox_env/activate.d/$i';"
+        "$_flox_activate_tracer" "$_flox_env/activate.d/$i" END
+      else
+        "$_flox_activate_tracer" "$_flox_env/activate.d/$i" NOT FOUND
+      fi
+    done
   done
 
   # Disable command hashing to allow for newly installed flox packages

--- a/assets/activation-scripts/activate.d/generate-tcsh-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-tcsh-startup-commands.bash
@@ -16,8 +16,6 @@ generate_tcsh_startup_commands() {
   shift
   _activate_d="${1?}"
   shift
-  FLOX_ENV="${1?}"
-  shift
   _FLOX_ACTIVATION_PROFILE_ONLY="${1?}"
   shift
 
@@ -51,15 +49,25 @@ generate_tcsh_startup_commands() {
   # dotfiles may have changed them, so finish by doing this again.
   echo "eval \"\`$_flox_env_helper tcsh\`\";"
 
-  # Source user-specified profile scripts if they exist.
-  for i in profile-common profile-tcsh; do
-    if [ -e "$FLOX_ENV/activate.d/$i" ]; then
-      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" START
-      echo "source '$FLOX_ENV/activate.d/$i';"
-      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" END
-    else
-      "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" NOT FOUND
-    fi
+  # Iterate over $FLOX_ENV_DIRS in reverse order and
+  # source user-specified profile scripts if they exist.
+  # Our custom .tcshrc sources users files that may modify FLOX_ENV_DIRS,
+  # and then _flox_env_helper may fix it up.
+  # If this happens, we want to respect those modifications,
+  # so we use FLOX_ENV_DIRS from the environment
+  local -a _flox_env_dirs
+  IFS=':' read -r -a _flox_env_dirs <<< "$FLOX_ENV_DIRS"
+  for ((x = ${#_flox_env_dirs[@]} - 1; x >= 0; x--)); do
+    local _flox_env="${_flox_env_dirs["$x"]}"
+    for i in profile-common profile-tcsh; do
+      if [ -e "$_flox_env/activate.d/$i" ]; then
+        "$_flox_activate_tracer" "$_flox_env/activate.d/$i" START
+        echo "source '$_flox_env/activate.d/$i';"
+        "$_flox_activate_tracer" "$_flox_env/activate.d/$i" END
+      else
+        "$_flox_activate_tracer" "$_flox_env/activate.d/$i" NOT FOUND
+      fi
+    done
   done
 
   # Disable command hashing to allow for newly installed flox packages

--- a/assets/activation-scripts/activate.d/zsh
+++ b/assets/activation-scripts/activate.d/zsh
@@ -77,14 +77,23 @@ fi
 source =("$_flox_env_helper" "zsh")
 
 # Source user-specified profile scripts if they exist.
-for i in profile-common profile-zsh hook-script; do
-  if [ -e "$FLOX_ENV/activate.d/$i" ]; then
-    "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" START
-    source "$FLOX_ENV/activate.d/$i"
-    "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" END
-  else
-    "$_flox_activate_tracer" "$FLOX_ENV/activate.d/$i" NOT FOUND
-  fi
+# Iterate over $FLOX_ENV_DIRS in reverse order using zsh-specific "(Oa)".
+# See: https://www.zsh.org/mla/workers/2003/msg00413.html
+  # Our ZDOTDIR startup files source user RC files that may modify FLOX_ENV_DIRS,
+  # and then _flox_env_helper may fix it up.
+  # If this happens, we want to respect those modifications,
+  # so we use FLOX_ENV_DIRS from the environment
+IFS=':' read -r -A _flox_env_dirs <<< "$FLOX_ENV_DIRS"
+for _flox_env in ${(Oa)_flox_env_dirs[@]}; do
+  for i in profile-common profile-zsh hook-script; do
+    if [ -e "$_flox_env/activate.d/$i" ]; then
+      "$_flox_activate_tracer" "$_flox_env/activate.d/$i" START
+      source "$_flox_env/activate.d/$i"
+      "$_flox_activate_tracer" "$_flox_env/activate.d/$i" END
+    else
+      "$_flox_activate_tracer" "$_flox_env/activate.d/$i" NOT FOUND
+    fi
+  done
 done
 
 # Disable command hashing to allow for newly installed flox packages

--- a/cli/tests/activate/nested-activate.exp
+++ b/cli/tests/activate/nested-activate.exp
@@ -1,0 +1,54 @@
+# Activate a project environment using --dir
+
+set outer_dir [lindex $argv 0]
+set expect_eof [lindex $argv 1]
+set inner_activate_command [lindex $argv 2]
+set flox $env(FLOX_BIN)
+set timeout 10
+
+spawn $flox activate --dir $outer_dir
+expect_after {
+  timeout { exit 1 }
+  eof { exit 2 }
+  "*\n" { exp_continue }
+  "*\r" { exp_continue }
+}
+expect "You are now using the environment"
+
+send "$inner_activate_command\r"
+expect_after {
+  timeout { exit 1 }
+  eof { exit 2 }
+  "*\n" { exp_continue }
+  "*\r" { exp_continue }
+}
+expect "common hook running"
+
+send "inner\r"
+expect "the inner alias is defined"
+
+send "outer\r"
+expect "the outer alias is defined"
+
+send "current\r"
+expect "the current alias is inner"
+
+puts "INFO: exiting inner env"
+send "exit 0\r"
+
+puts "INFO: exiting outer env"
+send "exit 0\r"
+
+if { $expect_eof eq "yes" } {
+  puts "INFO: waiting for eof";
+  expect eof;
+  puts "TEST COMPLETE: received eof";
+} else {
+  # Fish does not reliably deliver eof to expect in CI for some Linux hosts
+  # but not others, and we haven't been able to reproduce the problem outside
+  # of CI. For now just draw the test to a close without expecting eof as
+  # happens above.
+  puts "TEST COMPLETE";
+}
+
+exit 0


### PR DESCRIPTION
## Proposed Changes

When nesting environment activations the relevant `profile` hooks for all activated environments should be sourced when starting a new subshell. Prior to this patch only the profile hooks for the current / most recent environment was being sourced, but this patch adds logic to iterate over the contents of the FLOX_ENV_DIRS variable when looking for profile hook scripts to be sourced.

Closes #2574.

## Release Notes

- Fixed sourcing of profile scripts for all active environments. Among other things this allows aliases to be set in any environment within a nested activation, but also underscores the importance of writing idempotent profile scripts. As with environment variables, profile scripts for the most recently-activated environment run last, and therefore take precedence over actions performed in "outer" activations.