### PR TITLE
fix: restore previous installation package conflict error message

### DIFF
--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -740,12 +740,14 @@ if ($manifest) {
         my $references = shift @_;
         my $pkg = shift @_;
         my @retarray = ( $pkg );
-        if (defined $references->{$pkg} and not defined $seen{$pkg}) {
-            foreach my $reference (@{$references->{$pkg}}) {
-                next if $reference eq $pkg;
-                push @retarray, walkReferences($references, $reference);
+        if (defined $references->{$pkg}) {
+            if (not defined $seen{$pkg}) {
+                foreach my $reference (@{$references->{$pkg}}) {
+                    next if $reference eq $pkg;
+                    push @retarray, walkReferences($references, $reference);
+                }
+                $seen{$pkg} = 1;
             }
-            $seen{$pkg} = 1;
         } else {
             warn "references for package $pkg not found\n";
         }

--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -12,8 +12,8 @@ use Time::HiRes qw( gettimeofday tv_interval );
 
 STDOUT->autoflush(1);
 
-$SIG{__WARN__} = sub { warn "warning: ", @_ };
-$SIG{__DIE__}  = sub { die "error: ", @_ };
+$SIG{__WARN__} = sub { warn "⚠️ WARNING: ", @_ };
+$SIG{__DIE__}  = sub { die "❌ ERROR: ", @_ };
 
 # <flox>
 # Set required ENV variables to avoid warnings.
@@ -96,7 +96,7 @@ sub findFilesInDir {
     my @names = readdir DIR or die;
     closedir DIR;
 
-    foreach my $name (@names) {
+    foreach my $name (sort @names) {
         next if $name eq "." || $name eq "..";
         findFiles("$relName/$name", "$target/$name", $name, $ignoreCollisions, $checkCollisionContents, $priority);
     }
@@ -125,6 +125,31 @@ sub checkCollision {
 sub prependDangling {
     my $path = shift;
     return (-l $path && ! -e $path ? "dangling symlink " : "") . "`$path'";
+}
+
+# Parses a /nix/store/<checksum>-<name>-<version>/<basename> path and
+# returns its constituent (name, version, basename) parts.
+sub parseStorePath($) {
+    my $path = shift;
+    # Split the path into its components.
+    my @path = split "/", $path;
+    # Removes the "/nix/store/<checksum>-<name>-<version>" part.
+    my $storePath = join "/", (splice @path, 0, 4);
+    # Verify that the path prefix is the expected store path.
+    die "not a store path: $storePath" unless isStorePath $storePath;
+    # Discard the checksum part of $path[3] to identify the package name
+    # and version.
+    my ($checksum, $pkgName) = split /-/, basename($storePath), 2;
+    die "invalid checksum '$checksum' in store path: $storePath"
+        unless length($checksum) == 32;
+    # Split the package name from its version by splitting on
+    # the first instance of "-" followed by a number.
+    my @pkgParts = split /-(?=\d)/, $pkgName;
+    # Assign and return all elements of the tuple.
+    my $name = shift @pkgParts;
+    my $version = shift @pkgParts;
+    my $basename = join "/", @path;
+    return ($name, $version, $basename);
 }
 
 sub findFiles {
@@ -197,7 +222,21 @@ sub findFiles {
         } elsif ($checkCollisionContents && checkCollision($oldTarget, $target)) {
             return;
         } else {
-            die "collision between $targetRef and $oldTargetRef\n";
+            # Improve upon the default collision message from upstream.
+            my ($targetName, $targetVersion, $targetBasename) = parseStorePath($target);
+            my ($oldTargetName, $oldTargetVersion, $oldTargetBasename) = parseStorePath($oldTarget);
+            my $origPriority = $oldPriority / 1000; # Convert to original priority value
+            my $errmsg = "'$oldTargetName' conflicts with '$targetName'. ";
+            if ($targetBasename eq $oldTargetBasename) {
+                $errmsg .= "Both packages provide the file '$targetBasename'";
+            } else {
+                # This is unexpected ... revert to reporting the exact refs encountered.
+                $errmsg .= "collision between $targetRef and $oldTargetRef";
+            }
+            die $errmsg . "\n\n" .
+                "Resolve by uninstalling one of the conflicting packages or " .
+                "setting the priority of the preferred package to a value " .
+                "lower than '$origPriority'\n";
         }
     }
 
@@ -562,6 +601,17 @@ if ($manifest) {
         return \@outputData;
     }
 
+    # Subroutine for stable sorting of store paths by package name,
+    # version, and basename.
+    sub byPackageName {
+        my ($aName, $aVersion, $aBasename) = parseStorePath($a);
+        my ($bName, $bVersion, $bBasename) = parseStorePath($b);
+        return ( 8 * ($aName cmp $bName) ) +
+               ( 4 * ($aVersion cmp $bVersion) ) +
+               ( 2 * ($aBasename cmp $bBasename) ) +
+               ( 1 * ($a cmp $b) );
+    }
+
     sub buildEnv($$$$) {
         my $envName = shift;
         my $requisites = shift;
@@ -574,7 +624,7 @@ if ($manifest) {
         # Symlink to the packages that have been installed explicitly by the
         # user.
         for my $pkg (@{$pkgs}) {
-            for my $path (@{$pkg->{paths}}) {
+            for my $path (sort byPackageName @{$pkg->{paths}}) {
                 addPkg($path,
                        $ENV{"ignoreCollisions"} eq "1",
                        $ENV{"checkCollisionContents"} eq "1",
@@ -591,7 +641,7 @@ if ($manifest) {
         while (scalar(keys %postponed) > 0) {
             my @pkgDirs = keys %postponed;
             %postponed = ();
-            foreach my $pkgDir (sort @pkgDirs) {
+            foreach my $pkgDir (sort byPackageName @pkgDirs) {
                 addPkg($pkgDir, 2, $ENV{"checkCollisionContents"} eq "1", $priorityCounter++);
             }
         }

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1333,8 +1333,6 @@ mod buildenv_tests {
     use std::collections::HashSet;
     use std::os::unix::fs::PermissionsExt;
 
-    use regex::Regex;
-
     use super::*;
     use crate::providers::catalog::{MockClient, GENERATED_DATA, MANUALLY_GENERATED};
 
@@ -1466,13 +1464,14 @@ mod buildenv_tests {
             panic!("expected build to fail, got {}", err);
         };
 
-        let output_matches = Regex::new("error: collision between .*-vim-.* and .*-vim-.*")
-            .unwrap()
-            .is_match(&output);
+        let expected =
+            "> ❌ ERROR: 'vim' conflicts with 'vim-full'. Both packages provide the file 'bin/ex'";
 
         assert!(
-            output_matches,
-            "expected output to contain a conflict message: {output}"
+            output.contains(expected),
+            "expected output to contain a conflict message:\n\
+            actual: {output}\n\
+            expected: {expected}"
         );
     }
 
@@ -1578,7 +1577,14 @@ mod buildenv_tests {
             panic!("expected build to fail, got {}", err);
         };
 
-        assert!(output.contains("error: package 'vim' is not in 'toplevel' pkg-group"));
+        let expected = "❌ ERROR: package 'vim' is not in 'toplevel' pkg-group";
+
+        assert!(
+            output.contains(expected),
+            "expected output to contain an error message\n\
+            actual: {output}\n\
+            expected: {expected}"
+        );
     }
 
     #[test]
@@ -1593,7 +1599,13 @@ mod buildenv_tests {
             panic!("expected build to fail, got {}", err);
         };
 
-        assert!(output
-            .contains("error: package 'goodbye' not found in '[install]' section of manifest"));
+        let expected = "❌ ERROR: package 'goodbye' not found in '[install]' section of manifest";
+
+        assert!(
+            output.contains(expected),
+            "expected output to contain an error message\n\
+            actual: {output}\n\
+            expected: {expected}"
+        );
     }
 }


### PR DESCRIPTION
## Proposed Changes

This patch restores the flox custom error message that existed before the introduction of buildenv.nix:

> ❌ ERROR: 'bar' conflicts with 'foo'. Both packages provide the file 'bin/hello'

It also updates the error and warning handlers respectively to more closely resemble their rust counterparts.

Closes #2619

## Release Notes

* fixed regression in error message displayed when attempting to install package conflicts