### PR TITLE
test: skip compatability check for relase commits

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4199,7 +4199,16 @@ Setting PATH from ${rc_file}"
   mkfifo "$TEARDOWN_FIFO"
 
   # Pre-fetch without a timeout.
-  nix build "github:flox/flox/v${FLOX_LATEST_VERSION}"
+  # Skip the test if we're running a release
+  if ! OUTPUT=$(nix build "github:flox/flox/v${FLOX_LATEST_VERSION}" 2>&1); then
+    if [[ "$OUTPUT" == *"No commit found for SHA: v${FLOX_LATEST_VERSION}"* ]]; then
+      skip "skipping compatibility check for what is likely a release commit"
+    else
+      echo "$OUTPUT"
+      exit 1
+    fi
+  fi
+
 
   # Start an activation with the previously released version.
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO


### PR DESCRIPTION
We recently added a test to check activation compatability with the previous release. As the test depends on the latest flox version having been released on GitHub, the test fails when run on a commit that bumps flox version but has not yet actually been released.

We could alternatively make sure to tag the release commit and then re-run CI, but that seems like it would introduce unnecessary friction into the release process.

## Release Notes

NA