### PR TITLE
feat(debug): anyhow backtrace with `RUST_[LIB_]BACKTRACE=1`

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1048,7 +1048,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "textwrap",
- "thiserror",
+ "thiserror 2.0.11",
  "time",
  "tokio",
  "toml 0.8.19",
@@ -1100,7 +1100,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.11",
  "time",
  "tracing",
 ]
@@ -1140,7 +1140,7 @@ dependencies = [
  "shell-escape",
  "temp-env",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.11",
  "time",
  "tokio",
  "toml 0.8.19",
@@ -1167,7 +1167,7 @@ dependencies = [
  "serde_json",
  "temp-env",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1921,7 +1921,7 @@ dependencies = [
  "dyn-clone",
  "lazy_static",
  "newline-converter",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -2288,7 +2288,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -2590,7 +2590,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.98",
- "thiserror",
+ "thiserror 1.0.69",
  "typify",
  "unicode-ident",
 ]
@@ -2735,7 +2735,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3229,7 +3229,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "url",
  "uuid",
@@ -3476,7 +3476,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -3682,7 +3682,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -3690,6 +3699,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3876,7 +3896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
@@ -3979,7 +3999,7 @@ dependencies = [
  "schemars",
  "serde_json",
  "syn 2.0.98",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-ident",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -76,7 +76,7 @@ sysinfo = "0.32.1"
 sys-info = "0.9"
 tempfile = "3.16.0"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
-thiserror = "1"
+thiserror = "2"
 time = { version = "0.3", features = ["serde", "formatting"] }
 tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -80,7 +80,7 @@ pub enum ManagedEnvironmentError {
     LocalRevDoesNotExist,
     #[error("can't find environment at revision specified in lockfile; this could have been caused by force pushing")]
     RevDoesNotExist,
-    #[error("invalid {} file: {0}", GENERATION_LOCK_FILENAME)]
+    #[error("invalid {0} file: {filename}", filename = GENERATION_LOCK_FILENAME)]
     InvalidLock(serde_json::Error),
     #[error("failed to read pointer lockfile")]
     ReadPointerLock(#[source] io::Error),

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -157,6 +157,8 @@ fn main() -> ExitCode {
 
             if let Some(message) = message {
                 message::error(message);
+                debug!(target: "flox::backtrace", "{}", e.backtrace());
+
                 return ExitCode::from(1);
             }
 
@@ -167,6 +169,8 @@ fn main() -> ExitCode {
                 .fold(e.to_string(), |acc, cause| format!("{acc}: {cause}"));
 
             message::error(err_str);
+
+            debug!(target: "flox::backtrace", "{}", e.backtrace());
 
             ExitCode::from(1)
         },

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -1,3 +1,4 @@
+use std::backtrace::BacktraceStatus;
 use std::env;
 use std::fmt::{Debug, Display};
 use std::process::ExitCode;
@@ -157,7 +158,10 @@ fn main() -> ExitCode {
 
             if let Some(message) = message {
                 message::error(message);
-                debug!(target: "flox::backtrace", "{}", e.backtrace());
+
+                if matches!(e.backtrace().status(), BacktraceStatus::Captured) {
+                    eprintln!("{}", e.backtrace());
+                }
 
                 return ExitCode::from(1);
             }
@@ -170,7 +174,9 @@ fn main() -> ExitCode {
 
             message::error(err_str);
 
-            debug!(target: "flox::backtrace", "{}", e.backtrace());
+            if matches!(e.backtrace().status(), BacktraceStatus::Captured) {
+                eprintln!("{}", e.backtrace());
+            }
 
             ExitCode::from(1)
         },

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -240,7 +240,8 @@ function skip_if_linux() {
 
   "$FLOX_BIN" init
 
-  run bash -c 'PATH= "$FLOX_BIN" containerize' 3>&-
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 run bash -c 'PATH= "$FLOX_BIN" containerize' 3>&-
   assert_failure
   assert_output "❌ ERROR: No container runtime found in PATH.
 
@@ -417,12 +418,12 @@ EOF
 
 @test "container with user:group set can run as specified user:group" {
   skip_if_not_linux # config is implemented in the Linux build of flox entirely
-  
+
   "$FLOX_BIN" init
 
   MANIFEST_CONTENTS="$(cat << "EOF"
     version = 1
-    
+
     [containerize.config]
     user = "foo:bar"
 EOF

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -88,12 +88,14 @@ EOF
   assert_output "🗑️  'hello' uninstalled from environment 'test'"
 }
 
-@test "'flox uninstall' errors (without proceedign) for already uninstalled packages" {
+@test "'flox uninstall' errors (without proceeding) for already uninstalled packages" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
   "$FLOX_BIN" init
   run "$FLOX_BIN" install hello
   assert_success
-  run "$FLOX_BIN" uninstall hello curl
+
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 run "$FLOX_BIN" uninstall hello curl
   assert_failure
   assert_output "❌ ERROR: couldn't uninstall 'curl', wasn't previously installed"
 }
@@ -320,6 +322,8 @@ EOF
 @test "resolution message: single package not found, without curation" {
   "$FLOX_BIN" init
 
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 \
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/badpkg.json" \
     run "$FLOX_BIN" install badpkg
 
@@ -335,6 +339,8 @@ EOF
 @test "resolution message: multiple packages not found, without curation" {
   "$FLOX_BIN" init
 
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 \
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/badpkg1_badpkg2.json" \
     run "$FLOX_BIN" install badpkg1 badpkg2
 
@@ -353,6 +359,8 @@ EOF
 @test "resolution message: single package not found, with curation" {
   "$FLOX_BIN" init
 
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 \
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/node_suggestions.json" \
     run "$FLOX_BIN" install node
 
@@ -407,6 +415,8 @@ EOF
 @test "resolution message: package not available on all systems with no fix when there is another error" {
   "$FLOX_BIN" init
 
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 \
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/badpkg_bpftrace.json" \
     run "$FLOX_BIN" install badpkg bpftrace
 
@@ -432,6 +442,8 @@ EOF
 @test "resolution message: constraints too tight" {
   "$FLOX_BIN" init
 
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 \
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_node.json" \
     run "$FLOX_BIN" install nodejs@14.16.1
 
@@ -449,6 +461,8 @@ EOF
 @test "resolution message: systems not on same page" {
   "$FLOX_BIN" init
 
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 \
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/torchvision-bin.json" \
     run "$FLOX_BIN" install python311Packages.torchvision-bin
 

--- a/cli/tests/search.bats
+++ b/cli/tests/search.bats
@@ -100,6 +100,8 @@ setup_file() {
 
 @test "'flox search' error message when no results" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/search/surely_doesnt_exist.json"
+  # disable backtrace; we expect this to fail and assert output
+  export RUST_BACKTRACE=0
   run "$FLOX_BIN" search surely_doesnt_exist
   assert_equal "${#lines[@]}" 1
   assert_output --partial "No packages matched this search term: 'surely_doesnt_exist'"


### PR DESCRIPTION
With `RUST_[LIB_]BACKTRACE=1` anyhow captures backtraces
to the origin of an error chain.
The backtrace can then be accessed via `anyhow::Error::backtrace`,
which returns a `Display`able type (`std::backtrace::Backtrace`
at our version of rust).

To avoid being too noisy and allow targeted enabling of backtraces,
the backtrace is logged with `debug!` under the `flox::backtrace` target.

Unfortunately, `thiserror` supports backtraces only
when compiled with rust nightly [1] [2], on account of being blocked by
the stabilization of `error_generic_member_access` [3].

[1]: <dtolnay/thiserror#390>
[2]: <dtolnay/thiserror#387>
[3]: <rust-lang/rust#99301>
