### PR TITLE
refactor: remove Manifest* naming

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1107,7 +1107,7 @@ mod tests {
     use crate::flox::test_helpers::flox_instance;
     use crate::models::lockfile;
     use crate::models::lockfile::test_helpers::fake_catalog_package_lock;
-    use crate::models::manifest::typed::{ManifestPackageDescriptorCatalog, DEFAULT_GROUP_NAME};
+    use crate::models::manifest::typed::{PackageDescriptorCatalog, DEFAULT_GROUP_NAME};
     use crate::providers::flake_installable_locker::InstallableLockerMock;
     use crate::providers::services::SERVICE_CONFIG_FILENAME;
 
@@ -1433,7 +1433,7 @@ mod tests {
         for (test_iid, dotted_package) in entries {
             typed_manifest_mock.install.inner_mut().insert(
                 test_iid.to_string(),
-                ManifestPackageDescriptor::Catalog(ManifestPackageDescriptorCatalog {
+                ManifestPackageDescriptor::Catalog(PackageDescriptorCatalog {
                     pkg_path: dotted_package.to_string(),
                     pkg_group: None,
                     priority: None,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1669,7 +1669,7 @@ mod test {
     use crate::models::floxmeta::floxmeta_dir;
     use crate::models::lockfile::test_helpers::fake_catalog_package_lock;
     use crate::models::lockfile::Lockfile;
-    use crate::models::manifest::typed::{Inner, Manifest, ManifestPackageDescriptorCatalog};
+    use crate::models::manifest::typed::{Inner, Manifest, PackageDescriptorCatalog};
     use crate::providers::catalog::test_helpers::reset_mocks_from_file;
     use crate::providers::catalog::{MockClient, GENERATED_DATA};
     use crate::providers::git::tests::commit_file;
@@ -2453,7 +2453,7 @@ mod test {
         let mut new_manifest = Manifest::default();
         new_manifest.install.inner_mut().insert(
             "hello".to_string(),
-            ManifestPackageDescriptorCatalog {
+            PackageDescriptorCatalog {
                 pkg_path: "hello".to_string(),
                 pkg_group: None,
                 priority: None,

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -27,8 +27,8 @@ use super::manifest::typed::{
     Inner,
     Manifest,
     ManifestPackageDescriptor,
-    ManifestPackageDescriptorCatalog,
-    ManifestPackageDescriptorFlake,
+    PackageDescriptorCatalog,
+    PackageDescriptorFlake,
     DEFAULT_GROUP_NAME,
     DEFAULT_PRIORITY,
 };
@@ -218,7 +218,7 @@ impl LockedPackageCatalog {
     /// There may be more validation/parsing we could do here in the future.
     pub fn from_parts(
         package: catalog::PackageResolutionInfo,
-        descriptor: ManifestPackageDescriptorCatalog,
+        descriptor: PackageDescriptorCatalog,
     ) -> Self {
         // unpack package to avoid missing new fields
         let catalog::PackageResolutionInfo {
@@ -316,7 +316,7 @@ impl LockedPackageFlake {
 #[derive(Debug, Clone, PartialEq)]
 struct FlakeInstallableToLock {
     install_id: String,
-    descriptor: ManifestPackageDescriptorFlake,
+    descriptor: PackageDescriptorFlake,
     system: System,
 }
 
@@ -1250,8 +1250,8 @@ impl Lockfile {
 /// TODO: drop in favor of mapping to `(ManifestPackageDescriptor*, LockedPackage*)`
 #[derive(Debug, Clone, PartialEq)]
 pub enum PackageToList {
-    Catalog(ManifestPackageDescriptorCatalog, LockedPackageCatalog),
-    Flake(ManifestPackageDescriptorFlake, LockedPackageFlake),
+    Catalog(PackageDescriptorCatalog, LockedPackageCatalog),
+    Flake(PackageDescriptorFlake, LockedPackageFlake),
     StorePath(LockedPackageStorePath),
 }
 
@@ -1321,7 +1321,7 @@ pub enum LockedManifestError {
 
 pub mod test_helpers {
     use super::*;
-    use crate::models::manifest::typed::ManifestPackageDescriptorStorePath;
+    use crate::models::manifest::typed::PackageDescriptorStorePath;
 
     pub fn fake_catalog_package_lock(
         name: &str,
@@ -1329,7 +1329,7 @@ pub mod test_helpers {
     ) -> (String, ManifestPackageDescriptor, LockedPackageCatalog) {
         let install_id = format!("{}_install_id", name);
 
-        let descriptor = ManifestPackageDescriptorCatalog {
+        let descriptor = PackageDescriptorCatalog {
             pkg_path: name.to_string(),
             pkg_group: group.map(|s| s.to_string()),
             systems: Some(vec![SystemEnum::Aarch64Darwin.to_string()]),
@@ -1370,10 +1370,10 @@ pub mod test_helpers {
 
     pub fn fake_flake_installable_lock(
         name: &str,
-    ) -> (String, ManifestPackageDescriptorFlake, LockedPackageFlake) {
+    ) -> (String, PackageDescriptorFlake, LockedPackageFlake) {
         let install_id = format!("{}_install_id", name);
 
-        let descriptor = ManifestPackageDescriptorFlake {
+        let descriptor = PackageDescriptorFlake {
             flake: format!("github:nowhere/exciting#{name}"),
             priority: None,
             systems: None,
@@ -1409,14 +1409,10 @@ pub mod test_helpers {
 
     pub fn fake_store_path_lock(
         name: &str,
-    ) -> (
-        String,
-        ManifestPackageDescriptorStorePath,
-        LockedPackageStorePath,
-    ) {
+    ) -> (String, PackageDescriptorStorePath, LockedPackageStorePath) {
         let install_id = format!("{}_install_id", name);
 
-        let descriptor = ManifestPackageDescriptorStorePath {
+        let descriptor = PackageDescriptorStorePath {
             store_path: format!("/nix/store/{}", name),
             systems: Some(vec![SystemEnum::Aarch64Darwin.to_string()]),
             priority: None,
@@ -1431,8 +1427,8 @@ pub mod test_helpers {
         (install_id, descriptor, locked)
     }
 
-    pub fn nix_eval_jobs_descriptor() -> ManifestPackageDescriptorFlake {
-        ManifestPackageDescriptorFlake {
+    pub fn nix_eval_jobs_descriptor() -> PackageDescriptorFlake {
+        PackageDescriptorFlake {
             flake: "github:nix-community/nix-eval-jobs".to_string(),
             priority: None,
             systems: None,
@@ -1575,7 +1571,7 @@ pub(crate) mod tests {
         fn lock_flake_installable(
             &self,
             _: impl AsRef<str>,
-            _: &ManifestPackageDescriptorFlake,
+            _: &PackageDescriptorFlake,
         ) -> Result<LockedInstallable, FlakeInstallableError> {
             panic!("this flake locker always panics")
         }
@@ -2004,7 +2000,7 @@ pub(crate) mod tests {
         // Add a package to the manifest that is not already locked
         manifest.install.inner_mut().insert(
             "unlocked".to_string(),
-            ManifestPackageDescriptorCatalog {
+            PackageDescriptorCatalog {
                 pkg_path: "unlocked".to_string(),
                 pkg_group: Some("group".to_string()),
                 systems: None,

--- a/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
@@ -9,16 +9,16 @@ use proptest::prelude::*;
 use thiserror::Error;
 
 use super::typed::{
+    Build,
+    Containerize,
+    ContainerizeConfig,
+    Hook,
+    Install,
     Manifest,
-    ManifestBuild,
-    ManifestContainerize,
-    ManifestContainerizeConfig,
-    ManifestHook,
-    ManifestInstall,
-    ManifestOptions,
-    ManifestProfile,
-    ManifestServices,
-    ManifestVariables,
+    Options,
+    Profile,
+    Services,
+    Vars,
 };
 
 #[derive(Error, Debug)]
@@ -61,37 +61,28 @@ trait ManifestMergeStrategy {
         high_priority: &Version<1>,
     ) -> Result<Version<1>, MergeError>;
     fn merge_install(
-        low_priority: &ManifestInstall,
-        high_priority: &ManifestInstall,
-    ) -> Result<ManifestInstall, MergeError>;
-    fn merge_vars(
-        low_priority: &ManifestVariables,
-        high_priority: &ManifestVariables,
-    ) -> Result<ManifestVariables, MergeError>;
-    fn merge_hook(
-        low_priority: &ManifestHook,
-        high_priority: &ManifestHook,
-    ) -> Result<ManifestHook, MergeError>;
+        low_priority: &Install,
+        high_priority: &Install,
+    ) -> Result<Install, MergeError>;
+    fn merge_vars(low_priority: &Vars, high_priority: &Vars) -> Result<Vars, MergeError>;
+    fn merge_hook(low_priority: &Hook, high_priority: &Hook) -> Result<Hook, MergeError>;
     fn merge_profile(
-        low_priority: &ManifestProfile,
-        high_priority: &ManifestProfile,
-    ) -> Result<ManifestProfile, MergeError>;
+        low_priority: &Profile,
+        high_priority: &Profile,
+    ) -> Result<Profile, MergeError>;
     fn merge_options(
-        low_priority: &ManifestOptions,
-        high_priority: &ManifestOptions,
-    ) -> Result<ManifestOptions, MergeError>;
+        low_priority: &Options,
+        high_priority: &Options,
+    ) -> Result<Options, MergeError>;
     fn merge_services(
-        low_priority: &ManifestServices,
-        high_priority: &ManifestServices,
-    ) -> Result<ManifestServices, MergeError>;
-    fn merge_build(
-        low_priority: &ManifestBuild,
-        high_priority: &ManifestBuild,
-    ) -> Result<ManifestBuild, MergeError>;
+        low_priority: &Services,
+        high_priority: &Services,
+    ) -> Result<Services, MergeError>;
+    fn merge_build(low_priority: &Build, high_priority: &Build) -> Result<Build, MergeError>;
     fn merge_containerize(
-        low_priority: Option<&ManifestContainerize>,
-        high_priority: Option<&ManifestContainerize>,
-    ) -> Result<Option<ManifestContainerize>, MergeError>;
+        low_priority: Option<&Containerize>,
+        high_priority: Option<&Containerize>,
+    ) -> Result<Option<Containerize>, MergeError>;
     fn merge(
         &self,
         low_priority: &Manifest,
@@ -182,15 +173,15 @@ fn shallow_merge_options<T: Clone>(
 }
 
 fn deep_merge_optional_containerize_config(
-    low_priority: Option<&ManifestContainerizeConfig>,
-    high_priority: Option<&ManifestContainerizeConfig>,
-) -> Option<ManifestContainerizeConfig> {
+    low_priority: Option<&ContainerizeConfig>,
+    high_priority: Option<&ContainerizeConfig>,
+) -> Option<ContainerizeConfig> {
     match (low_priority, high_priority) {
         (None, None) => None,
         (Some(cfg), None) => Some(cfg.clone()),
         (None, Some(cfg)) => Some(cfg.clone()),
         (Some(cfg_lp), Some(cfg_hp)) => {
-            let cfg = ManifestContainerizeConfig {
+            let cfg = ContainerizeConfig {
                 user: shallow_merge_options(cfg_lp.user.as_ref(), cfg_hp.user.as_ref()),
                 exposed_ports: optional_set_union(
                     cfg_lp.exposed_ports.as_ref(),

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1083,7 +1083,7 @@ mod realise_flakes_tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::models::manifest::typed::ManifestPackageDescriptorFlake;
+    use crate::models::manifest::typed::PackageDescriptorFlake;
     use crate::providers::flake_installable_locker::{InstallableLocker, InstallableLockerImpl};
 
     // region: tools to configure mock flakes for testing
@@ -1150,17 +1150,14 @@ mod realise_flakes_tests {
             };
             fs::write(tempdir.path().join("flake.nix"), flake_contents).unwrap();
             let mut locked_installable = InstallableLockerImpl::default()
-                .lock_flake_installable(
-                    env!("NIX_TARGET_SYSTEM"),
-                    &ManifestPackageDescriptorFlake {
-                        flake: format!(
-                            "path:{}#package",
-                            tempdir.path().canonicalize().unwrap().display()
-                        ),
-                        systems: None,
-                        priority: None,
-                    },
-                )
+                .lock_flake_installable(env!("NIX_TARGET_SYSTEM"), &PackageDescriptorFlake {
+                    flake: format!(
+                        "path:{}#package",
+                        tempdir.path().canonicalize().unwrap().display()
+                    ),
+                    systems: None,
+                    priority: None,
+                })
                 .unwrap();
 
             // We cause an eval failure by not providing a valid flake.

--- a/cli/flox-rust-sdk/src/providers/container_builder.rs
+++ b/cli/flox-rust-sdk/src/providers/container_builder.rs
@@ -11,7 +11,7 @@ use tracing::{debug, info, instrument};
 
 use super::buildenv::BuiltStorePath;
 use crate::flox::Flox;
-use crate::models::manifest::typed::ManifestContainerizeConfig;
+use crate::models::manifest::typed::ContainerizeConfig;
 use crate::providers::build::BUILDTIME_NIXPKGS_URL;
 use crate::providers::nix::nix_base_command;
 use crate::utils::gomap::GoMap;
@@ -47,8 +47,8 @@ pub struct OCIConfig {
     stop_signal: Option<String>,
 }
 
-impl From<ManifestContainerizeConfig> for OCIConfig {
-    fn from(config: ManifestContainerizeConfig) -> Self {
+impl From<ContainerizeConfig> for OCIConfig {
+    fn from(config: ContainerizeConfig) -> Self {
         Self {
             user: config.user,
             exposed_ports: config.exposed_ports.map(GoMap::from),
@@ -270,7 +270,7 @@ mod container_source_tests {
 
     #[test]
     fn oci_config_from_manifest() {
-        let manifest_config = ManifestContainerizeConfig {
+        let manifest_config = ContainerizeConfig {
             user: Some("root".to_string()),
             exposed_ports: Some(BTreeSet::from(["80/tcp".to_string()])),
             volumes: Some(BTreeSet::from(["/app".to_string()])),

--- a/cli/flox-rust-sdk/src/providers/services.rs
+++ b/cli/flox-rust-sdk/src/providers/services.rs
@@ -23,7 +23,7 @@ use tracing::debug;
 
 use crate::flox::Flox;
 use crate::models::lockfile::Lockfile;
-use crate::models::manifest::typed::{Inner, ManifestServiceShutdown, ManifestServices};
+use crate::models::manifest::typed::{Inner, ServiceShutdown, Services};
 use crate::utils::logging::traceable_path;
 use crate::utils::CommandExt;
 
@@ -147,8 +147,8 @@ pub struct ProcessShutdown {
     pub command: String,
 }
 
-impl From<ManifestServiceShutdown> for ProcessShutdown {
-    fn from(value: ManifestServiceShutdown) -> Self {
+impl From<ServiceShutdown> for ProcessShutdown {
+    fn from(value: ServiceShutdown) -> Self {
         Self {
             command: value.command,
         }
@@ -187,8 +187,8 @@ pub fn generate_never_exit_process() -> ProcessConfig {
     }
 }
 
-impl From<ManifestServices> for ProcessComposeConfig {
-    fn from(services: ManifestServices) -> Self {
+impl From<Services> for ProcessComposeConfig {
+    fn from(services: Services) -> Self {
         let processes = services
             .0
             .into_iter()

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::data::System;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::manifest::typed::ManifestServices;
+use flox_rust_sdk::models::manifest::typed::Services;
 use flox_rust_sdk::providers::services::{
     process_compose_down,
     restart_service,
@@ -111,7 +111,7 @@ impl Restart {
     // Defaults to restarting all services if no services are specified.
     fn restart_with_existing_process_compose(
         socket: impl AsRef<Path>,
-        manifest_services: &ManifestServices,
+        manifest_services: &Services,
         system: impl Into<System>,
         names: &[String],
         processes: ProcessStates,

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use bpaf::Bpaf;
 use flox_rust_sdk::data::System;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::manifest::typed::ManifestServices;
+use flox_rust_sdk::models::manifest::typed::Services;
 use flox_rust_sdk::providers::services::{
     shutdown_process_compose_if_all_processes_stopped,
     start_service,
@@ -80,7 +80,7 @@ impl Start {
     /// Defaults to starting all services if no services are specified.
     fn start_with_existing_process_compose(
         socket: impl AsRef<Path>,
-        manifest_services: &ManifestServices,
+        manifest_services: &Services,
         system: impl Into<System>,
         names: &[String],
         err_stream: &mut impl std::io::Write,


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
There are no behavior changes here, this just makes the names of some of our data structures less verbose. The only data structure that wasn't renamed is `ManifestPackageDescriptor` because renaming it to `PackageDescriptor` causes conflicts  with the `api_types::PackageDescriptor` type. These two types are used in very similar contexts, and the `catalog-server` type can't be easily renamed, so we'll stick with `ManifestPackageDescriptor` for now.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
