### PR TITLE
fix: don't allow ignoring .flox/env

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -480,6 +480,7 @@ impl PathEnvironment {
             {CACHE_DIR_NAME}/
             {LIB_DIR_NAME}/
             {LOG_DIR_NAME}/
+            !{ENV_DIR_NAME}/
             "})
         .map_err(EnvironmentError::WriteGitignore)?;
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Prevents ignoring `.flox/env` by mistake. A local or global `.gitignore` that ignores `env/` or `ENV/` breaks managed environments. See #2118 for more details.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
