### PR TITLE
fix(tests): round timestamps down to seconds

### DIFF
--- a/cli/flox-rust-sdk/src/providers/upgrade_checks.rs
+++ b/cli/flox-rust-sdk/src/providers/upgrade_checks.rs
@@ -263,7 +263,7 @@ mod tests {
         let mut locked = guard.lock_if_unlocked().unwrap().unwrap();
 
         *locked.info_mut() = Some(UpgradeInformation {
-            last_checked: OffsetDateTime::now_utc(),
+            last_checked: OffsetDateTime::now_utc().replace_millisecond(0).unwrap(),
             result: UpgradeResult {
                 old_lockfile: None,
                 new_lockfile: Lockfile::default(),
@@ -284,7 +284,7 @@ mod tests {
         let guard = UpgradeInformationGuard::read_in(temp_dir.path()).unwrap();
         let mut locked = guard.lock_if_unlocked().unwrap().unwrap();
         let info = UpgradeInformation {
-            last_checked: OffsetDateTime::now_utc(),
+            last_checked: OffsetDateTime::now_utc().replace_millisecond(0).unwrap(),
             result: UpgradeResult {
                 old_lockfile: None,
                 new_lockfile: Lockfile::default(),


### PR DESCRIPTION
## Proposed Changes

We saw a few tests fail sporadically, due to ser/de of iso8601 timestamps created by `time::serde::iso8601` [1].
Deseralization of timestamps, casued the resulting native value to be off by -1 nanosecond.
The underlying issue seems to be the storage of time as a float with tricky behaviour at this granularity.
We discussed dropping `time`
(which was only first introduced to `flox-rust-sdk` for this task) in favor of using `chrono`,
but for the time being decided to fix the tests instead, done here by lowering the granularity to seconds,
which should avoid the float floor'ing.


## Release Notes

Internal testing fixes.