### PR TITLE
feat: add include section to manifest template

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -96,7 +96,7 @@ pub struct Flox {
 
 impl Flox {}
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default)]
 pub struct Features {
     #[serde(default)]
     pub build: bool,

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -410,6 +410,7 @@ impl PathEnvironment {
         let manifest = {
             tracing::debug!("creating raw catalog manifest");
             RawManifest::new_documented(
+                flox.features,
                 &DEFAULT_SYSTEMS_STR.iter().collect::<Vec<_>>(),
                 customization,
             )

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -356,7 +356,7 @@ impl FloxArgs {
             catalog_client,
             installable_locker: Default::default(),
             #[allow(deprecated, reason = "This should be the only internal use")]
-            features: config.features.clone().unwrap_or_default(),
+            features: config.features.unwrap_or_default(),
             verbosity: self.verbosity.to_i32(),
         };
         debug!(


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Puts the `[include]` section in the manifest template when the feature flag is enabled.
A second commit refactors the manifest template into helper functions to make it easier to read.

The manifest template now looks like this with the feature flag enabled (feel free to bikeshed the `... include other environments to merge with this one` language):
```toml
## Flox Environment Manifest -----------------------------------------
##
##   _Everything_ you need to know about the _manifest_ is here:
##
##               https://flox.dev/docs/concepts/manifest
##
## -------------------------------------------------------------------
# Flox manifest version managed by Flox CLI
version = 1


## Install Packages --------------------------------------------------
##  $ flox install gum  <- puts a package in [install] section below
##  $ flox search gum   <- search for a package
##  $ flox show gum     <- show all versions of a package
## -------------------------------------------------------------------
[install]
# gum.pkg-path = "gum"
# gum.version = "^0.14.5"


## Environment Variables ---------------------------------------------
##  ... available for use in the activated environment
##      as well as [hook], [profile] scripts and [services] below.
## -------------------------------------------------------------------
[vars]
# INTRO_MESSAGE = "It's gettin' Flox in here"


## Activation Hook ---------------------------------------------------
##  ... run by _bash_ shell when you run 'flox activate'.
## -------------------------------------------------------------------
[hook]
# on-activate = '''
#   # -> Set variables, create files and directories
#   # -> Perform initialization steps, e.g. create a python venv
#   # -> Useful environment variables:
#   #      - FLOX_ENV_PROJECT=/home/user/example
#   #      - FLOX_ENV=/home/user/example/.flox/run
#   #      - FLOX_ENV_CACHE=/home/user/example/.flox/cache
# '''


## Profile script ----------------------------------------------------
## ... sourced by _your shell_ when you run 'flox activate'.
## -------------------------------------------------------------------
[profile]
# common = '''
#   gum style \
#   --foreground 212 --border-foreground 212 --border double \
#   --align center --width 50 --margin "1 2" --padding "2 4" \
#     $INTRO_MESSAGE
# '''
## Shell specific profiles go here:
# bash = ...
# zsh  = ...
# fish = ...


## Services ----------------------------------------------------------
##  $ flox services start             <- Starts all services
##  $ flox services status            <- Status of running services
##  $ flox activate --start-services  <- Activates & starts all
## -------------------------------------------------------------------
[services]
# myservice.command = "python3 -m http.server"


## Include ----------------------------------------------------------
## ... include other environments to merge with this one
## ------------------------------------------------------------------
[include]
# environments = [
#     { dir = "../common" }
# ]


## Other Environment Options -----------------------------------------
[options]
# Systems that environment is compatible with
systems = [
  "aarch64-darwin",
  "aarch64-linux",
  "x86_64-darwin",
  "x86_64-linux",
]
# Uncomment to disable CUDA detection.
# cuda-detection = false

```

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
