### PR TITLE
test: ensure activation doesn't create writable generations

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -18,8 +18,8 @@
 //! ```
 
 use std::collections::BTreeMap;
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::{env, fs};
 
 use chrono::{DateTime, Utc};
 use flox_core::Version;
@@ -212,6 +212,10 @@ impl Generations<ReadOnly> {
         &mut self,
         tempdir: impl AsRef<Path>,
     ) -> Result<Generations<ReadWrite<'_>>, GenerationsError> {
+        if env::var("_FLOX_TESTING_NO_WRITABLE").is_ok() {
+            panic!("Can't create writable generations when _FLOX_TESTING_NO_WRITABLE is set");
+        }
+
         let repo = checkout_to_tempdir(
             &self.repo,
             &self.branch,

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -73,7 +73,7 @@ pub struct RemoteEnvironment {
 
 impl RemoteEnvironment {
     /// Pull a remote environment into a provided (temporary) managed environment.
-    /// Constructiing a [RemoteEnvironment] _does not_ create a gc-root
+    /// Constructing a [RemoteEnvironment] _does not_ create a gc-root
     /// or guarantee that the environment is valid.
     #[instrument(skip_all, fields(progress = "Pulling remote environment"))]
     pub fn new_in(

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -525,3 +525,20 @@ EOF
   assert_success
   refute_output --partial "sourcing hook.on-activate"
 }
+
+# bats test_tags=activate,activate:attach
+@test "activating a managed environment doesn't create a writable instance" {
+  project_setup
+  export OWNER="owner"
+  floxhub_setup "$OWNER"
+
+  "$FLOX_BIN" init
+  MANIFEST_CONTENTS="$(cat << "EOF"
+    version = 1
+EOF
+  )"
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
+  "$FLOX_BIN" push --owner "$OWNER"
+
+  _FLOX_TESTING_NO_WRITABLE=true "$FLOX_BIN" activate -- true
+}

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -354,3 +354,21 @@ EOF
   assert_success
   refute_output --partial "sourcing hook.on-activate"
 }
+
+# bats test_tags=activate,activate:attach
+@test "activating a remote environment doesn't create a writable instance" {
+  project_setup
+  export OWNER="owner"
+  floxhub_setup "$OWNER"
+
+  "$FLOX_BIN" init
+  MANIFEST_CONTENTS="$(cat << "EOF"
+    version = 1
+EOF
+  )"
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
+  "$FLOX_BIN" push --owner "$OWNER"
+
+  ensure_remote_environment_built "$OWNER/test"
+  _FLOX_TESTING_NO_WRITABLE=true "$FLOX_BIN" activate --trust -r "$OWNER/test" -- true
+}


### PR DESCRIPTION
Creating writable generations is slow, so we want to avoid it during activation. It's not obvious exactly what actions will lead to creating writable generations - previously validating a local checkout was doing so. Add a regression test to ensure we don't make similar mistakes in the future.

## Release Notes

NA