### PR TITLE
docs: add docs for publish command

### DIFF
--- a/cli/flox/doc/doc-build/flox-publish.md
+++ b/cli/flox/doc/doc-build/flox-publish.md
@@ -1,0 +1,181 @@
+---
+title: FLOX-PUBLISH
+section: 1
+header: "Flox User Manuals"
+...
+
+```{.include}
+./include/experimental-warning.md
+```
+> Feature flag: `publish`
+
+# NAME
+
+flox-publish - Publish local packages for Flox
+
+
+# SYNOPSIS
+
+```
+flox [<general-options>] publish
+     [-d=<path>]
+     [--store-url]
+     [--signing-key]
+     [<package>]...
+```
+
+# DESCRIPTION
+
+Build the specified `<package>` from the environment in `<path>`,
+and output build artifacts at `result-<package>` adjacent to the environment.
+
+## Manifest defined Packages
+
+Possible values for `<package>` are all keys under the `build` attribute
+in the `manifest.toml`.
+If no `<package>` is specified, flox will attempt to build all packages
+that are defined in the environment.
+
+Packages are built by running the script defined in `build.<package>.command`
+within a `bash` subshell.
+The shell will behave as if `flox activate` was run
+immediately prior to running the build script.
+
+By default, builds are run in a sandbox.
+For a sandboxed build, the current project is _copied_ into a sandbox directory.
+To avoid copying excessive files, e.g. accumulating build artifacts from earlier
+manual builds, `.env` files containing secrets etc.,
+only files tracked by `git` are available.
+Untracked files, files outside of the repository and notably network access
+will be restricted to encourage "pure" and reproducible builds.
+Builds can opt out of the sandbox by setting `build.<package>.sandbox = "off"`.
+With the sandbox disabled, building is equivalent
+to running the build script manually within a shell created by `flox activate`.
+Any build can access the _results_ of other builds
+(including non-sandboxed ones) by referring to their name via `${<package>}`.
+In the example below, the `app` package depends on the `dep` package
+by using `${deps}/node_modules`.
+
+`flox build` creates a temporary directory for the build script
+to output build artifacts to.
+The environment variable `out` is set to this directory,
+and the build script is expected to copy or move artifacts to `$out`.
+
+Upon conclusion of the build, the build result
+will be symlinked to `result-<package>` adjacent to the `.flox` directory
+that defines the package.
+
+
+# OPTIONS
+
+`-L`, `--build-logs`
+:   Enable detailed logging emitted by the build scripts.
+    **not implemented yet**
+
+`<package>`
+:   The package(s) to build.
+    Possible values are all keys under the `build` attribute
+    in the environment's `manifest.toml`.
+
+
+```{.include}
+./include/environment-options.md
+./include/general-options.md
+```
+
+# EXAMPLES
+
+`flox build` is an experimental feature.
+To use it the `build` feature flag has to be enabled:
+
+```shell
+$ flox config --set-bool features.build true
+# OR
+$ export FLOX_FEATURE_BUILD=true
+```
+
+## Building a simple pure package
+
+1. Add build instructions to the manifest:
+
+```toml
+# file: .flox/env/manifest.toml
+
+...
+[build]
+hello.command = '''
+# produce something and move it to $out
+mkdir -p $out
+echo "hello world" >> $out/hello.txt
+'''
+```
+
+2. Build the package and verify its contents:
+
+```
+$ flox build hello
+$ ls ./result-hello
+hello.txt
+$ cat ./result-hello/hello.txt
+hello, world
+```
+
+## Building a simple multi-stage app
+
+Assume a simple `nodejs` project
+
+```
+.
+├── .git/
+├── package-lock.json
+├── package.json
+├── public/
+├── README.md
+├── src/
+...
+```
+
+1. Initialize a Flox environment
+
+```shell
+$ flox init
+```
+
+2. Install dependencies and add build instructions
+
+```toml
+# file: .flox/env/manifest.toml
+version = 1
+
+[install]
+nodejs.pkg-path = "nodejs"
+rsync.pkg-path = "rsync"
+
+# install node dependencies using npm
+# disable the sandbox to allow access to the network
+[build]
+deps.command = '''
+npm ci
+mkdir -p $out
+mv node_modules $out/node_modules
+'''
+deps.sandbox = "off"
+
+# build the application using previously fetched dependencies
+app.command = '''
+rsync -lr ${deps}/node_modules ./
+npm run build
+mv dist $out/
+'''
+```
+
+3. Verify the result
+
+```shell
+$ npx serve result-app
+```
+
+# SEE ALSO
+
+[`flox-activate(1)`](./flox-activate.md)
+[`manifest.toml(5)`](./manifest.toml.md)

