### PR TITLE
feat(upgrade): add --dry-run option

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -923,13 +923,15 @@ impl UpgradeResult {
         packages_with_upgrades
     }
 
+    /// Return a map of packages that have upgrades in the format
+    /// packages[install_id] = (old_package, new_package)
     pub fn diff_for_system(&self, system: &str) -> SingleSystemUpgradeDiff {
         self.diff()
             .into_iter()
             .filter_map(|(install_id, mut by_system)| {
-                by_system.remove(system).map(|(old_package, new_package)| {
-                    (install_id, (old_package.clone(), new_package.clone()))
-                })
+                by_system
+                    .remove(system)
+                    .map(|(old_package, new_package)| (install_id, (old_package, new_package)))
             })
             .collect()
     }

--- a/cli/flox/doc/flox-upgrade.md
+++ b/cli/flox/doc/flox-upgrade.md
@@ -14,30 +14,36 @@ flox-upgrade - upgrade packages in an environment
 ```
 flox [<general-options>] upgrade
      [-d=<path> | -r=<owner>/<name>]
+     [--dry-run]
      [<package or pkg-group>]...
 ```
 
 # DESCRIPTION
 
-Upgrade packages in an environment to versions present in the catalog.
+Upgrade packages in the environment.
 
-When no arguments are specified, all packages in the environment are upgraded.
+When no arguments are specified,
+all packages in the environment are upgraded if possible.
+A package is upgraded if its version, build configuration,
+or dependency graph changes.
 
-Packages to upgrade can be specified by either pkg-group name, or by ID.
-If the specified argument is both a pkg-group name and an install ID,
-both the package with the install ID
-and packages belonging to the pkg-group are upgraded.
+Packages to upgrade can be specified by group name.
+Packages without a specified pkg-group in the manifest
+are placed in a group named 'toplevel'.
+The packages in that group can be upgraded without updating any other groups
+by passing 'toplevel' as the group name.
 
-Packages without a specified pkg-group in the manifest are placed in a
-pkg-group named 'toplevel'.
-The packages in that pkg-group can be upgraded without updating any other
-pkg-groups by passing 'toplevel' as the pkg-group name.
+A single package can only be specified to upgrade by ID
+if it is not in a group with any other packages.
 
 See [`manifest.toml(5)`](./manifest.toml.md) for more on using pkg-groups.
 
 # OPTIONS
 
 ## Upgrade Options
