### PR TITLE
refactor/fix: Helpers for Nix commands

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -604,6 +604,7 @@ mod realise_nixpkgs_tests {
     use super::*;
     use crate::models::lockfile;
     use crate::providers::catalog::{MockClient, StoreInfo, StoreInfoResponse, GENERATED_DATA};
+    use crate::providers::nix::test_helpers::known_store_path;
 
     /// Read a single locked package for the current system from a mock lockfile.
     /// This is a helper function to avoid repetitive boilerplate in the tests.
@@ -819,15 +820,16 @@ mod realise_nixpkgs_tests {
 
     #[test]
     fn nixpkgs_published_pkg_cache_download_success() {
-        let real_storepath = env!("NIX_BIN").to_string();
-        let locked_package = locked_published_package(Some(&real_storepath));
+        let real_storepath = known_store_path();
+        let real_storepath_str = real_storepath.to_string_lossy();
+        let locked_package = locked_published_package(Some(&real_storepath_str));
         let mut client = MockClient::new(None::<String>).unwrap();
         let mut resp = StoreInfoResponse {
             items: std::collections::HashMap::new(),
         };
 
         // This is a trick for a known storepath
-        resp.items.insert(real_storepath.clone(), vec![
+        resp.items.insert(real_storepath_str.to_string(), vec![
             // Put something invalid first, to test that we try all locations
             StoreInfo {
                 url: "blasphemy*".to_string(),

--- a/cli/flox-rust-sdk/src/providers/container_builder.rs
+++ b/cli/flox-rust-sdk/src/providers/container_builder.rs
@@ -13,7 +13,7 @@ use super::buildenv::BuiltStorePath;
 use crate::flox::Flox;
 use crate::models::manifest::ManifestContainerizeConfig;
 use crate::providers::build::BUILDTIME_NIXPKGS_URL;
-use crate::providers::buildenv::NIX_BIN;
+use crate::providers::nix::nix_base_command;
 use crate::utils::gomap::GoMap;
 use crate::utils::CommandExt;
 
@@ -133,8 +133,7 @@ impl ContainerBuilder for MkContainerNix {
         name: impl AsRef<str>,
         tag: impl AsRef<str>,
     ) -> Result<ContainerSource, Self::Error> {
-        let mut command = Command::new(&*NIX_BIN);
-        command.args(["--extra-experimental-features", "nix-command flakes"]);
+        let mut command = nix_base_command();
         command.args(["--option", "pure-eval", "true"]);
         command.arg("build");
         command.arg("--json");

--- a/cli/flox-rust-sdk/src/providers/flake_installable_locker.rs
+++ b/cli/flox-rust-sdk/src/providers/flake_installable_locker.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
-use std::process::Command;
 use std::sync::{Arc, Mutex};
 
 use enum_dispatch::enum_dispatch;
@@ -9,7 +8,7 @@ use serde_with::skip_serializing_none;
 use thiserror::Error;
 use tracing::{debug, instrument};
 
-use super::buildenv::NIX_BIN;
+use super::nix::nix_base_command;
 use crate::models::manifest::{ManifestPackageDescriptorFlake, DEFAULT_PRIORITY};
 use crate::models::nix_plugins::NIX_PLUGINS;
 use crate::utils::CommandExt;
@@ -206,12 +205,7 @@ impl InstallableLocker for Nix {
         system: impl AsRef<str>,
         descriptor: &ManifestPackageDescriptorFlake,
     ) -> Result<LockedInstallable, FlakeInstallableError> {
-        let mut command = Command::new(&*NIX_BIN);
-        command.args([
-            "--option",
-            "extra-experimental-features",
-            "nix-command flakes",
-        ]);
+        let mut command = nix_base_command();
         command.args(["--option", "extra-plugin-files", &*NIX_PLUGINS]);
 
         command.args(["--option", "pure-eval", "false"]);

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -4,6 +4,7 @@ pub mod catalog;
 pub mod container_builder;
 pub mod flake_installable_locker;
 pub mod git;
+pub mod nix;
 pub mod publish;
 pub mod services;
 pub mod upgrade_checks;

--- a/cli/flox-rust-sdk/src/providers/nix.rs
+++ b/cli/flox-rust-sdk/src/providers/nix.rs
@@ -1,0 +1,10 @@
+pub mod test_helpers {
+    use std::path::PathBuf;
+
+    use crate::providers::buildenv::NIX_BIN;
+
+    /// Returns a Nix store path that's known to exist.
+    pub fn known_store_path() -> PathBuf {
+        NIX_BIN.to_path_buf()
+    }
+}

--- a/cli/flox-rust-sdk/src/providers/nix.rs
+++ b/cli/flox-rust-sdk/src/providers/nix.rs
@@ -1,7 +1,28 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::LazyLock;
+
+static NIX_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
+    std::env::var("NIX_BIN")
+        .unwrap_or_else(|_| env!("NIX_BIN").to_string())
+        .into()
+});
+
+/// Returns a `Command` for `nix` with a default set of features enabled.
+pub fn nix_base_command() -> Command {
+    let mut command = Command::new(&*NIX_BIN);
+    command.args([
+        "--option",
+        "extra-experimental-features",
+        "nix-command flakes",
+    ]);
+    command
+}
+
 pub mod test_helpers {
     use std::path::PathBuf;
 
-    use crate::providers::buildenv::NIX_BIN;
+    use super::*;
 
     /// Returns a Nix store path that's known to exist.
     pub fn known_store_path() -> PathBuf {

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -470,6 +470,7 @@ pub mod tests {
     use crate::providers::build::test_helpers::assert_build_status;
     use crate::providers::build::FloxBuildMk;
     use crate::providers::catalog::{MockClient, GENERATED_DATA};
+    use crate::providers::nix::test_helpers::known_store_path;
 
     fn example_remote() -> (tempfile::TempDir, GitCommandProvider, String) {
         let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
@@ -600,8 +601,9 @@ pub mod tests {
 
     #[test]
     fn test_check_build_meta_storepath_nominal() {
-        let real_storepath = env!("NIX_BIN").to_string();
-        let meta = check_build_metadata_from_storepath("mypkg", &real_storepath).unwrap();
+        let real_storepath = known_store_path();
+        let meta = check_build_metadata_from_storepath("mypkg", &real_storepath.to_string_lossy())
+            .unwrap();
 
         // Some of this found heuristically, and _probably_ won't change
         assert_eq!(meta.name.starts_with("nix-"), true);

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::error;
 use std::path::PathBuf;
-use std::process::Command;
 
 use catalog_api_v1::types::{Output, Outputs, SystemEnum};
 use chrono::{DateTime, Utc};
@@ -17,8 +16,8 @@ use super::catalog::{Client, ClientTrait, UserBuildInfo, UserDerivationInfo};
 use super::git::GitCommandProvider;
 use crate::flox::Flox;
 use crate::models::environment::{Environment, EnvironmentError};
-use crate::providers::buildenv::NIX_BIN;
 use crate::providers::git::GitProvider;
+use crate::providers::nix::nix_base_command;
 use crate::utils::CommandExt;
 
 #[derive(Debug, Error)]
@@ -127,7 +126,7 @@ impl BinaryCache for NixCopyCache {
             .append_pair("write-nar-listing", "true")
             .finish();
 
-        let mut copy_command = Command::new(&*NIX_BIN);
+        let mut copy_command = nix_base_command();
         copy_command
             .arg("copy")
             .arg("--to")
@@ -256,7 +255,7 @@ where
 }
 
 pub fn get_derivation_info(path: &str) -> Result<(String, DerivationInfo), PublishError> {
-    let mut info_cmd = Command::new(&*NIX_BIN);
+    let mut info_cmd = nix_base_command();
     info_cmd.arg("derivation").arg("show").arg(path);
     let output = info_cmd
         .output()
@@ -488,7 +487,7 @@ pub mod tests {
         let mut temp_key_file =
             tempfile::NamedTempFile::new().expect("Should create named temp file");
 
-        let mut key_command = Command::new(&*NIX_BIN);
+        let mut key_command = nix_base_command();
         key_command
             .arg("key")
             .arg("generate-secret")

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -225,7 +225,7 @@ fn available_packages(lockfile: &Lockfile, packages: Vec<String>) -> Result<Vec<
 mod test {
     use flox_rust_sdk::flox::test_helpers::flox_instance;
     use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment_in;
-    use flox_rust_sdk::providers::buildenv::NIX_BIN;
+    use flox_rust_sdk::providers::nix::test_helpers::known_store_path;
     use tempfile::tempdir_in;
 
     use super::*;
@@ -244,7 +244,7 @@ mod test {
         let package = "foo";
         let symlink = dot_flox_parent_path.join(format!("result-{package}"));
         // We just want some random symlink possibly into the /nix/store
-        std::os::unix::fs::symlink(&*NIX_BIN, &symlink).unwrap();
+        std::os::unix::fs::symlink(known_store_path(), &symlink).unwrap();
         let displayed = Build::check_and_display_symlink(
             &environment,
             package,

--- a/cli/flox/src/commands/upload.rs
+++ b/cli/flox/src/commands/upload.rs
@@ -77,7 +77,10 @@ fn validate_store_path(store_path: PathBuf) -> Result<PathBuf> {
     Ok(store_path)
 }
 
+#[cfg(test)]
 mod test {
+    use flox_rust_sdk::providers::nix::test_helpers::known_store_path;
+
     #[test]
     fn validate_store_path_nonexistent_file() {
         let store_path = std::path::PathBuf::from("/nix/store/nonexistent-store-path");
@@ -105,7 +108,7 @@ mod test {
 
     #[test]
     fn validate_store_path_folow_symlinks() {
-        let store_path = std::path::PathBuf::from(env!("NIX_BIN"));
+        let store_path = known_store_path();
         let tempdir = tempfile::tempdir().unwrap();
         let symlink = tempdir.path().join("test-link");
         std::os::unix::fs::symlink(&store_path, &symlink).unwrap();


### PR DESCRIPTION
## Proposed Changes

**refactor: Extract known_store_path test helper**

I plan to make `NIX_BIN` private so that we can control a default set of
feature arguments but there are a number of places where we also use it
to get a known store path for tests. Refactor these to use a test helper
rather than accessing the static or environment variable directly.

Also incldues a missing `#[cfg(test)]` because `commands::upload` was
complaining about unused imports on build after adding the helper.

**refactor: Add providers:nix::nix_base_command**

To ensure that we apply the correct set of default options to all `nix`
commands. Not doing so causes `flox publish` to fail if the system
defaults don't match:

    % NIX_CONFIG='experimental-features = ""' ft publish hello2
    ❌ ERROR: Unable to interpret derivation info: EOF while parsing a value at line 1 column 0: EOF while parsing a value at line 1 column 0

This now works:

    % NIX_CONFIG='experimental-features = ""' ft publish hello2
    ✅ Package published successfully.

    Use 'flox install dcarley/hello2' to install it.

We also had the same issue with `flox containerize` in 0aeeb92. This
wouldn't have helped for `ContainerProxy` though, where the commands are
nested and we have to apply additional options like aecd753.

I've standardised on `--optional extra-experimental-features` rather
than `--extra-experimental-features` per 108f282.

## Release Notes

N/A, unreleased feature.