### PR TITLE
feat: publish from a clean build

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -555,10 +555,18 @@ pub mod test_helpers {
         flox: &Flox,
         env_files_dir: impl AsRef<Path>,
     ) -> PathEnvironment {
+        let dot_flox_parent_path = tempdir_in(&flox.temp_dir).unwrap().into_path();
+        new_path_environment_from_env_files_in(flox, env_files_dir, dot_flox_parent_path)
+    }
+
+    pub fn new_path_environment_from_env_files_in(
+        flox: &Flox,
+        env_files_dir: impl AsRef<Path>,
+        dot_flox_parent_path: impl AsRef<Path>,
+    ) -> PathEnvironment {
         let env_files_dir = env_files_dir.as_ref();
         let manifest_contents = fs::read_to_string(env_files_dir.join(MANIFEST_FILENAME)).unwrap();
         let lockfile_contents = fs::read_to_string(env_files_dir.join(LOCKFILE_FILENAME)).unwrap();
-        let dot_flox_parent_path = tempdir_in(&flox.temp_dir).unwrap().into_path();
         let pointer = PathPointer::new("name".parse().unwrap());
         PathEnvironment::write_new_unchecked(
             flox,
@@ -567,7 +575,8 @@ pub mod test_helpers {
             &manifest_contents,
         )
         .unwrap();
-        let dot_flox_path = CanonicalPath::new(dot_flox_parent_path.join(DOT_FLOX)).unwrap();
+        let dot_flox_path =
+            CanonicalPath::new(dot_flox_parent_path.as_ref().join(DOT_FLOX)).unwrap();
         let env_dir = dot_flox_path.join(ENV_DIR_NAME);
         let lockfile_path = env_dir.join(LOCKFILE_FILENAME);
         fs::write(lockfile_path, lockfile_contents).unwrap();

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -95,9 +95,13 @@ pub struct BuildResults(Vec<BuildResult>);
 
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct BuildResult {
+    #[serde(rename = "drvPath")]
+    pub drv_path: String,
+    pub name: String,
     pub pname: String,
     pub outputs: HashMap<String, BuiltStorePath>,
     pub version: String,
+    pub system: Option<String>,
     pub log: BuiltStorePath,
 }
 
@@ -239,6 +243,7 @@ impl ManifestBuilder for FloxBuildMk {
                     },
                 };
 
+                println!("build results: {build_results}");
                 match serde_json::from_str(&build_results) {
                     Ok(build_results) => build_results,
                     Err(e) => {

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -243,7 +243,6 @@ impl ManifestBuilder for FloxBuildMk {
                     },
                 };
 
-                println!("build results: {build_results}");
                 match serde_json::from_str(&build_results) {
                     Ok(build_results) => build_results,
                     Err(e) => {

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -404,9 +404,6 @@ fn gather_base_repo_meta(
     let lockfile = Lockfile::read_from_file(&lockfile_path.unwrap())
         .map_err(|e| PublishError::UnsupportedEnvironmentState(e.to_string()))?;
 
-    // let lockfile = environment
-    //     .lockfile(flox)
-    //     .map_err(|e| PublishError::UnsupportedEnvironmentState(e.to_string()))?;
     let install_ids_in_toplevel_group = lockfile
         .manifest
         .pkg_descriptors_in_toplevel_group()
@@ -590,10 +587,7 @@ pub mod tests {
 
         let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME);
         match meta {
-            Err(PublishError::UnsupportedEnvironmentState(msg)) => {
-                println!("{}", msg);
-                ()
-            },
+            Err(PublishError::UnsupportedEnvironmentState(_msg)) => {},
             _ => panic!("Expected error to be of type UnsupportedEnvironmentState"),
         }
     }
@@ -614,10 +608,7 @@ pub mod tests {
 
         let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME);
         match meta {
-            Err(PublishError::UnsupportedEnvironmentState(msg)) => {
-                println!("{}", msg);
-                ()
-            },
+            Err(PublishError::UnsupportedEnvironmentState(_msg)) => {},
             _ => panic!("Expected error to be of type UnsupportedEnvironmentState"),
         }
     }
@@ -629,6 +620,7 @@ pub mod tests {
         let (env, build_repo) = example_path_environment(&flox, Some(&remote_uri));
 
         let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME).unwrap();
+        let description_in_manifest = "Some sample package description from our tests";
 
         let build_repo_meta = meta.build_repo_ref;
         assert!(build_repo_meta.url.contains(&remote_uri));
@@ -649,10 +641,7 @@ pub mod tests {
         );
         assert_eq!(meta.base_catalog_ref.rev_date, locked_base_pkg.rev_date);
         assert_eq!(meta.package, EXAMPLE_PACKAGE_NAME);
-        assert_eq!(
-            meta.description,
-            Some("Some sample package description from our tests".to_string())
-        );
+        assert_eq!(meta.description, Some(description_in_manifest.to_string()));
     }
 
     #[test]
@@ -669,11 +658,13 @@ pub mod tests {
         let meta = check_build_metadata(&flox, &env_metadata, &env, &builder, EXAMPLE_PACKAGE_NAME)
             .unwrap();
 
+        let version_in_manifest = "1.0.2a";
+
         assert_eq!(meta.outputs.len(), 1);
         assert_eq!(meta.outputs_to_install.len(), 1);
         assert_eq!(meta.outputs[0].store_path.starts_with("/nix/store/"), true);
         assert_eq!(meta.drv_path.starts_with("/nix/store/"), true);
-        assert_eq!(meta.version, Some("1.0.2a".to_string()));
+        assert_eq!(meta.version, Some(version_in_manifest.to_string()));
         assert_eq!(meta.pname, EXAMPLE_PACKAGE_NAME.to_string());
         assert_eq!(meta.system.to_string(), flox.system);
     }

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -347,11 +347,11 @@ pub fn check_build_metadata(
     }
 
     let build_results = output_build_results.ok_or(PublishError::NonexistentOutputs(
-        "No build results".to_string(),
+        "No results returned from build command.".to_string(),
     ))?;
     if build_results.len() != 1 {
         return Err(PublishError::NonexistentOutputs(
-            "No build results".to_string(),
+            "No results returned from build command.".to_string(),
         ));
     }
     let build_result = &build_results[0];
@@ -369,17 +369,19 @@ fn gather_build_repo_meta(git: &impl GitProvider) -> Result<LockedUrlInfo, Publi
     // Gather build repo info
 
     // This call will fail if the local head is not in the remote
-    let origin = git
-        .get_origin()
-        .map_err(|e| PublishError::UnsupportedEnvironmentState(format!("Git get origin {e}")))?;
+    let origin = git.get_origin().map_err(|_e| {
+        PublishError::UnsupportedEnvironmentState(
+            "Unable to identify repository origin info, are all commits pushed?".to_string(),
+        )
+    })?;
 
-    let status = git
-        .status()
-        .map_err(|e| PublishError::UnsupportedEnvironmentState(format!("Git get status {e}")))?;
+    let status = git.status().map_err(|_e| {
+        PublishError::UnsupportedEnvironmentState("Unable to get respository status.".to_string())
+    })?;
 
     if status.is_dirty {
         return Err(PublishError::UnsupportedEnvironmentState(
-            "Build repo is dirty".to_string(),
+            "Build repository must be clean, but has dirty tracked files.".to_string(),
         ));
     }
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -310,7 +310,15 @@ pub fn check_build_metadata(
             .path()
             .join(env_metadata.rel_dotflox_path.as_path()),
     )
-    .map_err(|err| EnvironmentError::DotFloxNotFound(err.path))?;
+    .map_err(|err| {
+        PublishError::UnsupportedEnvironmentState(
+            format!(
+                ".flox folder not found at {:?}, is it tracked in the repository?",
+                err.path
+            )
+            .to_string(),
+        )
+    })?;
     let mut clean_build_env =
         PathEnvironment::open(flox, PathPointer::new(env.name()), dot_flox_path)?;
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -4,9 +4,8 @@ use std::str::FromStr;
 
 use catalog_api_v1::types::{Output, Outputs, SystemEnum};
 use chrono::{DateTime, Utc};
-use log::info;
 use thiserror::Error;
-use tracing::instrument;
+use tracing::{info, instrument};
 use url::Url;
 
 use super::build::{BuildResult, BuildResults, ManifestBuilder};

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -310,13 +310,10 @@ pub fn check_build_metadata(
             .path()
             .join(env_metadata.rel_dotflox_path.as_path()),
     )
-    .map_err(|err| {
+    .map_err(|_err| {
         PublishError::UnsupportedEnvironmentState(
-            format!(
-                ".flox folder not found at {:?}, is it tracked in the repository?",
-                err.path
-            )
-            .to_string(),
+            ".flox folder not found in clean checkout, is it tracked in the repository?"
+                .to_string(),
         )
     })?;
     let mut clean_build_env =
@@ -333,6 +330,7 @@ pub fn check_build_metadata(
                 .unwrap()
                 .development,
             &[pkg.to_owned()],
+            Some(false),
         )
         .map_err(|e| PublishError::BuildError(e.to_string()))?;
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -83,7 +83,7 @@ pub struct CheckedEnvironmentMetadata {
 
     // These are collected from the environment manifest
     pub package: String,
-    pub description: Option<String>,
+    pub description: String,
 
     // This field isn't "pub", so no one outside this module can construct this struct. That helps
     // ensure that we can only make this struct as a result of doing the "right thing."
@@ -215,7 +215,7 @@ where
         let build_info = UserBuildInfo {
             derivation: UserDerivationInfo {
                 broken: Some(false),
-                description: "".to_string(),
+                description: self.env_metadata.description.clone(),
                 drv_path: self.build_metadata.drv_path.clone(),
                 license: None,
                 name: self.build_metadata.name.clone(),
@@ -474,7 +474,7 @@ pub fn check_environment_metadata(
         package: pkg.to_string(),
         repo_root_path: git.path().to_path_buf(),
         rel_dotflox_path: rel_dotflox_path.to_path_buf(),
-        description,
+        description: description.unwrap_or_else(|| "Not Provided".to_string()),
         _private: (),
     })
 }
@@ -639,7 +639,7 @@ pub mod tests {
         );
         assert_eq!(meta.base_catalog_ref.rev_date, locked_base_pkg.rev_date);
         assert_eq!(meta.package, EXAMPLE_PACKAGE_NAME);
-        assert_eq!(meta.description, Some(description_in_manifest.to_string()));
+        assert_eq!(meta.description, description_in_manifest.to_string());
     }
 
     #[test]

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -118,6 +118,7 @@ impl Build {
             &built_environments,
             &FLOX_INTERPRETER,
             &packages_to_build,
+            None,
         )?;
 
         for message in output {

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -331,8 +331,8 @@ define BUILD_nix_sandbox_template =
 	  $(if $(_do_buildCache),--argstr buildCache "$($(_pvarname)_buildCache)") \
 	  --out-link "result-$(_pname)" \
 	  --json '^*' | \
-	$(_jq) --arg pname "$(_pname)" --arg version "$(_version)" \
-	  '.[0] * {pname:$$$$pname, version:$$$$version, log:.[0].outputs.log}' > $($(_pvarname)_buildMetaJSON)
+	$(_jq) --arg pname "$(_pname)" --arg version "$(_version)" --arg name "$(_name)" \
+	  '.[0] * {name:$$$$name, pname:$$$$pname, version:$$$$version, log:.[0].outputs.log}' > $($(_pvarname)_buildMetaJSON)
 	@echo "Completed build of $(_name) in Nix sandbox mode" && echo ""
 	@# Check to see if a new buildCache has been created, and if so then go
 	@# ahead and run 'nix store delete' on the previous cache, keeping in

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -261,9 +261,9 @@ define BUILD_local_template =
 	  --argstr nixpkgs-url "$(BUILDTIME_NIXPKGS_URL)" \
 	  --out-link "result-$(_pname)" \
 	  --json '^*' | \
-	$(_jq) --arg pname "$(_pname)" --arg version "$(_version)" \
+	$(_jq) --arg pname "$(_pname)" --arg version "$(_version)" --arg name "$(_name)" \
 	  --arg log "$(shell $(_readlink) result-$(_pname)-log)" \
-	  '.[0] * {pname:$$$$pname, version:$$$$version, log:$$$$log}' > $($(_pvarname)_buildMetaJSON)
+	  '.[0] * {name:$$$$name, pname:$$$$pname, version:$$$$version, log:$$$$log}' > $($(_pvarname)_buildMetaJSON)
 	@echo "Completed build of $(_name) in local mode" && echo ""
 
 endef

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -270,10 +270,9 @@ endef
 
 # The following template renders targets for the sandbox build mode.
 define BUILD_nix_sandbox_template =
-  # We anticipate that we may eventually want to specify the caching mode
-  # on a per-build basis within the manifest, but in the meantime we configure
-  # the use of a build cache for all pure builds.
-  $(eval _do_buildCache = true)
+  # If set, the DISABLE_BUILDCACHE variable will cause the build to omit the
+  # build cache.  This is used for (at least) publish.
+  $(eval _do_buildCache = $(if $(DISABLE_BUILDCACHE),,true))
 
   # The sourceTarball value needs to be stable when nothing changes across builds,
   # so we create a tarball at a stable TMPDIR path and pass that to the derivation

--- a/test_data/generated/envs/publish-simple/manifest.toml
+++ b/test_data/generated/envs/publish-simple/manifest.toml
@@ -4,6 +4,8 @@ version = 1
 hello.pkg-path = "hello"
 
 [build]
+mypkg.description = "Some sample package description from our tests"
+mypkg.version = "1.0.2a"
 mypkg.command = """
     mkdir $out
     echo -n "Happy Floxing!" > $out/mypkg

--- a/test_data/generated/envs/publish-simple/manifest.toml
+++ b/test_data/generated/envs/publish-simple/manifest.toml
@@ -7,7 +7,9 @@ hello.pkg-path = "hello"
 mypkg.description = "Some sample package description from our tests"
 mypkg.version = "1.0.2a"
 mypkg.command = """
-    mkdir $out
-    echo -n "Happy Floxing!" > $out/mypkg
+    mkdir -p $out/bin
+    echo -n "!#/bin/sh" > $out/bin/mypkg
+    echo -n "echo Happy Floxing!" > $out/bin/mypkg
+    chmod +x $out/bin/mypkg
 """
 


### PR DESCRIPTION
A publish operation will now create a clean clone of the rev to publish in a temp directory, invoke a clean build on that, and capture the BuildResults from that build to identify the version, pname, and outputs of the build.


## Release Notes

- Publish will now ensure a clean repo and build, and now supports version and description metadata from the manifest.