### PR TITLE
test(activate): Attach to previous release version

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2770,7 +2770,7 @@ attach_runs_hooks_once() {
 
   "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" 2> output &
 
-  cat activate_finished
+  timeout 2s cat activate_finished
   run cat output
   assert_output --partial "sourcing hook.on-activate for first time"
   assert_output --partial "hook.on-activate"
@@ -2831,7 +2831,7 @@ attach_runs_profile_twice() {
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
   FLOX_SHELL="$shell" "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > $TEARDOWN_FIFO" >> output 2>&1 &
 
-  cat activate_finished
+  timeout 2s cat activate_finished
   run cat output
   assert_output --partial "sourcing profile.common"
   assert_output --partial "sourcing profile.$shell"
@@ -2959,7 +2959,7 @@ EOF
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
   FLOX_SHELL="$shell" "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > $TEARDOWN_FIFO" >> output 2>&1 &
 
-  cat activate_finished
+  timeout 2s cat activate_finished
 
   case "$mode" in
     interactive)
@@ -3075,7 +3075,7 @@ attach_sets_profile_vars() {
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
   FLOX_SHELL="$shell" "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > $TEARDOWN_FIFO" &
 
-  cat activate_finished
+  timeout 2s cat activate_finished
 
   case "$mode" in
     interactive)
@@ -3267,7 +3267,7 @@ EOF
       ;;
   esac
 
-  timeout 2 cat activate_finished
+  timeout 2s cat activate_finished
 
   run cat output
   assert_success
@@ -3551,7 +3551,7 @@ EOF
 
       # vim gets added to MANPATH
       _man=$_man "$FLOX_BIN" activate -d vim -- bash -c "$_man --path vim > output; echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
-      cat activate_finished
+      timeout 2s cat activate_finished
       run cat output
       assert_success
       assert_output "$VIM_MAN"
@@ -3576,7 +3576,7 @@ EOF
 
       # vim gets added to MANPATH
       "$FLOX_BIN" activate -d vim -- bash -c "/usr/bin/manpath > output && echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
-      cat activate_finished
+      timeout 2s cat activate_finished
       run cat output
       assert_success
       assert_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
@@ -3623,7 +3623,7 @@ EOF
   refute_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/bin/emacs"
 
   "$FLOX_BIN" activate -d vim -- bash -c "command -v vim > output; echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
-  cat activate_finished
+  timeout 2s cat activate_finished
 
   run cat output
   assert_success

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4198,13 +4198,16 @@ Setting PATH from ${rc_file}"
   TEARDOWN_FIFO="$PROJECT_DIR/teardown_activate"
   mkfifo "$TEARDOWN_FIFO"
 
+  # Pre-fetch without a timeout.
+  nix build "github:flox/flox/v${FLOX_LATEST_VERSION}"
+
   # Start an activation with the previously released version.
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
   nix run "github:flox/flox/v${FLOX_LATEST_VERSION}" -- \
     activate -- \
     "$shell_path" -c "echo > activate_finished && echo > $TEARDOWN_FIFO" > output 2>&1 &
 
-  # Longer timeout to allow for `nix run`.
+  # Longer timeout to allow for `nix run` locking.
   wait_for_background_activation 15s
   run cat output
   # This the only place we use `--partial` because we only want to know that the

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -30,6 +30,9 @@ user_dotfiles_setup() {
 
   BADPATH="/usr/local/bin:/usr/bin:/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
 
+  # Allow predictable output from interactive tests that use expect.
+  KNOWN_PROMPT="myprompt> "
+
   # Posix-compliant shells
   for i in "profile" "bashrc" \
     "zshrc" "zshenv" "zlogin" "zlogout" "zprofile"; do
@@ -37,6 +40,7 @@ user_dotfiles_setup() {
 echo "Sourcing .$i" >&2
 echo "Setting PATH from .$i" >&2
 export PATH="$BADPATH"
+export PS1="$KNOWN_PROMPT"
 if [ -f "$HOME/.$i.extra" ]; then
   source "$HOME/.$i.extra";
 fi
@@ -49,6 +53,9 @@ EOF
 echo "Sourcing config.fish" >&2
 echo "Setting PATH from config.fish" >&2
 set -gx PATH "$BADPATH"
+function fish_prompt
+  echo -n "$KNOWN_PROMPT"
+end
 if test -e "$HOME/.config/fish/config.fish.extra"
   source "$HOME/.config/fish/config.fish.extra"
 end
@@ -60,6 +67,7 @@ EOF
 sh -c "echo 'Sourcing .$i' >&2"
 sh -c "echo 'Setting PATH from .$i' >&2"
 setenv PATH "$BADPATH"
+set prompt = "$KNOWN_PROMPT"
 if ( -e "$HOME/.$i.extra" ) then
   source "$HOME/.$i.extra"
 endif

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -205,7 +205,7 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="bash" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -216,7 +216,7 @@ EOF
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
-  FLOX_SHELL="fish" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="fish" run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -228,7 +228,7 @@ EOF
   run "$FLOX_BIN" install -d "$PROJECT_DIR" hello
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
-  FLOX_SHELL="tcsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="tcsh" run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -241,7 +241,7 @@ EOF
   assert_success
   assert_output --partial "✅ 'hello' installed to environment"
 
-  FLOX_SHELL="zsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" run -0 expect "$TESTS_DIR/activate/interactive-hello.exp" "$PROJECT_DIR"
   assert_output --regexp "bin/hello"
   refute_output "not found"
 }
@@ -325,7 +325,7 @@ EOF
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="bash" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -457,7 +457,7 @@ EOF
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="fish" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+  FLOX_SHELL="fish" run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -590,7 +590,7 @@ EOF
   sed -i -e "s/^\[profile\]/${HELLO_PROFILE_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
   sed -i -e "s/^\[hook\]/${VARS_HOOK_SCRIPT//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="tcsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+  FLOX_SHELL="tcsh" run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -723,7 +723,7 @@ EOF
 
 
   # FLOX_SHELL="zsh" run -0 bash -c "echo exit | $FLOX_CLI activate --dir $PROJECT_DIR";
-  FLOX_SHELL="zsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   assert_output --partial "sourcing hook.on-activate"
   assert_output --partial "sourcing profile.common"
@@ -1072,7 +1072,7 @@ EOF
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
 
-  FLOX_SHELL="bash" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   refute_output --partial "ERROR"
   assert_output --partial "sourcing hook.on-activate for first time"
@@ -1098,7 +1098,7 @@ EOF
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/only-once.toml"
 
-  FLOX_SHELL="zsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   assert_success
   refute_output --partial "ERROR"
   assert_output --partial "sourcing hook.on-activate for first time"
@@ -1113,7 +1113,7 @@ EOF
   project_setup
   echo "alias test_alias='echo testing'" >"$HOME/.bashrc.extra"
 
-  FLOX_SHELL="bash" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is aliased to \`echo testing'"
 }
 
@@ -1122,7 +1122,7 @@ EOF
   project_setup
   echo "alias test_alias='echo testing'" >"$HOME/.config/fish/config.fish.extra"
 
-  FLOX_SHELL="fish" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  FLOX_SHELL="fish" run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   # fish's liberal use of color codes forces us to use regex matching here,
   # and I've given up trying to match the single quotes. Here's the output
   # we're trying to match:
@@ -1139,7 +1139,7 @@ EOF
   project_setup
   echo 'alias test_alias "echo testing"' >"$HOME/.tcshrc.extra"
 
-  FLOX_SHELL="tcsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc-tcsh.exp" "$PROJECT_DIR"
+  FLOX_SHELL="tcsh" run -0 expect "$TESTS_DIR/activate/rc-tcsh.exp" "$PROJECT_DIR"
   assert_line --partial "echo testing"
 }
 
@@ -1148,7 +1148,7 @@ EOF
   project_setup
   echo "alias test_alias='echo testing'" >"$HOME/.zshrc.extra"
 
-  FLOX_SHELL="zsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" run -0 expect "$TESTS_DIR/activate/rc.exp" "$PROJECT_DIR"
   assert_output --partial "test_alias is an alias for echo testing"
 }
 
@@ -1242,7 +1242,7 @@ EOF
   project_setup
   sed -i -e "s/^\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="bash" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
   FLOX_SHELL="bash" NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
@@ -1255,7 +1255,7 @@ EOF
   project_setup
   sed -i -e "s/^\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="fish" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+  FLOX_SHELL="fish" run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
   FLOX_SHELL="fish" NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
@@ -1268,7 +1268,7 @@ EOF
   project_setup
   sed -i -e "s/^\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
-  FLOX_SHELL="tcsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+  FLOX_SHELL="tcsh" run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
   FLOX_SHELL="tcsh" NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
@@ -1282,7 +1282,7 @@ EOF
   sed -i -e "s/^\[vars\]/${VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
 
 
-  FLOX_SHELL="zsh" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
+  FLOX_SHELL="zsh" run -0 expect "$TESTS_DIR/activate/envVar.exp" "$PROJECT_DIR"
   assert_output --partial "baz"
 
   FLOX_SHELL="zsh" NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -- echo '$foo'
@@ -2554,7 +2554,7 @@ confirm_tracelevel() {
   # Activate the test environment, which will launch an interactive shell that
   # sources the relevant dotfile.
 
-  FLOX_SHELL="$shell" NO_COLOR=1 run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
+  FLOX_SHELL="$shell" run -0 expect "$TESTS_DIR/activate/activate.exp" "$PROJECT_DIR"
   refute_output --partial "_flox_activate_tracelevel not defined"
   run rm "$PROJECT_DIR/_flox_activate_tracelevel.in_test"
   assert_success
@@ -2777,7 +2777,7 @@ attach_runs_hooks_once() {
 
   case "$mode" in
     interactive)
-      NO_COLOR=1 run expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" true
+      run expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" true
       ;;
     command)
       run "$FLOX_BIN" activate -- true
@@ -2838,7 +2838,7 @@ attach_runs_profile_twice() {
 
   case "$mode" in
     interactive)
-      FLOX_SHELL="$shell" NO_COLOR=1 run expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" true
+      FLOX_SHELL="$shell" run expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" true
       ;;
     command)
       FLOX_SHELL="$shell" run "$FLOX_BIN" activate -- true
@@ -2963,7 +2963,7 @@ EOF
 
   case "$mode" in
     interactive)
-      FLOX_SHELL="$shell" NO_COLOR=1 run expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" "echo \$HOOK_ON_ACTIVATE"
+      FLOX_SHELL="$shell" run expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" "echo \$HOOK_ON_ACTIVATE"
       ;;
     command)
       FLOX_SHELL="$shell" run "$FLOX_BIN" activate -- echo \$HOOK_ON_ACTIVATE
@@ -3080,7 +3080,7 @@ attach_sets_profile_vars() {
   case "$mode" in
     interactive)
       # using assert_line with expect is racey so just direct the output we need to a file
-      FLOX_SHELL="$shell" NO_COLOR=1 expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" "echo \$PROFILE_COMMON > output && echo \$PROFILE_$shell >> output"
+      FLOX_SHELL="$shell" expect "$TESTS_DIR/activate/attach.exp" "$PROJECT_DIR" "echo \$PROFILE_COMMON > output && echo \$PROFILE_$shell >> output"
       run cat output
       ;;
     command)
@@ -3773,7 +3773,7 @@ EOF
     echo "$_FLOX_ACTIVE_ENVIRONMENTS"
     # We can't double check the alias has been loaded because bash isn't
     # interactive and discards it
-    FLOX_SHELL="bash" NO_COLOR=1 $_expect "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" "type project_alias && type default_alias"
+    FLOX_SHELL="bash" $_expect "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" "type project_alias && type default_alias"
 EOF
 )
   assert_success
@@ -3814,7 +3814,7 @@ EOF
       echo "default not in PATH: $PATH"
       exit 1
     fi
-    FLOX_SHELL="bash" NO_COLOR=1 $_expect "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" 'echo "$PATH"'
+    FLOX_SHELL="bash" $_expect "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" 'echo "$PATH"'
 EOF
 )
   assert_success
@@ -3955,7 +3955,7 @@ EOF
       echo "default_alias not found"
       exit 1
     end
-    FLOX_SHELL="$FISH" NO_COLOR=1 "$EXPECT" "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" "type project_alias && type default_alias"
+    FLOX_SHELL="$FISH" "$EXPECT" "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" "type project_alias && type default_alias"
 EOF
 )
   assert_success
@@ -3991,7 +3991,7 @@ EOF
       echo "default not in PATH: \$PATH"
       exit 1
     end
-    FLOX_SHELL="$FISH" NO_COLOR=1 "$EXPECT" "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" 'echo "\$PATH"'
+    FLOX_SHELL="$FISH" "$EXPECT" "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" 'echo "\$PATH"'
 EOF
 )
   assert_success
@@ -4036,7 +4036,7 @@ EOF
       echo "default_alias not found"
       exit 1
     fi
-    FLOX_SHELL="$ZSH" NO_COLOR=1 "$EXPECT" "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" "type project_alias && type default_alias"
+    FLOX_SHELL="$ZSH" "$EXPECT" "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" "type project_alias && type default_alias"
 EOF
 )
   assert_success
@@ -4096,7 +4096,7 @@ EOF
       echo "default not in PATH: \$PATH"
       exit 1
     fi
-    FLOX_SHELL="$ZSH" NO_COLOR=1 "$EXPECT" "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" 'echo "\$PATH"'
+    FLOX_SHELL="$ZSH" "$EXPECT" "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR/project" 'echo "\$PATH"'
 EOF
 )
   assert_success

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -32,6 +32,10 @@ user_dotfiles_setup() {
 
   # Allow predictable output from interactive tests that use expect.
   KNOWN_PROMPT="myprompt> "
+  # This isn't honoured by zsh or fish.
+  cat >"${HOME}/.inputrc" <<EOF
+set enable-bracketed-paste off
+EOF
 
   # Posix-compliant shells
   for i in "profile" "bashrc" \

--- a/cli/tests/activate/activate-command.exp
+++ b/cli/tests/activate/activate-command.exp
@@ -5,6 +5,8 @@ set command [lindex $argv 1]
 set flox $env(FLOX_BIN)
 set timeout 10
 set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
 
 spawn $flox activate --dir $dir
 expect_after {

--- a/cli/tests/activate/activate-command.exp
+++ b/cli/tests/activate/activate-command.exp
@@ -4,6 +4,8 @@ set dir [lindex $argv 0]
 set command [lindex $argv 1]
 set flox $env(FLOX_BIN)
 set timeout 10
+set env(NO_COLOR) 1
+
 spawn $flox activate --dir $dir
 expect_after {
   timeout { exit 1 }

--- a/cli/tests/activate/activate.exp
+++ b/cli/tests/activate/activate.exp
@@ -4,6 +4,8 @@ set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
 set timeout 10
 set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
 
 spawn $flox activate --dir $dir
 expect_after {

--- a/cli/tests/activate/activate.exp
+++ b/cli/tests/activate/activate.exp
@@ -3,6 +3,8 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
 set timeout 10
+set env(NO_COLOR) 1
+
 spawn $flox activate --dir $dir
 expect_after {
   timeout { exit 1 }

--- a/cli/tests/activate/attach.exp
+++ b/cli/tests/activate/attach.exp
@@ -7,6 +7,8 @@ set flox $env(FLOX_BIN)
 set timeout 10
 set env(NO_COLOR) 1
 
+log_file -noappend expect.log
+
 spawn $flox activate --dir $dir
 expect_after {
   timeout { exit 1 }

--- a/cli/tests/activate/attach.exp
+++ b/cli/tests/activate/attach.exp
@@ -5,6 +5,8 @@ set dir [lindex $argv 0]
 set command [lindex $argv 1]
 set flox $env(FLOX_BIN)
 set timeout 10
+set env(NO_COLOR) 1
+
 spawn $flox activate --dir $dir
 expect_after {
   timeout { exit 1 }

--- a/cli/tests/activate/attach.exp
+++ b/cli/tests/activate/attach.exp
@@ -6,6 +6,8 @@ set command [lindex $argv 1]
 set flox $env(FLOX_BIN)
 set timeout 10
 set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
 
 log_file -noappend expect.log
 

--- a/cli/tests/activate/envVar.exp
+++ b/cli/tests/activate/envVar.exp
@@ -3,6 +3,7 @@
 
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
+set env(NO_COLOR) 1
 
 spawn $flox activate --dir $dir
 expect_after {

--- a/cli/tests/activate/envVar.exp
+++ b/cli/tests/activate/envVar.exp
@@ -4,6 +4,8 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
 set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
 
 spawn $flox activate --dir $dir
 expect_after {

--- a/cli/tests/activate/histfile.exp
+++ b/cli/tests/activate/histfile.exp
@@ -1,5 +1,6 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
+set env(NO_COLOR) 1
 
 set timeout 300
 spawn $flox activate --dir $dir

--- a/cli/tests/activate/histfile.exp
+++ b/cli/tests/activate/histfile.exp
@@ -1,6 +1,8 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
 set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
 
 set timeout 300
 spawn $flox activate --dir $dir

--- a/cli/tests/activate/interactive-hello.exp
+++ b/cli/tests/activate/interactive-hello.exp
@@ -6,6 +6,8 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
 set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
 
 set timeout 20
 exp_internal 1

--- a/cli/tests/activate/interactive-hello.exp
+++ b/cli/tests/activate/interactive-hello.exp
@@ -5,6 +5,7 @@
 
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
+set env(NO_COLOR) 1
 
 set timeout 20
 exp_internal 1

--- a/cli/tests/activate/rc-tcsh.exp
+++ b/cli/tests/activate/rc-tcsh.exp
@@ -4,6 +4,8 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
 set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
 
 set timeout 300
 spawn $flox activate --dir $dir

--- a/cli/tests/activate/rc-tcsh.exp
+++ b/cli/tests/activate/rc-tcsh.exp
@@ -3,6 +3,7 @@
 
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
+set env(NO_COLOR) 1
 
 set timeout 300
 spawn $flox activate --dir $dir

--- a/cli/tests/activate/rc.exp
+++ b/cli/tests/activate/rc.exp
@@ -4,6 +4,8 @@
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
 set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
 
 set timeout 300
 spawn $flox activate --dir $dir

--- a/cli/tests/activate/rc.exp
+++ b/cli/tests/activate/rc.exp
@@ -3,6 +3,7 @@
 
 set dir [lindex $argv 0]
 set flox $env(FLOX_BIN)
+set env(NO_COLOR) 1
 
 set timeout 300
 spawn $flox activate --dir $dir

--- a/cli/tests/auth/loginPrompt.exp
+++ b/cli/tests/auth/loginPrompt.exp
@@ -1,9 +1,0 @@
-set flox $env(FLOX_BIN)
-
-
-spawn $flox auth login
-
-set timeout 3
-expect {
-   timeout { exit 0 }
-}

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -416,6 +416,7 @@ common_suite_setup() {
     print_var FLOX_META
     print_var FLOX_ENVIRONMENTS
     print_var NIX_SYSTEM
+    print_var FLOX_LATEST_VERSION
     print_var FLOX_TEST_SSH_KEY
     print_var SSH_AUTH_SOCK
     print_var GIT_CONFIG_SYSTEM

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -30,6 +30,7 @@
   jq,
   man,
   nix,
+  ncurses,
   yq,
   openssh,
   parallel,
@@ -81,6 +82,7 @@ let
       gnutar
       jq
       man
+      ncurses
       nix
       openssh
       parallel

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -141,6 +141,9 @@ writeShellScriptBin PROJECT_NAME ''
   esac
   export PROJECT_TESTS_DIR;
 
+  FLOX_LATEST_VERSION=${builtins.readFile ../../VERSION}
+  export FLOX_LATEST_VERSION
+
   # TODO: we shouldn't do this but rather use absolute paths
   # Look if we can use https://github.com/abathur/resholve
   export PATH="$PROJECT_PATH:${lib.makeBinPath paths}"


### PR DESCRIPTION
## Proposed Changes

Test that we can attach to an activation that was started by the
previously released version of Flox. This will prevent regressions like
40a77b4 and other breaking changes to activation state.

This is best reviewed commit-by-commit, where you can find more detail.

## Release Notes

N/A, internal only.