### PR TITLE
fix: New hash is needed for nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -193,6 +193,7 @@
           rust-external-deps
           rust-internal-deps
           floxDevelopmentPackages
+          nix
           ;
 
         default = pkgs.flox;

--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -64,6 +64,7 @@ nixVersions."${nixVersion}".overrideAttrs (prev: {
     Libs: -L\''${libdir} -lnixfetchers
     Cflags: -isystem \''${includedir} -std=c++2a
     EOF
+
   '';
 })
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

This just adds a space and forces nix package to be rebuilt.
This change is needed as an aftermath of recent incident (incident-10).


## Release Notes

N/A


