### PR TITLE
fix: don't prompt for default env in current dir

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1124,6 +1124,12 @@ pub fn detect_environment(
             Some(UninitializedEnvironment::DotFlox(detected))
         },
 
+        // If an environment is activated and a 'default' environment is present
+        // in the current directory or git repo, prefer the activated one.
+        (Some(activated), Some(detected)) if detected.pointer.name().as_ref() == DEFAULT_NAME => {
+            Some(activated.clone())
+        },
+
         // If we can't prompt, use the environment found in the current directory or git repo
         (Some(_), Some(found)) if !Dialog::can_prompt() => {
             debug!("No TTY detected, using the environment {found:?} found in the current directory or an ancestor directory");


### PR DESCRIPTION
When deciding which environment to perform an operation on, we already give precedence to the current directory over an activated default environment.

Add a similar exception to give precedence to an activated environment over a default environment in the current directory.

This avoids the annoyance of a prompt in the situation, where the user most likely wants to operate on the active environment
- Start shell in ~ (which contains an activated default environment)
- flox activate -r owner/name
- Run a flox environment command

Notably, this does not regress the behavior that flox environment commands default to an activated default environment when no other environment is active, which makes Flox feel more similar to a system package manager.

## Release Notes

For flox environment commands that detect what environment to operate on, give precedence to an activated environment over a default environment in the current directory, rather than prompting