### PR TITLE
fix(watchdog): Loop on GC logs and include upgrade-check

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "derive_more",
  "dirs",
  "enum_dispatch",
+ "flox-core",
  "flox-rust-sdk",
  "flox-test-utils",
  "fslock",

--- a/cli/flox-core/src/lib.rs
+++ b/cli/flox-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod canonical_path;
 pub mod proc_status;
 mod version;
 
+use std::fmt::Display;
 use std::io::BufWriter;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
@@ -71,4 +72,9 @@ where
 pub fn traceable_path(p: impl AsRef<Path>) -> impl tracing::Value {
     let path = p.as_ref();
     path.display().to_string()
+}
+
+/// Returns a log file name, or glob pattern, for upgrade-check logs.
+pub fn log_file_format_upgrade_check(index: impl Display) -> String {
+    format!("upgrade-check.{}.log", index)
 }

--- a/cli/flox-watchdog/src/logger.rs
+++ b/cli/flox-watchdog/src/logger.rs
@@ -4,6 +4,7 @@ use std::thread::{sleep, spawn};
 use std::time::{Duration, SystemTime};
 
 use anyhow::{Context, Result};
+use flox_core::log_file_format_upgrade_check;
 use glob::glob;
 use tracing::{debug, error};
 use tracing_subscriber::layer::SubscriberExt;
@@ -72,8 +73,12 @@ pub(crate) fn spawn_logs_gc_threads(dir: impl AsRef<Path>) {
             .unwrap_or_else(|err| error!(%err, "failed to delete watchdog logs"));
         gc_logs_per_process(&dir, "services.*.log", KEEP_LAST_N_PROCESSES)
             .unwrap_or_else(|err| error!(%err, "failed to delete services logs"));
-        gc_logs_per_process(&dir, "upgrade-check.*.log", KEEP_LAST_N_PROCESSES)
-            .unwrap_or_else(|err| error!(%err, "failed to delete upgrade-check logs"));
+        gc_logs_per_process(
+            &dir,
+            &log_file_format_upgrade_check("*"),
+            KEEP_LAST_N_PROCESSES,
+        )
+        .unwrap_or_else(|err| error!(%err, "failed to delete upgrade-check logs"));
 
         std::thread::sleep(WATCHDOG_GC_INTERVAL);
     });

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -54,6 +54,7 @@ tracing-subscriber.workspace = true
 url.workspace = true
 uuid.workspace = true
 xdg.workspace = true
+flox-core.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/cli/flox/src/commands/check_for_upgrades.rs
+++ b/cli/flox/src/commands/check_for_upgrades.rs
@@ -6,6 +6,7 @@ use std::time::SystemTime;
 
 use anyhow::{bail, Context, Result};
 use bpaf::{Bpaf, Parser};
+use flox_core::log_file_format_upgrade_check;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::providers::catalog::{self, CatalogQoS};
@@ -187,7 +188,7 @@ pub fn spawn_detached_check_for_upgrades_process(
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("now is after UNIX EPOCH")
         .as_secs();
-    let upgrade_check_log = log_dir.join(format!("upgrade-check.{}.log", timestamp));
+    let upgrade_check_log = log_dir.join(log_file_format_upgrade_check(timestamp));
 
     debug!(
         log_file=?upgrade_check_log,


### PR DESCRIPTION
## Proposed Changes

**feat(watchdog): Loop on GCing all log types**

Rather than special casing the watchdog logs.

It's possible for `process-compose` to be stopped and started multiple
times for a long running watchdog, so long as there is at least one
attachment to the activation. And we're about to add handling for
`upgrade-check` logs.

So we should attempt to garbage collect for the life of the watchdog.
This is done every 1hr which still seems reasonable.

**fix(watchdog): GC upgrade-check logs**

Each activation backgrounds `flox check-for-upgrades` which creates a
Log file. I had 128 log files in my test environment. Ensure that these
are cleaned up in the loop whilst the watchdog is running.

Internal thread about whether we should background for every activation:

- https://flox-dev.slack.com/archives/C05P6A5J6U8/p1739200828190839

## Release Notes

Fixed garbage collection of upgrade check logs.