### PR TITLE
refactor(activate): Remove dupe FLOX_PROMPT_COLOR_

### DIFF
--- a/assets/activation-scripts/activate
+++ b/assets/activation-scripts/activate
@@ -55,6 +55,7 @@ source "${_activate_d}/generate-tcsh-startup-commands.bash"
 # in particular does not tolerate references to undefined variables.
 export FLOX_PROMPT_ENVIRONMENTS="${FLOX_PROMPT_ENVIRONMENTS:-}"
 export _FLOX_SET_PROMPT="${_FLOX_SET_PROMPT:-true}"
+# https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
 export FLOX_PROMPT_COLOR_1="${FLOX_PROMPT_COLOR_1:-99}"
 export FLOX_PROMPT_COLOR_2="${FLOX_PROMPT_COLOR_2:-141}"
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -48,7 +48,7 @@ use crate::commands::{ensure_environment_trust, EnvironmentSelectError};
 use crate::config::{Config, EnvironmentPromptConfig};
 use crate::utils::openers::Shell;
 use crate::utils::{default_nix_env_vars, message};
-use crate::{environment_subcommand_metric, subcommand_metric, utils};
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 pub static INTERACTIVE_BASH_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
     PathBuf::from(
@@ -311,11 +311,6 @@ impl Activate {
         let flox_prompt_environments =
             Self::make_prompt_environments(hide_default_prompt, &flox_active_environments);
 
-        let prompt_color_1 = env::var("FLOX_PROMPT_COLOR_1")
-            .unwrap_or(utils::colors::INDIGO_400.to_ansi256().to_string());
-        let prompt_color_2 = env::var("FLOX_PROMPT_COLOR_2")
-            .unwrap_or(utils::colors::INDIGO_300.to_ansi256().to_string());
-
         let mut exports = HashMap::from([
             (FLOX_ENV_VAR, mode_link_path.to_string_lossy().to_string()),
             (
@@ -334,8 +329,6 @@ impl Activate {
                 FLOX_ENV_PROJECT_VAR,
                 environment.project_path()?.to_string_lossy().to_string(),
             ),
-            ("FLOX_PROMPT_COLOR_1", prompt_color_1),
-            ("FLOX_PROMPT_COLOR_2", prompt_color_2),
             // Set `FLOX_PROMPT_ENVIRONMENTS` to the constructed prompt string,
             // which may be ""
             (FLOX_PROMPT_ENVIRONMENTS_VAR, flox_prompt_environments),

--- a/cli/flox/src/utils/colors.rs
+++ b/cli/flox/src/utils/colors.rs
@@ -85,10 +85,6 @@ pub struct FloxColor {
 }
 
 impl FloxColor {
-    pub fn to_ansi256(&self) -> u8 {
-        self.ansi256
-    }
-
     #[allow(dead_code)] // todo: discuss how/where to integrate colors
     pub fn to_crossterm(&self) -> Option<crossterm::style::Color> {
         match supports_color::on(supports_color::Stream::Stderr) {
@@ -129,12 +125,14 @@ impl FloxColor {
     }
 }
 
+/// Should match the defaults in `activation-scripts`.
 pub const INDIGO_300: FloxColor = FloxColor {
     ansi256: 141,
     rgb: (175, 135, 255),
     basic: BasicColor::DarkYellow,
 };
 
+/// Should match the defaults in `activation-scripts`.
 pub const INDIGO_400: FloxColor = FloxColor {
     ansi256: 99,
     rgb: (135, 95, 255),

--- a/cli/flox/src/utils/colors.rs
+++ b/cli/flox/src/utils/colors.rs
@@ -26,34 +26,7 @@ pub enum BasicColor {
 }
 
 impl BasicColor {
-    /// Create crossterm compatible types
-    #[allow(dead_code)] // todo: discuss how/where to integrate colors
-    pub fn to_crossterm(&self) -> crossterm::style::Color {
-        match self {
-            BasicColor::Black => crossterm::style::Color::Black,
-            BasicColor::DarkRed => crossterm::style::Color::DarkRed,
-            BasicColor::DarkGreen => crossterm::style::Color::DarkGreen,
-            BasicColor::DarkYellow => crossterm::style::Color::DarkYellow,
-            BasicColor::DarkBlue => crossterm::style::Color::DarkBlue,
-            BasicColor::DarkMagenta => crossterm::style::Color::DarkMagenta,
-            BasicColor::DarkCyan => crossterm::style::Color::DarkCyan,
-            BasicColor::Grey => crossterm::style::Color::Grey,
-
-            BasicColor::DarkGrey => crossterm::style::Color::DarkGrey,
-
-            BasicColor::Red => crossterm::style::Color::Red,
-            BasicColor::Green => crossterm::style::Color::Green,
-            BasicColor::Yellow => crossterm::style::Color::Yellow,
-            BasicColor::Blue => crossterm::style::Color::Blue,
-            BasicColor::Magenta => crossterm::style::Color::Magenta,
-            BasicColor::Cyan => crossterm::style::Color::Cyan,
-            BasicColor::White => crossterm::style::Color::White,
-        }
-    }
-
     /// Create inquire compatible types
-    ///
-    /// Basically the same as `.to_crossterm()`, except that "light" colors are prefixed
     pub fn to_inquire(&self) -> inquire::ui::Color {
         match self {
             BasicColor::Black => inquire::ui::Color::Black,
@@ -85,26 +58,6 @@ pub struct FloxColor {
 }
 
 impl FloxColor {
-    #[allow(dead_code)] // todo: discuss how/where to integrate colors
-    pub fn to_crossterm(&self) -> Option<crossterm::style::Color> {
-        match supports_color::on(supports_color::Stream::Stderr) {
-            Some(supports_color::ColorLevel { has_16m: true, .. }) => {
-                Some(crossterm::style::Color::Rgb {
-                    r: self.rgb.0,
-                    g: self.rgb.1,
-                    b: self.rgb.2,
-                })
-            },
-            Some(supports_color::ColorLevel { has_256: true, .. }) => {
-                Some(crossterm::style::Color::AnsiValue(self.ansi256))
-            },
-            Some(supports_color::ColorLevel {
-                has_basic: true, ..
-            }) => Some(self.basic.to_crossterm()),
-            _ => None,
-        }
-    }
-
     pub fn to_inquire(&self) -> Option<inquire::ui::Color> {
         match supports_color::on(supports_color::Stream::Stderr) {
             Some(supports_color::ColorLevel { has_16m: true, .. }) => {

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -152,8 +152,6 @@ let
         Env = mapAttrsToList (name: value: "${name}=${value}") {
           "FLOX_ENV" = environment;
           "FLOX_PROMPT_ENVIRONMENTS" = "floxenv";
-          "FLOX_PROMPT_COLOR_1" = "99";
-          "FLOX_PROMPT_COLOR_2" = "141";
           "_FLOX_ACTIVE_ENVIRONMENTS" = "[]";
           "FLOX_SOURCED_FROM_SHELL_RC" = "1"; # don't source from shell rc (again)
           "_FLOX_FORCE_INTERACTIVE" = "1"; # Required when running podman without "-t"


### PR DESCRIPTION
## Proposed Changes

**refactor(activate): Remove dupe FLOX_PROMPT_COLOR_**

We have the defaults for these in three places and pass along
environment variables when we could just rely on `activations-scripts`
setting a default if there is no user-provided value.

**refactor(utils): Remove color to_crossterm**

We stopped using these in 5539831.

## Release Notes

N/A, refactor without any functional change.