### PR TITLE
docs: update flox-config man page with all options

### DIFF
--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -116,10 +116,19 @@ flox config --set 'trusted_environments."owner/name"' trust
     * "hide-all": disables the modification of the shell prompt
     * "hide-default": filters out environments named 'default' from the shell prompt
 
+`state_dir`
+:   Directory where flox should store data that's not critical but also
+    shouldn't be able to be freely deleted like data in the cache directory.
+    (default: `$XDG_STATE_HOME/flox` e.g. `~/.local/state/flox`)
+
 `trusted_environments`
 :   Remote environments that are trusted for activation.
     Contains keys of the form `"<owner>/<name>"` that map to either `"trust"` or
     `"deny"`.
+
+`upgrade_notifications`
+:   Print notification if upgrades are available on `flox activate`
+    (default: true).
 
 # ENVIRONMENT VARIABLES
 

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -127,8 +127,14 @@ flox config --set 'trusted_environments."owner/name"' trust
     `"deny"`.
 
 `upgrade_notifications`
-:   Print notification if upgrades are available on `flox activate`
-    (default: true).
+:   Print notification if upgrades are available on `flox activate`.
+    The notification message is:
+    ```
+    Upgrades are available for packages in 'environment-name'.
+    Use 'flox upgrade' to get the latest.
+    ```
+
+    (default: true)
 
 # ENVIRONMENT VARIABLES
 

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -81,7 +81,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 :   Directory where flox should load its configuration file
     (default: `$XDG_CONFIG_HOME/flox`).
     This option will only take effect if set with `$FLOX_CONFIG_DIR`.
-    `$FLOX_CONFIG_DIR` and `config_dir` are ignored.
+    `config_dir` is ignored.
 
 `cache_dir`
 :   Directory where flox should store ephemeral data

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -736,6 +736,7 @@ fn notify_upgrade_if_available(flox: &Flox, environment: &mut ConcreteEnvironmen
     let description =
         UninitializedEnvironment::from_concrete_environment(environment)?.message_description()?;
 
+    // Update this message in flox-config.md if you change it here
     let message = formatdoc! {"
         ℹ️  Upgrades are available for packages in {description}.
         Use 'flox upgrade' to get the latest.

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -94,7 +94,14 @@ pub struct FloxConfig {
     /// Hide environments named 'default' from the shell prompt
     pub hide_default_prompt: Option<bool>,
 
-    /// Print notification if upgrades are available on `flox activate` (default: true)
+    /// Print notification if upgrades are available on `flox activate`.
+    /// The notification message is:
+    /// ```
+    /// Upgrades are available for packages in 'environment-name'.
+    /// Use 'flox upgrade' to get the latest.
+    /// ```
+    ///
+    /// (default: true)
     pub upgrade_notifications: Option<bool>,
 }
 


### PR DESCRIPTION
[docs: update flox-config man page with all options](https://github.com/flox/flox/pull/2591/commits/c532ab6c8ca92200984f6101d1a275a191f1de33)
[c532ab6](https://github.com/flox/flox/pull/2591/commits/c532ab6c8ca92200984f6101d1a275a191f1de33)

The options `state_dir` and `upgrade_notifications` have been added to
config but were never added to the man page.

[docs: add upgrade notification text to man page](https://github.com/flox/flox/pull/2591/commits/8d33802749741785a679cd82c7edfad922137acd)
[8d33802](https://github.com/flox/flox/pull/2591/commits/8d33802749741785a679cd82c7edfad922137acd)

Add upgrade notification text to `man flox-config` so the config setting
will appear if a user searches the text of the message. The man pages
are included on our docs site

## Release Notes

A config option was added to control whether update notifications are printed in `flox activate`