### PR TITLE
Revert "test(containerize): Override FLAKE_REF_OR_REV"

### DIFF
--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -408,8 +408,7 @@ EOF
 
   TAG="cmd-runs-in-activation"
 
-  # TODO: Reset REF_OR_REV to `main` after merging.
-  bash -c "FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=dcarley/containerize-manifest-format $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
+  bash -c "FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 
   run podman run --rm "test:$TAG"
   assert_success


### PR DESCRIPTION
## Proposed Changes

This reverts commit 7c35e74055511b416925e570150196bf95119fb3.

Now that the change has been merged to `main`. Which incidentally failed because the branch was automatically deleted after merge:

- https://github.com/flox/flox/actions/runs/12829247263/job/35774996409

## Release Notes

N/A, internal only
