### PR TITLE
chore: adjust error message formatting

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -461,7 +461,7 @@ fn format_single_resolution_failure(failure: &ResolutionFailure, is_one_of_many:
             if is_one_of_many {
                 indent_by(2, msg.to_string())
             } else {
-                msg.to_string()
+                format!("\n{}", msg)
             }
         },
     }
@@ -2532,7 +2532,11 @@ pub(crate) mod tests {
                 Lockfile::lock_manifest(manifest, None, &client, &InstallableLockerMock::new())
                     .await;
             if let Err(LockedManifestError::ResolutionFailed(res_failures)) = locked_manifest {
-                assert_eq!(res_failures.to_string(), response_msg.msg());
+                // A newline is added for formatting when it's a single message
+                assert_eq!(
+                    res_failures.to_string(),
+                    format!("\n{}", response_msg.msg())
+                );
             } else {
                 panic!("expected resolution failure, got {:?}", locked_manifest);
             }

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -330,7 +330,8 @@ EOF
   assert_failure
   assert_output "$(
     cat << EOF
-❌ ERROR: resolution failed: Could not find package 'badpkg'.
+❌ ERROR: resolution failed: 
+Could not find package 'badpkg'.
 Try 'flox search' with a broader search term.
 EOF
   )"
@@ -367,7 +368,8 @@ EOF
   assert_failure
   assert_output --partial "$(
     cat << EOF
-❌ ERROR: resolution failed: Could not find package 'node'.
+❌ ERROR: resolution failed: 
+Could not find package 'node'.
 Try 'flox install nodejs' instead.
 
 Here are a few other similar options:
@@ -469,7 +471,8 @@ EOF
   assert_failure
   assert_output "$(
     cat << EOF
-❌ ERROR: resolution failed: The attr_path python311Packages.torchvision-bin is not found for all requested systems on the same page, consider package groups with the following system groupings: (aarch64-darwin,aarch64-linux,x86_64-linux), (aarch64-darwin,x86_64-darwin,x86_64-linux), (aarch64-darwin,x86_64-linux), (x86_64-linux).
+❌ ERROR: resolution failed:
+The attr_path python311Packages.torchvision-bin is not found for all requested systems on the same page, consider package groups with the following system groupings: (aarch64-darwin,aarch64-linux,x86_64-linux), (aarch64-darwin,x86_64-darwin,x86_64-linux), (aarch64-darwin,x86_64-linux), (x86_64-linux).
 EOF
   )"
 }

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -471,7 +471,7 @@ EOF
   assert_failure
   assert_output "$(
     cat << EOF
-❌ ERROR: resolution failed:
+❌ ERROR: resolution failed: 
 The attr_path python311Packages.torchvision-bin is not found for all requested systems on the same page, consider package groups with the following system groupings: (aarch64-darwin,aarch64-linux,x86_64-linux), (aarch64-darwin,x86_64-darwin,x86_64-linux), (aarch64-darwin,x86_64-linux), (x86_64-linux).
 EOF
   )"


### PR DESCRIPTION
## Proposed Changes
Resolution error messages can and often are multi-line, which look better if the first line is not appended to the `resolution error: ` line.  So we insert a newline after that for the following message(s) to start on new lines.  Similar adjustments were made for consistency, as well as some capitalization for consistency and adherence to the style guide.