### PR TITLE
chore(containerize): Disable tests aarch64-darwin

### DIFF
--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -250,6 +250,10 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:default-to-file
 @test "container is written to a runtime by default" {
+  if ! is_linux; then
+    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
+  fi
+
   env_setup_catalog
 
   # Check that podman is installed
@@ -272,6 +276,10 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:container-tag
 @test "container is tagged with specified tag" {
+  if ! is_linux; then
+    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
+  fi
+
   env_setup_catalog
 
   # Check that podman is installed
@@ -284,6 +292,10 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:piped-to-runtime
 @test "container is written to runtime when '--runtime <runtime>' is passed" {
+  if ! is_linux; then
+    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
+  fi
+
   env_setup_catalog
 
   run bash -c '"$FLOX_BIN" containerize --tag "runtime" --runtime podman' 3>&-
@@ -331,6 +343,10 @@ function assert_container_output() {
 
 # bats test_tags=containerize:run-container-i
 @test "container can be run with 'podman run' with/without -i'" {
+  if ! is_linux; then
+    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
+  fi
+
   env_setup_catalog
 
   # Also tests writing to STDOUT with `-f -`
@@ -393,6 +409,10 @@ EOF
 }
 
 @test "cmd can run binary from activated environment" {
+  if ! is_linux; then
+    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
+  fi
+
   "$FLOX_BIN" init
 
   MANIFEST_CONTENTS="$(cat << "EOF"


### PR DESCRIPTION
## Proposed Changes

These are failing very frequently at the moment, which is slowing down work on other tickets, and isn't helping us understand or fix the underlying problem any quicker. We've prioritised the ticket (https://github.com/flox/flox/issues/2743) for this coming sprint so temporarily disable the tests in the meantime.

## Release Notes

N/A