### PR TITLE
feat: add LD_FLOXLIB_{FILES,DIRS}_PATH support to ld-floxlib

### DIFF
--- a/assets/activation-scripts/activate.d/flox-env-helper.awk
+++ b/assets/activation-scripts/activate.d/flox-env-helper.awk
@@ -42,10 +42,6 @@ BEGIN {
   # subshells.
   new_flox_env_dirs = prepend_if_not_found(ENVIRON["FLOX_ENV"], ENVIRON["FLOX_ENV_DIRS"])
 
-  # The FLOX_ENV_LIB_DIRS variable is a direct translation of the FLOX_ENV_DIRS
-  # variable but with each directory having "/lib" appended to it.
-  new_flox_env_lib_dirs = append_dirs("/lib", new_flox_env_dirs)
-
   # Calculate the values to be prepended to the PATH and MANPATH variables.
   # First add directories found in FLOX_ENV_DIRS, then add the current value
   # of FLOX_ENV. Don't worry about duplicating the FLOX_ENV directory as
@@ -93,22 +89,18 @@ BEGIN {
   flox_shell_basename = basename(ARGV[1])
   if (flox_shell_basename == "bash") {
     print "export FLOX_ENV_DIRS=\"" new_flox_env_dirs "\";"
-    print "export FLOX_ENV_LIB_DIRS=\"" new_flox_env_lib_dirs "\";"
     print "export PATH=\"" new_path "\";"
     print "export MANPATH=\"" new_manpath "\";"
   } else if (flox_shell_basename == "tcsh") {
     print "setenv FLOX_ENV_DIRS \"" new_flox_env_dirs "\";"
-    print "setenv FLOX_ENV_LIB_DIRS \"" new_flox_env_lib_dirs "\";"
     print "setenv PATH \"" new_path "\";"
     print "setenv MANPATH \"" new_manpath "\";"
   } else if (flox_shell_basename == "fish") {
     print "set -gx FLOX_ENV_DIRS \"" new_flox_env_dirs "\";"
-    print "set -gx FLOX_ENV_LIB_DIRS \"" new_flox_env_lib_dirs "\";"
     print "set -gx PATH \"" new_path "\";"
     print "set -gx MANPATH \"" new_manpath "\";"
   } else if (flox_shell_basename == "zsh") {
     print "export FLOX_ENV_DIRS=\"" new_flox_env_dirs "\";"
-    print "export FLOX_ENV_LIB_DIRS=\"" new_flox_env_lib_dirs "\";"
     print "export PATH=\"" new_path "\";"
     print "export MANPATH=\"" new_manpath "\";"
   } else {
@@ -130,20 +122,6 @@ BEGIN {
 #
 # So the presence of "extra" parameters in the following function
 # definitions is intentional and for declaring local variables.
-
-function append_dirs(string, path, _path_array, _result, i)
-{
-  # local variables: _path_array, _result, i
-  _result = ""
-  for (i = 1; i <= split(path, _path_array, ":"); i++) {
-    if (_result == "") {
-      _result = _path_array[i] string
-    } else {
-      _result = _result ":" _path_array[i] string
-    }
-  }
-  return _result
-}
 
 function basename(file, _a, _n)
 {

--- a/assets/activation-scripts/etc/profile.d/0100_common-paths.sh
+++ b/assets/activation-scripts/etc/profile.d/0100_common-paths.sh
@@ -27,10 +27,10 @@ export \
 
 # ---------------------------------------------------------------------------- #
 
-if [ -n "${FLOX_ENV_LIB_DIRS:-}" ]; then
+if [ -n "${FLOX_ENV_DIRS:-}" ]; then
   case "$($_uname -s)" in
     Linux*)
-      # N.B. ld-floxlib.so makes use of FLOX_ENV_LIB_DIRS directly.
+      # N.B. ld-floxlib.so makes use of FLOX_ENV_DIRS directly.
       LD_FLOXLIB="${LD_FLOXLIB:-$_ld_floxlib_so}"
       if [ -z "${FLOX_NOSET_LD_AUDIT:-}" ] && [ -e "$LD_FLOXLIB" ]; then
         LD_AUDIT="$LD_FLOXLIB"
@@ -39,7 +39,15 @@ if [ -n "${FLOX_ENV_LIB_DIRS:-}" ]; then
       ;;
     Darwin*)
       if [ -z "${FLOX_NOSET_DYLD_FALLBACK_LIBRARY_PATH:-}" ]; then
-        DYLD_FALLBACK_LIBRARY_PATH="$FLOX_ENV_LIB_DIRS:${DYLD_FALLBACK_LIBRARY_PATH:-/usr/local/lib:/usr/lib}"
+        # Calculate a list of FLOX_ENV directories with "/lib" appended.
+        _flox_env_lib_dirs=""
+        _ifs_orig="$IFS"
+        IFS=:
+        for dir in $FLOX_ENV_DIRS; do
+          _flox_env_lib_dirs="${_flox_env_lib_dirs:+${_flox_env_lib_dirs}:}$dir/lib"
+        done
+        IFS="$_ifs_orig"
+        DYLD_FALLBACK_LIBRARY_PATH="$_flox_env_lib_dirs:${DYLD_FALLBACK_LIBRARY_PATH:-/usr/local/lib:/usr/lib}"
         export DYLD_FALLBACK_LIBRARY_PATH
       fi
       ;;

--- a/cli/flox/doc/doc-build/manifest.toml.md
+++ b/cli/flox/doc/doc-build/manifest.toml.md
@@ -546,8 +546,7 @@ Semver ::= {
 :   Whether to detect CUDA libraries and provide them to the environment.
     The default is `true`.
     When enabled, Flox will detect if you have an Nvidia device and attempt to
-    locate `libcuda` in well-known paths. Then it will symlink the libraries
-    into `.flox/lib` and add that path to `FLOX_ENV_LIB_DIRS`.
+    locate `libcuda` in well-known paths.
 
 # SEE ALSO
 [`flox-init(1)`](./flox-init.md),

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -523,8 +523,7 @@ Semver ::= {
 :   Whether to detect CUDA libraries and provide them to the environment.
     The default is `true`.
     When enabled, Flox will detect if you have an Nvidia device and attempt to
-    locate `libcuda` in well-known paths. Then it will symlink the libraries
-    into `.flox/lib` and add that path to `FLOX_ENV_LIB_DIRS`.
+    locate `libcuda` in well-known paths.
 
 # SEE ALSO
 [`flox-init(1)`](./flox-init.md),

--- a/cli/tests/cuda/cuda-disabled.sh
+++ b/cli/tests/cuda/cuda-disabled.sh
@@ -6,17 +6,14 @@ LDCONFIG_MOCK="${2}"
 # Get the function without loading support.
 _FLOX_ENV_CUDA_DETECTION=0 source "${FLOX_ENV}/etc/profile.d/0800_cuda.sh"
 
-LIBS_BEFORE="$FLOX_ENV_LIB_DIRS"
+LD_FLOXLIB_FILES_PATH_BEFORE="${LD_FLOXLIB_FILES_PATH:-}"
 activate_cuda "${FHS_ROOT}" "${LDCONFIG_MOCK}"
-LIBS_AFTER="$FLOX_ENV_LIB_DIRS"
+LD_FLOXLIB_FILES_PATH_AFTER="${LD_FLOXLIB_FILES_PATH:-}"
 
-if [[ "$LIBS_AFTER" != "$LIBS_BEFORE" ]]; then
+if [[ "$LD_FLOXLIB_FILES_PATH_AFTER" != "$LD_FLOXLIB_FILES_PATH_BEFORE" ]]; then
     set +x # make it easier to read the comparison
-    echo "FLOX_ENV_LIB_DIRS was modified and it shouldn't have been"
-    echo "  before: ${LIBS_BEFORE}"
-    echo "  after:  ${LIBS_AFTER}"
+    echo "LD_FLOXLIB_FILES_PATH was modified and it shouldn't have been"
+    echo "  before: ${LD_FLOXLIB_FILES_PATH_BEFORE}"
+    echo "  after:  ${LD_FLOXLIB_FILES_PATH_AFTER}"
     exit 1
 fi
-
-# Assert directory absence and list contents to help debug test failures.
-! ls -al "${FLOX_ENV_PROJECT}/.flox/lib"

--- a/cli/tests/ld-floxlib.bats
+++ b/cli/tests/ld-floxlib.bats
@@ -12,7 +12,7 @@
 # * curl, libarchive (runtime libraries required by libnixmain.so)
 #
 # It then activates the env to perform three distinct tests:
-# 1: load libraries found in $FLOX_ENV_LIB_DIRS last, i.e. don't use env-
+# 1: load libraries found in $FLOX_ENV_DIRS last, i.e. don't use env-
 #    provided libraries in preference to ones available on the system
 #   - invoke /bin/sh
 #   - confirm that the one version of glibc present in the namespace is
@@ -103,7 +103,7 @@ teardown() {
   assert_success
   assert_output --partial -- "-glibc-2.34-210/lib/ld-linux-"
 
-  ### Test 1: load libraries found in $FLOX_ENV_LIB_DIRS last
+  ### Test 1: load libraries found in $FLOX_ENV_DIRS last
   run "$FLOX_BIN" activate -- bash ./test-load-library-last.sh
   assert_success
 

--- a/cli/tests/ld-floxlib/test-load-library-last.sh
+++ b/cli/tests/ld-floxlib/test-load-library-last.sh
@@ -5,8 +5,8 @@
 # assertion (-e) and be verbose about it (-x).
 set -ex
 
-# FLOX_ENV_LIB_DIRS is defined
-test -n "$FLOX_ENV_LIB_DIRS"
+# FLOX_ENV_DIRS is defined
+test -n "$FLOX_ENV_DIRS"
 
 # LD_AUDIT is defined, exists and points to ld-floxlib.so
 test -e "$LD_AUDIT"

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -17,7 +17,8 @@ bats_require_minimum_version '1.5.0'
 # back into test activations.
 unset_flox_env_setup() {
   for var in $(env | awk -F= '{print $1}'); do
-    if [[ $var == FLOX_ENV* || $var == _FLOX_ENV* ]]; then
+    if [[ $var == FLOX_ENV* || $var == _FLOX_ENV* || $var == LD_FLOXLIB_* ]];
+    then
       unset "$var"
     fi
   done

--- a/ld-floxlib/Makefile
+++ b/ld-floxlib/Makefile
@@ -23,64 +23,88 @@ unit-test: unit-test.c ld-floxlib.so
 	$(CC) $< -o $@ ./ld-floxlib.so
 
 # Set up test libraries.
-tests/test1/libtest1.so: libtest.c
+tests/test1/lib/libtest1.so: libtest.c
 	mkdir -p $(@D)
 	$(CC) -DTEST_FUNCTION=test1 -shared -fPIC $< -o $@
 
-tests/test2/libtest2.so: libtest.c
+tests/test2/lib/libtest2.so: libtest.c
 	mkdir -p $(@D)
 	$(CC) -DTEST_FUNCTION=test2 -shared -fPIC $< -o $@
 
-tests/test3/libtest3.so: libtest.c
+tests/test3/lib/libtest3.so: libtest.c
 	mkdir -p $(@D)
 	$(CC) -DTEST_FUNCTION=test3 -shared -fPIC $< -o $@
 	# Render test3 directory unreadable
 	chmod ugo-rwx $(@D)
 
 .PHONY: testlibs
-testlibs: tests/test1/libtest1.so tests/test2/libtest2.so tests/test3/libtest3.so
+testlibs: tests/test1/lib/libtest1.so tests/test2/lib/libtest2.so tests/test3/lib/libtest3.so
 
-# By design ld-floxlib only parses FLOX_ENV_LIB_DIRS once per invocation,
-# so testing la_objsearch() for various combinations of env and arg input
-# requires multiple invocations. We use the following template as a way
-# to generate targets for each test to be performed, while building a list
-# of all targets in $(unit_tests).
+# By design ld-floxlib parses FLOX_ENV_DIRS and LD_FLOXLIB_{FILES,DIRS}_PATH
+# once per invocation, so testing la_objsearch() for various combinations of
+# env and arg input requires multiple invocations. We use the following
+# template as a way to generate targets for each test to be performed, for
+# each of the FLOX_ENV_DIRS and LD_FLOXLIB_{FILES,DIRS}_PATH combinations,
+# while building a list of tests targets in $(unit_tests).
 define unit_test_TEMPLATE =
   $(eval _args = $(1))
   # name of unit test
   $(eval _test_name = $(word 1,$(_args)))
-  # value of FLOX_ENV_LIB_DIRS
+  # value of FLOX_ENV_DIRS
   $(eval _value = $(word 2,$(_args)))
+  # value with "/lib" appended to each element in ordered PATH.
+  $(eval _value_with_lib = $(if $(_value),$(subst :/lib:,::,$(subst :,/lib:,$(_value)))/lib))
   # "name" arg to pass to la_obsearch()
   $(eval _name = $(word 3,$(_args)))
+  # value with $(_name) appended to each element in ordered PATH.
+  $(eval _value_with_lib_and_name = $(if $(_value),$(subst :/lib/$(_name):,::,$(subst :,/lib/$(_name):,$(_value)))/lib/$(_name)))
   # expected return value
   $(eval _expected = $(word 4,$(_args)))
   # capture remaining args to recurse
   $(eval _remaining_args = $(wordlist 5,$(words $(_args)),$(_args)))
 
-  .PHONY: _unit_test_$(_test_name)
-  _unit_test_$(_test_name): unit-test testlibs
-	LD_FLOXLIB_AUDIT=1 FLOX_ENV_LIB_DIRS=$(_value) \
+  .PHONY: _unit_test_flox_env_dirs_$(_test_name)
+  _unit_test_flox_env_dirs_$(_test_name): unit-test testlibs
+	LD_FLOXLIB_DEBUG=1 LD_FLOXLIB_FILES_PATH= LD_FLOXLIB_DIRS_PATH= \
+	  FLOX_ENV_DIRS=$(_value) \
 	  ./$$< "$(_name)" "$(_expected)"
 	@echo -e "$(GREENCHECK)" "$(_test_name)" 1>&2
 
-  unit_tests += _unit_test_$(_test_name)
+  unit_tests += _unit_test_flox_env_dirs_$(_test_name)
+
+  .PHONY: _unit_test_ld_floxlib_files_path_$(_test_name)
+  _unit_test_ld_floxlib_files_path_$(_test_name): unit-test testlibs
+	LD_FLOXLIB_AUDIT=1 FLOX_ENV_DIRS= LD_FLOXLIB_DIRS_PATH= \
+	  LD_FLOXLIB_FILES_PATH=$(_value_with_lib_and_name) \
+	  ./$$< "$(_name)" "$(_expected)"
+	@echo -e "$(GREENCHECK)" "$(_test_name)" 1>&2
+
+  unit_tests += _unit_test_ld_floxlib_files_path_$(_test_name)
+
+  .PHONY: _unit_test_ld_floxlib_dirs_path_$(_test_name)
+  _unit_test_ld_floxlib_dirs_path_$(_test_name): unit-test testlibs
+	LD_FLOXLIB_DEBUG=1 FLOX_ENV_DIRS= LD_FLOXLIB_FILES_PATH= \
+	  LD_FLOXLIB_DIRS_PATH=$(_value_with_lib) \
+	  ./$$< "$(_name)" "$(_expected)"
+	@echo -e "$(GREENCHECK)" "$(_test_name)" 1>&2
+
+  unit_tests += _unit_test_ld_floxlib_dirs_path_$(_test_name)
 
   # recurse if any remaining args
   $(if $(_remaining_args),$(call unit_test_TEMPLATE,$(_remaining_args)))
 endef
 
 # Declare unit test targets to be performed.
-# test_name     FLOX_ENV_LIB_DIRS                     name_arg    expected_value
+# test_name     FLOX_ENV_DIRS / LD_FLOXLIB_*_PATH     name_arg    expected_value
 # ------------- ------------------------------------- ----------- --------------
 $(eval $(call unit_test_TEMPLATE,$(strip \
   empty         ""                                    libtest1.so libtest1.so \
   no_exist      /does/not/exist                       libtest1.so libtest1.so \
-  relative      tests/test1                           libtest1.so tests/test1/libtest1.so \
-  absolute      $(abspath tests/test1)                libtest1.so $(abspath tests/test1)/libtest1.so \
-  multiple      tests/test1:tests/test2               libtest1.so tests/test1/libtest1.so \
+  relative      tests/test1                           libtest1.so tests/test1/lib/libtest1.so \
+  absolute      $(abspath tests/test1)                libtest1.so $(abspath tests/test1)/lib/libtest1.so \
+  multiple      tests/test1:tests/test2               libtest1.so tests/test1/lib/libtest1.so \
   unreadable    tests/test1:tests/test2:tests/test3   libtest3.so libtest3.so \
-  empty_element tests/test1::tests/test2::tests/test3 libtest2.so tests/test2/libtest2.so \
+  empty_element tests/test1::tests/test2::tests/test3 libtest2.so tests/test2/lib/libtest2.so \
 )))
 
 # Also configure integration tests which exercise ld-floxlib.so by
@@ -98,18 +122,36 @@ define integration_test_TEMPLATE =
   ifeq ($(_rc),0)
     integration_$(_test_name): integration-test.c $(unit_tests)
 	$(CC) -DTEST_FUNCTION=$(_test_name) $$< -o $$@ \
-	  -L./tests/$(_test_name) -l$(_test_name)
+	  -L./tests/$(_test_name)/lib -l$(_test_name)
 
-    run_integration_$(_test_name): integration_$(_test_name) ld-floxlib.so
+    _integration_test_flox_env_dirs_$(_test_name): integration_$(_test_name) ld-floxlib.so
 	LD_FLOXLIB_AUDIT=1 LD_AUDIT=./ld-floxlib.so \
-	  FLOX_ENV_LIB_DIRS=tests/test1:tests/test2:tests/test3 ./$$<
+	  LD_FLOXLIB_FILES_PATH= LD_FLOXLIB_DIRS_PATH= \
+	  FLOX_ENV_DIRS=tests/test1:tests/test2:tests/test3 ./$$<
 	@echo -e "$(GREENCHECK)" "$$@" 1>&2
 
-    integration_tests += run_integration_$(_test_name)
+    integration_tests += _integration_test_flox_env_dirs_$(_test_name)
+
+    _integration_test_ld_floxlib_files_path_$(_test_name): integration_$(_test_name) ld-floxlib.so
+	LD_FLOXLIB_AUDIT=1 LD_AUDIT=./ld-floxlib.so \
+	  FLOX_ENV_DIRS= LD_FLOXLIB_DIRS_PATH= \
+	  LD_FLOXLIB_FILES_PATH=tests/test1/lib/libtest1.so:tests/test2/lib/libtest2.so:tests/test3/lib/libtest3.so ./$$<
+	@echo -e "$(GREENCHECK)" "$$@" 1>&2
+
+    integration_tests += _integration_test_ld_floxlib_files_path_$(_test_name)
+
+    _integration_test_ld_floxlib_dirs_path_$(_test_name): integration_$(_test_name) ld-floxlib.so
+	LD_FLOXLIB_AUDIT=1 LD_AUDIT=./ld-floxlib.so \
+	  LD_FLOXLIB_FILES_PATH= FLOX_ENV_DIRS= \
+	  LD_FLOXLIB_DIRS_PATH=tests/test1/lib:tests/test2/lib:tests/test3/lib ./$$<
+	@echo -e "$(GREENCHECK)" "$$@" 1>&2
+
+    integration_tests += _integration_test_ld_floxlib_dirs_path_$(_test_name)
+
   else
     integration_$(_test_name): integration-test.c $(unit_tests)
 	-$(CC) -DTEST_FUNCTION=$(_test_name) $$< -o $$@ \
-	  -L./tests/$(_test_name) -l$(_test_name)
+	  -L./tests/$(_test_name)/lib -l$(_test_name)
 	# The above compilation should fail, so if the target
 	# exists then this test has failed.
 	@if [ -f $$@ ]; then \

--- a/ld-floxlib/unit-test.c
+++ b/ld-floxlib/unit-test.c
@@ -1,7 +1,7 @@
 /*
  * Unit test runner for ld-floxlib.so.
  *
- * By design ld-floxlib only parses FLOX_ENV_LIB_DIRS once per invocation,
+ * By design ld-floxlib only parses FLOX_ENV_DIRS once per invocation,
  * so testing la_objsearch() for various combinations of env and arg input
  * requires multiple invocations. This test program calls the ld-floxlib.so
  * la_objsearch() function with the provided "name" arg and asserts that it
@@ -37,7 +37,7 @@ main( int argc, char **argv )
   assert(la_version(3) != 2);
   assert(la_version(-1) == -1);
 
-  // la_objsearch() searches the contents of the FLOX_ENV_LIB_DIRS
+  // la_objsearch() searches the contents of the FLOX_ENV_DIRS
   // variable looking for library matches, but only when invoked
   // with the LA_SER_DEFAULT flag. Take a moment to ensure all other
   // flags return the input unaltered.

--- a/package-builder/closure.c
+++ b/package-builder/closure.c
@@ -9,7 +9,7 @@
  * set in the environment, and we do this when wrapping files in the bin
  * directory in the course of performing a manifest build.
  *
- * As with the parsing of FLOX_ENV_LIB_DIRS, it is essential that this parsing
+ * As with the parsing of FLOX_ENV_DIRS, it is essential that this parsing
  * of the closure be performant and initialized only once per invocation, so we
  * start by reading closure paths into a btable from $FLOX_ENV/requisites.txt.
  */
@@ -35,7 +35,7 @@
 // This is somewhat arbitrary but should be more than enough for most cases.
 #define FLOX_ENV_CLOSURE_MAXENTRIES 4096
 
-// Define the maximum length of a directory path in the FLOX_ENV_LIB_DIRS
+// Define the maximum length of a directory path in the FLOX_ENV_DIRS
 // environment variable. This is also somewhat arbitrary, but it should
 // be more than enough for most cases.
 #define FLOX_ENV_REQUISITE_MAXLEN PATH_MAX

--- a/package-builder/sandbox.c
+++ b/package-builder/sandbox.c
@@ -9,7 +9,7 @@
  * set in the environment, and we do this when wrapping files in the bin
  * directory in the course of performing a manifest build.
  *
- * As with the parsing of FLOX_ENV_LIB_DIRS, it is essential that this parsing
+ * As with the parsing of FLOX_ENV_DIRS, it is essential that this parsing
  * of the closure be performant and initialized only once per invocation, so we
  * start by reading closure paths into a btable from $FLOX_ENV/requisites.txt.
  */


### PR DESCRIPTION
## Proposed Changes

We had been previously adding [impure] paths to the `FLOX_ENV_LIB_DIRS` variable in order for `ld-floxlib` to serve up libraries found in these directories. We then forgot this requirement as we added validation for `FLOX_ENV_LIB_DIRS` with a recent refactor, and this correspondingly broke the cuda "profile.d" init script.

This patch updates `ld-floxlib` to instead serve up libraries found in the `/lib` subdirectory of entries in the FLOX_ENV_DIRS variable, and adds support for a new pair of `LD_FLOXLIB_{FILES,DIR}_PATH` variables which can be used to direct `ld-floxlib` to serve up libraries in arbitrary locations. The order of precedence for these [three] variables is as follows:

1. `/lib` subdirectories of `FLOX_ENV_DIRS` entries
2. libraries as listed in `LD_FLOXLIB_FILES_PATH`
3. libraries found in directories listed in `LD_FLOXLIB_DIRS_PATH`

Within each of these categories the locations listed within each variable are processed from left to right, providing fine-grained control over the search order when required.

This patch also updates the [1] cuda script that had previously been updating the `FLOX_ENV_LIB_DIRS` variable to instead use the `LD_FLOXLIB_FILES_PATH` for specifying known cuda libraries.

## Release Notes

* Fixed bug with the use of CUDA libraries introduced with flox 1.3.9.