### PR TITLE
feat(services): format status JSON output as an array, not JSON lines

### DIFF
--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -87,10 +87,8 @@ impl Status {
         }?;
 
         if self.json {
-            for proc in process_states_display {
-                let line = serde_json::to_string(&proc)?;
-                println!("{line}");
-            }
+            let json_array = serde_json::to_string(&process_states_display)?;
+            println!("{json_array}");
         } else {
             println!("{process_states_display}");
         }
@@ -221,8 +219,6 @@ impl Display for ProcessStatesDisplay {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
     use flox_rust_sdk::providers::services::test_helpers::{
         generate_completed_process_state,
         generate_process_state,
@@ -302,23 +298,17 @@ mod tests {
     }
 
     #[test]
-    fn test_processstatedisplay_json_lines() {
+    fn test_processstatesdisplay_json_array() {
         let states = ProcessStates::from(vec![
             generate_process_state("aaa", "Running", 123, true),
             generate_stopped_process_state("bbb", 456),
             generate_completed_process_state("ccc", 789, 0),
         ]);
         let states_display: ProcessStatesDisplay = states.into();
-        let mut buffer = Vec::new();
-        for proc in states_display {
-            let line = serde_json::to_string(&proc).unwrap();
-            writeln!(buffer, "{line}").unwrap();
-        }
-        let buffer_str = String::from_utf8(buffer).unwrap();
-        assert_eq!(buffer_str, indoc! {r#"
-            {"name":"aaa","status":"Running","pid":123,"exit_code":null}
-            {"name":"bbb","status":"Stopped","pid":456,"exit_code":null}
-            {"name":"ccc","status":"Completed","pid":789,"exit_code":0}
-        "#});
+        let json_array = serde_json::to_string(&states_display).unwrap();
+        assert_eq!(
+            json_array,
+            r#"[{"name":"aaa","status":"Running","pid":123,"exit_code":null},{"name":"bbb","status":"Stopped","pid":456,"exit_code":null},{"name":"ccc","status":"Completed","pid":789,"exit_code":0}]"#
+        );
     }
 }

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -87,7 +87,7 @@ impl Status {
         }?;
 
         if self.json {
-            let json_array = serde_json::to_string(&process_states_display)?;
+            let json_array = serde_json::to_string_pretty(&process_states_display)?;
             println!("{json_array}");
         } else {
             println!("{process_states_display}");
@@ -305,10 +305,26 @@ mod tests {
             generate_completed_process_state("ccc", 789, 0),
         ]);
         let states_display: ProcessStatesDisplay = states.into();
-        let json_array = serde_json::to_string(&states_display).unwrap();
-        assert_eq!(
-            json_array,
-            r#"[{"name":"aaa","status":"Running","pid":123,"exit_code":null},{"name":"bbb","status":"Stopped","pid":456,"exit_code":null},{"name":"ccc","status":"Completed","pid":789,"exit_code":0}]"#
-        );
+        let json_array = serde_json::to_string_pretty(&states_display).unwrap();
+        assert_eq!(json_array, indoc! {r#"[
+              {
+                "name": "aaa",
+                "status": "Running",
+                "pid": 123,
+                "exit_code": null
+              },
+              {
+                "name": "bbb",
+                "status": "Stopped",
+                "pid": 456,
+                "exit_code": null
+              },
+              {
+                "name": "ccc",
+                "status": "Completed",
+                "pid": 789,
+                "exit_code": 0
+              }
+            ]"#});
     }
 }

--- a/cli/tests/services/wait_for_service_status.sh
+++ b/cli/tests/services/wait_for_service_status.sh
@@ -15,7 +15,7 @@ check_status() {
     for status in "${name_status_pairs[@]}"; do
         service_name=$(echo $status | cut -d':' -f1)
         expected_status=$(echo $status | cut -d':' -f2)
-        current_status=$(echo "$status_output" | jq --slurp --raw-output ".[] | select(.name==\"$service_name\") | .status")
+        current_status=$(echo "$status_output" | jq --raw-output ".[] | select(.name==\"$service_name\") | .status")
 
         if [ "$current_status" != "$expected_status" ]; then
             echo "Service '$service_name' status current=$current_status, expected=$expected_status"


### PR DESCRIPTION
## Proposed Changes

Closes #2597 

This formats the output of `flox services status --json` as a JSON array instead of as JSON lines. This is more consistent with JSON output elsewhere in the CLI, per discussion in this comment and elsewhere: https://github.com/flox/flox/issues/2597#issuecomment-2610807555.

## Release Notes

- The output of `flox services status --json` is now a JSON array instead of JSON lines
