### PR TITLE
feat: add support for _FLOX_SHELL_FORCE

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -180,7 +180,8 @@ fi
 # The rust CLI contains sophisticated logic to set $FLOX_SHELL based on the
 # process listening on STDOUT, but that won't happen when activating from
 # the top-level activation script, so fall back to $SHELL as a default.
-declare -r _flox_shell="${FLOX_SHELL:-$SHELL}"
+# Respect _FLOX_SHELL_FORCE if set.
+declare -r _flox_shell="${_FLOX_SHELL_FORCE:-${FLOX_SHELL:-$SHELL}}"
 # Unset FLOX_SHELL to detect the parent shell anew with each flox invocation.
 unset FLOX_SHELL
 

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -155,18 +155,23 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
 
 ## Variables used by `flox activate`
 
-`$FLOX_SHELL`
-:  When launching an interactive sub-shell, Flox launches the shell specified in
-   `$FLOX_SHELL` if it is set.
-   When printing a shell for sourcing in the current shell,
-   Flox will produce a script suitable for `$FLOX_SHELL` if it is set.
+`$FLOX_SHELL`, `$SHELL`
+:  When activating an environment
+   Flox will either launch a sub-shell
+   or emit commands to configure an already-running (parent) shell.
+   In both of these cases Flox needs to know which shell to use,
+   and these variables are used to control the selection process.
 
-`$SHELL`
-:  When launching an interactive sub-shell, Flox launches the shell specified in
-   `$SHELL` if it is set and `$FLOX_SHELL` is not set.
-   When printing a shell for sourcing in the current shell,
-   Flox will produce a script suitable for `$SHELL` if it is set
-   and `$FLOX_SHELL` is not set and Flox can't detect the parent shell.
+       * interactive and command modes: When launching a sub-shell
+         Flox will invoke
+         the shell specified in `$FLOX_SHELL` if set
+         or fall back to invoke `$SHELL` by default.
+
+       * in-place mode: When performing an "in place" activation
+         Flox will attempt to detect its parent shell type unless overridden by
+         the `$FLOX_SHELL` variable,
+         and if it cannot detect its parent shell type then will
+         produce a script with syntax determined by `$SHELL`.
 
 `$FLOX_PROMPT_COLOR_{1,2}`
 :   Flox adds text to the beginning of the shell prompt to indicate which


### PR DESCRIPTION
## Proposed Changes

Added support for _FLOX_SHELL_FORCE - a version of FLOX_SHELL that is useful in testing because it will not be clobbered by the activate script.

## Release Notes

N/A