### PR TITLE
fix(containerize): Proxy vol per Flox version

### DIFF
--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -35,10 +35,10 @@ the container is written to `./<env name>-container.tar` instead.
 **Note**: Exporting a container from macOS requires a supported runtime to be
 found because a proxy container is used to build the environment and image. You
 may be prompted for permissions to share files into the proxy container.
-Files used in the proxy container are cached using a `docker` or `podman`
-volume named `flox-nix`.
-It can safely be removed any time a `flox containerize` command is not running
-using either `docker volume rm flox-nix` or `podman volume rm flox-nix`.
+Files used in the proxy container are cached in `docker` or `podman` volumes
+which are named by the Flox version in use, e.g. `flox-nix-v1.2.3`.
+These can safely be removed any time a `flox containerize` command is not running
+using either `docker volume rm <name>` or `podman volume rm <name>`.
 
 Running the container will behave like running `flox activate`.
 Running the container interactively with `docker run -it <container id>`,


### PR DESCRIPTION
## Proposed Changes

Our approach to caching the store of the proxy container in a volume doesn't work across versions because it shadows new store paths needed by the base "OS" in newer container images:

    % nix run github:flox/flox/v1.3.9 -- containerize -d ~/tmp
    …
    % nix run github:flox/flox/v1.3.10 -- containerize -d ~/tmp
    ⠉ Writing container
    warning: the group 'nixbld' specified in 'build-users-group' does not exist
    this derivation will be built:
      /nix/store/aflz8nigx9lbmm8xpn58lg138a8ibysh-flox-1.3.10-g8778414.drv
    ⠙ Writing container
    error: the group 'nixbld' specified in 'build-users-group' does not exist
    open /var/lib/docker/tmp/docker-import-1278828303/repositories: no such file or directory
    ❌ ERROR: Writing to runtime was unsuccessful

Fix this by using one volume per Flox version, at the expense of:

- slower builds after changing Flox versions because you need to pull both the new container and store paths for the environment
- putting the onus on the user to manually clean up the volumes more frequently if they want to reclaim disk space

It would still be beneficial to switch to a `nixos/nix` container image for the proxy because it would change less frequently and we would likely get more store path re-use between Flox flakes than we currently get image layer re-use between Flox containers. However it requires some additional work to match the correct Nix version and ensure that substitutors are configured correctly, which deserve a separate ticket.

I also considered automating the GC of older volumes but it would slow down the hot-path of `flox containerize`, it's not possible to apply labels when creating volumes on-demand, and the interfaces are inconsistent between Docker and Podman. So we'd have to shell out to `<runtime> volume list` with string parsing and this would likely be better incorporated into the recently revived `flox gc`.

I was previous resistant to this approach and spent a lot of time trying to get an overlayfs mount working within the container, so that we could combine the container's store with our volume's store, but ran into numerous issues with:

- performance degrading with repeated use on Docker
- the overlayfs mount being completely empty on Podman
- chicken-and-egg problem of not being able to cache `mount`

For reference, here is the pertinent part of what I was testing:

    let proxy_command = formatdoc! {r#"
        set -euo pipefail
        mkdir -p {MOUNT_CACHE}/upper
        mkdir -p {MOUNT_CACHE}/workdir
        echo 'extra-experimental-features = nix-command flakes' >> /etc/nix/nix.conf
        nix shell nixpkgs#util-linuxMinimal --command mount \
            -t overlay overlay \
            -o lowerdir=/nix \
            -o upperdir={MOUNT_CACHE}/upper \
            -o workdir={MOUNT_CACHE}/workdir \
            /nix
        nix --accept-flake-config \
            run {flox_flake} -- \
                {verbosity} containerize --dir {MOUNT_ENV} --tag {tag} --file -
    "#, tag = tag.as_ref()};
    command.args(["bash", "-c", &proxy_command]);

I also tried the experimental `local-overlay-store` support with:

    let proxy_command = formatdoc! {r#"
        set -euo pipefail
        mkdir -p \
            {MOUNT_CACHE}/store \
            {MOUNT_CACHE}/store.workdir \
            {MOUNT_CACHE}/store.merged/nix/store
        echo 'extra-experimental-features = nix-command flakes local-overlay-store' >> /etc/nix/nix.conf
        nix shell nixpkgs#util-linuxMinimal --command mount \
            -t overlay overlay \
            -o lowerdir=/nix/store \
            -o upperdir={MOUNT_CACHE}/store \
            -o workdir={MOUNT_CACHE}/store.workdir \
            {MOUNT_CACHE}/store.merged/nix/store
        echo 'store = local-overlay://?root={MOUNT_CACHE}/store.merged&upper-layer={MOUNT_CACHE}/store' >> /etc/nix/nix.conf
        nix --accept-flake-config \
            run {flox_flake} -- \
                {verbosity} containerize --dir {MOUNT_ENV} --tag {tag} --file -
    "#, tag = tag.as_ref()};

But that didn't seem any better and occasionally produced errors when switching between base containers:

    flox_rust_sdk::providers::container_builder: copying path '/nix/store/lsy6c2f9alj2gkjj36h754kk63x6701l-source' from 'https://cache.flox.dev' to 'local-overlay://'...
    flox_rust_sdk::providers::container_builder: error: don't know how to recreate store derivation '/nix/store/xk6lzs2apswjc9sb5bwsc7b7xhqhqa29-flox-1.3.11-g9557a20.drv'!

## Release Notes

Fix `flox containerize` on macOS after upgrading Flox versions. It will now create a cache volume per Flox version, which currently need to be garbage collected manually.