### PR TITLE
chore(manifest): Remove dupe skip_serializing_none

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest.rs
+++ b/cli/flox-rust-sdk/src/models/manifest.rs
@@ -769,7 +769,6 @@ pub struct ManifestPackageDescriptorFlake {
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
-#[skip_serializing_none]
 pub struct ManifestPackageDescriptorStorePath {
     pub(crate) store_path: String,
     #[cfg_attr(


### PR DESCRIPTION
## Proposed Changes

Noticed this during my demo today. I added a working entry in cc2ac7c4 but didn't notice this non-working entry (because it has to be first).

## Release Notes

N/A