### PR TITLE
feat(publish): Allow cache options from config

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -109,6 +109,7 @@ pub trait BinaryCache {
     fn cache_url(&self) -> &Url;
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct NixCopyCache {
     pub url: Url,
     pub key_file: PathBuf,

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -12,7 +12,6 @@ use tracing::instrument;
 
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::activate::FLOX_INTERPRETER;
-use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::message;
 
@@ -54,8 +53,8 @@ enum SubcommandOrBuildTargets {
 }
 
 impl Build {
-    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
-        if !config.features.unwrap_or_default().build {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        if !flox.features.build {
             message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
             bail!("'build' feature is not enabled.");
         }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -346,6 +346,7 @@ impl FloxArgs {
             floxhub,
             catalog_client,
             installable_locker: Default::default(),
+            #[allow(deprecated, reason = "This should be the only internal use")]
             features: config.features.clone().unwrap_or_default(),
             verbosity: self.verbosity.to_i32(),
         };
@@ -943,9 +944,9 @@ impl InternalCommands {
         match self {
             InternalCommands::ResetMetrics(args) => args.handle(config, flox).await?,
             InternalCommands::Auth(args) => args.handle(config, flox).await?,
-            InternalCommands::Build(args) => args.handle(config, flox).await?,
-            InternalCommands::Publish(args) => args.handle(config, flox).await?,
-            InternalCommands::Upload(args) => args.handle(config, flox).await?,
+            InternalCommands::Build(args) => args.handle(flox).await?,
+            InternalCommands::Publish(args) => args.handle(flox).await?,
+            InternalCommands::Upload(args) => args.handle(flox).await?,
             InternalCommands::LockManifest(args) => args.handle(flox).await?,
             InternalCommands::CheckForUpgrades(args) => args.handle(flox).await?,
         }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -945,7 +945,7 @@ impl InternalCommands {
             InternalCommands::ResetMetrics(args) => args.handle(config, flox).await?,
             InternalCommands::Auth(args) => args.handle(config, flox).await?,
             InternalCommands::Build(args) => args.handle(flox).await?,
-            InternalCommands::Publish(args) => args.handle(flox).await?,
+            InternalCommands::Publish(args) => args.handle(config, flox).await?,
             InternalCommands::Upload(args) => args.handle(flox).await?,
             InternalCommands::LockManifest(args) => args.handle(flox).await?,
             InternalCommands::CheckForUpgrades(args) => args.handle(flox).await?,

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -20,7 +20,6 @@ use url::Url;
 
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::ensure_floxhub_token;
-use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::message;
 
@@ -54,8 +53,8 @@ struct PublishTarget {
 }
 
 impl Publish {
-    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
-        if !config.features.unwrap_or_default().publish {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        if !flox.features.publish {
             message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
             bail!("'publish' feature is not enabled.");
         }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -37,11 +37,13 @@ pub struct Publish {
 
 #[derive(Debug, Bpaf, Clone)]
 struct CacheArgs {
-    #[bpaf(long("cache"))]
-    url: Url,
+    /// URL of store to copy packages to.
+    #[bpaf(long, argument("URL"))]
+    store_url: Url,
 
-    #[bpaf(long("signing-key"))]
-    key_file: PathBuf,
+    /// Path of the key file used to sign packages before copying.
+    #[bpaf(long, argument("FILE"))]
+    signing_key: PathBuf,
 }
 
 #[derive(Debug, Bpaf, Clone)]
@@ -89,8 +91,8 @@ impl Publish {
         let build_metadata = check_build_metadata(&env, &package)?;
 
         let cache = cache_args.map(|args| NixCopyCache {
-            url: args.url,
-            key_file: args.key_file,
+            url: args.store_url,
+            key_file: args.signing_key,
         });
 
         let publish_provider = PublishProvider::<&FloxBuildMk, &NixCopyCache> {

--- a/cli/flox/src/commands/upload.rs
+++ b/cli/flox/src/commands/upload.rs
@@ -21,11 +21,13 @@ pub struct Upload {
 
 #[derive(Debug, Bpaf, Clone)]
 struct CacheArgs {
-    #[bpaf(long("cache"))]
-    url: Url,
+    /// URL of store to copy packages to.
+    #[bpaf(long, argument("URL"))]
+    store_url: Url,
 
-    #[bpaf(long("signing-key"))]
-    key_file: PathBuf,
+    /// Path of the key file used to sign packages before copying.
+    #[bpaf(long, argument("FILE"))]
+    signing_key: PathBuf,
 }
 
 impl Upload {
@@ -41,8 +43,8 @@ impl Upload {
         let store_path = validate_store_path(self.store_path)?;
 
         let cache = NixCopyCache {
-            url: self.cache.url,
-            key_file: self.cache.key_file,
+            url: self.cache.store_url,
+            key_file: self.cache.signing_key,
         };
 
         cache

--- a/cli/flox/src/commands/upload.rs
+++ b/cli/flox/src/commands/upload.rs
@@ -7,7 +7,6 @@ use flox_rust_sdk::providers::publish::{BinaryCache, NixCopyCache};
 use tracing::instrument;
 use url::Url;
 
-use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::message;
 
@@ -31,8 +30,8 @@ struct CacheArgs {
 
 impl Upload {
     #[instrument(name = "upload", skip_all)]
-    pub async fn handle(self, config: Config, _flox: Flox) -> Result<()> {
-        if !config.features.unwrap_or_default().upload {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        if !flox.features.upload {
             message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
             bail!("'upload' feature is not enabled.");
         }

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -37,6 +37,7 @@ pub struct Config {
     /// Accessing from `flox_rust_sdk::flox::Flox.features` should be preferred
     /// over `flox::config::Config.features` if both are available.
     #[serde(default)]
+    #[deprecated(note = "Access `flox_rust_sdk::flox::Flox.features` instead")]
     pub features: Option<Features>,
 }
 

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -104,6 +104,9 @@ pub struct FloxConfig {
     ///
     /// (default: true)
     pub upgrade_notifications: Option<bool>,
+
+    /// Configuration for 'flox publish'.
+    pub publish: Option<PublishConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -123,6 +126,15 @@ pub enum EnvironmentPromptConfig {
     /// Change the shell prompt to show the active environments,
     /// but omit 'default' environments
     HideDefault,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PublishConfig {
+    /// Default URL of the store used by 'flox publish'
+    pub store_url: Option<Url>,
+
+    /// Default path of the signing key used by 'flox publish'
+    pub signing_key: Option<PathBuf>,
 }
 
 /// Error returned by [`Config::get()`]


### PR DESCRIPTION
## Proposed Changes

**refactor(commands): {config->flox}.features**

Use `flox.features` instead of `config.features` for all of the build
and publish commands which are feature flagged.

Unfortunately we have to carry two copies of it around per 7ba717f but
`Flox.features` is easier to access because defaults have already been
applied and we don't need to move/ref it in doing so.

**feat(publish): Rename --cache to --store-url**

To better reflect that it's copying to a store rather than actually
caching the package.

The fields have been renamed at the same time so that we don't need to
specify the argument name separately (which was easy to overlook) and
hints have been added for the argument values.

**feat(publish): Merge cache opts from config**

Allow `publish.store_url` and `publish.signing_key` to be provided from
config. Any CLI arguments that are provided are merged over the top of
these. The names match the (renamed) arguments.

The URL and key can be mixed-and-matched from different sources but they
are required to be mutually present or absent. For this reason the
individual entries are now `Option<>`. Related discussion:

- https://flox-dev.slack.com/archives/C07GRNPFNJE/p1737037013075899

We may in the future decide that it doesn't make sense to provide these
from host config because you would only change them on a per-project
rather than per-host basis but we want to make it easier to use and
gather some feedback in the meantime. Related discussion:

- https://flox-dev.slack.com/archives/C07GRNPFNJE/p1737038217746299

These new keys haven't been added to the `flox-config(1)` docs because
we're not currently publicising the feature.

**feat(publish): Add hidden --no-store**

Requested by Bill:

> We should consider adding a no-cache or no-store argument that would
> instruct the CLI to skip the upload step of publish. This would only
> publish the metadata without a store location. In this case the
> package could only be re-built with a local build (which is not yet
> supported).  This could be useful for testing.

This is marked as hidden from `--help` because we don't think it will be
useful to external users and we may decide to remove it again in the
future.

## Release Notes

N/A, until `publish` is Generally Available.
