### PR TITLE
feat: Show full pkg path for custom catalog packages

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -10,7 +10,6 @@ use url::Url;
 
 use crate::data::FloxVersion;
 pub use crate::models::environment_ref::{self, *};
-use crate::models::search::SearchStrategy;
 use crate::providers::{catalog, flake_installable_locker};
 
 pub static FLOX_VERSION_STRING: LazyLock<String> =
@@ -70,9 +69,6 @@ impl Flox {}
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Features {
-    /// Which matching logic to use when searching for packages
-    #[serde(default)]
-    pub search_strategy: SearchStrategy,
     #[serde(default)]
     pub build: bool,
     #[serde(default)]

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1495,7 +1495,7 @@ pub(crate) mod tests {
     use self::catalog::PackageResolutionInfo;
     use super::*;
     use crate::models::manifest::{Manifest, RawManifest};
-    use crate::models::search::{PackageDetails, SearchLimit};
+    use crate::models::search::{PackageDetails, SearchLimit, SearchResults};
     use crate::providers::flake_installable_locker::{
         FlakeInstallableError,
         InstallableLockerMock,

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1495,7 +1495,7 @@ pub(crate) mod tests {
     use self::catalog::PackageResolutionInfo;
     use super::*;
     use crate::models::manifest::{Manifest, RawManifest};
-    use crate::models::search::{SearchLimit, SearchResults};
+    use crate::models::search::{SearchLimit, PackageDetails};
     use crate::providers::flake_installable_locker::{
         FlakeInstallableError,
         InstallableLockerMock,
@@ -1523,7 +1523,7 @@ pub(crate) mod tests {
         async fn package_versions(
             &self,
             _: impl AsRef<str> + Send + Sync,
-        ) -> Result<SearchResults, VersionsError> {
+        ) -> Result<PackageDetails, VersionsError> {
             unreachable!("package_versions should not be called");
         }
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1495,7 +1495,7 @@ pub(crate) mod tests {
     use self::catalog::PackageResolutionInfo;
     use super::*;
     use crate::models::manifest::{Manifest, RawManifest};
-    use crate::models::search::{SearchLimit, PackageDetails};
+    use crate::models::search::{PackageDetails, SearchLimit};
     use crate::providers::flake_installable_locker::{
         FlakeInstallableError,
         InstallableLockerMock,

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -27,26 +27,12 @@ pub type ResultCount = Option<u64>;
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchResult {
-    /// Which input the package came from
-    ///
-    /// This is also abused to be the name of the catalog.
-    /// At some point we should rename this to catalog.
-    pub input: String,
     /// The system that the package can be built for
     pub system: String,
-    /// The part of the attribute path after `<subtree>.<system>`.
-    ///
-    /// For an arbitrary flake this will simply be the name of the package, but
-    /// for nixpkgs this can be something like `python310Packages.flask`
-    pub attr_path: Vec<String>,
     /// The package path including catalog name
     pub pkg_path: String,
-    /// The package name
-    pub pname: Option<String>,
     /// The package version
     pub version: Option<String>,
     /// The package description
     pub description: Option<String>,
-    /// Which license the package is licensed under
-    pub license: Option<String>,
 }

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -25,12 +25,26 @@ pub type ResultCount = Option<u64>;
 
 pub type SearchResults = ResultsPage<SearchResult>;
 
-pub type PackageDetails = ResultsPage<SearchResult>;
+pub type PackageDetails = ResultsPage<PackageBuild>;
 
 /// A package search result
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchResult {
+    /// The system that the package can be built for
+    pub system: String,
+    /// The package path including catalog name
+    pub pkg_path: String,
+    /// The package version
+    pub version: Option<String>,
+    /// The package description
+    pub description: Option<String>,
+}
+
+/// Details about a single build of a package
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageBuild {
     /// The system that the package can be built for
     pub system: String,
     /// The package path including catalog name

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -1,8 +1,7 @@
 use std::num::NonZeroU8;
 
-use serde::{Deserialize, Serialize};
-
 use catalog_api_v1::types::{PackageInfoSearch, PackageResolutionInfo};
+use serde::{Deserialize, Serialize};
 
 pub type SearchLimit = Option<NonZeroU8>;
 

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -2,6 +2,8 @@ use std::num::NonZeroU8;
 
 use serde::{Deserialize, Serialize};
 
+use catalog_api_v1::types::{PackageInfoSearch, PackageResolutionInfo};
+
 pub type SearchLimit = Option<NonZeroU8>;
 
 /// Representation of search results.
@@ -14,34 +16,8 @@ pub struct ResultsPage<T> {
 }
 pub type ResultCount = Option<u64>;
 
+pub type SearchResult = PackageInfoSearch;
 pub type SearchResults = ResultsPage<SearchResult>;
 
+pub type PackageBuild = PackageResolutionInfo;
 pub type PackageDetails = ResultsPage<PackageBuild>;
-
-/// A package search result
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SearchResult {
-    /// The system that the package can be built for
-    pub system: String,
-    /// The package path including catalog name
-    pub pkg_path: String,
-    /// The package version
-    pub version: Option<String>,
-    /// The package description
-    pub description: Option<String>,
-}
-
-/// Details about a single build of a package
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PackageBuild {
-    /// The system that the package can be built for
-    pub system: String,
-    /// The package path including catalog name
-    pub pkg_path: String,
-    /// The package version
-    pub version: Option<String>,
-    /// The package description
-    pub description: Option<String>,
-}

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -4,15 +4,6 @@ use serde::{Deserialize, Serialize};
 
 pub type SearchLimit = Option<NonZeroU8>;
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Default, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum SearchStrategy {
-    Match,
-    MatchName,
-    #[default]
-    MatchNameOrRelPath,
-}
-
 /// Representation of search results.
 /// Created via [crate::providers::catalog::ClientTrait::search],
 /// which translates raw api responses to this struct.

--- a/cli/flox-rust-sdk/src/models/search.rs
+++ b/cli/flox-rust-sdk/src/models/search.rs
@@ -17,11 +17,15 @@ pub enum SearchStrategy {
 /// Created via [crate::providers::catalog::ClientTrait::search],
 /// which translates raw api responses to this struct.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SearchResults {
-    pub results: Vec<SearchResult>,
+pub struct ResultsPage<T> {
+    pub results: Vec<T>,
     pub count: ResultCount,
 }
 pub type ResultCount = Option<u64>;
+
+pub type SearchResults = ResultsPage<SearchResult>;
+
+pub type PackageDetails = ResultsPage<SearchResult>;
 
 /// A package search result
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1261,18 +1261,9 @@ impl TryFrom<PackageInfoSearch> for SearchResult {
 
     fn try_from(package_info: PackageInfoSearch) -> Result<Self, SearchError> {
         Ok(Self {
-            input: package_info.catalog.unwrap_or(NIXPKGS_CATALOG.to_string()),
             system: package_info.system.to_string(),
-            // The server does not include legacyPackages.<system> in attr_path
-            attr_path: package_info
-                .attr_path
-                .split('.')
-                .map(String::from)
-                .collect(),
-            pname: Some(package_info.pname),
             version: None,
             description: package_info.description,
-            license: None,
             pkg_path: package_info.pkg_path,
         })
     }
@@ -1283,18 +1274,9 @@ impl TryFrom<api_types::PackageResolutionInfo> for SearchResult {
 
     fn try_from(package_info: api_types::PackageResolutionInfo) -> Result<Self, VersionsError> {
         Ok(Self {
-            input: package_info.catalog.unwrap_or(NIXPKGS_CATALOG.to_string()),
             system: package_info.system.to_string(),
-            // The server does not include legacyPackages.<system> in attr_path
-            attr_path: package_info
-                .attr_path
-                .split('.')
-                .map(String::from)
-                .collect(),
-            pname: Some(package_info.pname),
             version: Some(package_info.version),
             description: package_info.description,
-            license: package_info.license,
             pkg_path: package_info.pkg_path,
         })
     }

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -769,7 +769,7 @@ impl ClientTrait for MockClient {
                 err.try_into()
                     .expect("couldn't convert mock error response"),
             )),
-            _ => panic!("expected resolve response, found {:?}", &mock_resp),
+            _ => panic!("expected search response, found {:?}", &mock_resp),
         }
     }
 
@@ -788,7 +788,7 @@ impl ClientTrait for MockClient {
                 err.try_into()
                     .expect("couldn't convert mock error response"),
             )),
-            _ => panic!("expected resolve response, found {:?}", &mock_resp),
+            _ => panic!("expected packages response, found {:?}", &mock_resp),
         }
     }
 

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -17,7 +17,6 @@ use catalog_api_v1::types::{
     ErrorResponse,
     MessageLevel,
     MessageType,
-    PackageInfoSearch,
     ResolutionMessageGeneral,
 };
 use catalog_api_v1::{Client as APIClient, Error as APIError, ResponseValue};
@@ -34,7 +33,7 @@ use tracing::instrument;
 
 use crate::data::System;
 use crate::flox::FLOX_VERSION;
-use crate::models::search::{PackageBuild, PackageDetails, ResultCount, SearchLimit, SearchResult, SearchResults};
+use crate::models::search::{PackageDetails, ResultCount, SearchLimit, SearchResults};
 use crate::utils::traceable_path;
 
 const NIXPKGS_CATALOG: &str = "nixpkgs";
@@ -487,11 +486,7 @@ impl ClientTrait for CatalogClient {
 
                 Ok::<_, SearchError>((
                     packages.total_count,
-                    packages
-                        .items
-                        .into_iter()
-                        .map(TryInto::<SearchResult>::try_into)
-                        .collect::<Result<Vec<_>, _>>()?,
+                    packages.items
                 ))
             },
             page_size,
@@ -531,11 +526,7 @@ impl ClientTrait for CatalogClient {
 
                 Ok::<_, VersionsError>((
                     packages.total_count,
-                    packages
-                        .items
-                        .into_iter()
-                        .map(TryInto::<PackageBuild>::try_into)
-                        .collect::<Result<Vec<_>, _>>()?,
+                    packages.items
                 ))
             },
             RESPONSE_PAGE_SIZE,
@@ -1256,32 +1247,6 @@ impl From<api_types::CatalogPageInput> for CatalogPage {
 /// We should consider whether adding a shim to [api_types::PackageResolutionInfo]
 /// is not adding unnecessary complexity.
 pub type PackageResolutionInfo = api_types::ResolvedPackageDescriptor;
-
-impl TryFrom<PackageInfoSearch> for SearchResult {
-    type Error = SearchError;
-
-    fn try_from(package_info: PackageInfoSearch) -> Result<Self, SearchError> {
-        Ok(Self {
-            system: package_info.system.to_string(),
-            version: None,
-            description: package_info.description,
-            pkg_path: package_info.pkg_path,
-        })
-    }
-}
-
-impl TryFrom<api_types::PackageResolutionInfo> for PackageBuild {
-    type Error = VersionsError;
-
-    fn try_from(package_info: api_types::PackageResolutionInfo) -> Result<Self, VersionsError> {
-        Ok(Self {
-            system: package_info.system.to_string(),
-            version: Some(package_info.version),
-            description: package_info.description,
-            pkg_path: package_info.pkg_path,
-        })
-    }
-}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SearchTerm {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -484,10 +484,7 @@ impl ClientTrait for CatalogClient {
 
                 let packages = response.into_inner();
 
-                Ok::<_, SearchError>((
-                    packages.total_count,
-                    packages.items
-                ))
+                Ok::<_, SearchError>((packages.total_count, packages.items))
             },
             page_size,
         );
@@ -524,10 +521,7 @@ impl ClientTrait for CatalogClient {
 
                 let packages = response.into_inner();
 
-                Ok::<_, VersionsError>((
-                    packages.total_count,
-                    packages.items
-                ))
+                Ok::<_, VersionsError>((packages.total_count, packages.items))
             },
             RESPONSE_PAGE_SIZE,
         );

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1282,11 +1282,6 @@ impl TryFrom<api_types::PackageResolutionInfo> for SearchResult {
     type Error = VersionsError;
 
     fn try_from(package_info: api_types::PackageResolutionInfo) -> Result<Self, VersionsError> {
-        let pkg_path = match &package_info.catalog {
-            Some(catalog) => format!("{}/{}", catalog, package_info.attr_path),
-            None => package_info.attr_path.clone(),
-        };
-
         Ok(Self {
             input: package_info.catalog.unwrap_or(NIXPKGS_CATALOG.to_string()),
             system: package_info.system.to_string(),
@@ -1300,7 +1295,7 @@ impl TryFrom<api_types::PackageResolutionInfo> for SearchResult {
             version: Some(package_info.version),
             description: package_info.description,
             license: package_info.license,
-            pkg_path,
+            pkg_path: package_info.pkg_path,
         })
     }
 }

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -34,7 +34,7 @@ use tracing::instrument;
 
 use crate::data::System;
 use crate::flox::FLOX_VERSION;
-use crate::models::search::{ResultCount, SearchLimit, SearchResult, SearchResults, PackageDetails};
+use crate::models::search::{PackageBuild, PackageDetails, ResultCount, SearchLimit, SearchResult, SearchResults};
 use crate::utils::traceable_path;
 
 const NIXPKGS_CATALOG: &str = "nixpkgs";
@@ -534,7 +534,7 @@ impl ClientTrait for CatalogClient {
                     packages
                         .items
                         .into_iter()
-                        .map(TryInto::<SearchResult>::try_into)
+                        .map(TryInto::<PackageBuild>::try_into)
                         .collect::<Result<Vec<_>, _>>()?,
                 ))
             },
@@ -1270,7 +1270,7 @@ impl TryFrom<PackageInfoSearch> for SearchResult {
     }
 }
 
-impl TryFrom<api_types::PackageResolutionInfo> for SearchResult {
+impl TryFrom<api_types::PackageResolutionInfo> for PackageBuild {
     type Error = VersionsError;
 
     fn try_from(package_info: api_types::PackageResolutionInfo) -> Result<Self, VersionsError> {

--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::data::System;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::search::{SearchResult, PackageDetails};
+use flox_rust_sdk::models::search::{PackageBuild, PackageDetails};
 use flox_rust_sdk::providers::catalog::{ClientTrait, VersionsError};
 use tracing::instrument;
 
@@ -59,7 +59,7 @@ impl Show {
 }
 
 fn render_show_catalog(
-    search_results: &[SearchResult],
+    search_results: &[PackageBuild],
     expected_systems: &HashSet<System>,
 ) -> Result<()> {
     if search_results.is_empty() {
@@ -80,10 +80,6 @@ fn render_show_catalog(
     let version_to_systems = {
         let mut map = BTreeMap::new();
         for pkg in search_results.iter() {
-            // The `version` field on `SearchResult` is optional for compatibility with `pkgdb`.
-            // Every package from the catalog will have a version, but right now `search` and `show`
-            // both convert to `SearchResult` with this optional `version` field for compatibility
-            // with `pkgdb` even though with the catalog we get much more data.
             if let Some(ref version) = pkg.version {
                 map.entry(version.clone())
                     .or_insert(HashSet::new())

--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -67,13 +67,14 @@ fn render_show_catalog(
         // set of results is non-empty.
         bail!("no packages found");
     }
-    let pkg_name = search_results[0].attr_path.join(".");
+    let pkg_path = search_results[0].pkg_path.clone();
     let description = search_results[0]
         .description
         .as_ref()
         .map(|d| d.replace('\n', " "))
+        .filter(|d| !d.trim().is_empty())
         .unwrap_or(DEFAULT_DESCRIPTION.into());
-    println!("{pkg_name} - {description}");
+    println!("{pkg_path} - {description}");
 
     // Organize the versions to be queried and printed
     let version_to_systems = {
@@ -117,11 +118,11 @@ fn render_show_catalog(
             };
             if available_systems.len() != expected_systems.len() {
                 println!(
-                    "    {pkg_name}@{version} ({} only)",
+                    "    {pkg_path}@{version} ({} only)",
                     available_systems.join(", ")
                 );
             } else {
-                println!("    {pkg_name}@{version}");
+                println!("    {pkg_path}@{version}");
             }
             seen_versions.insert(version);
         }

--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::data::System;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::search::{SearchResult, SearchResults};
+use flox_rust_sdk::models::search::{SearchResult, PackageDetails};
 use flox_rust_sdk::providers::catalog::{ClientTrait, VersionsError};
 use tracing::instrument;
 
@@ -34,7 +34,7 @@ impl Show {
             // didn't match a package.
             // So translate 404 into an empty vec![].
             // Once we drop the pkgdb code path, we can clean this up.
-            Err(VersionsError::Versions(e)) if e.status() == 404 => SearchResults {
+            Err(VersionsError::Versions(e)) if e.status() == 404 => PackageDetails {
                 results: vec![],
                 count: None::<u64>,
             },

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -161,26 +161,32 @@ impl DisplaySearchResults {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use flox_rust_sdk::models::search::SearchResult;
+    use flox_rust_sdk::providers::catalog::SystemEnum;
     use indoc::indoc;
 
     use super::*;
 
+    fn stub_search_result(name: &str, description: Option<&str>) -> SearchResult {
+        SearchResult {
+            attr_path: name.to_string(),
+            name: name.to_string(),
+            pname: name.to_string(),
+            stabilities: vec![],
+            system: SystemEnum::from_str("aarch64-darwin").unwrap(),
+            catalog: None,
+            pkg_path: name.to_string(),
+            description: description.map(|s| s.to_string()),
+        }
+    }
+
     #[test]
     fn test_display_search_result() {
         let search_results = vec![
-            SearchResult {
-                input: "nixpkgs".to_string(),
-                pkg_path: "pkg1".to_string(),
-                description: Some("description of pkg1".to_string()),
-                ..Default::default()
-            },
-            SearchResult {
-                input: "mycatalog".to_string(),
-                pkg_path: "mycatalog/pkg1".to_string(),
-                description: Some("description of mycatalog/pkg1".to_string()),
-                ..Default::default()
-            },
+            stub_search_result("pkg1", Some("description of pkg1")),
+            stub_search_result("mycatalog/pkg1", Some("description of mycatalog/pkg1")),
         ];
 
         let display = DisplaySearchResults {
@@ -201,16 +207,8 @@ mod tests {
     #[test]
     fn test_display_empty_description() {
         let search_results = vec![
-            SearchResult {
-                pkg_path: "pkg1".to_string(),
-                description: None,
-                ..Default::default()
-            },
-            SearchResult {
-                pkg_path: "pkg2".to_string(),
-                description: Some("".to_string()),
-                ..Default::default()
-            },
+            stub_search_result("pkg1", None),
+            stub_search_result("pkg2", Some("")),
         ];
 
         let display = DisplaySearchResults {

--- a/test_data/generated/resolve/node_suggestions.json
+++ b/test_data/generated/resolve/node_suggestions.json
@@ -19,40 +19,34 @@
     "count": 70,
     "results": [
       {
-        "attrPath": [
-          "nodejs"
-        ],
+        "attr_path": "nodejs",
+        "catalog": null,
         "description": "Event-driven I/O framework for the V8 JavaScript engine",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "nodejs",
+        "name": "nodejs-22.11.0",
+        "pkg_path": "nodejs",
         "pname": "nodejs",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "nodejs_14"
-        ],
+        "attr_path": "nodejs_14",
+        "catalog": null,
         "description": "Event-driven I/O framework for the V8 JavaScript engine",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "nodejs_14",
+        "name": "nodejs-14.21.3",
+        "pkg_path": "nodejs_14",
         "pname": "nodejs_14",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "nodejs_16"
-        ],
+        "attr_path": "nodejs_16",
+        "catalog": null,
         "description": "Event-driven I/O framework for the V8 JavaScript engine",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "nodejs_16",
+        "name": "nodejs-16.20.2",
+        "pkg_path": "nodejs_16",
         "pname": "nodejs_16",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       }
     ]
   }

--- a/test_data/generated/resolve/package_suggestions.json
+++ b/test_data/generated/resolve/package_suggestions.json
@@ -19,40 +19,34 @@
     "count": 3496,
     "results": [
       {
-        "attrPath": [
-          "packagekit"
-        ],
+        "attr_path": "packagekit",
+        "catalog": null,
         "description": "System to facilitate installing and updating packages",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "packagekit",
+        "name": "packagekit-1.3.0",
+        "pkg_path": "packagekit",
         "pname": "packagekit",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "psc-package"
-        ],
+        "attr_path": "psc-package",
+        "catalog": null,
         "description": "Package manager for PureScript based on package sets",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "psc-package",
+        "name": "psc-package-simple-0.6.2",
+        "pkg_path": "psc-package",
         "pname": "psc-package",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "patch-package"
-        ],
+        "attr_path": "patch-package",
+        "catalog": null,
         "description": "Fix broken node modules instantly",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "patch-package",
+        "name": "patch-package-8.0.0",
+        "pkg_path": "patch-package",
         "pname": "patch-package",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       }
     ]
   }

--- a/test_data/generated/search/ello_all.json
+++ b/test_data/generated/search/ello_all.json
@@ -3,877 +3,684 @@
     "count": 68,
     "results": [
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "catalog": null,
         "description": "Program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello",
+        "name": "hello-2.12.1",
+        "pkg_path": "hello",
         "pname": "hello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "jello"
-        ],
+        "attr_path": "jello",
+        "catalog": null,
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "jello",
+        "name": "jello-1.6.0",
+        "pkg_path": "jello",
         "pname": "jello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hello-go"
-        ],
+        "attr_path": "hello-go",
+        "catalog": null,
         "description": "Simple program printing hello world in Go",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello-go",
+        "name": "hello-go",
+        "pkg_path": "hello-go",
         "pname": "hello-go",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "libcello"
-        ],
+        "attr_path": "libcello",
+        "catalog": null,
         "description": "Higher level programming in C",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "libcello",
+        "name": "libcello-2.1.0",
+        "pkg_path": "libcello",
         "pname": "libcello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hello-cpp"
-        ],
+        "attr_path": "hello-cpp",
+        "catalog": null,
         "description": "Basic sanity check that C++ and cmake infrastructure are working",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello-cpp",
+        "name": "hello-cpp",
+        "pkg_path": "hello-cpp",
         "pname": "hello-cpp",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "nwg-hello"
-        ],
+        "attr_path": "nwg-hello",
+        "catalog": null,
         "description": "GTK3-based greeter for the greetd daemon, written in python",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "nwg-hello",
+        "name": "nwg-hello-0.3.0",
+        "pkg_path": "nwg-hello",
         "pname": "nwg-hello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "cannelloni"
-        ],
+        "attr_path": "cannelloni",
+        "catalog": null,
         "description": "SocketCAN over Ethernet tunnel",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "cannelloni",
+        "name": "cannelloni-1.1.0",
+        "pkg_path": "cannelloni",
         "pname": "cannelloni",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hello-unfree"
-        ],
+        "attr_path": "hello-unfree",
+        "catalog": null,
         "description": "Example package with unfree license (for testing)",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello-unfree",
+        "name": "example-unfree-package-1.0",
+        "pkg_path": "hello-unfree",
         "pname": "hello-unfree",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "mellowplayer"
-        ],
+        "attr_path": "mellowplayer",
+        "catalog": null,
         "description": "Cloud music integration for your desktop",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "mellowplayer",
+        "name": "MellowPlayer-3.6.8",
+        "pkg_path": "mellowplayer",
         "pname": "mellowplayer",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hello-wayland"
-        ],
+        "attr_path": "hello-wayland",
+        "catalog": null,
         "description": "Hello world Wayland client",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello-wayland",
+        "name": "hello-wayland-0-unstable-2024-03-04",
+        "pkg_path": "hello-wayland",
         "pname": "hello-wayland",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "marwaita-yellow"
-        ],
+        "attr_path": "marwaita-yellow",
+        "catalog": null,
         "description": "Marwaita GTK theme with Pop_os Linux style",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "marwaita-yellow",
+        "name": "marwaita-yellow-23",
+        "pkg_path": "marwaita-yellow",
         "pname": "marwaita-yellow",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "libsForQt5",
-          "umbrello"
-        ],
+        "attr_path": "libsForQt5.umbrello",
+        "catalog": null,
         "description": "Unified Modelling Language (UML) diagram program",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "libsForQt5.umbrello",
+        "name": "umbrello-23.08.5",
+        "pkg_path": "libsForQt5.umbrello",
         "pname": "umbrello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "fcitx5-mellow-themes"
-        ],
+        "attr_path": "fcitx5-mellow-themes",
+        "catalog": null,
         "description": "Aesthetic, modern fcitx5 theme featuring rounded rectangle design",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "fcitx5-mellow-themes",
+        "name": "fcitx5-mellow-themes-0-unstable-2024-11-11",
+        "pkg_path": "fcitx5-mellow-themes",
         "pname": "fcitx5-mellow-themes",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "kdePackages",
-          "umbrello"
-        ],
+        "attr_path": "kdePackages.umbrello",
+        "catalog": null,
         "description": "GUI for diagramming Unified Modelling Language (UML)",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "kdePackages.umbrello",
+        "name": "umbrello-24.12.1",
+        "pkg_path": "kdePackages.umbrello",
         "pname": "umbrello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "libsForQt512",
-          "umbrello"
-        ],
+        "attr_path": "libsForQt512.umbrello",
+        "catalog": null,
         "description": "A Unified Modelling Language (UML) diagram program",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "libsForQt512.umbrello",
+        "name": "umbrello-22.08.3",
+        "pkg_path": "libsForQt512.umbrello",
         "pname": "umbrello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "libsForQt514",
-          "umbrello"
-        ],
+        "attr_path": "libsForQt514.umbrello",
+        "catalog": null,
         "description": "A Unified Modelling Language (UML) diagram program",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "libsForQt514.umbrello",
+        "name": "umbrello-22.08.3",
+        "pkg_path": "libsForQt514.umbrello",
         "pname": "umbrello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "libsForQt515",
-          "umbrello"
-        ],
+        "attr_path": "libsForQt515.umbrello",
+        "catalog": null,
         "description": "A Unified Modelling Language (UML) diagram program",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "libsForQt515.umbrello",
