### PR TITLE
fix: spaces in PATH for fish shell

### DIFF
--- a/assets/activation-scripts/activate.d/generate-fish-startup-commands.bash
+++ b/assets/activation-scripts/activate.d/generate-fish-startup-commands.bash
@@ -46,8 +46,14 @@ generate_fish_startup_commands() {
 
   # We already customized the PATH and MANPATH, but the user and system
   # dotfiles may have changed them, so finish by doing this again.
+
   echo "$_flox_activations set-env-dirs --shell fish --flox-env $FLOX_ENV --env-dirs ${FLOX_ENV_DIRS:-} | source;"
-  echo "$_flox_activations fix-paths --shell fish --env-dirs $FLOX_ENV_DIRS --path $PATH --manpath ${MANPATH:-} | source;"
+
+  # fish doesn't have {foo:-} syntax, so we need to provide a temporary variable
+  # (manpath_with_default) that is either the runtime (not generation-time) MANPATH
+  # or the empty string.
+  echo "set manpath_with_default (if set -q MANPATH; echo \"\$MANPATH\"; else; echo ""; end);"
+  echo "$_flox_activations fix-paths --shell fish --env-dirs $FLOX_ENV_DIRS --path \"\$PATH\" --manpath \"\$manpath_with_default\" | source;"
 
   # Iterate over $FLOX_ENV_DIRS in reverse order and
   # source user-specified profile scripts if they exist.

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2107,7 +2107,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:paths_spaces,activate:paths_spaces:bash
-@test "bash: tolerates paths containing spaces" {
+@test "bash: tolerates env paths containing spaces" {
   project_setup # TODO: we need PROJECT_DIR, but not flox init
   bad_dir="contains space/project"
   mkdir -p "$PWD/$bad_dir"
@@ -2119,7 +2119,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:paths_spaces,activate:paths_spaces:fish
-@test "fish: tolerates paths containing spaces" {
+@test "fish: tolerates env paths containing spaces" {
   project_setup # TODO: we need PROJECT_DIR, but not flox init
   bad_dir="contains space/project"
   mkdir -p "$PWD/$bad_dir"
@@ -2131,7 +2131,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:paths_spaces,activate:paths_spaces:tcsh
-@test "tcsh: tolerates paths containing spaces" {
+@test "tcsh: tolerates env paths containing spaces" {
   project_setup # TODO: we need PROJECT_DIR, but not flox init
   bad_dir="contains space/project"
   mkdir -p "$PWD/$bad_dir"
@@ -2143,7 +2143,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:paths_spaces,activate:paths_spaces:zsh
-@test "zsh: tolerates paths containing spaces" {
+@test "zsh: tolerates env paths containing spaces" {
   project_setup # TODO: we need PROJECT_DIR, but not flox init
   bad_dir="contains space/project"
   mkdir -p "$PWD/$bad_dir"
@@ -2152,6 +2152,68 @@ EOF
   run zsh -c 'eval "$("$FLOX_BIN" activate)"'
   assert_success
   refute_output --partial "no such file or directory"
+}
+
+# bats test_tags=activate,activate:paths_spaces,activate:paths_spaces:bash
+@test "bash: tolerates PATH already containing spaces" {
+  project_setup
+  bad_dir="$PWD/contains space/project"
+  export bad_dir="$PWD/CONTAINS SPACE/project"
+  mkdir -p "$bad_dir"
+  activation_cmd="$(cat <<'EOF'
+    export PATH="$bad_dir:$PATH"
+    eval "$("$FLOX_BIN" activate)"  
+EOF
+)"
+  run bash -c "$activation_cmd"
+  assert_success
+  refute_output --partial "unexpected argument 'SPACE"
+}
+
+# bats test_tags=activate,activate:paths_spaces,activate:paths_spaces:fish
+@test "fish: tolerates PATH already containing spaces" {
+  project_setup
+  export bad_dir="$PWD/CONTAINS SPACE/project"
+  mkdir -p "$bad_dir"
+  activation_cmd="$(cat <<'EOF'
+    fish_add_path "$bad_dir"
+    "$FLOX_BIN" activate | source
+EOF
+)"
+  run fish -c "$activation_cmd"
+  assert_success
+  refute_output --partial "unexpected argument 'SPACE"
+}
+
+# bats test_tags=activate,activate:paths_spaces,activate:paths_spaces:tcsh
+@test "tcsh: tolerates PATH already containing spaces" {
+  project_setup
+  export bad_dir="$PWD/contains space/project"
+  mkdir -p "$bad_dir"
+  activation_cmd="$(cat <<'EOF'
+    setenv PATH "$bad_dir:$PATH"
+    eval "`"$FLOX_BIN" activate`"  
+EOF
+)"
+  run tcsh -c "$activation_cmd"
+  assert_success
+  refute_output --partial "unexpected argument 'SPACE"
+}
+
+# bats test_tags=activate,activate:paths_spaces,activate:paths_spaces:zsh
+@test "zsh: tolerates PATH already containing spaces" {
+  project_setup
+  bad_dir="$PWD/contains space/project"
+  export bad_dir="$PWD/CONTAINS SPACE/project"
+  mkdir -p "$bad_dir"
+  activation_cmd="$(cat <<'EOF'
+    export PATH="$bad_dir:$PATH"
+    eval "$("$FLOX_BIN" activate)"  
+EOF
+)"
+  run zsh -c "$activation_cmd"
+  assert_success
+  refute_output --partial "unexpected argument 'SPACE"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

**test: regression test for spaces in PATH**

The 1.3.13 release contains the new path helper that's written in Rust.
There is a bug in how this is called that does not handle spaces in
PATH. This bug wasn't caught in the test suite, so this change adds a
new collection of tests meant to catch this regression in the future.

**fix: spaces in PATH for fish shell**

There are actually two bugs fixed by this change:
- In-place activations for fish shells would use the generation-time
  PATH instead of the runtime PATH, meaning that a user's RC-file
  config could be removed from PATH.
- PATH that contains a space gets split in the Bash shell that
  generates the startup commands for the fish shell. When the fish
  shell then calls `flox-activations fix-paths` it sees too many
  arguments due to the word splitting that happened in Bash.

This change addresses the bugs by properly quoting in the Bash shell.
One bit of weirdness involved is that fish doesn't have variable
expansion syntax like Bash does, so there's no built-in way to expand
a variable with a default value if it's unset. To address that we use a
temporary variable that we manually expand and set to a default value.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Addresses a bug that causes activations to fail for Fish shell when `PATH` contains one or more spaces.

<!-- Many thanks! -->
