### PR TITLE
refactor: replace `activate --turbo` with wrapper script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,7 @@ trim_trailing_whitespace = true
 # Shell files
 # -----------
 
-[{*.{sh,bash,bats,zsh},activate}]
+[{*.{sh,bash,bats,zsh},activate,wrapper}]
 indent_style       = space  # Use spaces not tabs
 indent_size        = 2      # 2 space width
 binary_next_line   = true   # Pipes go at beginning of newline, not end.

--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -46,6 +46,8 @@ source "${_activate_d}/generate-bash-startup-commands.bash"
 source "${_activate_d}/generate-fish-startup-commands.bash"
 # shellcheck source-path=SCRIPTDIR/activate.d
 source "${_activate_d}/generate-tcsh-startup-commands.bash"
+# shellcheck source-path=SCRIPTDIR/activate.d
+source "${_activate_d}/source-profile-d.bash"
 
 # Top-level Flox environment activation script.
 

--- a/assets/activation-scripts/activate.d/source-profile-d.bash
+++ b/assets/activation-scripts/activate.d/source-profile-d.bash
@@ -1,0 +1,27 @@
+# source_profile_d <profile.d directory>
+#
+# source all scripts in <profile.d directory>
+function source_profile_d {
+  local _profile_d="${1?}"
+  shift
+
+  # make sure the directory exists
+  [ -d "$_profile_d" ] || {
+    echo "'$_profile_d' is not a directory" >&2
+    return 1
+  }
+
+  declare -a _profile_scripts
+  # TODO: figure out why this is needed
+  set +e
+  read -r -d '' -a _profile_scripts < <(
+    cd "$_profile_d" || exit
+    shopt -s nullglob
+    echo *.sh
+  )
+  set -e
+  for profile_script in "${_profile_scripts[@]}"; do
+    # shellcheck disable=SC1090 # from rendered environment
+    source "$_profile_d/$profile_script"
+  done
+}

--- a/assets/activation-scripts/activate.d/start.bash
+++ b/assets/activation-scripts/activate.d/start.bash
@@ -24,21 +24,9 @@ export | LC_ALL=C $_sort > "$_start_env"
 # Process the flox environment customizations, which includes (amongst
 # other things) prepending this environment's bin directory to the PATH.
 # shellcheck disable=SC2154 # set in the main `activate` script
-if [ "$_FLOX_ENV_ACTIVATION_MODE" = "dev" ] && [ -d "$_profile_d" ]; then
-  declare -a _profile_scripts
-  # TODO: figure out why this is needed
-  set +e
-  read -r -d '' -a _profile_scripts < <(
-    cd "$_profile_d" || exit
-    shopt -s nullglob
-    echo *.sh
-  )
-  set -e
-  for profile_script in "${_profile_scripts[@]}"; do
-    # shellcheck disable=SC1090 # from rendered environment
-    source "$_profile_d/$profile_script"
-  done
-  unset _profile_scripts
+if [ "$_FLOX_ENV_ACTIVATION_MODE" = "dev" ]; then
+  # shellcheck disable=SC1090 # from rendered environment
+  source_profile_d "$_profile_d"
 fi
 
 # Capture post-etc-profiles.env.