+        "name": "umbrello-22.08.3",
+        "pkg_path": "libsForQt515.umbrello",
         "pname": "umbrello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "emacsPackages",
-          "ellocate"
-        ],
+        "attr_path": "emacsPackages.ellocate",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "emacsPackages.ellocate",
+        "name": "emacs-ellocate-20200112.1931",
+        "pkg_path": "emacsPackages.ellocate",
         "pname": "ellocate",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "jello"
-        ],
+        "attr_path": "python310Packages.jello",
+        "catalog": null,
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python310Packages.jello",
+        "name": "python3.10-jello-1.6.0",
+        "pkg_path": "python310Packages.jello",
         "pname": "jello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python311Packages",
-          "jello"
-        ],
+        "attr_path": "python311Packages.jello",
+        "catalog": null,
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python311Packages.jello",
+        "name": "python3.11-jello-1.6.0",
+        "pkg_path": "python311Packages.jello",
         "pname": "jello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python312Packages",
-          "jello"
-        ],
+        "attr_path": "python312Packages.jello",
+        "catalog": null,
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python312Packages.jello",
+        "name": "jello-1.6.0",
+        "pkg_path": "python312Packages.jello",
         "pname": "jello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python313Packages",
-          "jello"
-        ],
+        "attr_path": "python313Packages.jello",
+        "catalog": null,
         "description": "CLI tool to filter JSON and JSON Lines data with Python syntax",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python313Packages.jello",
