### PR TITLE
perf(managed): avoid full checkout to validate local environment

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1221,7 +1221,7 @@ impl UninitializedEnvironment {
             ConcreteEnvironment::Managed(managed_env) => {
                 let pointer = managed_env.pointer().clone().into();
                 Ok(Self::DotFlox(DotFlox {
-                    path: managed_env.path.to_path_buf(),
+                    path: managed_env.dot_flox_path().to_path_buf(),
                     pointer,
                 }))
             },

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -397,7 +397,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
         .to_string(),
 
         ManagedEnvironmentError::ReadLocalManifest(_) => display_chain(err),
-        ManagedEnvironmentError::ReadGenerationManifest(_) => display_chain(err),
+        ManagedEnvironmentError::Generations(_) => display_chain(err),
 
         ManagedEnvironmentError::BadBranchName(_) => display_chain(err),
 


### PR DESCRIPTION
## Context 

We are running git commands to clone from a local bare repo
to a tempdir to materialize the environment files through
`Generations::<ReadWrite>::get_current_generation()` / `Generations::<Read>::writable`.
The `ReadWrite` typestate is a bit of a misnomer as it allows writiting
but is currently also required for readonly operations
where the physical files are required
(i.e. to provide a `CoreEnvironment` to build, link, etc)
-- this has been acknowledeg in comments.
What seems to trigger that materialization in activate
(despite activate generally not building, linking, etc),
are various other calls that internally call
`ManagedEnvironment::ensure_locked`[1]
   -> `ManifestEnvironment::validate_checkout(_, self.get_current_generation)`[2].

-----

What I'm wondering about is the performance disparity
that we have even between the two/three of us.
A clone of the default branch in `~/.local/share/flox/meta/stahnma/`
takes   77.4 ms ±   3.7 ms for me (see below)
but apparently took 0.8 seconds for @stahnma  according to his logs.

```
 nix run nixpkgs#hyperfine -- -C 'rm -rf ./default' 'git clone --branch default --single-branch  /Users/yannik/.local/share/flox/meta/stahnma/ ./default'
Benchmark 1: git clone --branch default --single-branch  /Users/yannik/.local/share/flox/meta/stahnma/ ./default
  Time (mean ± σ):      72.3 ms ±   2.5 ms    [User: 14.6 ms, System: 55.2 ms]
  Range (min … max):    69.8 ms …  78.8 ms    27 runs
```

Apparently size _does_ matter here,as doing the same for the vhs branch
is about 50% quicker
and fs recency/caching seems to be in play here as well:

```
Benchmark 1: git clone --branch vhs --single-branch  /Users/yannik/.local/share/flox/meta/stahnma/ ./vhs
  Time (mean ± σ):      36.4 ms ±   7.7 ms    [User: 7.3 ms, System: 25.8 ms]
  Range (min … max):    31.9 ms …  65.0 ms    37 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (59.5 ms).
```

FWIW, i checked whether `--depth 1` or some other git clone flags
make a meaningful difference, and so far i dont see any.


[1] https://github.com/flox/flox/blob/7b31629f4cc1b5f616db76c2b47efeb5745278dd/cli/flox-rust-sdk/src/models/environment/managed_environment.rs#L503-L516

[2] https://github.com/flox/flox/blob/7b31629f4cc1b5f616db76c2b47efeb5745278dd/cli/flox-rust-sdk/src/models/environment/managed_environment.rs#L1013-L1043


## Proposed Changes

What to do about it if we decide to do so:

We could call `ensure_locked()`  once
at creation of the `ManagedEnvironment` and cache the result,
so we dont need to recompute for every subcommand
although then we need make sure to recompute it for all locking methods.
Similarly we could store the current generation somewhere
and would respectively be obligated to keep that in sync with reality.
I dont really like creating separate sources of thruths...

beside that, instead of cloning a branch,
we could read out individual files from the generation,
which means `validate_checkout` would take a `&Generation:<Read>`
and call `read_current_{manifest,lockfle}`
instead of taking a `&CoreEnvironment`.
In that case we trade a `git show` + `git clone` for `git show` x 3+.
Turns out that `git show` is substantially faster,z
so this is what is implemented here.

## Release Notes

Significant speedup of activations of managed environments.