### PR TITLE
feat: drop manifest variables from build_executable_wrapper

### DIFF
--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -42,9 +42,9 @@ source "${_activate_d}/source-profile-d.bash"
 # Top-level Flox environment activation script.
 
 # Parse command-line arguments.
-OPTIONS="c:e:"
-LONGOPTS="command:,env:"
-USAGE="Usage: $0 [-c \"<cmd> <args>\"] [(-e|--env) <env>]"
+OPTIONS="e:c:"
+LONGOPTS="set-vars,env:,command:"
+USAGE="Usage: $0 [--set-vars] [(-e|--env) <env>] [-c \"<cmd> <args>\"] "
 
 PARSED=$("$_getopt" --options="$OPTIONS" --longoptions="$LONGOPTS" --name "$0" -- "$@")
 # shellcheck disable=SC2181
@@ -79,6 +79,10 @@ while true; do
       fi
       FLOX_ENV="$1"
       shift
+      ;;
+    --set-vars)
+      shift
+      SET_VARS="1"
       ;;
     --)
       shift
@@ -116,14 +120,16 @@ fi
 # prepend path
 export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin:$PATH"
 
+if [ "${SET_VARS-}" = "1" ]; then
+ # Set static environment variables from the manifest.
+ if [ -f "$FLOX_ENV/activate.d/envrc" ]; then
+   # shellcheck disable=SC1091 # from rendered environment
+   source "$FLOX_ENV/activate.d/envrc"
+ fi
+fi
+
 # source profile.d scripts
 source_profile_d "$_profile_d"
-
-# Set static environment variables from the manifest.
-if [ -f "$FLOX_ENV/activate.d/envrc" ]; then
-  # shellcheck disable=SC1091 # from rendered environment
-  source "$FLOX_ENV/activate.d/envrc"
-fi
 
 "$_flox_activate_tracer" "${BASH_SOURCE[0]}" "$@" END
 

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -165,7 +165,7 @@ pkgs.runCommandNoCC name
                 # strips color codes from output anyway.
                 FLOX_SRC_DIR=$(pwd) FLOX_RUNTIME_DIR="$TMP" \
                   ${flox-env-package}/activate --env ${flox-env-package} --mode run --turbo -- \
-                    ${build-wrapper-env-package}/wrapper --env ${build-wrapper-env-package}  -- \
+                    ${build-wrapper-env-package}/wrapper --env ${build-wrapper-env-package} --set-vars -- \
                       ${t3-package}/bin/t3 --relative $log -- bash -e ${buildScript-contents}
               ''
             else
@@ -179,7 +179,7 @@ pkgs.runCommandNoCC name
                 # /private/tmp/nix-build-file-0.0.0.drv-0
                 FLOX_SRC_DIR=$(pwd) FLOX_RUNTIME_DIR="$TMP" \
                   ${flox-env-package}/activate --env ${flox-env-package} --mode run --turbo -- \
-                    ${build-wrapper-env-package}/wrapper --env ${build-wrapper-env-package} -- \
+                    ${build-wrapper-env-package}/wrapper --env ${build-wrapper-env-package} --set-vars -- \
                       ${t3-package}/bin/t3 --relative $log -- bash -e ${buildScript-contents} || \
                 ( rm -rf $out && echo "flox build failed (caching build dir)" | tee $out 1>&2 )
               ''

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -247,7 +247,7 @@ define BUILD_local_template =
 	  $(if $(_virtualSandbox),$(PRELOAD_VARS) FLOX_SRC_DIR=$$$$($(_pwd)) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
 	  $(FLOX_INTERPRETER)/activate --env $(FLOX_ENV) --mode dev --turbo -- \
 	    $(_env) -i out=$(_out) $(foreach i,$(ALLOW_OUTER_ENV_VARS),$(i)="$$$$$(i)") \
-	      $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) -- \
+	      $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) --set-vars -- \
 	        $(_t3) $($(_pvarname)_logfile) -- $(_bash) -e $($(_pvarname)_buildScript)
 	$(_V_) $(_nix) build -L `$(_nix) store add-file "$(shell $(_realpath) "$($(_pvarname)_logfile)")"` \
 	  --out-link "result-$(_pname)-log"


### PR DESCRIPTION
**follow up to #2734 and #2729**


The late consensus was that variables defined in the manifest shall be
scoped to the manifest only and not baked into binaries.
Because variables are _set_ in the wrapper,
which sits between the executing environment and the binary,
these variables cannot be reset.
