### PR TITLE
feat(containerize): Simplify array options

### DIFF
--- a/cli/flox-rust-sdk/src/providers/container_builder.rs
+++ b/cli/flox-rust-sdk/src/providers/container_builder.rs
@@ -12,6 +12,7 @@ use crate::flox::Flox;
 use crate::models::manifest::ManifestContainerizeConfig;
 use crate::providers::build::BUILDTIME_NIXPKGS_URL;
 use crate::providers::buildenv::NIX_BIN;
+use crate::utils::gomap::GoMap;
 use crate::utils::CommandExt;
 
 static MK_CONTAINER_NIX: LazyLock<PathBuf> = LazyLock::new(|| {
@@ -48,7 +49,7 @@ pub trait ContainerBuilder {
 #[derive(Debug)]
 pub struct MkContainerNix {
     store_path: BuiltStorePath,
-    container_config: Option<ManifestContainerizeConfig>,
+    container_config: Option<ManifestContainerizeConfig<GoMap>>,
 }
 
 #[derive(Debug, Error)]
@@ -79,7 +80,7 @@ impl MkContainerNix {
     )]
     pub fn new(
         store_path: BuiltStorePath,
-        container_config: Option<ManifestContainerizeConfig>,
+        container_config: Option<ManifestContainerizeConfig<GoMap>>,
     ) -> Self {
         Self {
             store_path,

--- a/cli/flox-rust-sdk/src/utils/gomap.rs
+++ b/cli/flox-rust-sdk/src/utils/gomap.rs
@@ -1,0 +1,35 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Representation of Go's `struct{}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GoEmptyStruct(BTreeMap<(), ()>);
+
+/// Representation of Go's `map[string]struct{}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GoMap(BTreeMap<String, GoEmptyStruct>);
+
+impl GoMap {
+    // Construct a new GoMap from a vec of keys.
+    pub fn new(keys: Vec<String>) -> Self {
+        GoMap(
+            keys.into_iter()
+                .map(|key| (key, GoEmptyStruct::default()))
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    #[test]
+    fn new() {
+        let keys = vec!["a".to_string(), "b".to_string()];
+        let gomap = super::GoMap::new(keys);
+        let json = serde_json::to_string(&gomap).unwrap();
+        assert_eq!(json, r#"{"a":{},"b":{}}"#);
+    }
+}

--- a/cli/flox-rust-sdk/src/utils/gomap.rs
+++ b/cli/flox-rust-sdk/src/utils/gomap.rs
@@ -3,11 +3,11 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 /// Representation of Go's `struct{}`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct GoEmptyStruct(BTreeMap<(), ()>);
 
 /// Representation of Go's `map[string]struct{}`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct GoMap(BTreeMap<String, GoEmptyStruct>);
 
 impl GoMap {

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -1,5 +1,7 @@
 pub mod errors;
+pub mod gomap;
 pub mod guard;
+
 #[cfg(any(test, feature = "tests"))]
 use std::collections::BTreeMap;
 use std::fmt::Display;

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -68,7 +68,8 @@ impl Containerize {
                 .lockfile(&flox)?
                 .manifest
                 .containerize
-                .and_then(|c| c.config);
+                .and_then(|c| c.config)
+                .map(|c| c.into());
             // this method is only executed on linux
             #[cfg_attr(not(target_os = "linux"), allow(deprecated))]
             let builder = MkContainerNix::new(built_environment.develop, container_config);

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -356,9 +356,9 @@ function assert_container_output() {
     version = 1
     [containerize.config]
     User = "user"
-    ExposedPorts = { "80/tcp" = {} }
+    ExposedPorts = [ "80/tcp" ]
     Cmd = [ "some", "command" ]
-    Volumes = { "/some/volume" = {} }
+    Volumes = [ "/some/volume" ]
     WorkingDir = "/working/dir"
     Labels = { "dev.flox.key" = "value" }
     StopSignal = "SIGKILL"


### PR DESCRIPTION
⚠️ Docs from https://github.com/flox/flox/pull/2599 need to be updated in sync with this.

## Proposed Changes

Represent them as `Vec<String>` in `manifest.toml` and `manifest.lock`, then convert them to `map[string]struct{}` when creating a container.

## Release Notes

N/A until released.