+        "name": "python3.13-jello-1.6.0",
+        "pkg_path": "python313Packages.jello",
         "pname": "jello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "sbclPackages",
-          "hello-clog"
-        ],
+        "attr_path": "sbclPackages.hello-clog",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "sbclPackages.hello-clog",
+        "name": "sbcl-hello-clog-20241012-git",
+        "pkg_path": "sbclPackages.hello-clog",
         "pname": "hello-clog",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "texlivePackages",
-          "othello"
-        ],
+        "attr_path": "texlivePackages.othello",
+        "catalog": null,
         "description": "Modification of a Go package to create othello boards",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "texlivePackages.othello",
+        "name": "othello-15878",
+        "pkg_path": "texlivePackages.othello",
         "pname": "othello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "emacsPackages",
-          "org-trello"
-        ],
+        "attr_path": "emacsPackages.org-trello",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "emacsPackages.org-trello",
+        "name": "emacs-org-trello-20210314.1901",
+        "pkg_path": "emacsPackages.org-trello",
         "pname": "org-trello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "plasma5Packages",
-          "umbrello"
-        ],
+        "attr_path": "plasma5Packages.umbrello",
+        "catalog": null,
         "description": "Unified Modelling Language (UML) diagram program",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "plasma5Packages.umbrello",
+        "name": "umbrello-23.08.5",
+        "pkg_path": "plasma5Packages.umbrello",
         "pname": "umbrello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python37Packages",
-          "bellows"
-        ],
+        "attr_path": "python37Packages.bellows",
+        "catalog": null,
         "description": "A Python 3 project to implement EZSP for EmberZNet devices",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python37Packages.bellows",
+        "name": "python3.7-bellows-0.21.0",
+        "pkg_path": "python37Packages.bellows",
         "pname": "bellows",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python38Packages",
-          "bellows"
-        ],
+        "attr_path": "python38Packages.bellows",
+        "catalog": null,
         "description": "Python module to implement EZSP for EmberZNet devices",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python38Packages.bellows",
+        "name": "python3.8-bellows-0.29.0",
+        "pkg_path": "python38Packages.bellows",
         "pname": "bellows",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python38Packages",
-          "pynello"
-        ],
+        "attr_path": "python38Packages.pynello",
+        "catalog": null,
         "description": "Python library for nello.io intercoms",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python38Packages.pynello",
+        "name": "python3.8-pynello-2.0.3",
+        "pkg_path": "python38Packages.pynello",
         "pname": "pynello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python39Packages",
-          "bellows"
-        ],
+        "attr_path": "python39Packages.bellows",
+        "catalog": null,
         "description": "Python module to implement EZSP for EmberZNet devices",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python39Packages.bellows",
+        "name": "python3.9-bellows-0.34.5",
+        "pkg_path": "python39Packages.bellows",
         "pname": "bellows",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python39Packages",
-          "pynello"
-        ],
+        "attr_path": "python39Packages.pynello",
+        "catalog": null,
         "description": "Python library for nello.io intercoms",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python39Packages.pynello",
+        "name": "python3.9-pynello-2.0.3",
+        "pkg_path": "python39Packages.pynello",
         "pname": "pynello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "bellows"
-        ],
+        "attr_path": "python310Packages.bellows",
+        "catalog": null,
         "description": "Python module to implement EZSP for EmberZNet devices",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python310Packages.bellows",
+        "name": "python3.10-bellows-0.37.6",
+        "pkg_path": "python310Packages.bellows",
         "pname": "bellows",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "pynello"
-        ],
+        "attr_path": "python310Packages.pynello",
+        "catalog": null,
         "description": "Python library for nello.io intercoms",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python310Packages.pynello",
+        "name": "python3.10-pynello-2.0.3",
+        "pkg_path": "python310Packages.pynello",
         "pname": "pynello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python311Packages",
-          "bellows"
-        ],
+        "attr_path": "python311Packages.bellows",
+        "catalog": null,
         "description": "Python module to implement EZSP for EmberZNet devices",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python311Packages.bellows",
+        "name": "python3.11-bellows-0.42.0",
+        "pkg_path": "python311Packages.bellows",
         "pname": "bellows",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python311Packages",
-          "pynello"
-        ],
+        "attr_path": "python311Packages.pynello",
+        "catalog": null,
         "description": "Python library for nello.io intercoms",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python311Packages.pynello",
+        "name": "python3.11-pynello-2.0.3",
+        "pkg_path": "python311Packages.pynello",
         "pname": "pynello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python312Packages",
-          "bellows"
-        ],
+        "attr_path": "python312Packages.bellows",
+        "catalog": null,
         "description": "Python module to implement EZSP for EmberZNet devices",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python312Packages.bellows",
+        "name": "python3.12-bellows-0.42.6",
+        "pkg_path": "python312Packages.bellows",
         "pname": "bellows",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python312Packages",
-          "pynello"
-        ],
+        "attr_path": "python312Packages.pynello",
+        "catalog": null,
         "description": "Python library for nello.io intercoms",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python312Packages.pynello",
+        "name": "python3.12-pynello-2.0.3",
+        "pkg_path": "python312Packages.pynello",
         "pname": "pynello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python313Packages",
-          "bellows"
-        ],
+        "attr_path": "python313Packages.bellows",
+        "catalog": null,
         "description": "Python module to implement EZSP for EmberZNet devices",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python313Packages.bellows",
+        "name": "python3.13-bellows-0.42.6",
+        "pkg_path": "python313Packages.bellows",
         "pname": "bellows",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python313Packages",
-          "pynello"
-        ],
+        "attr_path": "python313Packages.pynello",
+        "catalog": null,
         "description": "Python library for nello.io intercoms",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python313Packages.pynello",
+        "name": "python3.13-pynello-2.0.3",
+        "pkg_path": "python313Packages.pynello",
         "pname": "pynello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "emacsPackages",
-          "mellow-theme"
-        ],
+        "attr_path": "emacsPackages.mellow-theme",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "emacsPackages.mellow-theme",
+        "name": "emacs-mellow-theme-20170808.1317",
+        "pkg_path": "emacsPackages.mellow-theme",
         "pname": "mellow-theme",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "perlPackages",
-          "ParallelLoops"
-        ],
+        "attr_path": "perlPackages.ParallelLoops",
+        "catalog": null,
         "description": "Execute loops using parallel forked subprocesses",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "perlPackages.ParallelLoops",
+        "name": "perl5.40.0-Parallel-Loops-0.12",
+        "pkg_path": "perlPackages.ParallelLoops",
         "pname": "ParallelLoops",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "sbclPackages",
-          "hello-builder"
-        ],
+        "attr_path": "sbclPackages.hello-builder",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "sbclPackages.hello-builder",
+        "name": "sbcl-hello-builder-20241012-git",
+        "pkg_path": "sbclPackages.hello-builder",
         "pname": "hello-builder",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "javaPackages",
-          "mavenHello_1_0"
-        ],
+        "attr_path": "javaPackages.mavenHello_1_0",
+        "catalog": null,
         "description": "Maven Hello World",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "javaPackages.mavenHello_1_0",
