### PR TITLE
feat(upgrade): Reference dry-run in notifications

### DIFF
--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -131,7 +131,7 @@ flox config --set 'trusted_environments."owner/name"' trust
     The notification message is:
     ```
     Upgrades are available for packages in 'environment-name'.
-    Use 'flox upgrade' to get the latest.
+    Use 'flox upgrade --dry-run' for details.
     ```
 
     (default: true)

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -698,7 +698,7 @@ fn notify_upgrade_if_available(flox: &Flox, environment: &mut ConcreteEnvironmen
     // Update this message in flox-config.md if you change it here
     let message = formatdoc! {"
         ℹ️  Upgrades are available for packages in {description}.
-        Use 'flox upgrade' to get the latest.
+        Use 'flox upgrade --dry-run' for details.
     "};
 
     message::plain(message);
@@ -961,7 +961,7 @@ mod upgrade_notification_tests {
 
         assert_eq!(printed, formatdoc! {"
             ℹ️  Upgrades are available for packages in 'name'.
-            Use 'flox upgrade' to get the latest.
+            Use 'flox upgrade --dry-run' for details.
 
         "});
     }

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -99,7 +99,7 @@ pub struct FloxConfig {
     /// The notification message is:
     /// ```
     /// Upgrades are available for packages in 'environment-name'.
-    /// Use 'flox upgrade' to get the latest.
+    /// Use 'flox upgrade --dry-run' for details.
     /// ```
     ///
     /// (default: true)


### PR DESCRIPTION
## Proposed Changes

To help users see what upgrades are available before committing to them. Per the design in #2572 (which might have been missed due to the ordering and size of the tickets) and the suggestion from Eric Torreborre in this thread:

- https://floxcommunitygroup.slack.com/archives/C06NYALM8P8/p1740482265759719

Also updates all occurrences of the message in docs to match.

## Release Notes

Improved the messaging to use `flox upgrade --dry-run` in upgrade notifications to see what upgrades are available before performing them.