### PR TITLE
feat(containerize): pipe subprocess output into tracing

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "toml 0.8.19",
  "toml_edit",
  "tracing",
+ "tracing-subscriber",
  "url",
  "url-escape",
  "uuid",

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -43,6 +43,9 @@ uuid.workspace = true
 walkdir.workspace = true
 xdg.workspace = true
 serial_test = { workspace = true, features = ["file_locks"] }
+tracing-subscriber = { workspace = true, optional = true }
+proptest = {workspace = true, optional = true}
+proptest-derive= { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow.workspace = true
@@ -51,9 +54,10 @@ pretty_assertions.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
 serial_test.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
 # allow exporting test helpers in dev mode only
-tests = []
+tests = ["tracing-subscriber", "proptest", "proptest-derive"]
 extra-tests = ["impure-unit-tests"]
 impure-unit-tests = []

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 use super::environment::{path_hash, EnvironmentPointer};
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
-use crate::utils::traceable_path;
+use crate::utils::logging::traceable_path;
 
 pub const ENV_REGISTRY_FILENAME: &str = "env-registry.json";
 

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -34,7 +34,7 @@ use tracing::instrument;
 use crate::data::System;
 use crate::flox::FLOX_VERSION;
 use crate::models::search::{PackageDetails, ResultCount, SearchLimit, SearchResults};
-use crate::utils::traceable_path;
+use crate::utils::logging::traceable_path;
 
 const NIXPKGS_CATALOG: &str = "nixpkgs";
 pub const FLOX_CATALOG_MOCK_DATA_VAR: &str = "_FLOX_USE_CATALOG_MOCK";

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -24,7 +24,8 @@ use tracing::debug;
 use crate::flox::Flox;
 use crate::models::lockfile::Lockfile;
 use crate::models::manifest::{ManifestServiceShutdown, ManifestServices};
-use crate::utils::{traceable_path, CommandExt};
+use crate::utils::logging::traceable_path;
+use crate::utils::CommandExt;
 
 const PROCESS_NEVER_EXIT_NAME: &str = "flox_never_exit";
 /// The path to the nix provided `sleep` binary.

--- a/cli/flox-rust-sdk/src/utils/logging.rs
+++ b/cli/flox-rust-sdk/src/utils/logging.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+pub use flox_core::traceable_path;
+
+/// Returns a `tracing`-compatible form of an `Option<PathBuf>`
+pub fn maybe_traceable_path(maybe_path: &Option<PathBuf>) -> impl tracing::Value {
+    if let Some(ref p) = maybe_path {
+        p.display().to_string()
+    } else {
+        String::from("null")
+    }
+}
+
+#[cfg(any(test, feature = "tests"))]
+pub mod test_helpers {
+    use std::fmt::Display;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Debug, Default)]
+    pub struct CollectingWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Display for CollectingWriter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let buffer = self.buffer.lock().unwrap();
+            let str_content = String::from_utf8_lossy(&buffer);
+            write!(f, "{str_content}")
+        }
+    }
+
+    impl std::io::Write for &CollectingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            // panic!("Cannot write to a read-only writer");
+            self.buffer.lock().unwrap().write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.buffer.lock().unwrap().flush()
+        }
+    }
+
+    impl<'w> tracing_subscriber::fmt::MakeWriter<'w> for CollectingWriter {
+        type Writer = <Mutex<Vec<u8>> as tracing_subscriber::fmt::MakeWriter<'w>>::Writer;
+
+        fn make_writer(&'w self) -> Self::Writer {
+            (*self.buffer).make_writer()
+        }
+    }
+
+    // For now this is a POC of using tracing for output tests,
+    // evenatually we should probably move that to the tracing utils or `message` module.
+    #[cfg(any(test, feature = "tests"))]
+    pub fn test_subscriber() -> (impl tracing::Subscriber, CollectingWriter) {
+        let writer = CollectingWriter::default();
+
+        // TODO: also tee to test output?
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .compact()
+            .without_time()
+            .with_level(false)
+            .with_target(false)
+            .finish();
+
+        (subscriber, writer)
+    }
+}

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -15,8 +15,6 @@ pub use flox_core::traceable_path;
 #[cfg(any(test, feature = "tests"))]
 use proptest::prelude::*;
 use thiserror::Error;
