### PR TITLE
feat(containerize): add single-user install capability

### DIFF
--- a/cli/flox-rust-sdk/src/providers/container_builder.rs
+++ b/cli/flox-rust-sdk/src/providers/container_builder.rs
@@ -152,7 +152,7 @@ impl ContainerBuilder for MkContainerNix {
         if let Some(container_config) = &self.container_config {
             command.args([
                 "--argstr",
-                "containerConfig",
+                "containerConfigJSON",
                 &serde_json::to_string(container_config)
                     .map_err(MkContainerNixError::SerializeContainerConfig)?,
             ]);

--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -93,6 +93,7 @@ ContainerizeConfig ::= {
     For Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.
     If `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` and `/etc/group` from the container are applied.
     If `group`/`gid` is specified, supplementary groups from the container are ignored.
+    This will add an entry to /etc/passwd and /etc/groups inside the container, so no manual useradd is required.
 
 `exposed-ports`
 :   A set of ports to expose from a container running this image.

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -181,17 +181,17 @@ setup_file() {
     # The develop is responsible for starting the VM.
     cat > "$FLOX_TEST_HOME/bin/podman" << EOF
 #!/usr/bin/env bash
-HOME=$HOME USER=podman-user XDG_DATA_HOME="$REAL_XDG_DATA_HOME" XDG_CONFIG_HOME="$REAL_XDG_CONFIG_HOME" exec $ORIGINAL_PODMAN "\$@"
+HOME=$HOME XDG_DATA_HOME="$REAL_XDG_DATA_HOME" XDG_CONFIG_HOME="$REAL_XDG_CONFIG_HOME" exec $ORIGINAL_PODMAN "\$@"
 EOF
   else
     cat > "$FLOX_TEST_HOME/bin/podman" << EOF
 #!/usr/bin/env bash
-HOME=$HOME USER=podman-user exec $ORIGINAL_PODMAN "\$@"
+HOME=$HOME exec $ORIGINAL_PODMAN "\$@"
 EOF
   fi
 
   chmod +x "$FLOX_TEST_HOME/bin/podman"
-  export PATH="$FLOX_TEST_HOME/bin:$PATH"
+  export PATH="$FLOX_TEST_HOME/bin:$PATH:/run/wrappers/bin"
 }
 
 teardown() {

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -8,72 +8,152 @@
   # the system to build for
   system,
   containerSystem,
+  environment ? builtins.storePath environmentOutPath,
+  nixpkgsFlake ? builtins.getFlake nixpkgsFlakeRef,
+  pkgs ? nixpkgsFlake.legacyPackages.${system},
+  containerPkgs ? nixpkgsFlake.legacyPackages.${containerSystem},
   containerName ? "flox-env-container",
   containerTag ? null,
   containerCreated ? "now",
-  containerConfig ? null,
+  containerConfigJSON ? "{}",
 }:
 let
-  environment = builtins.storePath environmentOutPath;
-  nixpkgsFlake = builtins.getFlake nixpkgsFlakeRef;
-  pkgs = nixpkgsFlake.legacyPackages.${system};
-  containerPkgs = nixpkgsFlake.legacyPackages.${containerSystem};
-  lib = pkgs.lib;
-  lowPriority =
-    pkg:
-    pkg.overrideAttrs (
-      old:
-      old
-      // {
-        meta = (old.meta or { }) // {
-          priority = 10000;
-        };
-      }
-    );
+  inherit (builtins)
+    fromJSON
+    toString
+    elemAt
+    match
+    ;
+  inherit (pkgs.lib)
+    mapAttrsToList
+    optionalString
+    optionalAttrs
+    optionals
+    toIntBase10
+    assertMsg
+    isValidPosixName
+    isInt
+    ;
+  inherit (pkgs.lib.meta)
+    lowPrio
+    ;
 
-  buildLayeredImageArgs = {
-    name = containerName;
-    tag = containerTag;
-    created = containerCreated;
-    # symlinkJoin fails when drv contains a symlinked bin directory, so wrap in an additional buildEnv
-    contents = pkgs.buildEnv {
-      name = "contents";
-      paths = [
-        environment
-        (lowPriority containerPkgs.bashInteractive) # for a usable shell
-        (lowPriority containerPkgs.coreutils) # for just the basic utils
-      ];
+  containerConfig = fromJSON containerConfigJSON;
+
+  nixStoreOwner = (containerConfig.User or "0:0");
+
+  isNixStoreUserOwned = (null == (match "^(root|0):\?(root|0)\?$" nixStoreOwner));
+
+  nixStoreUserGroup =
+    let
+      userGroupValues =
+        let
+          values = match "^(([_]*[[:alpha:]]+):?|([[:digit:]]+):?)(([_]*[[:alpha:]]+)|([[:digit:]]+))?$" nixStoreOwner;
+        in
+        assert assertMsg (
+          null != values
+        ) "Failed to parse nixStoreOwner, ${nixStoreOwner} did not match the expected pattern";
+        values;
+      uname = elemAt userGroupValues 1;
+      gname = if (null != (elemAt userGroupValues 4)) then (elemAt userGroupValues 4) else "flox";
+      uid =
+        if (null != (elemAt userGroupValues 2)) then toIntBase10 (elemAt userGroupValues 2) else 10000;
+      gid =
+        if (null != (elemAt userGroupValues 5)) then toIntBase10 (elemAt userGroupValues 5) else 10000;
+    in
+    assert assertMsg (null != uname && null != uid) "Either uname or uid must always be set";
+    assert assertMsg (
+      null != gname
+    ) "The group part should not be null, if left empty it must get swallowed";
+    assert assertMsg (isValidPosixName uname) "uname must be a valid POSIX name";
+    assert assertMsg (isValidPosixName gname) "gname must be a valid POSIX name";
+    assert assertMsg (isInt uid) "uid must be an integer";
+    assert assertMsg (isInt gid) "gid must be an integer";
+    {
+      inherit
+        uname
+        gname
+        uid
+        gid
+        ;
     };
-    # Activate script requires writable /tmp.
-    extraCommands = ''
-      mkdir -m 1777 tmp
-      mkdir -p -m 1777 tmp/flox/run
-    '';
-    config = (if containerConfig == null then { } else (builtins.fromJSON containerConfig)) // {
-      # Use activate script as the [one] entrypoint capable of
-      # detecting interactive vs. command activation modes.
-      # Usage:
-      #   podman run -it
-      #     -> launches interactive shell with controlling terminal
-      #   podman run -i <cmd>
-      #     -> invokes interactive command
-      #   podman run -i [SIC]
-      #     -> launches crippled interactive shell with no controlling
-      #        terminal .. kinda useless
-      Entrypoint = [ "${environment}/activate" ];
 
-      Env = lib.mapAttrsToList (name: value: "${name}=${value}") {
-        "FLOX_ENV" = environment;
-        "FLOX_PROMPT_ENVIRONMENTS" = "floxenv";
-        "FLOX_PROMPT_COLOR_1" = "99";
-        "FLOX_PROMPT_COLOR_2" = "141";
-        "_FLOX_ACTIVE_ENVIRONMENTS" = "[]";
-        "FLOX_SOURCED_FROM_SHELL_RC" = "1"; # don't source from shell rc (again)
-        "_FLOX_FORCE_INTERACTIVE" = "1"; # Required when running podman without "-t"
-        "FLOX_SHELL" = "${containerPkgs.bashInteractive}/bin/bash";
-        "FLOX_RUNTIME_DIR" = "/tmp/flox/run";
+  fakeNss = containerPkgs.dockerTools.fakeNss.override {
+    extraPasswdLines = optionals isNixStoreUserOwned [
+      "${nixStoreUserGroup.uname}:x:${toString nixStoreUserGroup.uid}:${toString nixStoreUserGroup.gid}:created by Flox:/var/empty:/bin/sh"
+    ];
+    extraGroupLines = optionals isNixStoreUserOwned [
+      "${nixStoreUserGroup.gname}:x:${toString nixStoreUserGroup.gid}:"
+    ];
+  };
+
+  buildLayeredImageArgs =
+    optionalAttrs (isNixStoreUserOwned) {
+      inherit (nixStoreUserGroup)
+        uname
+        gname
+        uid
+        gid
+        ;
+
+      # chown the /run directory to the nixStoreOwner, so that Nix can run as a
+      # single user installation inside the container
+      fakeRootCommands = ''
+        chown -R ${toString nixStoreUserGroup.uid}:${toString nixStoreUserGroup.gid} /run
+      '';
+      enableFakechroot = true;
+    }
+    // {
+      name = containerName;
+      tag = containerTag;
+      created = containerCreated;
+
+      # Ensures the container configuration contains the correct architecture of
+      # the binaries contained within it. Runtimes can use this to short-circuit
+      # errors when users try to run a container on an incompatible architecture.
+      architecture = containerPkgs.go.GOARCH;
+
+      # Activate script requires writable directory, /run feels like a logical place.
+      extraCommands = ''
+        mkdir -m 1770 run
+        mkdir -p -m 1770 run/flox
+      '';
+
+      # symlinkJoin fails when drv contains a symlinked bin directory, so wrap in an additional buildEnv.
+      contents = pkgs.buildEnv {
+        name = "contents";
+        paths = [
+          fakeNss
+          environment
+          (lowPrio containerPkgs.bashInteractive) # for a usable shell
+          (lowPrio containerPkgs.coreutils) # for just the basic utils
+        ];
+      };
+      config = containerConfig // {
+        # Use activate script as the [one] entrypoint capable of
+        # detecting interactive vs. command activation modes.
+        # Usage:
+        #   podman run -it
+        #     -> launches interactive shell with controlling terminal
+        #   podman run -i <cmd>
+        #     -> invokes interactive command
+        #   podman run -i [SIC]
+        #     -> launches crippled interactive shell with no controlling
+        #        terminal .. kinda useless
+        Entrypoint = [ "${environment}/activate" ];
+
+        Env = mapAttrsToList (name: value: "${name}=${value}") {
+          "FLOX_ENV" = environment;
+          "FLOX_PROMPT_ENVIRONMENTS" = "floxenv";
+          "FLOX_PROMPT_COLOR_1" = "99";
+          "FLOX_PROMPT_COLOR_2" = "141";
+          "_FLOX_ACTIVE_ENVIRONMENTS" = "[]";
+          "FLOX_SOURCED_FROM_SHELL_RC" = "1"; # don't source from shell rc (again)
+          "_FLOX_FORCE_INTERACTIVE" = "1"; # Required when running podman without "-t"
+          "FLOX_SHELL" = "${containerPkgs.bashInteractive}/bin/bash";
+          "FLOX_RUNTIME_DIR" = "/run/flox";
+        };
       };
     };
-  };
 in
 pkgs.dockerTools.streamLayeredImage buildLayeredImageArgs

--- a/mkContainer/tests.nix
+++ b/mkContainer/tests.nix
@@ -1,0 +1,94 @@
+# Note that all tests should start with "test", otherwise runTests will not pick them up.
+{
+  lib,
+  internals,
+}:
+let
+  inherit (builtins) match tryEval;
+in
+lib.debug.runTests {
+  testIsNixStoreUserGroupOwned = {
+    expr = (null == (match internals.isNixStoreUserOwnedRegex "foo:1234"));
+    expected = true;
+  };
+  testIsNixStoreUserOwned = {
+    expr = (null == (match internals.isNixStoreUserOwnedRegex "foo"));
+    expected = true;
+  };
+  testIsNixStoreRootOwned = {
+    expr = (null == (match internals.isNixStoreUserOwnedRegex "root:root"));
+    expected = false;
+  };
+  testIsNixStore0Owned = {
+    expr = (null == (match internals.isNixStoreUserOwnedRegex "0:0"));
+    expected = false;
+  };
+  testUserConfigMatchUnameGid = {
+    expr = (match internals.unameGnameRegex "foo:1234");
+    expected = [
+      "foo:"
+      "foo"
+      null
+      "1234"
+      null
+      "1234"
+    ];
+  };
+  testUserConfigMatchUidGid = {
+    expr = (match internals.unameGnameRegex "1234:1234");
+    expected = [
+      "1234:"
+      null
+      "1234"
+      "1234"
+      null
+      "1234"
+    ];
+  };
+  testUserConfigMatchUname = {
+    expr = (match internals.unameGnameRegex "foo");
+    expected = [
+      "foo"
+      "foo"
+      null
+      null
+      null
+      null
+    ];
+  };
+  testUserConfigMatchInvalidUname = {
+    expr = (match internals.unameGnameRegex "-foo");
+    expected = null;
+  };
+  testmkUnameGnameUidGidWithUnameGid = {
+    expr = (internals.mkUnameGnameUidGid "foo:1234");
+    expected = {
+      uname = "foo";
+      gname = "flox";
+      uid = 10000;
+      gid = 1234;
+    };
+  };
+  testmkUnameGnameUidGidWithUnameGname = {
+    expr = (internals.mkUnameGnameUidGid "foo:bar");
+    expected = {
+      uname = "foo";
+      gname = "bar";
+      uid = 10000;
+      gid = 10000;
+    };
+  };
+  testmkUnameGnameUidGidWithUname = {
+    expr = (internals.mkUnameGnameUidGid "foo");
+    expected = {
+      uname = "foo";
+      gname = "flox";
+      uid = 10000;
+      gid = 10000;
+    };
+  };
+  testmkUnameGnameUidGidWithInvalidUname = {
+    expr = (tryEval (internals.mkUnameGnameUidGid "-foo")).success;
+    expected = false;
+  };
+}

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -94,7 +94,10 @@ let
       yq
       process-compose
       procps
-      podman
+      (podman.override (prev: {
+        extraPackages = [ "/run/wrappers" ];
+      }))
+      "/run/wrappers"
     ]
     # TODO: this hack is not going to be needed once we test against stuff on system
     ++ lib.optional stdenv.isDarwin (


### PR DESCRIPTION
flox containerize expected to always run as root inside the container, since the
Nix store was owned by root, and the following files were basically missing.

    /etc/passwd
    /etc/groups
    /etc/shadow

This commit changes that by extending the container with a "fakeNss" to provide
those missing files, and also abuse the fact that we can insert custom lines
during build-time. We derive most information from containerize.config.user
inside Flox's toml.

All that being said, it allows us to do the following.

    $ flox containerize --file='-' | docker load
    ✨ 'tmp.GtqsVDTJut:latest' written to stdout
    Loaded image: tmp.gtqsvdtjut:latest
    $ # Works perfeclty fine when we just run it with the default user root
    $ docker run --rm -it tmp.gtqsvdtjut:latest 'cowsay hello'
     _______
    < hello >
     -------
            \   ^__^
             \  (oo)\_______
                (__)\       )\/\
                    ||----w |
                    ||     ||
    $ # There is a "bryan" user on this system, let's try to use that...
    $ docker run --user='bryan' --rm -it tmp.gtqsvdtjut:latest 'cowsay hello'
    Error: failed to acquire lockfile

    Caused by:
        Permission denied (os error 13)
    $ # This is expected since the Docker image wasn't build with extra users in
    $ # mind. Let's try changing that with the changes in this commit...
    $ echo '[containerize.config]' >> .flox/env/manifest.toml
    $ echo "user = 'bryan:bryan'" >> .flox/env/manifest.toml
    $ flox containerize --file='-' | docker load
    ✨ 'tmp.Fc9KpHvftX:latest' written to stdout
    Loaded image: tmp.fc9kphvftx:latest
    $ # root still works...
    $ docker run --rm -it tmp.fc9kphvftx:latest 'cowsay hello'
     _______
    < hello >
     -------
            \   ^__^
             \  (oo)\_______
                (__)\       )\/\
                    ||----w |
                    ||     ||
    $ # But this now also works...
    $ docker run \
    >  --user='bryan:bryan' \
    >  --rm -it \
    >  tmp.fc9kphvftx:latest 'cowsay hello'
     _______
    < hello >
     -------
            \   ^__^
             \  (oo)\_______
                (__)\       )\/\
                    ||----w |
                    ||     ||

