### PR TITLE
feat: add include section

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/composite/shallow.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/shallow.rs
@@ -12,6 +12,7 @@ use crate::models::manifest::typed::{
     Build,
     Containerize,
     Hook,
+    Include,
     Inner,
     Install,
     Manifest,
@@ -164,6 +165,9 @@ impl ManifestMergeStrategy for ShallowMerger {
                 low_priority.containerize.as_ref(),
                 high_priority.containerize.as_ref(),
             )?,
+            // Intentionally blank out the includes since the includes are
+            // inputs to the merge operation.
+            include: Include::default(),
         };
 
         Ok(manifest)


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This adds the `include` section to the manifest. For now users can only add environments via relative path, but remote environments will be added at some point in the future. The syntax looks like this:
```toml
version = 1

[include]
environments = [
	{ dir = "../foo", name = "bar" }
]
```

The `dir` field is meant to resemble the `--dir` flag used on the command line. The `name` field is required only for path environments for the following reasons:
- At some point a user will be able to request updates to individual environments. Thus, you need a way to identify this environment. You could use the built-in name of the environment (since every environment has one), but this name isn't guaranteed to be unique throughout the (eventual) dependency graph, and the name itself isn't visible without running a command that only incidentally prints the name of the environment (e.g. `flox install`).
- At some point we will need to print warnings and error messages about individual environments, and this solution feels cleaner than printing the relative path or the possibly-ambiguous built-in name.

Feel free to bikeshed the `name` field, the need stands regardless of the syntax.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
