### PR TITLE
perf: improve environment caching and build times

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1335,7 +1335,8 @@ mod buildenv_tests {
         let result = buildenv.build(&client, &lockfile_path, None);
         assert!(
             result.is_ok(),
-            "conflicting packages should be resolved by priority"
+            "conflicting packages should be resolved by priority: {}",
+            result.unwrap_err()
         );
     }
 

--- a/cli/flox-rust-sdk/src/providers/upgrade_checks.rs
+++ b/cli/flox-rust-sdk/src/providers/upgrade_checks.rs
@@ -90,7 +90,6 @@ impl UpgradeInformationGuard<Unlocked> {
 
         debug!(
             ?upgrade_information_path,
-            ?info,
             "created unlocked upgrade information guard"
         );
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3514,6 +3514,7 @@ EOF
   link_name="$NIX_SYSTEM.bad_interpreter.dev"
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install hello
   hello_path="$(realpath ".flox/run/$link_name/bin/hello")"
+  lockfile_path="$(realpath ".flox/run/$link_name/manifest.lock")"
 
   # Delete the symlink to the environment
   rm .flox/run/*
@@ -3523,6 +3524,7 @@ EOF
   mkdir ./fake_env/bin
   echo "exit 1" > ./fake_env/activate # this is our dummy interpreter
   chmod +x ./fake_env/activate
+  cp "$lockfile_path" ./fake_env/manifest.lock # this is so flox doesnt try to rebuild over the fake-env
   ln -s "$PWD/fake_env" ".flox/run/$link_name"
 
   # Attempt activation with the bundled interpreter


### PR DESCRIPTION
## [perf: use lockfile content as cache key for rebuilds](https://github.com/flox/flox/commit/cc0da1b9e7f3e9f4af3fb3cac03d19b5d584e4d8)

Managed environments check with timestamps whether the environment needs to be rebuilt.

More precisely, flox compares the mtime of `.flox/env/manifest.toml` against the mtime of `.flox/env/name.system.dev`.

If the manifest was modified more recently,
we perform a build and link of the environment,
now requiring (local) clones again, as well as at least nix evaluation,
and store queries.

To benchmark this case, we touch `.flox/env/*` essentially forcing a rebuild in every run:

```bash
hyperfine --warmup 1 \
	'touch .flox/env/* ; ./1.3.10/bin/flox activate --print-script' \
	'touch .flox/env/* ; ./1.3.11/bin/flox activate --print-script' \
	'touch .flox/env/* ; ./1.3.12/bin/flox activate --print-script' \
	'touch .flox/env/* ; main/bin/flox activate --print-script'
Benchmark 1: touch .flox/env/* ; ./1.3.10/bin/flox activate --print-script
 Time (mean ± σ):      3.824 s ±  0.266 s    [User: 1.674 s, System: 1.184 s]
 Range (min … max):    3.478 s …  4.301 s    10 runs

Benchmark 2: touch .flox/env/* ; ./1.3.11/bin/flox activate --print-script
  Time (mean ± σ):      4.393 s ±  0.204 s    [User: 1.779 s, System: 1.717 s]
  Range (min … max):    4.014 s …  4.653 s    10 runs

Benchmark 3: touch .flox/env/* ; ./1.3.12/bin/flox activate --print-script
  Time (mean ± σ):      6.419 s ±  2.102 s    [User: 2.087 s, System: 1.982 s]
  Range (min … max):    4.120 s … 10.546 s    10 runs

Benchmark 4: touch .flox/env/* ; main/bin/flox activate --print-script
  Time (mean ± σ):      4.525 s ±  2.148 s    [User: 2.020 s, System: 1.083 s]
  Range (min … max):    3.520 s … 10.626 s    10 runs
```

We can see that compared to “cached” activations,
we are about one order of magnitude slower here,
now reaching into “multiple seconds” territory,
with runs taking up to ~10.5 seconds.

This Commit attempts to address this by replacing the check of the `mtime`s
with a comparison of the lockfile in the environment
to the lockfile included in the built environment.
This was originally proposed by @mkenigs, but at the time we considered
`mtime` to be stable enough of a measure.
As a side effect `touch`ing manifest files also allowd rebuilding environments,
with new activation assets.
On the other hand, flox ow uses the "interpreters" bundled with the flox binary by default,
somewhat minimizing the need for this measure.
Additionally, this way of forcing rebuilds was never quite polished
or meant for non-internal use.



## [perf: optimistically check whether store paths exist in the filesystem](https://github.com/flox/flox/commit/437b517cbf5586a218365fd2e24b656f6a7bf552) 

<details>
<summary>Details</summary>

Digging deeper into where environment build times go shows
that a large fraction of the time is spent on realizing packages of the environment,
in particular checking and optionally substituting packages using `nix build --no-link <store path>`.

```bash
2025-02-07T13:25:08.124143Z DEBUG build{progress="Building environment"}:subsitute catalog package{progress="Downloading 'ack'"}: flox_rust_sdk::providers::buildenv: using 'auto' store
[...] 47 more substitutions of packages
2025-02-07T13:25:11.420666Z DEBUG build{progress="Building environment"}:subsitute catalog package{progress="Downloading 'zsh-completions'"}: flox_rust_sdk::providers::buildenv: checking store paths, including substituters cmd=/nix/store/hhandlwac85h67gpkb010p8nzix10ahk-nix-2.24.9/bin/nix --option extra-experimental-features 'nix-command flakes' --option pure-eval false --print-build-logs build --no-link /nix/store/h1m8wmx1nxg01zdi1sdrpgyhz5qs10xq-zsh-completions-0.35.0
2025-02-07T13:25:11.471314Z DEBUG build{progress="Building environment"}: flox_rust_sdk::providers::buildenv: using 'auto' store
2025-02-07T13:25:11.471332Z DEBUG build{progress="Building environment"}: flox_rust_sdk::providers::buildenv: building environment cmd=/nix/store/hhandlwac85h67gpkb010p8nzix10ahk-nix-2.24.9/bin/nix --option extra-experimental-features 'nix-command flakes' --option pure-eval false --print-build-logs build --no-link --offline --json --file /Volumes/Projects/Flox/flox/auchflox/build/flox-buildenv/lib/buildenv.nix --argstr manifestLock /private/tmp/nix-shell.EFeVD7/tmp.tvb3gYgZ89/.flox/env/manifest.lock
2025-02-07T13:25:11.593710Z DEBUG flox_rust_sdk::models::environment::core_environment: built environment outputs=BuildEnvOutputs { develop: BuiltStorePath("/nix/store/303jmh8mfj19pkgnfnc8zhaqd2zvqzz6-environment-develop"), runtime: BuiltStorePath("/nix/store/jq88nwcv0mf41fjgif9ipdliql1yr38m-environment-runtime"), manifest_build_runtimes: {} }
```

With warm caches `nix build <store path>` takes ~0.05s.
Which in the ideal case is $49*0.05s=2.45s$. Not exactly great.
Add to that that `nix build` or `nix path-info` *can* take 0.1s or more,
and multiple seconds become more .. likely.
This overhead is likely a result of communication with the nix daemon where sockets
and internal computation add a significant overhead after all.

What is notable is that the runtime of these commands is pretty much constant wrt number of path arguments,
passing 5 store path arguments takes about as long as passing one.
We currently make use of this on a per package basis,
i.e. we test all outputs of a package *at once* rather than sequentially,
but we still check packages sequentially effectively causing linear runtime.

We originally chose to use `nix {path-info,build}` over simple `stat` / `Path::exists` calls
because nix additionally verifies the integrity of the reference graph behind the store paths
and also allows using nix alternative stores (relevant for proposed testing purposes).
Yet, we are giving up significant runtime for this. E.g. where `nix` takes tens of milliseconds,
`stat` will usually perform about an order of magnitude faster.
Unlike the nix command, we need to stat files individually,
so potential packages with many many outputs might favor the nix method.
Such packages are rare at best.

Here we change the `check_store_path` methods to first check whether the store paths exist on the local filesystem.
Then, only if the store paths do not exist, the function will fall back to querying the nix store for the store paths.
</details>


[feat: pre-check all referenced store paths at once](https://github.com/flox/flox/pull/2705/commits/5fab1cf8fd36ac0a0a2982f77274eec4b07129c5)

The previous changes sped up flox builds immensely,
however they turned out not to be concurrency safe.
We saw two ci jobs fail deterministically with

```bash
#        error: path '/nix/store/5apah73slavjjl9nbj1hhf6ds42dck9x-emacs-29.4' does not exist and cannot be created
```

After some further diagnostics, it turns out that these issues arise when two tests need to substitute the same path. In this case the `emacs` package was locked by to concurrently running processes. One process correctly `stat`s the store path, finds it’s missing and decides to escalate this to a `nix build` which substitutes the package. However `nix` will create the file as substitution begins and *later* record the path as valid. When a parallel processes now successfully `stat`s the store path and attempts to build the environment, the build will fail as `builtins.storePath` requires the path to be valid in nix’ store database. Ergo, `stat` itself is an unreliable measure to determine the validity of a path, more than we were willing to accept.

As an alternative, we can attempt check all referenced store paths preemptively, before realizing packages individually. Luckily, `nix store-path` runs in relative constant time wrt the number of store paths being checked, presumably because its simply querying the nix database, where establishing the store connection contributes the largest overhead.

With that, the runtime of `flox activate` remains comparable to using `stat`:

```bash
hyperfine --warmup 1  'touch .flox/env/* ; ./1.3.10/bin/flox activate --print-script' 'touch .flox/env/* ; ./1.3.11/bin/flox activate --print-script' 'touch .flox/env/* ; ./1.3.12/bin/flox activate --print-script' 'touch .flox/env/* ; main/bin/flox activate --print-script' 'touch .flox/env/* ; /Volumes/Projects/Flox/flox/auchflox/cli/target/debug/flox activate --print-script'
Benchmark 1: touch .flox/env/* ; ./1.3.10/bin/flox activate --print-script
  Time (mean ± σ):      3.573 s ±  0.350 s    [User: 1.365 s, System: 1.049 s]
  Range (min … max):    3.169 s …  4.174 s    10 runs

Benchmark 2: touch .flox/env/* ; ./1.3.11/bin/flox activate --print-script
  Time (mean ± σ):      4.139 s ±  0.650 s    [User: 1.512 s, System: 1.468 s]
  Range (min … max):    3.424 s …  5.687 s    10 runs

Benchmark 3: touch .flox/env/* ; ./1.3.12/bin/flox activate --print-script
  Time (mean ± σ):      4.264 s ±  0.568 s    [User: 1.666 s, System: 1.541 s]
  Range (min … max):    3.621 s …  5.353 s    10 runs

Benchmark 4: touch .flox/env/* ; main/bin/flox activate --print-script
  Time (mean ± σ):      3.883 s ±  0.414 s    [User: 1.638 s, System: 0.953 s]
  Range (min … max):    3.305 s …  4.585 s    10 runs

Benchmark 5: touch .flox/env/* ; /Volumes/Projects/Flox/flox/auchflox/cli/target/debug/flox activate --print-script
  Time (mean ± σ):     215.1 ms ±   7.0 ms    [User: 127.2 ms, System: 75.4 ms]
  Range (min … max):   208.0 ms … 226.6 ms    13 runs

Summary
  touch .flox/env/* ; /Volumes/Projects/Flox/flox/auchflox/cli/target/debug/flox activate --print-script ran
   16.61 ± 1.71 times faster than touch .flox/env/* ; ./1.3.10/bin/flox activate --print-script
   18.05 ± 2.01 times faster than touch .flox/env/* ; main/bin/flox activate --print-script
   19.24 ± 3.08 times faster than touch .flox/env/* ; ./1.3.11/bin/flox activate --print-script
   19.82 ± 2.72 times faster than touch .flox/env/* ; ./1.3.12/bin/flox activate --print-script
```

* doc: document pre-check methods and highlight possible TOCTOU risks
regarding concurrent deletion of store paths e.g. through GC.
