### PR TITLE
Activate metrics

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -126,7 +126,11 @@ pub struct Activate {
 
 impl Activate {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
-        environment_subcommand_metric!("activate", self.environment);
+        environment_subcommand_metric!(
+            "activate",
+            self.environment,
+            start_services = self.start_services
+        );
 
         let mut concrete_environment = match self.environment.to_concrete_environment(&flox) {
             Ok(concrete_environment) => concrete_environment,

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -47,7 +47,7 @@ use crate::commands::{ensure_environment_trust, EnvironmentSelectError};
 use crate::config::{Config, EnvironmentPromptConfig};
 use crate::utils::openers::Shell;
 use crate::utils::{default_nix_env_vars, message};
-use crate::{subcommand_metric, utils};
+use crate::{environment_subcommand_metric, subcommand_metric, utils};
 
 pub static INTERACTIVE_BASH_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
     PathBuf::from(
@@ -126,7 +126,7 @@ pub struct Activate {
 
 impl Activate {
     pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
-        subcommand_metric!("activate");
+        environment_subcommand_metric!("activate", self.environment);
 
         let mut concrete_environment = match self.environment.to_concrete_environment(&flox) {
             Ok(concrete_environment) => concrete_environment,

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -12,8 +12,8 @@ use tracing::instrument;
 
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::activate::FLOX_INTERPRETER;
-use crate::subcommand_metric;
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[allow(unused)] // remove when we implement the command
 #[derive(Bpaf, Clone)]
@@ -61,6 +61,7 @@ impl Build {
 
         match self.subcommand_or_targets {
             SubcommandOrBuildTargets::Clean { targets } => {
+                environment_subcommand_metric!("build::clean", self.environment);
                 let env = self
                     .environment
                     .detect_concrete_environment(&flox, "Build packages of")?;
@@ -68,6 +69,7 @@ impl Build {
                 Self::clean(flox, env, targets).await
             },
             SubcommandOrBuildTargets::BuildTargets { targets } => {
+                environment_subcommand_metric!("build", self.environment);
                 let env = self
                     .environment
                     .detect_concrete_environment(&flox, "Clean build files of")?;
@@ -79,8 +81,6 @@ impl Build {
 
     #[instrument(name = "build::clean", skip_all)]
     async fn clean(flox: Flox, env: ConcreteEnvironment, packages: Vec<String>) -> Result<()> {
-        subcommand_metric!("build::clean");
-
         if let ConcreteEnvironment::Remote(_) = &env {
             bail!("Cannot build from a remote environment");
         };
@@ -102,8 +102,6 @@ impl Build {
 
     #[instrument(name = "build", skip_all, fields(packages))]
     async fn build(flox: Flox, mut env: ConcreteEnvironment, packages: Vec<String>) -> Result<()> {
-        subcommand_metric!("build");
-
         if let ConcreteEnvironment::Remote(_) = &env {
             bail!("Cannot build from a remote environment");
         };

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -17,9 +17,9 @@ use macos_containerize_proxy::ContainerizeProxy;
 use tracing::{debug, info, instrument};
 
 use super::{environment_select, EnvironmentSelect};
-use crate::subcommand_metric;
 use crate::utils::message;
 use crate::utils::openers::first_in_path;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 mod macos_containerize_proxy;
 
@@ -42,7 +42,7 @@ pub struct Containerize {
 impl Containerize {
     #[instrument(name = "containerize", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        subcommand_metric!("containerize");
+        environment_subcommand_metric!("containerize", self.environment);
 
         let mut env = self
             .environment

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -7,9 +7,9 @@ use tracing::instrument;
 
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::environment_description;
-use crate::subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Delete an environment
 #[derive(Bpaf, Clone)]
@@ -25,7 +25,7 @@ pub struct Delete {
 impl Delete {
     #[instrument(name = "delete", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        subcommand_metric!("delete");
+        environment_subcommand_metric!("delete", self.environment);
         let environment = self
             .environment
             .detect_concrete_environment(&flox, "Delete")?;

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -32,10 +32,10 @@ use super::{
     UninitializedEnvironment,
 };
 use crate::commands::{ensure_floxhub_token, EnvironmentSelectError};
-use crate::subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::errors::format_core_error;
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Edit declarative environment configuration
 #[derive(Bpaf, Clone)]
@@ -76,7 +76,7 @@ pub enum EditAction {
 impl Edit {
     #[instrument(name = "edit", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
-        subcommand_metric!("edit");
+        environment_subcommand_metric!("edit", self.environment);
 
         // Ensure the user is logged in for the following remote operations
         if let EnvironmentSelect::Remote(_) = self.environment {

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -56,7 +56,7 @@ use crate::utils::errors::format_error;
 use crate::utils::message;
 use crate::utils::openers::Shell;
 use crate::utils::tracing::sentry_set_tag;
-use crate::{subcommand_metric, Exit};
+use crate::{environment_subcommand_metric, subcommand_metric, Exit};
 
 // Install a package into an environment
 #[derive(Bpaf, Clone)]
@@ -94,7 +94,7 @@ pub struct PkgWithIdOption {
 impl Install {
     #[instrument(name = "install", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
-        subcommand_metric!("install");
+        environment_subcommand_metric!("install", self.environment);
 
         debug!(
             "attempting to install packages [{}] to {:?}",

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -16,9 +16,9 @@ use itertools::Itertools;
 use tracing::{debug, instrument};
 
 use super::{environment_select, EnvironmentSelect};
-use crate::subcommand_metric;
 use crate::utils::message;
 use crate::utils::tracing::sentry_set_tag;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 // List packages installed in an environment
 #[derive(Bpaf, Clone)]
@@ -53,7 +53,7 @@ impl List {
     #[instrument(name = "list", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
         sentry_set_tag("list_mode", format!("{:?}", &self.list_mode));
-        subcommand_metric!("list");
+        environment_subcommand_metric!("list", self.environment);
 
         let mut env = self
             .environment

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -21,8 +21,8 @@ use url::Url;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::ensure_floxhub_token;
 use crate::config::{Config, PublishConfig};
-use crate::subcommand_metric;
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Clone)]
 pub struct Publish {
@@ -68,6 +68,7 @@ impl Publish {
             bail!("'publish' feature is not enabled.");
         }
 
+        environment_subcommand_metric!("publish", self.environment);
         let PublishTarget { target } = self.publish_target;
         let env = self
             .environment
@@ -85,8 +86,6 @@ impl Publish {
         no_store: bool,
         cache_args: Option<CacheArgs>,
     ) -> Result<()> {
-        subcommand_metric!("publish");
-
         if !check_target_exists(&env.lockfile(&flox)?, &package)? {
             bail!("Package '{}' not found in environment", package);
         }

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 
 use crate::commands::services::{guard_service_commands_available, ServicesEnvironment};
 use crate::commands::{environment_select, EnvironmentSelect};
-use crate::subcommand_metric;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Logs {
@@ -34,7 +34,7 @@ pub struct Logs {
 impl Logs {
     #[instrument(name = "logs", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        subcommand_metric!("services::logs");
+        environment_subcommand_metric!("services::logs", self.environment);
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         guard_service_commands_available(&env, &flox.system)?;

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -22,8 +22,8 @@ use crate::commands::services::{
 };
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::config::Config;
-use crate::subcommand_metric;
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Restart {
@@ -38,7 +38,7 @@ pub struct Restart {
 impl Restart {
     #[instrument(name = "restart", skip_all)]
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
-        subcommand_metric!("services::restart");
+        environment_subcommand_metric!("services::restart", self.environment);
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         guard_is_within_activation(&env, "restart")?;

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -21,8 +21,8 @@ use crate::commands::services::{
 };
 use crate::commands::{environment_select, EnvironmentSelect};
 use crate::config::Config;
-use crate::subcommand_metric;
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Start {
@@ -37,7 +37,7 @@ pub struct Start {
 impl Start {
     #[instrument(name = "start", skip_all)]
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
-        subcommand_metric!("services::start");
+        environment_subcommand_metric!("services::start", self.environment);
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         guard_is_within_activation(&env, "start")?;

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -11,7 +11,7 @@ use tracing::instrument;
 
 use crate::commands::services::{guard_service_commands_available, ServicesEnvironment};
 use crate::commands::{environment_select, EnvironmentSelect};
-use crate::subcommand_metric;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Status {
@@ -30,7 +30,7 @@ pub struct Status {
 impl Status {
     #[instrument(name = "status", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        subcommand_metric!("services::status");
+        environment_subcommand_metric!("services::status", self.environment);
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         guard_service_commands_available(&env, &flox.system)?;

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -6,8 +6,8 @@ use tracing::instrument;
 
 use crate::commands::services::{guard_service_commands_available, ServicesEnvironment};
 use crate::commands::{environment_select, EnvironmentSelect};
-use crate::subcommand_metric;
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Stop {
@@ -22,7 +22,7 @@ pub struct Stop {
 impl Stop {
     #[instrument(name = "stop", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        subcommand_metric!("services::stop");
+        environment_subcommand_metric!("services::stop", self.environment);
 
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         guard_service_commands_available(&env, &flox.system)?;

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -10,9 +10,9 @@ use tracing::{info_span, instrument};
 use super::services::warn_manifest_changes_for_services;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{ensure_floxhub_token, environment_description, EnvironmentSelectError};
-use crate::subcommand_metric;
 use crate::utils::message;
 use crate::utils::tracing::sentry_set_tag;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Uninstall installed packages from an environment
 #[derive(Bpaf, Clone)]
@@ -28,7 +28,7 @@ pub struct Uninstall {
 impl Uninstall {
     #[instrument(name = "uninstall", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
-        subcommand_metric!("uninstall");
+        environment_subcommand_metric!("uninstall", self.environment);
         sentry_set_tag("packages", self.packages.iter().join(","));
 
         debug!(

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -9,8 +9,8 @@ use tracing::{info_span, instrument};
 use super::services::warn_manifest_changes_for_services;
 use super::{environment_select, EnvironmentSelect};
 use crate::commands::{ensure_floxhub_token, environment_description};
-use crate::subcommand_metric;
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Upgrade packages in an environment
 #[derive(Bpaf, Clone)]
@@ -29,7 +29,7 @@ pub struct Upgrade {
 impl Upgrade {
     #[instrument(name = "upgrade", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
-        subcommand_metric!("upgrade");
+        environment_subcommand_metric!("upgrade", self.environment);
         tracing::debug!(
             to_upgrade = self.groups_or_iids.join(","),
             "upgrading groups and install ids"

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -44,6 +44,23 @@ macro_rules! subcommand_metric {
     }};
 }
 
+/// Creates a trace event for the given environment subcommand.
+///
+/// Do NOT inline functions as fields values because any child tracing events
+/// will cause this event to be logged at TRACE level for reasons unknown.
+///
+/// We set the target to `flox_command` so that we can filter for these exact events.
+#[macro_export]
+macro_rules! environment_subcommand_metric {
+    ($subcommand:tt, $environment_select:expr $(, $key:tt = $value:expr)*) => {{
+        if let EnvironmentSelect::Remote(environment_ref) = &$environment_select {
+            subcommand_metric!($subcommand, remote_environment = environment_ref.to_string() $(, $key = $value)*);
+        } else {
+            subcommand_metric!($subcommand $(, $key = $value)*);
+        }
+    }};
+}
+
 /// Extracts [MetricEvent] data from a raw [tracing] event
 struct MetricVisitor<'a>(&'a mut Option<String>, &'a mut HashMap<String, String>);
 


### PR DESCRIPTION
[feat: add remote environment used to metrics](https://github.com/flox/flox/commit/5964cc896a721700984ab4c78c7ea33a68b328ab)

Add an environment_subcommand_metric!() macro that adds
`remote_environment = owner/name` to metrics.

Use it for all environment commands.

[feat: add --start-services metric](https://github.com/flox/flox/commit/65aac3048842317fe2b9e4c9976e817b55c00640)

Add a start_services = true/false metric for all activation commands

## Release Notes

NA