--- a/assets/activation-scripts/wrapper
+++ b/assets/activation-scripts/wrapper
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+# Trace levels supported by activation scripts:
+#   1. (-v) top-level activate script
+#   2. (-vv) language-specific profile scripts
+#   3. (-vvv) zsh `autoload -U compinit` (very verbose)
+export _flox_activate_tracelevel="${_FLOX_PKGDB_VERBOSITY:-0}"
+[ "$_flox_activate_tracelevel" -eq 0 ] || set -x
+
+# Ensure that $_flox_activate_tracer is defined as an executable.
+if [ -z "${FLOX_ACTIVATE_TRACE-}" ]; then
+  # If FLOX_ACTIVATE_TRACE is empty or not set, set _flox_activate_tracer to
+  # `true` which can always be invoked with any arguments without error.
+  export _flox_activate_tracer=true
+else
+  # If FLOX_ACTIVATE_TRACE is set but does not refer to an executable, then
+  # set _flox_activate_tracer to the default trace script.
+  if [ -x "${FLOX_ACTIVATE_TRACE:-}" ]; then
+    export _flox_activate_tracer="$FLOX_ACTIVATE_TRACE"
+  else
+    export _flox_activate_tracer="__OUT__/activate.d/trace"
+  fi
+fi
+"$_flox_activate_tracer" "${BASH_SOURCE[0]}" "$@" START
+
+_dirname="@coreutils@/bin/dirname"
+_getopt="@getopt@/bin/getopt"
+_readlink="@coreutils@/bin/readlink"
+
+set -euo pipefail
+
+# These all derive from the `flox-interpreter` package.
+# FIXME This is wrong; the profile.d scripts in particular should be
+#       sourced from the environment itself so that users can add pkgs
+#       which add additional scripts to the etc/profile.d directory.
+_activate_d="__OUT__/activate.d"
+_profile_d="__OUT__/etc/profile.d"
+# shellcheck source-path=SCRIPTDIR/activate.d
+source "${_activate_d}/source-profile-d.bash"
+
+# Top-level Flox environment activation script.
+
+# Parse command-line arguments.
+OPTIONS="c:e:"
+LONGOPTS="command:,env:"
+USAGE="Usage: $0 [-c \"<cmd> <args>\"] [(-e|--env) <env>]"
+
+PARSED=$("$_getopt" --options="$OPTIONS" --longoptions="$LONGOPTS" --name "$0" -- "$@")
+# shellcheck disable=SC2181
+if [[ $? -ne 0 ]]; then
+  echo "Failed to parse options."
+  exit 1
+fi
+
+# Use eval to remove quotes and replace them with spaces.
+eval set -- "$PARSED"
+
+# Set default values for options.
+FLOX_CMD=""
+while true; do
+  case "$1" in
+    -c | --command)
+      shift
+      if [ -z "${1:-}" ]; then
+        echo "Option -c requires an argument." >&2
+        echo "$USAGE" >&2
+        exit 1
+      fi
+      FLOX_CMD="$1"
+      shift
+      ;;
+    -e | --env)
+      shift
+      if [ -z "${1:-}" ] || [ ! -d "$1" ]; then
+        echo "Option --env requires a valid environment path as an argument." >&2
+        echo "$USAGE" >&2
+        exit 1
+      fi
+      FLOX_ENV="$1"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Invalid option: $1" >&2
+      echo "$USAGE" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Convert the provided command string into an array of arguments in "$@".
+# Henceforth in the script it is assumed that these are the arguments to be
+# invoked either by this shell (with FLOX_TURBO) or with the chosen userShell.
+if [ -n "$FLOX_CMD" ]; then
+  # Throw an error if passed additional arguments along with the -c arg.
+  if [ $# -gt 0 ]; then
+    echo "Unexpected arguments provided with -c argument: $*" >&2
+    echo "$USAGE" >&2
+    exit 1
+  fi
+
+  # Set $@ to reflect the command to be invoked.
+  set -- "$FLOX_CMD"
+fi
+
+if [ -z "${FLOX_ENV-}" ]; then
+  echo "No environment specified." >&2
+  echo "$USAGE" >&2
+  exit 1
+fi
+
+# prepend path
+export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin/$PATH"
+
+# source profile.d scripts
+source_profile_d "$_profile_d"
+
+# Set static environment variables from the manifest.
+if [ -f "$FLOX_ENV/activate.d/envrc" ]; then
+  # shellcheck disable=SC1091 # from rendered environment
+  source "$FLOX_ENV/activate.d/envrc"
+fi
+
+"$_flox_activate_tracer" "${BASH_SOURCE[0]}" "$@" END
+
+# exec the command
+exec -a "${FLOX_SET_ARG0:-$0}" "$@"

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1090,17 +1090,17 @@ mod tests {
     }
 
     #[test]
-    fn build_uses_hook_from_manifest() {
+    fn build_does_not_use_hook_from_manifest() {
         let package_name = String::from("foo");
         let file_name = String::from("bar");
-        let file_content = String::from("some content");
+        let file_content = String::from("");
 
         let manifest = formatdoc! {r#"
             version = 1
 
             [hook]
             on-activate = '''
-              export FOO="{file_content}"
+              export FOO="will not be used"
             '''
 
             [build.{package_name}]

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -165,7 +165,7 @@ pkgs.runCommandNoCC name
                 # strips color codes from output anyway.
                 FLOX_SRC_DIR=$(pwd) FLOX_RUNTIME_DIR="$TMP" \
                   ${flox-env-package}/activate --env ${flox-env-package} --mode run --turbo -- \
-                    ${build-wrapper-env-package}/activate --env ${build-wrapper-env-package} --mode dev --turbo -- \
+                    ${build-wrapper-env-package}/wrapper --env ${build-wrapper-env-package}  -- \
                       ${t3-package}/bin/t3 --relative $log -- bash -e ${buildScript-contents}
               ''
             else
@@ -179,7 +179,7 @@ pkgs.runCommandNoCC name
                 # /private/tmp/nix-build-file-0.0.0.drv-0
                 FLOX_SRC_DIR=$(pwd) FLOX_RUNTIME_DIR="$TMP" \
                   ${flox-env-package}/activate --env ${flox-env-package} --mode run --turbo -- \
-                    ${build-wrapper-env-package}/activate --env ${build-wrapper-env-package} --mode dev --turbo -- \
+                    ${build-wrapper-env-package}/wrapper --env ${build-wrapper-env-package} -- \
                       ${t3-package}/bin/t3 --relative $log -- bash -e ${buildScript-contents} || \
                 ( rm -rf $out && echo "flox build failed (caching build dir)" | tee $out 1>&2 )
               ''
@@ -260,7 +260,7 @@ pkgs.runCommandNoCC name
         # build wrapper environment over the "develop" environment.
         patchShebangs "$prog"
 
-        # Wrap contents of executables with ${build-wrapper-env-package}/activate
+        # Wrap contents of executables with ${build-wrapper-env-package}/wrapper
         if [ -L "$prog" ]; then
           : # You cannot wrap a symlink, so just leave it be?
         else
@@ -268,13 +268,12 @@ pkgs.runCommandNoCC name
           hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
           mv "$prog" "$hidden"
           # TODO: we shouldn't need to set FLOX_RUNTIME_DIR here
-          makeShellWrapper "${build-wrapper-env-package}/activate" "$prog" \
+          makeShellWrapper "${build-wrapper-env-package}/wrapper" "$prog" \
             --inherit-argv0 \
             --set FLOX_MANIFEST_BUILD_OUT "$out" \
             --set FLOX_RUNTIME_DIR "/tmp" \
             --run 'export FLOX_SET_ARG0="$0"' \
             --add-flags "--env ${build-wrapper-env-package}" \
-            --add-flags --turbo \
             --add-flags -- \
             --add-flags "$hidden"
         fi

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -247,7 +247,7 @@ define BUILD_local_template =
 	  $(if $(_virtualSandbox),$(PRELOAD_VARS) FLOX_SRC_DIR=$$$$($(_pwd)) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
 	  $(FLOX_INTERPRETER)/activate --env $(FLOX_ENV) --mode dev --turbo -- \
 	    $(_env) -i out=$(_out) $(foreach i,$(ALLOW_OUTER_ENV_VARS),$(i)="$$$$$(i)") \
-	      $(_build_wrapper_env)/activate --env $(_build_wrapper_env) --mode dev --turbo -- \
+	      $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) -- \
 	        $(_t3) $($(_pvarname)_logfile) -- $(_bash) -e $($(_pvarname)_buildScript)
 	$(_V_) $(_nix) build -L `$(_nix) store add-file "$(shell $(_realpath) "$($(_pvarname)_logfile)")"` \
 	  --out-link "result-$(_pname)-log"

--- a/pkgs/flox-activation-scripts/default.nix
+++ b/pkgs/flox-activation-scripts/default.nix
@@ -82,18 +82,9 @@ runCommandNoCC "flox-activation-scripts"
     chmod +x $out/activate.d/trace
     patchShebangs $out/activate.d/trace
 
-    # Next create the (lesser) "build_wrapper" output.
-    cp -R $out $build_wrapper
-
     # Replace __OUT__ with the output path for both outputs.
     substituteInPlace $out/activate --replace-fail "__OUT__" "$out"
-    substituteInPlace $build_wrapper/activate --replace-fail "__OUT__" "$build_wrapper"
 
-    # TODO: come up with neater way to master activate script for build_wrapper case.
-
-    # Remove start-services.bash.
-    rm $build_wrapper/activate.d/start-services.bash
-    sed -i 's/source ".*start-services.bash"/echo no services in build_wrapper script >\&2; false/' $build_wrapper/activate
 
     # That's the build done, now shellcheck the results.
     ${shellcheck}/bin/shellcheck --external-sources --check-sourced \
@@ -102,13 +93,8 @@ runCommandNoCC "flox-activation-scripts"
       $out/activate.d/generate-fish-startup-commands.bash \
       $out/activate.d/generate-tcsh-startup-commands.bash \
       $out/activate.d/set-prompt.bash \
-      $out/etc/profile.d/* \
-      $build_wrapper/activate \
-      $build_wrapper/activate.d/generate-bash-startup-commands.bash \
-      $build_wrapper/activate.d/generate-fish-startup-commands.bash \
-      $build_wrapper/activate.d/generate-tcsh-startup-commands.bash \
-      $build_wrapper/activate.d/set-prompt.bash \
-      $build_wrapper/etc/profile.d/*
+      $out/activate.d/source-profile-d.bash \
+      $out/etc/profile.d/*
 
     # Finally check the formatting of the scripts with shfmt. Only check
     # $out as the contents of $build_wrapper will be virtually identical.
@@ -116,4 +102,38 @@ runCommandNoCC "flox-activation-scripts"
     # This will only catch extensions and shebangs that `shfmt --find` knows about.
     ${shfmt}/bin/shfmt --diff $out
     rm $out/.editorconfig
+
+    # Remove the wrapper script from the output,
+    # we dont need that in environment interpreters.
+    rm $out/wrapper
+
+    # Next create the (lesser) "build_wrapper" output.
+    # TODO: come up with neater way to master activate script for build_wrapper case.
+
+    mkdir -p $build_wrapper
+    cp ${activation-scripts}/wrapper $build_wrapper/
+
+    # create activate.d directory and copy the required scripts
+    mkdir -p $build_wrapper/activate.d
+    cp ${activation-scripts}/activate.d/source-profile-d.bash $build_wrapper/activate.d/
+    cp ${activation-scripts}/activate.d/trace.bash $build_wrapper/activate.d/
+
+    # copy the etc/profile.d directory
+    cp -R ${activation-scripts}/etc $build_wrapper/
+
+    # make the wrapper and trace script executable
+    chmod +x $build_wrapper/wrapper
+    patchShebangs $build_wrapper/wrapper
+
+    mv $build_wrapper/activate.d/trace.bash $build_wrapper/activate.d/trace
+    chmod +x $build_wrapper/activate.d/trace
+    patchShebangs $build_wrapper/activate.d/trace
+
+    # Replace __OUT__ with the output path for both outputs.
+    substituteInPlace $build_wrapper/wrapper --replace-fail "__OUT__" "$build_wrapper"
+
+    ${shellcheck}/bin/shellcheck --external-sources --check-sourced \
+      $build_wrapper/wrapper \
+      $build_wrapper/activate.d/* \
+      $build_wrapper/etc/profile.d/*
   ''


### PR DESCRIPTION
## [feat(activation): add trimmed down wrapper script](https://github.com/flox/flox/commit/6b279500dbc0c5c492fc465ad8ec659b6933e7a6) 

The `wrapper` script is derived from `activate` by pruning off all functionality
not required for wrapping flox-built binaries,
e.g. shell hooks, or `profile.*` scripts from the manifest.
Further, wrapping binaries requires neither services (`process-compose`),
nor a watchdog and lifecycle management via `flox-activations`.

`wrapper` is to be executed in place of `activate --turbo (-- | -c)`,
which disables certain activate functionality _at runtime_.
`wrapper` drops those functions and with it related (unused) dependencies for a smaller closure.

## [refactor: use wrapper in builds and binary wrappers](https://github.com/flox/flox/commit/0057051dc0872f7e00fc2ac194cc45a9ce7ff497)

* Build the `build_wrapper` output of `flox-activation-scripts`[sic]
with the `wrapper` scripts in place of `activate`.
Since the `wrapper` script drops references to store paths of non-relevant dependencies
during builds and wrapping of binaries, the resulting output
has a slightly smaller closure due to the lack of `flox-activations`.

Before (flox v1.3.12):

```
$ nix path-info -r github:flox/flox/v1.3.12#flox-activation-scripts^build_wrapper
/nix/store/0w0hhy7rmn5xisasdr4v4p958x114sj1-bash-5.2p32
/nix/store/5sr3r043k7s49g13qisr8vpzsbyrglx6-getopt-1.1.6
/nix/store/8yjj9w5ay33pb741sr2mcfszmsvzbqaz-gnused-4.9
/nix/store/999knpijcj4iai9wmnd3xv3s6r9dlxfi-nawk-20240728
/nix/store/lzzd5jgybnpfj86xkcpnd54xgwc4m457-libcxx-16.0.6
/nix/store/bdgyka2y1xqc59jxqprgqf2xw8j7p675-gmp-with-cxx-6.3.0
/nix/store/b7j95xd7yccclshfln10k843q2qf20yg-coreutils-9.5
/nix/store/jnvmyc9kz3vdffs3axzd3zs6ia1lsx6h-libiconv-99
/nix/store/bmhzwrvlj10815zdba5cd637dbr44dkb-flox-activations-1.3.12
/nix/store/q8pjl22r3x66x6dlk8w36a7axjlyl3rn-findutils-4.10.0
/nix/store/siazqkqk57jr36ssqrybznh95px1q4ym-daemonize-1.7.8
/nix/store/jzwvhvc2rg18f4z7f91mwczkkygpi4ln-flox-activation-scripts-build_wrapper

$ nix path-info --closure-size --human-readable github:flox/flox/v1.3.12#flox-activation-scripts^build_wrapper
/nix/store/jzwvhvc2rg18f4z7f91mwczkkygpi4ln-flox-activation-scripts-build_wrapper         53.9 MiB
```

```
nix path-info --recursive .#flox-activation-scripts^build_wrapper
/nix/store/3x7yf0wxskaixyyzc3p5anp2x007jg8y-nawk-20240728
/nix/store/md8l82d1ggi4136ja9qdpg855z6wavip-libcxx-16.0.6
/nix/store/74cfw4h9hw6idrpqly7imp0pc636fa8q-gmp-with-cxx-6.3.0
/nix/store/dka6i6yj8sgws93wc6m0lmqzhk21kq87-libiconv-107
/nix/store/s2cn7m2bsjssjyhl0xpmzm867qjkcv85-coreutils-9.5
/nix/store/5n4nhq1ip73g686cxj78r9igmmzxnbdk-findutils-4.10.0
/nix/store/7dkrmf9gqhwl6cz766s26j3k4a6z0n00-bash-5.2p37
/nix/store/kjm8hdd1w7bhf5bksdnqzqv6f774q53x-getopt-1.1.6
/nix/store/d07aymh0vffxk06rjx77y9vk3gz4vlqb-flox-activation-scripts-build_wrapper

$ nix path-info --closure-size --human-readable .#flox-activation-scripts^build_wrapper
/nix/store/d07aymh0vffxk06rjx77y9vk3gz4vlqb-flox-activation-scripts-build_wrapper         52.8 MiB
```

Note, that this is on macos where more than 90% of this correspond to `libiconv`,
which is generally an input to almost anything.

* Explicitly list included scripts, rather than deleting from the `out` output.

* refactor(package-builder): replace occurrences of `activate` where `activate` was used in wrapper/`--turbo` mode
  with calls to `wrapper` instead.
