### PR TITLE
fix(containerize): Re-use cache across versions on macOS

### DIFF
--- a/cli/flox-rust-sdk/src/providers/nix.rs
+++ b/cli/flox-rust-sdk/src/providers/nix.rs
@@ -7,6 +7,7 @@ static NIX_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
         .unwrap_or_else(|_| env!("NIX_BIN").to_string())
         .into()
 });
+pub static NIX_VERSION: LazyLock<String> = LazyLock::new(|| env!("NIX_VERSION").to_string());
 
 /// Returns a `Command` for `nix` with a default set of features enabled.
 pub fn nix_base_command() -> Command {

--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -35,10 +35,10 @@ the container is written to `./<env name>-container.tar` instead.
 **Note**: Exporting a container from macOS requires a supported runtime to be
 found because a proxy container is used to build the environment and image. You
 may be prompted for permissions to share files into the proxy container.
-Files used in the proxy container are cached in `docker` or `podman` volumes
-which are named by the Flox version in use, e.g. `flox-nix-v1.2.3`.
-These can safely be removed any time a `flox containerize` command is not running
-using either `docker volume rm <name>` or `podman volume rm <name>`.
+Files used in the proxy container are cached using a `docker` or `podman`
+volume named `flox-nix`.
+It can safely be removed any time a `flox containerize` command is not running
+using either `docker volume rm flox-nix` or `podman volume rm flox-nix`.
 
 Running the container will behave like running `flox activate`.
 Running the container interactively with `docker run -it <container id>`,

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -16,7 +16,7 @@ const NIX_PROXY_IMAGE: &str = "nixos/nix";
 const FLOX_FLAKE: &str = "github:flox/flox";
 const FLOX_PROXY_IMAGE_FLOX_CONFIG_DIR: &str = "/root/.config/flox";
 static FLOX_CONTAINERIZE_FLAKE_REF_OR_REV: LazyLock<Option<String>> =
-    LazyLock::new(|| env::var("FLOX_CONTAINERIZE_FLAKE_REF_OR_REV").ok());
+    LazyLock::new(|| env::var("_FLOX_CONTAINERIZE_FLAKE_REF_OR_REV").ok());
 const CONTAINER_VOLUME_PREFIX: &str = "flox-nix-";
 
 const MOUNT_ENV: &str = "/flox_env";

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -14,7 +14,7 @@ use crate::config::{FLOX_CONFIG_FILE, FLOX_DISABLE_METRICS_VAR};
 const FLOX_FLAKE: &str = "github:flox/flox";
 const FLOX_PROXY_IMAGE: &str = "ghcr.io/flox/flox";
 const FLOX_PROXY_IMAGE_FLOX_CONFIG_DIR: &str = "/root/.config/flox";
-pub static FLOX_CONTAINERIZE_FLAKE_REF_OR_REV: LazyLock<Option<String>> =
+static FLOX_CONTAINERIZE_FLAKE_REF_OR_REV: LazyLock<Option<String>> =
     LazyLock::new(|| env::var("FLOX_CONTAINERIZE_FLAKE_REF_OR_REV").ok());
 const CONTAINER_VOLUME_PREFIX: &str = "flox-nix-";
 

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -7,12 +7,13 @@ use std::sync::LazyLock;
 
 use flox_rust_sdk::flox::{Flox, FLOX_VERSION};
 use flox_rust_sdk::providers::container_builder::{ContainerBuilder, ContainerSource};
+use flox_rust_sdk::providers::nix::NIX_VERSION;
 
 use super::Runtime;
 use crate::config::{FLOX_CONFIG_FILE, FLOX_DISABLE_METRICS_VAR};
 
+const NIX_PROXY_IMAGE: &str = "nixos/nix";
 const FLOX_FLAKE: &str = "github:flox/flox";
-const FLOX_PROXY_IMAGE: &str = "ghcr.io/flox/flox";
 const FLOX_PROXY_IMAGE_FLOX_CONFIG_DIR: &str = "/root/.config/flox";
 static FLOX_CONTAINERIZE_FLAKE_REF_OR_REV: LazyLock<Option<String>> =
     LazyLock::new(|| env::var("FLOX_CONTAINERIZE_FLAKE_REF_OR_REV").ok());
@@ -123,14 +124,13 @@ impl ContainerizeProxy {
             ]);
         }
 