+        "name": "maven-hello-1.0",
+        "pkg_path": "javaPackages.mavenHello_1_0",
         "pname": "mavenHello_1_0",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "javaPackages",
-          "mavenHello_1_1"
-        ],
+        "attr_path": "javaPackages.mavenHello_1_1",
+        "catalog": null,
         "description": "Maven Hello World",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "javaPackages.mavenHello_1_1",
+        "name": "maven-hello-1.1",
+        "pkg_path": "javaPackages.mavenHello_1_1",
         "pname": "mavenHello_1_1",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "texlivePackages",
-          "othelloboard"
-        ],
+        "attr_path": "texlivePackages.othelloboard",
+        "catalog": null,
         "description": "Typeset Othello (Reversi) diagrams of any size, with annotations",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "texlivePackages.othelloboard",
+        "name": "othelloboard-1.2",
+        "pkg_path": "texlivePackages.othelloboard",
         "pname": "othelloboard",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "emacsPackages",
-          "sly-hello-world"
-        ],
+        "attr_path": "emacsPackages.sly-hello-world",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "emacsPackages.sly-hello-world",
+        "name": "emacs-sly-hello-world-20200225.1755",
+        "pkg_path": "emacsPackages.sly-hello-world",
         "pname": "sly-hello-world",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "perl536Packages",
-          "ParallelLoops"
-        ],
+        "attr_path": "perl536Packages.ParallelLoops",
+        "catalog": null,
         "description": "Execute loops using parallel forked subprocesses",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "perl536Packages.ParallelLoops",
+        "name": "perl5.36.3-Parallel-Loops-0.12",
+        "pkg_path": "perl536Packages.ParallelLoops",
         "pname": "ParallelLoops",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "perl538Packages",
-          "ParallelLoops"
-        ],
+        "attr_path": "perl538Packages.ParallelLoops",
+        "catalog": null,
         "description": "Execute loops using parallel forked subprocesses",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "perl538Packages.ParallelLoops",
+        "name": "perl5.38.2-Parallel-Loops-0.12",
+        "pkg_path": "perl538Packages.ParallelLoops",
         "pname": "ParallelLoops",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "perl540Packages",
-          "ParallelLoops"
-        ],
+        "attr_path": "perl540Packages.ParallelLoops",
+        "catalog": null,
         "description": "Execute loops using parallel forked subprocesses",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "perl540Packages.ParallelLoops",
+        "name": "perl5.40.0-Parallel-Loops-0.12",
+        "pkg_path": "perl540Packages.ParallelLoops",
         "pname": "ParallelLoops",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "sbclPackages",
-          "qtools-helloworld"
-        ],
+        "attr_path": "sbclPackages.qtools-helloworld",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "sbclPackages.qtools-helloworld",
+        "name": "sbcl-qtools-helloworld-20230214-git",
+        "pkg_path": "sbclPackages.qtools-helloworld",
         "pname": "qtools-helloworld",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "libsForQt5_openssl_1_1",
-          "umbrello"
-        ],
+        "attr_path": "libsForQt5_openssl_1_1.umbrello",
+        "catalog": null,
         "description": "A Unified Modelling Language (UML) diagram program",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "libsForQt5_openssl_1_1.umbrello",
+        "name": "umbrello-22.08.1",
+        "pkg_path": "libsForQt5_openssl_1_1.umbrello",
         "pname": "umbrello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "apacheHttpdPackages",
-          "mod_auth_mellon"
-        ],
+        "attr_path": "apacheHttpdPackages.mod_auth_mellon",
+        "catalog": null,
         "description": "Apache module with a simple SAML 2.0 service provider",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "apacheHttpdPackages.mod_auth_mellon",
+        "name": "mod_auth_mellon-0.19.1",
+        "pkg_path": "apacheHttpdPackages.mod_auth_mellon",
         "pname": "mod_auth_mellon",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "apacheHttpdPackages_2_4",
-          "mod_auth_mellon"
-        ],
+        "attr_path": "apacheHttpdPackages_2_4.mod_auth_mellon",
+        "catalog": null,
         "description": "Apache module with a simple SAML 2.0 service provider",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "apacheHttpdPackages_2_4.mod_auth_mellon",
+        "name": "mod_auth_mellon-0.19.1",
+        "pkg_path": "apacheHttpdPackages_2_4.mod_auth_mellon",
         "pname": "mod_auth_mellon",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "lispPackages_new",
-          "sbclPackages",
-          "hello-clog"
-        ],
+        "attr_path": "lispPackages_new.sbclPackages.hello-clog",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "lispPackages_new.sbclPackages.hello-clog",
+        "name": "hello-clog-20221106-git",
+        "pkg_path": "lispPackages_new.sbclPackages.hello-clog",
         "pname": "hello-clog",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "lispPackages_new",
-          "sbclPackages",
-          "hello-builder"
-        ],
+        "attr_path": "lispPackages_new.sbclPackages.hello-builder",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "lispPackages_new.sbclPackages.hello-builder",
+        "name": "hello-builder-20221106-git",
+        "pkg_path": "lispPackages_new.sbclPackages.hello-builder",
         "pname": "hello-builder",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "lispPackages_new",
-          "sbclPackages",
-          "qtools-helloworld"
-        ],
+        "attr_path": "lispPackages_new.sbclPackages.qtools-helloworld",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "lispPackages_new.sbclPackages.qtools-helloworld",
+        "name": "qtools-helloworld-20200427-git",
+        "pkg_path": "lispPackages_new.sbclPackages.qtools-helloworld",
         "pname": "qtools-helloworld",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "sbclPackages",
-          "cl-mw_dot_examples_dot_hello-world"
-        ],
+        "attr_path": "sbclPackages.cl-mw_dot_examples_dot_hello-world",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "sbclPackages.cl-mw_dot_examples_dot_hello-world",
+        "name": "sbcl-cl-mw.examples.hello-world-20150407-git",
+        "pkg_path": "sbclPackages.cl-mw_dot_examples_dot_hello-world",
         "pname": "cl-mw_dot_examples_dot_hello-world",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "home-assistant-component-tests",
-          "homeassistant_yellow"
-        ],
+        "attr_path": "home-assistant-component-tests.homeassistant_yellow",
+        "catalog": null,
         "description": "Open source home automation that puts local control and privacy first",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "home-assistant-component-tests.homeassistant_yellow",
+        "name": "homeassistant-test-homeassistant_yellow-2025.1.2",
+        "pkg_path": "home-assistant-component-tests.homeassistant_yellow",
         "pname": "homeassistant_yellow",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "lispPackages_new",
-          "sbclPackages",
-          "cl-mw_dot_examples_dot_hello-world"
-        ],
+        "attr_path": "lispPackages_new.sbclPackages.cl-mw_dot_examples_dot_hello-world",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "lispPackages_new.sbclPackages.cl-mw_dot_examples_dot_hello-world",
+        "name": "cl-mw.examples.hello-world-20150407-git",
+        "pkg_path": "lispPackages_new.sbclPackages.cl-mw_dot_examples_dot_hello-world",
         "pname": "cl-mw_dot_examples_dot_hello-world",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "_3llo"
-        ],
+        "attr_path": "_3llo",
+        "catalog": null,
         "description": "Trello interactive CLI on terminal",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "_3llo",
+        "name": "3llo-1.3.1",
+        "pkg_path": "_3llo",
         "pname": "_3llo",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "iagno"
-        ],
+        "attr_path": "iagno",
+        "catalog": null,
         "description": "Computer version of the game Reversi, more popularly called Othello",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "iagno",
+        "name": "iagno-3.38.1",
+        "pkg_path": "iagno",
         "pname": "iagno",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "gerbolyze"
-        ],
+        "attr_path": "gerbolyze",
+        "catalog": null,
         "description": "Directly render SVG overlays into Gerber and Excellon files",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "gerbolyze",
+        "name": "gerbolyze-3.1.9",
+        "pkg_path": "gerbolyze",
         "pname": "gerbolyze",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "gnome",
-          "iagno"
-        ],
+        "attr_path": "gnome.iagno",
+        "catalog": null,
         "description": "Computer version of the game Reversi, more popularly called Othello",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "gnome.iagno",
+        "name": "iagno-3.38.1",
+        "pkg_path": "gnome.iagno",
         "pname": "iagno",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "gnome3",
-          "iagno"
-        ],
+        "attr_path": "gnome3.iagno",
+        "catalog": null,
         "description": "Computer version of the game Reversi, more popularly called Othello",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "gnome3.iagno",
+        "name": "iagno-3.38.1",
+        "pkg_path": "gnome3.iagno",
         "pname": "iagno",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "texlivePackages",
-          "songs"
-        ],
+        "attr_path": "texlivePackages.songs",
+        "catalog": null,
         "description": "Produce song books for church or fellowship",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "texlivePackages.songs",
+        "name": "songs-3.1",
+        "pkg_path": "texlivePackages.songs",
         "pname": "songs",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python311Packages",
-          "gerbonara"
-        ],
+        "attr_path": "python311Packages.gerbonara",
+        "catalog": null,
         "description": "Pythonic library for reading/modifying/writing Gerber/Excellon/IPC-356 files",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python311Packages.gerbonara",
+        "name": "python3.11-gerbonara-1.4.0",
+        "pkg_path": "python311Packages.gerbonara",
         "pname": "gerbonara",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python312Packages",
-          "gerbonara"
-        ],
+        "attr_path": "python312Packages.gerbonara",
+        "catalog": null,
         "description": "Pythonic library for reading/modifying/writing Gerber/Excellon/IPC-356 files",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python312Packages.gerbonara",
+        "name": "python3.12-gerbonara-1.4.0",
+        "pkg_path": "python312Packages.gerbonara",
         "pname": "gerbonara",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python313Packages",
-          "gerbonara"
-        ],
+        "attr_path": "python313Packages.gerbonara",
+        "catalog": null,
         "description": "Pythonic library for reading/modifying/writing Gerber/Excellon/IPC-356 files",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python313Packages.gerbonara",
+        "name": "python3.13-gerbonara-1.4.0",
+        "pkg_path": "python313Packages.gerbonara",
         "pname": "gerbonara",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       }
     ]
   }

--- a/test_data/generated/search/exactly_ten.json
+++ b/test_data/generated/search/exactly_ten.json
@@ -3,124 +3,104 @@
     "count": 10,
     "results": [
       {
-        "attrPath": [
-          "python"
-        ],
+        "attr_path": "python",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python",
+        "name": "python-2.7.18.8",
+        "pkg_path": "python",
         "pname": "python",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "gpython"
-        ],
+        "attr_path": "gpython",
+        "catalog": null,
         "description": "Python interpreter written in Go",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "gpython",
+        "name": "gpython-0.2.0",
+        "pkg_path": "gpython",
         "pname": "gpython",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python2"
-        ],
+        "attr_path": "python2",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python2",
+        "name": "python-2.7.18.8",
+        "pkg_path": "python2",
         "pname": "python2",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python3"
-        ],
+        "attr_path": "python3",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python3",
+        "name": "python3-3.12.8",
+        "pkg_path": "python3",
         "pname": "python3",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python27"
-        ],
+        "attr_path": "python27",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python27",
+        "name": "python-2.7.18.8",
+        "pkg_path": "python27",
         "pname": "python27",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python36"
-        ],
+        "attr_path": "python36",
+        "catalog": null,
         "description": "A high-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python36",
+        "name": "python3-3.6.14",
+        "pkg_path": "python36",
         "pname": "python36",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python37"
