### PR TITLE
feat(gc): Prune branches from floxmeta

### DIFF
--- a/cli/flox-core/src/canonical_path.rs
+++ b/cli/flox-core/src/canonical_path.rs
@@ -33,6 +33,13 @@ impl CanonicalPath {
         Ok(Self(canonicalized))
     }
 
+    /// Create a [`CanonicalPath`] without checking if the path is canonical or
+    /// exists. Only to be used when dealing with paths that are known to be
+    /// deleted.
+    pub fn new_unchecked(path: impl AsRef<Path>) -> Self {
+        Self(path.as_ref().to_path_buf())
+    }
+
     /// Destruct the [`CanonicalPath`] and return the inner [`PathBuf`]
     pub fn into_inner(self) -> PathBuf {
         self.0

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1147,13 +1147,9 @@ fn write_pointer_lockfile(
 /// unique copies of the environment are created.
 /// I.e. `install`ing a package in one directory does not affect the other
 /// until synchronized through FloxHub.
-/// To identify the individual branches per directory,
-/// the directory path is encoded using [`ManagedEnvironment::encode`].
 ///
 /// `dot_flox_path` is expected to point to the `.flox/` directory
 /// that link to an environment identified by `pointer`.
-/// `dot_flox_path` does _not_ need to be passed in its canonicalized form;
-/// [`ManagedEnvironment::encode`] will canonicalize the path if necessary.
 fn branch_name(pointer: &ManagedPointer, dot_flox_path: &CanonicalPath) -> String {
     format!("{}.{}", pointer.name, path_hash(dot_flox_path))
 }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use tracing::{debug, instrument};
 
 use super::core_environment::UpgradeResult;
-use super::managed_environment::{remote_branch_name, ManagedEnvironment, ManagedEnvironmentError};
+use super::managed_environment::{ManagedEnvironment, ManagedEnvironmentError};
 use super::{
     gcroots_dir,
     CanonicalPath,
@@ -155,7 +155,7 @@ impl RemoteEnvironment {
 
             RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
                 &base_dir,
-                remote_branch_name(&pointer),
+                pointer.name.as_ref(),
                 &flox.system,
             )
         };

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -314,7 +314,8 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
     match err {
         // todo: communicate reasons for this error
         // git auth errors may be caught separately or reported
-        ManagedEnvironmentError::OpenFloxmeta(err) => formatdoc! {"
+        ManagedEnvironmentError::OpenFloxmeta(err)
+        | ManagedEnvironmentError::UpdateFloxmeta(err) => formatdoc! {"
             Failed to fetch environment: {err}
         "},
 


### PR DESCRIPTION
## Proposed Changes

Follow-up from https://github.com/flox/flox/pull/2708#discussion_r1949786418

Prune branches from floxmeta when removing managed environments from the
registry which no longer have `.flox` paths on disk.

This also removes the suffixed "remote branch" if there aren't any
suffixed "local branches" remaining and applies the same logic when
deleting a `ManagedEnvironment`.

The intersections between `ManagedEnvironment`, `FloxMeta`, and
`EnvironmentRegistry` feel kinda weird here and I made several aborted
attempts to:

- refactor pointer and git methods onto `FloxMeta`
- constructing a `ManagedEnvironment` without a path or registry entry

It's worth noting that..

Remote environments will never be GCed in practice because there's no
user interface to remove the local clone. As such, the remote branch
will never be removed if all of the managed environments have been
deleted but it's still shared by a remote environment

We can't easily work backwards from the floxmeta branches of all owners,
so we're working forwards from the registry, but that means that old
branches (e.g. from before we short hashed path names) will remain
untouched. As such, this change should ship in the same release as the
initial `flox gc` command

## Release Notes

N/A, roll into `flox gc` announcement.