-        // Use a released Flox container of the same semantic version as a base
-        // because it already has:
-        //
-        // - most of the dependency store paths
-        // - substitutors configured
-        // - correct version of nix
-        let flox_container = format!("{}:{}", FLOX_PROXY_IMAGE, flox_version_tag);
-        command.arg(flox_container);
+        // Use a Nix container that matches the version of Nix that this Flox
+        // has been built with because it's smaller and changes less frequently
+        // than a Flox container of the corresponding version, which result in less
+        // container image pulls. It also prevents the chicken-and-egg problem when
+        // we bump `VERSION` in Flox but haven't published the container image yet.
+        let nix_container = format!("{}:{}", NIX_PROXY_IMAGE, &*NIX_VERSION);
+        command.arg(nix_container);
     }
 
     /// Inception L2: Nix args.

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -1,13 +1,15 @@
-use std::convert::Infallible;
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::LazyLock;
 
 use flox_rust_sdk::flox::{Flox, FLOX_VERSION};
 use flox_rust_sdk::providers::container_builder::{ContainerBuilder, ContainerSource};
 use flox_rust_sdk::providers::nix::NIX_VERSION;
+use indoc::formatdoc;
+use thiserror::Error;
+use tracing::debug;
 
 use super::Runtime;
 use crate::config::{FLOX_CONFIG_FILE, FLOX_DISABLE_METRICS_VAR};
@@ -20,9 +22,15 @@ const FLOX_FLAKE: &str = "github:flox/flox";
 const FLOX_PROXY_IMAGE_FLOX_CONFIG_DIR: &str = "/root/.config/flox";
 static FLOX_CONTAINERIZE_FLAKE_REF_OR_REV: LazyLock<Option<String>> =
     LazyLock::new(|| env::var("_FLOX_CONTAINERIZE_FLAKE_REF_OR_REV").ok());
-const CONTAINER_VOLUME_PREFIX: &str = "flox-nix-";
+const CONTAINER_VOLUME: &str = "flox-nix";
 
 const MOUNT_ENV: &str = "/flox_env";