-        ],
+        "attr_path": "python37",
+        "catalog": null,
         "description": "A high-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python37",
+        "name": "python3-3.7.16",
+        "pkg_path": "python37",
         "pname": "python37",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python38"
-        ],
+        "attr_path": "python38",
+        "catalog": null,
         "description": "A high-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python38",
+        "name": "python3-3.8.18",
+        "pkg_path": "python38",
         "pname": "python38",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python39"
-        ],
+        "attr_path": "python39",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python39",
+        "name": "python3-3.9.21",
+        "pkg_path": "python39",
         "pname": "python39",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python310"
-        ],
+        "attr_path": "python310",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python310",
+        "name": "python3-3.10.16",
+        "pkg_path": "python310",
         "pname": "python310",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       }
     ]
   }

--- a/test_data/generated/search/hello.json
+++ b/test_data/generated/search/hello.json
@@ -3,128 +3,104 @@
     "count": 22,
     "results": [
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "catalog": null,
         "description": "Program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello",
+        "name": "hello-2.12.1",
+        "pkg_path": "hello",
         "pname": "hello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hello-go"
-        ],
+        "attr_path": "hello-go",
+        "catalog": null,
         "description": "Simple program printing hello world in Go",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello-go",
+        "name": "hello-go",
+        "pkg_path": "hello-go",
         "pname": "hello-go",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hello-cpp"
-        ],
+        "attr_path": "hello-cpp",
+        "catalog": null,
         "description": "Basic sanity check that C++ and cmake infrastructure are working",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello-cpp",
+        "name": "hello-cpp",
+        "pkg_path": "hello-cpp",
         "pname": "hello-cpp",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "nwg-hello"
-        ],
+        "attr_path": "nwg-hello",
+        "catalog": null,
         "description": "GTK3-based greeter for the greetd daemon, written in python",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "nwg-hello",
+        "name": "nwg-hello-0.3.0",
+        "pkg_path": "nwg-hello",
         "pname": "nwg-hello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hello-unfree"
-        ],
+        "attr_path": "hello-unfree",
+        "catalog": null,
         "description": "Example package with unfree license (for testing)",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello-unfree",
+        "name": "example-unfree-package-1.0",
+        "pkg_path": "hello-unfree",
         "pname": "hello-unfree",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hello-wayland"
-        ],
+        "attr_path": "hello-wayland",
+        "catalog": null,
         "description": "Hello world Wayland client",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hello-wayland",
+        "name": "hello-wayland-0-unstable-2024-03-04",
+        "pkg_path": "hello-wayland",
         "pname": "hello-wayland",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "sbclPackages",
-          "hello-clog"
-        ],
+        "attr_path": "sbclPackages.hello-clog",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "sbclPackages.hello-clog",
+        "name": "sbcl-hello-clog-20241012-git",
+        "pkg_path": "sbclPackages.hello-clog",
         "pname": "hello-clog",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "texlivePackages",
-          "othello"
-        ],
+        "attr_path": "texlivePackages.othello",
+        "catalog": null,
         "description": "Modification of a Go package to create othello boards",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "texlivePackages.othello",
+        "name": "othello-15878",
+        "pkg_path": "texlivePackages.othello",
         "pname": "othello",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "sbclPackages",
-          "hello-builder"
-        ],
+        "attr_path": "sbclPackages.hello-builder",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "sbclPackages.hello-builder",
+        "name": "sbcl-hello-builder-20241012-git",
+        "pkg_path": "sbclPackages.hello-builder",
         "pname": "hello-builder",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "javaPackages",
-          "mavenHello_1_0"
-        ],
+        "attr_path": "javaPackages.mavenHello_1_0",
+        "catalog": null,
         "description": "Maven Hello World",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "javaPackages.mavenHello_1_0",
+        "name": "maven-hello-1.0",
+        "pkg_path": "javaPackages.mavenHello_1_0",
         "pname": "mavenHello_1_0",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       }
     ]
   }

--- a/test_data/generated/search/java_suggestions.json
+++ b/test_data/generated/search/java_suggestions.json
@@ -1,126 +1,106 @@
 [
   {
-    "count": 865,
+    "count": 864,
     "results": [
       {
-        "attrPath": [
-          "javacc"
-        ],
+        "attr_path": "javacc",
+        "catalog": null,
         "description": "Parser generator for building parsers from grammars",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "javacc",
+        "name": "javacc-7.0.13",
+        "pkg_path": "javacc",
         "pname": "javacc",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "javaCup"
-        ],
+        "attr_path": "javaCup",
+        "catalog": null,
         "description": "LALR parser generator for Java",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "javaCup",
+        "name": "java-cup-11b-20160615",
+        "pkg_path": "javaCup",
         "pname": "javaCup",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "hdf_java"
-        ],
+        "attr_path": "hdf_java",
+        "catalog": null,
         "description": "A Java package that implements HDF4 and HDF5 data objects in an object-oriented form",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "hdf_java",
+        "name": "hdf-java-3.3.2",
+        "pkg_path": "hdf_java",
         "pname": "hdf_java",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "dbus_java"
-        ],
+        "attr_path": "dbus_java",
+        "catalog": null,
         "description": null,
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "dbus_java",
+        "name": "dbus-java-2.7",
+        "pkg_path": "dbus_java",
         "pname": "dbus_java",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "geoipjava"
-        ],
+        "attr_path": "geoipjava",
+        "catalog": null,
         "description": "GeoIP Java API",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "geoipjava",
+        "name": "GeoIPJava-1.2.5",
+        "pkg_path": "geoipjava",
         "pname": "geoipjava",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "tabula-java"
-        ],
+        "attr_path": "tabula-java",
+        "catalog": null,
         "description": "Library for extracting tables from PDF files",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "tabula-java",
+        "name": "tabula-java-1.0.5",
+        "pkg_path": "tabula-java",
         "pname": "tabula-java",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "erlang_javac"
-        ],
+        "attr_path": "erlang_javac",
+        "catalog": null,
         "description": "Programming language used for massively scalable soft real-time systems",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "erlang_javac",
+        "name": "erlang_javac-25.3.2.12",
+        "pkg_path": "erlang_javac",
         "pname": "erlang_javac",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "swigWithJava"
-        ],
+        "attr_path": "swigWithJava",
+        "catalog": null,
         "description": "Interface compiler that connects C/C++ code to higher-level languages",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "swigWithJava",
+        "name": "swig-4.2.1",
+        "pkg_path": "swigWithJava",
         "pname": "swigWithJava",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "yourkit-java"
-        ],
+        "attr_path": "yourkit-java",
+        "catalog": null,
         "description": "Award winning, fully featured low overhead profiler for Java EE and Java SE platforms",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "yourkit-java",
+        "name": "yourkit-java-2024.9-b161",
+        "pkg_path": "yourkit-java",
         "pname": "yourkit-java",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "java-hamcrest"
-        ],
+        "attr_path": "java-hamcrest",
+        "catalog": null,
         "description": "Java library containing matchers that can be combined to create flexible expressions of intent",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "java-hamcrest",
+        "name": "java-hamcrest-3.0",
+        "pkg_path": "java-hamcrest",
         "pname": "java-hamcrest",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       }
     ]
   },
@@ -128,40 +108,34 @@
     "count": 141,
     "results": [
       {
-        "attrPath": [
-          "jdk"
-        ],
-        "description": "Certified builds of OpenJDK",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "jdk",
-        "pname": "jdk",
-        "system": "aarch64-darwin",
-        "version": null
-      },
-      {
-        "attrPath": [
-          "jdk8"
-        ],
+        "attr_path": "jdk",
+        "catalog": null,
         "description": "Open-source Java Development Kit",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "jdk8",
-        "pname": "jdk8",
-        "system": "aarch64-darwin",
-        "version": null
+        "name": "openjdk-21.0.5+11",
+        "pkg_path": "jdk",
+        "pname": "jdk",
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "jdk11"
-        ],
+        "attr_path": "jdk8",
+        "catalog": null,
         "description": "Certified builds of OpenJDK",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "jdk11",
+        "name": "zulu-ca-jdk-8.0.422",
+        "pkg_path": "jdk8",
+        "pname": "jdk8",
+        "stabilities": [],
+        "system": "aarch64-darwin"
+      },
+      {
+        "attr_path": "jdk11",
+        "catalog": null,
+        "description": "Certified builds of OpenJDK",
+        "name": "zulu-ca-jdk-11.0.24",
+        "pkg_path": "jdk11",
         "pname": "jdk11",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       }
     ]
   }

--- a/test_data/generated/search/python.json
+++ b/test_data/generated/search/python.json
@@ -1,126 +1,106 @@
 [
   {
-    "count": 20924,
+    "count": 20928,
     "results": [
       {
-        "attrPath": [
-          "python"
-        ],
+        "attr_path": "python",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python",
+        "name": "python-2.7.18.8",
+        "pkg_path": "python",
         "pname": "python",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "gpython"
-        ],
+        "attr_path": "gpython",
+        "catalog": null,
         "description": "Python interpreter written in Go",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "gpython",
+        "name": "gpython-0.2.0",
+        "pkg_path": "gpython",
         "pname": "gpython",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python2"
-        ],
+        "attr_path": "python2",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python2",
+        "name": "python-2.7.18.8",
+        "pkg_path": "python2",
         "pname": "python2",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python3"
-        ],
+        "attr_path": "python3",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python3",
+        "name": "python3-3.12.8",
+        "pkg_path": "python3",
         "pname": "python3",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python27"
-        ],
+        "attr_path": "python27",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python27",
+        "name": "python-2.7.18.8",
+        "pkg_path": "python27",
         "pname": "python27",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python36"
-        ],
+        "attr_path": "python36",
+        "catalog": null,
         "description": "A high-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python36",
+        "name": "python3-3.6.14",
+        "pkg_path": "python36",
         "pname": "python36",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python37"
-        ],
+        "attr_path": "python37",
+        "catalog": null,
         "description": "A high-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python37",
+        "name": "python3-3.7.16",
+        "pkg_path": "python37",
         "pname": "python37",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python38"
-        ],
+        "attr_path": "python38",
+        "catalog": null,
         "description": "A high-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python38",
+        "name": "python3-3.8.18",
+        "pkg_path": "python38",
         "pname": "python38",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python39"
-        ],
+        "attr_path": "python39",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python39",
+        "name": "python3-3.9.21",
+        "pkg_path": "python39",
         "pname": "python39",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       },
       {
-        "attrPath": [
-          "python310"
-        ],
+        "attr_path": "python310",
+        "catalog": null,
         "description": "High-level dynamically-typed programming language",
-        "input": "nixpkgs",
-        "license": null,
-        "pkgPath": "python310",
+        "name": "python3-3.10.16",
+        "pkg_path": "python310",
         "pname": "python310",
-        "system": "aarch64-darwin",
-        "version": null
+        "stabilities": [],
+        "system": "aarch64-darwin"
       }
     ]
   }

--- a/test_data/generated/show/flask.json
+++ b/test_data/generated/show/flask.json
@@ -10,7 +10,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-linux",
         "version": "python3.10-flask-2.3.3"
@@ -23,7 +23,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-darwin",
         "version": "python3.10-flask-2.3.3"
@@ -36,7 +36,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-darwin",
         "version": "python3.10-flask-2.3.3"
@@ -49,7 +49,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-linux",
         "version": "python3.10-flask-2.3.3"
@@ -62,7 +62,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-darwin",
         "version": "python3.10-flask-2.2.5"
@@ -75,7 +75,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-linux",
         "version": "python3.10-flask-2.2.5"
@@ -88,7 +88,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-linux",
         "version": "python3.10-flask-2.2.5"
