### PR TITLE
fix: restore .flox/lib in FLOX_ENV_LIB_DIRS

### DIFF
--- a/assets/activation-scripts/etc/profile.d/0800_cuda.sh
+++ b/assets/activation-scripts/etc/profile.d/0800_cuda.sh
@@ -62,8 +62,6 @@ activate_cuda() {
     --symbolic \
     --force \
     --target-directory="$LIB_DIR"
-
-  export FLOX_ENV_LIB_DIRS="$FLOX_ENV_LIB_DIRS":"$LIB_DIR"
 }
 
 activate_cuda "/" "$_ldconfig"

--- a/cli/tests/cuda.bats
+++ b/cli/tests/cuda.bats
@@ -168,3 +168,12 @@ teardown() {
     "${TESTS_DIR}/cuda/ldconfig-mock-present.sh"
   assert_success
 }
+
+# Even if we successfully link the libraries to the right location (.flox/lib)
+# CUDA acceleration will fail if that directory isn't added to FLOX_ENV_LIB_DIRS
+@test "linked cuda library location present in FLOX_ENV_LIB_DIRS" {
+  dot_flox_lib="$PWD/.flox/lib"
+  run "$FLOX_BIN" activate -- bash -c 'echo "$FLOX_ENV_LIB_DIRS"'
+  assert_success
+  assert_output --partial "$dot_flox_lib"
+}

--- a/cli/tests/cuda/cuda-disabled.sh
+++ b/cli/tests/cuda/cuda-disabled.sh
@@ -5,18 +5,7 @@ LDCONFIG_MOCK="${2}"
 
 # Get the function without loading support.
 _FLOX_ENV_CUDA_DETECTION=0 source "${FLOX_ENV}/etc/profile.d/0800_cuda.sh"
-
-LIBS_BEFORE="$FLOX_ENV_LIB_DIRS"
 activate_cuda "${FHS_ROOT}" "${LDCONFIG_MOCK}"
-LIBS_AFTER="$FLOX_ENV_LIB_DIRS"
-
-if [[ "$LIBS_AFTER" != "$LIBS_BEFORE" ]]; then
-    set +x # make it easier to read the comparison
-    echo "FLOX_ENV_LIB_DIRS was modified and it shouldn't have been"
-    echo "  before: ${LIBS_BEFORE}"
-    echo "  after:  ${LIBS_AFTER}"
-    exit 1
-fi
 
 # Assert directory absence and list contents to help debug test failures.
 ! ls -al "${FLOX_ENV_PROJECT}/.flox/lib"

--- a/cli/tests/cuda/cuda-enabled.sh
+++ b/cli/tests/cuda/cuda-enabled.sh
@@ -6,18 +6,7 @@ LDCONFIG_MOCK="${2}"
 
 # Get the function without executing it all.
 _FLOX_ENV_CUDA_DETECTION=0 source "${FLOX_ENV}/etc/profile.d/0800_cuda.sh"
-
-LIBS_BEFORE="$FLOX_ENV_LIB_DIRS"
 activate_cuda "${FHS_ROOT}" "${LDCONFIG_MOCK}"
-LIBS_AFTER="$FLOX_ENV_LIB_DIRS"
-
-if [[ "$LIBS_AFTER" == "$LIBS_BEFORE" ]]; then
-    set +x # make it easier to read the comparison
-    echo "FLOX_ENV_LIB_DIRS was not modified and it should have been"
-    echo "  before: ${LIBS_BEFORE}"
-    echo "  after:  ${LIBS_AFTER}"
-    exit 1
-fi
 
 # Assert directory presence and list contents to help debug test failures.
 ls -al "${FLOX_ENV_PROJECT}/.flox/lib"


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**fix: restore .flox/lib in FLOX_ENV_LIB_DIRS**

Commit aefa3d2 introduced the `flox-env-helper.awk` script, which is
intended to fix up the PATH and MANPATH variables. This change _also_
changed how the FLOX_ENV_LIB_DIRS variable was computed by removing
the logic from the CLI and into the helper script.

The intention was to directly compute FLOX_ENV_LIB_DIRS from
FLOX_ENV_DIRS, which makes sense. However, the `profile.d/0800_cuda.sh`
script directly appends the `.flox/lib` directory to
FLOX_ENV_LIB_DIRS after locating CUDA libraries, so FLOX_ENV_LIB_DIRS
can't simply be the directories in FLOX_ENV_DIRS with "/lib" appended.

This change fixes the awk script to conceptually do the following:
```
for dir in FLOX_ENV_DIRS:
    dot_flox_lib = "$dir/../../lib"
    flox_env_lib = "$dir/lib"
    joined = "$flox_env_lib:$dot_flox_lib"
    flox_env_lib_dirs = "$flox_env_lib_dirs:$joined"
```

**test: add cuda regression test**

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Addresses a bug that broke automatic CUDA support.

<!-- Many thanks! -->
