### PR TITLE
feat(gc): Remove non-existent envs from registry

### DIFF
--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -208,7 +208,7 @@ pub fn env_registry_path(flox: &Flox) -> PathBuf {
 /// of the lock file does not indicate an active lock because the file isn't
 /// removed after use. This is a separate file because we replace the registry
 /// on write.
-pub(crate) fn env_registry_lock_path(reg_path: impl AsRef<Path>) -> PathBuf {
+fn env_registry_lock_path(reg_path: impl AsRef<Path>) -> PathBuf {
     reg_path.as_ref().with_extension("lock")
 }
 
@@ -236,7 +236,7 @@ pub fn read_environment_registry(
 /// atomic. This also takes a [LockFile] argument to ensure that the write can only be performed
 /// when the lock is acquired. It is a bug if you pass a [LockFile] that doesn't correspond to the
 /// environment registry, as that is essentially bypassing the lock.
-pub fn write_environment_registry(
+fn write_environment_registry(
     reg: &EnvRegistry,
     reg_path: impl AsRef<Path>,
     _lock: LockFile,
@@ -245,7 +245,7 @@ pub fn write_environment_registry(
 }
 
 /// Acquires the filesystem-based lock on the user's environment registry file
-pub fn acquire_env_registry_lock(reg_path: impl AsRef<Path>) -> Result<LockFile, EnvRegistryError> {
+fn acquire_env_registry_lock(reg_path: impl AsRef<Path>) -> Result<LockFile, EnvRegistryError> {
     let lock_path = env_registry_lock_path(reg_path);
     let mut lock = LockFile::open(lock_path.as_os_str()).map_err(EnvRegistryError::AcquireLock)?;
     lock.lock().map_err(EnvRegistryError::AcquireLock)?;

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1654,21 +1654,13 @@ pub mod test_helpers {
 mod test {
     use std::str::FromStr;
 
-    use fslock::LockFile;
     use indoc::indoc;
     use test_helpers::{mock_managed_environment, mock_managed_environment_from_env_files};
     use url::Url;
 
     use super::*;
     use crate::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
-    use crate::models::env_registry::{
-        env_registry_lock_path,
-        env_registry_path,
-        read_environment_registry,
-        write_environment_registry,
-        RegisteredEnv,
-        RegistryEntry,
-    };
+    use crate::models::env_registry::read_environment_registry;
     use crate::models::environment::test_helpers::{
         new_core_environment,
         new_core_environment_with_lockfile,
@@ -2597,20 +2589,8 @@ mod test {
             floxhub_git_url_override: None,
             version: Version::<1>,
         };
-        let reg = EnvRegistry {
-            version: Version,
-            entries: vec![RegistryEntry {
-                path_hash: path_hash(&path),
-                path: path.to_path_buf(),
-                envs: vec![RegisteredEnv {
-                    created_at: 0,
-                    pointer: EnvironmentPointer::Managed(pointer.clone()),
-                }],
-            }],
-        };
-        let reg_path = env_registry_path(&flox);
-        let lock = LockFile::open(&env_registry_lock_path(reg_path)).unwrap();
-        write_environment_registry(&reg, env_registry_path(&flox), lock).unwrap();
+        ensure_registered(&flox, &path, &EnvironmentPointer::Managed(pointer.clone())).unwrap();
+
         let branch_name = branch_name(&pointer, &path);
         let decoded_path = ManagedEnvironment::decode(&flox, &branch_name).unwrap();
         let canonicalized_decoded_path = std::fs::canonicalize(decoded_path).unwrap();

--- a/cli/flox/doc/flox-gc.md
+++ b/cli/flox/doc/flox-gc.md
@@ -1,0 +1,28 @@
+---
+title: FLOX-GC
+section: 1
+header: "Flox User Manuals"
+...
+
+# NAME
+
+flox-gc - Garbage collection
+
+# SYNOPSIS
+
+```
+flox [<general options>] gc
+```
+
+# DESCRIPTION
+
+Garbage collects any data for deleted environments.
+
+# OPTIONS
+
+```{.include}
+./include/general-options.md
+```
+
+# SEE ALSO
+[`flox-envs(1)`](./flox-envs.md),

--- a/cli/flox/src/commands/envs.rs
+++ b/cli/flox/src/commands/envs.rs
@@ -7,11 +7,7 @@ use anyhow::Result;
 use bpaf::Bpaf;
 use crossterm::style::Stylize;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::env_registry::{
-    env_registry_path,
-    read_environment_registry,
-    EnvRegistry,
-};
+use flox_rust_sdk::models::env_registry::{garbage_collect, EnvRegistry};
 use flox_rust_sdk::models::environment::DotFlox;
 use serde_json::json;
 use tracing::instrument;
@@ -56,8 +52,7 @@ impl Envs {
         match self.mode {
             Mode::Active => tracing::info_span!("active").in_scope(|| self.handle_active(active)),
             Mode::All => tracing::info_span!("all").in_scope(|| {
-                let env_registry =
-                    read_environment_registry(env_registry_path(&flox))?.unwrap_or_default();
+                let env_registry = garbage_collect(&flox)?;
                 let registered = get_registered_environments(&env_registry);
 
                 self.handle_all(active, registered)
@@ -200,11 +195,6 @@ fn get_registered_environments(
     registry.entries.iter().filter_map(|entry| {
         let path = entry.path.clone();
         let pointer = entry.latest_env()?.pointer.clone();
-
-        // If we have a path registered that has since been deleted, skip it
-        if !entry.path.exists() {
-            return None;
-        }
 
         Some(UninitializedEnvironment::DotFlox(DotFlox { path, pointer }))
     })

--- a/cli/flox/src/commands/gc.rs
+++ b/cli/flox/src/commands/gc.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+use crate::message;
+
+#[derive(Bpaf, Debug, Clone)]
+pub struct Gc {}
+
+impl Gc {
+    #[instrument(
+        skip_all,
+        fields(progress = "Garbage collecting unused environment data")
+    )]
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        message::updated("Garbage collection complete");
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/gc.rs
+++ b/cli/flox/src/commands/gc.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::env_registry;
 use tracing::instrument;
 
 use crate::message;
@@ -14,6 +15,8 @@ impl Gc {
         fields(progress = "Garbage collecting unused environment data")
     )]
     pub fn handle(self, flox: Flox) -> Result<()> {
+        env_registry::garbage_collect(&flox)?;
+
         message::updated("Garbage collection complete");
         Ok(())
     }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -6,6 +6,7 @@ mod containerize;
 mod delete;
 mod edit;
 mod envs;
+mod gc;
 mod general;
 mod init;
 mod install;
@@ -110,7 +111,7 @@ static FLOX_DESCRIPTION: &'_ str = indoc! {"
 
 /// Manually documented commands that are to keep the help text short
 const ADDITIONAL_COMMANDS: &str = indoc! {"
-    auth, config, envs, upgrade
+    auth, config, envs, gc, upgrade
 "};
 
 fn vec_len<T>(x: Vec<T>) -> usize {
@@ -932,6 +933,10 @@ enum AdditionalCommands {
     /// Show active and available environments
     #[bpaf(command, hide, footer("Run 'man flox-envs' for more details."))]
     Envs(#[bpaf(external(envs::envs))] envs::Envs),
+
+    /// Garbage collect data for deleted environments
+    #[bpaf(command, hide, footer("Run 'man flox-gc' for more details."))]
+    Gc(#[bpaf(external(gc::gc))] gc::Gc),
 }
 
 impl AdditionalCommands {
@@ -948,6 +953,7 @@ impl AdditionalCommands {
             AdditionalCommands::Envs(args) => args.handle(flox)?,
             AdditionalCommands::Update(args) => args.handle(flox).await?,
             AdditionalCommands::Upgrade(args) => args.handle(flox).await?,
+            AdditionalCommands::Gc(args) => args.handle(flox)?,
         }
         Ok(())
     }

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -92,7 +92,7 @@ EOF
   run "$FLOX_BIN" --help
   assert_output --partial - << EOF
 Additional Commands. Use "flox COMMAND --help" for more info
-    auth, config, envs, upgrade
+    auth, config, envs, gc, upgrade
 EOF
 }
 


### PR DESCRIPTION
## Proposed Changes

Remove environments that have been deleted from disk without using `flox
delete`. Previously these could accumulate indefinitely in the registry,
despite us filtering them from `flox envs`.

More details in the individual commits.

Follow-ups:

- https://github.com/flox/flox/issues/2685
- https://github.com/flox/flox/issues/2398
- https://github.com/flox/flox/issues/2707
- https://github.com/flox/flox/issues/2706

## Release Notes

Added a `flox gc` command to clean up data from unused environments.