### PR TITLE
feat: add composition to lockfile

### DIFF
--- a/cli/flox-rust-sdk/proptest-regressions/models/manifest/typed.txt
+++ b/cli/flox-rust-sdk/proptest-regressions/models/manifest/typed.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5d62963a85a6e58af5814270c300697b69d52e7dd2670e653a7868c3ab7d7425 # shrinks to manifest = Manifest { version: Version { value: 1 }, install: Install({}), vars: Vars({}), hook: Hook { on_activate: None }, profile: Profile { common: None, bash: None, zsh: None, fish: None, tcsh: None }, options: Options { systems: None, allow: Allows { unfree: None, broken: None, licenses: [] }, semver: SemverOptions { allow_pre_releases: None }, cuda_detection: None }, services: Services({}), build: Build({}), containerize: None, include: Include { environments: [Local { dir: "", name: None }] } }

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1257,6 +1257,7 @@ mod tests {
             version: Version,
             packages: vec![foo_locked.into()],
             manifest: manifest.clone(),
+            compose: None,
         };
 
         let lockfile_str = serde_json::to_string_pretty(&lockfile).unwrap();

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use catalog_api_v1::types::{MessageLevel, SystemEnum};
 #[cfg(test)]
-use flox_test_utils::proptest::chrono_strat;
+use flox_test_utils::proptest::{alphanum_string, chrono_strat};
 use indent::{indent_all_by, indent_by};
 use indoc::formatdoc;
 use itertools::{Either, Itertools};
@@ -369,6 +369,8 @@ pub struct Compose {
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct LockedInclude {
     pub manifest: Manifest,
+    #[cfg_attr(test, proptest(strategy = "alphanum_string(5)"))]
+    pub name: String,
     pub descriptor: IncludeDescriptor,
     // TODO: once we consider remote environments, add this field
     // pub remote: Option<RemoteSource>

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -833,7 +833,9 @@ pub enum IncludeDescriptor {
         /// A name similar to an install ID that a user could use to specify
         /// the environment on the command line e.g. for upgrades, or in an
         /// error message.
-        name: String,
+        #[cfg_attr(test, proptest(strategy = "optional_string(5)"))]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
     },
 }
 
@@ -999,6 +1001,6 @@ pub(super) mod test {
         let included = parsed.include.environments[0].clone();
         let IncludeDescriptor::Local { dir, name } = included;
         assert_eq!(dir, PathBuf::from("../foo"));
-        assert_eq!(name.as_str(), "bar");
+        assert_eq!(name.unwrap().as_str(), "bar");
     }
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This adds an optional "compose" section to the lockfile. When this section is present it indicates that the lockfile's manifest was the result of merging other manifests.

An alternative to making this section optional would be to make the `compose.manifest` field optional. But that means we have a `compose` section in the lockfile even when we haven't done composition.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
