### PR TITLE
test(suite): Unset FLOX_SAVE_*

### DIFF
--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -15,9 +15,10 @@ bats_require_minimum_version '1.5.0'
 
 # Unset all FLOX_ENV related vars to prevent an outer activation from leaking
 # back into test activations.
+# Some of this will be unnecessary after https://github.com/flox/flox/issues/2629
 unset_flox_env_setup() {
   for var in $(env | awk -F= '{print $1}'); do
-    if [[ $var == FLOX_ENV* || $var == _FLOX_ENV* || $var == LD_FLOXLIB_* ]];
+    if [[ $var == FLOX_ENV* || $var == _FLOX_ENV* || $var == LD_FLOXLIB_* || $var == FLOX_SAVE_* ]];
     then
       unset "$var"
     fi


### PR DESCRIPTION
## Proposed Changes

All of the zsh activation tests that use a nested activation fail for me when `just integ-tests` is run from an existing zsh activation because `FLOX_SAVE_ZSH_PS1` leaks in and affects the known prompt for `expect`:

    not ok 1 zsh: repeat activation in .zshrc doesn't break aliases in 12206ms
    # tags: activate bats:focus
    # (from function `assert_success' in file /nix/store/yf08fkff6pbr4lya678aprc0nwsddxgn-bats-with-libraries-1.11.1/share/bats/bats-assert/src/assert_success.bash, line 42,
    #  from function `zsh_repeat_activation_aliases' in file activate.bats, line 4212,
    #  in test file activate.bats, line 4223)
    #   `zsh_repeat_activation_aliases zshrc' failed
    …
    # Sourcing .zshenv
    # Setting PATH from .zshenv
    # Sourcing .zshrc
    # Setting PATH from .zshrc
    # spawn /Users/dcarley/projects/flox/flox/cli/target/debug/flox activate --dir /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.oWFUmP/bats-run-DXJiEZ/test/1/project-1/project
    # ✅ You are now using the environment 'project'.
    # To stop using this environment, type 'exit'
    #
    # Sourcing .zshenv
    # Setting PATH from .zshenv
    # Sourcing .zshrc
    # Setting PATH from .zshrc
    # % … flox [project]
    # (8) ${SSH_TTY:+"dcarley in "}${SSH_TTY:+"mba15 in "}/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.oWFUmP/bats-run-DXJiEZ/test/1/project-1${(e)git_info[prompt]}${VIRTUAL_ENV:+" via ${VIRTUAL_ENV:t}"}${duration_info}
    # $(_prompt_asciiship_vimode)

This is another case where we shouldn't be exporting environment variables that aren't documented for public use. I did try using the `restore_saved_vars` trick to see if it would help here but it didn't solve this or my other Zsh prompt bug:

- https://github.com/flox/flox/issues/2728

The solution to that ticket, in addition to flox/flox#2629 and flox/flox#2767, might be to search and replace our indicator if it's found in the existing prompt rather than attempting to carry the original prompt forwards.

All of which is too much work to get the tests working for what I was originally working on so this workaround will do for now.

## Release Notes

N/A, test suite only.