@@ -101,7 +101,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-darwin",
         "version": "python3.10-flask-2.2.5"
@@ -114,7 +114,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-linux",
         "version": "python3.10-flask-2.2.3"
@@ -127,7 +127,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-linux",
         "version": "python3.10-flask-2.2.3"
@@ -140,7 +140,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-darwin",
         "version": "python3.10-flask-2.2.3"
@@ -153,7 +153,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-darwin",
         "version": "python3.10-flask-2.2.3"
@@ -166,7 +166,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-linux",
         "version": "python3.10-flask-2.2.2"
@@ -179,7 +179,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-linux",
         "version": "python3.10-flask-2.2.2"
@@ -192,7 +192,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-darwin",
         "version": "python3.10-flask-2.2.2"
@@ -205,7 +205,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-darwin",
         "version": "python3.10-flask-2.2.2"
@@ -218,7 +218,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-linux",
         "version": "python3.10-flask-2.1.3"
@@ -231,7 +231,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-darwin",
         "version": "python3.10-flask-2.1.3"
@@ -244,7 +244,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-darwin",
         "version": "python3.10-flask-2.1.3"
@@ -257,7 +257,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-linux",
         "version": "python3.10-flask-2.1.3"
@@ -270,7 +270,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-linux",
         "version": "python3.10-Flask-2.1.2"
@@ -283,7 +283,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-darwin",
         "version": "python3.10-Flask-2.1.2"
@@ -296,7 +296,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-linux",
         "version": "python3.10-Flask-2.1.2"
@@ -309,7 +309,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-darwin",
         "version": "python3.10-Flask-2.1.2"
@@ -322,7 +322,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-linux",
         "version": "python3.10-Flask-2.0.3"
@@ -335,7 +335,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-darwin",
         "version": "python3.10-Flask-2.0.3"
@@ -348,7 +348,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-darwin",
         "version": "python3.10-Flask-2.0.3"
@@ -361,7 +361,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-linux",
         "version": "python3.10-Flask-2.0.3"
@@ -374,7 +374,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-darwin",
         "version": "python3.10-Flask-2.0.2"
@@ -387,7 +387,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-linux",
         "version": "python3.10-Flask-2.0.2"
@@ -400,7 +400,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "x86_64-darwin",
         "version": "python3.10-Flask-2.0.2"
@@ -413,7 +413,7 @@
         "description": "The Python micro framework for building web applications",
         "input": "nixpkgs",
         "license": "BSD-3-Clause",
-        "pkgPath": "nixpkgs/python310Packages.flask",
+        "pkgPath": "python310Packages.flask",
         "pname": "flask",
         "system": "aarch64-linux",
         "version": "python3.10-Flask-2.0.2"