+
+#[derive(Debug, Error)]
+pub enum ContainerizeProxyError {
+    #[error("failed to populate proxy container cache volume")]
+    PopulateCacheVolume(#[source] std::io::Error),
+}
 
 /// An implementation of [ContainerBuilder] for macOS that uses `flox
 /// containerize` within a proxy container of a given [Runtime].
@@ -48,6 +56,68 @@ impl ContainerizeProxy {
         command
     }
 
+    // Use a Nix container that matches the version of Nix that this Flox
+    // has been built with because it's smaller and changes less frequently
+    // than a Flox container of the corresponding version, which result in less
+    // container image pulls. It also prevents the chicken-and-egg problem when
+    // we bump `VERSION` in Flox but haven't published the container image yet.
+    fn container_image(&self) -> String {
+        format!(
+            "{}:{}",
+            NIX_PROXY_IMAGE,
+            FLOX_CONTAINERIZE_PROXY_IMAGE_REF
+                .clone()
+                .unwrap_or(NIX_VERSION.clone())
+        )
+    }
+
+    /// Add a cache volume mount to the container runtime command.
+    fn add_cache_mount(&self, command: &mut Command, path: &str) {
+        command.args([
+            "--mount",
+            &format!("type=volume,src={},dst=/{}", CONTAINER_VOLUME, path),
+        ]);
+    }
+
+    /// Copy the Nix store from the container image to the cache volume.
+    fn populate_cache_volume(&self) -> Result<(), ContainerizeProxyError> {
+        let mut command = self.runtime_base_command();
+
+        // The cache volume has to be mounted in parallel to the container's own
+        // `/nix` and at a prefix where it can be treated as a new local root:
+        // https://nix.dev/manual/nix/2.24/command-ref/new-cli/nix3-help-stores#local-store
+        let cache_root = "/cache";
+        self.add_cache_mount(&mut command, &format!("{cache_root}/nix"));
+
+        command.arg(self.container_image());
+        // Profiles have to be copied too because the mount will shadow the
+        // container's `/nix/var/nix/profiles` and break `PATH`.
+        command.args(["bash", "-c", &formatdoc! {"
+            set -euo pipefail
+            nix --extra-experimental-features nix-command copy --all --no-check-sigs --to {cache_root}
+            cp -R /nix/var/nix/profiles {cache_root}/nix/var/nix/
+        "}]);
+
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        debug!(?command, "Populating container cache volume");
+
+        let output = command
+            .output()
+            .map_err(ContainerizeProxyError::PopulateCacheVolume)?;
+
+        if !output.status.success() {
+            return Err(ContainerizeProxyError::PopulateCacheVolume(
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    String::from_utf8_lossy(&output.stderr).to_string(),
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Inception L1: Container runtime args.
     fn add_runtime_args(&self, command: &mut Command, flox: &Flox) {
         // The `--userns` flag creates a mapping of users in the container,
@@ -67,36 +137,7 @@ impl ContainerizeProxy {
             ),
         ]);
 
-        let flox_version = &*FLOX_VERSION;
-        let flox_version_tag = format!("v{}", flox_version.base_semver());
-
-        // The cache volume must be unique per Flox version, otherwise store
-        // paths in the container will be shadowed by the cache.
-        let volume_name = format!("{}{}", CONTAINER_VOLUME_PREFIX, flox_version_tag);
-        command.args([
-            // From https://docs.docker.com/engine/storage/volumes
-            // If you mount an empty volume into a directory in the container in
-            // which files or directories exist, these files or directories are
-            // propagated (copied) into the volume by default. Similarly, if you
-            // start a container and specify a volume which does not already
-            // exist, an empty volume is created for you.
-            //
-            // From https://docs.podman.io/en/v5.1.1/markdown/podman-run.1.html
-            // If no such named volume exists, Podman creates one.
-            //
-            // I confirmed manually that Podman has the same propagation
-            // behavior as Docker for an auto created volume.
-            //
-            // This gives us precisely the behavior we want;
-            // /nix is bootstrapped from FLOX_PROXY_IMAGE,
-            // and then subsequently CONTAINER_VOLUME_NAME acts as a cache of
-            // /nix.
-            //
-            // There are no tests for this behavior since that would just be
-            // testing podman and Docker work as expected.
-            "--mount",
-            &format!("type=volume,src={},dst=/nix", volume_name),
-        ]);
+        self.add_cache_mount(command, "/nix");
 
         // Honour config from the user's flox.toml
         // This could include things like floxhub_token and floxhub_url
@@ -127,19 +168,7 @@ impl ContainerizeProxy {
             ]);
         }
 
-        // Use a Nix container that matches the version of Nix that this Flox
-        // has been built with because it's smaller and changes less frequently
-        // than a Flox container of the corresponding version, which result in less
-        // container image pulls. It also prevents the chicken-and-egg problem when
-        // we bump `VERSION` in Flox but haven't published the container image yet.
-        let nix_container = format!(
-            "{}:{}",
-            NIX_PROXY_IMAGE,
-            FLOX_CONTAINERIZE_PROXY_IMAGE_REF
-                .clone()
-                .unwrap_or(NIX_VERSION.clone())
-        );
-        command.arg(nix_container);
+        command.arg(self.container_image());
     }
 
     /// Inception L2: Nix args.
@@ -188,7 +217,7 @@ impl ContainerizeProxy {
 }
 
 impl ContainerBuilder for ContainerizeProxy {
-    type Error = Infallible;
+    type Error = ContainerizeProxyError;
 
     /// Create a [ContainerSource] for macOS that streams the output via a proxy container.
     fn create_container_source(
@@ -198,6 +227,8 @@ impl ContainerBuilder for ContainerizeProxy {
         _name: impl AsRef<str>,
         tag: impl AsRef<str>,
     ) -> Result<ContainerSource, Self::Error> {
+        self.populate_cache_volume()?;
+
         let mut command = self.runtime_base_command();
         self.add_runtime_args(&mut command, flox);
         self.add_nix_args(&mut command);

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -13,6 +13,9 @@ use super::Runtime;
 use crate::config::{FLOX_CONFIG_FILE, FLOX_DISABLE_METRICS_VAR};
 
 const NIX_PROXY_IMAGE: &str = "nixos/nix";
+static FLOX_CONTAINERIZE_PROXY_IMAGE_REF: LazyLock<Option<String>> =
+    LazyLock::new(|| env::var("_FLOX_CONTAINERIZE_PROXY_IMAGE_REF").ok());
+
 const FLOX_FLAKE: &str = "github:flox/flox";
 const FLOX_PROXY_IMAGE_FLOX_CONFIG_DIR: &str = "/root/.config/flox";
 static FLOX_CONTAINERIZE_FLAKE_REF_OR_REV: LazyLock<Option<String>> =
@@ -129,7 +132,13 @@ impl ContainerizeProxy {
         // than a Flox container of the corresponding version, which result in less
         // container image pulls. It also prevents the chicken-and-egg problem when
         // we bump `VERSION` in Flox but haven't published the container image yet.
-        let nix_container = format!("{}:{}", NIX_PROXY_IMAGE, &*NIX_VERSION);
+        let nix_container = format!(
+            "{}:{}",
+            NIX_PROXY_IMAGE,
+            FLOX_CONTAINERIZE_PROXY_IMAGE_REF
+                .clone()
+                .unwrap_or(NIX_VERSION.clone())
+        );
         command.arg(nix_container);
     }
 

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -416,7 +416,7 @@ EOF
 
   TAG="cmd-runs-in-activation"
 
-  bash -c "FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
+  bash -c "_FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 
   run podman run --rm "test:$TAG"
   assert_success
@@ -440,7 +440,7 @@ EOF
 
   TAG="whoami-in-container"
 
-  bash -c "FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
+  bash -c "_FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 
   run podman run --rm "test:$TAG" 'whoami'
   assert_success

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -30,6 +30,7 @@ let
       # rather than relying on or modifying the user's `PATH` variable
       GIT_PKG = gitMinimal;
       NIX_BIN = "${nix}/bin/nix";
+      NIX_VERSION = nix.version;
       GNUMAKE_BIN = "${gnumake}/bin/make";
       SLEEP_BIN = "${coreutils}/bin/sleep";
       PROCESS_COMPOSE_BIN = "${process-compose}/bin/process-compose";


### PR DESCRIPTION
## Proposed Changes

Refactoring commits are best reviewed one-by-one.

**fix(containerize): Use nixos/nix proxy image**

Instead of using a `flox/flox` image of the corresponding version because it's smaller and changes less frequently than a Flox container of the corresponding version, which result in less container image pulls. It also prevents the chicken-and-egg problem when we bump `VERSION` in Flox but haven't published the container image yet.

**fix(containerize): Re-use cache across versions**

This takes us back to using a single `flox-nix` cache volume so that
users don't suffer complete cache invalidations or have to manually
garbage collect volumes after each upgrade of Flox.

We'll mention in the release notes that the version suffixed volumes
that were created between v1.3.12 and v1.3.15 (inclusive) can be deleted
after upgrading.

This is achieved by starting a container before creating the
`ContainerSource` command which copies the contents of the container
image's store into the cache volume mounted at a different location. The
copy is idempotent, so it's cheaper if the cache volume already has the
necessary store paths, unlike `nix-store --export | nix-store --import`.

Running this command early also has the side-effect of adding an
additional guard against the race condition seen in https://github.com/flox/flox/commit/fb881cfc24deaa70da4443d44628f51a73c6f01f.

Some notes about the examples below:

- PATH has to be overridden to favour Docker until we fix 2538
- container images are already cached so pull times are not shown
- my broadband isn't super fast so substitution still takes a little

Using the Flox from before we adding version suffixing to the volume:

    % PATH="$(dirname $(which docker)):$PATH" nix run github:flox/flox/v1.3.11 -- containerize -d ~/tmp
    ✨ 'tmp:latest' written to Docker runtime

    (2) ~/projects/flox/flox on dcarley/2661-containerize-cache-pt200 [$>] took 44s
    % PATH="$(dirname $(which docker)):$PATH" nix run github:flox/flox/v1.3.11 -- containerize -d ~/tmp
    ✨ 'tmp:latest' written to Docker runtime

    (2) ~/projects/flox/flox on dcarley/2661-containerize-cache-pt200 [$>] took 10s

Using the new caching strategy on top of that existing `flox-nix `volume
to demonstrate compatibility. It's slightly slower initially because we
no longer have Flox store paths from the container image:

    % PATH="$(dirname $(which docker)):$PATH" FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=v1.3.15 flox containerize -d ~/tmp
    ✨ 'tmp:latest' written to Docker runtime

    (2) ~/projects/flox/flox on dcarley/2661-containerize-cache-pt200 [$>] took 1m38s
    % PATH="$(dirname $(which docker)):$PATH" FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=v1.3.15 flox containerize -d ~/tmp
    ✨ 'tmp:latest' written to Docker runtime

    (2) ~/projects/flox/flox on dcarley/2661-containerize-cache-pt200 [$>] took 16s

Using a newer `nixos/nix` container and the same cache volume again:

    % PATH="$(dirname $(which docker)):$PATH" FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=v1.3.15 FLOX_CONTAINERIZE_PROXY_IMAGE_REF=2.24.12 flox containerize -d ~/tmp
    ✨ 'tmp:latest' written to Docker runtime

    (2) ~/projects/flox/flox on dcarley/2661-containerize-cache-pt200 [$>] took 16s

Using an older version of Flox where we changed a lot of dependencies
and we have to fetch them from substitutors, which should still be
slightly faster than pulling a new Flox image:

    % PATH="$(dirname $(which docker)):$PATH" FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=v1.3.14 flox containerize -d ~/tmp
    ✨ 'tmp:latest' written to Docker runtime

    (2) ~/projects/flox/flox on dcarley/2661-containerize-cache-pt200 [$>] took 1m41s
    % PATH="$(dirname $(which docker)):$PATH" FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=v1.3.14 flox containerize -d ~/tmp
    ✨ 'tmp:latest' written to Docker runtime

    (2) ~/projects/flox/flox on dcarley/2661-containerize-cache-pt200 [$>] took 17s

## Release Notes

`flox containerize` on macOS no longer uses separate cache volumes per Flox version, which prevents unnecessary cache invalidations and no longer requires manual garbage collection when upgrading Flox. Any version suffixed volumes can be safely deleted after this release with `docker volume rm flox-nix-v{VERSION}` or `podman volume rm flox-nix-v{VERSION}`.