### PR TITLE
Cleanup background activation

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2796,7 +2796,7 @@ attach_runs_hooks_once() {
 
   "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" 2> output &
 
-  wait_for_background_activation
+  cat activate_finished
   run cat output
   assert_output --partial "sourcing hook.on-activate for first time"
   assert_output --partial "hook.on-activate"
@@ -2857,7 +2857,7 @@ attach_runs_profile_twice() {
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
   FLOX_SHELL="$shell" "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > $TEARDOWN_FIFO" >> output 2>&1 &
 
-  wait_for_background_activation
+  cat activate_finished
   run cat output
   assert_output --partial "sourcing profile.common"
   assert_output --partial "sourcing profile.$shell"
@@ -2985,7 +2985,7 @@ EOF
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
   FLOX_SHELL="$shell" "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > $TEARDOWN_FIFO" >> output 2>&1 &
 
-  wait_for_background_activation
+  cat activate_finished
 
   case "$mode" in
     interactive)
@@ -3101,7 +3101,7 @@ attach_sets_profile_vars() {
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
   FLOX_SHELL="$shell" "$FLOX_BIN" activate -- bash -c "echo > activate_finished && echo > $TEARDOWN_FIFO" &
 
-  wait_for_background_activation
+  cat activate_finished
 
   case "$mode" in
     interactive)
@@ -3293,7 +3293,7 @@ EOF
       ;;
   esac
 
-  wait_for_background_activation
+  cat activate_finished
 
   run cat output
   assert_success
@@ -3577,7 +3577,7 @@ EOF
 
       # vim gets added to MANPATH
       _man=$_man "$FLOX_BIN" activate -d vim -- bash -c "$_man --path vim > output; echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
-      wait_for_background_activation
+      cat activate_finished
       run cat output
       assert_success
       assert_output "$VIM_MAN"
@@ -3602,7 +3602,7 @@ EOF
 
       # vim gets added to MANPATH
       "$FLOX_BIN" activate -d vim -- bash -c "/usr/bin/manpath > output && echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
-      wait_for_background_activation
+      cat activate_finished
       run cat output
       assert_success
       assert_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
@@ -3649,7 +3649,7 @@ EOF
   refute_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/bin/emacs"
 
   "$FLOX_BIN" activate -d vim -- bash -c "command -v vim > output; echo > activate_finished && echo > \"$TEARDOWN_FIFO\"" &
-  wait_for_background_activation
+  cat activate_finished
 
   run cat output
   assert_success

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -114,13 +114,24 @@ project_teardown() {
 
 # Wait for a backgrounded activation to start, signalled by a blocking writing
 # to a FIFO file.
+# $1: background_pid
+#       This PID must be in a new process group otherwise this will kill bats as
+#       well
+# $2: (optional) timeout
 wait_for_background_activation() {
+  background_pid="${1?}"
+  shift
   timeout="${1:-2s}"
   fifo_file="activate_finished"
   output_file="output"
 
   timeout "$timeout" cat "$fifo_file" || (
     echo "Background activation did not start within timeout: $timeout" >&2
+    # activate may be running a command like bash -c "cmd1 && cmd2"
+    # Bash won't kill its children when it receives SIGTERM,
+    # so we need to kill the whole process group.
+    background_group="$(ps -o pgid= -p "$background_pid")"
+    kill -SIGTERM -"$background_group"
     [ -f "$output_file" ] && cat "$output_file" >&2
     exit 1
   )
@@ -4212,12 +4223,13 @@ Setting PATH from ${rc_file}"
 
   # Start an activation with the previously released version.
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
-  nix run "github:flox/flox/v${FLOX_LATEST_VERSION}" -- \
-    activate -- \
+  # Use setsid so that wait_for_background_activation can kill the process group
+  setsid ./result/bin/flox activate -- \
     "$shell_path" -c "echo > activate_finished && echo > $TEARDOWN_FIFO" > output 2>&1 &
 
   # Longer timeout to allow for `nix run` locking.
-  wait_for_background_activation 15s
+  background_pid="$!"
+  wait_for_background_activation "$background_pid" 15s
   run cat output
   # This the only place we use `--partial` because we only want to know that the
   # intial activation started.

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -38,6 +38,7 @@
   procps,
   pstree,
   unixtools,
+  util-linux,
   which,
   writeShellScriptBin,
   process-compose,
@@ -88,6 +89,7 @@ let
       parallel
       pstree
       unixtools.util-linux
+      util-linux # for setsid
       which
       yq
       process-compose


### PR DESCRIPTION
[test: partially revert background timeouts](https://github.com/flox/flox/commit/90e301d25b13074dd1961ccf33b79220b3078f2f)

Revert the addition of timeouts to `cat activate_finished` in
https://github.com/flox/flox/commit/a412f54c05b29947883c90182271b7034205ddd3 and
https://github.com/flox/flox/commit/2864016e1eb9185ed4dc3ee26cfa653dad30c0f6

The timeout was added so that the output of the activate command will be
displayed upon timeout, rather than an indefinite hang.

This has caused tests to flake:
https://github.com/flox/flox/actions/runs/13181851477/job/36794503671?pr=2701

Although better debug output would be useful, we haven't to my knowledge
ever timed out CI due to `cat activate_finished` hanging indefinitely.

For most tests that use `cat activate_finished`, any breakage that would
cause an indefinite hang would require breaking `flox activate -- $cmd`,
which would cause many other failures as well, so there would be plenty
of output to understand the failure.

The one exception is `attach_previous_release`, which could be regressed
without a larger breakage.

Remove the timeout for all cases except for `attach_previous_release` to
cut down on flakey tests.


[test: cleanup background activations](https://github.com/flox/flox/commit/43c87709e41240a21945af4fcfa8e7a9a534e61c)

When a backgrounded activation reached timeout, we would fail the test
suite, but we wouldn't clean up the activation or watchdog left behind. This
could lead to build up of orphaned processes.

To reproduce this, I added `sleep 1s` before `echo > activate_finished`
and lowered the wait_for_background_activation timeout to .5s. Then
running:
flox-cli-tests activate.bats -- -f "interactive: bash attachs to an activation from the previous release"; pstree -ws bats

Would leave behind:
```
-+= 00001 root (launchd)
 |--= 54832 matthew /nix/store/xgiggnk7c2d1n0xy8x2cyvml42gjngc4-flox-watchdog-1.3.12/libexec/flox-watchdog --disable-metrics --log-dir /private/var/folders/2w/r9qm37r12qs4xn3sjn4cv2ym0000gn/T/nix-shell.27hGkZ/bats-run-pXupvJ/test/1/project-1/.flox/log --socket /tmp/flox.tests.9Mv4kw/tmp.3CsewV5DHc/run/flox.87161cb9.sock --flox-env /private/var/folders/2w/r9qm37r12qs4xn3sjn4cv2ym0000gn/T/nix-shell.27hGkZ/bats-run-pXupvJ/test/1/project-1/.flox/run/aarch64-darwin.project-1.dev --activation-id dd9d3c20 --runtime-dir /tmp/flox.tests.9Mv4kw/tmp.3CsewV5DHc/run
 \-+- 54777 matthew /nix/store/jin4ifpw4bvi554g02phy668gvaylqn1-bash-interactive-5.2p32/bin/bash --noprofile --norc -s
   \--- 54847 matthew /nix/store/jin4ifpw4bvi554g02phy668gvaylqn1-bash-interactive-5.2p32/bin/bash -c sleep 1s && echo > activate_finished && echo > /var/folders/2w/r9qm37r12qs4xn3sjn4cv2ym0000gn/T/nix-shell.27hGkZ/bats-run-pXupvJ/test/1/project-1/teardown_activate
```

To fix this, start the background activation in a new process group, and
kill the process group if the timeout is reached.

A new process group had to be used since Bash doesn't cleanup it's
children when it receives SIGTERM.

## Release Notes

NA