--- a/test_data/generated/show/flask.json
+++ b/test_data/generated/show/flask.json
@@ -3,419 +3,1127 @@
     "count": 32,
     "results": [
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/rrikvp9mgbrini920i4n2sf3lhbvlrx6-python3.10-flask-2.3.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=a9bf124c46ef298113270b1f84a164865987a91c",
+        "name": "python3.10-flask-2.3.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/b54vjn6jzrnvgw6wb57lmdnph8dh6ipj-python3.10-flask-2.3.3"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/yin372ygf3k1rcda1lvzag4p125dcizw-python3.10-flask-2.3.3-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
+        "rev_count": 558881,
+        "rev_date": "2023-12-11T16:35:24Z",
+        "scrape_date": "2024-08-15T23:00:37Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.3.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/30wf3q5j61xwi5pyb2i1bac8n7fzr638-python3.10-flask-2.3.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
+        "name": "python3.10-flask-2.3.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/mcpc0b2gcgh0prhv084ls9yjzdpwnp1i-python3.10-flask-2.3.3"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/9mkv1f65kbrnfj6rz216g4j274l3ahmc-python3.10-flask-2.3.3-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
+        "rev_count": 553283,
+        "rev_date": "2023-11-27T06:58:46Z",
+        "scrape_date": "2024-08-15T23:15:20Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.3.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/wz34qddi07hrk3dyvcpnjx939wv5zq74-python3.10-flask-2.3.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
+        "name": "python3.10-flask-2.3.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/8gm4fxpfnjxqhxg54vhwz7gg1rbygjcx-python3.10-flask-2.3.3"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/gvdb50dibadwjhndkm82b6c8i4s71zal-python3.10-flask-2.3.3-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
+        "rev_count": 553283,
+        "rev_date": "2023-11-27T06:58:46Z",
+        "scrape_date": "2024-08-15T23:15:20Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.3.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/s8ik593kqsi7rqsc822m6359cnbx8gb6-python3.10-flask-2.3.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "name": "python3.10-flask-2.3.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/0hdwsijsmz4gcqf4xfrflvasvdajy64b-python3.10-flask-2.3.3"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/489gd4s4087ahqgnsj7vrrlpz9wyjjz2-python3.10-flask-2.3.3-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "rev_count": 542330,
+        "rev_date": "2023-10-29T20:30:40Z",
+        "scrape_date": "2024-08-15T23:37:33Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.3.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/1hz4gf66p4ssaiv35vyn2ra16r37w0a3-python3.10-flask-2.2.5.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=ca012a02bf8327be9e488546faecae5e05d7d749",
+        "name": "python3.10-flask-2.2.5",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/9zp9r2szafcj147jcsbbb3ghcaa35md9-python3.10-flask-2.2.5"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/2miqf6lgyaxshkhbal1an4ckabm2lhcq-python3.10-flask-2.2.5-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "ca012a02bf8327be9e488546faecae5e05d7d749",
+        "rev_count": 536534,
+        "rev_date": "2023-10-16T11:38:32Z",
+        "scrape_date": "2024-08-15T23:44:26Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.2.5"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/iaq409fxw812489sf52kz66df96q730k-python3.10-flask-2.2.5.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=f99e5f03cc0aa231ab5950a15ed02afec45ed51a",
+        "name": "python3.10-flask-2.2.5",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/wxasc1cp17p7bvx5h3ybwf3f7g9x8z0w-python3.10-flask-2.2.5"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/zn78ybl870c1c36pmfwfb81b74vgc3q2-python3.10-flask-2.2.5-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "f99e5f03cc0aa231ab5950a15ed02afec45ed51a",
+        "rev_count": 534224,
+        "rev_date": "2023-10-09T19:29:22Z",
+        "scrape_date": "2024-08-15T23:51:17Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.2.5"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/59zdx6ycr3p9qss8mbl5bzbwlfpw9zxp-python3.10-flask-2.2.5.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=e56990880811a451abd32515698c712788be5720",
+        "name": "python3.10-flask-2.2.5",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/cdkf924n4mbz2qawrw9ljl669qdgnji3-python3.10-flask-2.2.5"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/d42vrvshrf7r025xd4iz2wk2x5bw5kyf-python3.10-flask-2.2.5-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "e56990880811a451abd32515698c712788be5720",
+        "rev_count": 521611,
+        "rev_date": "2023-09-02T14:03:41Z",
+        "scrape_date": "2024-08-16T00:19:10Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.2.5"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/ps6bxvjl1ill2hrp2b233ya8hrxf2cmy-python3.10-flask-2.2.5.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=645ff62e09d294a30de823cb568e9c6d68e92606",
+        "name": "python3.10-flask-2.2.5",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/v616mwfr8b2hs6n51zblx7478kmyqgvr-python3.10-flask-2.2.5"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/r39p4m1cwpv8784w86aad70aq9ghr84s-python3.10-flask-2.2.5-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "645ff62e09d294a30de823cb568e9c6d68e92606",
+        "rev_count": 500267,
+        "rev_date": "2023-07-01T17:09:17Z",
+        "scrape_date": "2024-08-16T00:53:17Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.2.5"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/sxvawq8h68a74xplapgmialyknm72imq-python3.10-flask-2.2.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=963006aab35e3e8ebbf6052b6bf4ea712fdd3c28",
+        "name": "python3.10-flask-2.2.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/n0syiwyy2bxg30l13sia42y13isgacqg-python3.10-flask-2.2.3"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/yzfj0va1v94p6rv8ir5hx0kxjlb42qb4-python3.10-flask-2.2.3-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "963006aab35e3e8ebbf6052b6bf4ea712fdd3c28",
+        "rev_count": 484945,
+        "rev_date": "2023-05-16T05:42:51Z",
+        "scrape_date": "2024-08-16T01:05:45Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.2.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/awv25lpkb73sdvjhlfpbhs6k06mn41rd-python3.10-flask-2.2.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=963006aab35e3e8ebbf6052b6bf4ea712fdd3c28",
+        "name": "python3.10-flask-2.2.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/56jrm3m0b0n41m315waxswq5jw3xgfkl-python3.10-flask-2.2.3"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/gnhyfgkc6yvd0syrca9kgvca3iqza93c-python3.10-flask-2.2.3-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "963006aab35e3e8ebbf6052b6bf4ea712fdd3c28",
+        "rev_count": 484945,
+        "rev_date": "2023-05-16T05:42:51Z",
+        "scrape_date": "2024-08-16T01:05:45Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.2.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/s83vc8vlv4nh0gf2caws8afbflf2zl8n-python3.10-flask-2.2.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "name": "python3.10-flask-2.2.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/dmqfwhvh615bhxkjrz7l0x4b9abnh60p-python3.10-flask-2.2.3"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/wp55hqjdac1slalcql037nq9nadk023x-python3.10-flask-2.2.3-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "rev_count": 481752,
+        "rev_date": "2023-05-06T21:28:42Z",
+        "scrape_date": "2024-08-16T01:12:06Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.2.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/87kzgzrafkxw9j4jkhxab7h0hfsm6c5r-python3.10-flask-2.2.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=f00994e78cd39e6fc966f0c4103f908e63284780",
+        "name": "python3.10-flask-2.2.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/l4m0njksq280v5fah7j7hgrfgxn8nbmw-python3.10-flask-2.2.3"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/7f9i4ba8wn1xla5w5cdz8983l01fpl2j-python3.10-flask-2.2.3-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "f00994e78cd39e6fc966f0c4103f908e63284780",
+        "rev_count": 474575,
+        "rev_date": "2023-04-17T13:26:37Z",
+        "scrape_date": "2024-08-16T01:18:04Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.2.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/ml23yrz53g90lb503gza4cgxcprn8db3-python3.10-flask-2.2.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+        "name": "python3.10-flask-2.2.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/9l024wr0w428bqrxz4xzhlwbnwkd749i-python3.10-flask-2.2.2"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/3gx1xpmas1lc9mc8clismvraib9iga06-python3.10-flask-2.2.2-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+        "rev_count": 439146,
+        "rev_date": "2023-01-02T00:06:23Z",
+        "scrape_date": "2024-08-16T02:13:46Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.2.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/63hh1fhvqldpcw7m0d2wvn46ky14azdb-python3.10-flask-2.2.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=2788904d26dda6cfa1921c5abb7a2466ffe3cb8c",
+        "name": "python3.10-flask-2.2.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/my9lm1j2687y8ip6a9fq20lm3wq08ca9-python3.10-flask-2.2.2"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/qw8gp8g5mb56rfickqf6jrd8ad32phsl-python3.10-flask-2.2.2-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "2788904d26dda6cfa1921c5abb7a2466ffe3cb8c",
+        "rev_count": 428801,
+        "rev_date": "2022-11-22T18:11:15Z",
+        "scrape_date": "2024-06-13T19:38:58Z",
+        "stabilities": [
+          "lts",
+          "stable",
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.2.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/iqx0hxvj9hxwmp2zxzwxv5f6crphnbvj-python3.10-flask-2.2.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=d40fea9aeb8840fea0d377baa4b38e39b9582458",
+        "name": "python3.10-flask-2.2.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/2zbqrlhmw0v64qiv2a89l6zyj8irhby4-python3.10-flask-2.2.2"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/aby5gb608wbbk36a9zasrlmwn1i2apgf-python3.10-flask-2.2.2-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "d40fea9aeb8840fea0d377baa4b38e39b9582458",
+        "rev_count": 422531,
+        "rev_date": "2022-10-31T15:44:53Z",
+        "scrape_date": "2024-08-16T02:43:28Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.2.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/z0nsjvchmjxx6sickgyk3bi4jpp586p5-python3.10-flask-2.2.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=285e77efe87df64105ec14b204de6636fb0a7a27",
+        "name": "python3.10-flask-2.2.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/amllm8kxkrm1ac3y4pps597zjqpbvi70-python3.10-flask-2.2.2"
+          },
+          {
+            "name": "dist",
+            "store_path": "/nix/store/nwvx3gg67zplb761hsdlspp4lj6chf0n-python3.10-flask-2.2.2-dist"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "285e77efe87df64105ec14b204de6636fb0a7a27",
+        "rev_count": 416449,
+        "rev_date": "2022-10-11T00:47:48Z",
+        "scrape_date": "2024-08-16T02:52:51Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.2.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/w7ba025ln8jqxrg0h0ybcc6y5h34f7zm-python3.10-flask-2.1.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=a63021a330d8d33d862a8e29924b42d73037dd37",
+        "name": "python3.10-flask-2.1.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/7857wcgk27mcknxqv2ziqikmwwmip636-python3.10-flask-2.1.3"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "a63021a330d8d33d862a8e29924b42d73037dd37",
+        "rev_count": 404572,
+        "rev_date": "2022-08-28T21:06:20Z",
+        "scrape_date": "2024-08-16T03:01:21Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.1.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/l0rap3wjkj9m2km8lsh10lrkmbk9rrfl-python3.10-flask-2.1.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=5e804cd8a27f835a402b22e086e36e797716ef8b",
+        "name": "python3.10-flask-2.1.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/pw5srfcfv41hxg5qa7j77mh80y1g6d3a-python3.10-flask-2.1.3"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "5e804cd8a27f835a402b22e086e36e797716ef8b",
+        "rev_count": 402830,
+        "rev_date": "2022-08-23T07:20:11Z",
+        "scrape_date": "2024-08-15T20:38:48Z",
+        "stabilities": [
+          "stable",
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.1.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/7yyyj5mhzq1nfpdfrkallgmfz5fh4vl4-python3.10-flask-2.1.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=12363fb6d89859a37cd7e27f85288599f13e49d9",
+        "name": "python3.10-flask-2.1.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/9xb032waj6zl11m4alabb708q8c4bg4i-python3.10-flask-2.1.3"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "12363fb6d89859a37cd7e27f85288599f13e49d9",
+        "rev_count": 397203,
+        "rev_date": "2022-08-03T00:52:54Z",
+        "scrape_date": "2024-08-16T03:05:00Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "python3.10-flask-2.1.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/9ryhhvnzhgm6b0i69i1ymmj7ghihyyc5-python3.10-flask-2.1.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=12363fb6d89859a37cd7e27f85288599f13e49d9",
+        "name": "python3.10-flask-2.1.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/1mn8p8k4m2hd1svl9si4c1x9rfs744jp-python3.10-flask-2.1.3"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "12363fb6d89859a37cd7e27f85288599f13e49d9",
+        "rev_count": 397203,
+        "rev_date": "2022-08-03T00:52:54Z",
+        "scrape_date": "2024-08-16T03:05:00Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "python3.10-flask-2.1.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/blxhvh1m08wayx8fgjrj4wrczj6phxmd-python3.10-Flask-2.1.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=ce49cb7792a7ffd65ef352dda1110a4e4a204eac",
+        "name": "python3.10-Flask-2.1.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/kxqv24p3gaq517z1qw0pbk2arjp2pp09-python3.10-Flask-2.1.2"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "ce49cb7792a7ffd65ef352dda1110a4e4a204eac",
+        "rev_count": 394203,
+        "rev_date": "2022-07-26T09:07:44Z",
+        "scrape_date": "2024-08-15T20:42:32Z",
+        "stabilities": [
+          "stable",
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "python3.10-Flask-2.1.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/y79ib0k16jksprvymhgpbhllma9mp51n-python3.10-Flask-2.1.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=614a842b74b7a1497e8cfca7c61bec38f51911b3",
+        "name": "python3.10-Flask-2.1.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/3ljajhn8v29rr83116hj1jqvs6dj1d22-python3.10-Flask-2.1.2"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "614a842b74b7a1497e8cfca7c61bec38f51911b3",
+        "rev_count": 393074,
+        "rev_date": "2022-07-20T04:19:55Z",
+        "scrape_date": "2024-08-16T03:08:48Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "python3.10-Flask-2.1.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/j0j7p5ljcayavy6blanf7gnlx1rhklj2-python3.10-Flask-2.1.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=614a842b74b7a1497e8cfca7c61bec38f51911b3",
+        "name": "python3.10-Flask-2.1.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/0qj20537vzq0ngm055g5aa1s8mzs4xa8-python3.10-Flask-2.1.2"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "614a842b74b7a1497e8cfca7c61bec38f51911b3",
+        "rev_count": 393074,
+        "rev_date": "2022-07-20T04:19:55Z",
+        "scrape_date": "2024-08-16T03:08:48Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "python3.10-Flask-2.1.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/wys5cszi2kifiqn94kvnggccr2ybg2za-python3.10-Flask-2.1.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=dfd82985c273aac6eced03625f454b334daae2e8",
+        "name": "python3.10-Flask-2.1.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/pcv9l8k8qrzjfv282yy5k5bpfgfs4s03-python3.10-Flask-2.1.2"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "dfd82985c273aac6eced03625f454b334daae2e8",
+        "rev_count": 379159,
+        "rev_date": "2022-05-20T15:32:24Z",
+        "scrape_date": "2024-06-13T19:42:27Z",
+        "stabilities": [
+          "lts",
+          "stable",
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-darwin",
+        "unfree": false,
         "version": "python3.10-Flask-2.1.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/4sircldl84rb6hyyn2sl58yi8g8px35l-python3.10-Flask-2.0.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "name": "python3.10-Flask-2.0.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/0szzxgphdmc86cf5529hcmwvwm8sfhfr-python3.10-Flask-2.0.3"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "rev_count": 369988,
+        "rev_date": "2022-04-17T02:14:46Z",
+        "scrape_date": "2024-08-16T03:30:08Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "python3.10-Flask-2.0.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/jvgqwh1w7wl0svqpgqn9n9228xj9jkrs-python3.10-Flask-2.0.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=a1d12edc46f08cf09a8caad32bfff64df8bca75e",
+        "name": "python3.10-Flask-2.0.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/n23hjnwc7ffs1ccd7ib1y1bc3jq82w60-python3.10-Flask-2.0.3"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "a1d12edc46f08cf09a8caad32bfff64df8bca75e",
+        "rev_count": 368870,
+        "rev_date": "2022-04-12T15:49:08Z",
+        "scrape_date": "2024-08-15T20:49:24Z",
+        "stabilities": [
+          "stable"
+        ],
         "system": "aarch64-darwin",
+        "unfree": false,
         "version": "python3.10-Flask-2.0.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/ylhq6ic7903sdl7nr625wd9s6sa2xc31-python3.10-Flask-2.0.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=a1d12edc46f08cf09a8caad32bfff64df8bca75e",
+        "name": "python3.10-Flask-2.0.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/cnh7nfx1v60pdhzk64g6i3yjpwrgxngz-python3.10-Flask-2.0.3"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "a1d12edc46f08cf09a8caad32bfff64df8bca75e",
+        "rev_count": 368870,
+        "rev_date": "2022-04-12T15:49:08Z",
+        "scrape_date": "2024-08-15T20:49:24Z",
+        "stabilities": [
+          "stable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "python3.10-Flask-2.0.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/x2i2d01ppgn6c76mys522jpcnagr4r6r-python3.10-Flask-2.0.3.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=33772708c6d0e33f697426ba386aa0149cbcbecb",
+        "name": "python3.10-Flask-2.0.3",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/iqj6pq28982d92j89vsid393bhnh3y5l-python3.10-Flask-2.0.3"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "33772708c6d0e33f697426ba386aa0149cbcbecb",
+        "rev_count": 368735,
+        "rev_date": "2022-04-11T10:33:51Z",
+        "scrape_date": "2024-08-16T03:33:35Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "python3.10-Flask-2.0.3"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/8zv5fzxgkmym4471n6w77hy6i95xw1b3-python3.10-Flask-2.0.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=bc4b9eef3ce3d5a90d8693e8367c9cbfc9fc1e13",
+        "name": "python3.10-Flask-2.0.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/w0l7bvp88syg6c26i4hdqx7r9cmc2h2a-python3.10-Flask-2.0.2"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "bc4b9eef3ce3d5a90d8693e8367c9cbfc9fc1e13",
+        "rev_count": 366144,
+        "rev_date": "2022-04-03T18:54:34Z",
+        "scrape_date": "2024-08-16T03:37:01Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-darwin",
+        "unfree": false,
         "version": "python3.10-Flask-2.0.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/75w845qgxl20hckd5is10jp2vni0npwq-python3.10-Flask-2.0.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=bc4b9eef3ce3d5a90d8693e8367c9cbfc9fc1e13",
+        "name": "python3.10-Flask-2.0.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/qzpclxj7x23wzikxxibi672h1sfnsq3z-python3.10-Flask-2.0.2"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "bc4b9eef3ce3d5a90d8693e8367c9cbfc9fc1e13",
+        "rev_count": 366144,
+        "rev_date": "2022-04-03T18:54:34Z",
+        "scrape_date": "2024-08-16T03:37:01Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "python3.10-Flask-2.0.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/8wqnwhy4ag4bj69k2pqyf6ng3a8rl707-python3.10-Flask-2.0.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
+        "name": "python3.10-Flask-2.0.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/dp3p84nmblfx50jjdhbvbb25jvm20waq-python3.10-Flask-2.0.2"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
+        "rev_count": 360796,
+        "rev_date": "2022-03-14T22:40:14Z",
+        "scrape_date": "2024-08-16T03:43:46Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "python3.10-Flask-2.0.2"
       },
       {
-        "attrPath": [
-          "python310Packages",
-          "flask"
-        ],
+        "attr_path": "python310Packages.flask",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/c0hmi86jsm3pskg1bq80czj5c3dnp6v9-python3.10-Flask-2.0.2.drv",
         "description": "The Python micro framework for building web applications",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "BSD-3-Clause",
-        "pkgPath": "python310Packages.flask",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=c5051e2b5fe9fab43a64f0e0d06b62c81a890b90",
+        "name": "python3.10-Flask-2.0.2",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/7iqapakj40fvwqf5shsf5nrpmi0mc8qj-python3.10-Flask-2.0.2"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "python310Packages.flask",
         "pname": "flask",
+        "rev": "c5051e2b5fe9fab43a64f0e0d06b62c81a890b90",
+        "rev_count": 352272,
+        "rev_date": "2022-02-08T22:27:14Z",
+        "scrape_date": "2024-08-16T03:53:32Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "python3.10-Flask-2.0.2"
       }
     ]

--- a/test_data/generated/show/hello.json
+++ b/test_data/generated/show/hello.json
@@ -3,147 +3,391 @@
     "count": 12,
     "results": [
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/9vkdb4vqqyqjkm2825vkm74gdxcr0m46-hello-2.12.1.drv",
         "description": "Program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=a73246e2eef4c6ed172979932bc80e1404ba2d56",
+        "name": "hello-2.12.1",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl-hello-2.12.1"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
+        "rev_count": 719504,
+        "rev_date": "2024-12-09T15:59:59Z",
+        "scrape_date": "2024-12-11T03:49:32Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "2.12.1"
       },
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/lr7225xhsi9h9q6dl9xp83y3a122jpf4-hello-2.12.1.drv",
         "description": "Program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
-        "pname": "hello",
-        "system": "aarch64-darwin",
-        "version": "2.12.1"
-      },
-      {
-        "attrPath": [
-          "hello"
+        "locked_url": "https://github.com/flox/nixpkgs?rev=18536bf04cd71abd345f9579158841376fdd0c5a",
+        "name": "hello-2.12.1",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/h6lx6hmccksq64nsa4h3c8p9gl1vzqcf-hello-2.12.1"
+          }
         ],
-        "description": "Program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
-        "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
+        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "rev_count": 696981,
+        "rev_date": "2024-10-25T18:19:15Z",
+        "scrape_date": "2024-10-28T04:00:37Z",
+        "stabilities": null,
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "2.12.1"
       },
       {
-        "attrPath": [
-          "hello"
-        ],
-        "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/4j3iail1qqp97p2vfw9ykkg23aqkqn6d-hello-2.12.1.drv",
+        "description": "Program that produces a familiar, friendly greeting",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=a58bc8ad779655e790115244571758e8de055e3d",
+        "name": "hello-2.12.1",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/i16w788fnhvc23y0fi3289h9hixdckf6-hello-2.12.1"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "rev_count": 665011,
+        "rev_date": "2024-08-11T07:55:43Z",
+        "scrape_date": "2024-08-14T02:08:40Z",
+        "stabilities": null,
         "system": "aarch64-linux",
+        "unfree": false,
         "version": "2.12.1"
       },
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/fr2w0kzy5fpc5lmzzbz8084fa0gpxcj0-hello-2.12.1.drv",
         "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
+        "name": "hello-2.12.1",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/8w58chlflyzhmajrp0d54j51gw7ya7p5-hello-2.12.1"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
-        "system": "aarch64-linux",
+        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
+        "rev_count": 446447,
+        "rev_date": "2023-01-23T07:39:43Z",
+        "scrape_date": "2024-06-13T20:58:50Z",
+        "stabilities": [
+          "stable",
+          "staging",
+          "unstable"
+        ],
+        "system": "aarch64-darwin",
+        "unfree": false,
+        "version": "2.12.1"
+      },
+      {
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/slv59780f0d2a3k60z894s1pbl7hinnz-hello-2.12.drv",
+        "description": "A program that produces a familiar, friendly greeting",
+        "insecure": false,
+        "license": "GPL-3.0-or-later",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=38860c9e91cb00f4d8cd19c7b4e36c45680c89b5",
+        "name": "hello-2.12",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/wb00v7c9wsw5hpxkfpyv26725rgxrwsq-hello-2.12"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
+        "pname": "hello",
+        "rev": "38860c9e91cb00f4d8cd19c7b4e36c45680c89b5",
+        "rev_count": 391169,
+        "rev_date": "2022-07-11T10:02:42Z",
+        "scrape_date": "2024-08-16T03:12:27Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
+        "system": "aarch64-darwin",
+        "unfree": false,
         "version": "2.12"
       },
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/b0a7ca9kk0ss3bibw40k2ga24gw57072-hello-2.12.drv",
         "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=dfd82985c273aac6eced03625f454b334daae2e8",
+        "name": "hello-2.12",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/1wqx1ka5lm4inawhpd36w9apiqkyvhbm-hello-2.12"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
+        "rev": "dfd82985c273aac6eced03625f454b334daae2e8",
+        "rev_count": 379159,
+        "rev_date": "2022-05-20T15:32:24Z",
+        "scrape_date": "2024-06-13T19:42:27Z",
+        "stabilities": [
+          "lts",
+          "stable",
+          "staging",
+          "unstable"
+        ],
+        "system": "aarch64-linux",
+        "unfree": false,
+        "version": "2.12"
+      },
+      {
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/fdbrmsw4hvy63hv0hvn2x0fisp3cf26g-hello-2.12.drv",
+        "description": "A program that produces a familiar, friendly greeting",
+        "insecure": false,
+        "license": "GPL-3.0-or-later",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=ce8cbe3c01fd8ee2de526ccd84bbf9b82397a510",
+        "name": "hello-2.12",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/k0zs6fa3lijcpzxirl75g10j30277awy-hello-2.12"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
+        "pname": "hello",
+        "rev": "ce8cbe3c01fd8ee2de526ccd84bbf9b82397a510",
+        "rev_count": 364329,
+        "rev_date": "2022-03-27T14:17:51Z",
+        "scrape_date": "2024-08-16T03:40:26Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
+        "system": "x86_64-darwin",
+        "unfree": false,
+        "version": "2.12"
+      },
+      {
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/880m2s76cxsg2lg6hrlnfn0khazd1xz1-hello-2.12.drv",
+        "description": "A program that produces a familiar, friendly greeting",
+        "insecure": false,
+        "license": "GPL-3.0-or-later",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=c5051e2b5fe9fab43a64f0e0d06b62c81a890b90",
+        "name": "hello-2.12",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/2a1m8qmdafvmshm93236q3sz3rhrjd9f-hello-2.12"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
+        "pname": "hello",
+        "rev": "c5051e2b5fe9fab43a64f0e0d06b62c81a890b90",
+        "rev_count": 352272,
+        "rev_date": "2022-02-08T22:27:14Z",
+        "scrape_date": "2024-08-16T03:53:32Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "2.12"
       },
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/2qh4bh6nc188sd1v7k7g830w0k9haiz6-hello-2.10.drv",
         "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=8d8a28b47b7c41aeb4ad01a2bd8b7d26986c3512",
