### PR TITLE
feat(check_for_upgrade): set QoS class header to background 

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -121,7 +121,8 @@ pub enum Client {
 pub struct CatalogClientConfig {
     pub catalog_url: String,
     pub floxhub_token: Option<String>,
-    pub extra_headers: Option<BTreeMap<String, String>>,
+    pub extra_headers: BTreeMap<String, String>,
+}
 }
 
 /// A client for the catalog service.
@@ -189,13 +190,11 @@ impl CatalogClient {
             );
         };
 
-        if let Some(extra_headers) = &config.extra_headers {
-            for (key, value) in extra_headers {
-                header_map.insert(
-                    header::HeaderName::from_str(key).unwrap(),
-                    header::HeaderValue::from_str(value).unwrap(),
-                );
-            }
+        for (key, value) in &config.extra_headers {
+            header_map.insert(
+                header::HeaderName::from_str(key).unwrap(),
+                header::HeaderValue::from_str(value).unwrap(),
+            );
         }
 
         header_map
@@ -1352,7 +1351,7 @@ mod tests {
         CatalogClientConfig {
             catalog_url: url.to_string(),
             floxhub_token: None,
-            extra_headers: None,
+            extra_headers: Default::default(),
         }
     }
 
@@ -1440,7 +1439,7 @@ mod tests {
         let config = CatalogClientConfig {
             catalog_url: server.base_url().to_string(),
             floxhub_token: None,
-            extra_headers: Some(extra_headers),
+            extra_headers,
         };
 
         let client = CatalogClient::new(config);

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -123,6 +123,39 @@ pub struct CatalogClientConfig {
     pub floxhub_token: Option<String>,
     pub extra_headers: BTreeMap<String, String>,
 }
+
+#[derive(Clone, Copy, Debug, Default, derive_more::Display, PartialEq)]
+/// The QoS class of a catalog request.
+///
+/// Referencing macos perfomance classes, described [1].
+///
+/// [1]: <https://blog.xoria.org/macos-tips-threading/>
+pub enum CatalogQoS {
+    /// your app’s user interface will stutter if this work is preempted
+    #[display(fmt = "user_interactive")]
+    UserInteractive,
+    /// the user must wait for this work to finish before they can keep using your app, e.g. loading the contents of a document that was just opened
+    #[display(fmt = "user_initiated")]
+    UserInitiated,
+    /// used as a fallback for threads which don’t have a QoS class assigned
+    #[default]
+    #[display(fmt = "default")]
+    Default,
+    /// the user knows this work is happening but doesn’t wait for it to finish because they can keep using your app while it’s in progress, e.g. exporting in a video editor, downloading a file in a web browser
+    #[display(fmt = "utility")]
+    Utility,
+    /// the user doesn’t know this work is happening, e.g. search indexing
+    #[display(fmt = "background")]
+    Background,
+    /// the user doesn’t know this work is happening, e.g. garbage collection?
+    #[display(fmt = "maintenance")]
+    Maintenance,
+}
+
+impl CatalogQoS {
+    pub fn as_header_pair(&self) -> (String, String) {
+        ("X-Flox-QoS-Context".to_string(), self.to_string())
+    }
 }
 
 /// A client for the catalog service.

--- a/cli/flox/src/utils/init/catalog_client.rs
+++ b/cli/flox/src/utils/init/catalog_client.rs
@@ -51,9 +51,9 @@ pub fn init_catalog_client(config: &Config) -> Result<Client, anyhow::Error> {
                         metrics_headers.insert(k.to_string(), v);
                     }
                 }
-                Some(metrics_headers)
+                metrics_headers
             } else {
-                None
+                Default::default()
             }
         };
 


### PR DESCRIPTION
Upgrade checks running in the background,
may eventually be handled differently,
e.g. given lower priority over user attended resolution requests.
One way of doing so, is by attaching a QoS class header to requests
made by  the `check-for-upgrades` command,
that describes the requested Quality of Service.
In this case we accept a low priority/quality as the request isn't user attended.

## [refactor(catalog): make extra_headers config, non-optional](https://github.com/flox/flox/commit/e40130399a1e86b6f9751ddfc71aa3ffb058d6db) 

We can omit a layer of wrapping `CatalogClientConfig::extra_headers` in an `Option`,
because the field is a `BTreeMap`.
`BTreeMap` implements `Default` by returning an empty map,
which wrt the client behaves equivalently to `None`.
I.e. there is no difference between `None` and `Some(BTreeMap::default())`.
Besides, it makes modifying options more ergonomic,
as it removes the need to check whether an option was set.

## [feat(catalog): add an enum for Quality of Service classes](https://github.com/flox/flox/commit/d9145b19c1fa491ff0cdc596c960071f28a0edf4) 

`CatalogQoS` is represents the QoS classes exposed by macos
and described for example in [1].
As of now we don't have a usecase for the majority of these,
and will start with only using `background` for `upgrade`/`resolve`
requests made by the `check_for_upgrade` command,
which runs ... in the background.
Additional classes are included to provide a "proven" framework
for QoS classes in full.

[1]: <https://blog.xoria.org/macos-tips-threading/>