--- a/cli/flox/doc/doc-build/flox-publish.md
+++ b/cli/flox/doc/doc-build/flox-publish.md
@@ -41,10 +41,10 @@ This allows re-use of the package in other environments.
 
 Flox makes some assertions before publishing, specifically
 
-- The flox environment used to build the package is tracked as a git repo.
-- Tracked files in the repo are all clean.
-- The repo has an upstream origin.
-- The build environment must have at least one package to establish the page the package is being built against.
+- The flox environment used to build the package is tracked as a git repository.
+- Tracked files in the repository are all clean.
+- The repository has a remote defined and the current revision has been pushed to it.
+- The build environment must have at least one package installed.
 
 Flox will then perform a clone of the repository
 to a temporary location
@@ -54,7 +54,7 @@ required to build the package are included in the git repo.
 
 Upon completion,
 the package closure is signed with the key file provided in `--signing-key`
-and uploaded to the location specified in `--signing-key`.
+and uploaded to the location specified in `--store_url`.
 
 ## After publishing
 
@@ -62,7 +62,7 @@ After publishing,
 the package will be availble for `search`, `show`, and `install` operations
 like any other package.
 The package will be published
-to the catalog named as your github user handle.
+to the catalog named as your FloxHub user handle.
 To distinguish these packages
 from base catalog pacakges,
 the name is prefixed with your catalog name.
@@ -76,7 +76,7 @@ The package will be downloaded from the location where it was uploaded.
 
 ## Store Location and Authorization
 
-Currently Flox only supports S3 store locations,
+Currently Flox only supports S3 compatibile store locations,
 and defers authorization to the nix AWS provider.
 
 Flox uses nix's S3 provider to perform the uploads and downloads,
@@ -134,7 +134,7 @@ By default only you can see and use these packages.
 To allow others
 to search and install the packages in you catalog,
 you will need to add thier github handles
-to a whitelist of users allowed to read from your catalog.
+to a allowlist of users allowed to read from your catalog.
 
 Currently this is managed by a CLI utility shared
 [here](https://github.com/flox/catalog-util).

--- a/cli/flox/doc/doc-build/manifest.toml.md
+++ b/cli/flox/doc/doc-build/manifest.toml.md
@@ -453,10 +453,12 @@ with the produced `hello.txt` file in it.
 The full set of options is shown below:
 ```
 BuildDescriptor ::= {
-  command    = STRING
-, sandbox    = null | ("off" | "pure")
-, files      = null | [PATH]
-, systems    = null | [STRING, ...]
+  command     = STRING
+, sandbox     = null | ("off" | "pure")
+, files       = null | [PATH]
+, systems     = null | [STRING, ...]
+, version     = STRING
+, description = null | STRING
 }
 
 ```
@@ -484,6 +486,13 @@ BuildDescriptor ::= {
 `systems`
 :   An optional list of systems on which to build this package.
     If omitted, the package can be built on any system.
+
+`version`
+:   The version string to attach to this build artifact.
+
+`description`
+:   The description string to attach to this build artifact.
+
 
 ## `[options]`
 


### PR DESCRIPTION
Initial pass on publish man page.  

This is distinct from the floxdocs and reference architecture documentation where ever that should live.  I didn't want to spend too much time on it since we are in the process of changing much of this and I'm not sure what we have now will go into anyone's hands.

I'm happy to leave on a branch, do a bit of clean up, merge as is, or collaborate with someone based on feedback.