### PR TITLE
fix(containerize): Set FLOX_ENV_{DESC,CACHE}

### DIFF
--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -423,6 +423,17 @@ EOF
   run podman run --rm "test:$TAG"
   assert_success
   assert_output --partial "Hello, world!"
+
+  # Verify that the `activate` entrypoint is still used when an ad-hoc command
+  # is used and that (since it's quicker than executing a separate test)
+  # `FLOX_ENV_*` are set correctly.
+  run podman run --rm "test:$TAG" -c 'echo $FLOX_ENV_CACHE'
+  assert_success
+  assert_output "/tmp"
+
+  run podman run --rm "test:$TAG" -c 'echo $FLOX_ENV_DESCRIPTION'
+  assert_success
+  assert_output "test"
 }
 
 @test "container with user:group set can run as specified user:group" {

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -132,8 +132,6 @@ setup() {
 }
 
 setup_file() {
-  export _FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main
-
   echo "FLOX_CI_RUNNER: '${FLOX_CI_RUNNER}'" >&3
   common_file_setup
   # The individual tests run faster this way because podman doesn't need to

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -157,6 +157,10 @@ let
           environment
           "--mode"
           activationMode
+          "--env-cache"
+          "/tmp"
+          "--env-description"
+          containerName
           "--shell"
           "${containerPkgs.bashInteractive}/bin/bash"
         ];

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -122,8 +122,10 @@ let
       # errors when users try to run a container on an incompatible architecture.
       architecture = containerPkgs.go.GOARCH;
 
+      # No /tmp by default: https://github.com/NixOS/nixpkgs/issues/257172
       # Activate script requires writable directory, /run feels like a logical place.
       extraCommands = ''
+        mkdir -m 1777 tmp
         mkdir -m 1770 run
         mkdir -p -m 1770 run/flox
       '';


### PR DESCRIPTION
## Proposed Changes

Follow-up from 2178ba3e for the documented environment variables that are now passed as args and can be derived for containers. We're not passing `--env-project` because there is no source project in the rendered container.

## Release Notes

`/tmp` now exists in containers built by `flox containerize`.

`FLOX_ENV*` changes roll into other ticket.