### PR TITLE
fix(gc): Allow floxmeta branches to not exist

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1639,7 +1639,11 @@ mod test {
 
     use super::*;
     use crate::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
-    use crate::models::env_registry::{env_registry_path, read_environment_registry};
+    use crate::models::env_registry::{
+        env_registry_path,
+        garbage_collect,
+        read_environment_registry,
+    };
     use crate::models::environment::test_helpers::{
         new_core_environment,
         new_core_environment_with_lockfile,
@@ -2630,7 +2634,7 @@ mod test {
     }
 
     #[test]
-    fn prunes_branches_on_delete() {
+    fn gc_prunes_floxmeta_branches() {
         let (flox, _temp_dir_handle) = flox_instance();
 
         let env1_dir = flox.temp_dir.join("env1");
@@ -2676,20 +2680,25 @@ mod test {
         )
         .unwrap();
 
+        // All branches should exist.
         assert!(floxmeta.git.has_branch(&remote_branch).unwrap());
         assert!(floxmeta.git.has_branch(&env1_branch).unwrap());
         assert!(floxmeta.git.has_branch(&env2_branch).unwrap());
 
-        env2.delete(&flox).unwrap();
-
-        // Only env2 should be pruned.
+        // env2 is pruned when no longer on disk.
+        fs::remove_dir_all(&env2.path).unwrap();
+        garbage_collect(&flox).unwrap();
         assert!(floxmeta.git.has_branch(&remote_branch).unwrap());
         assert!(floxmeta.git.has_branch(&env1_branch).unwrap());
         assert!(!floxmeta.git.has_branch(&env2_branch).unwrap());
 
-        env1.delete(&flox).unwrap();
-
-        // All branches should be pruned.
+        // env1 is pruned when no longer on disk, remote is pruned when there
+        // are no local branches, and is resilient to the branch not existing,
+        // e.g. if the floxmeta repo has been manually deleted or the hashing
+        // algorithm has changed in the past.
+        fs::remove_dir_all(&env1.path).unwrap();
+        floxmeta.git.delete_branch(&env1_branch, true).unwrap();
+        garbage_collect(&flox).unwrap();
         assert!(!floxmeta.git.has_branch(&remote_branch).unwrap());
         assert!(!floxmeta.git.has_branch(&env1_branch).unwrap());
         assert!(!floxmeta.git.has_branch(&env2_branch).unwrap());

--- a/cli/flox-rust-sdk/src/models/floxmeta.rs
+++ b/cli/flox-rust-sdk/src/models/floxmeta.rs
@@ -181,32 +181,43 @@ impl FloxMeta {
     }
 
     /// Prune the local branch for a deleted environment. If there are no more
-    /// local branches, then also prune the remote branch.
+    /// local branches, then also prune the remote branch. Already absent
+    /// branches are not treated as errors.
     pub fn prune_branches(
         &self,
         pointer: &ManagedPointer,
         dot_flox_path: &CanonicalPath,
     ) -> Result<(), FloxMetaError> {
-        self.git
-            .delete_branch(&branch_name(pointer, dot_flox_path), true)
-            .map_err(FloxMetaError::DeleteBranch)?;
-
-        let branch_prefix = pointer.name.to_string();
-        let branches = self
+        let branch_names = self
             .git
             .list_branches()
-            .map_err(FloxMetaError::ListBranch)?;
-        let branches_for_other_paths = branches.iter().any(|branch| {
-            match branch.name.rsplit_once(BRANCH_NAME_PATH_SEPARATOR) {
-                Some((prefix, _)) => prefix == branch_prefix,
-                _ => false,
-            }
-        });
+            .map_err(FloxMetaError::ListBranch)?
+            .iter()
+            .map(|branch| branch.name.clone())
+            .collect::<Vec<_>>();
 
-        if !branches_for_other_paths {
+        let local_branch = branch_name(pointer, dot_flox_path);
+        if branch_names.contains(&local_branch) {
             self.git
-                .delete_branch(&remote_branch_name(pointer), true)
+                .delete_branch(&local_branch, true)
                 .map_err(FloxMetaError::DeleteBranch)?;
+        }
+
+        let remote_branch = remote_branch_name(pointer);
+        if branch_names.contains(&remote_branch) {
+            let branch_prefix = pointer.name.to_string();
+            let branches_for_other_paths = branch_names.iter().any(|name| {
+                match name.rsplit_once(BRANCH_NAME_PATH_SEPARATOR) {
+                    Some((prefix, _)) => prefix == branch_prefix,
+                    _ => false,
+                }
+            });
+
+            if !branches_for_other_paths {
+                self.git
+                    .delete_branch(&remote_branch_name(pointer), true)
+                    .map_err(FloxMetaError::DeleteBranch)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Proposed Changes

Be resilient to floxmeta branches not existing when pruning. To fix an error seen by Stahnke; we haven't debugged the particular case, but it's plausible to happen if the floxmeta repo has ever been manually deleted:

    > flox gc
    ❌ ERROR: Failed to delete branch: Git failed with: [exit code 1]
      stdout:
      stderr: error: branch 'default.cf7e1b06' not found

I originally started to implement the error handling higher up in `EnvRegistry::prune_nonexistent` but changed my mind because:

1. It would still leave `flox delete` open to potential errors when deleting remote branches for managed environments.
2. A branch not existing is the same intent as the branch being deleted, so long as we surface any git errors from `list_branches` early on.
3. Leaving stray branches in floxmeta isn't the worst thing, compared to leaving environments registered and unable to GC from the store.

Tests have been adjusted to use utilise more of the GC code-path as suggested in a previous PR review and to forcibly delete one of the branches before GCing.

I considered adding more logging to diagnose failures in the future but we already get plenty from the underlying providers:

    % flox pull --quiet -d ~/tmp2 dcarley/tailscale; rm -rf ~/tmp2; flox gc -vv
    2025-02-19T11:38:27.339239Z DEBUG flox::config: reading raw config (initialized: false, reload: false)
    2025-02-19T11:38:27.339298Z DEBUG flox::config: `$FLOX_CONFIG_DIR` set: /Users/dcarley/dotfiles/.config/flox
    2025-02-19T11:38:27.340259Z DEBUG flox: set _FLOX_PKGDB_VERBOSITY=2
    2025-02-19T11:38:27.341205Z DEBUG flox::config: reading raw config (initialized: true, reload: false)
    2025-02-19T11:38:27.341834Z DEBUG flox::commands: Skipping update check in development mode
    2025-02-19T11:38:27.341984Z DEBUG flox::commands: Metrics collection disabled
    2025-02-19T11:38:27.342089Z DEBUG flox::utils::init::catalog_client: using catalog client with url: https://api.flox.dev
    2025-02-19T11:38:27.345110Z DEBUG flox::utils::init::metrics: Attempting to read own UUID from file
    2025-02-19T11:38:27.345182Z DEBUG flox::commands: features enabled, build=true, publish=true, upload=false, compose=false
    2025-02-19T11:38:27.345690Z DEBUG handle{progress="Garbage collecting unused environment data"}:open{pointer=ManagedPointer { owner: EnvironmentOwner("dcarley"), name: EnvironmentName("tailscale"), floxhub_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } } progress="Updating environment metadata for dcarley/tailscale"}: flox_rust_sdk::models::floxmeta: no FloxHub token configured
    2025-02-19T11:38:27.345742Z DEBUG handle{progress="Garbage collecting unused environment data"}:open{pointer=ManagedPointer { owner: EnvironmentOwner("dcarley"), name: EnvironmentName("tailscale"), floxhub_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } } progress="Updating environment metadata for dcarley/tailscale"}: flox_rust_sdk::providers::git: attempting to open repo: path=/Users/dcarley/.local/share/flox/meta/dcarley
    2025-02-19T11:38:27.345784Z DEBUG handle{progress="Garbage collecting unused environment data"}:open{pointer=ManagedPointer { owner: EnvironmentOwner("dcarley"), name: EnvironmentName("tailscale"), floxhub_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } } progress="Updating environment metadata for dcarley/tailscale"}: flox_rust_sdk::providers::git: running git command: /nix/store/bng0gq0gs3kk7lmjfz6lby5v0cbi3d9k-git-minimal-2.47.0/bin/git -C /Users/dcarley/.local/share/flox/meta/dcarley rev-parse --is-bare-repository
    2025-02-19T11:38:27.349185Z DEBUG handle{progress="Garbage collecting unused environment data"}:open{pointer=ManagedPointer { owner: EnvironmentOwner("dcarley"), name: EnvironmentName("tailscale"), floxhub_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } } progress="Updating environment metadata for dcarley/tailscale"}: flox_rust_sdk::providers::git: determining path to git repo
    2025-02-19T11:38:27.349259Z DEBUG handle{progress="Garbage collecting unused environment data"}:open{pointer=ManagedPointer { owner: EnvironmentOwner("dcarley"), name: EnvironmentName("tailscale"), floxhub_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } } progress="Updating environment metadata for dcarley/tailscale"}: flox_rust_sdk::providers::git: running git command: env FLOX_FLOXHUB_TOKEN='' GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null /nix/store/bng0gq0gs3kk7lmjfz6lby5v0cbi3d9k-git-minimal-2.47.0/bin/git -c 'credential.https://api.flox.dev/git.helper='\!'f(){ echo "username=oauth"; echo "password=$FLOX_FLOXHUB_TOKEN"; }; f' -c 'remote.dynamicorigin.url=https://api.flox.dev/git/dcarley/floxmeta' -c 'user.email=floxuser@example.invalid' -c 'user.name=Flox User' -C /Users/dcarley/.local/share/flox/meta/dcarley rev-parse --absolute-git-dir
    2025-02-19T11:38:27.352679Z DEBUG handle{progress="Garbage collecting unused environment data"}:open{pointer=ManagedPointer { owner: EnvironmentOwner("dcarley"), name: EnvironmentName("tailscale"), floxhub_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } } progress="Updating environment metadata for dcarley/tailscale"}: flox_rust_sdk::providers::git: got non-canonical path: path=/Users/dcarley/.local/share/flox/meta/dcarley
    2025-02-19T11:38:27.352764Z DEBUG handle{progress="Garbage collecting unused environment data"}:open{pointer=ManagedPointer { owner: EnvironmentOwner("dcarley"), name: EnvironmentName("tailscale"), floxhub_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } } progress="Updating environment metadata for dcarley/tailscale"}: flox_rust_sdk::providers::git: canonicalized path: path=/Users/dcarley/.local/share/flox/meta/dcarley
    2025-02-19T11:38:27.352810Z DEBUG handle{progress="Garbage collecting unused environment data"}:open{pointer=ManagedPointer { owner: EnvironmentOwner("dcarley"), name: EnvironmentName("tailscale"), floxhub_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } } progress="Updating environment metadata for dcarley/tailscale"}: flox_rust_sdk::providers::git: running git command: env FLOX_FLOXHUB_TOKEN='' GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null /nix/store/bng0gq0gs3kk7lmjfz6lby5v0cbi3d9k-git-minimal-2.47.0/bin/git -c 'credential.https://api.flox.dev/git.helper='\!'f(){ echo "username=oauth"; echo "password=$FLOX_FLOXHUB_TOKEN"; }; f' -c 'remote.dynamicorigin.url=https://api.flox.dev/git/dcarley/floxmeta' -c 'user.email=floxuser@example.invalid' -c 'user.name=Flox User' -C /Users/dcarley/.local/share/flox/meta/dcarley show-ref --hash refs/heads/tailscale
    2025-02-19T11:38:27.357409Z DEBUG handle{progress="Garbage collecting unused environment data"}: flox_rust_sdk::providers::git: running git command: env FLOX_FLOXHUB_TOKEN='' GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null /nix/store/bng0gq0gs3kk7lmjfz6lby5v0cbi3d9k-git-minimal-2.47.0/bin/git -c 'credential.https://api.flox.dev/git.helper='\!'f(){ echo "username=oauth"; echo "password=$FLOX_FLOXHUB_TOKEN"; }; f' -c 'remote.dynamicorigin.url=https://api.flox.dev/git/dcarley/floxmeta' -c 'user.email=floxuser@example.invalid' -c 'user.name=Flox User' -C /Users/dcarley/.local/share/flox/meta/dcarley branch --all --verbose
    2025-02-19T11:38:27.363852Z DEBUG handle{progress="Garbage collecting unused environment data"}: flox_rust_sdk::providers::git: running git command: env FLOX_FLOXHUB_TOKEN='' GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null /nix/store/bng0gq0gs3kk7lmjfz6lby5v0cbi3d9k-git-minimal-2.47.0/bin/git -c 'credential.https://api.flox.dev/git.helper='\!'f(){ echo "username=oauth"; echo "password=$FLOX_FLOXHUB_TOKEN"; }; f' -c 'remote.dynamicorigin.url=https://api.flox.dev/git/dcarley/floxmeta' -c 'user.email=floxuser@example.invalid' -c 'user.name=Flox User' -C /Users/dcarley/.local/share/flox/meta/dcarley branch --delete --force tailscale.419a7cb1
    ✅ Garbage collection complete
    2025-02-19T11:38:27.368963Z DEBUG flox::utils::metrics: No metrics client setup, skipping flush

## Release Notes

We probably shouldn't announce GC until after https://github.com/flox/flox/issues/2685