### PR TITLE
feat: add upgrade information to list

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -906,7 +906,12 @@ impl UpgradeResult {
             for (prev_system, prev_package) in prev_packages_by_system {
                 // We must have the same packages before and after upgrading
                 let after_package = after_packages_by_system.remove(&prev_system).unwrap();
-                if prev_package.derivation() != after_package.derivation() {
+                // Store paths return None for the derivation,
+                // and we shouldn't say store paths have an upgrade.
+                if prev_package.derivation().is_some()
+                    && after_package.derivation().is_some()
+                    && prev_package.derivation() != after_package.derivation()
+                {
                     let by_system = packages_with_upgrades
                         .entry(prev_install_id.to_owned())
                         .or_default();

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -36,6 +36,7 @@ pub use core_environment::{
     CoreEnvironment,
     CoreEnvironmentError,
     EditResult,
+    SingleSystemUpgradeDiff,
     UpgradeResult,
 };
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -1068,7 +1068,7 @@ mod upgrade_notification_tests {
                 store_path: None,
             };
 
-            assert_eq!(result.diff(), vec![]);
+            assert!(result.diff().is_empty());
 
             let mut locked = upgrade_information.lock_if_unlocked().unwrap().unwrap();
 

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -3,7 +3,7 @@ use std::io::{stdout, Write};
 use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::Environment;
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::models::lockfile::{
     InstalledPackage,
     LockedPackageFlake,
@@ -58,8 +58,7 @@ impl List {
 
         let mut env = self
             .environment
-            .detect_concrete_environment(&flox, "List using")?
-            .into_dyn_environment();
+            .detect_concrete_environment(&flox, "List using")?;
 
         let manifest_contents = env.manifest_contents(&flox)?;
         if self.list_mode == ListMode::Config {
@@ -68,7 +67,7 @@ impl List {
         }
 
         let system = &flox.system;
-        let lockfile = Self::get_lockfile(&flox, &mut *env)?;
+        let lockfile = Self::get_lockfile(&flox, &mut env)?;
         let packages = lockfile.list_packages(system)?;
 
         if packages.is_empty() {
@@ -270,7 +269,7 @@ impl List {
     ///
     /// Check the implementation docs of [Environment::lockfile] for more
     /// information.
-    fn get_lockfile(flox: &Flox, env: &mut dyn Environment) -> Result<Lockfile> {
+    fn get_lockfile(flox: &Flox, env: &mut ConcreteEnvironment) -> Result<Lockfile> {
         // TODO: it would be better if we knew when a lock was actually happening
         let lockfile = env.lockfile(flox)?;
 


### PR DESCRIPTION
When a prior check for an upgrade has been run, add `- upgrade
available` to the output of `flox list`, e.g.:
hello: hello (2.12.1 - upgrade available)

When a prior check for an upgrade has been run, add `(upgrade available)`
to the output of `flox list --all`.

Also move pname into the table instead of the header and change Path ->
Package Path.

Example output:
```
python_install_id: (upgrade available)
  Description:  Python interpreter
  Package Path: python3Packages.python
  Package Name: python
  Priority:     10
  Version:      3.9.5
  License:      PSF
  Unfree:       false
  Broken:       false
```

Prior to this change, output would be:
```
python_install_id: (python)
  Description: Python interpreter
  Path:     python3Packages.python
  Priority: 10
  Version:  3.9.5
  License:  PSF
  Unfree:   false
  Broken:   false
```


## Release Notes

Add `upgrade available` to the output of `flox list` for packages that have upgrades