### PR TITLE
feat(containerize): Change manifest format (kebab-case and arrays)

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -1049,7 +1049,7 @@ pub struct ManifestContainerize {
 /// Env and Entrypoint are left out since they interfere with our activation implementation
 /// Deprecated and reserved keys are also left out
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ManifestContainerizeConfig {
@@ -1059,7 +1059,7 @@ pub struct ManifestContainerizeConfig {
     /// If `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` and `/etc/group` from the container are applied.
     /// If `group`/`gid` is specified, supplementary groups from the container are ignored.
     #[serde(skip_serializing_if = "Option::is_none")]
-    user: Option<String>,
+    pub user: Option<String>,
     /// A set of ports to expose from a container running this image.
     /// Its keys can be in the format of:
     /// `port/tcp`, `port/udp`, `port` with the default protocol being `tcp` if not specified.
@@ -1072,12 +1072,12 @@ pub struct ManifestContainerizeConfig {
         )
     )]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    exposed_ports: Option<BTreeMap<String, BTreeMap<(), ()>>>,
+    pub exposed_ports: Option<BTreeMap<String, BTreeMap<(), ()>>>,
     /// Default arguments to the entrypoint of the container.
     /// These values act as defaults and may be replaced by any specified when creating a container.
     /// If an `Entrypoint` value is not specified, then the first entry of the `Cmd` array SHOULD be interpreted as the executable to run.
     #[serde(skip_serializing_if = "Option::is_none")]
-    cmd: Option<Vec<String>>,
+    pub cmd: Option<Vec<String>>,
     /// A set of directories describing where the process is
     /// likely to write data specific to a container instance.
     /// This JSON structure value is unusual because it is a direct JSON serialization of the Go type map[string]struct{} and is represented in JSON as an object mapping its keys to an empty object.
@@ -1088,18 +1088,18 @@ pub struct ManifestContainerizeConfig {
             strategy = "proptest::option::of(proptest_btree_map_alphanum_keys_empty_map(10, 3))"
         )
     )]
-    volumes: Option<BTreeMap<String, BTreeMap<(), ()>>>,
+    pub volumes: Option<BTreeMap<String, BTreeMap<(), ()>>>,
     /// Sets the current working directory of the entrypoint process in the container.
     /// This value acts as a default and may be replaced by a working directory specified when creating a container.
     #[serde(skip_serializing_if = "Option::is_none")]
-    working_dir: Option<String>,
+    pub working_dir: Option<String>,
     /// The field contains arbitrary metadata for the container.
     /// This property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules).
     #[serde(skip_serializing_if = "Option::is_none")]
-    labels: Option<BTreeMap<String, String>>,
+    pub labels: Option<BTreeMap<String, String>>,
     /// The field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format `SIGNAME`, for instance `SIGKILL` or `SIGRTMIN+3`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    stop_signal: Option<String>,
+    pub stop_signal: Option<String>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -1065,7 +1065,7 @@ pub struct ManifestContainerizeConfig {
     /// `port/tcp`, `port/udp`, `port` with the default protocol being `tcp` if not specified.
     /// These values act as defaults and are merged with any specified when creating a container.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub exposed_ports: Option<Vec<String>>,
+    pub exposed_ports: Option<BTreeSet<String>>,
     /// Default arguments to the entrypoint of the container.
     /// These values act as defaults and may be replaced by any specified when creating a container.
     /// If an `Entrypoint` value is not specified, then the first entry of the `Cmd` array SHOULD be interpreted as the executable to run.
@@ -1074,7 +1074,7 @@ pub struct ManifestContainerizeConfig {
     /// A set of directories describing where the process is
     /// likely to write data specific to a container instance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub volumes: Option<Vec<String>>,
+    pub volumes: Option<BTreeSet<String>>,
     /// Sets the current working directory of the entrypoint process in the container.
     /// This value acts as a default and may be replaced by a working directory specified when creating a container.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -19,7 +19,7 @@ use super::environment::path_environment::InitCustomization;
 use crate::data::System;
 use crate::providers::services::ServiceError;
 #[cfg(test)]
-use crate::utils::{proptest_btree_map_alphanum_keys, proptest_btree_map_alphanum_keys_empty_map};
+use crate::utils::proptest_btree_map_alphanum_keys;
 
 pub(super) const DEFAULT_GROUP_NAME: &str = "toplevel";
 pub const DEFAULT_PRIORITY: u64 = 5;
@@ -1064,15 +1064,8 @@ pub struct ManifestContainerizeConfig {
     /// Its keys can be in the format of:
     /// `port/tcp`, `port/udp`, `port` with the default protocol being `tcp` if not specified.
     /// These values act as defaults and are merged with any specified when creating a container.
-    /// **NOTE:** This JSON structure value is unusual because it is a direct JSON serialization of the Go type `map[string]struct{}` and is represented in JSON as an object mapping its keys to an empty object.
-    #[cfg_attr(
-        test,
-        proptest(
-            strategy = "proptest::option::of(proptest_btree_map_alphanum_keys_empty_map(10, 3))"
-        )
-    )]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub exposed_ports: Option<BTreeMap<String, BTreeMap<(), ()>>>,
+    pub exposed_ports: Option<Vec<String>>,
     /// Default arguments to the entrypoint of the container.
     /// These values act as defaults and may be replaced by any specified when creating a container.
     /// If an `Entrypoint` value is not specified, then the first entry of the `Cmd` array SHOULD be interpreted as the executable to run.
@@ -1080,15 +1073,8 @@ pub struct ManifestContainerizeConfig {
     pub cmd: Option<Vec<String>>,
     /// A set of directories describing where the process is
     /// likely to write data specific to a container instance.
-    /// This JSON structure value is unusual because it is a direct JSON serialization of the Go type map[string]struct{} and is represented in JSON as an object mapping its keys to an empty object.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(
-        test,
-        proptest(
-            strategy = "proptest::option::of(proptest_btree_map_alphanum_keys_empty_map(10, 3))"
-        )
-    )]
-    pub volumes: Option<BTreeMap<String, BTreeMap<(), ()>>>,
+    pub volumes: Option<Vec<String>>,
     /// Sets the current working directory of the entrypoint process in the container.
     /// This value acts as a default and may be replaced by a working directory specified when creating a container.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/flox-rust-sdk/src/providers/container_builder.rs
