### PR TITLE
test: use flox package instead of flox-cli

### DIFF
--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -19,7 +19,7 @@
   flox-buildenv,
   flox-nix-plugins,
   flox-watchdog,
-  flox-cli,
+  flox,
   flox-activation-scripts,
   gawk,
   git,
@@ -50,7 +50,7 @@
   NIX_BIN ? "${nix}/bin/nix",
   BUILDENV_BIN ? "${flox-buildenv}/bin/buildenv",
   NIX_PLUGINS ? "${flox-nix-plugins}/lib/nix-plugins",
-  FLOX_BIN ? "${flox-cli}/bin/flox",
+  FLOX_BIN ? "${flox}/bin/flox",
   WATCHDOG_BIN ? "${flox-watchdog}/libexec/flox-watchdog",
   FLOX_ACTIVATIONS_BIN ? "${flox-activations}/bin/flox-activations",
 }:


### PR DESCRIPTION
The flox package applies versioning to the wrapped flox-cli package, which always uses the version in FLOX_VERSION.

For macOS containerize tests, we use the version to construct a flakeref for the flox to run inside the proxy container. For feature branches, we need to test the feature branch, so we need the version to include a commit SHA.

## Release Notes

NA