+        "name": "hello-2.10",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/s56w716cp2rvm9l37jh79zwh7r0mvww0-hello-2.10"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
+        "rev": "8d8a28b47b7c41aeb4ad01a2bd8b7d26986c3512",
+        "rev_count": 312335,
+        "rev_date": "2021-08-29T14:49:37Z",
+        "scrape_date": "2024-08-16T04:15:31Z",
+        "stabilities": [
+          "staging",
+          "unstable"
+        ],
         "system": "aarch64-darwin",
-        "version": "2.12"
-      },
-      {
-        "attrPath": [
-          "hello"
-        ],
-        "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
-        "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
-        "pname": "hello",
-        "system": "x86_64-darwin",
-        "version": "2.12"
-      },
-      {
-        "attrPath": [
-          "hello"
-        ],
-        "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
-        "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
-        "pname": "hello",
-        "system": "aarch64-linux",
+        "unfree": false,
         "version": "2.10"
       },
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/mic03kwmyphr3pd9l0rrq28cf60b215s-hello-2.10.drv",
         "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=fa0326ce5233f7d592271df52c9d0812bec47b84",
+        "name": "hello-2.10",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/qwn4c03x5s1ydajfbqwdv236qkajpa4j-hello-2.10"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
+        "rev": "fa0326ce5233f7d592271df52c9d0812bec47b84",
+        "rev_count": 295280,
+        "rev_date": "2021-06-13T10:36:29Z",
+        "scrape_date": "2024-08-15T21:00:57Z",
+        "stabilities": [
+          "stable",
+          "staging",
+          "unstable"
+        ],
         "system": "x86_64-darwin",
+        "unfree": false,
         "version": "2.10"
       },
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/rjgp4m7s19x1krjq0h1d6cwkgqqag4xm-hello-2.10.drv",
         "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=7cb76200088f45cd24a9aa67fd2f9657943d78a4",
+        "name": "hello-2.10",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/06mk2d48d3qm2k2w7q5l52va2ri5m5m7-hello-2.10"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
-        "system": "aarch64-darwin",
+        "rev": "7cb76200088f45cd24a9aa67fd2f9657943d78a4",
+        "rev_count": 286880,
+        "rev_date": "2021-05-03T20:48:10Z",
+        "scrape_date": "2024-08-16T04:27:00Z",
+        "stabilities": null,
+        "system": "aarch64-linux",
+        "unfree": false,
         "version": "2.10"
       },
       {
-        "attrPath": [
-          "hello"
-        ],
+        "attr_path": "hello",
+        "broken": false,
+        "catalog": "nixpkgs",
+        "derivation": "/nix/store/k182vqjdz55djsdg4ya6v58dcwlq3999-hello-2.10.drv",
         "description": "A program that produces a familiar, friendly greeting",
-        "input": "nixpkgs",
+        "insecure": false,
         "license": "GPL-3.0-or-later",
-        "pkgPath": "hello",
+        "locked_url": "https://github.com/flox/nixpkgs?rev=7cb76200088f45cd24a9aa67fd2f9657943d78a4",
+        "name": "hello-2.10",
+        "outputs": [
+          {
+            "name": "out",
+            "store_path": "/nix/store/544psc5aqpbmyffi7c6pgf8bhkkabkry-hello-2.10"
+          }
+        ],
+        "outputs_to_install": [
+          "out"
+        ],
+        "pkg_path": "hello",
         "pname": "hello",
+        "rev": "7cb76200088f45cd24a9aa67fd2f9657943d78a4",
+        "rev_count": 286880,
+        "rev_date": "2021-05-03T20:48:10Z",
+        "scrape_date": "2024-08-16T04:27:00Z",
+        "stabilities": null,
         "system": "x86_64-linux",
+        "unfree": false,
         "version": "2.10"
       }
     ]

--- a/test_data/generated/show/hello.json
+++ b/test_data/generated/show/hello.json
@@ -9,7 +9,7 @@
         "description": "Program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "x86_64-linux",
         "version": "2.12.1"
@@ -21,7 +21,7 @@
         "description": "Program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "aarch64-darwin",
         "version": "2.12.1"
@@ -33,7 +33,7 @@
         "description": "Program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "x86_64-darwin",
         "version": "2.12.1"
@@ -45,7 +45,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "aarch64-linux",
         "version": "2.12.1"
@@ -57,7 +57,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "aarch64-linux",
         "version": "2.12"
@@ -69,7 +69,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "x86_64-linux",
         "version": "2.12"
@@ -81,7 +81,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "aarch64-darwin",
         "version": "2.12"
@@ -93,7 +93,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "x86_64-darwin",
         "version": "2.12"
@@ -105,7 +105,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "aarch64-linux",
         "version": "2.10"
@@ -117,7 +117,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "x86_64-darwin",
         "version": "2.10"
@@ -129,7 +129,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "aarch64-darwin",
         "version": "2.10"
@@ -141,7 +141,7 @@
         "description": "A program that produces a familiar, friendly greeting",
         "input": "nixpkgs",
         "license": "GPL-3.0-or-later",
-        "pkgPath": "nixpkgs/hello",
+        "pkgPath": "hello",
         "pname": "hello",
         "system": "x86_64-linux",
         "version": "2.10"


### PR DESCRIPTION
Previously, we only displayed the attr_path portion for custom catalog
packages (ie. mycatalog/foo would display foo). That name can't be used to
install the package, so we now properly show the full pkg path.

This includes a refactor of some of the search and show code to a) use separate types for search and show, as they correspond to different catalog service endpoints and use different fields, b) remove the intermediate `SearchResult` type and use the underlying client type directly.

This is best reviewed commitwise, in order.