### PR TITLE
test: don't use duct or jq for builds test

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -862,18 +862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "duct"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
-dependencies = [
- "libc",
- "once_cell",
- "os_pipe",
- "shared_child",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,7 +1102,6 @@ dependencies = [
  "catalog-api-v1",
  "chrono",
  "derive_more",
- "duct",
  "enum_dispatch",
  "flox-core",
  "fslock",
@@ -2367,16 +2354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,16 +3392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shared_child"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,6 @@ config = { version = "0.13.4", default-features = false, features = ["toml"]}
 crossterm = "0.27"
 derive_more = "0.99.18"
 dirs = "5.0.0"
-duct = "0.13.7"
 enum_dispatch = "0.3.13"
 flox-activations = { path = "flox-activations" }
 flox-core = { path = "flox-core" }

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -55,7 +55,6 @@ proptest.workspace = true
 proptest-derive.workspace = true
 serial_test.workspace = true
 tracing-subscriber.workspace = true
-duct.workspace = true
 
 [features]
 # allow exporting test helpers in dev mode only


### PR DESCRIPTION
Using serde is more readable in a Rust project than shelling out to jq

## Release Notes

NA