+++ b/cli/flox-rust-sdk/src/providers/container_builder.rs
@@ -240,6 +240,7 @@ pub enum ContainerSourceError {
 
 #[cfg(test)]
 mod container_source_tests {
+    use std::collections::BTreeSet;
     use std::fs::{self, File};
     use std::os::unix::fs::PermissionsExt;
 
@@ -252,8 +253,8 @@ mod container_source_tests {
     fn oci_config_from_manifest() {
         let manifest_config = ManifestContainerizeConfig {
             user: Some("root".to_string()),
-            exposed_ports: Some(vec![("80/tcp".to_string())]),
-            volumes: Some(vec![("/app".to_string())]),
+            exposed_ports: Some(BTreeSet::from(["80/tcp".to_string()])),
+            volumes: Some(BTreeSet::from(["/app".to_string()])),
             working_dir: Some("/app".to_string()),
             ..Default::default()
         };
@@ -263,7 +264,7 @@ mod container_source_tests {
         // Selection of fields that verify From + Serialize:
         // - omits fields that are `None`
         // - renames keys from kebab-case to PascalCase
-        // - converts values from `Vec` to `GoMap`
+        // - converts values from `BTreeSet` to `GoMap`
         assert_eq!(json, indoc! {r#"{
           "User": "root",
           "ExposedPorts": {

--- a/cli/flox-rust-sdk/src/utils/gomap.rs
+++ b/cli/flox-rust-sdk/src/utils/gomap.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -10,8 +10,8 @@ pub struct GoEmptyStruct(BTreeMap<(), ()>);
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct GoMap(BTreeMap<String, GoEmptyStruct>);
 
-impl From<Vec<String>> for GoMap {
-    fn from(v: Vec<String>) -> Self {
+impl From<BTreeSet<String>> for GoMap {
+    fn from(v: BTreeSet<String>) -> Self {
         GoMap(
             v.into_iter()
                 .map(|s| (s, GoEmptyStruct::default()))
@@ -27,8 +27,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new() {
-        let vals = vec!["aaa".to_string(), "bbb".to_string(), "ccc".to_string()];
+    fn from_btreeset_string() {
+        let vals = BTreeSet::from([
+            "aaa".to_string(),
+            "bbb".to_string(),
+            "ccc".to_string(),
+            // Set don't have dupes but just in case the type is later changed.
+            "aaa".to_string(),
+        ]);
         let gomap = GoMap::from(vals);
         let json = serde_json::to_string(&gomap).unwrap();
 

--- a/cli/flox-rust-sdk/src/utils/gomap.rs
+++ b/cli/flox-rust-sdk/src/utils/gomap.rs
@@ -1,0 +1,37 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Representation of Go's `struct{}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GoEmptyStruct(BTreeMap<(), ()>);
+
+/// Representation of Go's `map[string]struct{}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GoMap(BTreeMap<String, GoEmptyStruct>);
+
+impl From<Vec<String>> for GoMap {
+    fn from(v: Vec<String>) -> Self {
+        GoMap(
+            v.into_iter()
+                .map(|s| (s, GoEmptyStruct::default()))
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn new() {
+        let vals = vec!["aaa".to_string(), "bbb".to_string(), "ccc".to_string()];
+        let gomap = GoMap::from(vals);
+        let json = serde_json::to_string(&gomap).unwrap();
+
+        assert_eq!(json, r#"{"aaa":{},"bbb":{},"ccc":{}}"#);
+    }
+}

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -1,5 +1,7 @@
 pub mod errors;
+pub mod gomap;
 pub mod guard;
+
 #[cfg(any(test, feature = "tests"))]
 use std::collections::BTreeMap;
 use std::fmt::Display;

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -68,7 +68,8 @@ impl Containerize {
                 .lockfile(&flox)?
                 .manifest
                 .containerize
-                .and_then(|c| c.config);
+                .and_then(|c| c.config)
+                .map(|c| c.into());
             // this method is only executed on linux
             #[cfg_attr(not(target_os = "linux"), allow(deprecated))]
             let builder = MkContainerNix::new(built_environment.develop, container_config);

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -408,7 +408,8 @@ EOF
 
   TAG="cmd-runs-in-activation"
 
-  bash -c "FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
+  # TODO: Reset REF_OR_REV to `main` after merging.
+  bash -c "FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=dcarley/containerize-manifest-format $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 
   run podman run --rm "test:$TAG"
   assert_success

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -353,13 +353,13 @@ function assert_container_output() {
   MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
     [containerize.config]
-    User = "user"
-    ExposedPorts = { "80/tcp" = {} }
-    Cmd = [ "some", "command" ]
-    Volumes = { "/some/volume" = {} }
-    WorkingDir = "/working/dir"
-    Labels = { "dev.flox.key" = "value" }
-    StopSignal = "SIGKILL"
+    user = "user"
+    exposed-ports = { "80/tcp" = {} }
+    cmd = [ "some", "command" ]
+    volumes = { "/some/volume" = {} }
+    working-dir = "/working/dir"
+    labels = { "dev.flox.key" = "value" }
+    stop-signal = "SIGKILL"
 EOF
   )"
 
@@ -391,7 +391,7 @@ EOF
 EOF
 }
 
-@test "Cmd can run binary from activated environment" {
+@test "cmd can run binary from activated environment" {
   "$FLOX_BIN" init
 
   MANIFEST_CONTENTS="$(cat << "EOF"
@@ -400,13 +400,13 @@ EOF
     hello.pkg-path = "hello"
 
     [containerize.config]
-    Cmd = [ "hello" ]
+    cmd = [ "hello" ]
 EOF
   )"
 
   echo "$MANIFEST_CONTENTS" | _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" edit -f -
 
-  TAG="Cmd-runs-in-activation"
+  TAG="cmd-runs-in-activation"
 
   bash -c "FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -354,9 +354,9 @@ function assert_container_output() {
     version = 1
     [containerize.config]
     user = "user"
-    exposed-ports = { "80/tcp" = {} }
+    exposed-ports = [ "80/tcp" ]
     cmd = [ "some", "command" ]
-    volumes = { "/some/volume" = {} }
+    volumes = [ "/some/volume" ]
     working-dir = "/working/dir"
     labels = { "dev.flox.key" = "value" }
     stop-signal = "SIGKILL"


### PR DESCRIPTION
## Proposed Changes

**feat(containerize): PascalCase -> kebab-case**

Rename `containerize.config` keys from PascalCase to kebab-case in the
user-facing manifest and only convert them when passing over to the
provider. Rationale from Jenny's update to the DR:

- https://www.notion.so/floxdev/011-Containerize-image-options-14a744c8e31680f09425d84de06a3bd4?pvs=4#14a744c8e3168199a9d0e320587a089d

> We will change the capitalization of the keys to kebab-case instead of
> PascalCase. This will be consistent with the rest of the Flox manifest
> fields. Since the values for each key will have a slightly
> different (nicer) format in the manifest.toml vs the spec, we don’t
> think it’s necessary to follow the capitalization convention of the spec
> file.

We'll maintain two structs, one user facing and the other provider
facing, because we're also going to modify the behaviour of values that
are unnecessary maps in a subsequent commit.

We considered using the third-party `oci_spec::image::Config` but we
don't need any of the other functionality so it doesn't seem worth
carrying an extra dependency.

**feat(containerize): Simplify arrays**

Present `exposed-ports` and `volumes` as `Vec<String>` instead of
`BTreeMap<String, BTreeMap<(), ()>>>` in the manifest. Perform an
internal conversion for Go's `map[string]struct{}` on the way over to
the provider.

This will be less surprising to users, especially if they aren't
familiar with the internals of OCI and Go. It also makes it much easier
to describe the syntax in our docs.

## Release Notes

N/A. These aren't breaking changes because it hasn't been released yet.
