### PR TITLE
refactor: amend flox version detection

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,12 +15,24 @@ nix_options := "--extra-experimental-features nix-command \
 INPUT_DATA := "${PWD}/test_data/input_data"
 cargo_test_invocation := "cargo nextest run --manifest-path ${PWD}/cli/Cargo.toml --workspace"
 
+# Set the FLOX_VERSION variable so that it can be used in the build/runtime
+# It's important to add the git revision to the version string,
+# so to that `containerize` can build the correct version of flox in CI.
+# While technically we'd want to add `-dirty` to the version string if the
+# working directory is dirty, we omit this here because in practice
+# it causes tests to fail that expect a FLAKE_VERSION to be "clean",
+# and doesn't add practical information.
+export FLOX_VERSION := shell('cat ./VERSION') + "-g" + shell('git rev-parse --short HEAD')
 
 # ---------------------------------------------------------------------------- #
 
 @_default:
     just --list --unsorted
 
+# ---------------------------------------------------------------------------- #
+
+version:
+    echo "${FLOX_VERSION}"
 
 # ---------------------------------------------------------------------------- #
 

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -15,10 +15,14 @@ use crate::providers::{catalog, flake_installable_locker};
 pub static FLOX_VERSION_STRING: LazyLock<String> =
     LazyLock::new(|| std::env::var("FLOX_VERSION").unwrap_or(env!("FLOX_VERSION").to_string()));
 pub static FLOX_VERSION: LazyLock<FloxVersion> = LazyLock::new(|| {
-    (*FLOX_VERSION_STRING)
-        .parse()
-        // Won't panic since we run flox --version in pkgs/flox/default.nix
-        .expect("Version '{version}' can not be parsed.")
+    let Ok(version) = (*FLOX_VERSION_STRING).parse() else {
+        // Production builds won't panic since we run `flox --version` in pkgs/flox/default.nix.
+        panic!(
+            "Version '{version}' can not be parsed",
+            version = *FLOX_VERSION_STRING
+        )
+    };
+    version
 });
 pub static FLOX_SENTRY_ENV: LazyLock<Option<String>> =
     LazyLock::new(|| std::env::var("FLOX_SENTRY_ENV").ok());

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -12,8 +12,33 @@ use crate::data::FloxVersion;
 pub use crate::models::environment_ref::{self, *};
 use crate::providers::{catalog, flake_installable_locker};
 
