### PR TITLE
fix(test): avoid race condition at first parallel run of podman

### DIFF
--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -192,6 +192,13 @@ EOF
 
   chmod +x "$FLOX_TEST_HOME/bin/podman"
   export PATH="$FLOX_TEST_HOME/bin:$PATH:/run/wrappers/bin"
+
+  # Check that podman is functioning
+  # and ensure it has created the necessary directories.
+  # Without this, starting multiple podman containers in parallel,
+  # may cause a race between the containers to create the directories,
+  # in particular `$HOME/.ssh`.
+  podman ps
 }
 
 teardown() {

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -257,10 +257,6 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:default-to-file
 @test "container is written to a runtime by default" {
-  if ! is_linux; then
-    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
-  fi
-
   env_setup_catalog
 
   # Check that podman is installed
@@ -283,10 +279,6 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:container-tag
 @test "container is tagged with specified tag" {
-  if ! is_linux; then
-    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
-  fi
-
   env_setup_catalog
 
   # Check that podman is installed
@@ -299,10 +291,6 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
 # bats test_tags=containerize:piped-to-runtime
 @test "container is written to runtime when '--runtime <runtime>' is passed" {
-  if ! is_linux; then
-    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
-  fi
-
   env_setup_catalog
 
   run bash -c '"$FLOX_BIN" containerize --tag "runtime" --runtime podman' 3>&-
@@ -350,10 +338,6 @@ function assert_container_output() {
 
 # bats test_tags=containerize:run-container-i
 @test "container can be run with 'podman run' with/without -i'" {
-  if ! is_linux; then
-    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
-  fi
-
   env_setup_catalog
 
   # Also tests writing to STDOUT with `-f -`
@@ -416,10 +400,6 @@ EOF
 }
 
 @test "cmd can run binary from activated environment" {
-  if ! is_linux; then
-    skip "FIXME: Temporarily disabled on macOS until https://github.com/flox/flox/pull/2746"
-  fi
-
   "$FLOX_BIN" init
 
   MANIFEST_CONTENTS="$(cat << "EOF"


### PR DESCRIPTION
Check that podman is functioning
and ensure it has created the necessary directories.
Without this, starting multiple podman containers in parallel,
may cause a race between the containers to create the directories.

We started seeing the effect of the race condition frequently
when running the containerize.bats tests, both locally and in CI [^1].
When running `flox containerize` (which by default writes into a registry)
was run on macos, two processes of `podman` are spawned;

1. `podman run ...` which runs `flox containerize` from within a container and writes that to stdout
2. `podman import` which adds the created container to the local runtime.

As part of their initialization both connect via ssh to the "podman machine",
a VM specifically for running containers.
During this connection both processes probe `$HOME/.ssh` and create it if is absent [^2].
However this leaves a window where both processes see the directory as absent
and consequently attempt to create it.
If the race is "lost" by the `podman run` process, it fails to start up with

    Error: unable to connect to Podman socket: mkdir /tmp/home.AywAp0/.ssh: file exists

(Assumption) If the race is lost by the `podman import` the process appears to silently die,
causing subsequent writes to its `stdin` to err `BrokenPipe`.
However, these pipe errors are communicated via a SIGPIPE signal, that we chose to ignore
to avoid a panic when printing to `stdout` with `stdout` closed [^3] [^4].

Somewhat tellingly,

    flox show hello  | true

returns with a 141 exit code, exactly as the containerize command.

The silver lining of these issues is that they are unlikely to affect users,
unless you frequently run `containerize` on clean macos machines,
without e.g. `$HOME/.ssh` directories.

[^1]: <#2743>
[^2]: <https://github.com/containers/common/blob/3c510166fd8563d1c4da81aba3c6d5c7a9cc0b9b/pkg/ssh/connection_golang.go#L316-L320>
[^3]: <https://github.com/flox/flox/blob/2c404edf5ed0503cb1c366fc6c735d64d26088b1/cli/flox/src/main.rs#L51-L52>
[^4]: <#1193>