-use tokio::fs::OpenOptions;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use walkdir;
 
 use self::errors::IoError;
@@ -31,52 +29,6 @@ pub enum FindAndReplaceError {
     ReadTemplateFile(std::io::Error),
     #[error("Error writing to template file")]
     WriteTemplateFile(std::io::Error),
-}
-
-/// Replace all occurrences of `find` with `replace` in a directory or file
-pub async fn find_and_replace(
-    path: &Path,
-    find: &str,
-    replace: &str,
-) -> Result<(), FindAndReplaceError> {
-    for entry in walkdir::WalkDir::new(path) {
-        let entry = entry.map_err(FindAndReplaceError::WalkDir)?;
-        if entry.file_type().is_file() {
-            let mut file = match tokio::fs::File::open(entry.path()).await {
-                Ok(f) => f,
-                Err(err) => return Err(FindAndReplaceError::OpenTemplateFile(err)),
-            };
-
-            let mut file_contents = String::new();
-            file.read_to_string(&mut file_contents)
-                .await
-                .map_err(FindAndReplaceError::ReadTemplateFile)?;
-
-            // TODO optimize with find or something?
-            if file_contents.contains(find) {
-                let new_contents = file_contents.replace(find, replace);
-                match OpenOptions::new()
-                    .write(true)
-                    .truncate(true)
-                    .open(entry.path())
-                    .await
-                {
-                    Ok(mut f) => f
-                        .write_all(new_contents.as_bytes())
-                        .await
-                        .map_err(FindAndReplaceError::WriteTemplateFile)?,
-                    Err(err) => return Err(FindAndReplaceError::OpenTemplateFile(err)),
-                };
-            }
-        } else {
-            debug!(
-                "Skipping entry that is not a regular file: {}",
-                entry.path().to_string_lossy()
-            );
-        }
-    }
-
-    Ok(())
 }
 
 /// Using fs::copy copies permissions from the Nix store, which we don't want, so open (or

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -1,11 +1,12 @@
 pub mod errors;
 pub mod gomap;
 pub mod guard;
+pub mod logging;
 
 #[cfg(any(test, feature = "tests"))]
 use std::collections::BTreeMap;
 use std::fmt::Display;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::SystemTime;
 use std::{fs, io};
 
@@ -183,15 +184,6 @@ impl Display for DisplayCommand<'_> {
         }
 
         Ok(())
-    }
-}
-
-/// Returns a `tracing`-compatible form of an `Option<PathBuf>`
-pub fn maybe_traceable_path(maybe_path: &Option<PathBuf>) -> impl tracing::Value {
-    if let Some(ref p) = maybe_path {
-        p.display().to_string()
-    } else {
-        String::from("null")
     }
 }
 

--- a/cli/flox-watchdog/src/main.rs
+++ b/cli/flox-watchdog/src/main.rs
@@ -14,7 +14,7 @@ use flox_core::activations::{
 };
 use flox_rust_sdk::flox::FLOX_VERSION_STRING;
 use flox_rust_sdk::providers::services::process_compose_down;
-use flox_rust_sdk::utils::{maybe_traceable_path, traceable_path};
+use flox_rust_sdk::utils::logging::{maybe_traceable_path, traceable_path};
 use logger::{init_logger, spawn_heartbeat_log, spawn_logs_gc_threads};
 use nix::libc::{SIGINT, SIGQUIT, SIGTERM, SIGUSR1};
 use nix::unistd::{getpgid, getpid, setsid};

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -62,6 +62,7 @@ serial_test.workspace = true
 temp-env.workspace = true
 tempfile.workspace = true
 toml.workspace = true
+flox-rust-sdk = { workspace = true, features = ["tests"] }
 
 
 [features]

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -63,6 +63,7 @@ impl Containerize {
         );
 
         let built_environment = env.build(&flox)?;
