### PR TITLE
chore: update flake.lock

### DIFF
--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -90,7 +90,7 @@ impl Activations<UncheckedVersion> {
             });
         }
 
-        return Err(Unsupported {
+        Err(Unsupported {
             version: self.version,
             pids: self
                 .activations
@@ -102,7 +102,7 @@ impl Activations<UncheckedVersion> {
                         .map(|attached_pid| attached_pid.pid)
                 })
                 .collect(),
-        });
+        })
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1409,7 +1409,7 @@ mod tests {
     }
 
     /// UNINSTALL TESTS
-
+    ///
     /// Generates a mock `TypedManifest` for testing purposes.
     /// This function is designed to simplify the creation of test data by
     /// generating a `TypedManifest` based on a list of install IDs and

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -175,7 +175,6 @@ pub(crate) fn pkg_descriptors_in_named_group(
 
 /// Scans the provided package descriptors to determine if the search term is a package or
 /// group in the manifest.
-
 fn pkg_or_group_found_in_manifest(
     search_term: impl AsRef<str>,
     descriptors: &BTreeMap<String, ManifestPackageDescriptor>,

--- a/cli/flox/src/commands/envs.rs
+++ b/cli/flox/src/commands/envs.rs
@@ -154,7 +154,7 @@ impl<'a> DisplayEnvironments<'a> {
     }
 }
 
-impl<'a> Display for DisplayEnvironments<'a> {
+impl Display for DisplayEnvironments<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let widest = self
             .envs

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -266,7 +266,7 @@ impl Config {
             *config_guard = read_raw_config()?;
         }
 
-        return Ok(config_guard.deref().clone());
+        Ok(config_guard.deref().clone())
     }
 
     /// Creates a [Config] from the environment and config file

--- a/cli/flox/src/utils/dialog.rs
+++ b/cli/flox/src/utils/dialog.rs
@@ -25,7 +25,7 @@ pub struct Dialog<'a, Type> {
     pub typed: Type,
 }
 
