### PR TITLE
fix(activate): Don't propagate FLOX_VERSION

### DIFF
--- a/cli/tests/version.bats
+++ b/cli/tests/version.bats
@@ -1,0 +1,91 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test the `flox --version` command.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=version
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  export PROJECT_NAME="${PROJECT_DIR##*/}"
+
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" > /dev/null || return
+
+  "$FLOX_BIN" init -d "$PROJECT_DIR"
+}
+
+project_teardown() {
+  popd > /dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  setup_isolated_flox
+  project_setup
+}
+
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+# We can't easily or safely predict the buildtime version so assert that the two
+# different formats never appear at the same time. When running in CI remote
+# builders it will fallback to "0.0.0-dirty".
+MOCK_RUNTIME_VERSION="1.2.3"
+REGEX_BUILDTIME_VERSION='^([0-9]+\.[0-9]+\.[0-9]+-g.+|0.0.0-dirty)$'
+
+function assert_runtime_version() {
+  assert_output "$MOCK_RUNTIME_VERSION"
+  refute_output --regexp "$REGEX_BUILDTIME_VERSION"
+}
+
+function assert_buildtime_version() {
+  assert_output --regexp "$REGEX_BUILDTIME_VERSION"
+  refute_output --partial "$MOCK_RUNTIME_VERSION"
+}
+
+@test "version: accepts runtime version from wrapper derivation" {
+  FLOX_VERSION="$MOCK_RUNTIME_VERSION" run "$FLOX_BIN" --version
+  assert_success
+  assert_runtime_version
+}
+
+@test "version: doesn't propagate runtime version into activations" {
+  run bash <(
+    cat << EOF
+export FLOX_VERSION="$MOCK_RUNTIME_VERSION"
+$FLOX_BIN activate -- $FLOX_BIN --version
+EOF
+  )
+  assert_success
+  assert_buildtime_version
+}
+
+@test "version: uses buildtime version in absence of wrapper derivation" {
+  project_setup
+
+  run bash <(
+    cat << EOF
+unset FLOX_VERSION
+$FLOX_BIN --version
+EOF
+  )
+  assert_success
+  assert_buildtime_version
+}


### PR DESCRIPTION
## Proposed Changes

I noticed that `flox --version` and the `containerize` tests were still incorrect for me when the devShell is running from within an interactive activation:

    % env -i /run/current-system/sw/bin/flox --version
    1.3.14-g8fa0811
    % ./cli/target/debug/flox --version
    1.3.14-g8fa0811
    % env -i ./cli/target/debug/flox --version
    1.3.15-g2c0ae4c3

We can't easily test the wrapper script from the integration tests so they attempt to exercise the same combination of code paths. Failure from before this change:

    version.bats
     ✓ version: accepts runtime version from wrapper derivation [917]
     ✗ version: doesn't propagate runtime version into activations [1147]
       tags: version
       (from function `assert_output' in file /nix/store/yf08fkff6pbr4lya678aprc0nwsddxgn-bats-with-libraries-1.11.1/share/bats/bats-assert/src/assert_output.bash, line 178,
        from function `assert_buildtime_version' in file version.bats, line 58,
        in test file version.bats, line 76)
         `assert_buildtime_version' failed
       ✨ Created environment 'project-2' (aarch64-darwin)

       Next:
         $ flox search <package>    <- Search for a package
         $ flox install <package>   <- Install a package into an environment
         $ flox activate            <- Enter the environment
         $ flox edit                <- Add environment variables and shell hooks

       1.2.3

       -- regular expression does not match output --
       regexp : [0-9]+\.[0-9]+\.[0-9]+-g.+
       output : 1.2.3
       --

       Last output:
       1.2.3
     ✓ version: uses buildtime version in absence of wrapper derivation [894]

Fix this by eagerly evaluating the version when `flox` starts and then unsetting the `FLOX_VERSION` environment variable once we've read it. I considered putting the unset in `FLOX_VERSION_STRING` but it feels clearer to do it at the point we evaluate. Matthew kinda predicted this in:

- https://github.com/flox/flox/pull/2659/files#r1934753653

## Release Notes

Fixed `flox --version` reporting when running in activations from different Flox versions.