-pub static FLOX_VERSION_STRING: LazyLock<String> =
-    LazyLock::new(|| std::env::var("FLOX_VERSION").unwrap_or(env!("FLOX_VERSION").to_string()));
+/// The Flox version, this is crate is part of.
+/// This is _also_ used to determine the version of the CLI.
+/// The version is determined by the following rules:
+/// 1. `github:flox/flox#flox`, provides a wrapper that sets `FLOX_VERSION`.
+///    This is the main production artifact and canonical version.
+/// 2. Our `just` targets will set `FLOX_VERSION` using the current git tag,
+///    so `just` builds will have the correct updated version _with_ git metadata.
+/// 3. `cargo build` when run outside of `just` will fallback to `0.0.0-dirty`.
+///    This is the version that also local IDEs / rust-analyzer will use.
+///    However, binaries built this way may fail to run in some cases,
+///    e.g. `containerize` on macos which relies on the flox version.
+pub static FLOX_VERSION_STRING: LazyLock<String> = LazyLock::new(|| {
+    // Runtime provided version,
+    // i.e. the flox cli wrapper of the nix built production flox package.
+    if let Ok(version) = std::env::var("FLOX_VERSION") {
+        return version;
+    };
+
+    // Buildtime provided version, i.e. `just build-flox`.
+    if let Some(version) = option_env!("FLOX_VERSION") {
+        return version.to_string();
+    }
+
+    // Fallback to dev version, to allow building without just,
+    // and default configurations in IDEs.
+    "0.0.0-dirty".to_string()
+});
 pub static FLOX_VERSION: LazyLock<FloxVersion> = LazyLock::new(|| {
     let Ok(version) = (*FLOX_VERSION_STRING).parse() else {
         // Production builds won't panic since we run `flox --version` in pkgs/flox/default.nix.

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -143,8 +143,15 @@ writeShellScriptBin PROJECT_NAME ''
   esac
   export PROJECT_TESTS_DIR;
 
+  # Find the latest released version of flox.
+  # Despite the name this is generally _older_ than the tested version of flox.
   FLOX_LATEST_VERSION=${builtins.readFile ../../VERSION}
   export FLOX_LATEST_VERSION
+
+  # if FLOX_VERSION is not set, use the latest released version
+  # otherwise use the provided version
+  # when running tests with just, just will set FLOX_VERSION.
+  export FLOX_VERSION="''${FLOX_VERSION:-$FLOX_LATEST_VERSION}"
 
   # TODO: we shouldn't do this but rather use absolute paths
   # Look if we can use https://github.com/abathur/resholve

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -58,9 +58,6 @@ let
       # used internally to ensure CA certificates are available
       NIXPKGS_CACERT_BUNDLE_CRT = cacert.outPath + "/etc/ssl/certs/ca-bundle.crt";
 
-      # The current version of flox being built
-      inherit FLOX_VERSION;
-
       # Reexport of the platform flox is being built for
       NIX_TARGET_SYSTEM = targetPlatform.system;
     }
@@ -84,7 +81,7 @@ in
 craneLib.buildPackage (
   {
     pname = "flox";
-    version = envs.FLOX_VERSION;
+    version = FLOX_VERSION;
     src = flox-src;
 
     # Set up incremental compilation

--- a/pkgs/flox-watchdog/default.nix
+++ b/pkgs/flox-watchdog/default.nix
@@ -1,5 +1,6 @@
 {
   inputs,
+  lib,
   gnused,
   pkgsFor,
   rust-toolchain,
@@ -8,6 +9,8 @@
   flox-src,
 }:
 let
+  FLOX_VERSION = lib.fileContents ./../../VERSION;
+
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
 
@@ -17,7 +20,7 @@ in
 craneLib.buildPackage (
   {
     pname = "flox-watchdog";
-    version = envs.FLOX_VERSION;
+    version = FLOX_VERSION;
     src = flox-src;
 
     # Set up incremental compilation

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -41,9 +41,6 @@ let
       # b) use this version of nixpkgs i.e. (nix library utils such as `lib` and `runCommand`)
       COMMON_NIXPKGS_URL = "path:${inputs.nixpkgs.outPath}";
 
-      # The current version of flox being built
-      inherit FLOX_VERSION;
-
       # Reexport of the platform flox is being built for
       NIX_TARGET_SYSTEM = targetPlatform.system;
     }
@@ -66,7 +63,7 @@ in
 (craneLib.buildDepsOnly (
   {
     pname = "flox-internal-deps";
-    version = envs.FLOX_VERSION;
+    version = FLOX_VERSION;
     src = flox-src;
 
     # `buildDepsOnly` replaces the source of _all_ crates in the workspace


### PR DESCRIPTION
[build: remove FLOX_VERSION from dev shel](https://github.com/flox/flox/commit/ab6f297ee889504ff3ec5041ac197e3da418c4ca)

`FLOX_VERSION` set by the dev shell has the tendency to become stale,
especially when we depend on the current git commit rev,
which changes with every commit.
Also since activate inherits the version, activations made with an older version of flox,
affect the version printed by cargo built versions of flox.

For one, that may prevent _us_ from reliably putting correct versions into bug reports.
More importantly, missing the git rev "prevents flox containerize tests on macOS
from using the same version of Flox in the proxy container
because we don't have access to the current commit rev" [1].

[refactor: amend flox version detection and document](https://github.com/flox/flox/commit/eb7b84f64a3e38a882734ddad606e5e91f4ef749) 

The version is determined by the following rules:
1. `github:flox/flox#flox`, provides a wrapper that sets `FLOX_VERSION`.
   This is the main production artifact and canonical version.
2. Our `just` targets will set `FLOX_VERSION` using the current git tag,
   so `just` builds will have the correct updated version _with_ git metadata.
3. `cargo build` when run outside of `just` will fallback to `0.0.0-dirty`.
   This is the version that also local IDEs / rust-analyzer will use.
   However, binaries built this way may fail to run in some cases,
   e.g. `containerize` on macos which relies on the flox version.

In short, if your work requires the current version of flox,
use a nix or `just` build artifact.
If you use flox _inside_ of another flox activation, call it with `just flox`
or use the wrapped nix build.


[1]: <#2502>