-impl<'a> Dialog<'a, Confirm> {
+impl Dialog<'_, Confirm> {
     #[allow(unused)]
     pub async fn prompt(self) -> inquire::error::InquireResult<bool> {
         let message = self.message.to_owned();
@@ -84,7 +84,7 @@ impl Display for Choice {
     }
 }
 
-impl<'a, T: Display> Dialog<'a, Select<T>> {
+impl<T: Display> Dialog<'_, Select<T>> {
     #[allow(dead_code)]
     pub async fn prompt(self) -> inquire::error::InquireResult<T> {
         let message = self.message.to_owned();

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -64,7 +64,7 @@ macro_rules! environment_subcommand_metric {
 /// Extracts [MetricEvent] data from a raw [tracing] event
 struct MetricVisitor<'a>(&'a mut Option<String>, &'a mut HashMap<String, String>);
 
-impl<'a> tracing::field::Visit for MetricVisitor<'a> {
+impl tracing::field::Visit for MetricVisitor<'_> {
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
         if field.name() == "subcommand" {
             *self.0 = Some(value.to_string());

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -126,7 +126,7 @@ setup_start_counter_services() {
 @test "can call process-compose" {
   run "$PROCESS_COMPOSE_BIN" version
   assert_success
-  assert_output --partial "v1.34.0"
+  assert_output --partial "v1.40.1"
 }
 
 @test "process-compose can run generated config file" {
@@ -907,7 +907,7 @@ EOF
   run "$FLOX_BIN" services status one
   assert_success
 
-  
+
   # Note that the PID is omitted if the service hasn't been started
   assert_output --regexp "NAME +STATUS +PID"
   assert_output --regexp "one +Stopped +"
@@ -1546,4 +1546,3 @@ EOF
     "${TESTS_DIR}"/services/wait_for_service_status.sh one:Stopped two:Stopped
   '
 }
-

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1730652660,
-        "narHash": "sha256-+XVYfmVXAiYA0FZT7ijHf555dxCe+AoAT5A6RU+6vSo=",
+        "lastModified": 1737689766,
+        "narHash": "sha256-ivVXYaYlShxYoKfSo5+y5930qMKKJ8CLcAoIBPQfJ6s=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a4ca93905455c07cb7e3aca95d4faf7601cba458",
+        "rev": "6fe74265bbb6d016d663b1091f015e2976c4a527",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1730702146,
-        "narHash": "sha256-a657FU8MS5m0Y4pQvcmQPfvXYOPpxih7u2hU57Bn2i4=",
+        "lastModified": 1738305171,
+        "narHash": "sha256-Bt7jBEGnOmxyvma4S7MFFf3vbPUiTbr8TJoZLXEDXKc=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "fa3610f841725c8e20fc0fab070ee60609fdd5ee",
+        "rev": "667e3751a708b886bb67879147f71c07b0014c7f",
         "type": "github"
       },
       "original": {
@@ -75,32 +75,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
         "type": "github"
       },
       "original": {
         "owner": "flox",
         "ref": "stable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -111,15 +95,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -140,11 +123,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1730645367,
-        "narHash": "sha256-RnmBO+9zmZ3NpU6+NfYUDRg31dsPZ17xUqXVw/ZOKZ8=",
+        "lastModified": 1738224931,
+        "narHash": "sha256-1zhfA5NBqin0Z79Se85juvqQteq7uClJMEb7l2pdDUY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "e44691a60443f1246a077df659607ca89f2ddc58",
+        "rev": "3c2aca1e5e9fbabb4e05fc4baa62e807aadc476a",
         "type": "github"
       },
       "original": {
@@ -157,15 +140,16 @@
     "t3-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1734542708,
-        "narHash": "sha256-D0igUpqO2Es9QyhcJtPUc1rInSVC96lrx4z+takOwWg=",
+        "lastModified": 1738681975,
+        "narHash": "sha256-QLaOMYlEYjUZpuXJ/MOKb+UqzrTiOu6Isuqj07HTxkQ=",
         "owner": "flox",
         "repo": "t3",
-        "rev": "813ed220eab7f678a1bfbf70e4145d9de738d562",
+        "rev": "83caeb1cc47fd07117ee5cf478f82cc177cca598",
         "type": "github"
       },
       "original": {
         "owner": "flox",
+        "ref": "v1.0.7",
         "repo": "t3",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
   inputs.fenix.url = "github:nix-community/fenix";
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
 
-  inputs.t3-src.url = "github:flox/t3";
+  inputs.t3-src.url = "github:flox/t3/v1.0.7"; # Keep in sync with t3 overlay below.
   inputs.t3-src.flake = false;
 
   # -------------------------------------------------------------------------- #
@@ -57,7 +57,10 @@
           nix = final.callPackage ./pkgs/nix { };
 
           cpp-semver = final.callPackage ./pkgs/cpp-semver { };
-          t3 = final.callPackage ./pkgs/t3 { inherit (inputs) t3-src; };
+          t3 = final.callPackage ./pkgs/t3 {
+            src = inputs.t3-src;
+            version = "1.0.7"; # Keep in sync with input line above.
+          };
         })
         inputs.fenix.overlays.default
       ];

--- a/pkgs/t3/default.nix
+++ b/pkgs/t3/default.nix
@@ -3,17 +3,13 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  t3-src,
+  src,
+  version,
 }:
 
-let
-  pname = "t3";
-  version = "1.0.3";
-  src = t3-src;
-
-in
 stdenv.mkDerivation rec {
-  inherit pname version src;
+  pname = "t3";
+  inherit version src;
 
   installFlags = [
     "PREFIX=$(out)"


### PR DESCRIPTION
## Proposed Changes

Update external system dependencies by updating our flake lock.

## Release Notes

bump: nix 2.24.9 -> 2.24.11
bump: rust 1.82 -> 1.84
bump: process-compose 1.34.0 -> 1.40.1