Cool, now we can use non-root user inside of the container. Note that the UID
and GID are currently hard-coded to 501, since I'm not sure the OCI spec can
support setting both at the same time. It looks to me as if its and either or
thing.

Nixpkgs' streamLayeredImage now also uses the correct architecture when building
containers. We're putting binaries coming from the containerPkgs attribute into
the final  image, so the container's architecture config should be set to
containerPkgs' architecture as well. Using containerPkgs.go.GOARCH is just a
shorthand to give us the correct format that the OCI spec is expecting.

I also took a little time to refactor the mkContainer.nix file, the biggest
change being that I moved some of the attributes that were first inside of a let
binding, to the function's argument attribute set. This just made it a bit
easier for me to itterate on this issue, without having to constantly rebuild
Flox.

Ref: https://github.com/flox/product/issues/822

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Use the `containerize.config.User` setting to `chwon` the Nix store and runtime directories inside the container. Allows for stuff like `docker run --user=...` to work.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
- `flox containerize` now uses the `containerize.config.User` value to create a "single-user install" out of the container. Meaning the internal Nix store and runtime directories will be owned by the specified user.
- `flox containerize` will use some default values if the `containerize.config.User` is set.
    - If the `uname` and `gname` are provided; `uid` and `gid` will be `10000`
    - If the `uid` and `gid` are provided; `uname` and `gname` will be `flox`
    - If only `uname` is provided; `gname` will be `flox`, `uid` and `gid` will be `10000`
    - If only `uid` is provided; `uname` and `gname` will be `flox`, `gid` will be `10000`

<!-- Many thanks! -->
