### PR TITLE
fix(flox): update manpage reference to the flox-config

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -22,3 +22,4 @@ yes,charmitro,Charalampos Mitrodimas,<charmitro@posteo.net>
 yes,sschuberth,Sebastian Schuberth,<sschuberth@gmail.com>
 yes,oxcabe,Óscar Carrasco,<me@oxca.be>
 yes,crsche,Conor Scheidt,<me@crsche.com>
+yes,philiptaron,Philip Taron,<philip.taron@gmail.com>

--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -55,7 +55,7 @@ impl ResetMetrics {
 
                 environment: FLOX_DISABLE_METRICS=true
                 user-wide: flox config --set-bool disable_metrics true
-                system-wide: update /etc/flox.toml as described in flox(1)
+                system-wide: update /etc/flox.toml as described in flox-config(1)
         "};
 
         message::plain(notice);

--- a/cli/flox/src/utils/init/metrics.rs
+++ b/cli/flox/src/utils/init/metrics.rs
@@ -81,7 +81,7 @@ pub fn init_telemetry_uuid(data_dir: impl AsRef<Path>, cache_dir: impl AsRef<Pat
 
           environment: FLOX_DISABLE_METRICS=true
             user-wide: flox config --set-bool disable_metrics true
-          system-wide: update /etc/flox.toml as described in flox(1)
+          system-wide: update /etc/flox.toml as described in flox-config(1)
 
         This is a one-time notice.
 


### PR DESCRIPTION
I read the linked manpage and it wasn't helpful; `man flox-config` on the other hand was just the thing.

## Proposed Changes

- [x] Update the metrics notice in the two places it occurs in the codebase with the right reference ([`man flox-config`](https://flox.dev/docs/reference/command-reference/flox-config/)).

## Release Notes

N/A.