### PR TITLE
fix(activate): export internal variables required for in-place

### DIFF
--- a/assets/activation-scripts/activate.d/generate-bash-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-bash-startup-commands.bash
@@ -39,14 +39,14 @@ generate_bash_startup_commands() {
     # Restore environment variables set in the previous bash initialization.
     $_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"
     $_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"
-
-    # Propagate $_activate_d to the environment.
-    echo "export _activate_d='$_activate_d';"
-    # Propagate $_flox_activate_tracer to the environment.
-    echo "export _flox_activate_tracer='$_flox_activate_tracer';"
-    # Propagate $_flox_env_helper to the environment.
-    echo "export _flox_env_helper='$_flox_env_helper';"
   fi
+
+  # Propagate $_activate_d to the environment.
+  echo "export _activate_d='$_activate_d';"
+  # Propagate $_flox_activate_tracer to the environment.
+  echo "export _flox_activate_tracer='$_flox_activate_tracer';"
+  # Propagate $_flox_env_helper to the environment.
+  echo "export _flox_env_helper='$_flox_env_helper';"
 
   # Set the prompt if we're in an interactive shell.
   echo "if [ -t 1 ]; then source '$_activate_d/set-prompt.bash'; fi;"

--- a/assets/activation-scripts/activate.d/generate-fish-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-fish-startup-commands.bash
@@ -33,12 +33,14 @@ generate_fish_startup_commands() {
     # Restore environment variables set in the previous bash initialization.
     $_sed -e 's/^/set -e /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"
     $_sed -e 's/^/set -gx /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"
-
-    # Propagate $_activate_d to the environment.
-    echo "set -gx _activate_d $_activate_d;"
-    # Propagate $_flox_activate_tracer to the environment.
-    echo "set -gx _flox_activate_tracer $_flox_activate_tracer;"
   fi
+
+  # Propagate $_activate_d to the environment.
+  echo "set -gx _activate_d '$_activate_d';"
+  # Propagate $_flox_activate_tracer to the environment.
+  echo "set -gx _flox_activate_tracer '$_flox_activate_tracer';"
+  # Propagate $_flox_env_helper to the environment.
+  echo "set -gx _flox_env_helper '$_flox_env_helper';"
 
   # Set the prompt if we're in an interactive shell.
   echo "if isatty 1; source '$_activate_d/set-prompt.fish'; end;"

--- a/assets/activation-scripts/activate.d/generate-tcsh-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-tcsh-startup-commands.bash
@@ -35,12 +35,14 @@ generate_tcsh_startup_commands() {
     # Restore environment variables set in the previous bash initialization.
     $_sed -e 's/^/unsetenv /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"
     $_sed -e 's/^/setenv /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"
-
-    # Propagate $_activate_d to the environment.
-    echo "setenv _activate_d '$_activate_d';"
-    # Propagate $_flox_activate_tracer to the environment.
-    echo "setenv _flox_activate_tracer '$_flox_activate_tracer';"
   fi
+
+  # Propagate $_activate_d to the environment.
+  echo "setenv _activate_d '$_activate_d';"
+  # Propagate $_flox_activate_tracer to the environment.
+  echo "setenv _flox_activate_tracer '$_flox_activate_tracer';"
+  # Propagate $_flox_env_helper to the environment.
+  echo "setenv _flox_env_helper '$_flox_env_helper';"
 
   # Set the prompt if we're in an interactive shell.
   echo "if ( \$?tty ) then; source '$_activate_d/set-prompt.tcsh'; endif;"


### PR DESCRIPTION
## Proposed Changes

From @limeytexan:

We were exporting required flox internal variables when first activating an environment but not when attaching, and that caused problems for activation scripts that were expecting those variables to be defined. This patch moves those activation blocks further down where they can be defined for all activation types and makes them consistent across the bash, fish, and tcsh cases. The zsh case is handled differently on account of the way that zdotdir works, and is not a problem.

From @dcarley:

The reproduction for this is to in-place "attach" to an activation that's been "started" with a previous Flox version:

```console
% FLOX_SHELL=bash nix run github:flox/flox/v1.3.8 -- activate -d ~/tmp
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
✅ You are now using the environment 'tmp'.
To stop using this environment, type 'exit'

flox [tmp shell] bash-5.2$ eval "$(nix run github:flox/flox/v1.3.9 -- activate -d ~/tmp)"
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
bash: : command not found
bash: : command not found
```

With the changes from this branch:

```
% FLOX_SHELL=bash nix run github:flox/flox/v1.3.8 -- activate -d ~/tmp
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
✅ Attached to existing activation of environment 'tmp'
To stop using this environment, type 'exit'

flox [tmp shell] bash-5.2$ which flox
/Users/dcarley/projects/flox/flox/cli/target/debug/flox
flox [tmp shell] bash-5.2$ eval "$(flox activate -d ~/tmp)"
flox [tmp shell] bash-5.2$
```

I'm not sure how we'd write a integration test for that short of investing effort in https://github.com/flox/flox-installers/issues/309 so I suggest that we merge this as-is for now.

## Release Notes

Fix a bug with in-place and default environment activations that would result in "command not found" errors after upgrading to Flox v1.3.9