### PR TITLE
feat: improved install messages

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "dirs",
  "enum_dispatch",
  "flox-rust-sdk",
+ "flox-test-utils",
  "fslock",
  "futures",
  "indent",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,6 +31,7 @@ enum_dispatch = "0.3.13"
 flox-activations = { path = "flox-activations" }
 flox-core = { path = "flox-core" }
 flox-rust-sdk = { path = "flox-rust-sdk" }
+flox-test-utils = { path = "flox-test-utils" }
 fslock = "0.2.1"
 fs_extra = "1.3.0"
 futures = "0.3"

--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -426,6 +426,14 @@ impl PackageToInstall {
             _ => Ok(PackageToInstall::Catalog(s.parse()?)),
         }
     }
+
+    pub fn systems(&self) -> Option<Vec<String>> {
+        match self {
+            PackageToInstall::Catalog(pkg) => pkg.systems.clone(),
+            PackageToInstall::Flake(_) => None,
+            PackageToInstall::StorePath(pkg) => Some(vec![pkg.system.clone()]),
+        }
+    }
 }
 
 /// Tries to infer an install id from the flake ref URL, or falls back to "flake".

--- a/cli/flox-test-utils/src/lib.rs
+++ b/cli/flox-test-utils/src/lib.rs
@@ -14,6 +14,8 @@ use nix::unistd::Pid;
 // use rexpect::session::{spawn_specific_bash, PtyReplSession};
 use tempfile::TempDir;
 
+pub mod manifests;
+
 type Error = anyhow::Error;
 
 // Modifications to `rexpect`:

--- a/cli/flox-test-utils/src/manifests.rs
+++ b/cli/flox-test-utils/src/manifests.rs
@@ -1,0 +1,8 @@
+//! Example manifests
+
+pub const EMPTY_ALL_SYSTEMS: &str = r#"
+    version = 1
+
+    [options]
+    systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]
+"#;

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -63,6 +63,7 @@ temp-env.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 flox-rust-sdk = { workspace = true, features = ["tests"] }
+flox-test-utils.workspace = true
 
 
 [features]

--- a/cli/tests/lang-python.bats
+++ b/cli/tests/lang-python.bats
@@ -59,8 +59,7 @@ teardown() {
       run "$FLOX_BIN" install -i pip python310Packages.pip python3
 
   assert_success
-  assert_output --partial "✅ 'pip' installed to environment"
-  assert_output --partial "✅ 'python3' installed to environment"
+  assert_output --partial "✅ 'python3', 'pip' installed to environment"
 
   "$FLOX_BIN" activate -- bash "$INPUT_DATA/init/python/requests-with-pip.sh"
 }

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -91,6 +91,14 @@ ignore_cmd_errors = true # build will fail on macos, that's fine
 pre_cmd = "flox init"
 cmd = "flox install influxdb2"
 
+# This is used to trigger the "only install for some systems" code path
+[resolve.darwin_ps_all]
+pre_cmd = '''
+    flox init
+'''
+cmd = "flox install darwin.ps"
+ignore_cmd_errors = true # build will fail on linux, that's fine
+
 [resolve.darwin_ps]
 pre_cmd = '''
     flox init

--- a/test_data/generated/resolve/darwin_ps_all.json
+++ b/test_data/generated/resolve/darwin_ps_all.json
@@ -1,0 +1,120 @@
+[
+  [
+    {
+      "msgs": [
+        {
+          "AttrPathNotFoundNotFoundForAllSystems": {
+            "attr_path": "darwin.ps",
+            "install_id": "ps",
+            "level": "error",
+            "msg": "The attr_path darwin.ps is not found for all the requested systems, suggest limiting systems to (aarch64-darwin,x86_64-darwin).",
+            "valid_systems": [
+              "aarch64-darwin",
+              "x86_64-darwin"
+            ]
+          }
+        }
+      ],
+      "name": "toplevel",
+      "page": null
+    }
+  ],
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "darwin.ps",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/jmvl0q00vdqm22910djbl0l4pphv1bd5-adv_cmds-231.drv",
+            "description": "Advanced commands package for Darwin",
+            "insecure": false,
+            "install_id": "ps",
+            "license": "[ APSL-1.0, APSL-2.0 ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=799ba5bffed04ced7067a91798353d360788b30d",
+            "name": "adv_cmds-231",
+            "outputs": [
+              {
+                "name": "ps",
+                "store_path": "/nix/store/1h357r2s3xgl9pi29pjbdw4h333v4z38-adv_cmds-231-ps"
+              },
+              {
+                "name": "man",
+                "store_path": "/nix/store/8wmmlj8gdcvfmayrrhr9r844qvcrlaqj-adv_cmds-231-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/gwr4kii7wvds0f76hp10s4q1gypd5awb-adv_cmds-231"
+              }
+            ],
+            "outputs_to_install": [
+              "man",
+              "out"
+            ],
+            "pkg_path": "darwin.ps",
+            "pname": "ps",
+            "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+            "rev_count": 747653,
+            "rev_date": "2025-02-04T14:46:40Z",
+            "scrape_date": "2025-02-05T00:30:07Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "adv_cmds-231"
+          },
+          {
+            "attr_path": "darwin.ps",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/dbs8ibnaq3x26av6ay00pwq1nymyriaq-adv_cmds-231.drv",
+            "description": "Advanced commands package for Darwin",
+            "insecure": false,
+            "install_id": "ps",
+            "license": "[ APSL-1.0, APSL-2.0 ]",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=799ba5bffed04ced7067a91798353d360788b30d",
+            "name": "adv_cmds-231",
+            "outputs": [
+              {
+                "name": "ps",
+                "store_path": "/nix/store/x0nz7rkn54sgs992jb8z36vfd4g8m943-adv_cmds-231-ps"
+              },
+              {
+                "name": "man",
+                "store_path": "/nix/store/bk1qm5q8fcc4wg86qd9g3zp09qr69vsw-adv_cmds-231-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/jsrx6jhbf5dc7s53ylngbji04idnpbrz-adv_cmds-231"
+              }
+            ],
+            "outputs_to_install": [
+              "man",
+              "out"
+            ],
+            "pkg_path": "darwin.ps",
+            "pname": "ps",
+            "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+            "rev_count": 747653,
+            "rev_date": "2025-02-04T14:46:40Z",
+            "scrape_date": "2025-02-05T00:30:07Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "adv_cmds-231"
+          }
+        ],
+        "page": 747653,
+        "url": ""
+      }
+    }
+  ]
+]


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

This change generally makes the `flox install` output clearer and more friendly.
- All packages that were successfully installed for all requested systems are condensed onto a single line.
- All packages that were requested but already installed are condensed onto a single line.
- Packages that were only installed for _some_ of the requested systems are reported with a warning. Previously they were reported with a warning and then a subsequent line indicating that the package was installed successfully.

The output now looks like this:
```
✅ 'curl', 'jujutsu', 'fd' installed to environment 'flox-jj'
⚠  'bpftrace' installed only for the following systems: aarch64-linux, x86_64-linux
⚠  Packages with ids 'hello', 'bat' already installed to environment 'flox-jj'
```

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
The output of `flox install` is now clearer.

<!-- Many thanks! -->
