### PR TITLE
feat(activate): Add activate.mode to manifest

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -19,7 +19,7 @@ use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
 use super::lockfile::{Lockfile, ResolveError};
 use super::manifest::raw::PackageToInstall;
-use super::manifest::typed::{Manifest, ManifestError};
+use super::manifest::typed::{ActivateMode, Manifest, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
 use crate::flox::{Flox, Floxhub};
 use crate::providers::buildenv::BuildEnvOutputs;
@@ -308,6 +308,14 @@ impl RenderedEnvironmentLinks {
         let runtime_name = format!("{system}.{name}.run", name = name.as_ref());
         let runtime_path = base_dir.join(runtime_name);
         Self::new_unchecked(development_path, runtime_path)
+    }
+
+    /// Returns the built environment path for an activation mode.
+    pub fn for_mode(self, mode: &ActivateMode) -> RenderedEnvironmentLink {
+        match mode {
+            ActivateMode::Dev => self.development,
+            ActivateMode::Run => self.runtime,
+        }
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -49,7 +49,7 @@ use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::lockfile::{Lockfile, DEFAULT_SYSTEMS_STR};
 use crate::models::manifest::raw::{CatalogPackage, PackageToInstall, RawManifest};
-use crate::models::manifest::typed::Manifest;
+use crate::models::manifest::typed::{ActivateMode, Manifest};
 use crate::providers::buildenv::BuildEnvOutputs;
 
 /// Struct representing a local environment
@@ -86,6 +86,7 @@ pub struct InitCustomization {
     pub profile_tcsh: Option<String>,
     pub profile_zsh: Option<String>,
     pub packages: Option<Vec<CatalogPackage>>,
+    pub activate_mode: Option<ActivateMode>,
 }
 
 impl PartialEq for PathEnvironment {

--- a/cli/flox-rust-sdk/src/models/manifest/composite/shallow.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/shallow.rs
@@ -11,6 +11,7 @@ use super::{
     Warning,
 };
 use crate::models::manifest::typed::{
+    ActivateOptions,
     Allows,
     Build,
     Containerize,
@@ -149,6 +150,12 @@ impl ShallowMerger {
             high_priority.systems.clone(),
         );
 
+        let (merged_activate_mode, activate_mode_warning) = shallow_merge_options(
+            root_key.extend(["activate", "mode"]),
+            low_priority.activate.mode.clone(),
+            high_priority.activate.mode.clone(),
+        );
+
         let merged = Options {
             systems: merged_systems,
             allow: Allows {
@@ -160,10 +167,14 @@ impl ShallowMerger {
                 allow_pre_releases: merged_semver_allow_pre_releases,
             },
             cuda_detection: merged_cuda_detection,
+            activate: ActivateOptions {
+                mode: merged_activate_mode,
+            },
         };
 
         warnings.extend(
             [
+                activate_mode_warning,
                 allow_unfree_warning,
                 allow_broken_warning,
                 allow_licenses_warning,
@@ -419,7 +430,10 @@ mod tests {
             };
             let semver = SemverOptions { allow_pre_releases: options2.semver.allow_pre_releases.or(options1.semver.allow_pre_releases) };
             let cuda_detection = options2.cuda_detection.or(options1.cuda_detection);
-            let expected = Options { systems, allow, semver, cuda_detection, };
+            let activate = ActivateOptions {
+                mode: options2.activate.mode.or(options1.activate.mode),
+            };
+            let expected = Options { systems, allow, semver, cuda_detection, activate };
             prop_assert_eq!(merged, expected);
         }
 

--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -265,6 +265,16 @@ impl RawManifest {
             # "#});
         }
 
+        // `options.activate.mode`, only when customized.
+        if let Some(activate_mode) = &customization.activate_mode {
+            let activate_key = Key::new("activate");
+            let mut activate_table = Table::new();
+
+            let mode_key = Key::new("mode");
+            activate_table.insert(&mode_key, toml_edit::value(activate_mode.to_string()));
+            options_table.insert(&activate_key, Item::Table(activate_table));
+        }
+
         manifest.insert(MANIFEST_OPTIONS_KEY, Item::Table(options_table));
 
         RawManifest(manifest)
@@ -927,6 +937,7 @@ pub(super) mod test {
 
     use super::*;
     use crate::models::lockfile::DEFAULT_SYSTEMS_STR;
+    use crate::models::manifest::typed::ActivateMode;
 
     const DUMMY_MANIFEST: &str = indoc! {r#"
         version = 1
@@ -1328,6 +1339,100 @@ pub(super) mod test {
             ]
             # Uncomment to disable CUDA detection.
             # cuda-detection = false
+        "#};
+
+        let manifest = RawManifest::new_documented(systems.as_slice(), &customization);
+        assert_eq!(manifest.to_string(), expected_string.to_string());
+    }
+
+    #[test]
+    fn create_documented_manifest_with_activate_mode() {
+        let systems = [&"x86_64-linux".to_string()];
+        let customization = InitCustomization {
+            activate_mode: Some(ActivateMode::Run),
+            ..Default::default()
+        };
+
+        let expected_string = indoc! {r#"
+            ## Flox Environment Manifest -----------------------------------------
+            ##
+            ##   _Everything_ you need to know about the _manifest_ is here:
+            ##
+            ##               https://flox.dev/docs/concepts/manifest
+            ##
+            ## -------------------------------------------------------------------
+            # Flox manifest version managed by Flox CLI
+            version = 1
+
+
+            ## Install Packages --------------------------------------------------
+            ##  $ flox install gum  <- puts a package in [install] section below
+            ##  $ flox search gum   <- search for a package
+            ##  $ flox show gum     <- show all versions of a package
+            ## -------------------------------------------------------------------
+            [install]
+            # gum.pkg-path = "gum"
+            # gum.version = "^0.14.5"
+
+
+            ## Environment Variables ---------------------------------------------
+            ##  ... available for use in the activated environment
+            ##      as well as [hook], [profile] scripts and [services] below.
+            ## -------------------------------------------------------------------
+            [vars]
+            # INTRO_MESSAGE = "It's gettin' Flox in here"
+
+
+            ## Activation Hook ---------------------------------------------------
+            ##  ... run by _bash_ shell when you run 'flox activate'.
+            ## -------------------------------------------------------------------
+            [hook]
+            # on-activate = '''
+            #   # -> Set variables, create files and directories
+            #   # -> Perform initialization steps, e.g. create a python venv
+            #   # -> Useful environment variables:
+            #   #      - FLOX_ENV_PROJECT=/home/user/example
+            #   #      - FLOX_ENV=/home/user/example/.flox/run
+            #   #      - FLOX_ENV_CACHE=/home/user/example/.flox/cache
+            # '''
+
+
+            ## Profile script ----------------------------------------------------
+            ## ... sourced by _your shell_ when you run 'flox activate'.
+            ## -------------------------------------------------------------------
+            [profile]
+            # common = '''
+            #   gum style \
+            #   --foreground 212 --border-foreground 212 --border double \
+            #   --align center --width 50 --margin "1 2" --padding "2 4" \
+            #     $INTRO_MESSAGE
+            # '''
+            ## Shell specific profiles go here:
+            # bash = ...
+            # zsh  = ...
+            # fish = ...
+
+
+            ## Services ----------------------------------------------------------
+            ##  $ flox services start             <- Starts all services
+            ##  $ flox services status            <- Status of running services
+            ##  $ flox activate --start-services  <- Activates & starts all
+            ## -------------------------------------------------------------------
+            [services]
+            # myservice.command = "python3 -m http.server"
+
+
+            ## Other Environment Options -----------------------------------------
+            [options]
+            # Systems that environment is compatible with
+            systems = [
+              "x86_64-linux",
+            ]
+            # Uncomment to disable CUDA detection.
+            # cuda-detection = false
+
+            [options.activate]
+            mode = "run"
         "#};
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization);

--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -1057,6 +1057,7 @@ pub(super) mod test {
 
         let manifest = RawManifest::new_documented(systems, &customization);
         assert_eq!(manifest.to_string(), expected_string.to_string());
+        manifest.to_typed().expect("should parse as typed");
     }
 
     #[test]
@@ -1155,6 +1156,7 @@ pub(super) mod test {
 
         let manifest = RawManifest::new_documented(systems, &customization);
         assert_eq!(manifest.to_string(), expected_string.to_string());
+        manifest.to_typed().expect("should parse as typed");
     }
 
     #[test]
@@ -1254,6 +1256,7 @@ pub(super) mod test {
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization);
         assert_eq!(manifest.to_string(), expected_string.to_string());
+        manifest.to_typed().expect("should parse as typed");
     }
 
     #[test]
@@ -1343,6 +1346,7 @@ pub(super) mod test {
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization);
         assert_eq!(manifest.to_string(), expected_string.to_string());
+        manifest.to_typed().expect("should parse as typed");
     }
 
     #[test]
@@ -1437,6 +1441,7 @@ pub(super) mod test {
 
         let manifest = RawManifest::new_documented(systems.as_slice(), &customization);
         assert_eq!(manifest.to_string(), expected_string.to_string());
+        manifest.to_typed().expect("should parse as typed");
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -959,13 +959,7 @@ pub(super) mod test {
     fn create_documented_manifest_not_customized() {
         let systems = &*DEFAULT_SYSTEMS_STR.iter().collect::<Vec<_>>();
         let customization = InitCustomization {
-            hook_on_activate: None,
-            profile_common: None,
-            profile_bash: None,
-            profile_fish: None,
-            profile_tcsh: None,
-            profile_zsh: None,
-            packages: None,
+            ..Default::default()
         };
 
         let expected_string = indoc! {r#"
@@ -1058,18 +1052,13 @@ pub(super) mod test {
     fn create_documented_manifest_with_packages() {
         let systems = &*DEFAULT_SYSTEMS_STR.iter().collect::<Vec<_>>();
         let customization = InitCustomization {
-            hook_on_activate: None,
-            profile_common: None,
-            profile_bash: None,
-            profile_fish: None,
-            profile_tcsh: None,
-            profile_zsh: None,
             packages: Some(vec![CatalogPackage {
                 id: "python3".to_string(),
                 pkg_path: "python3".to_string(),
                 version: Some("3.11.6".to_string()),
                 systems: None,
             }]),
+            ..Default::default()
         };
 
         let expected_string = indoc! {r#"
@@ -1171,12 +1160,7 @@ pub(super) mod test {
                 "#}
                 .to_string(),
             ),
-            profile_common: None,
-            profile_bash: None,
-            profile_fish: None,
-            profile_tcsh: None,
-            profile_zsh: None,
-            packages: None,
+            ..Default::default()
         };
 
         let expected_string = indoc! {r#"
@@ -1265,18 +1249,13 @@ pub(super) mod test {
     fn create_documented_profile_script() {
         let systems = [&"x86_64-linux".to_string()];
         let customization = InitCustomization {
-            hook_on_activate: None,
             profile_common: Some(
                 indoc! { r#"
                     echo "Hello from Flox"
                 "#}
                 .to_string(),
             ),
-            profile_bash: None,
-            profile_fish: None,
-            profile_tcsh: None,
-            profile_zsh: None,
-            packages: None,
+            ..Default::default()
         };
 
         let expected_string = indoc! {r#"

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -609,7 +609,7 @@ impl ActivateOptions {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq, Ord, PartialOrd, Default)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
 pub enum ActivateMode {

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -23,6 +23,7 @@ use crate::models::lockfile::{
     LockedPackageStorePath,
     Lockfile,
 };
+use crate::models::manifest::typed::ActivateMode;
 use crate::models::nix_plugins::NIX_PLUGINS;
 use crate::providers::catalog::CatalogClientError;
 use crate::utils::CommandExt;
@@ -101,6 +102,16 @@ pub struct BuildEnvOutputs {
     // todo: nest additional built paths for manifest builds
     #[serde(flatten)]
     pub manifest_build_runtimes: HashMap<String, BuiltStorePath>,
+}
+
+impl BuildEnvOutputs {
+    /// Returns the built environment path for an activation mode.
+    pub fn for_mode(self, mode: &ActivateMode) -> BuiltStorePath {
+        match mode {
+            ActivateMode::Dev => self.develop,
+            ActivateMode::Run => self.runtime,
+        }
+    }
 }
 
 #[derive(

--- a/cli/flox/doc/doc-compose/manifest.toml.md
+++ b/cli/flox/doc/doc-compose/manifest.toml.md
@@ -559,13 +559,12 @@ manifest, but things can be overridden or added by higher priority manifests.
   overwritten by a higher priority manifest, as is `options.allow.licenses`,
   etc.
 
-`[activate]`
-: Activate options are entirely overwritten by higher priority manifests. This
-  has implications for the activation mode of a composed environment. Since the
-  default activation mode is `dev`, it is not present in the manifest by
-  default. This means that if one included environment sets `activate.mode` to
-  `run`, the merged manifest will also have `activate.mode = run` unless a
-  higher priority manifest explicitly sets `activate.mode = dev`.
+  This has implications for the activation mode of a composed environment. Since
+  the default activation mode is `dev`, it is not present in the manifest by
+  default. This means that if one included environment sets
+  `options.activate.mode` to `run`, the merged manifest will also have
+  `options.activate.mode = run` unless a higher priority manifest explicitly
+  sets `options.activate.mode = dev`.
 
 ## `[options]`
 
@@ -576,9 +575,14 @@ The full set of options are listed below:
 ```
 Options ::= {
   systems                   = null | [<STRING>, ...]
+, activate                  = null | Activate
 , allow                     = null | Allows
 , semver                    = null | Semver
 , cuda-detection            = null | <BOOL>
+}
+
+Activate ::= {
+  mode = null | 'dev' | 'run'
 }
 
 Allows ::= {
@@ -603,6 +607,19 @@ Semver ::= {
     system to this list.
     See [`flox-pull(1)`](./flox-pull.md) for more details.
 
+`activate.mode`
+:   Whether to activate in "dev" (default) or "run" mode. This value can be
+    overridden with `flox activate --mode`.
+
+    In "dev" mode a package, all of its development dependencies, and language
+    specific environment variables are made available. As the name implies, this
+    is useful at development time. However, this may causes unexpected failures
+    when layering environments or when activating an environment system-wide.
+
+    In "run" mode only the requested packages are made available in `PATH` (and
+    their man pages made available).  This behavior is more in line with what
+    you would expect from a system-wide package manager like `apt`, `yum`, or
+    `brew`.
 
 `allow.unfree`
 :   Allows packages with unfree licenses to be installed and appear in search

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -101,13 +101,10 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
    regardless of how many times the environment is activated concurrently.
 
 `-m (dev|run)`, `--mode (dev|run)`
-:  Activate the environment in either "dev" mode or "run" mode. In "dev" mode
-   sets environment variables and runs certain hooks to make the packages in the
-   environment and their dependencies available as is necessary for development.
-   In "run" mode the packages in the environment are simply added to `PATH`.
-
-   The default mode is "dev".
-
+:  Activate the environment in either "dev" or "run" mode.
+   Overrides the `options.activate.mode` setting in the manifest.
+   See [`manifest.toml(5)`](./manifest.toml.md) for more details on activation
+   modes.
 
 ```{.include}
 ./include/environment-options.md

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -471,9 +471,14 @@ The full set of options are listed below:
 ```
 Options ::= {
   systems                   = null | [<STRING>, ...]
+, activate                  = null | Activate
 , allow                     = null | Allows
 , semver                    = null | Semver
 , cuda-detection            = null | <BOOL>
+}
+
+Activate ::= {
+  mode = null | 'dev' | 'run'
 }
 
 Allows ::= {
@@ -498,6 +503,19 @@ Semver ::= {
     system to this list.
     See [`flox-pull(1)`](./flox-pull.md) for more details.
 
+`activate.mode`
+:   Whether to activate in "dev" (default) or "run" mode. This value can be
+    overridden with `flox activate --mode`.
+
+    In "dev" mode a package, all of its development dependencies, and language
+    specific environment variables are made available. As the name implies, this
+    is useful at development time. However, this may causes unexpected failures
+    when layering environments or when activating an environment system-wide.
+
+    In "run" mode only the requested packages are made available in `PATH` (and
+    their man pages made available).  This behavior is more in line with what
+    you would expect from a system-wide package manager like `apt`, `yum`, or
+    `brew`.
 
 `allow.unfree`
 :   Allows packages with unfree licenses to be installed and appear in search

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -87,7 +87,7 @@ impl FromStr for Mode {
         match s {
             "dev" => Ok(Mode::Dev),
             "run" => Ok(Mode::Run),
-            _ => Err(anyhow!("'{s}' is not a valid activation mode")),
+            _ => Err(anyhow!("not a valid activation mode")),
         }
     }
 }

--- a/cli/flox/src/commands/init/go.rs
+++ b/cli/flox/src/commands/init/go.rs
@@ -141,17 +141,13 @@ impl InitHook for Go {
 
         InitCustomization {
             hook_on_activate: Some(GO_HOOK.to_string()),
-            profile_common: None,
-            profile_bash: None,
-            profile_fish: None,
-            profile_tcsh: None,
-            profile_zsh: None,
             packages: Some(vec![CatalogPackage {
                 id: "go".to_string(),
                 pkg_path: "go".to_string(),
                 version: go_version,
                 systems: None,
             }]),
+            ..Default::default()
         }
     }
 }

--- a/cli/flox/src/commands/init/node.rs
+++ b/cli/flox/src/commands/init/node.rs
@@ -738,12 +738,8 @@ impl InitHook for Node {
 
         InitCustomization {
             hook_on_activate,
-            profile_common: None,
-            profile_bash: None,
-            profile_fish: None,
-            profile_tcsh: None,
-            profile_zsh: None,
             packages: Some(packages),
+            ..Default::default()
         }
     }
 }
@@ -1113,11 +1109,7 @@ mod tests {
                     systems: None,
                 }]),
                 hook_on_activate: Some(YARN_HOOK.to_string()),
-                profile_common: None,
-                profile_bash: None,
-                profile_fish: None,
-                profile_tcsh: None,
-                profile_zsh: None,
+                ..Default::default()
             }
         );
     }
@@ -1165,11 +1157,7 @@ mod tests {
                     systems: None,
                 }]),
                 hook_on_activate: Some(NPM_HOOK.to_string()),
-                profile_common: None,
-                profile_bash: None,
-                profile_fish: None,
-                profile_tcsh: None,
-                profile_zsh: None,
+                ..Default::default()
             }
         );
     }
@@ -1198,12 +1186,7 @@ mod tests {
                     version: Some("1".to_string()),
                     systems: None,
                 }]),
-                hook_on_activate: None,
-                profile_common: None,
-                profile_bash: None,
-                profile_fish: None,
-                profile_tcsh: None,
-                profile_zsh: None,
+                ..Default::default()
             }
         );
     }

--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -419,7 +419,6 @@ impl Provider for PoetryPyProject {
                 )"#}
                 .to_string(),
             ),
-            profile_common: None,
             profile_bash: Some(
                 indoc! {r#"
                 echo "Activating poetry virtual environment" >&2
@@ -458,6 +457,7 @@ impl Provider for PoetryPyProject {
                     systems: None,
                 },
             ]),
+            ..Default::default()
         }
     }
 }
@@ -617,7 +617,6 @@ impl Provider for PyProject {
                 )"#}
                 .to_string(),
             ),
-            profile_common: None,
             profile_bash: Some(
                 indoc! {r#"
                 echo "Activating python virtual environment" >&2
@@ -648,6 +647,7 @@ impl Provider for PyProject {
                 version: python_version,
                 systems: None,
             }]),
+            ..Default::default()
         }
     }
 }
@@ -769,7 +769,6 @@ impl Provider for Requirements {
                 )"#}
                 .to_string(),
             ),
-            profile_common: None,
             profile_bash: Some(
                 indoc! {r#"
                 echo "Activating python virtual environment" >&2
@@ -800,6 +799,7 @@ impl Provider for Requirements {
                 version: None,
                 systems: None,
             }]),
+            ..Default::default()
         }
     }
 }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -27,6 +27,7 @@ use flox_rust_sdk::models::manifest::raw::{
     CatalogPackage,
     PackageToInstall,
 };
+use flox_rust_sdk::models::manifest::typed::ActivateMode;
 use flox_rust_sdk::models::user_state::{
     lock_and_read_user_state_file,
     user_state_path,
@@ -553,7 +554,10 @@ fn package_list_for_prompt(packages: &[PackageToInstall]) -> Option<String> {
 /// customizations and skipping the normal `init` output.
 fn create_default_env(flox: &Flox) -> Result<PathEnvironment, anyhow::Error> {
     let home_dir = dirs::home_dir().context("user must have a home directory")?;
-    let customization = InitCustomization::default();
+    let customization = InitCustomization {
+        activate_mode: Some(ActivateMode::Run),
+        ..Default::default()
+    };
     PathEnvironment::init(
         PathPointer::new(
             EnvironmentName::from_str(DEFAULT_NAME)

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -5,11 +5,10 @@ use bpaf::Bpaf;
 use flox_rust_sdk::data::System;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
-use flox_rust_sdk::models::manifest::typed::{Inner, Manifest, Services};
+use flox_rust_sdk::models::manifest::typed::{ActivateMode, Inner, Manifest, Services};
 use flox_rust_sdk::providers::services::{new_services_to_start, ProcessState, ProcessStates};
 use tracing::{debug, instrument};
 
-use super::activate::Mode;
 use super::{
     activated_environments,
     ConcreteEnvironment,
@@ -315,7 +314,8 @@ pub async fn start_services_with_new_process_compose(
         print_script: false,
         start_services: true,
         use_fallback_interpreter: false,
-        mode: Some(Mode::Dev),
+        // FIXME: This should match the current activation.
+        mode: Some(ActivateMode::Dev),
         run_args: vec!["true".to_string()],
     }
     .activate(

--- a/cli/tests/activate-mode.bats
+++ b/cli/tests/activate-mode.bats
@@ -93,6 +93,8 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install -d "$top_layer_dir" hello
 
   run "$FLOX_BIN" activate -m run -d "$bottom_layer_dir" -- bash <(cat <<'EOF'
+    set -euo pipefail
+
     # This is where we *would* find `python3` if it was present
     python_path_bottom="$FLOX_ENV/bin/python3"
     if [ "$(command -v python3)" = "$python_path_bottom" ]; then
@@ -100,7 +102,8 @@ EOF
     fi
 
     # Layer another environment on top
-    source <("$FLOX_BIN" activate -d "$top_layer_dir")
+    to_eval=$("$FLOX_BIN" activate -d "$top_layer_dir")
+    eval "$to_eval"
 
     # Ensure that we don't find Python from the bottom environment
     if [ "$(command -v python3)" = "$python_path_bottom" ]; then
@@ -123,8 +126,11 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install -d "$top_layer_dir" almonds
 
   run "$FLOX_BIN" activate -d "$bottom_layer_dir" -m run  -- bash <(cat <<'EOF'
+    set -euo pipefail
+
     # Layer another environment on top
-    source <("$FLOX_BIN" activate -m run -d "$top_layer_dir")
+    to_eval=$("$FLOX_BIN" activate -m run -d "$top_layer_dir")
+    eval "$to_eval"
 
     # Ensure that we don't find Python from the bottom environment
     if [ "$(command -v python3)" = "$FLOX_ENV/bin/python3" ]; then

--- a/cli/tests/activate-mode.bats
+++ b/cli/tests/activate-mode.bats
@@ -48,15 +48,17 @@ teardown() {
 @test "can activate in dev mode" {
   project_setup
 
-  run "$FLOX_BIN" activate -m dev -- true
+  run "$FLOX_BIN" activate -m dev -- printenv FLOX_ENV
   assert_success
+  assert_output --partial "${NIX_SYSTEM}.${PROJECT_NAME}.dev"
 }
 
 @test "can activate in run mode" {
   project_setup
 
-  run "$FLOX_BIN" activate -m run -- true
+  run "$FLOX_BIN" activate -m run -- printenv FLOX_ENV
   assert_success
+  assert_output --partial "${NIX_SYSTEM}.${PROJECT_NAME}.run"
 }
 
 @test "runtime: dev dependencies aren't added to PATH" {

--- a/cli/tests/activate-mode.bats
+++ b/cli/tests/activate-mode.bats
@@ -1,0 +1,147 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test activation modes.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=activate-mode
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  export PROJECT_NAME="${PROJECT_DIR##*/}"
+
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" > /dev/null || return
+
+  "$FLOX_BIN" init -d "$PROJECT_DIR"
+}
+
+project_teardown() {
+  popd > /dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  setup_isolated_flox
+}
+
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "can activate in dev mode" {
+  project_setup
+
+  run "$FLOX_BIN" activate -m dev -- true
+  assert_success
+}
+
+@test "can activate in run mode" {
+  project_setup
+
+  run "$FLOX_BIN" activate -m run -- true
+  assert_success
+}
+
+@test "runtime: dev dependencies aren't added to PATH" {
+  project_setup
+  "$FLOX_BIN" edit -n "runtime_project" # give it a stable name
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install almonds
+  # `almonds` brings in Python as a development dependency, and we don't want
+  # that in runtime mode
+  run "$FLOX_BIN" activate -m run -- bash <(cat <<'EOF'
+    [ -e "$FLOX_ENV/bin/almonds" ]
+    [ ! -e "$FLOX_ENV/bin/python3" ]
+EOF
+)
+  assert_success
+}
+
+@test "runtime: packages still added to PATH" {
+  project_setup
+  "$FLOX_BIN" edit -n "runtime_project" # give it a stable name
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install almonds
+  run "$FLOX_BIN" activate -m run -- which almonds
+  assert_output --partial ".flox/run/$NIX_SYSTEM.runtime_project.run/bin/almonds"
+}
+
+@test "runtime: remains in runtime mode as bottom layer" {
+  # Prepare two environments that we're going to layer
+  export bottom_layer_dir="$BATS_TEST_TMPDIR/bottom_layer"
+  mkdir "$bottom_layer_dir"
+  "$FLOX_BIN" init -d "$bottom_layer_dir"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install -d "$bottom_layer_dir" almonds
+  export top_layer_dir="$BATS_TEST_TMPDIR/top_layer"
+  mkdir "$top_layer_dir"
+  "$FLOX_BIN" init -d "$top_layer_dir"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install -d "$top_layer_dir" hello
+
+  run "$FLOX_BIN" activate -m run -d "$bottom_layer_dir" -- bash <(cat <<'EOF'
+    # This is where we *would* find `python3` if it was present
+    python_path_bottom="$FLOX_ENV/bin/python3"
+    if [ "$(command -v python3)" = "$python_path_bottom" ]; then
+      exit 1
+    fi
+
+    # Layer another environment on top
+    source <("$FLOX_BIN" activate -d "$top_layer_dir")
+
+    # Ensure that we don't find Python from the bottom environment
+    if [ "$(command -v python3)" = "$python_path_bottom" ]; then
+      exit 1
+    fi
+EOF
+)
+  assert_success
+}
+
+@test "runtime: remains in runtime mode as top layer" {
+  # Prepare two environments that we're going to layer
+  export bottom_layer_dir="$BATS_TEST_TMPDIR/bottom_layer"
+  mkdir "$bottom_layer_dir"
+  "$FLOX_BIN" init -d "$bottom_layer_dir"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install -d "$bottom_layer_dir" hello
+  export top_layer_dir="$BATS_TEST_TMPDIR/top_layer"
+  mkdir "$top_layer_dir"
+  "$FLOX_BIN" init -d "$top_layer_dir"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install -d "$top_layer_dir" almonds
+
+  run "$FLOX_BIN" activate -d "$bottom_layer_dir" -m run  -- bash <(cat <<'EOF'
+    # Layer another environment on top
+    source <("$FLOX_BIN" activate -m run -d "$top_layer_dir")
+
+    # Ensure that we don't find Python from the bottom environment
+    if [ "$(command -v python3)" = "$FLOX_ENV/bin/python3" ]; then
+      exit 1
+    fi
+EOF
+)
+  assert_success
+}
+
+@test "runtime: doesn't set CPATH" {
+  project_setup
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install hello
+  export outer_cpath="$CPATH"
+  run "$FLOX_BIN" activate -m run -- bash <(cat <<'EOF'
+    [ "$CPATH" = "$outer_cpath" ]
+EOF
+)
+  assert_success
+}

--- a/cli/tests/activate-mode.bats
+++ b/cli/tests/activate-mode.bats
@@ -50,7 +50,7 @@ teardown() {
 
   run "$FLOX_BIN" activate -m invalid -- true
   assert_failure
-  assert_output "❌ ERROR: couldn't parse \`invalid\`: 'invalid' is not a valid activation mode"
+  assert_output "❌ ERROR: couldn't parse \`invalid\`: not a valid activation mode"
 }
 
 @test "can activate in dev mode" {

--- a/cli/tests/activate-mode.bats
+++ b/cli/tests/activate-mode.bats
@@ -45,6 +45,14 @@ teardown() {
 
 # ---------------------------------------------------------------------------- #
 
+@test "rejects invalid activate mode" {
+  project_setup
+
+  run "$FLOX_BIN" activate -m invalid -- true
+  assert_failure
+  assert_output "❌ ERROR: couldn't parse \`invalid\`: 'invalid' is not a valid activation mode"
+}
+
 @test "can activate in dev mode" {
   project_setup
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3621,20 +3621,6 @@ EOF
 
 # ---------------------------------------------------------------------------- #
 
-@test "can activate in dev mode" {
-  project_setup
-
-  run "$FLOX_BIN" activate -m dev -- true
-  assert_success
-}
-
-@test "can activate in run mode" {
-  project_setup
-
-  run "$FLOX_BIN" activate -m run -- true
-  assert_success
-}
-
 # bats test_tags=activate,activate:attach
 @test "attach doesn't break MANPATH" {
   project_setup
@@ -3766,93 +3752,6 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
-
-@test "runtime: dev dependencies aren't added to PATH" {
-  project_setup
-  "$FLOX_BIN" edit -n "runtime_project" # give it a stable name
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install almonds
-  # `almonds` brings in Python as a development dependency, and we don't want
-  # that in runtime mode
-  run "$FLOX_BIN" activate -m run -- bash <(cat <<'EOF'
-    [ -e "$FLOX_ENV/bin/almonds" ]
-    [ ! -e "$FLOX_ENV/bin/python3" ]
-EOF
-)
-  assert_success
-}
-
-@test "runtime: packages still added to PATH" {
-  project_setup
-  "$FLOX_BIN" edit -n "runtime_project" # give it a stable name
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install almonds
-  run "$FLOX_BIN" activate -m run -- which almonds
-  assert_output --partial ".flox/run/$NIX_SYSTEM.runtime_project.run/bin/almonds"
-}
-
-@test "runtime: remains in runtime mode as bottom layer" {
-  # Prepare two environments that we're going to layer
-  export bottom_layer_dir="$BATS_TEST_TMPDIR/bottom_layer"
-  mkdir "$bottom_layer_dir"
-  "$FLOX_BIN" init -d "$bottom_layer_dir"
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install -d "$bottom_layer_dir" almonds
-  export top_layer_dir="$BATS_TEST_TMPDIR/top_layer"
-  mkdir "$top_layer_dir"
-  "$FLOX_BIN" init -d "$top_layer_dir"
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install -d "$top_layer_dir" hello
-
-  run "$FLOX_BIN" activate -m run -d "$bottom_layer_dir" -- bash <(cat <<'EOF'
-    # This is where we *would* find `python3` if it was present
-    python_path_bottom="$FLOX_ENV/bin/python3"
-    if [ "$(command -v python3)" = "$python_path_bottom" ]; then
-      exit 1
-    fi
-
-    # Layer another environment on top
-    source <("$FLOX_BIN" activate -d "$top_layer_dir")
-
-    # Ensure that we don't find Python from the bottom environment
-    if [ "$(command -v python3)" = "$python_path_bottom" ]; then
-      exit 1
-    fi
-EOF
-)
-  assert_success
-}
-
-@test "runtime: remains in runtime mode as top layer" {
-  # Prepare two environments that we're going to layer
-  export bottom_layer_dir="$BATS_TEST_TMPDIR/bottom_layer"
-  mkdir "$bottom_layer_dir"
-  "$FLOX_BIN" init -d "$bottom_layer_dir"
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install -d "$bottom_layer_dir" hello
-  export top_layer_dir="$BATS_TEST_TMPDIR/top_layer"
-  mkdir "$top_layer_dir"
-  "$FLOX_BIN" init -d "$top_layer_dir"
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.json" "$FLOX_BIN" install -d "$top_layer_dir" almonds
-
-  run "$FLOX_BIN" activate -d "$bottom_layer_dir" -m run  -- bash <(cat <<'EOF'
-    # Layer another environment on top
-    source <("$FLOX_BIN" activate -m run -d "$top_layer_dir")
-
-    # Ensure that we don't find Python from the bottom environment
-    if [ "$(command -v python3)" = "$FLOX_ENV/bin/python3" ]; then
-      exit 1
-    fi
-EOF
-)
-  assert_success
-}
-
-@test "runtime: doesn't set CPATH" {
-  project_setup
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" install hello
-  export outer_cpath="$CPATH"
-  run "$FLOX_BIN" activate -m run -- bash <(cat <<'EOF'
-    [ "$CPATH" = "$outer_cpath" ]
-EOF
-)
-  assert_success
-}
 
 @test "bash: repeat activation in .bashrc doesn't break aliases" {
   # We don't need an environment, but we do need wait_for_watchdogs to have a

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -5,6 +5,8 @@
   nixpkgsFlakeRef,
   # the path to the environment that was built previously
   environmentOutPath,
+  # what mode it should be activation with
+  activationMode,
   # the system to build for
   system,
   containerSystem,
@@ -151,6 +153,8 @@ let
           "${environment}/activate"
           "--env"
           environment
+          "--mode"
+          activationMode
           "--shell"
           "${containerPkgs.bashInteractive}/bin/bash"
         ];


### PR DESCRIPTION
## Proposed Changes

This provides a default for the environment which still defaults to
`dev` if not specified and can still be overridden by `flox activate -m`

The `manifest.toml` docs have been copied and slightly modified from:

- https://flox.dev/docs/concepts/activation/#development-vs-runtime-mode

The `activate` docs have been slimmed down with a reference to
`manifest.toml` so that we don't have to repeat all of the same
information; some of which already varied between the three places they
were specified. I plan to change the concepts do to link back to
`manifest.toml` docs as well.

The new `[activate]` section of the manifest has been added before
`[options]` and not included in the manifest template to reflect that
most users won't need to set it and it's not a first-class feature that
we need to draw attention to like `[services]` are.

Includes support from `flox containerize` and "default" environments.

Best reviewed commit-by-commit because there's some refactoring along the way.

## Release Notes

Activation mode can now be specified from the manifest, is supported by `flox activate` and `flox containerize`, and is set when creating a "default" environment.