+
+`--dry-run`
+:   Show available upgrades but do not apply them.
 
 `<package or pkg-group>`
 :   Install ID or pkg-group to upgrade.

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -857,17 +857,19 @@ enum AdditionalCommands {
     Update(#[bpaf(external(update::update))] update::Update),
     /// Upgrade packages in an environment
     #[bpaf(command, hide, footer("Run 'man flox-upgrade' for more details."), header(indoc! {"
-        When no arguments are specified, all packages in the environment are upgraded.\n\n
+        When no arguments are specified,
+        all packages in the environment are upgraded if possible.
+        A package is upgraded if its version, build configuration,
+        or dependency graph changes.\n\n
 
-        Packages to upgrade can be specified by either group name, or, if a package is
-        not in a group with any other packages, it may be specified by ID.
-        If the specified argument is both a group name and a package ID, the group is
-        upgraded.\n\n
+        Packages to upgrade can be specified by group name.
+        Packages without a specified pkg-group in the manifest
+        are placed in a group named 'toplevel'.
+        The packages in that group can be upgraded without updating any other groups
+        by passing 'toplevel' as the group name.\n\n
 
-        Packages without a specified group in the manifest are placed in a group
-        named 'toplevel'.
-        The packages in that group can be upgraded without updating any other
-        groups by passing 'toplevel' as the group name.
+        A single package can only be specified to upgrade by ID
+        if it is not in a group with any other packages.
     "}))]
     Upgrade(#[bpaf(external(upgrade::upgrade))] upgrade::Upgrade),
     /// View and set configuration options

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::SingleSystemUpgradeDiff;
+use indoc::formatdoc;
+use itertools::Itertools;
 use tracing::{info_span, instrument};
 
 use super::services::warn_manifest_changes_for_services;
@@ -14,6 +17,10 @@ use crate::utils::message;
 pub struct Upgrade {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
+
+    /// Show available upgrades but do not apply them
+    #[bpaf(long)]
+    dry_run: bool,
 
     /// ID of a package or pkg-group name to upgrade
     #[bpaf(positional("package or pkg-group"))]
@@ -41,51 +48,257 @@ impl Upgrade {
 
         let mut environment = concrete_environment.into_dyn_environment();
 
+        let progress_message = {
+            let num_upgrades = if self.groups_or_iids.is_empty() {
+                "all".to_string()
+            } else {
+                format!("{}", self.groups_or_iids.len())
+            };
+
+            let dry_prefix = if self.dry_run { "Dry run: " } else { "" };
+
+            format!("{dry_prefix}Upgrading {num_upgrades} package(s) or group(s)")
+        };
+
         let span = info_span!(
             "upgrade",
             environment = %description,
-            progress = format!(
-                "Upgrading {} package(s) or group(s)",
-                if self.groups_or_iids.is_empty() {
-                    "all".to_string()
-                } else {
-                    format!("{}", self.groups_or_iids.len())
-                }
-            )
+            progress = %progress_message
         );
         let result = span.in_scope(|| {
-            environment.upgrade(
-                &flox,
-                &self
-                    .groups_or_iids
-                    .iter()
-                    .map(String::as_str)
-                    .collect::<Vec<_>>(),
-            )
+            let groups_or_iids = &self
+                .groups_or_iids
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+
+            if self.dry_run {
+                environment.dry_upgrade(&flox, groups_or_iids)
+            } else {
+                environment.upgrade(&flox, groups_or_iids)
+            }
         })?;
 
-        let upgraded = result.packages().collect::<Vec<_>>();
+        let diff = result.diff();
 
-        if upgraded.is_empty() {
+        if diff.is_empty() {
             if self.groups_or_iids.is_empty() {
                 message::plain(format!(
-                    "ℹ️  No packages need to be upgraded in environment {description}."
+                    "No upgrades available for packages in {description}."
                 ));
             } else {
                 message::plain(format!(
-                    "ℹ️  The specified packages do not need to be upgraded in environment {description}."
-                 ) );
-            }
-        } else {
-            for package in upgraded {
-                message::plain(format!(
-                    "⬆️  Upgraded '{package}' in environment {description}."
+                    "No upgrades available for the specified packages in {description}."
                 ));
             }
-
-            warn_manifest_changes_for_services(&flox, environment.as_ref());
+            return Ok(());
         }
 
+        let diff_for_system = result.diff_for_system(&flox.system);
+
+        let rendered_diff = render_diff(&diff_for_system);
+        let num_changes_for_system = diff_for_system.len();
+
+        if self.dry_run {
+            if diff_for_system.is_empty() {
+                message::plain(formatdoc! {"
+                    Upgrades are not available for {description} on this system, but upgrades are
+                    available for other systems supported by this environment."});
+                if self.groups_or_iids.is_empty() {
+                } else {
+                    message::plain(format!(
+                        "No upgrades available for the specified packages in {description}."
+                    ));
+                }
+                return Ok(());
+            }
+            message::plain(formatdoc! {"
+                Dry run: Upgrades available for {num_changes_for_system} package(s) in {description}:
+                {rendered_diff}
+
+                To apply these changes, run upgrade without the '--dry-run' flag.
+            "});
+
+            return Ok(());
+        }
+
+        if diff_for_system.is_empty() {
+            message::plain(formatdoc! {"
+            ✅  Upgraded {description}.
+            Upgrades were not available for this system, but upgrades were applied for other
+            systems supported by this environment."});
+        } else {
+            message::plain(formatdoc! {"
+            ✅  Upgraded {num_changes_for_system} package(s) in {description}:
+            {rendered_diff}
+            "});
+        }
+
+        warn_manifest_changes_for_services(&flox, environment.as_ref());
+
         Ok(())
+    }
+}
+
+/// Render a diff of locked packages before and after an upgrade
+fn render_diff(diff: &SingleSystemUpgradeDiff) -> String {
+    diff.iter()
+        .map(|(_, (before, after))| {
+            let install_id = before.install_id();
+            let old_version = before.version().unwrap_or("unknown");
+            let new_version = after.version().unwrap_or("unknown");
+
+            if new_version == old_version {
+                format!("- {install_id}: {old_version}")
+            } else {
+                format!("- {install_id}: {old_version} -> {new_version}")
+            }
+        })
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Display;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    use flox_rust_sdk::flox::test_helpers::flox_instance;
+    use flox_rust_sdk::models::environment::path_environment::test_helpers::{
+        new_path_environment,
+        new_path_environment_from_env_files,
+    };
+    use flox_rust_sdk::models::environment::Environment;
+    use flox_rust_sdk::models::manifest::PackageToInstall;
+    use flox_rust_sdk::providers::catalog::test_helpers::reset_mocks_from_file;
+    use flox_rust_sdk::providers::catalog::GENERATED_DATA;
+    use indoc::indoc;
+    use tracing::instrument::WithSubscriber;
+    use tracing::Subscriber;
+    use tracing_subscriber::filter::FilterFn;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::*;
+    use crate::commands::EnvironmentSelect;
+
+    #[derive(Debug, Default)]
+    struct CollectingWriter {
+        buffer: Mutex<Vec<u8>>,
+    }
+
+    impl Display for CollectingWriter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let buffer = self.buffer.lock().unwrap();
+            let str_content = String::from_utf8_lossy(&buffer);
+            write!(f, "{str_content}")
+        }
+    }
+    impl Write for &CollectingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.buffer.lock().unwrap().write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.buffer.lock().unwrap().flush()
+        }
+    }
+
+    // For now this is a POC of using tracing for output tests,
+    // evenatually we should probably move that to the tracing utils or `message` module.
+    fn test_subscriber() -> (impl Subscriber, Arc<CollectingWriter>) {
+        let writer = Arc::new(CollectingWriter::default());
+
+        // TODO: also tee to test output?
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .compact()
+            .without_time()
+            .with_level(false)
+            .with_target(false)
+            .finish()
+            .with(FilterFn::new(|metadata| {
+                metadata.target() == "flox::utils::message"
+            }));
+
+        (subscriber, writer)
+    }
+
+    #[tokio::test]
+    async fn no_notification_printed_if_absent() {
+        let (flox, _tempdir) = flox_instance();
+        let (subscriber, writer) = test_subscriber();
+
+        let environment =
+            new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
+
+        Upgrade {
+            environment: EnvironmentSelect::Dir(environment.parent_path().unwrap()),
+            dry_run: true,
+            groups_or_iids: Vec::new(),
+        }
+        .handle(flox)
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+        let printed = writer.to_string();
+
+        assert!(printed.is_empty(), "printed: {printed}");
+    }
+
+    /// Run an upgrade of an environment that only has upgrades on other systems
+    async fn run_upgrade_with_upgrades_on_other_system(dry_run: bool) -> String {
+        let (mut flox, _tempdir) = flox_instance();
+        let (subscriber, writer) = test_subscriber();
+
+        let mut environment = new_path_environment(&flox, "version = 1");
+
+        #[cfg(target_os = "macos")]
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/old_linux_hello.json");
+        #[cfg(target_os = "linux")]
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/old_darwin_hello.json");
+
+        environment
+            .install(
+                &[PackageToInstall::parse(&flox.system, "hello").unwrap()],
+                &flox,
+            )
+            .unwrap();
+
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
+        Upgrade {
+            environment: EnvironmentSelect::Dir(environment.parent_path().unwrap()),
+            dry_run,
+            groups_or_iids: Vec::new(),
+        }
+        .handle(flox)
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+        writer.to_string()
+    }
+
+    #[tokio::test]
+    async fn upgrade_on_other_system() {
+        assert_eq!(
+            run_upgrade_with_upgrades_on_other_system(false).await,
+            indoc! {"
+            ✅  Upgraded 'name'.
+            Upgrades were not available for this system, but upgrades were applied for other
+            systems supported by this environment.
+            "}
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_dry_run_on_other_system() {
+        assert_eq!(
+            run_upgrade_with_upgrades_on_other_system(true).await,
+            indoc! {"
+            Upgrades are not available for 'name' on this system, but upgrades are
+            available for other systems supported by this environment.
+            "}
+        );
     }
 }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -223,14 +223,16 @@ mod tests {
         (subscriber, writer)
     }
 
+    /// Check message printed when there are no upgrades available
     #[tokio::test]
-    async fn no_notification_printed_if_absent() {
-        let (flox, _tempdir) = flox_instance();
+    async fn confirmation_when_up_to_date() {
+        let (mut flox, _tempdir) = flox_instance();
         let (subscriber, writer) = test_subscriber();
 
         let environment =
             new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
 
+        reset_mocks_from_file(&mut flox.catalog_client, "resolve/hello.json");
         Upgrade {
             environment: EnvironmentSelect::Dir(environment.parent_path().unwrap()),
             dry_run: true,
@@ -243,7 +245,7 @@ mod tests {
 
         let printed = writer.to_string();
 
-        assert!(printed.is_empty(), "printed: {printed}");
+        assert_eq!(printed, "No upgrades available for packages in 'name'.\n");
     }
 
     /// Run an upgrade of an environment that only has upgrades on other systems

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -93,8 +93,9 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade
   assert_success
-  assert_line "✅  Upgrade sucessfully applied build changes to 1 package(s) in 'test':"
-  assert_line --regexp "- hello: $old_hello_response_version -> $hello_response_version"
+  assert_output \
+"✅  Upgraded 1 package(s) in 'test':
+- hello: $old_hello_response_version -> $hello_response_version"
 
   hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
@@ -122,8 +123,9 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade blue
   assert_success
-  assert_line "✅  Upgrade sucessfully applied build changes to 1 package(s) in 'test':"
-  assert_line --regexp "- hello: $old_hello_response_version -> $hello_response_version"
+  assert_output \
+"✅  Upgraded 1 package(s) in 'test':
+- hello: $old_hello_response_version -> $hello_response_version"
 
   hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
@@ -146,8 +148,9 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade toplevel
   assert_success
-  assert_line "✅  Upgrade sucessfully applied build changes to 1 package(s) in 'test':"
-  assert_line --regexp "- hello: $old_hello_response_version -> $hello_response_version"
+  assert_output \
+"✅  Upgraded 1 package(s) in 'test':
+- hello: $old_hello_response_version -> $hello_response_version"
 
   hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
@@ -170,8 +173,9 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade hello
   assert_success
-  assert_line "✅  Upgrade sucessfully applied build changes to 1 package(s) in 'test':"
-  assert_line --regexp "- hello: $old_hello_response_version -> $hello_response_version"
+  assert_output \
+"✅  Upgraded 1 package(s) in 'test':
+- hello: $old_hello_response_version -> $hello_response_version"
 
   hello_response_drv=$(jq -r '.[0].[0].page.packages[0].derivation' "$GENERATED_DATA/resolve/hello.json")
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
@@ -197,7 +201,7 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" \
     run "$FLOX_BIN" upgrade
   assert_success
-  assert_output "No package(s) need to be upgraded in 'test'."
+  assert_output "No upgrades available for packages in 'test'."
 }
 
 # bats test_tags=upgrade:page-not-upgraded
@@ -224,7 +228,7 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$BUMPED_REVS_RESPONE" \
     run "$FLOX_BIN" upgrade
   assert_success
-  assert_output "No package(s) need to be upgraded in 'test'."
+  assert_output "No upgrades available for packages in 'test'."
 
   curr_lock=$(jq --sort-keys . "$LOCK_PATH")
 
@@ -233,7 +237,7 @@ setup_pkgdb_env() {
 }
 
 # bats test_tags=upgrade:dry-run
-@test "'upgrade --dry-run' does not update the lockfil" {
+@test "'upgrade --dry-run' does not update the lockfile" {
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" "$FLOX_BIN" install hello
 
@@ -248,9 +252,11 @@ setup_pkgdb_env() {
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run "$FLOX_BIN" upgrade --dry-run
   assert_success
-  assert_line "Dry run: Upgrade will apply build changes to 1 package(s) in 'test':"
-  assert_line --regexp "- hello: $old_hello_response_version -> $hello_response_version"
-  assert_line "To apply these changes, run the command without the '--dry-run' flag."
+  assert_output \
+"Dry run: Upgrades available for 1 package(s) in 'test':
+- hello: $old_hello_response_version -> $hello_response_version
+
+To apply these changes, run upgrade without the '--dry-run' flag."
 
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
   assert_equal "$hello_locked_drv" "$old_hello_locked_drv"
@@ -263,7 +269,7 @@ setup_pkgdb_env() {
 
   run "$FLOX_BIN" upgrade
   assert_success
-  assert_output "No package(s) need to be upgraded in 'test'."
+  assert_output "No upgrades available for packages in 'test'."
 
   new_version="$(jq -r '.packages[0]."version"' "$LOCK_PATH")"
   old_version="2.10.0"
@@ -274,8 +280,9 @@ setup_pkgdb_env() {
   run "$FLOX_BIN" upgrade
   assert_success
 
-  assert_line "✅  Upgrade sucessfully applied build changes to 1 package(s) in 'test':"
-  assert_line --regexp "- hello: $old_version -> $new_version"
+  assert_output \
+"✅  Upgraded 1 package(s) in 'test':
+- hello: $old_version -> $new_version"
 }
 
 # bats test_tags=upgrade:flake:iid
@@ -286,5 +293,5 @@ setup_pkgdb_env() {
 
   run "$FLOX_BIN" upgrade hello
   assert_success
-  assert_output "The specified package(s) do not need to be upgraded in 'test'."
+  assert_output "No upgrades available for the specified packages in 'test'."
 }

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -194,16 +194,6 @@ setup_pkgdb_env() {
   assert_line "❌ ERROR: 'hello' is a package in the group 'toplevel' with multiple packages."
 }
 
-@test "check confirmation when all packages are up to date" {
-  "$FLOX_BIN" init
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" "$FLOX_BIN" install curl hello
-
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" \
-    run "$FLOX_BIN" upgrade
-  assert_success
-  assert_output "No upgrades available for packages in 'test'."
-}
-
 # bats test_tags=upgrade:page-not-upgraded
 @test "page changes should not be considered an upgrade" {
   "$FLOX_BIN" init

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -154,7 +154,36 @@ ignore_cmd_errors = true
 pre_cmd = "flox init"
 cmd = "flox install hello"
 post_cmd = '''
-    cat "$RESPONSE_FILE" | jq | sed 's/"derivation": .*$/"derivation": "\/nix\/store\/AAA-hello-2.12.1.drv",/g' > tmp.json
+    cat "$RESPONSE_FILE" | jq \
+    | sed 's/"derivation": .*$/"derivation": "\/nix\/store\/AAA-hello-2.10.1.drv",/g' \
+    | sed 's/"version": .*$/"version": "2.10.1"/g' \
+    > tmp.json
+    mv tmp.json "$RESPONSE_FILE"
+'''
+
+[resolve.old_linux_hello]
+pre_cmd = "flox init"
+cmd = "flox install hello"
+post_cmd = '''
+    cat "$RESPONSE_FILE" | jq \
+    '.[].[].page.packages |= map(if .system | contains("linux")
+      then .version = "2.10.1" | .derivation = "/nix/store/AAA-hello-2.10.1.drv"
+      else .
+      end)' \
+    > tmp.json
+    mv tmp.json "$RESPONSE_FILE"
+'''
+
+[resolve.old_darwin_hello]
+pre_cmd = "flox init"
+cmd = "flox install hello"
+post_cmd = '''
+    cat "$RESPONSE_FILE" | jq \
+    '.[].[].page.packages |= map(if .system | contains("darwin")
+      then .version = "2.10.1" | .derivation = "/nix/store/AAA-hello-2.10.1.drv"
+      else .
+      end)' \
+    > tmp.json
     mv tmp.json "$RESPONSE_FILE"
 '''
 

--- a/test_data/generated/envs/build-runtime-all-toplevel.json
+++ b/test_data/generated/envs/build-runtime-all-toplevel.json
@@ -36,29 +36,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/rnpar5fbj0h7gidf1h066iwi5vi16a9y-vim-9.1.0787.drv",
+      "derivation": "/nix/store/k7pwn9a32s22syrbhf58cafk4s1i4pbl-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/8d473xm8x7ff6k5mqwma6hxgpjnf6alh-vim-9.1.0787",
-        "xxd": "/nix/store/d6jx0lvmachd31rlnf71015rws4kpj3r-vim-9.1.0787-xxd"
+        "out": "/nix/store/rc1kfgzpb3aq5w7cj1adjb5yaqv4c2va-vim-9.1.0905",
+        "xxd": "/nix/store/mi0chjhw4cmyl2yq0z1lz8gmskzrq6da-vim-9.1.0905-xxd"
       },
       "system": "aarch64-darwin",
       "group": "not-toplevel",
@@ -67,29 +67,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/x0lgcqq1qdnwwx4hf9k8njz8z20d5iz9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/293nl3481mnav4l70bk4lba4n37gawi4-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zappfr3lr1xp0pxsjvllg4m3bsvjxgbf-vim-9.1.0787",
-        "xxd": "/nix/store/v1rrv6z3bppr0xkfp3q7spmiaabgmszw-vim-9.1.0787-xxd"
+        "out": "/nix/store/v5rz9y25dapc1j6q2xmgawgh5fgfa59q-vim-9.1.0905",
+        "xxd": "/nix/store/fb6h1rvcaf73pmvf7xlcn2ihh80xwymj-vim-9.1.0905-xxd"
       },
       "system": "aarch64-linux",
       "group": "not-toplevel",
@@ -98,29 +98,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/k9n77kiw39pv4kwhhhl6gdlp947zp9q9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/xri9bxkiw1lbnhba9032smdqs1gmq134-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zsvr88wh53ha4d6ilv8lnil44svnsbvs-vim-9.1.0787",
-        "xxd": "/nix/store/73f1xnfkx8ghsqj30zn9k2vs4h75v8xj-vim-9.1.0787-xxd"
+        "out": "/nix/store/ysnvbsyvysqm78pjbsw0zn7arlzp7yk8-vim-9.1.0905",
+        "xxd": "/nix/store/ml8dj1b4zsi25652lf5cnz5qv8fl1swy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-darwin",
       "group": "not-toplevel",
@@ -129,29 +129,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/0p8c65a0gp3qx8sjg46v01fnc6clvy2v-vim-9.1.0787.drv",
+      "derivation": "/nix/store/nlqlkb9pwhl6myjm3rm17bb6fsdyh37q-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/862qv45cwbjj2n60iyscyj5ci2vzycdh-vim-9.1.0787",
-        "xxd": "/nix/store/jkny5zx16y29fgnl45d29wcirna7gyvk-vim-9.1.0787-xxd"
+        "out": "/nix/store/g9x3rxi0p1dxbdyf222m0qprrw0anyg5-vim-9.1.0905",
+        "xxd": "/nix/store/v8k2x4bg8vbhwx1qgmz1cicf1ny01npy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-linux",
       "group": "not-toplevel",
@@ -160,17 +160,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/5naisiq61kp39x9mi4nnlh4h0agrv6ix-coreutils-9.5.drv",
+      "derivation": "/nix/store/nm1mg4ilciiwhzkj26scwybw6x4ijpf0-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -180,8 +180,8 @@
         "out"
       ],
       "outputs": {
-        "info": "/nix/store/ydfklbdc7sdv9jl2jy0prq0wa4cv2zzf-coreutils-9.5-info",
-        "out": "/nix/store/5g6np23z9q7vwwp1s5pxkgn8f8wrmihh-coreutils-9.5"
+        "info": "/nix/store/c263jjqg2mpap2fagjl34lziidkgph3i-coreutils-9.5-info",
+        "out": "/nix/store/p9m0bsw49c5m6wnm3m4fs97yx5rxcmfj-coreutils-9.5"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -190,17 +190,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/ir8y199idsk97agpjjkxk24nrrhlygiz-coreutils-9.5.drv",
+      "derivation": "/nix/store/18ysbs708pj8ps18fdjj81z7zn4c6fla-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -210,9 +210,9 @@
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/q70vk5m0nlz0qpy7z6nfczi8ksyaszap-coreutils-9.5-debug",
-        "info": "/nix/store/cbk08ylbni3vx41g1hdd013146yvcf5c-coreutils-9.5-info",
-        "out": "/nix/store/g5manmr2a4jc9m06cf2lpnx1092wvvjh-coreutils-9.5"
+        "debug": "/nix/store/r1x885lysldxid2575k87nld06pkbf4v-coreutils-9.5-debug",
+        "info": "/nix/store/xqglm4755lgpjrdyxi5f52fljrcarvqc-coreutils-9.5-info",
+        "out": "/nix/store/lhd4sbpf3l9jxmb8sl6881l924q151j0-coreutils-9.5"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -221,17 +221,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/5qkwxai9nx4hszq8m25ralrg5nrjfs6n-coreutils-9.5.drv",
+      "derivation": "/nix/store/67skpxi4kbs1nqf2xyvprbhxpsw6vmpy-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -241,8 +241,8 @@
         "out"
       ],
       "outputs": {
-        "info": "/nix/store/64g8lpl80mprjql96w0wsqc3n2q753l3-coreutils-9.5-info",
-        "out": "/nix/store/w95g6dz0b7byi4w2mgvmwpl692pilqf1-coreutils-9.5"
+        "info": "/nix/store/aghncv047lvr0xhil8fwwxpk6bi5yalh-coreutils-9.5-info",
+        "out": "/nix/store/ka9bhk1lwdqyv47kkw6ppqgx010xwghn-coreutils-9.5"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -251,17 +251,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/gk6as4in5fphr7ds30l9cyn70icxr54a-coreutils-9.5.drv",
+      "derivation": "/nix/store/rzf4njjb1pfpc2csazccxjn9452d96mi-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -271,9 +271,9 @@
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/h42j46bwd0fqsg70axqpkn49fzfgsxkd-coreutils-9.5-debug",
-        "info": "/nix/store/kszl2ij9l8ql5ai95h357rkwg77g2f68-coreutils-9.5-info",
-        "out": "/nix/store/k48bha2fjqzarg52picsdfwlqx75aqbb-coreutils-9.5"
+        "debug": "/nix/store/zs8k0d5dx7nkvs6vmxmkr1jdz3px2fhi-coreutils-9.5-debug",
+        "info": "/nix/store/hm7bqb710681rxgrq8b6l9zms50aj4k5-coreutils-9.5-info",
+        "out": "/nix/store/4s9rah4cwaxflicsk5cndnknqlk9n4p3-coreutils-9.5"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -282,17 +282,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -302,7 +302,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -311,17 +311,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -331,7 +331,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -340,17 +340,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -360,7 +360,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -369,17 +369,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -389,7 +389,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/build-runtime-packages-not-found.json
+++ b/test_data/generated/envs/build-runtime-packages-not-found.json
@@ -32,17 +32,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -52,7 +52,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -61,17 +61,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -81,7 +81,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -90,17 +90,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -110,7 +110,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -119,17 +119,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -139,7 +139,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/build-runtime-packages-not-toplevel.json
+++ b/test_data/generated/envs/build-runtime-packages-not-toplevel.json
@@ -39,29 +39,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/rnpar5fbj0h7gidf1h066iwi5vi16a9y-vim-9.1.0787.drv",
+      "derivation": "/nix/store/k7pwn9a32s22syrbhf58cafk4s1i4pbl-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/8d473xm8x7ff6k5mqwma6hxgpjnf6alh-vim-9.1.0787",
-        "xxd": "/nix/store/d6jx0lvmachd31rlnf71015rws4kpj3r-vim-9.1.0787-xxd"
+        "out": "/nix/store/rc1kfgzpb3aq5w7cj1adjb5yaqv4c2va-vim-9.1.0905",
+        "xxd": "/nix/store/mi0chjhw4cmyl2yq0z1lz8gmskzrq6da-vim-9.1.0905-xxd"
       },
       "system": "aarch64-darwin",
       "group": "not-toplevel",
@@ -70,29 +70,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/x0lgcqq1qdnwwx4hf9k8njz8z20d5iz9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/293nl3481mnav4l70bk4lba4n37gawi4-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zappfr3lr1xp0pxsjvllg4m3bsvjxgbf-vim-9.1.0787",
-        "xxd": "/nix/store/v1rrv6z3bppr0xkfp3q7spmiaabgmszw-vim-9.1.0787-xxd"
+        "out": "/nix/store/v5rz9y25dapc1j6q2xmgawgh5fgfa59q-vim-9.1.0905",
+        "xxd": "/nix/store/fb6h1rvcaf73pmvf7xlcn2ihh80xwymj-vim-9.1.0905-xxd"
       },
       "system": "aarch64-linux",
       "group": "not-toplevel",
@@ -101,29 +101,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/k9n77kiw39pv4kwhhhl6gdlp947zp9q9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/xri9bxkiw1lbnhba9032smdqs1gmq134-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zsvr88wh53ha4d6ilv8lnil44svnsbvs-vim-9.1.0787",
-        "xxd": "/nix/store/73f1xnfkx8ghsqj30zn9k2vs4h75v8xj-vim-9.1.0787-xxd"
+        "out": "/nix/store/ysnvbsyvysqm78pjbsw0zn7arlzp7yk8-vim-9.1.0905",
+        "xxd": "/nix/store/ml8dj1b4zsi25652lf5cnz5qv8fl1swy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-darwin",
       "group": "not-toplevel",
@@ -132,29 +132,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/0p8c65a0gp3qx8sjg46v01fnc6clvy2v-vim-9.1.0787.drv",
+      "derivation": "/nix/store/nlqlkb9pwhl6myjm3rm17bb6fsdyh37q-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/862qv45cwbjj2n60iyscyj5ci2vzycdh-vim-9.1.0787",
-        "xxd": "/nix/store/jkny5zx16y29fgnl45d29wcirna7gyvk-vim-9.1.0787-xxd"
+        "out": "/nix/store/g9x3rxi0p1dxbdyf222m0qprrw0anyg5-vim-9.1.0905",
+        "xxd": "/nix/store/v8k2x4bg8vbhwx1qgmz1cicf1ny01npy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-linux",
       "group": "not-toplevel",
@@ -163,17 +163,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/5naisiq61kp39x9mi4nnlh4h0agrv6ix-coreutils-9.5.drv",
+      "derivation": "/nix/store/nm1mg4ilciiwhzkj26scwybw6x4ijpf0-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -183,8 +183,8 @@
         "out"
       ],
       "outputs": {
-        "info": "/nix/store/ydfklbdc7sdv9jl2jy0prq0wa4cv2zzf-coreutils-9.5-info",
-        "out": "/nix/store/5g6np23z9q7vwwp1s5pxkgn8f8wrmihh-coreutils-9.5"
+        "info": "/nix/store/c263jjqg2mpap2fagjl34lziidkgph3i-coreutils-9.5-info",
+        "out": "/nix/store/p9m0bsw49c5m6wnm3m4fs97yx5rxcmfj-coreutils-9.5"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -193,17 +193,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/ir8y199idsk97agpjjkxk24nrrhlygiz-coreutils-9.5.drv",
+      "derivation": "/nix/store/18ysbs708pj8ps18fdjj81z7zn4c6fla-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -213,9 +213,9 @@
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/q70vk5m0nlz0qpy7z6nfczi8ksyaszap-coreutils-9.5-debug",
-        "info": "/nix/store/cbk08ylbni3vx41g1hdd013146yvcf5c-coreutils-9.5-info",
-        "out": "/nix/store/g5manmr2a4jc9m06cf2lpnx1092wvvjh-coreutils-9.5"
+        "debug": "/nix/store/r1x885lysldxid2575k87nld06pkbf4v-coreutils-9.5-debug",
+        "info": "/nix/store/xqglm4755lgpjrdyxi5f52fljrcarvqc-coreutils-9.5-info",
+        "out": "/nix/store/lhd4sbpf3l9jxmb8sl6881l924q151j0-coreutils-9.5"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -224,17 +224,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/5qkwxai9nx4hszq8m25ralrg5nrjfs6n-coreutils-9.5.drv",
+      "derivation": "/nix/store/67skpxi4kbs1nqf2xyvprbhxpsw6vmpy-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -244,8 +244,8 @@
         "out"
       ],
       "outputs": {
-        "info": "/nix/store/64g8lpl80mprjql96w0wsqc3n2q753l3-coreutils-9.5-info",
-        "out": "/nix/store/w95g6dz0b7byi4w2mgvmwpl692pilqf1-coreutils-9.5"
+        "info": "/nix/store/aghncv047lvr0xhil8fwwxpk6bi5yalh-coreutils-9.5-info",
+        "out": "/nix/store/ka9bhk1lwdqyv47kkw6ppqgx010xwghn-coreutils-9.5"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -254,17 +254,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/gk6as4in5fphr7ds30l9cyn70icxr54a-coreutils-9.5.drv",
+      "derivation": "/nix/store/rzf4njjb1pfpc2csazccxjn9452d96mi-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -274,9 +274,9 @@
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/h42j46bwd0fqsg70axqpkn49fzfgsxkd-coreutils-9.5-debug",
-        "info": "/nix/store/kszl2ij9l8ql5ai95h357rkwg77g2f68-coreutils-9.5-info",
-        "out": "/nix/store/k48bha2fjqzarg52picsdfwlqx75aqbb-coreutils-9.5"
+        "debug": "/nix/store/zs8k0d5dx7nkvs6vmxmkr1jdz3px2fhi-coreutils-9.5-debug",
+        "info": "/nix/store/hm7bqb710681rxgrq8b6l9zms50aj4k5-coreutils-9.5-info",
+        "out": "/nix/store/4s9rah4cwaxflicsk5cndnknqlk9n4p3-coreutils-9.5"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -285,17 +285,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -305,7 +305,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -314,17 +314,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -334,7 +334,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -343,17 +343,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -363,7 +363,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -372,17 +372,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -392,7 +392,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/build-runtime-packages-only-hello.json
+++ b/test_data/generated/envs/build-runtime-packages-only-hello.json
@@ -38,29 +38,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/rnpar5fbj0h7gidf1h066iwi5vi16a9y-vim-9.1.0787.drv",
+      "derivation": "/nix/store/k7pwn9a32s22syrbhf58cafk4s1i4pbl-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/8d473xm8x7ff6k5mqwma6hxgpjnf6alh-vim-9.1.0787",
-        "xxd": "/nix/store/d6jx0lvmachd31rlnf71015rws4kpj3r-vim-9.1.0787-xxd"
+        "out": "/nix/store/rc1kfgzpb3aq5w7cj1adjb5yaqv4c2va-vim-9.1.0905",
+        "xxd": "/nix/store/mi0chjhw4cmyl2yq0z1lz8gmskzrq6da-vim-9.1.0905-xxd"
       },
       "system": "aarch64-darwin",
       "group": "not-toplevel",
@@ -69,29 +69,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/x0lgcqq1qdnwwx4hf9k8njz8z20d5iz9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/293nl3481mnav4l70bk4lba4n37gawi4-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zappfr3lr1xp0pxsjvllg4m3bsvjxgbf-vim-9.1.0787",
-        "xxd": "/nix/store/v1rrv6z3bppr0xkfp3q7spmiaabgmszw-vim-9.1.0787-xxd"
+        "out": "/nix/store/v5rz9y25dapc1j6q2xmgawgh5fgfa59q-vim-9.1.0905",
+        "xxd": "/nix/store/fb6h1rvcaf73pmvf7xlcn2ihh80xwymj-vim-9.1.0905-xxd"
       },
       "system": "aarch64-linux",
       "group": "not-toplevel",
@@ -100,29 +100,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/k9n77kiw39pv4kwhhhl6gdlp947zp9q9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/xri9bxkiw1lbnhba9032smdqs1gmq134-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zsvr88wh53ha4d6ilv8lnil44svnsbvs-vim-9.1.0787",
-        "xxd": "/nix/store/73f1xnfkx8ghsqj30zn9k2vs4h75v8xj-vim-9.1.0787-xxd"
+        "out": "/nix/store/ysnvbsyvysqm78pjbsw0zn7arlzp7yk8-vim-9.1.0905",
+        "xxd": "/nix/store/ml8dj1b4zsi25652lf5cnz5qv8fl1swy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-darwin",
       "group": "not-toplevel",
@@ -131,29 +131,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/0p8c65a0gp3qx8sjg46v01fnc6clvy2v-vim-9.1.0787.drv",
+      "derivation": "/nix/store/nlqlkb9pwhl6myjm3rm17bb6fsdyh37q-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/862qv45cwbjj2n60iyscyj5ci2vzycdh-vim-9.1.0787",
-        "xxd": "/nix/store/jkny5zx16y29fgnl45d29wcirna7gyvk-vim-9.1.0787-xxd"
+        "out": "/nix/store/g9x3rxi0p1dxbdyf222m0qprrw0anyg5-vim-9.1.0905",
+        "xxd": "/nix/store/v8k2x4bg8vbhwx1qgmz1cicf1ny01npy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-linux",
       "group": "not-toplevel",
@@ -162,17 +162,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/5naisiq61kp39x9mi4nnlh4h0agrv6ix-coreutils-9.5.drv",
+      "derivation": "/nix/store/nm1mg4ilciiwhzkj26scwybw6x4ijpf0-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -182,8 +182,8 @@
         "out"
       ],
       "outputs": {
-        "info": "/nix/store/ydfklbdc7sdv9jl2jy0prq0wa4cv2zzf-coreutils-9.5-info",
-        "out": "/nix/store/5g6np23z9q7vwwp1s5pxkgn8f8wrmihh-coreutils-9.5"
+        "info": "/nix/store/c263jjqg2mpap2fagjl34lziidkgph3i-coreutils-9.5-info",
+        "out": "/nix/store/p9m0bsw49c5m6wnm3m4fs97yx5rxcmfj-coreutils-9.5"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -192,17 +192,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/ir8y199idsk97agpjjkxk24nrrhlygiz-coreutils-9.5.drv",
+      "derivation": "/nix/store/18ysbs708pj8ps18fdjj81z7zn4c6fla-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -212,9 +212,9 @@
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/q70vk5m0nlz0qpy7z6nfczi8ksyaszap-coreutils-9.5-debug",
-        "info": "/nix/store/cbk08ylbni3vx41g1hdd013146yvcf5c-coreutils-9.5-info",
-        "out": "/nix/store/g5manmr2a4jc9m06cf2lpnx1092wvvjh-coreutils-9.5"
+        "debug": "/nix/store/r1x885lysldxid2575k87nld06pkbf4v-coreutils-9.5-debug",
+        "info": "/nix/store/xqglm4755lgpjrdyxi5f52fljrcarvqc-coreutils-9.5-info",
+        "out": "/nix/store/lhd4sbpf3l9jxmb8sl6881l924q151j0-coreutils-9.5"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -223,17 +223,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/5qkwxai9nx4hszq8m25ralrg5nrjfs6n-coreutils-9.5.drv",
+      "derivation": "/nix/store/67skpxi4kbs1nqf2xyvprbhxpsw6vmpy-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -243,8 +243,8 @@
         "out"
       ],
       "outputs": {
-        "info": "/nix/store/64g8lpl80mprjql96w0wsqc3n2q753l3-coreutils-9.5-info",
-        "out": "/nix/store/w95g6dz0b7byi4w2mgvmwpl692pilqf1-coreutils-9.5"
+        "info": "/nix/store/aghncv047lvr0xhil8fwwxpk6bi5yalh-coreutils-9.5-info",
+        "out": "/nix/store/ka9bhk1lwdqyv47kkw6ppqgx010xwghn-coreutils-9.5"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -253,17 +253,17 @@
     {
       "attr_path": "coreutils",
       "broken": false,
-      "derivation": "/nix/store/gk6as4in5fphr7ds30l9cyn70icxr54a-coreutils-9.5.drv",
+      "derivation": "/nix/store/rzf4njjb1pfpc2csazccxjn9452d96mi-coreutils-9.5.drv",
       "description": "GNU Core Utilities",
       "install_id": "coreutils",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "coreutils-9.5",
       "pname": "coreutils",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -273,9 +273,9 @@
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/h42j46bwd0fqsg70axqpkn49fzfgsxkd-coreutils-9.5-debug",
-        "info": "/nix/store/kszl2ij9l8ql5ai95h357rkwg77g2f68-coreutils-9.5-info",
-        "out": "/nix/store/k48bha2fjqzarg52picsdfwlqx75aqbb-coreutils-9.5"
+        "debug": "/nix/store/zs8k0d5dx7nkvs6vmxmkr1jdz3px2fhi-coreutils-9.5-debug",
+        "info": "/nix/store/hm7bqb710681rxgrq8b6l9zms50aj4k5-coreutils-9.5-info",
+        "out": "/nix/store/4s9rah4cwaxflicsk5cndnknqlk9n4p3-coreutils-9.5"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -284,17 +284,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -304,7 +304,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -313,17 +313,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -333,7 +333,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -342,17 +342,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -362,7 +362,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -371,17 +371,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -391,7 +391,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/go_gcc.json
+++ b/test_data/generated/envs/go_gcc.json
@@ -11,25 +11,25 @@
             "attr_path": "gcc",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/3cwpfk4lz7in3d7qjv5p0ssygpcnispg-gcc-wrapper-13.3.0.drv",
-            "description": "GNU Compiler Collection, version 13.3.0 (wrapper script)",
+            "derivation": "/nix/store/wb9agahqw9yvy7lz6kvkypp17665mmp9-gcc-wrapper-14-20241116.drv",
+            "description": "GNU Compiler Collection, version 14-20241116 (wrapper script)",
             "insecure": false,
             "install_id": "gcc",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "gcc-wrapper-13.3.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "gcc-wrapper-14-20241116",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/shg3qxi31h2ywy89ra922d1jhssc820w-gcc-wrapper-13.3.0-man"
+                "store_path": "/nix/store/zdvmhplq052pzswiqh7ap84kxgfv3zpa-gcc-wrapper-14-20241116-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/2r2xi5pbg29bsmqywsm5zgl8l7adky4i-gcc-wrapper-13.3.0"
+                "store_path": "/nix/store/lypi8vf0lra99nx7nx2by1jyx5nhj9x0-gcc-wrapper-14-20241116"
               },
               {
                 "name": "info",
-                "store_path": "/nix/store/nwrpxic5hk3f928i8dwb915klzj99l1i-gcc-wrapper-13.3.0-info"
+                "store_path": "/nix/store/vzxp6yn3xjwhfndp6cl77qpayxlwmy1c-gcc-wrapper-14-20241116-info"
               }
             ],
             "outputs_to_install": [
@@ -37,41 +37,40 @@
               "man"
             ],
             "pname": "gcc",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "wrapper-13.3.0"
+            "version": "wrapper-14-20241116"
           },
           {
             "attr_path": "gcc",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/jw65jzcgyi0i3l3ppd4qnh865iwxpc62-gcc-wrapper-13.3.0.drv",
-            "description": "GNU Compiler Collection, version 13.3.0 (wrapper script)",
+            "derivation": "/nix/store/ziflg4wfjpcvrzbdsfpxfakcyyj9jfa1-gcc-wrapper-14-20241116.drv",
+            "description": "GNU Compiler Collection, version 14-20241116 (wrapper script)",
             "insecure": false,
             "install_id": "gcc",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "gcc-wrapper-13.3.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "gcc-wrapper-14-20241116",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/ylszr4j45y87x7qyxim5v8yi8g627q14-gcc-wrapper-13.3.0-man"
+                "store_path": "/nix/store/ifn8wv7q8qwi7pa7vf4rrj9fwknk6bzj-gcc-wrapper-14-20241116-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/3ix5h74n7ar9950vwzp4dxmil70pmx0k-gcc-wrapper-13.3.0"
+                "store_path": "/nix/store/xcn9p4xxfbvlkpah7pwchpav4ab9d135-gcc-wrapper-14-20241116"
               },
               {
                 "name": "info",
-                "store_path": "/nix/store/l41lyp7l1ks737avv6kz5ylhgbm8cjwq-gcc-wrapper-13.3.0-info"
+                "store_path": "/nix/store/h3b5gn5jh547jj8mz5g4c4270b5x1wl5-gcc-wrapper-14-20241116-info"
               }
             ],
             "outputs_to_install": [
@@ -79,152 +78,147 @@
               "man"
             ],
             "pname": "gcc",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "wrapper-13.3.0"
+            "version": "wrapper-14-20241116"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/mv8bpnbfg4j1gc7vnsq6glxdnrnz5smr-go-1.23.3.drv",
+            "derivation": "/nix/store/84bqd072ql6qzjmqsqcdbw3nv63waw49-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/qrj2wp6vzfpjfrrlcmr22818zg83fb73-go-1.23.3"
+                "store_path": "/nix/store/bva4mymi5b2lhvvbccx8ipws89rar1d8-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/w6x5p636f88nx6biff22rv8c0hqj29k4-go-1.23.3.drv",
+            "derivation": "/nix/store/fap65gsxy7m12f8b8p5j9yybfnh908ar-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/dm66qyl19skrwcmk4rb9xcs64xc1d071-go-1.23.3"
+                "store_path": "/nix/store/9lvi0l2yf6bwamsjs5d5n9i57c6kbd2c-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/si6gydplf7ybx7fp0brwzblv8m5awbps-go-1.23.3.drv",
+            "derivation": "/nix/store/jil5s3a20z15fkfhkxa3575ax6j7d9a3-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/vkjn6njpz4gy5ma763vh8hh93bgjwycr-go-1.23.3"
+                "store_path": "/nix/store/sf1y7x29wvp9lppx5ya9h5b42fcmxb32-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/hr6yjfp34id9pnhbrwfzzr8hmzzrr01a-go-1.23.3.drv",
+            "derivation": "/nix/store/h5i2qzmzj8hwyfxrf3fq23d7ngxpxyj2-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/bavnchxi7v6xs077jxv7fl5rrqc3y87w-go-1.23.3"
+                "store_path": "/nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/envs/go_gcc/manifest.lock
+++ b/test_data/generated/envs/go_gcc/manifest.lock
@@ -27,31 +27,30 @@
     {
       "attr_path": "gcc",
       "broken": false,
-      "derivation": "/nix/store/3cwpfk4lz7in3d7qjv5p0ssygpcnispg-gcc-wrapper-13.3.0.drv",
-      "description": "GNU Compiler Collection, version 13.3.0 (wrapper script)",
+      "derivation": "/nix/store/wb9agahqw9yvy7lz6kvkypp17665mmp9-gcc-wrapper-14-20241116.drv",
+      "description": "GNU Compiler Collection, version 14-20241116 (wrapper script)",
       "install_id": "gcc",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "name": "gcc-wrapper-13.3.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "gcc-wrapper-14-20241116",
       "pname": "gcc",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "wrapper-13.3.0",
+      "version": "wrapper-14-20241116",
       "outputs_to_install": [
         "out",
         "man"
       ],
       "outputs": {
-        "info": "/nix/store/nwrpxic5hk3f928i8dwb915klzj99l1i-gcc-wrapper-13.3.0-info",
-        "man": "/nix/store/shg3qxi31h2ywy89ra922d1jhssc820w-gcc-wrapper-13.3.0-man",
-        "out": "/nix/store/2r2xi5pbg29bsmqywsm5zgl8l7adky4i-gcc-wrapper-13.3.0"
+        "info": "/nix/store/vzxp6yn3xjwhfndp6cl77qpayxlwmy1c-gcc-wrapper-14-20241116-info",
+        "man": "/nix/store/zdvmhplq052pzswiqh7ap84kxgfv3zpa-gcc-wrapper-14-20241116-man",
+        "out": "/nix/store/lypi8vf0lra99nx7nx2by1jyx5nhj9x0-gcc-wrapper-14-20241116"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -60,31 +59,30 @@
     {
       "attr_path": "gcc",
       "broken": false,
-      "derivation": "/nix/store/jw65jzcgyi0i3l3ppd4qnh865iwxpc62-gcc-wrapper-13.3.0.drv",
-      "description": "GNU Compiler Collection, version 13.3.0 (wrapper script)",
+      "derivation": "/nix/store/ziflg4wfjpcvrzbdsfpxfakcyyj9jfa1-gcc-wrapper-14-20241116.drv",
+      "description": "GNU Compiler Collection, version 14-20241116 (wrapper script)",
       "install_id": "gcc",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "name": "gcc-wrapper-13.3.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "gcc-wrapper-14-20241116",
       "pname": "gcc",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "wrapper-13.3.0",
+      "version": "wrapper-14-20241116",
       "outputs_to_install": [
         "out",
         "man"
       ],
       "outputs": {
-        "info": "/nix/store/l41lyp7l1ks737avv6kz5ylhgbm8cjwq-gcc-wrapper-13.3.0-info",
-        "man": "/nix/store/ylszr4j45y87x7qyxim5v8yi8g627q14-gcc-wrapper-13.3.0-man",
-        "out": "/nix/store/3ix5h74n7ar9950vwzp4dxmil70pmx0k-gcc-wrapper-13.3.0"
+        "info": "/nix/store/h3b5gn5jh547jj8mz5g4c4270b5x1wl5-gcc-wrapper-14-20241116-info",
+        "man": "/nix/store/ifn8wv7q8qwi7pa7vf4rrj9fwknk6bzj-gcc-wrapper-14-20241116-man",
+        "out": "/nix/store/xcn9p4xxfbvlkpah7pwchpav4ab9d135-gcc-wrapper-14-20241116"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -93,28 +91,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/mv8bpnbfg4j1gc7vnsq6glxdnrnz5smr-go-1.23.3.drv",
+      "derivation": "/nix/store/84bqd072ql6qzjmqsqcdbw3nv63waw49-go-1.23.4.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "name": "go-1.23.3",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "go-1.23.4",
       "pname": "go",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "1.23.3",
+      "version": "1.23.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/qrj2wp6vzfpjfrrlcmr22818zg83fb73-go-1.23.3"
+        "out": "/nix/store/bva4mymi5b2lhvvbccx8ipws89rar1d8-go-1.23.4"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -123,28 +120,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/w6x5p636f88nx6biff22rv8c0hqj29k4-go-1.23.3.drv",
+      "derivation": "/nix/store/fap65gsxy7m12f8b8p5j9yybfnh908ar-go-1.23.4.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "name": "go-1.23.3",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "go-1.23.4",
       "pname": "go",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "1.23.3",
+      "version": "1.23.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/dm66qyl19skrwcmk4rb9xcs64xc1d071-go-1.23.3"
+        "out": "/nix/store/9lvi0l2yf6bwamsjs5d5n9i57c6kbd2c-go-1.23.4"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -153,28 +149,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/si6gydplf7ybx7fp0brwzblv8m5awbps-go-1.23.3.drv",
+      "derivation": "/nix/store/jil5s3a20z15fkfhkxa3575ax6j7d9a3-go-1.23.4.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "name": "go-1.23.3",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "go-1.23.4",
       "pname": "go",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "1.23.3",
+      "version": "1.23.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/vkjn6njpz4gy5ma763vh8hh93bgjwycr-go-1.23.3"
+        "out": "/nix/store/sf1y7x29wvp9lppx5ya9h5b42fcmxb32-go-1.23.4"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -183,28 +178,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/hr6yjfp34id9pnhbrwfzzr8hmzzrr01a-go-1.23.3.drv",
+      "derivation": "/nix/store/h5i2qzmzj8hwyfxrf3fq23d7ngxpxyj2-go-1.23.4.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "name": "go-1.23.3",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "go-1.23.4",
       "pname": "go",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "1.23.3",
+      "version": "1.23.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/bavnchxi7v6xs077jxv7fl5rrqc3y87w-go-1.23.3"
+        "out": "/nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/hello-unfree-lock.json
+++ b/test_data/generated/envs/hello-unfree-lock.json
@@ -20,17 +20,17 @@
     {
       "attr_path": "hello-unfree",
       "broken": false,
-      "derivation": "/nix/store/79xap8jzpff8v48m4rc675c14gaxxw7v-example-unfree-package-1.0.drv",
+      "derivation": "/nix/store/5sy7xzzk3mbb58jjpjys97203d8qa356-example-unfree-package-1.0.drv",
       "description": "Example package with unfree license (for testing)",
       "install_id": "hello-unfree",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "example-unfree-package-1.0",
       "pname": "hello-unfree",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -40,7 +40,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/5g2zkbys3gjixqqnh5nz0jxflm7d7kfs-example-unfree-package-1.0"
+        "out": "/nix/store/1lfrvy0dfp3xij13jar71bqp9saj5crw-example-unfree-package-1.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -49,17 +49,17 @@
     {
       "attr_path": "hello-unfree",
       "broken": false,
-      "derivation": "/nix/store/j9mscvr29dfgvr0zp12cdh4dz4a0kg0a-example-unfree-package-1.0.drv",
+      "derivation": "/nix/store/3i7nig9xpfj3vpbqm22xhxz0n7b4v6hw-example-unfree-package-1.0.drv",
       "description": "Example package with unfree license (for testing)",
       "install_id": "hello-unfree",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "example-unfree-package-1.0",
       "pname": "hello-unfree",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -69,7 +69,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/jx413f704ci0mawl2xlni51v8zjbwpjg-example-unfree-package-1.0"
+        "out": "/nix/store/c6zda6drrq5x0kx4r1wfzw7hk2h1pgwr-example-unfree-package-1.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -78,17 +78,17 @@
     {
       "attr_path": "hello-unfree",
       "broken": false,
-      "derivation": "/nix/store/nv31q4qig3qbzmj0j06anwxhwkhjh15j-example-unfree-package-1.0.drv",
+      "derivation": "/nix/store/5ln4c9k5p3gyhjyv7kb5f96lfpdl0z56-example-unfree-package-1.0.drv",
       "description": "Example package with unfree license (for testing)",
       "install_id": "hello-unfree",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "example-unfree-package-1.0",
       "pname": "hello-unfree",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -98,7 +98,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/k58b06qp8z5yg8g13xdi6gvc47qzj5c8-example-unfree-package-1.0"
+        "out": "/nix/store/xlis6d7055vbnnaqa98kvf6kxbvids9q-example-unfree-package-1.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -107,17 +107,17 @@
     {
       "attr_path": "hello-unfree",
       "broken": false,
-      "derivation": "/nix/store/gga6vz5d3nbj93skimr08j0gl7pyzkd5-example-unfree-package-1.0.drv",
+      "derivation": "/nix/store/4fpc7dqxs9gv3v8bhi11zp95i98wb2m3-example-unfree-package-1.0.drv",
       "description": "Example package with unfree license (for testing)",
       "install_id": "hello-unfree",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "example-unfree-package-1.0",
       "pname": "hello-unfree",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -127,7 +127,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/cqldvpw6naibpj3fi39jjs74pbl3sg0n-example-unfree-package-1.0"
+        "out": "/nix/store/f0sbs08vbbncr2yhpnl7ka4q29q1i3j9-example-unfree-package-1.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/hello/hello.json
+++ b/test_data/generated/envs/hello/hello.json
@@ -11,27 +11,27 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/60ppckivjh7cmvvrxgka1c5dr95vzzcc-hello-2.12.1.drv",
+            "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/9l3rahv16sipckaksiw988lxyfcihql9-hello-2.12.1"
+                "store_path": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
-            "rev_count": 721821,
-            "rev_date": "2024-12-13T19:53:07Z",
-            "scrape_date": "2024-12-16T03:51:20Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
               "unstable"
             ],
@@ -43,27 +43,27 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/g2q3c55j76hvsjmp1zinbvsm2n6g8f83-hello-2.12.1.drv",
+            "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/7pnx5bnl7h1j0zfzrlycjnk0knbplzq5-hello-2.12.1"
+                "store_path": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
-            "rev_count": 721821,
-            "rev_date": "2024-12-13T19:53:07Z",
-            "scrape_date": "2024-12-16T03:51:20Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
               "unstable"
             ],
@@ -75,27 +75,27 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/80c64w92rh8ydaf19z5zz17n5z15g2c7-hello-2.12.1.drv",
+            "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/532qk50xqh7m1fniq5zszca5s379ql35-hello-2.12.1"
+                "store_path": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
-            "rev_count": 721821,
-            "rev_date": "2024-12-13T19:53:07Z",
-            "scrape_date": "2024-12-16T03:51:20Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
               "unstable"
             ],
@@ -107,27 +107,27 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/9vkdb4vqqyqjkm2825vkm74gdxcr0m46-hello-2.12.1.drv",
+            "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl-hello-2.12.1"
+                "store_path": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
-            "rev_count": 721821,
-            "rev_date": "2024-12-13T19:53:07Z",
-            "scrape_date": "2024-12-16T03:51:20Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
               "unstable"
             ],
@@ -136,7 +136,7 @@
             "version": "2.12.1"
           }
         ],
-        "page": 721821,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/envs/hello/manifest.lock
+++ b/test_data/generated/envs/hello/manifest.lock
@@ -26,17 +26,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/60ppckivjh7cmvvrxgka1c5dr95vzzcc-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
-      "rev_count": 721821,
-      "rev_date": "2024-12-13T19:53:07Z",
-      "scrape_date": "2024-12-16T03:51:20Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -46,7 +46,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/9l3rahv16sipckaksiw988lxyfcihql9-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -55,17 +55,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g2q3c55j76hvsjmp1zinbvsm2n6g8f83-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
-      "rev_count": 721821,
-      "rev_date": "2024-12-13T19:53:07Z",
-      "scrape_date": "2024-12-16T03:51:20Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -75,7 +75,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7pnx5bnl7h1j0zfzrlycjnk0knbplzq5-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -84,17 +84,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/80c64w92rh8ydaf19z5zz17n5z15g2c7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
-      "rev_count": 721821,
-      "rev_date": "2024-12-13T19:53:07Z",
-      "scrape_date": "2024-12-16T03:51:20Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -104,7 +104,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/532qk50xqh7m1fniq5zszca5s379ql35-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -113,17 +113,17 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/9vkdb4vqqyqjkm2825vkm74gdxcr0m46-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
-      "rev_count": 721821,
-      "rev_date": "2024-12-13T19:53:07Z",
-      "scrape_date": "2024-12-16T03:51:20Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
@@ -133,7 +133,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/hello_and_htop_for_no_system/hello_and_htop_for_no_system.json
+++ b/test_data/generated/envs/hello_and_htop_for_no_system/hello_and_htop_for_no_system.json
@@ -11,29 +11,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+            "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+                "store_path": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+            "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+                "store_path": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -77,29 +75,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+            "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+                "store_path": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -110,29 +107,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+            "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+                "store_path": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "2.12.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/envs/hello_and_htop_for_no_system/manifest.lock
+++ b/test_data/generated/envs/hello_and_htop_for_no_system/manifest.lock
@@ -30,19 +30,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -51,7 +50,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -60,19 +59,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -81,7 +79,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -90,19 +88,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -111,7 +108,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -120,19 +117,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -141,7 +137,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/hello_as_greeting/hello_as_greeting.json
+++ b/test_data/generated/envs/hello_as_greeting/hello_as_greeting.json
@@ -11,29 +11,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+            "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "greeting",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+                "store_path": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+            "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "greeting",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+                "store_path": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+            "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "greeting",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+                "store_path": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+            "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "greeting",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+                "store_path": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "2.12.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/envs/hello_as_greeting/manifest.lock
+++ b/test_data/generated/envs/hello_as_greeting/manifest.lock
@@ -26,19 +26,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "greeting",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -47,7 +46,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -56,19 +55,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "greeting",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -77,7 +75,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -86,19 +84,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "greeting",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -107,7 +104,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -116,19 +113,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "greeting",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -137,7 +133,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/influxdb2/influxdb2.json
+++ b/test_data/generated/envs/influxdb2/influxdb2.json
@@ -11,29 +11,28 @@
             "attr_path": "influxdb2",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/fsiin22ha7rk80j73nwlyf5zjdsas1cw-influxdb2.drv",
+            "derivation": "/nix/store/2ic0apkxyxdzj1if697g1wrny0bikdps-influxdb2.drv",
             "description": null,
             "insecure": false,
             "install_id": "influxdb2",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "influxdb2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/pckmx1cq2grz3n0dwz6fb7i3gk22jll6-influxdb2"
+                "store_path": "/nix/store/xd785k0vh8vdkkxaslw86kkpyqp4cz4c-influxdb2"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "influxdb2",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "influxdb2",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/sw7ildp2k4jpxfvhswc60kibawrqhfxx-influxdb2.drv",
+            "derivation": "/nix/store/pdm0kc6ysjwiilsjd5iwsy4svglv8bcv-influxdb2.drv",
             "description": null,
             "insecure": false,
             "install_id": "influxdb2",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "influxdb2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/br5dizaryznhx54av8nfg94p9nifqgfm-influxdb2"
+                "store_path": "/nix/store/mx8924abbsjzvy3vxn4b1bmwcdsx8lf6-influxdb2"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "influxdb2",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "influxdb2",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/3j06iapz2hl3p3azxzgfkmwjc65i12h9-influxdb2.drv",
+            "derivation": "/nix/store/znfk3011pagg7sh0jslzb31j3vlfc3x8-influxdb2.drv",
             "description": null,
             "insecure": false,
             "install_id": "influxdb2",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "influxdb2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/xm4r1pxivqjhacm92glizx6pxvglgsk1-influxdb2"
+                "store_path": "/nix/store/l9mx423rvaimqaliiizfrsj3405rqylg-influxdb2"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "influxdb2",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "influxdb2",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/imnj14v7yp43l3f0b6srr4qznj676yns-influxdb2.drv",
+            "derivation": "/nix/store/89xckdnbz7h1r4fcnr2v59sd8b299sdc-influxdb2.drv",
             "description": null,
             "insecure": false,
             "install_id": "influxdb2",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "influxdb2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/4p2c8iwf3vppi8z8jlqpayw1a4pl4l00-influxdb2"
+                "store_path": "/nix/store/49050j55f0y68xyl1yxah5ghgqc5hs25-influxdb2"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "influxdb2",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "influxdb2"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/envs/influxdb2/manifest.lock
+++ b/test_data/generated/envs/influxdb2/manifest.lock
@@ -26,17 +26,16 @@
     {
       "attr_path": "influxdb2",
       "broken": false,
-      "derivation": "/nix/store/fsiin22ha7rk80j73nwlyf5zjdsas1cw-influxdb2.drv",
+      "derivation": "/nix/store/2ic0apkxyxdzj1if697g1wrny0bikdps-influxdb2.drv",
       "install_id": "influxdb2",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "influxdb2",
       "pname": "influxdb2",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -45,7 +44,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/pckmx1cq2grz3n0dwz6fb7i3gk22jll6-influxdb2"
+        "out": "/nix/store/xd785k0vh8vdkkxaslw86kkpyqp4cz4c-influxdb2"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -54,17 +53,16 @@
     {
       "attr_path": "influxdb2",
       "broken": false,
-      "derivation": "/nix/store/sw7ildp2k4jpxfvhswc60kibawrqhfxx-influxdb2.drv",
+      "derivation": "/nix/store/pdm0kc6ysjwiilsjd5iwsy4svglv8bcv-influxdb2.drv",
       "install_id": "influxdb2",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "influxdb2",
       "pname": "influxdb2",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -73,7 +71,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/br5dizaryznhx54av8nfg94p9nifqgfm-influxdb2"
+        "out": "/nix/store/mx8924abbsjzvy3vxn4b1bmwcdsx8lf6-influxdb2"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -82,17 +80,16 @@
     {
       "attr_path": "influxdb2",
       "broken": false,
-      "derivation": "/nix/store/3j06iapz2hl3p3azxzgfkmwjc65i12h9-influxdb2.drv",
+      "derivation": "/nix/store/znfk3011pagg7sh0jslzb31j3vlfc3x8-influxdb2.drv",
       "install_id": "influxdb2",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "influxdb2",
       "pname": "influxdb2",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -101,7 +98,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/xm4r1pxivqjhacm92glizx6pxvglgsk1-influxdb2"
+        "out": "/nix/store/l9mx423rvaimqaliiizfrsj3405rqylg-influxdb2"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -110,17 +107,16 @@
     {
       "attr_path": "influxdb2",
       "broken": false,
-      "derivation": "/nix/store/imnj14v7yp43l3f0b6srr4qznj676yns-influxdb2.drv",
+      "derivation": "/nix/store/89xckdnbz7h1r4fcnr2v59sd8b299sdc-influxdb2.drv",
       "install_id": "influxdb2",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "influxdb2",
       "pname": "influxdb2",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -129,7 +125,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/4p2c8iwf3vppi8z8jlqpayw1a4pl4l00-influxdb2"
+        "out": "/nix/store/49050j55f0y68xyl1yxah5ghgqc5hs25-influxdb2"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/kitchen_sink/kitchen_sink.json
+++ b/test_data/generated/envs/kitchen_sink/kitchen_sink.json
@@ -11,29 +11,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+            "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+                "store_path": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+            "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+                "store_path": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+            "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+                "store_path": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+            "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+                "store_path": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "2.12.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/envs/kitchen_sink/manifest.lock
+++ b/test_data/generated/envs/kitchen_sink/manifest.lock
@@ -31,19 +31,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -52,7 +51,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -61,19 +60,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -82,7 +80,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -91,19 +89,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -112,7 +109,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -121,19 +118,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -142,7 +138,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/pip/manifest.lock
+++ b/test_data/generated/envs/pip/manifest.lock
@@ -26,19 +26,18 @@
     {
       "attr_path": "python312Packages.pip",
       "broken": false,
-      "derivation": "/nix/store/4j069vj4iviry0k78ybvh1k31w303r5j-python3.12-pip-24.0.drv",
+      "derivation": "/nix/store/afbswdvvyv59jd2r6q2dc8mnrrbckc6v-python3.12-pip-24.0.drv",
       "description": "PyPA recommended tool for installing Python packages",
       "install_id": "pip",
       "license": "[ MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "python3.12-pip-24.0",
       "pname": "pip",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -48,9 +47,9 @@
         "man"
       ],
       "outputs": {
-        "dist": "/nix/store/2rrhhjlg4lwi46z37mzpd49hd8mhd3q4-python3.12-pip-24.0-dist",
-        "man": "/nix/store/dinm7vidm6maajw3sza2y7ndpp0zgvja-python3.12-pip-24.0-man",
-        "out": "/nix/store/y23i639vf79zawhi590v48r7f5f8dl37-python3.12-pip-24.0"
+        "dist": "/nix/store/7snpl8z9s2q3mqcv816viqhk7rbjr424-python3.12-pip-24.0-dist",
+        "man": "/nix/store/z4n0i1acnrjnqa06kcajk54jsdkpba3w-python3.12-pip-24.0-man",
+        "out": "/nix/store/3l3gn87y3s2z5h2r0ssxj0vgyiafnr5q-python3.12-pip-24.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -59,19 +58,18 @@
     {
       "attr_path": "python312Packages.pip",
       "broken": false,
-      "derivation": "/nix/store/b6gymll1gwsn7v62wmyv1jnkvz2abg4s-python3.12-pip-24.0.drv",
+      "derivation": "/nix/store/8pkrgvmsyxzl8ml6klkgzz2z3cwisf0d-python3.12-pip-24.0.drv",
       "description": "PyPA recommended tool for installing Python packages",
       "install_id": "pip",
       "license": "[ MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "python3.12-pip-24.0",
       "pname": "pip",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -81,9 +79,9 @@
         "man"
       ],
       "outputs": {
-        "dist": "/nix/store/92wyn6r8gyiizwd5pb4c1s2djcjshssd-python3.12-pip-24.0-dist",
-        "man": "/nix/store/3b9cfvmszlcsy7f5mpbd6zyh12aigi6i-python3.12-pip-24.0-man",
-        "out": "/nix/store/1lfhdikssg7iprknyz9qbl67l2989f47-python3.12-pip-24.0"
+        "dist": "/nix/store/9vbrkrm9m06wgzgwim6kv86hzff1qnd3-python3.12-pip-24.0-dist",
+        "man": "/nix/store/7n53c52klq143k4m36kwh0l1fj9ii3kj-python3.12-pip-24.0-man",
+        "out": "/nix/store/xrnh2s08w1grfga6cbcwh6whaxgzci4p-python3.12-pip-24.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -92,19 +90,18 @@
     {
       "attr_path": "python312Packages.pip",
       "broken": false,
-      "derivation": "/nix/store/3x4czxgjdddkj5grx1160lb7cj79wsvd-python3.12-pip-24.0.drv",
+      "derivation": "/nix/store/jdc5pi02dzzb234fwzhvkygq9fngyda3-python3.12-pip-24.0.drv",
       "description": "PyPA recommended tool for installing Python packages",
       "install_id": "pip",
       "license": "[ MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "python3.12-pip-24.0",
       "pname": "pip",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -114,9 +111,9 @@
         "man"
       ],
       "outputs": {
-        "dist": "/nix/store/ra2q58n53mf200xq3rah7hdmnwhy7w8z-python3.12-pip-24.0-dist",
-        "man": "/nix/store/n6ckhk7kbx82gcq9y9rbvc2is6jlgg83-python3.12-pip-24.0-man",
-        "out": "/nix/store/xf3psjaxgglhrhw5f4yp18g1663ac0l8-python3.12-pip-24.0"
+        "dist": "/nix/store/g9gi39q033nm03djpxd03c2ymxijl09w-python3.12-pip-24.0-dist",
+        "man": "/nix/store/mp350jswrjsijdk6p8k7qn4qmikxybm2-python3.12-pip-24.0-man",
+        "out": "/nix/store/3wgqwjv87phhkfgvjdsi8zrzclx36va0-python3.12-pip-24.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -125,19 +122,18 @@
     {
       "attr_path": "python312Packages.pip",
       "broken": false,
-      "derivation": "/nix/store/f6qlxiwxz47lc2n98ya01widgjm405nn-python3.12-pip-24.0.drv",
+      "derivation": "/nix/store/68brzcn4jyf85vp7sydq55pdl1mjv2xr-python3.12-pip-24.0.drv",
       "description": "PyPA recommended tool for installing Python packages",
       "install_id": "pip",
       "license": "[ MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "python3.12-pip-24.0",
       "pname": "pip",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -147,9 +143,9 @@
         "man"
       ],
       "outputs": {
-        "dist": "/nix/store/l206psannh6hnqxvv2mc7v0mhph2kq16-python3.12-pip-24.0-dist",
-        "man": "/nix/store/z88q2pwlm5m099hwysxw7a1acy8kmnxg-python3.12-pip-24.0-man",
-        "out": "/nix/store/ny7kw0chch81nwq3pwqwph293mhbf5n8-python3.12-pip-24.0"
+        "dist": "/nix/store/m7kpzms0vy46ymd6ygjffy1xydkaaklf-python3.12-pip-24.0-dist",
+        "man": "/nix/store/rvkq4d61gfalg4578ydrjig68cw8f0i3-python3.12-pip-24.0-man",
+        "out": "/nix/store/0b83d75slv47hx4q9wgzzm5wi74adal3-python3.12-pip-24.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/pip/pip.json
+++ b/test_data/generated/envs/pip/pip.json
@@ -11,25 +11,25 @@
             "attr_path": "python312Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/4j069vj4iviry0k78ybvh1k31w303r5j-python3.12-pip-24.0.drv",
+            "derivation": "/nix/store/afbswdvvyv59jd2r6q2dc8mnrrbckc6v-python3.12-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/dinm7vidm6maajw3sza2y7ndpp0zgvja-python3.12-pip-24.0-man"
+                "store_path": "/nix/store/z4n0i1acnrjnqa06kcajk54jsdkpba3w-python3.12-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/y23i639vf79zawhi590v48r7f5f8dl37-python3.12-pip-24.0"
+                "store_path": "/nix/store/3l3gn87y3s2z5h2r0ssxj0vgyiafnr5q-python3.12-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/2rrhhjlg4lwi46z37mzpd49hd8mhd3q4-python3.12-pip-24.0-dist"
+                "store_path": "/nix/store/7snpl8z9s2q3mqcv816viqhk7rbjr424-python3.12-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -37,12 +37,11 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -53,25 +52,25 @@
             "attr_path": "python312Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/b6gymll1gwsn7v62wmyv1jnkvz2abg4s-python3.12-pip-24.0.drv",
+            "derivation": "/nix/store/8pkrgvmsyxzl8ml6klkgzz2z3cwisf0d-python3.12-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/3b9cfvmszlcsy7f5mpbd6zyh12aigi6i-python3.12-pip-24.0-man"
+                "store_path": "/nix/store/7n53c52klq143k4m36kwh0l1fj9ii3kj-python3.12-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/1lfhdikssg7iprknyz9qbl67l2989f47-python3.12-pip-24.0"
+                "store_path": "/nix/store/xrnh2s08w1grfga6cbcwh6whaxgzci4p-python3.12-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/92wyn6r8gyiizwd5pb4c1s2djcjshssd-python3.12-pip-24.0-dist"
+                "store_path": "/nix/store/9vbrkrm9m06wgzgwim6kv86hzff1qnd3-python3.12-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -79,12 +78,11 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -95,25 +93,25 @@
             "attr_path": "python312Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/3x4czxgjdddkj5grx1160lb7cj79wsvd-python3.12-pip-24.0.drv",
+            "derivation": "/nix/store/jdc5pi02dzzb234fwzhvkygq9fngyda3-python3.12-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/n6ckhk7kbx82gcq9y9rbvc2is6jlgg83-python3.12-pip-24.0-man"
+                "store_path": "/nix/store/mp350jswrjsijdk6p8k7qn4qmikxybm2-python3.12-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/xf3psjaxgglhrhw5f4yp18g1663ac0l8-python3.12-pip-24.0"
+                "store_path": "/nix/store/3wgqwjv87phhkfgvjdsi8zrzclx36va0-python3.12-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/ra2q58n53mf200xq3rah7hdmnwhy7w8z-python3.12-pip-24.0-dist"
+                "store_path": "/nix/store/g9gi39q033nm03djpxd03c2ymxijl09w-python3.12-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -121,12 +119,11 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -137,25 +134,25 @@
             "attr_path": "python312Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/f6qlxiwxz47lc2n98ya01widgjm405nn-python3.12-pip-24.0.drv",
+            "derivation": "/nix/store/68brzcn4jyf85vp7sydq55pdl1mjv2xr-python3.12-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/z88q2pwlm5m099hwysxw7a1acy8kmnxg-python3.12-pip-24.0-man"
+                "store_path": "/nix/store/rvkq4d61gfalg4578ydrjig68cw8f0i3-python3.12-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/ny7kw0chch81nwq3pwqwph293mhbf5n8-python3.12-pip-24.0"
+                "store_path": "/nix/store/0b83d75slv47hx4q9wgzzm5wi74adal3-python3.12-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/l206psannh6hnqxvv2mc7v0mhph2kq16-python3.12-pip-24.0-dist"
+                "store_path": "/nix/store/m7kpzms0vy46ymd6ygjffy1xydkaaklf-python3.12-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -163,12 +160,11 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -176,7 +172,7 @@
             "version": "python3.12-pip-24.0"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/envs/publish-simple.json
+++ b/test_data/generated/envs/publish-simple.json
@@ -11,29 +11,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+            "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+                "store_path": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+            "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+                "store_path": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+            "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+                "store_path": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+            "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+                "store_path": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "2.12.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/envs/publish-simple/manifest.lock
+++ b/test_data/generated/envs/publish-simple/manifest.lock
@@ -29,19 +29,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+      "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -50,7 +49,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+        "out": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -59,19 +58,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+      "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -80,7 +78,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+        "out": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -89,19 +87,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+      "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -110,7 +107,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+        "out": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -119,19 +116,18 @@
     {
       "attr_path": "hello",
       "broken": false,
-      "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+      "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
       "description": "Program that produces a familiar, friendly greeting",
       "install_id": "hello",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
       "name": "hello-2.12.1",
       "pname": "hello",
-      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-      "rev_count": 710087,
-      "rev_date": "2024-11-19T11:04:08Z",
-      "scrape_date": "2024-11-21T04:00:36Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
-        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -140,7 +136,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+        "out": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/vim-vim-full-conflict-resolved.json
+++ b/test_data/generated/envs/vim-vim-full-conflict-resolved.json
@@ -24,29 +24,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/rnpar5fbj0h7gidf1h066iwi5vi16a9y-vim-9.1.0787.drv",
+      "derivation": "/nix/store/k7pwn9a32s22syrbhf58cafk4s1i4pbl-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/8d473xm8x7ff6k5mqwma6hxgpjnf6alh-vim-9.1.0787",
-        "xxd": "/nix/store/d6jx0lvmachd31rlnf71015rws4kpj3r-vim-9.1.0787-xxd"
+        "out": "/nix/store/rc1kfgzpb3aq5w7cj1adjb5yaqv4c2va-vim-9.1.0905",
+        "xxd": "/nix/store/mi0chjhw4cmyl2yq0z1lz8gmskzrq6da-vim-9.1.0905-xxd"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -55,29 +55,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/x0lgcqq1qdnwwx4hf9k8njz8z20d5iz9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/293nl3481mnav4l70bk4lba4n37gawi4-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zappfr3lr1xp0pxsjvllg4m3bsvjxgbf-vim-9.1.0787",
-        "xxd": "/nix/store/v1rrv6z3bppr0xkfp3q7spmiaabgmszw-vim-9.1.0787-xxd"
+        "out": "/nix/store/v5rz9y25dapc1j6q2xmgawgh5fgfa59q-vim-9.1.0905",
+        "xxd": "/nix/store/fb6h1rvcaf73pmvf7xlcn2ihh80xwymj-vim-9.1.0905-xxd"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -86,29 +86,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/k9n77kiw39pv4kwhhhl6gdlp947zp9q9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/xri9bxkiw1lbnhba9032smdqs1gmq134-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zsvr88wh53ha4d6ilv8lnil44svnsbvs-vim-9.1.0787",
-        "xxd": "/nix/store/73f1xnfkx8ghsqj30zn9k2vs4h75v8xj-vim-9.1.0787-xxd"
+        "out": "/nix/store/ysnvbsyvysqm78pjbsw0zn7arlzp7yk8-vim-9.1.0905",
+        "xxd": "/nix/store/ml8dj1b4zsi25652lf5cnz5qv8fl1swy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -117,29 +117,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/0p8c65a0gp3qx8sjg46v01fnc6clvy2v-vim-9.1.0787.drv",
+      "derivation": "/nix/store/nlqlkb9pwhl6myjm3rm17bb6fsdyh37q-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/862qv45cwbjj2n60iyscyj5ci2vzycdh-vim-9.1.0787",
-        "xxd": "/nix/store/jkny5zx16y29fgnl45d29wcirna7gyvk-vim-9.1.0787-xxd"
+        "out": "/nix/store/g9x3rxi0p1dxbdyf222m0qprrw0anyg5-vim-9.1.0905",
+        "xxd": "/nix/store/v8k2x4bg8vbhwx1qgmz1cicf1ny01npy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -148,29 +148,29 @@
     {
       "attr_path": "vim-full",
       "broken": false,
-      "derivation": "/nix/store/gyar1b08ap68shay002g3gvgddsx7yhs-vim-full-9.1.0787.drv",
+      "derivation": "/nix/store/yssbh4whnn23x0jy88p7h1h76275qd62-vim-full-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim-full",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-full-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-full-9.1.0905",
       "pname": "vim-full",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/ap5gr1kwgjjh82ncxzpvb5kvdsafjpgn-vim-full-9.1.0787",
-        "xxd": "/nix/store/ay24bkfr667dcpgn8d084bg86hcly4n2-vim-full-9.1.0787-xxd"
+        "out": "/nix/store/f5fkw7mwj5l4jw87iz0615x5qvil9q2s-vim-full-9.1.0905",
+        "xxd": "/nix/store/6yp7nbqn40myinqmjbmfdam6nl6rxa8j-vim-full-9.1.0905-xxd"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -179,29 +179,29 @@
     {
       "attr_path": "vim-full",
       "broken": false,
-      "derivation": "/nix/store/g785kmmcm2xl52rcxwidds9mipmhxnf8-vim-full-9.1.0787.drv",
+      "derivation": "/nix/store/mg1hrw76x0j1fslviqdh6pwmfwrjrwrq-vim-full-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim-full",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-full-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-full-9.1.0905",
       "pname": "vim-full",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zcb44rlik2ma990d1g9jj7vk0hwawjzx-vim-full-9.1.0787",
-        "xxd": "/nix/store/nwjspmxxjfm3j6407j5fgya580bvvb3k-vim-full-9.1.0787-xxd"
+        "out": "/nix/store/j34s2g2i4jg64fyyhm5w4rhddny015q0-vim-full-9.1.0905",
+        "xxd": "/nix/store/nl0h6a5iifmdf4709rwwgbxnfkk69y8k-vim-full-9.1.0905-xxd"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -210,29 +210,29 @@
     {
       "attr_path": "vim-full",
       "broken": false,
-      "derivation": "/nix/store/h75f1c60kdwh4i3vcipc7cr2mxg4qim2-vim-full-9.1.0787.drv",
+      "derivation": "/nix/store/z7k8avdnhnaiqxjxrms1w13wvjiihrlz-vim-full-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim-full",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-full-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-full-9.1.0905",
       "pname": "vim-full",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/ba79sb6cmicmbxz4yk4dacj4zr424hpq-vim-full-9.1.0787",
-        "xxd": "/nix/store/dspd6484b3zqynpii3bw4csrfnl0jf99-vim-full-9.1.0787-xxd"
+        "out": "/nix/store/ah4bvgxs4r0j64zhfjgdk99qpbbcd1i3-vim-full-9.1.0905",
+        "xxd": "/nix/store/682syvkmjf5kkdf4vcb5lrcgs2ghnxbc-vim-full-9.1.0905-xxd"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -241,29 +241,29 @@
     {
       "attr_path": "vim-full",
       "broken": false,
-      "derivation": "/nix/store/hprdkp0w6iwcana7wlckx1kkbhbkxm32-vim-full-9.1.0787.drv",
+      "derivation": "/nix/store/f8ra0r9wac23pzdb7p7isgkl287qpbjg-vim-full-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim-full",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-full-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-full-9.1.0905",
       "pname": "vim-full",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/p1aawrrbd44fl9qs9d6ld41i92vasj2v-vim-full-9.1.0787",
-        "xxd": "/nix/store/zcg4sir3ivhf585hl12k7qd3pcvkxgjw-vim-full-9.1.0787-xxd"
+        "out": "/nix/store/914bd4khdw9frfm18z756h915r7lq4x0-vim-full-9.1.0905",
+        "xxd": "/nix/store/8vdmla64qjh2jb0nnrw8bniqlhhnxs3a-vim-full-9.1.0905-xxd"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/envs/vim-vim-full-conflict.json
+++ b/test_data/generated/envs/vim-vim-full-conflict.json
@@ -23,29 +23,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/rnpar5fbj0h7gidf1h066iwi5vi16a9y-vim-9.1.0787.drv",
+      "derivation": "/nix/store/k7pwn9a32s22syrbhf58cafk4s1i4pbl-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/8d473xm8x7ff6k5mqwma6hxgpjnf6alh-vim-9.1.0787",
-        "xxd": "/nix/store/d6jx0lvmachd31rlnf71015rws4kpj3r-vim-9.1.0787-xxd"
+        "out": "/nix/store/rc1kfgzpb3aq5w7cj1adjb5yaqv4c2va-vim-9.1.0905",
+        "xxd": "/nix/store/mi0chjhw4cmyl2yq0z1lz8gmskzrq6da-vim-9.1.0905-xxd"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -54,29 +54,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/x0lgcqq1qdnwwx4hf9k8njz8z20d5iz9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/293nl3481mnav4l70bk4lba4n37gawi4-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zappfr3lr1xp0pxsjvllg4m3bsvjxgbf-vim-9.1.0787",
-        "xxd": "/nix/store/v1rrv6z3bppr0xkfp3q7spmiaabgmszw-vim-9.1.0787-xxd"
+        "out": "/nix/store/v5rz9y25dapc1j6q2xmgawgh5fgfa59q-vim-9.1.0905",
+        "xxd": "/nix/store/fb6h1rvcaf73pmvf7xlcn2ihh80xwymj-vim-9.1.0905-xxd"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -85,29 +85,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/k9n77kiw39pv4kwhhhl6gdlp947zp9q9-vim-9.1.0787.drv",
+      "derivation": "/nix/store/xri9bxkiw1lbnhba9032smdqs1gmq134-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zsvr88wh53ha4d6ilv8lnil44svnsbvs-vim-9.1.0787",
-        "xxd": "/nix/store/73f1xnfkx8ghsqj30zn9k2vs4h75v8xj-vim-9.1.0787-xxd"
+        "out": "/nix/store/ysnvbsyvysqm78pjbsw0zn7arlzp7yk8-vim-9.1.0905",
+        "xxd": "/nix/store/ml8dj1b4zsi25652lf5cnz5qv8fl1swy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -116,29 +116,29 @@
     {
       "attr_path": "vim",
       "broken": false,
-      "derivation": "/nix/store/0p8c65a0gp3qx8sjg46v01fnc6clvy2v-vim-9.1.0787.drv",
+      "derivation": "/nix/store/nlqlkb9pwhl6myjm3rm17bb6fsdyh37q-vim-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-9.1.0905",
       "pname": "vim",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/862qv45cwbjj2n60iyscyj5ci2vzycdh-vim-9.1.0787",
-        "xxd": "/nix/store/jkny5zx16y29fgnl45d29wcirna7gyvk-vim-9.1.0787-xxd"
+        "out": "/nix/store/g9x3rxi0p1dxbdyf222m0qprrw0anyg5-vim-9.1.0905",
+        "xxd": "/nix/store/v8k2x4bg8vbhwx1qgmz1cicf1ny01npy-vim-9.1.0905-xxd"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -147,29 +147,29 @@
     {
       "attr_path": "vim-full",
       "broken": false,
-      "derivation": "/nix/store/gyar1b08ap68shay002g3gvgddsx7yhs-vim-full-9.1.0787.drv",
+      "derivation": "/nix/store/yssbh4whnn23x0jy88p7h1h76275qd62-vim-full-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim-full",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-full-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-full-9.1.0905",
       "pname": "vim-full",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/ap5gr1kwgjjh82ncxzpvb5kvdsafjpgn-vim-full-9.1.0787",
-        "xxd": "/nix/store/ay24bkfr667dcpgn8d084bg86hcly4n2-vim-full-9.1.0787-xxd"
+        "out": "/nix/store/f5fkw7mwj5l4jw87iz0615x5qvil9q2s-vim-full-9.1.0905",
+        "xxd": "/nix/store/6yp7nbqn40myinqmjbmfdam6nl6rxa8j-vim-full-9.1.0905-xxd"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -178,29 +178,29 @@
     {
       "attr_path": "vim-full",
       "broken": false,
-      "derivation": "/nix/store/g785kmmcm2xl52rcxwidds9mipmhxnf8-vim-full-9.1.0787.drv",
+      "derivation": "/nix/store/mg1hrw76x0j1fslviqdh6pwmfwrjrwrq-vim-full-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim-full",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-full-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-full-9.1.0905",
       "pname": "vim-full",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/zcb44rlik2ma990d1g9jj7vk0hwawjzx-vim-full-9.1.0787",
-        "xxd": "/nix/store/nwjspmxxjfm3j6407j5fgya580bvvb3k-vim-full-9.1.0787-xxd"
+        "out": "/nix/store/j34s2g2i4jg64fyyhm5w4rhddny015q0-vim-full-9.1.0905",
+        "xxd": "/nix/store/nl0h6a5iifmdf4709rwwgbxnfkk69y8k-vim-full-9.1.0905-xxd"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -209,29 +209,29 @@
     {
       "attr_path": "vim-full",
       "broken": false,
-      "derivation": "/nix/store/h75f1c60kdwh4i3vcipc7cr2mxg4qim2-vim-full-9.1.0787.drv",
+      "derivation": "/nix/store/z7k8avdnhnaiqxjxrms1w13wvjiihrlz-vim-full-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim-full",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-full-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-full-9.1.0905",
       "pname": "vim-full",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/ba79sb6cmicmbxz4yk4dacj4zr424hpq-vim-full-9.1.0787",
-        "xxd": "/nix/store/dspd6484b3zqynpii3bw4csrfnl0jf99-vim-full-9.1.0787-xxd"
+        "out": "/nix/store/ah4bvgxs4r0j64zhfjgdk99qpbbcd1i3-vim-full-9.1.0905",
+        "xxd": "/nix/store/682syvkmjf5kkdf4vcb5lrcgs2ghnxbc-vim-full-9.1.0905-xxd"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -240,29 +240,29 @@
     {
       "attr_path": "vim-full",
       "broken": false,
-      "derivation": "/nix/store/hprdkp0w6iwcana7wlckx1kkbhbkxm32-vim-full-9.1.0787.drv",
+      "derivation": "/nix/store/f8ra0r9wac23pzdb7p7isgkl287qpbjg-vim-full-9.1.0905.drv",
       "description": "Most popular clone of the VI editor",
       "install_id": "vim-full",
       "license": "Vim",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "name": "vim-full-9.1.0787",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+      "name": "vim-full-9.1.0905",
       "pname": "vim-full",
-      "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
-      "rev_count": 712559,
-      "rev_date": "2024-11-25T07:53:41Z",
-      "scrape_date": "2024-11-27T03:52:37Z",
+      "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+      "rev_count": 736170,
+      "rev_date": "2025-01-10T15:43:18Z",
+      "scrape_date": "2025-01-13T03:35:32Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "9.1.0787",
+      "version": "9.1.0905",
       "outputs_to_install": [
         "out",
         "xxd"
       ],
       "outputs": {
-        "out": "/nix/store/p1aawrrbd44fl9qs9d6ld41i92vasj2v-vim-full-9.1.0787",
-        "xxd": "/nix/store/zcg4sir3ivhf585hl12k7qd3pcvkxgjw-vim-full-9.1.0787-xxd"
+        "out": "/nix/store/914bd4khdw9frfm18z756h915r7lq4x0-vim-full-9.1.0905",
+        "xxd": "/nix/store/8vdmla64qjh2jb0nnrw8bniqlhhnxs3a-vim-full-9.1.0905-xxd"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/test_data/generated/init/go.json
+++ b/test_data/generated/init/go.json
@@ -11,37 +11,36 @@
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/mv8bpnbfg4j1gc7vnsq6glxdnrnz5smr-go-1.23.3.drv",
+            "derivation": "/nix/store/84bqd072ql6qzjmqsqcdbw3nv63waw49-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/qrj2wp6vzfpjfrrlcmr22818zg83fb73-go-1.23.3"
+                "store_path": "/nix/store/bva4mymi5b2lhvvbccx8ipws89rar1d8-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -58,136 +57,132 @@
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/mv8bpnbfg4j1gc7vnsq6glxdnrnz5smr-go-1.23.3.drv",
+            "derivation": "/nix/store/84bqd072ql6qzjmqsqcdbw3nv63waw49-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/qrj2wp6vzfpjfrrlcmr22818zg83fb73-go-1.23.3"
+                "store_path": "/nix/store/bva4mymi5b2lhvvbccx8ipws89rar1d8-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/w6x5p636f88nx6biff22rv8c0hqj29k4-go-1.23.3.drv",
+            "derivation": "/nix/store/fap65gsxy7m12f8b8p5j9yybfnh908ar-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/dm66qyl19skrwcmk4rb9xcs64xc1d071-go-1.23.3"
+                "store_path": "/nix/store/9lvi0l2yf6bwamsjs5d5n9i57c6kbd2c-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/si6gydplf7ybx7fp0brwzblv8m5awbps-go-1.23.3.drv",
+            "derivation": "/nix/store/jil5s3a20z15fkfhkxa3575ax6j7d9a3-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/vkjn6njpz4gy5ma763vh8hh93bgjwycr-go-1.23.3"
+                "store_path": "/nix/store/sf1y7x29wvp9lppx5ya9h5b42fcmxb32-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/hr6yjfp34id9pnhbrwfzzr8hmzzrr01a-go-1.23.3.drv",
+            "derivation": "/nix/store/h5i2qzmzj8hwyfxrf3fq23d7ngxpxyj2-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/bavnchxi7v6xs077jxv7fl5rrqc3y87w-go-1.23.3"
+                "store_path": "/nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/node_npm.json
+++ b/test_data/generated/init/node_npm.json
@@ -11,152 +11,148 @@
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/v0v7dny82f4hmfp9s8zj31iykjrdblkn-nodejs-20.18.0.drv",
+            "derivation": "/nix/store/zh4vzz8z4g7k2p0iqpi8dfz6kgpxkgb1-nodejs-22.11.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "nodejs-20.18.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "nodejs-22.11.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/9grahx8677nlgbx3yfiggibw335lkgfr-nodejs-20.18.0"
+                "store_path": "/nix/store/9vkabbbbyfn8hv5l1r8fm59d27imq460-nodejs-22.11.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/hfchgw1as9fm02wcyr3iqya05ylll5f3-nodejs-20.18.0-libv8"
+                "store_path": "/nix/store/m3rxxwm6jp95kjmh4rklqn0d76biz6wm-nodejs-22.11.0-libv8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "nodejs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "20.18.0"
+            "version": "22.11.0"
           },
           {
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/d3mn4dx774ppvnajxls24jkgsscv4sq5-nodejs-20.18.0.drv",
+            "derivation": "/nix/store/q23y2j34i9ydidrllrm4gj857hqhvda1-nodejs-22.11.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "nodejs-20.18.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "nodejs-22.11.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/hsh74yzdb9yk834w9j5qz0w3sw84wcfv-nodejs-20.18.0"
+                "store_path": "/nix/store/z2lznj5fq0wagkhj7nkgmb5yr4gyv0ws-nodejs-22.11.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/yajvza262cb3bri9cryfrgpm3pvc066n-nodejs-20.18.0-libv8"
+                "store_path": "/nix/store/0xiwppqyszilzy9cg71c26fxg5qcxh89-nodejs-22.11.0-libv8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "nodejs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "20.18.0"
+            "version": "22.11.0"
           },
           {
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lmn1hdq8i3gf5d3r64l13nhanlb2pnx5-nodejs-20.18.0.drv",
+            "derivation": "/nix/store/vzxxfv1f1i83bnjib0q144v5gndhci33-nodejs-22.11.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "nodejs-20.18.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "nodejs-22.11.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/v8p36abnvrn9i5h41zkgrayaj7sclv6z-nodejs-20.18.0"
+                "store_path": "/nix/store/s81s2z275wnjazk4ij3zvn6kslfa5ipf-nodejs-22.11.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/93xdzgjsm1dnnw33lnba4i7h7k5yph4k-nodejs-20.18.0-libv8"
+                "store_path": "/nix/store/mm87n14lp5akdjlfwh1yg4l93zm8gv9h-nodejs-22.11.0-libv8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "nodejs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "20.18.0"
+            "version": "22.11.0"
           },
           {
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/l136ajs6lg3mic58rnb7cdwhfhl3qcyr-nodejs-20.18.0.drv",
+            "derivation": "/nix/store/542jkp10xz0nd5657bqksqwhhvjcmi9n-nodejs-22.11.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "nodejs-20.18.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "nodejs-22.11.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/z0ivg3dbal4sk5h0c7p1pfkxc7ff98ri-nodejs-20.18.0"
+                "store_path": "/nix/store/fkyp1bm5gll9adnfcj92snyym524mdrj-nodejs-22.11.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/czcxwki3zqih2pf355zk0vxbmrij2bzx-nodejs-20.18.0-libv8"
+                "store_path": "/nix/store/fyaac3q8qn3zfxy72airfabm3dakmgf5-nodejs-22.11.0-libv8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "nodejs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "20.18.0"
+            "version": "22.11.0"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/node_yarn.json
+++ b/test_data/generated/init/node_yarn.json
@@ -2,7 +2,7 @@
   [
     {
       "msgs": [],
-      "name": "default",
+      "name": "nodejs",
       "page": {
         "complete": true,
         "msgs": [],
@@ -11,41 +11,40 @@
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/v0v7dny82f4hmfp9s8zj31iykjrdblkn-nodejs-20.18.0.drv",
+            "derivation": "/nix/store/zh4vzz8z4g7k2p0iqpi8dfz6kgpxkgb1-nodejs-22.11.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
-            "install_id": "default",
+            "install_id": "nodejs",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "nodejs-20.18.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "nodejs-22.11.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/9grahx8677nlgbx3yfiggibw335lkgfr-nodejs-20.18.0"
+                "store_path": "/nix/store/9vkabbbbyfn8hv5l1r8fm59d27imq460-nodejs-22.11.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/hfchgw1as9fm02wcyr3iqya05ylll5f3-nodejs-20.18.0-libv8"
+                "store_path": "/nix/store/m3rxxwm6jp95kjmh4rklqn0d76biz6wm-nodejs-22.11.0-libv8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "nodejs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "20.18.0"
+            "version": "22.11.0"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -62,29 +61,28 @@
             "attr_path": "yarn",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/29jq3h1xvi33nid9na3bimxaff8bf67z-yarn-1.22.22.drv",
+            "derivation": "/nix/store/6bzsm7ddgqf9abmzn0hdyqxy4q2fybwk-yarn-1.22.22.drv",
             "description": "Fast, reliable, and secure dependency management for javascript",
             "insecure": false,
             "install_id": "yarn",
             "license": "BSD-2-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "yarn-1.22.22",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/0hmmpszg5wfrr43kvlk2cxjqpll0dh2z-yarn-1.22.22"
+                "store_path": "/nix/store/jcbyc2k0vkkm862r7f9nwxaa69khfr3h-yarn-1.22.22"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "yarn",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -92,7 +90,7 @@
             "version": "1.22.22"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -109,29 +107,28 @@
             "attr_path": "yarn",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/29jq3h1xvi33nid9na3bimxaff8bf67z-yarn-1.22.22.drv",
+            "derivation": "/nix/store/6bzsm7ddgqf9abmzn0hdyqxy4q2fybwk-yarn-1.22.22.drv",
             "description": "Fast, reliable, and secure dependency management for javascript",
             "insecure": false,
             "install_id": "yarn",
             "license": "BSD-2-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "yarn-1.22.22",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/0hmmpszg5wfrr43kvlk2cxjqpll0dh2z-yarn-1.22.22"
+                "store_path": "/nix/store/jcbyc2k0vkkm862r7f9nwxaa69khfr3h-yarn-1.22.22"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "yarn",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -142,29 +139,28 @@
             "attr_path": "yarn",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/vkm27crcfnsh8jvrvpi4bs2k67mb9b2z-yarn-1.22.22.drv",
+            "derivation": "/nix/store/nb4cp4lsvng7sivfcm6hxag551f6xsb5-yarn-1.22.22.drv",
             "description": "Fast, reliable, and secure dependency management for javascript",
             "insecure": false,
             "install_id": "yarn",
             "license": "BSD-2-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "yarn-1.22.22",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/vmx0di4y3m8amqwsfgyccf8zs8kml06q-yarn-1.22.22"
+                "store_path": "/nix/store/sxxpynsiv8mhq1f0gi1d1rzcj2v0af5w-yarn-1.22.22"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "yarn",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -175,29 +171,28 @@
             "attr_path": "yarn",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/rxkhv6b9iarrklhib18vnr8sj5428bxr-yarn-1.22.22.drv",
+            "derivation": "/nix/store/6n3rhkwv1rvgvnqsyzj67c8b7q3agaii-yarn-1.22.22.drv",
             "description": "Fast, reliable, and secure dependency management for javascript",
             "insecure": false,
             "install_id": "yarn",
             "license": "BSD-2-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "yarn-1.22.22",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/nbaa0rip3xw6l3bmnc2k2fm071pzvzwv-yarn-1.22.22"
+                "store_path": "/nix/store/gw4vlw2qhk94mjwdypqxdzczpml7x1w9-yarn-1.22.22"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "yarn",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -208,29 +203,28 @@
             "attr_path": "yarn",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/7bxc3x8jz6jbrg5gi2qlz1cffzgrba3a-yarn-1.22.22.drv",
+            "derivation": "/nix/store/shvzh94lfb4d8l2a8vn8z096yx1dznah-yarn-1.22.22.drv",
             "description": "Fast, reliable, and secure dependency management for javascript",
             "insecure": false,
             "install_id": "yarn",
             "license": "BSD-2-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "yarn-1.22.22",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/hlf55dc9jjm9xhhjx29ll65ya1rzlmal-yarn-1.22.22"
+                "store_path": "/nix/store/h705p6lmismdn6ay2pn04rvcb2p6vl6i-yarn-1.22.22"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "yarn",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -238,7 +232,7 @@
             "version": "1.22.22"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/python_poetry.json
+++ b/test_data/generated/init/python_poetry.json
@@ -11,37 +11,36 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -49,7 +48,7 @@
   [
     {
       "msgs": [],
-      "name": "default",
+      "name": "poetry",
       "page": {
         "complete": true,
         "msgs": [],
@@ -58,41 +57,40 @@
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/1aglkxnvsdga403k03yzr5nwqp61d0h4-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/898m8vw5hl59d6kysgbq3vrcnz7jv58p-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
-            "install_id": "default",
+            "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/j35y28w44dgc4pyip9r3iwdmwbz5qz31-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/wg8vq6mam2q9s5jb2daxqi8wn65r8gj3-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/zyy53rzq1id12fxgdbdq7c43cxz20skk-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/jzabl1fdy9id5d14afwld1gps70q85w8-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -100,7 +98,7 @@
   [
     {
       "msgs": [],
-      "name": "default",
+      "name": "python3",
       "page": {
         "complete": true,
         "msgs": [],
@@ -109,37 +107,36 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
-            "install_id": "default",
+            "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -156,292 +153,284 @@
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/1aglkxnvsdga403k03yzr5nwqp61d0h4-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/898m8vw5hl59d6kysgbq3vrcnz7jv58p-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/j35y28w44dgc4pyip9r3iwdmwbz5qz31-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/wg8vq6mam2q9s5jb2daxqi8wn65r8gj3-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/zyy53rzq1id12fxgdbdq7c43cxz20skk-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/jzabl1fdy9id5d14afwld1gps70q85w8-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           },
           {
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/1x2l57zzpq8y0wpi82v3r5xi5h7chll6-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/zckjfv2z9s94k0jmmhis4bc7rgh4a6ql-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/bghbwi0c9iink700fy31mcwb7dj0r8kl-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/j0c1lg9m8zj7kfsnzxdn60lb7i9rikbv-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/v8b5di8h9pj15vh3vafsj6288gydxx15-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/i089051gv82aa7d7chng0j8w0xx9sw04-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           },
           {
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/p7vyx1v0crlip4baym2wj77968vn9f4r-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/mfvvgbknjl2849zzgahnm9n5zgqfxwwg-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/kp07kv89agac71b5rz6lmwv029398kpd-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/jx8j1zhc2fz2rbkd33k6h67grj2if8k1-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/y3divx42dv49dfzsgjq6487i0gz6yb8s-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/4lq3f12k3mn461hld0fzh4sdk1rsq7r2-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           },
           {
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/h92vpdis7psk27ibvl30cnkbk5shxxsi-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/5p8cqdcy7mp7clzhzx2rcixwc709kdq2-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/jmzhpv3d2cjkhb6gam9rzz5s1c565qqc-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/yiqnrak3vhai33cfg21cpm7jlvv467as-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/sxvkyyws6n8kf82pwq8qfw90ivph6kda-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/saqqw8ca6vny49jwy9v1khz9fjj3dwc1-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/22lnksddxfiwc7may5a6x0fmf2q74ksx-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/66pn6ysmvx675061xaq2vz93s9vdc5p4-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/brcg3a34fi45ffky63g5pqd22sksvq13-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/6qinwykpnnb7qaz8pcz8915mcfjaz6qp-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/fpmkmdzgd1q7kqadc7czcjdhjj7bsc0i-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/ixs5a8kyvw6rd2xbingm0sxc2lgwli54-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/cicfrcjr8pky8qd0gxw0x84ynyviy6b5-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/python_poetry_zlib.json
+++ b/test_data/generated/init/python_poetry_zlib.json
@@ -11,325 +11,316 @@
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/1aglkxnvsdga403k03yzr5nwqp61d0h4-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/898m8vw5hl59d6kysgbq3vrcnz7jv58p-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/j35y28w44dgc4pyip9r3iwdmwbz5qz31-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/wg8vq6mam2q9s5jb2daxqi8wn65r8gj3-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/zyy53rzq1id12fxgdbdq7c43cxz20skk-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/jzabl1fdy9id5d14afwld1gps70q85w8-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           },
           {
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/1x2l57zzpq8y0wpi82v3r5xi5h7chll6-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/zckjfv2z9s94k0jmmhis4bc7rgh4a6ql-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/bghbwi0c9iink700fy31mcwb7dj0r8kl-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/j0c1lg9m8zj7kfsnzxdn60lb7i9rikbv-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/v8b5di8h9pj15vh3vafsj6288gydxx15-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/i089051gv82aa7d7chng0j8w0xx9sw04-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           },
           {
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/p7vyx1v0crlip4baym2wj77968vn9f4r-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/mfvvgbknjl2849zzgahnm9n5zgqfxwwg-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/kp07kv89agac71b5rz6lmwv029398kpd-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/jx8j1zhc2fz2rbkd33k6h67grj2if8k1-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/y3divx42dv49dfzsgjq6487i0gz6yb8s-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/4lq3f12k3mn461hld0fzh4sdk1rsq7r2-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           },
           {
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/h92vpdis7psk27ibvl30cnkbk5shxxsi-python3.12-poetry-1.8.4.drv",
+            "derivation": "/nix/store/5p8cqdcy7mp7clzhzx2rcixwc709kdq2-python3.12-poetry-2.0.0.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "poetry-1.8.4",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "poetry-2.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/jmzhpv3d2cjkhb6gam9rzz5s1c565qqc-python3.12-poetry-1.8.4"
+                "store_path": "/nix/store/yiqnrak3vhai33cfg21cpm7jlvv467as-python3.12-poetry-2.0.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/sxvkyyws6n8kf82pwq8qfw90ivph6kda-python3.12-poetry-1.8.4-dist"
+                "store_path": "/nix/store/saqqw8ca6vny49jwy9v1khz9fjj3dwc1-python3.12-poetry-2.0.0-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "poetry",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "1.8.4"
+            "version": "2.0.0"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/22lnksddxfiwc7may5a6x0fmf2q74ksx-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/66pn6ysmvx675061xaq2vz93s9vdc5p4-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/brcg3a34fi45ffky63g5pqd22sksvq13-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/6qinwykpnnb7qaz8pcz8915mcfjaz6qp-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/fpmkmdzgd1q7kqadc7czcjdhjj7bsc0i-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/ixs5a8kyvw6rd2xbingm0sxc2lgwli54-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/cicfrcjr8pky8qd0gxw0x84ynyviy6b5-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ljyjimnyj1n8pfdlgk6pz5z64i32szdm-zlib-1.3.1.drv",
+            "derivation": "/nix/store/n21gz774cv5876qgn7q19vp9cjaz9nf4-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/bx5p9dfdmsryflrfrvwdqnkbh3ll9glz-zlib-1.3.1-dev"
+                "store_path": "/nix/store/71xw751ph6bi99rr7ffbqqh0ikhdjz1d-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/iy73mkdcq2k949jai8m8bm850dq0ghrk-zlib-1.3.1"
+                "store_path": "/nix/store/5s3b3s1kc2i2y9j8zcm03nphg7lmcxrg-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d5rzvaygj99wgw5d4df7wv16f4pqf2ca-zlib-1.3.1-static"
+                "store_path": "/nix/store/fag55rivkmydmfljv33ria8f1krr7lwg-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -340,37 +331,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/8f2yz681rgrk20rww9d0z7w0f10zga62-zlib-1.3.1.drv",
+            "derivation": "/nix/store/a4h39gzds75gfkrq9gqbsazrswkbl1qa-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/nbcm7viydknijmak98kwcsgv384x31fv-zlib-1.3.1-dev"
+                "store_path": "/nix/store/2him7162mh9pcbxz5i9xwdpssyimlzfd-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/71gnhixfqrjj0mfhzflb6zgab5kdd2gj-zlib-1.3.1"
+                "store_path": "/nix/store/9x5hfhl8gqgqj4iq6mkhkgxhy9zpsknr-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d89hpsc802zxmj69r06iclq5c11ljkim-zlib-1.3.1-static"
+                "store_path": "/nix/store/6fs5fnhzsmqq6jc5vmf0c8bjkk9fygx7-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -381,37 +371,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/5bjvskg5i9pbjpnlfvbpjw85m8sa1p2i-zlib-1.3.1.drv",
+            "derivation": "/nix/store/rmjrv75fr25a0i97dvq2xblimyckcmi3-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/7qvsb4qvnnxlc3s7z3dzq5jfwc0hwdg0-zlib-1.3.1-dev"
+                "store_path": "/nix/store/r525ad0rjb5w30mbjjvp2pqn4h1yih3q-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/z1r8rsa2bgx5gg4cj49r9fbcs9nx1izd-zlib-1.3.1"
+                "store_path": "/nix/store/z4yvzzm1cvlcpaakvj5wy7j0v8n2r18a-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/z1mfgsb4dhsiyjlk7fzj9gh46xmf1xlb-zlib-1.3.1-static"
+                "store_path": "/nix/store/5rm6spch337xg4rzx91jrl7scha8fk1l-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -422,37 +411,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/0cxw25gsi8y1jhh81ibfq52dnv3j363h-zlib-1.3.1.drv",
+            "derivation": "/nix/store/pjbjsc3ncx8r4cqg8xr28ihcrbab7d5s-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/h0j60865g7m591zqw6bl1pjq33x4l9m9-zlib-1.3.1-dev"
+                "store_path": "/nix/store/1lggwqzapn5mn49l9zy4h566ysv9kzdb-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/y6bcc1vzg315zzzpir608zkhnmvp49kc-zlib-1.3.1"
+                "store_path": "/nix/store/cqlaa2xf6lslnizyj9xqa8j0ii1yqw0x-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d38iarfb3f5a3xlpkm3bm3zimrxx7r8y-zlib-1.3.1-static"
+                "store_path": "/nix/store/9qiki938i359zih1y9hc19ibs6k8ib0y-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -460,7 +448,7 @@
             "version": "1.3.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/python_pyproject_pip.json
+++ b/test_data/generated/init/python_pyproject_pip.json
@@ -2,7 +2,7 @@
   [
     {
       "msgs": [],
-      "name": "default",
+      "name": "python3",
       "page": {
         "complete": true,
         "msgs": [],
@@ -11,37 +11,36 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
-            "install_id": "default",
+            "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -58,144 +57,140 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/22lnksddxfiwc7may5a6x0fmf2q74ksx-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/66pn6ysmvx675061xaq2vz93s9vdc5p4-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/brcg3a34fi45ffky63g5pqd22sksvq13-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/6qinwykpnnb7qaz8pcz8915mcfjaz6qp-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/fpmkmdzgd1q7kqadc7czcjdhjj7bsc0i-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/ixs5a8kyvw6rd2xbingm0sxc2lgwli54-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/cicfrcjr8pky8qd0gxw0x84ynyviy6b5-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/python_pyproject_pip_zlib.json
+++ b/test_data/generated/init/python_pyproject_pip_zlib.json
@@ -11,177 +11,172 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/22lnksddxfiwc7may5a6x0fmf2q74ksx-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/66pn6ysmvx675061xaq2vz93s9vdc5p4-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/brcg3a34fi45ffky63g5pqd22sksvq13-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/6qinwykpnnb7qaz8pcz8915mcfjaz6qp-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/fpmkmdzgd1q7kqadc7czcjdhjj7bsc0i-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/ixs5a8kyvw6rd2xbingm0sxc2lgwli54-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/cicfrcjr8pky8qd0gxw0x84ynyviy6b5-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ljyjimnyj1n8pfdlgk6pz5z64i32szdm-zlib-1.3.1.drv",
+            "derivation": "/nix/store/n21gz774cv5876qgn7q19vp9cjaz9nf4-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/bx5p9dfdmsryflrfrvwdqnkbh3ll9glz-zlib-1.3.1-dev"
+                "store_path": "/nix/store/71xw751ph6bi99rr7ffbqqh0ikhdjz1d-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/iy73mkdcq2k949jai8m8bm850dq0ghrk-zlib-1.3.1"
+                "store_path": "/nix/store/5s3b3s1kc2i2y9j8zcm03nphg7lmcxrg-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d5rzvaygj99wgw5d4df7wv16f4pqf2ca-zlib-1.3.1-static"
+                "store_path": "/nix/store/fag55rivkmydmfljv33ria8f1krr7lwg-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -192,37 +187,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/8f2yz681rgrk20rww9d0z7w0f10zga62-zlib-1.3.1.drv",
+            "derivation": "/nix/store/a4h39gzds75gfkrq9gqbsazrswkbl1qa-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/nbcm7viydknijmak98kwcsgv384x31fv-zlib-1.3.1-dev"
+                "store_path": "/nix/store/2him7162mh9pcbxz5i9xwdpssyimlzfd-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/71gnhixfqrjj0mfhzflb6zgab5kdd2gj-zlib-1.3.1"
+                "store_path": "/nix/store/9x5hfhl8gqgqj4iq6mkhkgxhy9zpsknr-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d89hpsc802zxmj69r06iclq5c11ljkim-zlib-1.3.1-static"
+                "store_path": "/nix/store/6fs5fnhzsmqq6jc5vmf0c8bjkk9fygx7-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -233,37 +227,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/5bjvskg5i9pbjpnlfvbpjw85m8sa1p2i-zlib-1.3.1.drv",
+            "derivation": "/nix/store/rmjrv75fr25a0i97dvq2xblimyckcmi3-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/7qvsb4qvnnxlc3s7z3dzq5jfwc0hwdg0-zlib-1.3.1-dev"
+                "store_path": "/nix/store/r525ad0rjb5w30mbjjvp2pqn4h1yih3q-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/z1r8rsa2bgx5gg4cj49r9fbcs9nx1izd-zlib-1.3.1"
+                "store_path": "/nix/store/z4yvzzm1cvlcpaakvj5wy7j0v8n2r18a-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/z1mfgsb4dhsiyjlk7fzj9gh46xmf1xlb-zlib-1.3.1-static"
+                "store_path": "/nix/store/5rm6spch337xg4rzx91jrl7scha8fk1l-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -274,37 +267,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/0cxw25gsi8y1jhh81ibfq52dnv3j363h-zlib-1.3.1.drv",
+            "derivation": "/nix/store/pjbjsc3ncx8r4cqg8xr28ihcrbab7d5s-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/h0j60865g7m591zqw6bl1pjq33x4l9m9-zlib-1.3.1-dev"
+                "store_path": "/nix/store/1lggwqzapn5mn49l9zy4h566ysv9kzdb-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/y6bcc1vzg315zzzpir608zkhnmvp49kc-zlib-1.3.1"
+                "store_path": "/nix/store/cqlaa2xf6lslnizyj9xqa8j0ii1yqw0x-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d38iarfb3f5a3xlpkm3bm3zimrxx7r8y-zlib-1.3.1-static"
+                "store_path": "/nix/store/9qiki938i359zih1y9hc19ibs6k8ib0y-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -312,7 +304,7 @@
             "version": "1.3.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/python_requests.json
+++ b/test_data/generated/init/python_requests.json
@@ -2,7 +2,7 @@
   [
     {
       "msgs": [],
-      "name": "default",
+      "name": "python3",
       "page": {
         "complete": true,
         "msgs": [],
@@ -11,37 +11,36 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
-            "install_id": "default",
+            "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -58,144 +57,140 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/22lnksddxfiwc7may5a6x0fmf2q74ksx-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/66pn6ysmvx675061xaq2vz93s9vdc5p4-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/brcg3a34fi45ffky63g5pqd22sksvq13-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/6qinwykpnnb7qaz8pcz8915mcfjaz6qp-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/fpmkmdzgd1q7kqadc7czcjdhjj7bsc0i-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/ixs5a8kyvw6rd2xbingm0sxc2lgwli54-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/cicfrcjr8pky8qd0gxw0x84ynyviy6b5-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/python_requirements.json
+++ b/test_data/generated/init/python_requirements.json
@@ -2,7 +2,7 @@
   [
     {
       "msgs": [],
-      "name": "default",
+      "name": "python3",
       "page": {
         "complete": true,
         "msgs": [],
@@ -11,37 +11,36 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
-            "install_id": "default",
+            "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }
@@ -58,144 +57,140 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/22lnksddxfiwc7may5a6x0fmf2q74ksx-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/66pn6ysmvx675061xaq2vz93s9vdc5p4-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/brcg3a34fi45ffky63g5pqd22sksvq13-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/6qinwykpnnb7qaz8pcz8915mcfjaz6qp-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/fpmkmdzgd1q7kqadc7czcjdhjj7bsc0i-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/ixs5a8kyvw6rd2xbingm0sxc2lgwli54-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/cicfrcjr8pky8qd0gxw0x84ynyviy6b5-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/init/python_requirements_zlib.json
+++ b/test_data/generated/init/python_requirements_zlib.json
@@ -11,177 +11,172 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/22lnksddxfiwc7may5a6x0fmf2q74ksx-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/66pn6ysmvx675061xaq2vz93s9vdc5p4-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/brcg3a34fi45ffky63g5pqd22sksvq13-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/6qinwykpnnb7qaz8pcz8915mcfjaz6qp-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/fpmkmdzgd1q7kqadc7czcjdhjj7bsc0i-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/ixs5a8kyvw6rd2xbingm0sxc2lgwli54-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/cicfrcjr8pky8qd0gxw0x84ynyviy6b5-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ljyjimnyj1n8pfdlgk6pz5z64i32szdm-zlib-1.3.1.drv",
+            "derivation": "/nix/store/n21gz774cv5876qgn7q19vp9cjaz9nf4-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/bx5p9dfdmsryflrfrvwdqnkbh3ll9glz-zlib-1.3.1-dev"
+                "store_path": "/nix/store/71xw751ph6bi99rr7ffbqqh0ikhdjz1d-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/iy73mkdcq2k949jai8m8bm850dq0ghrk-zlib-1.3.1"
+                "store_path": "/nix/store/5s3b3s1kc2i2y9j8zcm03nphg7lmcxrg-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d5rzvaygj99wgw5d4df7wv16f4pqf2ca-zlib-1.3.1-static"
+                "store_path": "/nix/store/fag55rivkmydmfljv33ria8f1krr7lwg-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -192,37 +187,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/8f2yz681rgrk20rww9d0z7w0f10zga62-zlib-1.3.1.drv",
+            "derivation": "/nix/store/a4h39gzds75gfkrq9gqbsazrswkbl1qa-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/nbcm7viydknijmak98kwcsgv384x31fv-zlib-1.3.1-dev"
+                "store_path": "/nix/store/2him7162mh9pcbxz5i9xwdpssyimlzfd-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/71gnhixfqrjj0mfhzflb6zgab5kdd2gj-zlib-1.3.1"
+                "store_path": "/nix/store/9x5hfhl8gqgqj4iq6mkhkgxhy9zpsknr-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d89hpsc802zxmj69r06iclq5c11ljkim-zlib-1.3.1-static"
+                "store_path": "/nix/store/6fs5fnhzsmqq6jc5vmf0c8bjkk9fygx7-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -233,37 +227,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/5bjvskg5i9pbjpnlfvbpjw85m8sa1p2i-zlib-1.3.1.drv",
+            "derivation": "/nix/store/rmjrv75fr25a0i97dvq2xblimyckcmi3-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/7qvsb4qvnnxlc3s7z3dzq5jfwc0hwdg0-zlib-1.3.1-dev"
+                "store_path": "/nix/store/r525ad0rjb5w30mbjjvp2pqn4h1yih3q-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/z1r8rsa2bgx5gg4cj49r9fbcs9nx1izd-zlib-1.3.1"
+                "store_path": "/nix/store/z4yvzzm1cvlcpaakvj5wy7j0v8n2r18a-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/z1mfgsb4dhsiyjlk7fzj9gh46xmf1xlb-zlib-1.3.1-static"
+                "store_path": "/nix/store/5rm6spch337xg4rzx91jrl7scha8fk1l-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -274,37 +267,36 @@
             "attr_path": "zlib",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/0cxw25gsi8y1jhh81ibfq52dnv3j363h-zlib-1.3.1.drv",
+            "derivation": "/nix/store/pjbjsc3ncx8r4cqg8xr28ihcrbab7d5s-zlib-1.3.1.drv",
             "description": "Lossless data-compression library",
             "insecure": false,
             "install_id": "zlib",
             "license": "Zlib",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "zlib-1.3.1",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/h0j60865g7m591zqw6bl1pjq33x4l9m9-zlib-1.3.1-dev"
+                "store_path": "/nix/store/1lggwqzapn5mn49l9zy4h566ysv9kzdb-zlib-1.3.1-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/y6bcc1vzg315zzzpir608zkhnmvp49kc-zlib-1.3.1"
+                "store_path": "/nix/store/cqlaa2xf6lslnizyj9xqa8j0ii1yqw0x-zlib-1.3.1"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/d38iarfb3f5a3xlpkm3bm3zimrxx7r8y-zlib-1.3.1-static"
+                "store_path": "/nix/store/9qiki938i359zih1y9hc19ibs6k8ib0y-zlib-1.3.1-static"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "zlib",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -312,7 +304,7 @@
             "version": "1.3.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/almonds.json
+++ b/test_data/generated/resolve/almonds.json
@@ -11,33 +11,32 @@
             "attr_path": "almonds",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/rxlg3pwkhp1ckmy84bhjwbx0lmxqd31q-almonds-1.25b.drv",
+            "derivation": "/nix/store/b03w5q0mgxardrzrsq0r9knf81ipzcac-almonds-1.25b.drv",
             "description": "Terminal Mandelbrot fractal viewer",
             "insecure": false,
             "install_id": "almonds",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "almonds-1.25b",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/ycd3jihdx9y9s82xaw63z3lgdrhy8y8g-almonds-1.25b"
+                "store_path": "/nix/store/h6j143ip6fvvdsk1csyrf8cszwbr3zjl-almonds-1.25b"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/5h9ym73piqn7xjdxzz1lyrhjfk148kqc-almonds-1.25b-dist"
+                "store_path": "/nix/store/l7bll5pd67ppllh5pyn7mwj09fbbk8sq-almonds-1.25b-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "almonds",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -48,33 +47,32 @@
             "attr_path": "almonds",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/b9pngy97z31mj57fl5qsxiasvp3iib33-almonds-1.25b.drv",
+            "derivation": "/nix/store/5aalc4ky5z612xy7lm0wx6pkmadjy3jw-almonds-1.25b.drv",
             "description": "Terminal Mandelbrot fractal viewer",
             "insecure": false,
             "install_id": "almonds",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "almonds-1.25b",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/skli4q5hfs99hnnb9lx4ca83bhrbl9jq-almonds-1.25b"
+                "store_path": "/nix/store/h8zzmgzn4xnh435nhj7wv25hvmbpnpfr-almonds-1.25b"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/xfvncg6i337l7fn7akni9w32pac86s2v-almonds-1.25b-dist"
+                "store_path": "/nix/store/c2m67ja625hxpbx726q2kx35k9kxy345-almonds-1.25b-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "almonds",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -85,33 +83,32 @@
             "attr_path": "almonds",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/41bx2k7r7yla4kazcmgbhin4nf6a4jhg-almonds-1.25b.drv",
+            "derivation": "/nix/store/jrnhkk0rhf1sg5hg3fwv4sh5c010sl7k-almonds-1.25b.drv",
             "description": "Terminal Mandelbrot fractal viewer",
             "insecure": false,
             "install_id": "almonds",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "almonds-1.25b",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/fp2raabshhwfd6x97prvb3jdxwc42g42-almonds-1.25b"
+                "store_path": "/nix/store/5dkd3vrrsksx1dzch5bhfnqbgbf5cd79-almonds-1.25b"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/40z30sc5pzzzzi17gannmiyv8jjyj1sa-almonds-1.25b-dist"
+                "store_path": "/nix/store/fhb91wgvgbgxhcb9f5lzb8sb6c43wa04-almonds-1.25b-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "almonds",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -122,33 +119,32 @@
             "attr_path": "almonds",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/6zzplzw7nxhqyp49a40f2ihlyswspy71-almonds-1.25b.drv",
+            "derivation": "/nix/store/gbazpc12r756rm4yi3phmdc6q6cpr7ig-almonds-1.25b.drv",
             "description": "Terminal Mandelbrot fractal viewer",
             "insecure": false,
             "install_id": "almonds",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "almonds-1.25b",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/1fzhsv4j3l5x5hm92azbykg055hwsl8r-almonds-1.25b"
+                "store_path": "/nix/store/5rx02dh1fmhrn4ac3g2ngwj38721hql5-almonds-1.25b"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/1d34b3alf19jdikvjq9s2dnp4jgj0jib-almonds-1.25b-dist"
+                "store_path": "/nix/store/h0qxjmg8prbfgpgzqdkdha4mzbid4cv6-almonds-1.25b-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "almonds",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -156,7 +152,7 @@
             "version": "1.25b"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/bpftrace.json
+++ b/test_data/generated/resolve/bpftrace.json
@@ -31,21 +31,21 @@
             "attr_path": "bpftrace",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/wpqpghximcs4p4kk5s7j8c1xb7p2i9g2-bpftrace-0.21.2.drv",
+            "derivation": "/nix/store/6g6xnc73di6azqfh4z7b6llvqjh2djzn-bpftrace-0.21.3.drv",
             "description": "High-level tracing language for Linux eBPF",
             "insecure": false,
             "install_id": "bpftrace",
             "license": "Apache-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "bpftrace-0.21.2",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "bpftrace-0.21.3",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/7jsdcmzn61rw7fppplww2jnw4dvnrc1l-bpftrace-0.21.2-man"
+                "store_path": "/nix/store/5wx28y3hh96lg7rfni4gbncsdr9i4bbv-bpftrace-0.21.3-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/l40awkmh4y98sw0kadv8cpw5diyxizk2-bpftrace-0.21.2"
+                "store_path": "/nix/store/x9966ilqpfl5pvqlvn91j867hkjx5sj5-bpftrace-0.21.3"
               }
             ],
             "outputs_to_install": [
@@ -53,37 +53,36 @@
               "man"
             ],
             "pname": "bpftrace",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "0.21.2"
+            "version": "0.21.3"
           },
           {
             "attr_path": "bpftrace",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/8cvsnn4f0ksn9nsx53rsjdq1vdn374cp-bpftrace-0.21.2.drv",
+            "derivation": "/nix/store/j0f92xc5ghqcpwddiil37m8dd44r43f0-bpftrace-0.21.3.drv",
             "description": "High-level tracing language for Linux eBPF",
             "insecure": false,
             "install_id": "bpftrace",
             "license": "Apache-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "bpftrace-0.21.2",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "bpftrace-0.21.3",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/mw8gfbbi5n1j16gl6l2jjdplwwc18zr8-bpftrace-0.21.2-man"
+                "store_path": "/nix/store/bljfg54hnvpjvzn0g257i5jxflk9kp0r-bpftrace-0.21.3-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/nhk5kki340vghf9fjqlzbql6ipnvf2yh-bpftrace-0.21.2"
+                "store_path": "/nix/store/5x7v4si2yfyjsjka42zq6bv7sgspi4ag-bpftrace-0.21.3"
               }
             ],
             "outputs_to_install": [
@@ -91,20 +90,19 @@
               "man"
             ],
             "pname": "bpftrace",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "0.21.2"
+            "version": "0.21.3"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/bpftrace_systemd.json
+++ b/test_data/generated/resolve/bpftrace_systemd.json
@@ -43,21 +43,21 @@
             "attr_path": "bpftrace",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/wpqpghximcs4p4kk5s7j8c1xb7p2i9g2-bpftrace-0.21.2.drv",
+            "derivation": "/nix/store/6g6xnc73di6azqfh4z7b6llvqjh2djzn-bpftrace-0.21.3.drv",
             "description": "High-level tracing language for Linux eBPF",
             "insecure": false,
             "install_id": "bpftrace",
             "license": "Apache-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "bpftrace-0.21.2",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "bpftrace-0.21.3",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/7jsdcmzn61rw7fppplww2jnw4dvnrc1l-bpftrace-0.21.2-man"
+                "store_path": "/nix/store/5wx28y3hh96lg7rfni4gbncsdr9i4bbv-bpftrace-0.21.3-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/l40awkmh4y98sw0kadv8cpw5diyxizk2-bpftrace-0.21.2"
+                "store_path": "/nix/store/x9966ilqpfl5pvqlvn91j867hkjx5sj5-bpftrace-0.21.3"
               }
             ],
             "outputs_to_install": [
@@ -65,37 +65,36 @@
               "man"
             ],
             "pname": "bpftrace",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "0.21.2"
+            "version": "0.21.3"
           },
           {
             "attr_path": "bpftrace",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/8cvsnn4f0ksn9nsx53rsjdq1vdn374cp-bpftrace-0.21.2.drv",
+            "derivation": "/nix/store/j0f92xc5ghqcpwddiil37m8dd44r43f0-bpftrace-0.21.3.drv",
             "description": "High-level tracing language for Linux eBPF",
             "insecure": false,
             "install_id": "bpftrace",
             "license": "Apache-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "bpftrace-0.21.2",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "bpftrace-0.21.3",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/mw8gfbbi5n1j16gl6l2jjdplwwc18zr8-bpftrace-0.21.2-man"
+                "store_path": "/nix/store/bljfg54hnvpjvzn0g257i5jxflk9kp0r-bpftrace-0.21.3-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/nhk5kki340vghf9fjqlzbql6ipnvf2yh-bpftrace-0.21.2"
+                "store_path": "/nix/store/5x7v4si2yfyjsjka42zq6bv7sgspi4ag-bpftrace-0.21.3"
               }
             ],
             "outputs_to_install": [
@@ -103,45 +102,44 @@
               "man"
             ],
             "pname": "bpftrace",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "0.21.2"
+            "version": "0.21.3"
           },
           {
             "attr_path": "systemd",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/pm5zdp4hjrzx9ki728ay424rnf8srfm3-systemd-256.7.drv",
+            "derivation": "/nix/store/nsrard6xcvw6cgcchi47ywki27gk49ar-systemd-256.8.drv",
             "description": "System and service manager for Linux",
             "insecure": false,
             "install_id": "systemd",
             "license": "[ BSD-2-Clause, BSD-3-Clause, CC0-1.0, LGPL-2.1-or-later, LGPL-2.0-or-later, MIT, MIT-0, OFL-1.1, Public Domain ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "systemd-256.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "systemd-256.8",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/3sm4df8d12jbzschlld72z1amr23gz4d-systemd-256.7-dev"
+                "store_path": "/nix/store/1jkmjkhc1gh697a7dr85crflb0dc6r0i-systemd-256.8-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/cm9nqxiy230rypxdycjw88c4fm18cq68-systemd-256.7-man"
+                "store_path": "/nix/store/4m8a67mw04gpglgaz4y0iq7g3i1sa0m7-systemd-256.8-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/qdcd8agvxxxm7fj2qc3dsw3xi310ck9x-systemd-256.7"
+                "store_path": "/nix/store/cjvamvl1gw2p1vyzjfa5zsq5lhwnmyqf-systemd-256.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/yny4jr1v9y4g96v10d7inz47x1v5k30n-systemd-256.7-debug"
+                "store_path": "/nix/store/3cywm5l780ph20f03l83vgpl4viqi4ih-systemd-256.8-debug"
               }
             ],
             "outputs_to_install": [
@@ -149,45 +147,44 @@
               "man"
             ],
             "pname": "systemd",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "256.7"
+            "version": "256.8"
           },
           {
             "attr_path": "systemd",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/00s8nn272p62iq863aw0b13syfamfq77-systemd-256.7.drv",
+            "derivation": "/nix/store/dzcpsdp4p3w2r5cxgj1s2irkqzzypzw4-systemd-256.8.drv",
             "description": "System and service manager for Linux",
             "insecure": false,
             "install_id": "systemd",
             "license": "[ BSD-2-Clause, BSD-3-Clause, CC0-1.0, LGPL-2.1-or-later, LGPL-2.0-or-later, MIT, MIT-0, OFL-1.1, Public Domain ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "systemd-256.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "systemd-256.8",
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/4s6vf2gn20iqwcadv351d1nd33y5bwvp-systemd-256.7-dev"
+                "store_path": "/nix/store/ixwyfddsia31qxchy5rjm3nz0j0f4011-systemd-256.8-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/220s7xj5m4xgvd6cz53p8bflw5lhjhkg-systemd-256.7-man"
+                "store_path": "/nix/store/da87j1q0yl3g4k4sclizf61396swhi1p-systemd-256.8-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/ivqjhj99firnjq7gp14qf35821viwi5m-systemd-256.7"
+                "store_path": "/nix/store/lji0hh2w2rv6q9mal3vpxbg413d57vfd-systemd-256.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/60wixgv33j5dsfjyk4nr08cc0whygg0f-systemd-256.7-debug"
+                "store_path": "/nix/store/n0imqhyjwcyajkrd91887mqrigfmva66-systemd-256.8-debug"
               }
             ],
             "outputs_to_install": [
@@ -195,20 +192,19 @@
               "man"
             ],
             "pname": "systemd",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "256.7"
+            "version": "256.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/curl_hello.json
+++ b/test_data/generated/resolve/curl_hello.json
@@ -11,33 +11,33 @@
             "attr_path": "curl",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/60xxwy8fpbdifjlh9lx9ffg44rmhwkca-curl-8.11.0.drv",
+            "derivation": "/nix/store/ljas0gkxh1lcw65fx17mcs3cvbjivz57-curl-8.11.0.drv",
             "description": "Command line tool for transferring files with URL syntax",
             "insecure": false,
             "install_id": "curl",
             "license": "curl",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "curl-8.11.0",
             "outputs": [
               {
                 "name": "bin",
-                "store_path": "/nix/store/nnikik66h1i9pirm86685gsx12cr9fix-curl-8.11.0-bin"
+                "store_path": "/nix/store/s4idvq3pgjprcjg7sqp2h5cgp1pn8frs-curl-8.11.0-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/7rmqp8prvgxac73s6sqymnkff18kmhxb-curl-8.11.0-dev"
+                "store_path": "/nix/store/i4z3xbailna79bxycv6apy5f6phr3q0v-curl-8.11.0-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/ird5cbdpbf3zjlmnvrbk54vw26x511kk-curl-8.11.0-man"
+                "store_path": "/nix/store/gjv4ljqxdby4bm8z21rspqd247aprpcc-curl-8.11.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/b4mz7xlyv99bdrdb9z0yq1imgjwlx20l-curl-8.11.0"
+                "store_path": "/nix/store/ifcj5pbackbazl7b91g64m3kbd4v1q01-curl-8.11.0"
               },
               {
                 "name": "devdoc",
-                "store_path": "/nix/store/q63dfwa5zlgya57vgk1wrsv1cggx17ag-curl-8.11.0-devdoc"
+                "store_path": "/nix/store/2grp27ghxrmg56rzmc9cfqy6wvcv4mp0-curl-8.11.0-devdoc"
               }
             ],
             "outputs_to_install": [
@@ -45,12 +45,11 @@
               "man"
             ],
             "pname": "curl",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -61,37 +60,37 @@
             "attr_path": "curl",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/3ywrmiw7fb8b22h3yw8vrg4vv945idd9-curl-8.11.0.drv",
+            "derivation": "/nix/store/6cqbg626w2zdssnhkyp5mj2fkypypykl-curl-8.11.0.drv",
             "description": "Command line tool for transferring files with URL syntax",
             "insecure": false,
             "install_id": "curl",
             "license": "curl",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "curl-8.11.0",
             "outputs": [
               {
                 "name": "bin",
-                "store_path": "/nix/store/3h40h6q80knif55wvdx0qcz72fjw8crc-curl-8.11.0-bin"
+                "store_path": "/nix/store/yq8dwiyxrflg270359yvxk8xckkid04q-curl-8.11.0-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/6ydf7d2j8lcszzvmadnyxsf11ikx517h-curl-8.11.0-dev"
+                "store_path": "/nix/store/kjri2i96wsg99wqd4yaj50rdjh3hz531-curl-8.11.0-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/wx27cnm4x44gs13kdyiplrmvj03ab4q8-curl-8.11.0-man"
+                "store_path": "/nix/store/y3bzv3q3226l5w1ia8ybb4rfwi0z5y0d-curl-8.11.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/ygwnjglxwvmladk25fsdghzh2cacczfg-curl-8.11.0"
+                "store_path": "/nix/store/y340kr2q8x0y40krwzpv32x7d5c31jy7-curl-8.11.0"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/cfjpyw5bbslnl6a8n43bl1yjqnp8vbc1-curl-8.11.0-debug"
+                "store_path": "/nix/store/hrzm29djj4n2l61pc3555kw3g17sr7z1-curl-8.11.0-debug"
               },
               {
                 "name": "devdoc",
-                "store_path": "/nix/store/img4rmd3gd8wiahagrfsscq812a7aggw-curl-8.11.0-devdoc"
+                "store_path": "/nix/store/02aq6i8g4mzs5bf0gvb562wcq51hizas-curl-8.11.0-devdoc"
               }
             ],
             "outputs_to_install": [
@@ -99,12 +98,11 @@
               "man"
             ],
             "pname": "curl",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -115,33 +113,33 @@
             "attr_path": "curl",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/zyi9364hscqw6zrccb67j5g2sc28nrfp-curl-8.11.0.drv",
+            "derivation": "/nix/store/zwy97fvvn4zf07fqy5dhbxhh0fyjrwbg-curl-8.11.0.drv",
             "description": "Command line tool for transferring files with URL syntax",
             "insecure": false,
             "install_id": "curl",
             "license": "curl",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "curl-8.11.0",
             "outputs": [
               {
                 "name": "bin",
-                "store_path": "/nix/store/740pphyabn1dmrl58p26xdqfnfckbcir-curl-8.11.0-bin"
+                "store_path": "/nix/store/fmrh9cvrsfxv5bvv3cq853sz0y2q3cpd-curl-8.11.0-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/d3y9362zhb6jjw3aj98xnkj7a2f5ris0-curl-8.11.0-dev"
+                "store_path": "/nix/store/ipjg6nffgq68mwdkqnj8nf5jri3hs1xf-curl-8.11.0-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/jgnjz8ibbrnkm3ga27mfvwrqhqz3h0dx-curl-8.11.0-man"
+                "store_path": "/nix/store/c4n42gazswc9l8iiirv23xbpdk923gfw-curl-8.11.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/zjgsyb3n5sasw8jmixx97jh32ywrzspx-curl-8.11.0"
+                "store_path": "/nix/store/32qkm0f9j9qdc91m4jnvj9imp6mfxxfz-curl-8.11.0"
               },
               {
                 "name": "devdoc",
-                "store_path": "/nix/store/bzng06n0agwkxbgrk5rfm0i6hv6l8b6z-curl-8.11.0-devdoc"
+                "store_path": "/nix/store/gqbnhsqw8m6cz49apl1cj2llgsbz5mic-curl-8.11.0-devdoc"
               }
             ],
             "outputs_to_install": [
@@ -149,12 +147,11 @@
               "man"
             ],
             "pname": "curl",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -165,37 +162,37 @@
             "attr_path": "curl",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lyayny5miyiz1pccqfpqnygnyq0hf5kn-curl-8.11.0.drv",
+            "derivation": "/nix/store/m7di48m22z13xdfzakhlrqi8hvh13ygg-curl-8.11.0.drv",
             "description": "Command line tool for transferring files with URL syntax",
             "insecure": false,
             "install_id": "curl",
             "license": "curl",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "curl-8.11.0",
             "outputs": [
               {
                 "name": "bin",
-                "store_path": "/nix/store/glxqkgx86mir5f756zr7a7clgzhggg43-curl-8.11.0-bin"
+                "store_path": "/nix/store/yckhqngmx90bakzhcyrsk7dww1fm352s-curl-8.11.0-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/nnsm67hycch65y7pandck3c28g9q5p7h-curl-8.11.0-dev"
+                "store_path": "/nix/store/g26bs63hz87c9s3sg0v42d6d8gjk36qw-curl-8.11.0-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/0pas219azsv4hpriqcwrr3fxis0g6fr1-curl-8.11.0-man"
+                "store_path": "/nix/store/fpm2i0k76mxbdjpwn8nifqpm25py1pfz-curl-8.11.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/lz8snrzdzwkcbdjccqxd2r4f792cnwsg-curl-8.11.0"
+                "store_path": "/nix/store/8yfak7dis3yqqls4mclzp5jb1ic2jzab-curl-8.11.0"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/1ydpd4pdb2cqm3cxy0awa62628cm04ab-curl-8.11.0-debug"
+                "store_path": "/nix/store/qb1m3if99v266fzlwvrhsh3sq8wxcdg6-curl-8.11.0-debug"
               },
               {
                 "name": "devdoc",
-                "store_path": "/nix/store/8h3prj4fzbc2jl6df6l82hgf3yhvss1z-curl-8.11.0-devdoc"
+                "store_path": "/nix/store/9fpcw3582c7p7rbq6v3hzj89gd7ibgif-curl-8.11.0-devdoc"
               }
             ],
             "outputs_to_install": [
@@ -203,12 +200,11 @@
               "man"
             ],
             "pname": "curl",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -219,29 +215,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+            "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+                "store_path": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -252,29 +247,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+            "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+                "store_path": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -285,29 +279,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+            "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+                "store_path": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -318,29 +311,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+            "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+                "store_path": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -348,7 +340,7 @@
             "version": "2.12.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/darwin_ps.json
+++ b/test_data/generated/resolve/darwin_ps.json
@@ -11,25 +11,25 @@
             "attr_path": "darwin.ps",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/cjwbwvkakhard8ifvglanp9zaiij8k37-adv_cmds-231.drv",
+            "derivation": "/nix/store/hj6sic67398wlwgb34i7mfhh42izl9cy-adv_cmds-231.drv",
             "description": "Advanced commands package for Darwin",
             "insecure": false,
             "install_id": "ps",
             "license": "[ APSL-1.0, APSL-2.0 ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "adv_cmds-231",
             "outputs": [
               {
                 "name": "ps",
-                "store_path": "/nix/store/hvgagb1ckx9h00wxijj987ix8cw12afb-adv_cmds-231-ps"
+                "store_path": "/nix/store/1yg5prpnr3c620xxqkrf2m5ngmywicl4-adv_cmds-231-ps"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/avksjclqaqvsp9a6rrcd6aqgvas6nqbc-adv_cmds-231-man"
+                "store_path": "/nix/store/dy5qdi86y95cm2w8cfdix9414dpcck0a-adv_cmds-231-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/3ljcyqr576blfhzngzaci4pzp3801gr8-adv_cmds-231"
+                "store_path": "/nix/store/8kpn1n46hqzl2sbsmzw5k5xmwybaw7ir-adv_cmds-231"
               }
             ],
             "outputs_to_install": [
@@ -37,12 +37,11 @@
               "man"
             ],
             "pname": "ps",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -50,7 +49,7 @@
             "version": "adv_cmds-231"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/emacs.json
+++ b/test_data/generated/resolve/emacs.json
@@ -11,29 +11,28 @@
             "attr_path": "emacs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/x31khiyjk5qqzs112lk9mbybzh3s66m1-emacs-29.4.drv",
+            "derivation": "/nix/store/n0zb16n660yfpvc8m5bh3pzwsilz2v5a-emacs-29.4.drv",
             "description": "Extensible, customizable GNU text editor",
             "insecure": false,
             "install_id": "emacs",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "emacs-29.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/1237af4vssyidzv3y0gbvjq6fgz9g9pm-emacs-29.4"
+                "store_path": "/nix/store/apm4gxv4p2bf53dvk3ilncvgdig8m5kc-emacs-29.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "emacs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "emacs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/5nmm3ih26s7fq369pzx0nnb39abc9z75-emacs-29.4.drv",
+            "derivation": "/nix/store/ybmj89ihhbrrw3bsv7j17jc8s956q939-emacs-29.4.drv",
             "description": "Extensible, customizable GNU text editor",
             "insecure": false,
             "install_id": "emacs",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "emacs-29.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/csd9ir6v836hw6w4psiwy0k023zrs47d-emacs-29.4"
+                "store_path": "/nix/store/9iv0hrxf8x84axq2j2zm6m9yizf42fcr-emacs-29.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "emacs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "emacs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/czr6sip24r7ibm0j21gw21jx0pbgv6fm-emacs-29.4.drv",
+            "derivation": "/nix/store/plhzgnzx9dgca8d9zzhkyzlbb6sfj58s-emacs-29.4.drv",
             "description": "Extensible, customizable GNU text editor",
             "insecure": false,
             "install_id": "emacs",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "emacs-29.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/yvi1ca0mpwl2b3dnhh9cqf3jjp2nd1g2-emacs-29.4"
+                "store_path": "/nix/store/cwhasf440kg223jj9m651lq83zil81w4-emacs-29.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "emacs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "emacs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/z19nabhg4qimrc0wg7iq7vfhbx65vkvj-emacs-29.4.drv",
+            "derivation": "/nix/store/cmf9ra3c6zip2y61yd6kmjhxflzrjj06-emacs-29.4.drv",
             "description": "Extensible, customizable GNU text editor",
             "insecure": false,
             "install_id": "emacs",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "emacs-29.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/a3kfh7mx5ssar7z835vsiq7gmf7df2mg-emacs-29.4"
+                "store_path": "/nix/store/5apah73slavjjl9nbj1hhf6ds42dck9x-emacs-29.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "emacs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "29.4"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/emacs_vim.json
+++ b/test_data/generated/resolve/emacs_vim.json
@@ -11,29 +11,28 @@
             "attr_path": "emacs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/x31khiyjk5qqzs112lk9mbybzh3s66m1-emacs-29.4.drv",
+            "derivation": "/nix/store/n0zb16n660yfpvc8m5bh3pzwsilz2v5a-emacs-29.4.drv",
             "description": "Extensible, customizable GNU text editor",
             "insecure": false,
             "install_id": "emacs",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "emacs-29.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/1237af4vssyidzv3y0gbvjq6fgz9g9pm-emacs-29.4"
+                "store_path": "/nix/store/apm4gxv4p2bf53dvk3ilncvgdig8m5kc-emacs-29.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "emacs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "emacs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/5nmm3ih26s7fq369pzx0nnb39abc9z75-emacs-29.4.drv",
+            "derivation": "/nix/store/ybmj89ihhbrrw3bsv7j17jc8s956q939-emacs-29.4.drv",
             "description": "Extensible, customizable GNU text editor",
             "insecure": false,
             "install_id": "emacs",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "emacs-29.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/csd9ir6v836hw6w4psiwy0k023zrs47d-emacs-29.4"
+                "store_path": "/nix/store/9iv0hrxf8x84axq2j2zm6m9yizf42fcr-emacs-29.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "emacs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "emacs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/czr6sip24r7ibm0j21gw21jx0pbgv6fm-emacs-29.4.drv",
+            "derivation": "/nix/store/plhzgnzx9dgca8d9zzhkyzlbb6sfj58s-emacs-29.4.drv",
             "description": "Extensible, customizable GNU text editor",
             "insecure": false,
             "install_id": "emacs",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "emacs-29.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/yvi1ca0mpwl2b3dnhh9cqf3jjp2nd1g2-emacs-29.4"
+                "store_path": "/nix/store/cwhasf440kg223jj9m651lq83zil81w4-emacs-29.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "emacs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "emacs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/z19nabhg4qimrc0wg7iq7vfhbx65vkvj-emacs-29.4.drv",
+            "derivation": "/nix/store/cmf9ra3c6zip2y61yd6kmjhxflzrjj06-emacs-29.4.drv",
             "description": "Extensible, customizable GNU text editor",
             "insecure": false,
             "install_id": "emacs",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "emacs-29.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/a3kfh7mx5ssar7z835vsiq7gmf7df2mg-emacs-29.4"
+                "store_path": "/nix/store/5apah73slavjjl9nbj1hhf6ds42dck9x-emacs-29.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "emacs",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -143,21 +139,21 @@
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/rnpar5fbj0h7gidf1h066iwi5vi16a9y-vim-9.1.0787.drv",
+            "derivation": "/nix/store/k7pwn9a32s22syrbhf58cafk4s1i4pbl-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/8d473xm8x7ff6k5mqwma6hxgpjnf6alh-vim-9.1.0787"
+                "store_path": "/nix/store/rc1kfgzpb3aq5w7cj1adjb5yaqv4c2va-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/d6jx0lvmachd31rlnf71015rws4kpj3r-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/mi0chjhw4cmyl2yq0z1lz8gmskzrq6da-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -165,37 +161,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/x0lgcqq1qdnwwx4hf9k8njz8z20d5iz9-vim-9.1.0787.drv",
+            "derivation": "/nix/store/293nl3481mnav4l70bk4lba4n37gawi4-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zappfr3lr1xp0pxsjvllg4m3bsvjxgbf-vim-9.1.0787"
+                "store_path": "/nix/store/v5rz9y25dapc1j6q2xmgawgh5fgfa59q-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/v1rrv6z3bppr0xkfp3q7spmiaabgmszw-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/fb6h1rvcaf73pmvf7xlcn2ihh80xwymj-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -203,37 +198,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/k9n77kiw39pv4kwhhhl6gdlp947zp9q9-vim-9.1.0787.drv",
+            "derivation": "/nix/store/xri9bxkiw1lbnhba9032smdqs1gmq134-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zsvr88wh53ha4d6ilv8lnil44svnsbvs-vim-9.1.0787"
+                "store_path": "/nix/store/ysnvbsyvysqm78pjbsw0zn7arlzp7yk8-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/73f1xnfkx8ghsqj30zn9k2vs4h75v8xj-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/ml8dj1b4zsi25652lf5cnz5qv8fl1swy-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -241,37 +235,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/0p8c65a0gp3qx8sjg46v01fnc6clvy2v-vim-9.1.0787.drv",
+            "derivation": "/nix/store/nlqlkb9pwhl6myjm3rm17bb6fsdyh37q-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/862qv45cwbjj2n60iyscyj5ci2vzycdh-vim-9.1.0787"
+                "store_path": "/nix/store/g9x3rxi0p1dxbdyf222m0qprrw0anyg5-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/jkny5zx16y29fgnl45d29wcirna7gyvk-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/v8k2x4bg8vbhwx1qgmz1cicf1ny01npy-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -279,20 +272,19 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/glibc.json
+++ b/test_data/generated/resolve/glibc.json
@@ -11,49 +11,48 @@
             "attr_path": "glibc",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/nxxwgq50lc44h9jb92d7wpya8dzdyv4f-glibc-2.40-36.drv",
+            "derivation": "/nix/store/kk0dsdn4q1d3cmfgzsg8m5g1v0m18b59-glibc-2.40-36.drv",
             "description": "GNU C Library",
             "insecure": false,
             "install_id": "glibc",
             "license": "LGPL-2.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "glibc-2.40-36",
             "outputs": [
               {
                 "name": "bin",
-                "store_path": "/nix/store/26dy2y29fhissya64ygahwpidpvs3bm3-glibc-2.40-36-bin"
+                "store_path": "/nix/store/1c6bmxrrhm8bd26ai2rjqld2yyjrxhds-glibc-2.40-36-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/aax0hx68i2ikhpf27hdm6a2a209d4s6p-glibc-2.40-36-dev"
+                "store_path": "/nix/store/kj8hbqx4ds9qm9mq7hyikxyfwwg13kzj-glibc-2.40-36-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/pacbfvpzqz2mksby36awvbcn051zcji3-glibc-2.40-36"
+                "store_path": "/nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/1qqb6gq3jy59vyiziid7v61ndfnyyhpi-glibc-2.40-36-debug"
+                "store_path": "/nix/store/9agwbwbsh5g70wkzrb887pkn3c1jw5b5-glibc-2.40-36-debug"
               },
               {
                 "name": "getent",
-                "store_path": "/nix/store/vl4lc1kqvvdmwsp0dvqlhqk10nhhddpl-glibc-2.40-36-getent"
+                "store_path": "/nix/store/yjakygrl2hy5fqnyzq394864smw01jhw-glibc-2.40-36-getent"
               },
               {
                 "name": "static",
-                "store_path": "/nix/store/s11lgr4hm29dr32pfw936fgnbk0w4jhb-glibc-2.40-36-static"
+                "store_path": "/nix/store/jbv9kcr08y41vd0czlxqgjq767y6p00p-glibc-2.40-36-static"
               }
             ],
             "outputs_to_install": [
               "bin"
             ],
             "pname": "glibc",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -61,7 +60,7 @@
             "version": "2.40-36"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/go.json
+++ b/test_data/generated/resolve/go.json
@@ -11,136 +11,132 @@
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/mv8bpnbfg4j1gc7vnsq6glxdnrnz5smr-go-1.23.3.drv",
+            "derivation": "/nix/store/84bqd072ql6qzjmqsqcdbw3nv63waw49-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/qrj2wp6vzfpjfrrlcmr22818zg83fb73-go-1.23.3"
+                "store_path": "/nix/store/bva4mymi5b2lhvvbccx8ipws89rar1d8-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/w6x5p636f88nx6biff22rv8c0hqj29k4-go-1.23.3.drv",
+            "derivation": "/nix/store/fap65gsxy7m12f8b8p5j9yybfnh908ar-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/dm66qyl19skrwcmk4rb9xcs64xc1d071-go-1.23.3"
+                "store_path": "/nix/store/9lvi0l2yf6bwamsjs5d5n9i57c6kbd2c-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/si6gydplf7ybx7fp0brwzblv8m5awbps-go-1.23.3.drv",
+            "derivation": "/nix/store/jil5s3a20z15fkfhkxa3575ax6j7d9a3-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/vkjn6njpz4gy5ma763vh8hh93bgjwycr-go-1.23.3"
+                "store_path": "/nix/store/sf1y7x29wvp9lppx5ya9h5b42fcmxb32-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           },
           {
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/hr6yjfp34id9pnhbrwfzzr8hmzzrr01a-go-1.23.3.drv",
+            "derivation": "/nix/store/h5i2qzmzj8hwyfxrf3fq23d7ngxpxyj2-go-1.23.4.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "go-1.23.3",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "go-1.23.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/bavnchxi7v6xs077jxv7fl5rrqc3y87w-go-1.23.3"
+                "store_path": "/nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "go",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "1.23.3"
+            "version": "1.23.4"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/gzip.json
+++ b/test_data/generated/resolve/gzip.json
@@ -11,25 +11,25 @@
             "attr_path": "gzip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/6vkv9wh7j4paqamrb8knji5lvxyf7ag3-gzip-1.13.drv",
+            "derivation": "/nix/store/6ch0xl0a37wc5czypmc07vw7zikjgdbb-gzip-1.13.drv",
             "description": "GNU zip compression program",
             "insecure": false,
             "install_id": "gzip",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "gzip-1.13",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/0y5ha72s3wpsbyaf3v2d4gzqrhldlwdx-gzip-1.13-man"
+                "store_path": "/nix/store/6zqrfcn31xndnr0g0npk1xzdr4isl9n5-gzip-1.13-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/jnnmwj5nsh4y8avg72q23nshq5z74pck-gzip-1.13"
+                "store_path": "/nix/store/li7r2lv82i1a90k9gir1w7c0rzf8lmir-gzip-1.13"
               },
               {
                 "name": "info",
-                "store_path": "/nix/store/9kl38agrsm4mn3fdzppb65rg6vj38g07-gzip-1.13-info"
+                "store_path": "/nix/store/m74v653g3hxjhl5fs4n2k2njg71aniav-gzip-1.13-info"
               }
             ],
             "outputs_to_install": [
@@ -37,12 +37,11 @@
               "man"
             ],
             "pname": "gzip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -53,25 +52,25 @@
             "attr_path": "gzip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/iqk8ls1xpygswfnxhvzi4hga92ibwinz-gzip-1.13.drv",
+            "derivation": "/nix/store/9g3kgj711gg4pvfnl5aad1rghzw81sr8-gzip-1.13.drv",
             "description": "GNU zip compression program",
             "insecure": false,
             "install_id": "gzip",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "gzip-1.13",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/3943ip7ivgbpzyi3s48r31wsw4fq2iz1-gzip-1.13-man"
+                "store_path": "/nix/store/2bv0pm3v9z44fhv58bh79l6dl7a3swqd-gzip-1.13-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/xjl8rkn0b43gsh0lcsrwp1g1ranvxk6f-gzip-1.13"
+                "store_path": "/nix/store/fl5mjwwd1ibphb011kmwqsl697n2abhr-gzip-1.13"
               },
               {
                 "name": "info",
-                "store_path": "/nix/store/gdiznjbd6hqbl1pi4qg8yw2g6ni8yxxn-gzip-1.13-info"
+                "store_path": "/nix/store/d1yrk6mmqxzbly0f8f4yqym293233npk-gzip-1.13-info"
               }
             ],
             "outputs_to_install": [
@@ -79,12 +78,11 @@
               "man"
             ],
             "pname": "gzip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -95,25 +93,25 @@
             "attr_path": "gzip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lhhr5ba7ybpdhd1vip1m52wprv8wrqix-gzip-1.13.drv",
+            "derivation": "/nix/store/3c8ac3hbmcrw8n9x6lx3pmyvh0qin137-gzip-1.13.drv",
             "description": "GNU zip compression program",
             "insecure": false,
             "install_id": "gzip",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "gzip-1.13",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/ysi14sgqdz562q9mvc0dhq8vw0vqj42d-gzip-1.13-man"
+                "store_path": "/nix/store/vpx5xvrs06y0bdlnjpqfskj6fz0bypn2-gzip-1.13-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/i6w5gh3nn79ym0fhhx0bnqkfp23bg0jq-gzip-1.13"
+                "store_path": "/nix/store/722whnv22srsczgrg9ykb60igrm9g2jd-gzip-1.13"
               },
               {
                 "name": "info",
-                "store_path": "/nix/store/5zh8jdiyyk4wmjsyqsl8a9vi0gw4bvzs-gzip-1.13-info"
+                "store_path": "/nix/store/z52iwjkw7w6aqxda7ai503drgvvyamsg-gzip-1.13-info"
               }
             ],
             "outputs_to_install": [
@@ -121,12 +119,11 @@
               "man"
             ],
             "pname": "gzip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -137,25 +134,25 @@
             "attr_path": "gzip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/s4yv5jwiyy8pmj3s092rsw395pvzvsgd-gzip-1.13.drv",
+            "derivation": "/nix/store/ccd1f56hff8ngky1kksafv9zmgvf250a-gzip-1.13.drv",
             "description": "GNU zip compression program",
             "insecure": false,
             "install_id": "gzip",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "gzip-1.13",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/khgkzrmzikvk6dk26wxyvs5dgi3vh3qv-gzip-1.13-man"
+                "store_path": "/nix/store/s8qg96l0nvzb1pwv5ckjwyclk304lka3-gzip-1.13-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/pg1n8f8zlwh4q4bsbnm9gwhx7cbix1m6-gzip-1.13"
+                "store_path": "/nix/store/nvvj6sk0k6px48436drlblf4gafgbvzr-gzip-1.13"
               },
               {
                 "name": "info",
-                "store_path": "/nix/store/1mlyi2c28013wg4q8p1qaj26hcxkkxar-gzip-1.13-info"
+                "store_path": "/nix/store/6abxhv54fq1xlljjnki2r8kzz954494b-gzip-1.13-info"
               }
             ],
             "outputs_to_install": [
@@ -163,12 +160,11 @@
               "man"
             ],
             "pname": "gzip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -176,7 +172,7 @@
             "version": "1.13"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/hello.json
+++ b/test_data/generated/resolve/hello.json
@@ -11,29 +11,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dwkzl7flwsi6rjginyhv9driwvyqf1s4-hello-2.12.1.drv",
+            "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/99hmg51vhxrapv3n0d7afr10mlsyyq68-hello-2.12.1"
+                "store_path": "/nix/store/c30rygy0wnk5y2swq5zlsaf5kfl2z5mp-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/f2gkm8y06w3qh5y02ycl4111diappd7g-hello-2.12.1.drv",
+            "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/7m8hnxx2k849ambsfl0vq0ahxz77rmly-hello-2.12.1"
+                "store_path": "/nix/store/hfr5r75d63nsbxax52y4xnhcjam5sq74-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/g41hdyykxyh5h6jxnai3rm82mvidh6a7-hello-2.12.1.drv",
+            "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/yx96gxl47m6ls4r6wq1vwla799rsq7cn-hello-2.12.1"
+                "store_path": "/nix/store/b4is8brcm8b82ppgv1zv590hzk85qvk8-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lrrywp3k594k3295lh92lm7a387wk0j9-hello-2.12.1.drv",
+            "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/041gszy7ccgmjv83lif6j6rzbqz5vjzg-hello-2.12.1"
+                "store_path": "/nix/store/a7hnr9dcmx3qkkn8a20g7md1wya5zc9l-hello-2.12.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "2.12.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/hello_unfree.json
+++ b/test_data/generated/resolve/hello_unfree.json
@@ -11,29 +11,28 @@
             "attr_path": "hello-unfree",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/79xap8jzpff8v48m4rc675c14gaxxw7v-example-unfree-package-1.0.drv",
+            "derivation": "/nix/store/5sy7xzzk3mbb58jjpjys97203d8qa356-example-unfree-package-1.0.drv",
             "description": "Example package with unfree license (for testing)",
             "insecure": false,
             "install_id": "hello-unfree",
             "license": "Unfree",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "example-unfree-package-1.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/5g2zkbys3gjixqqnh5nz0jxflm7d7kfs-example-unfree-package-1.0"
+                "store_path": "/nix/store/1lfrvy0dfp3xij13jar71bqp9saj5crw-example-unfree-package-1.0"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello-unfree",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "hello-unfree",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/j9mscvr29dfgvr0zp12cdh4dz4a0kg0a-example-unfree-package-1.0.drv",
+            "derivation": "/nix/store/3i7nig9xpfj3vpbqm22xhxz0n7b4v6hw-example-unfree-package-1.0.drv",
             "description": "Example package with unfree license (for testing)",
             "insecure": false,
             "install_id": "hello-unfree",
             "license": "Unfree",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "example-unfree-package-1.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/jx413f704ci0mawl2xlni51v8zjbwpjg-example-unfree-package-1.0"
+                "store_path": "/nix/store/c6zda6drrq5x0kx4r1wfzw7hk2h1pgwr-example-unfree-package-1.0"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello-unfree",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "hello-unfree",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/nv31q4qig3qbzmj0j06anwxhwkhjh15j-example-unfree-package-1.0.drv",
+            "derivation": "/nix/store/5ln4c9k5p3gyhjyv7kb5f96lfpdl0z56-example-unfree-package-1.0.drv",
             "description": "Example package with unfree license (for testing)",
             "insecure": false,
             "install_id": "hello-unfree",
             "license": "Unfree",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "example-unfree-package-1.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/k58b06qp8z5yg8g13xdi6gvc47qzj5c8-example-unfree-package-1.0"
+                "store_path": "/nix/store/xlis6d7055vbnnaqa98kvf6kxbvids9q-example-unfree-package-1.0"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello-unfree",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "hello-unfree",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/gga6vz5d3nbj93skimr08j0gl7pyzkd5-example-unfree-package-1.0.drv",
+            "derivation": "/nix/store/4fpc7dqxs9gv3v8bhi11zp95i98wb2m3-example-unfree-package-1.0.drv",
             "description": "Example package with unfree license (for testing)",
             "insecure": false,
             "install_id": "hello-unfree",
             "license": "Unfree",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "example-unfree-package-1.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/cqldvpw6naibpj3fi39jjs74pbl3sg0n-example-unfree-package-1.0"
+                "store_path": "/nix/store/f0sbs08vbbncr2yhpnl7ka4q29q1i3j9-example-unfree-package-1.0"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "hello-unfree",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "example-unfree-package-1.0"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/influxdb2.json
+++ b/test_data/generated/resolve/influxdb2.json
@@ -11,29 +11,28 @@
             "attr_path": "influxdb2",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/fsiin22ha7rk80j73nwlyf5zjdsas1cw-influxdb2.drv",
+            "derivation": "/nix/store/2ic0apkxyxdzj1if697g1wrny0bikdps-influxdb2.drv",
             "description": null,
             "insecure": false,
             "install_id": "influxdb2",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "influxdb2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/pckmx1cq2grz3n0dwz6fb7i3gk22jll6-influxdb2"
+                "store_path": "/nix/store/xd785k0vh8vdkkxaslw86kkpyqp4cz4c-influxdb2"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "influxdb2",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "influxdb2",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/sw7ildp2k4jpxfvhswc60kibawrqhfxx-influxdb2.drv",
+            "derivation": "/nix/store/pdm0kc6ysjwiilsjd5iwsy4svglv8bcv-influxdb2.drv",
             "description": null,
             "insecure": false,
             "install_id": "influxdb2",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "influxdb2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/br5dizaryznhx54av8nfg94p9nifqgfm-influxdb2"
+                "store_path": "/nix/store/mx8924abbsjzvy3vxn4b1bmwcdsx8lf6-influxdb2"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "influxdb2",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "influxdb2",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/3j06iapz2hl3p3azxzgfkmwjc65i12h9-influxdb2.drv",
+            "derivation": "/nix/store/znfk3011pagg7sh0jslzb31j3vlfc3x8-influxdb2.drv",
             "description": null,
             "insecure": false,
             "install_id": "influxdb2",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "influxdb2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/xm4r1pxivqjhacm92glizx6pxvglgsk1-influxdb2"
+                "store_path": "/nix/store/l9mx423rvaimqaliiizfrsj3405rqylg-influxdb2"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "influxdb2",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "influxdb2",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/imnj14v7yp43l3f0b6srr4qznj676yns-influxdb2.drv",
+            "derivation": "/nix/store/89xckdnbz7h1r4fcnr2v59sd8b299sdc-influxdb2.drv",
             "description": null,
             "insecure": false,
             "install_id": "influxdb2",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "influxdb2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/4p2c8iwf3vppi8z8jlqpayw1a4pl4l00-influxdb2"
+                "store_path": "/nix/store/49050j55f0y68xyl1yxah5ghgqc5hs25-influxdb2"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "influxdb2",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "influxdb2"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/jupyter_with_extensions.json
+++ b/test_data/generated/resolve/jupyter_with_extensions.json
@@ -11,165 +11,160 @@
             "attr_path": "jupyter",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/i6bfdbi505myyn1skji1pz6c9z3kvaln-python3-3.12.7-env.drv",
+            "derivation": "/nix/store/0wmscmdqq8md9w5hs0icxl6frnvv50k0-python3-3.12.8-env.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "jupyter",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7-env",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8-env",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/qk0gn1i38hg0nzh09p4112c2jhjgs6fp-python3-3.12.7-env"
+                "store_path": "/nix/store/d5h891svf5zdfjww2nsmw1cm5lhsxa0f-python3-3.12.8-env"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyter",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "python3-3.12.7-env"
+            "version": "python3-3.12.8-env"
           },
           {
             "attr_path": "jupyter",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/wfxri67szjbd9581jj6fr5wcfqcjipns-python3-3.12.7-env.drv",
+            "derivation": "/nix/store/7qjjppd809xv5i8d1xbp67b5yqgjv90w-python3-3.12.8-env.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "jupyter",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7-env",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8-env",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/nz06qc4cc76rgzrjm2iagaikfxbiqax5-python3-3.12.7-env"
+                "store_path": "/nix/store/s2vbnlsyj287x721sh7w6glxq3zjv6m4-python3-3.12.8-env"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyter",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "python3-3.12.7-env"
+            "version": "python3-3.12.8-env"
           },
           {
             "attr_path": "jupyter",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/rb0sdg188k06wkzg74pw5h3dmak6wl0g-python3-3.12.7-env.drv",
+            "derivation": "/nix/store/k0z28n22iwyipl4dzypjhlyabk28vffd-python3-3.12.8-env.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "jupyter",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7-env",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8-env",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/mi76xx4iy95b41rn3rqc0j3rh4p0xsaf-python3-3.12.7-env"
+                "store_path": "/nix/store/iwlvrpz7lmyw8rf4qhsckmrlnlaas8h6-python3-3.12.8-env"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyter",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "python3-3.12.7-env"
+            "version": "python3-3.12.8-env"
           },
           {
             "attr_path": "jupyter",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/hsp3lgkscqg9r88wacvasdkfhb0f25a9-python3-3.12.7-env.drv",
+            "derivation": "/nix/store/4bpszzaf8bwl3vwhgq9rvbs5bdsgr942-python3-3.12.8-env.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "jupyter",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7-env",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8-env",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/gp9k9amxryfzp4apm72p3snrx2cs0ws2-python3-3.12.7-env"
+                "store_path": "/nix/store/szh98a2p5y8s5arayb09vyylc0apaqsq-python3-3.12.8-env"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyter",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "python3-3.12.7-env"
+            "version": "python3-3.12.8-env"
           },
           {
             "attr_path": "python312Packages.jupyterlab-git",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/kxzjs4p39mz90b9mf44lprb86qzqafgr-python3.12-jupyterlab-git-0.50.2.drv",
+            "derivation": "/nix/store/g6sj92xvjmfq40xqknb3slgn6pr5ny76-python3.12-jupyterlab-git-0.50.2.drv",
             "description": "Jupyter lab extension for version control with Git",
             "insecure": false,
             "install_id": "jupyterlab-git",
             "license": "[ BSD-3-Clause ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-jupyterlab-git-0.50.2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/gxf0vjawgy34lzcs02hpdqpf4gpyk1pg-python3.12-jupyterlab-git-0.50.2"
+                "store_path": "/nix/store/lvilaz763cm1gkz8cgfg5pba3h3x7k4v-python3.12-jupyterlab-git-0.50.2"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/6z5m5vjjgw5g24lwkrfc60sl5pihpp3l-python3.12-jupyterlab-git-0.50.2-dist"
+                "store_path": "/nix/store/7q2syhay9zmjai9lzry5dmd0alkbnsp3-python3.12-jupyterlab-git-0.50.2-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyterlab-git",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -180,33 +175,32 @@
             "attr_path": "python312Packages.jupyterlab-git",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lmvxzcpk05b5qd272fyzs605k9r174mn-python3.12-jupyterlab-git-0.50.2.drv",
+            "derivation": "/nix/store/mprycff51855ghqr03713nagnnhjpp4p-python3.12-jupyterlab-git-0.50.2.drv",
             "description": "Jupyter lab extension for version control with Git",
             "insecure": false,
             "install_id": "jupyterlab-git",
             "license": "[ BSD-3-Clause ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-jupyterlab-git-0.50.2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/h143h0lfsmr3jy5az5fm6wcriwp0fjv0-python3.12-jupyterlab-git-0.50.2"
+                "store_path": "/nix/store/hsk4kfap63cyk2v7vw2b7q4n3jmdwrsz-python3.12-jupyterlab-git-0.50.2"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/z72l450c11c588dyibdcqvmcy2rzjdwf-python3.12-jupyterlab-git-0.50.2-dist"
+                "store_path": "/nix/store/f97gp3l1yh33had65zk5qvzz77mhr09c-python3.12-jupyterlab-git-0.50.2-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyterlab-git",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -217,33 +211,32 @@
             "attr_path": "python312Packages.jupyterlab-git",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/3jqir1vfpm2vjp2nwsr7hz75k7h6xvdb-python3.12-jupyterlab-git-0.50.2.drv",
+            "derivation": "/nix/store/9z1nc34yqnlll12dmchkpwgk53kis8nn-python3.12-jupyterlab-git-0.50.2.drv",
             "description": "Jupyter lab extension for version control with Git",
             "insecure": false,
             "install_id": "jupyterlab-git",
             "license": "[ BSD-3-Clause ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-jupyterlab-git-0.50.2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/bnm7d0gh395v9565nmz9ylijdi72jm3h-python3.12-jupyterlab-git-0.50.2"
+                "store_path": "/nix/store/0g1ndvxdsl2ab4n7lsip1psnvn2vj43x-python3.12-jupyterlab-git-0.50.2"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/g4n30fq7clm6b6gjnks2dm9s8vayjw3w-python3.12-jupyterlab-git-0.50.2-dist"
+                "store_path": "/nix/store/z8aj52qi3za9za9y2pmr01ka34zi7rkf-python3.12-jupyterlab-git-0.50.2-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyterlab-git",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -254,33 +247,32 @@
             "attr_path": "python312Packages.jupyterlab-git",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/nynqx6cg655yyaydhhxaljja6qicd1nq-python3.12-jupyterlab-git-0.50.2.drv",
+            "derivation": "/nix/store/0ajps75nhv3wmmd1133aylvi2f87vr0j-python3.12-jupyterlab-git-0.50.2.drv",
             "description": "Jupyter lab extension for version control with Git",
             "insecure": false,
             "install_id": "jupyterlab-git",
             "license": "[ BSD-3-Clause ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-jupyterlab-git-0.50.2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/fgjrchgqw1w1fcb17xph2snhkiz6303h-python3.12-jupyterlab-git-0.50.2"
+                "store_path": "/nix/store/v0n61jqsng42p286dhfh55hdpk2ni8xf-python3.12-jupyterlab-git-0.50.2"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/2lfw59p0ybbv9cy2n8fgyz8d82fz80ka-python3.12-jupyterlab-git-0.50.2-dist"
+                "store_path": "/nix/store/4fcy91pxv41cb01yd31s50s57sxxsqyk-python3.12-jupyterlab-git-0.50.2-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyterlab-git",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -291,33 +283,32 @@
             "attr_path": "python312Packages.jupyterlab-widgets",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/qkcgb7ln3331ncl2cwm352dnl7syrzcq-python3.12-jupyterlab-widgets-3.0.13.drv",
+            "derivation": "/nix/store/g6nraslp8750hcibw002sq764nrpmxqq-python3.12-jupyterlab-widgets-3.0.13.drv",
             "description": "Jupyter Widgets JupyterLab Extension",
             "insecure": false,
             "install_id": "jupyterlab-widgets",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-jupyterlab-widgets-3.0.13",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/1x5956290fzg008ixnxvmgi02aj2p0nw-python3.12-jupyterlab-widgets-3.0.13"
+                "store_path": "/nix/store/idmjy1fbhn19m5cyl60qh9wqqwfvv2qd-python3.12-jupyterlab-widgets-3.0.13"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/px3vgdls52swl17hkqk458q78f0hm2k3-python3.12-jupyterlab-widgets-3.0.13-dist"
+                "store_path": "/nix/store/yd3882gzdhkpdvcs7msf6vj4bbm9c1yb-python3.12-jupyterlab-widgets-3.0.13-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyterlab-widgets",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -328,33 +319,32 @@
             "attr_path": "python312Packages.jupyterlab-widgets",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/akbh3hg2vfqw853hwqrcqjran7lgfv0c-python3.12-jupyterlab-widgets-3.0.13.drv",
+            "derivation": "/nix/store/yn79sk8flwnssr9965is4wc8i389ibf7-python3.12-jupyterlab-widgets-3.0.13.drv",
             "description": "Jupyter Widgets JupyterLab Extension",
             "insecure": false,
             "install_id": "jupyterlab-widgets",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-jupyterlab-widgets-3.0.13",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/5d95v489f2k4s5j1ldmln859xx70vbp0-python3.12-jupyterlab-widgets-3.0.13"
+                "store_path": "/nix/store/q12b0rnnfa3g2gw5f42912639yrd951w-python3.12-jupyterlab-widgets-3.0.13"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/10dq9xr9mpy8j1izpmajn9gbf8r1nb49-python3.12-jupyterlab-widgets-3.0.13-dist"
+                "store_path": "/nix/store/wp7mjic631qik541bjrdk3gp1gmyp70y-python3.12-jupyterlab-widgets-3.0.13-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyterlab-widgets",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -365,33 +355,32 @@
             "attr_path": "python312Packages.jupyterlab-widgets",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/yihkp0clabsm8k9lfjfj975852hcs6yq-python3.12-jupyterlab-widgets-3.0.13.drv",
+            "derivation": "/nix/store/q50rrybwzngswkjbp6p03cy849hamr47-python3.12-jupyterlab-widgets-3.0.13.drv",
             "description": "Jupyter Widgets JupyterLab Extension",
             "insecure": false,
             "install_id": "jupyterlab-widgets",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-jupyterlab-widgets-3.0.13",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/4ppw03syyv24745q8mkyn6g3h1nqizq1-python3.12-jupyterlab-widgets-3.0.13"
+                "store_path": "/nix/store/n0ir23igrfjmichahkfr08yvkfqv9fny-python3.12-jupyterlab-widgets-3.0.13"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/khd98y58gzdlr9sqhmn5q61zb9nr2d0f-python3.12-jupyterlab-widgets-3.0.13-dist"
+                "store_path": "/nix/store/9jqkzvmy4r7yr6ikpwyxz5hr2fzffylp-python3.12-jupyterlab-widgets-3.0.13-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyterlab-widgets",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -402,33 +391,32 @@
             "attr_path": "python312Packages.jupyterlab-widgets",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/np2vvb7lz77kacwpq6r8ljl081hsv3kv-python3.12-jupyterlab-widgets-3.0.13.drv",
+            "derivation": "/nix/store/zbgig65pzj2sfrf38wml8pvm7p055hbl-python3.12-jupyterlab-widgets-3.0.13.drv",
             "description": "Jupyter Widgets JupyterLab Extension",
             "insecure": false,
             "install_id": "jupyterlab-widgets",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "python3.12-jupyterlab-widgets-3.0.13",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/wdicrn7gljnbkb8risy5kbpix67plns2-python3.12-jupyterlab-widgets-3.0.13"
+                "store_path": "/nix/store/8sa0dsx4d6v5yv10mbk929z5k2ypriqy-python3.12-jupyterlab-widgets-3.0.13"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/b4saig0n38ypclgi0hfja7dlrahlzmkn-python3.12-jupyterlab-widgets-3.0.13-dist"
+                "store_path": "/nix/store/bjxg1ssc2jm3glg1sp1ap86sx8flrj7w-python3.12-jupyterlab-widgets-3.0.13-dist"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "jupyterlab-widgets",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -436,7 +424,7 @@
             "version": "python3.12-jupyterlab-widgets-3.0.13"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/old_darwin_hello.json
+++ b/test_data/generated/resolve/old_darwin_hello.json
@@ -16,7 +16,7 @@
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -28,12 +28,11 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,12 +43,12 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/AAA-hello-2.10.1.drv",
+            "derivation": "/nix/store/dn80hc3nj04lsrmnkvxzirbqj3j8lh5h-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -61,17 +60,16 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "2.10.1"
+            "version": "2.12.1"
           },
           {
             "attr_path": "hello",
@@ -82,7 +80,7 @@
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -94,12 +92,11 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,12 +107,12 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/AAA-hello-2.10.1.drv",
+            "derivation": "/nix/store/pznj731mjim1xdd5mir97l20pk3gy5a8-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -127,20 +124,19 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "2.10.1"
+            "version": "2.12.1"
           }
         ],
-        "page": 733374,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/old_hello.json
+++ b/test_data/generated/resolve/old_hello.json
@@ -16,7 +16,7 @@
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -28,12 +28,11 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -49,7 +48,7 @@
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -61,12 +60,11 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -82,7 +80,7 @@
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -94,12 +92,11 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -115,7 +112,7 @@
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -127,12 +124,11 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "2.10.1"
           }
         ],
-        "page": 733374,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/old_linux_hello.json
+++ b/test_data/generated/resolve/old_linux_hello.json
@@ -11,12 +11,12 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/AAA-hello-2.10.1.drv",
+            "derivation": "/nix/store/x0qhv021p9ah10ldmkbiyk0zdjdz4mx0-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -28,17 +28,16 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "2.10.1"
+            "version": "2.12.1"
           },
           {
             "attr_path": "hello",
@@ -49,7 +48,7 @@
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -61,12 +60,11 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,12 +75,12 @@
             "attr_path": "hello",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/AAA-hello-2.10.1.drv",
+            "derivation": "/nix/store/r9fkz0mrs84jh47817g0934fkmjkz7v4-hello-2.12.1.drv",
             "description": "Program that produces a familiar, friendly greeting",
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -94,17 +92,16 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "2.10.1"
+            "version": "2.12.1"
           },
           {
             "attr_path": "hello",
@@ -115,7 +112,7 @@
             "insecure": false,
             "install_id": "hello",
             "license": "GPL-3.0-or-later",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=8f3e1f807051e32d8c95cd12b9b421623850a34d",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "hello-2.12.1",
             "outputs": [
               {
@@ -127,12 +124,11 @@
               "out"
             ],
             "pname": "hello",
-            "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
-            "rev_count": 733374,
-            "rev_date": "2025-01-04T17:41:09Z",
-            "scrape_date": "2025-01-06T21:17:53Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "2.10.1"
           }
         ],
-        "page": 733374,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/overmind.json
+++ b/test_data/generated/resolve/overmind.json
@@ -11,29 +11,28 @@
             "attr_path": "overmind",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/is94fdvzcip0rscrbwaix1xyp1x2bi8f-overmind-2.5.1.drv",
+            "derivation": "/nix/store/j2kmf39bz5d6r3kds415ygn43icjf77r-overmind-2.5.1.drv",
             "description": "Process manager for Procfile-based applications and tmux",
             "insecure": false,
             "install_id": "overmind",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "overmind-2.5.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/gjf3m3pw4vp9w67jxhpvkz1lglg4yppc-overmind-2.5.1"
+                "store_path": "/nix/store/96wg0jwk9abmyq0qq6fibjv6j3897s7p-overmind-2.5.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "overmind",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "overmind",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/jfaq45llj6nnaxr339qday68qgl2mbpr-overmind-2.5.1.drv",
+            "derivation": "/nix/store/kb68idz36xsn1crzk6yyqxca4q86scsg-overmind-2.5.1.drv",
             "description": "Process manager for Procfile-based applications and tmux",
             "insecure": false,
             "install_id": "overmind",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "overmind-2.5.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/d2bnpgx8dr63z877xmk0s9qgrh093yv1-overmind-2.5.1"
+                "store_path": "/nix/store/j2xi9ihsl06092yvwwh5kc2839vasli3-overmind-2.5.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "overmind",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "overmind",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/i3d1ba5g7fsqrh0xyfa2ry9n1qy89c5m-overmind-2.5.1.drv",
+            "derivation": "/nix/store/dxmslb8mdivvjpbvg8db3mr6g55m42r2-overmind-2.5.1.drv",
             "description": "Process manager for Procfile-based applications and tmux",
             "insecure": false,
             "install_id": "overmind",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "overmind-2.5.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/3l2qlh8gi3hdizk4dfiz16h7gqqaas4d-overmind-2.5.1"
+                "store_path": "/nix/store/bx7i1wd431y9rwyz6x6l8isx18k1m1dy-overmind-2.5.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "overmind",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "overmind",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2g5bvc7zkkmgn9rvnn89402cwax52ang-overmind-2.5.1.drv",
+            "derivation": "/nix/store/kk25qbfpvgm86vxzmb2rd49837pzvilb-overmind-2.5.1.drv",
             "description": "Process manager for Procfile-based applications and tmux",
             "insecure": false,
             "install_id": "overmind",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "overmind-2.5.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/brj7jplby95vlpql6jx39141y94vfn6f-overmind-2.5.1"
+                "store_path": "/nix/store/wavmj40xjk441ql6wp5bzcmjba045b0f-overmind-2.5.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "overmind",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "2.5.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/python3.json
+++ b/test_data/generated/resolve/python3.json
@@ -11,144 +11,140 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/rvxbvqv6jbash9i0jdp2wjp45555qif4-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/8zc3wcplydp8gsxms24scpzdca438dk5-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/22lnksddxfiwc7may5a6x0fmf2q74ksx-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/66pn6ysmvx675061xaq2vz93s9vdc5p4-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/brcg3a34fi45ffky63g5pqd22sksvq13-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/6qinwykpnnb7qaz8pcz8915mcfjaz6qp-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/fpmkmdzgd1q7kqadc7czcjdhjj7bsc0i-python3-3.12.8"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           },
           {
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/ixs5a8kyvw6rd2xbingm0sxc2lgwli54-python3-3.12.8.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "python3-3.12.7",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "python3-3.12.8",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/cicfrcjr8pky8qd0gxw0x84ynyviy6b5-python3-3.12.8-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "3.12.7"
+            "version": "3.12.8"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/python311Packages.pip.json
+++ b/test_data/generated/resolve/python311Packages.pip.json
@@ -11,25 +11,25 @@
             "attr_path": "python311Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dis90fqd0npck7514df0km509p7q8gsf-python3.11-pip-24.0.drv",
+            "derivation": "/nix/store/gx3cp6lqdijxky0hgcpzs0nkc0n2i0pm-python3.11-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3.11-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/fpjk58kwhjajq2yhnx7f6npjl7zjld81-python3.11-pip-24.0-man"
+                "store_path": "/nix/store/8c0k3zmqxmc790jnq0iy741f0r59skq0-python3.11-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/8jv9y166i65sj7b05479f8crqzjcska6-python3.11-pip-24.0"
+                "store_path": "/nix/store/4rlmzs8imw8cnm7zxmb40qcg5zfilywm-python3.11-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/db0f27is9lrd5wz56d86p7sazlz6vzq5-python3.11-pip-24.0-dist"
+                "store_path": "/nix/store/qym844p07sk31c62yqj5b980rn9zjqp8-python3.11-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -37,11 +37,12 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -53,25 +54,25 @@
             "attr_path": "python311Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/smkqb4rqsnh5giji5jmw8awb99wlq2wd-python3.11-pip-24.0.drv",
+            "derivation": "/nix/store/pyk770l29hhkpag7p2vww40gyq51lx0j-python3.11-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3.11-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/i2i10x777lrp4jdyv9p0098091clkvis-python3.11-pip-24.0-man"
+                "store_path": "/nix/store/l6h3wn620pnsw00b3izh7qkh63v2h2mm-python3.11-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/i06zw5pkgidrliymm4dd7yr9g51krf28-python3.11-pip-24.0"
+                "store_path": "/nix/store/n1878qvhhl7a1238h52syhpyn3vpr9ap-python3.11-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/0dlnmbp7d3ici4m4hj90v9fvc0d3yhnm-python3.11-pip-24.0-dist"
+                "store_path": "/nix/store/9ai3zc1ml1hpl6r5a0wz20j73jzqc19k-python3.11-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -79,11 +80,12 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -95,25 +97,25 @@
             "attr_path": "python311Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/r14h9dm004cnmqxjamxr2f40daxssc23-python3.11-pip-24.0.drv",
+            "derivation": "/nix/store/m78wbwhxyj4shwrbpdkjfd14bnsscq1m-python3.11-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3.11-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/klshp981hwvshpxqxq6gp0w6c2nfzkjr-python3.11-pip-24.0-man"
+                "store_path": "/nix/store/v0m892bw1za9c84sdz7id7lsdqz5gn0m-python3.11-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/jf0bg90yjjp42w10r4aikg5s45w6qgqz-python3.11-pip-24.0"
+                "store_path": "/nix/store/b4rc80klr5hfjnndmxmzkr2h1ipsc0lw-python3.11-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/hb92nfclzanm234qmjcrz5dh81hdd9dn-python3.11-pip-24.0-dist"
+                "store_path": "/nix/store/543xg541cyv8azjfr0d4iy1r56bzr7l0-python3.11-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -121,11 +123,12 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -137,25 +140,25 @@
             "attr_path": "python311Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/wbyj0lzywdan41xj2dvzjr66ins9h7jm-python3.11-pip-24.0.drv",
+            "derivation": "/nix/store/14llrjh9jq8kfdj4mkgibp4gzprxrrcr-python3.11-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3.11-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/ic6pzqxwvpwjlrvn3xr38k8143935ac6-python3.11-pip-24.0-man"
+                "store_path": "/nix/store/5qlaabn7jli0d2djawr8ld8l6bi8jwwi-python3.11-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/plzg4344hgda5y4cc44ax8hgc59fs3d0-python3.11-pip-24.0"
+                "store_path": "/nix/store/9hhh5rh3qihyrh0y0wid9xl20i0z5pfq-python3.11-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/aysdx8s7bbvjsakkq3y30pbr4nwxgx93-python3.11-pip-24.0-dist"
+                "store_path": "/nix/store/ifs6g0gvihqkn6kbs91n88hxai1i3jcj-python3.11-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -163,11 +166,12 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -176,7 +180,7 @@
             "version": "python3.11-pip-24.0"
           }
         ],
-        "page": 710087,
+        "page": 724962,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/python3_pip.json
+++ b/test_data/generated/resolve/python3_pip.json
@@ -11,25 +11,25 @@
             "attr_path": "python311Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dis90fqd0npck7514df0km509p7q8gsf-python3.11-pip-24.0.drv",
+            "derivation": "/nix/store/gx3cp6lqdijxky0hgcpzs0nkc0n2i0pm-python3.11-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3.11-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/fpjk58kwhjajq2yhnx7f6npjl7zjld81-python3.11-pip-24.0-man"
+                "store_path": "/nix/store/8c0k3zmqxmc790jnq0iy741f0r59skq0-python3.11-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/8jv9y166i65sj7b05479f8crqzjcska6-python3.11-pip-24.0"
+                "store_path": "/nix/store/4rlmzs8imw8cnm7zxmb40qcg5zfilywm-python3.11-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/db0f27is9lrd5wz56d86p7sazlz6vzq5-python3.11-pip-24.0-dist"
+                "store_path": "/nix/store/qym844p07sk31c62yqj5b980rn9zjqp8-python3.11-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -37,11 +37,12 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -53,25 +54,25 @@
             "attr_path": "python311Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/smkqb4rqsnh5giji5jmw8awb99wlq2wd-python3.11-pip-24.0.drv",
+            "derivation": "/nix/store/pyk770l29hhkpag7p2vww40gyq51lx0j-python3.11-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3.11-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/i2i10x777lrp4jdyv9p0098091clkvis-python3.11-pip-24.0-man"
+                "store_path": "/nix/store/l6h3wn620pnsw00b3izh7qkh63v2h2mm-python3.11-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/i06zw5pkgidrliymm4dd7yr9g51krf28-python3.11-pip-24.0"
+                "store_path": "/nix/store/n1878qvhhl7a1238h52syhpyn3vpr9ap-python3.11-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/0dlnmbp7d3ici4m4hj90v9fvc0d3yhnm-python3.11-pip-24.0-dist"
+                "store_path": "/nix/store/9ai3zc1ml1hpl6r5a0wz20j73jzqc19k-python3.11-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -79,11 +80,12 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -95,25 +97,25 @@
             "attr_path": "python311Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/r14h9dm004cnmqxjamxr2f40daxssc23-python3.11-pip-24.0.drv",
+            "derivation": "/nix/store/m78wbwhxyj4shwrbpdkjfd14bnsscq1m-python3.11-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3.11-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/klshp981hwvshpxqxq6gp0w6c2nfzkjr-python3.11-pip-24.0-man"
+                "store_path": "/nix/store/v0m892bw1za9c84sdz7id7lsdqz5gn0m-python3.11-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/jf0bg90yjjp42w10r4aikg5s45w6qgqz-python3.11-pip-24.0"
+                "store_path": "/nix/store/b4rc80klr5hfjnndmxmzkr2h1ipsc0lw-python3.11-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/hb92nfclzanm234qmjcrz5dh81hdd9dn-python3.11-pip-24.0-dist"
+                "store_path": "/nix/store/543xg541cyv8azjfr0d4iy1r56bzr7l0-python3.11-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -121,11 +123,12 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -137,25 +140,25 @@
             "attr_path": "python311Packages.pip",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/wbyj0lzywdan41xj2dvzjr66ins9h7jm-python3.11-pip-24.0.drv",
+            "derivation": "/nix/store/14llrjh9jq8kfdj4mkgibp4gzprxrrcr-python3.11-pip-24.0.drv",
             "description": "PyPA recommended tool for installing Python packages",
             "insecure": false,
             "install_id": "pip",
             "license": "[ MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3.11-pip-24.0",
             "outputs": [
               {
                 "name": "man",
-                "store_path": "/nix/store/ic6pzqxwvpwjlrvn3xr38k8143935ac6-python3.11-pip-24.0-man"
+                "store_path": "/nix/store/5qlaabn7jli0d2djawr8ld8l6bi8jwwi-python3.11-pip-24.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/plzg4344hgda5y4cc44ax8hgc59fs3d0-python3.11-pip-24.0"
+                "store_path": "/nix/store/9hhh5rh3qihyrh0y0wid9xl20i0z5pfq-python3.11-pip-24.0"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/aysdx8s7bbvjsakkq3y30pbr4nwxgx93-python3.11-pip-24.0-dist"
+                "store_path": "/nix/store/ifs6g0gvihqkn6kbs91n88hxai1i3jcj-python3.11-pip-24.0-dist"
               }
             ],
             "outputs_to_install": [
@@ -163,11 +166,12 @@
               "man"
             ],
             "pname": "pip",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -179,28 +183,29 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/m8mnjdqkq6pp69hf4lsqd1pmx3yqnmdy-python3-3.12.7.drv",
+            "derivation": "/nix/store/xpsw6n12miasj1ipbsnh40s1mx6plh6l-python3-3.12.7.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3-3.12.7",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zyak8iqzh1ww83qa4sqwwz3qax0lrky7-python3-3.12.7"
+                "store_path": "/nix/store/7c494qcmh62av43zsxr3wvzh8hcpy1vl-python3-3.12.7"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -212,32 +217,33 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ni1cpv0m2lcpzd8c0g0f0hy86r405h5d-python3-3.12.7.drv",
+            "derivation": "/nix/store/zmj2nziiz98ndjap1hbhnvc8bwd4rakd-python3-3.12.7.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3-3.12.7",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/imz4prdh762l7jvwak2s7pqpq6hy5fyy-python3-3.12.7"
+                "store_path": "/nix/store/c1fbv3y657fp2m514gjxqqgqfsvayp6v-python3-3.12.7"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/fdldrf7jicbx1v2yn2jj4rp1gwcin5vy-python3-3.12.7-debug"
+                "store_path": "/nix/store/s5biairx04d930rlh4szdbqsrai3w8gm-python3-3.12.7-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -249,28 +255,29 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2my4flhwy6npmzmq9l8cb83c5a4v7b4b-python3-3.12.7.drv",
+            "derivation": "/nix/store/0f2a3r3jv31ppm89hm5zhha3f397f8hi-python3-3.12.7.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3-3.12.7",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/q2vqbhlx0i0k5bfavk04wiknrf7ygqls-python3-3.12.7"
+                "store_path": "/nix/store/c0zcl6sav8305n3pb1crk2ysrlfk9ppk-python3-3.12.7"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -282,32 +289,33 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/dg5sw7q1rk0fjy6d91asvgf603j8k1qb-python3-3.12.7.drv",
+            "derivation": "/nix/store/yjlx78f4khvqxa9d3j906qk8vdh6bd3r-python3-3.12.7.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
             "license": "Python-2.0",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
             "name": "python3-3.12.7",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/px2nj16i5gc3d4mnw5l1nclfdxhry61p-python3-3.12.7"
+                "store_path": "/nix/store/zv1kaq7f1q20x62kbjv6pfjygw5jmwl6-python3-3.12.7"
               },
               {
                 "name": "debug",
-                "store_path": "/nix/store/l13c89ykx82ffm2y025fnngszchsgq6b-python3-3.12.7-debug"
+                "store_path": "/nix/store/66ln8wcdigr854aacj657zfjilwn4lrv-python3-3.12.7-debug"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "python3",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+            "rev_count": 724962,
+            "rev_date": "2024-12-19T23:01:11Z",
+            "scrape_date": "2024-12-23T03:54:12Z",
             "stabilities": [
+              "stable",
               "staging",
               "unstable"
             ],
@@ -316,7 +324,7 @@
             "version": "3.12.7"
           }
         ],
-        "page": 710087,
+        "page": 724962,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/redis.json
+++ b/test_data/generated/resolve/redis.json
@@ -11,33 +11,33 @@
             "attr_path": "netcat",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/f87p7pgrjfd0j5nr35xda6rb524yp4ly-libressl-4.0.0.drv",
+            "derivation": "/nix/store/3rd3f997jrdssxznxyywp55ldxb68bvh-libressl-4.0.0.drv",
             "description": "Free TLS/SSL implementation",
             "insecure": false,
             "install_id": "netcat",
             "license": "[ Public Domain, BSD-4-Clause, 0BSD, BSD-3-Clause, GPL-3.0, ISC, OpenSSL ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "libressl-4.0.0",
             "outputs": [
               {
                 "name": "nc",
-                "store_path": "/nix/store/gpxl209vy5q0r36zl3w1l38g95qx4i4s-libressl-4.0.0-nc"
+                "store_path": "/nix/store/v1sf8n57drd6awzgcchaaknb4pjip0a7-libressl-4.0.0-nc"
               },
               {
                 "name": "bin",
-                "store_path": "/nix/store/0am6br5xv7yqgw686q00v6lf19q8rvkn-libressl-4.0.0-bin"
+                "store_path": "/nix/store/3fp6sqal6qmd715snqsfps1iia47f80p-libressl-4.0.0-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/hwhn7ms55grbb687vni41q3r1sicdx86-libressl-4.0.0-dev"
+                "store_path": "/nix/store/dhdkvasbarsan4k1i0jd0w5wpl2j25ls-libressl-4.0.0-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/716kg8zyx1ziq4yfsyxf2yyaqk5sxi9d-libressl-4.0.0-man"
+                "store_path": "/nix/store/8vmx6p9vb2wfka8cw5i7gspk6l8615l5-libressl-4.0.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/5k64sig7r4r0w159j9xr8vybvr4a4sb0-libressl-4.0.0"
+                "store_path": "/nix/store/lllzv28jcsph4079yj0p4c32vvkhr1as-libressl-4.0.0"
               }
             ],
             "outputs_to_install": [
@@ -45,12 +45,11 @@
               "man"
             ],
             "pname": "netcat",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -61,33 +60,33 @@
             "attr_path": "netcat",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/wnvhwkn4gg715s41hb8ikskch7dfrhjy-libressl-4.0.0.drv",
+            "derivation": "/nix/store/s9z22f1ky9yb9cjpd7bwl4abhlq109hh-libressl-4.0.0.drv",
             "description": "Free TLS/SSL implementation",
             "insecure": false,
             "install_id": "netcat",
             "license": "[ Public Domain, BSD-4-Clause, 0BSD, BSD-3-Clause, GPL-3.0, ISC, OpenSSL ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "libressl-4.0.0",
             "outputs": [
               {
                 "name": "nc",
-                "store_path": "/nix/store/i31x8x26n0hhlkisa147yagdix8zw6ii-libressl-4.0.0-nc"
+                "store_path": "/nix/store/jadarbnfg2mn0m32p1fcgd8r71ci8q4k-libressl-4.0.0-nc"
               },
               {
                 "name": "bin",
-                "store_path": "/nix/store/is9lhx7nx1amyrfy3hzwa4zzkkbmjdz6-libressl-4.0.0-bin"
+                "store_path": "/nix/store/aj0g27zb61gmpzk7jjx59ypb708wa4zg-libressl-4.0.0-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/njbn9nalschiqdjj7nk5acibl5awbr0s-libressl-4.0.0-dev"
+                "store_path": "/nix/store/s3624f6sm7gzibyjn3895r0kkfhmp9ha-libressl-4.0.0-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/02di4l4pgk4c20bjzid5lwlvrqxchh66-libressl-4.0.0-man"
+                "store_path": "/nix/store/sv36vp6mwx825jj4wvj2xck6v7mfbanj-libressl-4.0.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/xhbzwrk7aim6lm2r9asqf39qbifa0s8c-libressl-4.0.0"
+                "store_path": "/nix/store/rmw8bwq9kdw3qqzddv0c6p8d9j3pxy2k-libressl-4.0.0"
               }
             ],
             "outputs_to_install": [
@@ -95,12 +94,11 @@
               "man"
             ],
             "pname": "netcat",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -111,33 +109,33 @@
             "attr_path": "netcat",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/9qa7pvsy9dpvn3nz0rb1qszcnjacy0mg-libressl-4.0.0.drv",
+            "derivation": "/nix/store/zsa8lisif8k2sc0kznnqqrbqk5b6zwik-libressl-4.0.0.drv",
             "description": "Free TLS/SSL implementation",
             "insecure": false,
             "install_id": "netcat",
             "license": "[ Public Domain, BSD-4-Clause, 0BSD, BSD-3-Clause, GPL-3.0, ISC, OpenSSL ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "libressl-4.0.0",
             "outputs": [
               {
                 "name": "nc",
-                "store_path": "/nix/store/7cygidhghhcs2f0mdb4glx3zpya25p6k-libressl-4.0.0-nc"
+                "store_path": "/nix/store/plzwss4v6wfswdqmhjdnvnxyax5cyran-libressl-4.0.0-nc"
               },
               {
                 "name": "bin",
-                "store_path": "/nix/store/dadpb63x9c4gr1w2930j6jk4y8n7qjsr-libressl-4.0.0-bin"
+                "store_path": "/nix/store/5ywihjjfhffw5bvdwwwh59qkff0z1134-libressl-4.0.0-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/jn93a29900z7rgcz6aj8hq54firnb04n-libressl-4.0.0-dev"
+                "store_path": "/nix/store/9j35zdcx5vqxi518qa0ayf5gs2ipk72m-libressl-4.0.0-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/aj3cw6gfj3x463dnk9d9qs32lkgr88z3-libressl-4.0.0-man"
+                "store_path": "/nix/store/wlg32y3bis425nmk02a8vygnlzmhvp1i-libressl-4.0.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/s3sx2pid3ir3pas86mrb4p5m0cvz1nhq-libressl-4.0.0"
+                "store_path": "/nix/store/yzwmpnq96r892kyg8wqargsr6bhv93h3-libressl-4.0.0"
               }
             ],
             "outputs_to_install": [
@@ -145,12 +143,11 @@
               "man"
             ],
             "pname": "netcat",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -161,33 +158,33 @@
             "attr_path": "netcat",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/sfmgs5n1zndnlvvjwvaj5wpljqm19q60-libressl-4.0.0.drv",
+            "derivation": "/nix/store/d5bv8026r70bzq4dl5q887g4p99l90d2-libressl-4.0.0.drv",
             "description": "Free TLS/SSL implementation",
             "insecure": false,
             "install_id": "netcat",
             "license": "[ Public Domain, BSD-4-Clause, 0BSD, BSD-3-Clause, GPL-3.0, ISC, OpenSSL ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "libressl-4.0.0",
             "outputs": [
               {
                 "name": "nc",
-                "store_path": "/nix/store/sjkiagyc52yh3whg681gwb4vb6a9s78b-libressl-4.0.0-nc"
+                "store_path": "/nix/store/vchs9klky7kpcrc69p9mv6kfgpwgk7zy-libressl-4.0.0-nc"
               },
               {
                 "name": "bin",
-                "store_path": "/nix/store/4qc4z3qb9r32lvrhc98g0z8i8f2rs8r3-libressl-4.0.0-bin"
+                "store_path": "/nix/store/s7a932i20cz4d73gn9lliqkv1ag2vp6a-libressl-4.0.0-bin"
               },
               {
                 "name": "dev",
-                "store_path": "/nix/store/s0j8gbx3mbpbqiqxcd4vkd9j90g53m1m-libressl-4.0.0-dev"
+                "store_path": "/nix/store/fmc1n2dcy34g3xz8dr1nfz7hlwfnbk2s-libressl-4.0.0-dev"
               },
               {
                 "name": "man",
-                "store_path": "/nix/store/iz0amai27p9p5wdif8c34gdxnalw7370-libressl-4.0.0-man"
+                "store_path": "/nix/store/pvrbvj4kbhv8akx8qrkjs74kfrlnc1z4-libressl-4.0.0-man"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/ahhrfglnil7inrz6bwh5q1lnfzi7qyiv-libressl-4.0.0"
+                "store_path": "/nix/store/2x17a87n4921r2fnr646qn69vm4razky-libressl-4.0.0"
               }
             ],
             "outputs_to_install": [
@@ -195,12 +192,11 @@
               "man"
             ],
             "pname": "netcat",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -211,29 +207,28 @@
             "attr_path": "redis",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/b8hqpm9zh5vh45f3fqgys1bw2f1y46qx-redis-7.2.6.drv",
+            "derivation": "/nix/store/5nmj7fchmqxnq3fp3v0lc5p7lq064yrl-redis-7.2.6.drv",
             "description": "Open source, advanced key-value store",
             "insecure": false,
             "install_id": "redis",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "redis-7.2.6",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/wkkl1sa3d1va56rpyvz2ihd2xd16hd4p-redis-7.2.6"
+                "store_path": "/nix/store/9lcnhfbsgc8p3r2wadk9d7yqz9mmy6mv-redis-7.2.6"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "redis",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -244,29 +239,28 @@
             "attr_path": "redis",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ry4l2vy2wxy076gpl33i04la5izcnzhs-redis-7.2.6.drv",
+            "derivation": "/nix/store/cqrj0qv71a3bq25qhig11dk3kcnxffii-redis-7.2.6.drv",
             "description": "Open source, advanced key-value store",
             "insecure": false,
             "install_id": "redis",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "redis-7.2.6",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/2rdd6fnpykqknhh3yrq1bav9ald5mkh8-redis-7.2.6"
+                "store_path": "/nix/store/7q22qwaxn9771ynmsx83yz5r7lxvk0w9-redis-7.2.6"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "redis",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -277,29 +271,28 @@
             "attr_path": "redis",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/3s1ccbwsj8vfmvnlilx0wprfaxb8zh0m-redis-7.2.6.drv",
+            "derivation": "/nix/store/r2n5bgkdkbdn4w1ipwy5wx7yy85y0nql-redis-7.2.6.drv",
             "description": "Open source, advanced key-value store",
             "insecure": false,
             "install_id": "redis",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "redis-7.2.6",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/1rpq5w8rf7wxpdfx7ppphlwc2d8livs3-redis-7.2.6"
+                "store_path": "/nix/store/686i051ch1466l1v169sa40dhj0vqi8s-redis-7.2.6"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "redis",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -310,29 +303,28 @@
             "attr_path": "redis",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/hvc94jl9cv35lr8il2sfbn03wfp6jiwb-redis-7.2.6.drv",
+            "derivation": "/nix/store/jhxmnwykp7z5hd5rhv29sp43cxhrx15f-redis-7.2.6.drv",
             "description": "Open source, advanced key-value store",
             "insecure": false,
             "install_id": "redis",
             "license": "BSD-3-Clause",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "redis-7.2.6",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/ff8wp3wzc27gpn3p90ng7pal4i1p9pf5-redis-7.2.6"
+                "store_path": "/nix/store/rs6j9ss9d54z82aiqxq211f0a1p96aqx-redis-7.2.6"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "redis",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -340,7 +332,7 @@
             "version": "7.2.6"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/rubyPackages_3_2.rails.json
+++ b/test_data/generated/resolve/rubyPackages_3_2.rails.json
@@ -11,29 +11,28 @@
             "attr_path": "rubyPackages_3_2.rails",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lqgp83jfawdmml07cnj5q2kvr8jpp2q9-ruby3.2-rails-7.1.3.4.drv",
+            "derivation": "/nix/store/r8ixlw9210v5hz3b0m9mcbqilhq9kwq9-ruby3.2-rails-7.1.3.4.drv",
             "description": null,
             "insecure": false,
             "install_id": "rails",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-rails-7.1.3.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/lpcawsrfa1ra2xgrgv8r26rxxcfyzc23-ruby3.2-rails-7.1.3.4"
+                "store_path": "/nix/store/hl0ilb3c622l1bmwcvixvizlkwrbv35b-ruby3.2-rails-7.1.3.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rails",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "rubyPackages_3_2.rails",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/1ss670h3mzqyppx1hmmxzvy6pfc64sy2-ruby3.2-rails-7.1.3.4.drv",
+            "derivation": "/nix/store/60bp740apn7p17jil0jj89hxxl29p5i8-ruby3.2-rails-7.1.3.4.drv",
             "description": null,
             "insecure": false,
             "install_id": "rails",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-rails-7.1.3.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/f7bxzksbw0ib9vsiaw6rjy1c03vxkgck-ruby3.2-rails-7.1.3.4"
+                "store_path": "/nix/store/406s2bzxpqbqym0407y7qqzl664c88fm-ruby3.2-rails-7.1.3.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rails",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "rubyPackages_3_2.rails",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/xh4j6qnm2j8z5z0ilwja53n6281hqv8m-ruby3.2-rails-7.1.3.4.drv",
+            "derivation": "/nix/store/yr1p8zr37jx15160dnrmlka47rnkd21h-ruby3.2-rails-7.1.3.4.drv",
             "description": null,
             "insecure": false,
             "install_id": "rails",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-rails-7.1.3.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/ny8i0j5g7dijf8r0873yd9rp6kmllbha-ruby3.2-rails-7.1.3.4"
+                "store_path": "/nix/store/jazhf1w541h5rr9pxlc2k41awwq33c4i-ruby3.2-rails-7.1.3.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rails",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "rubyPackages_3_2.rails",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/9wg4ap6g0jhiq6v9b0jwdq3k6gy5xh6f-ruby3.2-rails-7.1.3.4.drv",
+            "derivation": "/nix/store/7in5bhssmsrjd0c67rldqisy3by0vzgs-ruby3.2-rails-7.1.3.4.drv",
             "description": null,
             "insecure": false,
             "install_id": "rails",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-rails-7.1.3.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/3c3pc6lhz7hilcgv98c73gl9jm7m4ly2-ruby3.2-rails-7.1.3.4"
+                "store_path": "/nix/store/zd7sfm3hhlzanra5j9kdig2vs1bqycyn-ruby3.2-rails-7.1.3.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rails",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "ruby3.2-rails-7.1.3.4"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/rust-lib-src.json
+++ b/test_data/generated/resolve/rust-lib-src.json
@@ -11,29 +11,28 @@
             "attr_path": "rustPlatform.rustLibSrc",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/pwyx6gcgsizvnks5wi301xsahng995s9-rust-lib-src.drv",
+            "derivation": "/nix/store/5rf3yma6vxqdf869h9s72rm8rr2xvxda-rust-lib-src.drv",
             "description": null,
             "insecure": false,
             "install_id": "rustLibSrc",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "rust-lib-src",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/p3plglv2bmw2ihx0wl7pxjhar7g59lgi-rust-lib-src"
+                "store_path": "/nix/store/hhh0lcy44vs2y1lw4xljyicsdqfx0jkz-rust-lib-src"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rustLibSrc",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "rustPlatform.rustLibSrc",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/jh3xnicirp316w94i06llwdr8pah1qqx-rust-lib-src.drv",
+            "derivation": "/nix/store/94nk5xszlpnqwilznzkwq521hji4cnjv-rust-lib-src.drv",
             "description": null,
             "insecure": false,
             "install_id": "rustLibSrc",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "rust-lib-src",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/9knw1vkjsf1p3x5mz7clv8gmzl2h0ghm-rust-lib-src"
+                "store_path": "/nix/store/cvgv47ld615zwpsc53llxpsyx072yx73-rust-lib-src"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rustLibSrc",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "rustPlatform.rustLibSrc",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/525hynvkpzya9bipsx8mbdrnkfwhsq9l-rust-lib-src.drv",
+            "derivation": "/nix/store/sb3anbilyl3frjwd466rcsrvybdlhida-rust-lib-src.drv",
             "description": null,
             "insecure": false,
             "install_id": "rustLibSrc",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "rust-lib-src",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/166mh6nn7n5cxsrzkbhsygdpimh6bbvr-rust-lib-src"
+                "store_path": "/nix/store/nxyqc7l1qasqhgz6ff6qf9b937wwmaxp-rust-lib-src"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rustLibSrc",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "rustPlatform.rustLibSrc",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2n2v9648y04f1jx27lrqdqpybxirizw2-rust-lib-src.drv",
+            "derivation": "/nix/store/f1n3bk87myi3190537f2jn763x4jfqkr-rust-lib-src.drv",
             "description": null,
             "insecure": false,
             "install_id": "rustLibSrc",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "rust-lib-src",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/xscyf1za8rdab2mqi7qqsw4vnyfmp30z-rust-lib-src"
+                "store_path": "/nix/store/8gaad5kb6piz2fj9yg03c1lhrajanry2-rust-lib-src"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rustLibSrc",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -140,7 +136,7 @@
             "version": "rust-lib-src"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/vim-vim-full-conflict.json
+++ b/test_data/generated/resolve/vim-vim-full-conflict.json
@@ -11,21 +11,21 @@
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/rnpar5fbj0h7gidf1h066iwi5vi16a9y-vim-9.1.0787.drv",
+            "derivation": "/nix/store/k7pwn9a32s22syrbhf58cafk4s1i4pbl-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/8d473xm8x7ff6k5mqwma6hxgpjnf6alh-vim-9.1.0787"
+                "store_path": "/nix/store/rc1kfgzpb3aq5w7cj1adjb5yaqv4c2va-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/d6jx0lvmachd31rlnf71015rws4kpj3r-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/mi0chjhw4cmyl2yq0z1lz8gmskzrq6da-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -33,37 +33,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/x0lgcqq1qdnwwx4hf9k8njz8z20d5iz9-vim-9.1.0787.drv",
+            "derivation": "/nix/store/293nl3481mnav4l70bk4lba4n37gawi4-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zappfr3lr1xp0pxsjvllg4m3bsvjxgbf-vim-9.1.0787"
+                "store_path": "/nix/store/v5rz9y25dapc1j6q2xmgawgh5fgfa59q-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/v1rrv6z3bppr0xkfp3q7spmiaabgmszw-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/fb6h1rvcaf73pmvf7xlcn2ihh80xwymj-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -71,37 +70,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/k9n77kiw39pv4kwhhhl6gdlp947zp9q9-vim-9.1.0787.drv",
+            "derivation": "/nix/store/xri9bxkiw1lbnhba9032smdqs1gmq134-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zsvr88wh53ha4d6ilv8lnil44svnsbvs-vim-9.1.0787"
+                "store_path": "/nix/store/ysnvbsyvysqm78pjbsw0zn7arlzp7yk8-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/73f1xnfkx8ghsqj30zn9k2vs4h75v8xj-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/ml8dj1b4zsi25652lf5cnz5qv8fl1swy-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -109,37 +107,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/0p8c65a0gp3qx8sjg46v01fnc6clvy2v-vim-9.1.0787.drv",
+            "derivation": "/nix/store/nlqlkb9pwhl6myjm3rm17bb6fsdyh37q-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/862qv45cwbjj2n60iyscyj5ci2vzycdh-vim-9.1.0787"
+                "store_path": "/nix/store/g9x3rxi0p1dxbdyf222m0qprrw0anyg5-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/jkny5zx16y29fgnl45d29wcirna7gyvk-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/v8k2x4bg8vbhwx1qgmz1cicf1ny01npy-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -147,37 +144,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim-full",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/gyar1b08ap68shay002g3gvgddsx7yhs-vim-full-9.1.0787.drv",
+            "derivation": "/nix/store/yssbh4whnn23x0jy88p7h1h76275qd62-vim-full-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim-full",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-full-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-full-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/ap5gr1kwgjjh82ncxzpvb5kvdsafjpgn-vim-full-9.1.0787"
+                "store_path": "/nix/store/f5fkw7mwj5l4jw87iz0615x5qvil9q2s-vim-full-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/ay24bkfr667dcpgn8d084bg86hcly4n2-vim-full-9.1.0787-xxd"
+                "store_path": "/nix/store/6yp7nbqn40myinqmjbmfdam6nl6rxa8j-vim-full-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -185,37 +181,36 @@
               "xxd"
             ],
             "pname": "vim-full",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim-full",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/g785kmmcm2xl52rcxwidds9mipmhxnf8-vim-full-9.1.0787.drv",
+            "derivation": "/nix/store/mg1hrw76x0j1fslviqdh6pwmfwrjrwrq-vim-full-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim-full",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-full-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-full-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zcb44rlik2ma990d1g9jj7vk0hwawjzx-vim-full-9.1.0787"
+                "store_path": "/nix/store/j34s2g2i4jg64fyyhm5w4rhddny015q0-vim-full-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/nwjspmxxjfm3j6407j5fgya580bvvb3k-vim-full-9.1.0787-xxd"
+                "store_path": "/nix/store/nl0h6a5iifmdf4709rwwgbxnfkk69y8k-vim-full-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -223,37 +218,36 @@
               "xxd"
             ],
             "pname": "vim-full",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim-full",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/h75f1c60kdwh4i3vcipc7cr2mxg4qim2-vim-full-9.1.0787.drv",
+            "derivation": "/nix/store/z7k8avdnhnaiqxjxrms1w13wvjiihrlz-vim-full-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim-full",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-full-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-full-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/ba79sb6cmicmbxz4yk4dacj4zr424hpq-vim-full-9.1.0787"
+                "store_path": "/nix/store/ah4bvgxs4r0j64zhfjgdk99qpbbcd1i3-vim-full-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/dspd6484b3zqynpii3bw4csrfnl0jf99-vim-full-9.1.0787-xxd"
+                "store_path": "/nix/store/682syvkmjf5kkdf4vcb5lrcgs2ghnxbc-vim-full-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -261,37 +255,36 @@
               "xxd"
             ],
             "pname": "vim-full",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim-full",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/hprdkp0w6iwcana7wlckx1kkbhbkxm32-vim-full-9.1.0787.drv",
+            "derivation": "/nix/store/f8ra0r9wac23pzdb7p7isgkl287qpbjg-vim-full-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim-full",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-full-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-full-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/p1aawrrbd44fl9qs9d6ld41i92vasj2v-vim-full-9.1.0787"
+                "store_path": "/nix/store/914bd4khdw9frfm18z756h915r7lq4x0-vim-full-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/zcg4sir3ivhf585hl12k7qd3pcvkxgjw-vim-full-9.1.0787-xxd"
+                "store_path": "/nix/store/8vdmla64qjh2jb0nnrw8bniqlhhnxs3a-vim-full-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -299,20 +292,19 @@
               "xxd"
             ],
             "pname": "vim-full",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/vim.json
+++ b/test_data/generated/resolve/vim.json
@@ -11,21 +11,21 @@
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/rnpar5fbj0h7gidf1h066iwi5vi16a9y-vim-9.1.0787.drv",
+            "derivation": "/nix/store/k7pwn9a32s22syrbhf58cafk4s1i4pbl-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/8d473xm8x7ff6k5mqwma6hxgpjnf6alh-vim-9.1.0787"
+                "store_path": "/nix/store/rc1kfgzpb3aq5w7cj1adjb5yaqv4c2va-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/d6jx0lvmachd31rlnf71015rws4kpj3r-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/mi0chjhw4cmyl2yq0z1lz8gmskzrq6da-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -33,37 +33,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/x0lgcqq1qdnwwx4hf9k8njz8z20d5iz9-vim-9.1.0787.drv",
+            "derivation": "/nix/store/293nl3481mnav4l70bk4lba4n37gawi4-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zappfr3lr1xp0pxsjvllg4m3bsvjxgbf-vim-9.1.0787"
+                "store_path": "/nix/store/v5rz9y25dapc1j6q2xmgawgh5fgfa59q-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/v1rrv6z3bppr0xkfp3q7spmiaabgmszw-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/fb6h1rvcaf73pmvf7xlcn2ihh80xwymj-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -71,37 +70,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/k9n77kiw39pv4kwhhhl6gdlp947zp9q9-vim-9.1.0787.drv",
+            "derivation": "/nix/store/xri9bxkiw1lbnhba9032smdqs1gmq134-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/zsvr88wh53ha4d6ilv8lnil44svnsbvs-vim-9.1.0787"
+                "store_path": "/nix/store/ysnvbsyvysqm78pjbsw0zn7arlzp7yk8-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/73f1xnfkx8ghsqj30zn9k2vs4h75v8xj-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/ml8dj1b4zsi25652lf5cnz5qv8fl1swy-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -109,37 +107,36 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           },
           {
             "attr_path": "vim",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/0p8c65a0gp3qx8sjg46v01fnc6clvy2v-vim-9.1.0787.drv",
+            "derivation": "/nix/store/nlqlkb9pwhl6myjm3rm17bb6fsdyh37q-vim-9.1.0905.drv",
             "description": "Most popular clone of the VI editor",
             "insecure": false,
             "install_id": "vim",
             "license": "Vim",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "name": "vim-9.1.0787",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
+            "name": "vim-9.1.0905",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/862qv45cwbjj2n60iyscyj5ci2vzycdh-vim-9.1.0787"
+                "store_path": "/nix/store/g9x3rxi0p1dxbdyf222m0qprrw0anyg5-vim-9.1.0905"
               },
               {
                 "name": "xxd",
-                "store_path": "/nix/store/jkny5zx16y29fgnl45d29wcirna7gyvk-vim-9.1.0787-xxd"
+                "store_path": "/nix/store/v8k2x4bg8vbhwx1qgmz1cicf1ny01npy-vim-9.1.0905-xxd"
               }
             ],
             "outputs_to_install": [
@@ -147,20 +144,19 @@
               "xxd"
             ],
             "pname": "vim",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
             "unfree": false,
-            "version": "9.1.0787"
+            "version": "9.1.0905"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }

--- a/test_data/generated/resolve/webmention_ripgrep_rails.json
+++ b/test_data/generated/resolve/webmention_ripgrep_rails.json
@@ -11,29 +11,28 @@
             "attr_path": "rubyPackages_3_2.rails",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lqgp83jfawdmml07cnj5q2kvr8jpp2q9-ruby3.2-rails-7.1.3.4.drv",
+            "derivation": "/nix/store/r8ixlw9210v5hz3b0m9mcbqilhq9kwq9-ruby3.2-rails-7.1.3.4.drv",
             "description": null,
             "insecure": false,
             "install_id": "bar",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-rails-7.1.3.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/lpcawsrfa1ra2xgrgv8r26rxxcfyzc23-ruby3.2-rails-7.1.3.4"
+                "store_path": "/nix/store/hl0ilb3c622l1bmwcvixvizlkwrbv35b-ruby3.2-rails-7.1.3.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rails",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -44,29 +43,28 @@
             "attr_path": "rubyPackages_3_2.rails",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/1ss670h3mzqyppx1hmmxzvy6pfc64sy2-ruby3.2-rails-7.1.3.4.drv",
+            "derivation": "/nix/store/60bp740apn7p17jil0jj89hxxl29p5i8-ruby3.2-rails-7.1.3.4.drv",
             "description": null,
             "insecure": false,
             "install_id": "bar",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-rails-7.1.3.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/f7bxzksbw0ib9vsiaw6rjy1c03vxkgck-ruby3.2-rails-7.1.3.4"
+                "store_path": "/nix/store/406s2bzxpqbqym0407y7qqzl664c88fm-ruby3.2-rails-7.1.3.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rails",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -77,29 +75,28 @@
             "attr_path": "rubyPackages_3_2.rails",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/xh4j6qnm2j8z5z0ilwja53n6281hqv8m-ruby3.2-rails-7.1.3.4.drv",
+            "derivation": "/nix/store/yr1p8zr37jx15160dnrmlka47rnkd21h-ruby3.2-rails-7.1.3.4.drv",
             "description": null,
             "insecure": false,
             "install_id": "bar",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-rails-7.1.3.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/ny8i0j5g7dijf8r0873yd9rp6kmllbha-ruby3.2-rails-7.1.3.4"
+                "store_path": "/nix/store/jazhf1w541h5rr9pxlc2k41awwq33c4i-ruby3.2-rails-7.1.3.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rails",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -110,29 +107,28 @@
             "attr_path": "rubyPackages_3_2.rails",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/9wg4ap6g0jhiq6v9b0jwdq3k6gy5xh6f-ruby3.2-rails-7.1.3.4.drv",
+            "derivation": "/nix/store/7in5bhssmsrjd0c67rldqisy3by0vzgs-ruby3.2-rails-7.1.3.4.drv",
             "description": null,
             "insecure": false,
             "install_id": "bar",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-rails-7.1.3.4",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/3c3pc6lhz7hilcgv98c73gl9jm7m4ly2-ruby3.2-rails-7.1.3.4"
+                "store_path": "/nix/store/zd7sfm3hhlzanra5j9kdig2vs1bqycyn-ruby3.2-rails-7.1.3.4"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "rails",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -143,29 +139,28 @@
             "attr_path": "rubyPackages_3_2.webmention",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/pfr9casl48z0c1xcwq9ky061zdlgzl81-ruby3.2-webmention-7.0.0.drv",
+            "derivation": "/nix/store/53fa7ydkl2p2bb449kf6vydhv8sk1yq5-ruby3.2-webmention-7.0.0.drv",
             "description": null,
             "insecure": false,
             "install_id": "foo",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-webmention-7.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/7nsin6769zyidzc97yccqrvk03flmsgh-ruby3.2-webmention-7.0.0"
+                "store_path": "/nix/store/d4wsskb0yya5dbajmlcd6sgp9lv2lcs8-ruby3.2-webmention-7.0.0"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "webmention",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -176,29 +171,28 @@
             "attr_path": "rubyPackages_3_2.webmention",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/ga01mm3n9pjpy4b8q710zm37prjkrhqd-ruby3.2-webmention-7.0.0.drv",
+            "derivation": "/nix/store/r3af06xy55zr7j2vs42fi9nd086l64cl-ruby3.2-webmention-7.0.0.drv",
             "description": null,
             "insecure": false,
             "install_id": "foo",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-webmention-7.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/gg2lm7k0h4c94jg0rkgcn3yh7a7dkgl8-ruby3.2-webmention-7.0.0"
+                "store_path": "/nix/store/hjswy1msawa2dl333m9yn3wbl590mhvi-ruby3.2-webmention-7.0.0"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "webmention",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -209,29 +203,28 @@
             "attr_path": "rubyPackages_3_2.webmention",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/rfipw72yhqrlnz91f1vigcf88v2blwy9-ruby3.2-webmention-7.0.0.drv",
+            "derivation": "/nix/store/hjgvp82pacg5xgp1s18i7jd60bakb74d-ruby3.2-webmention-7.0.0.drv",
             "description": null,
             "insecure": false,
             "install_id": "foo",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-webmention-7.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/3djic7w07ya4wbcwmcskqyw54kyad49g-ruby3.2-webmention-7.0.0"
+                "store_path": "/nix/store/ixc5nhan0pdnh3x6qsrrb817mwjxd7ys-ruby3.2-webmention-7.0.0"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "webmention",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -242,29 +235,28 @@
             "attr_path": "rubyPackages_3_2.webmention",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/vccll66nvihmpzsjnlna209wq9r8gpy9-ruby3.2-webmention-7.0.0.drv",
+            "derivation": "/nix/store/y94ra6hdsv5iasplbflvjp52xqfcblxw-ruby3.2-webmention-7.0.0.drv",
             "description": null,
             "insecure": false,
             "install_id": "foo",
             "license": null,
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ruby3.2-webmention-7.0.0",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/1z3mf6sk0jzmmpjwha3fgg7362wwn7dz-ruby3.2-webmention-7.0.0"
+                "store_path": "/nix/store/bp1yzdlfrwpxmvljr62pmnhii7nrk2j8-ruby3.2-webmention-7.0.0"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "webmention",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -275,29 +267,28 @@
             "attr_path": "ripgrep",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/kdj55pb6gdkb1bbars63h5nssnl8ssmx-ripgrep-14.1.1.drv",
+            "derivation": "/nix/store/4fgy4faidncginahncsgz6m63fxcmxp9-ripgrep-14.1.1.drv",
             "description": "Utility that combines the usability of The Silver Searcher with the raw speed of grep",
             "insecure": false,
             "install_id": "ripgrep",
             "license": "[ Unlicense, MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ripgrep-14.1.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/jnyzzwi0n9nbwzqxq9j9qsv7qjqdlnri-ripgrep-14.1.1"
+                "store_path": "/nix/store/4rgiqk6445n5kf8bp4bssjxzfwy964wk-ripgrep-14.1.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "ripgrep",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-darwin",
@@ -308,29 +299,28 @@
             "attr_path": "ripgrep",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/8y58pq010yc2dj0migc5x1x6gnxaxb2a-ripgrep-14.1.1.drv",
+            "derivation": "/nix/store/wxcf3gj1bh210dcnvaz6gkc5g2rhz4gs-ripgrep-14.1.1.drv",
             "description": "Utility that combines the usability of The Silver Searcher with the raw speed of grep",
             "insecure": false,
             "install_id": "ripgrep",
             "license": "[ Unlicense, MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ripgrep-14.1.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/cn3x8hlhpz8fyp0f2qpbsh8jjlxlrfm3-ripgrep-14.1.1"
+                "store_path": "/nix/store/448sgrj1wai6q51mvda6irqcmbjgidly-ripgrep-14.1.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "ripgrep",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "aarch64-linux",
@@ -341,29 +331,28 @@
             "attr_path": "ripgrep",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/bzd6zhr1a5rz7qh6r5jqk10ll84czb9f-ripgrep-14.1.1.drv",
+            "derivation": "/nix/store/s4585g1kni66bbbg3mmhqgr6z4cs5k80-ripgrep-14.1.1.drv",
             "description": "Utility that combines the usability of The Silver Searcher with the raw speed of grep",
             "insecure": false,
             "install_id": "ripgrep",
             "license": "[ Unlicense, MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ripgrep-14.1.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/lf1zp7xmzjzkr7xw47flx0h88ixy293z-ripgrep-14.1.1"
+                "store_path": "/nix/store/wpwrhmi5slhvsk7s18zhl0shy08jdaas-ripgrep-14.1.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "ripgrep",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-darwin",
@@ -374,29 +363,28 @@
             "attr_path": "ripgrep",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/kin9b605pmn90l92y7p5nirzrvvfifna-ripgrep-14.1.1.drv",
+            "derivation": "/nix/store/ywmpmz80ms7ph7pvczf345s5hwqa8igd-ripgrep-14.1.1.drv",
             "description": "Utility that combines the usability of The Silver Searcher with the raw speed of grep",
             "insecure": false,
             "install_id": "ripgrep",
             "license": "[ Unlicense, MIT ]",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=130595eba61081acde9001f43de3248d8888ac4a",
             "name": "ripgrep-14.1.1",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/6gd9yardd6qk9dkgdbmh1vnac0vmkh7d-ripgrep-14.1.1"
+                "store_path": "/nix/store/a9fc2dnhwc0nmv1ync9inan025zs6qn3-ripgrep-14.1.1"
               }
             ],
             "outputs_to_install": [
               "out"
             ],
             "pname": "ripgrep",
-            "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
-            "rev_count": 710087,
-            "rev_date": "2024-11-19T11:04:08Z",
-            "scrape_date": "2024-11-21T04:00:36Z",
+            "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+            "rev_count": 736170,
+            "rev_date": "2025-01-10T15:43:18Z",
+            "scrape_date": "2025-01-13T03:35:32Z",
             "stabilities": [
-              "staging",
               "unstable"
             ],
             "system": "x86_64-linux",
@@ -404,7 +392,7 @@
             "version": "14.1.1"
           }
         ],
-        "page": 710087,
+        "page": 736170,
         "url": ""
       }
     }


### PR DESCRIPTION
## Release Notes

* Add `--dry-run` flag to `flox upgrade`

With `--dry-run` upgrade will use `Environment::dry_upgrade` to produce an upgrade result,
without changing the current environment.
If anything could be applied, the result is then rendered back to the user.

* Touch up the wording of upgrade messages