+        let env_name = env.name();
 
         let source = if std::env::consts::OS == "linux" {
             let container_config = env
@@ -75,7 +76,7 @@ impl Containerize {
             #[cfg_attr(not(target_os = "linux"), allow(deprecated))]
             let builder = MkContainerNix::new(built_environment.develop, container_config);
 
-            builder.create_container_source(&flox, env.name().as_ref(), output_tag)?
+            builder.create_container_source(&flox, env_name.as_ref(), output_tag)?
         } else {
             let env_path = env.parent_path()?;
             let Some(container_runtime) = Runtime::detect_from_path() else {
@@ -86,14 +87,14 @@ impl Containerize {
                 "#});
             };
             let builder = ContainerizeProxy::new(env_path, container_runtime);
-            builder.create_container_source(&flox, env.name().as_ref(), output_tag)?
+            builder.create_container_source(&flox, env_name.as_ref(), output_tag)?
         };
 
         let mut writer = output.to_writer()?;
         source.stream_container(&mut writer)?;
         writer.wait()?;
 
-        message::created(format!("Container written to {output}"));
+        message::created(format!("'{env_name}:{output_tag}' written to {output}"));
         Ok(())
     }
 }

--- a/cli/flox/src/commands/init/go.rs
+++ b/cli/flox/src/commands/init/go.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::InitCustomization;
 use flox_rust_sdk::models::manifest::CatalogPackage;
-use flox_rust_sdk::utils::traceable_path;
+use flox_rust_sdk::utils::logging::traceable_path;
 use indoc::{formatdoc, indoc};
 use tracing::debug;
 

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::InitCustomization;
 use flox_rust_sdk::models::manifest::CatalogPackage;
-use flox_rust_sdk::utils::traceable_path;
+use flox_rust_sdk::utils::logging::traceable_path;
 use indoc::{formatdoc, indoc};
 use semver::VersionReq;
 

--- a/cli/flox/src/utils/init/catalog_client.rs
+++ b/cli/flox/src/utils/init/catalog_client.rs
@@ -9,7 +9,7 @@ use flox_rust_sdk::providers::catalog::{
     MockClient,
     FLOX_CATALOG_MOCK_DATA_VAR,
 };
-use flox_rust_sdk::utils::traceable_path;
+use flox_rust_sdk::utils::logging::traceable_path;
 use tracing::debug;
 
 use crate::config::Config;

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -256,7 +256,7 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
   run "$FLOX_BIN" containerize
   assert_success
-  assert_line --partial "Loaded image: localhost/test:latest"
+  assert_line "✨ 'test:latest' written to Podman runtime"
 }
 
 # bats test_tags=containerize:default-to-file
@@ -278,7 +278,7 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
   run "$FLOX_BIN" containerize --tag 'sometag'
   assert_success
-  assert_line --partial "Loaded image: localhost/test:sometag"
+  assert_line "✨ 'test:sometag' written to Podman runtime"
 }
 
 # bats test_tags=containerize:piped-to-runtime
@@ -287,7 +287,7 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
   run bash -c '"$FLOX_BIN" containerize --tag "runtime" --runtime podman' 3>&-
   assert_success
-  assert_line --partial "Loaded image:"
+  assert_line "✨ 'test:runtime' written to Podman runtime"
 
   run --separate-stderr podman run -q -i "localhost/test:runtime" -c 'echo $foo'
   assert_success


### PR DESCRIPTION
## Proposed Changes

### [feat: add a WireTap helper to tap into Read output](https://github.com/flox/flox/commit/38c6583db7553021eb40cffaa9922c63239ac9c2) 

Abstract processing of lines of data from a `Read` implementation.
`WireTap::tap_lines*` will read lines from the reader
and call a provided function for every line.
`tap_lines_with_context` allows to provide a context
that can hold state across multiple calls of the tap function.
That context is used by `WireTap<String>::tap_lines`
to collect lines back into a String.

### [feat(containerize): pipe ContainerSource output into tracing](https://github.com/flox/flox/commit/a02c90471a601d927fb9eb45069103278e81ddf0) 

Use `WireTap` to log `ContainerSource` output with `info` verbosity.
The effect will be that by default `containerize` will not print logs
of the container builder script and conflict with the spinners.

### [feat(containerize): pipe ContainerSink output into tracing](https://github.com/flox/flox/commit/29ea412e4eb895717e4c3a07f2c2d4c779fd8a95) 

Use `WireTap` to log `ContainerSink` output with `info` verbosity.
The effect will be that by default `containerize` will not print docker logs
and conflict with the spinners as we `<runtime> load` the container image.


## Release Notes

`flox containerize` will now omit output from its sub processes.
The logs can be enabled with one or more `-v|--verbose`.
