### PR TITLE
fix: add host attr of github/gitlab flakerefs to URL serialization

### DIFF
--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -30,6 +30,11 @@ nixVersions."${nixVersion}".overrideAttrs (prev: {
   # Apply patch files.
   patches = prev.patches ++ [
     (builtins.path { path = ./patches/multiple-github-tokens.2.24.9.patch; })
+    # Backport of upstream PR targeting nix >= 2.27
+    # <https://github.com/NixOS/nix/pull/12580>
+    (builtins.path {
+      path = ./patches/host-in-locked-github-url.2.24.11.patch;
+    })
   ];
 
   postFixup = ''
@@ -64,7 +69,6 @@ nixVersions."${nixVersion}".overrideAttrs (prev: {
     Libs: -L\''${libdir} -lnixfetchers
     Cflags: -isystem \''${includedir} -std=c++2a
     EOF
-
   '';
 })
 # ---------------------------------------------------------------------------- #

--- a/pkgs/nix/patches/host-in-locked-github-url.2.24.11.patch
+++ b/pkgs/nix/patches/host-in-locked-github-url.2.24.11.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libfetchers/github.cc b/src/libfetchers/github.cc
+index 9cddd8571..ea4dbe338 100644
+--- a/src/libfetchers/github.cc
++++ b/src/libfetchers/github.cc
+@@ -149,6 +149,9 @@ struct GitArchiveInputScheme : InputScheme
+         };
+         if (auto narHash = input.getNarHash())
+             url.query.insert_or_assign("narHash", narHash->to_string(HashFormat::SRI, true));
++        auto host = maybeGetStrAttr(input.attrs, "host");
++        if (host)
++            url.query.insert_or_assign("host", *host);
+         return url;
+     }


### PR DESCRIPTION
Backport of upstream PR targeting nix >= 2.27
<https://github.com/NixOS/nix/pull/12580>

When installing `github` or `gitlab` flake refs with an alternative host to an environment, the environment will fail to build in the general case where the store paths are not substitutable:

```
flox install gitlab:foo/bar?host=gitlab.example.com

❌ ERROR: Failed to build environment:

Failed to realise 'bar':
error:
       … while fetching the input 'gitlab:foo/bar/87687do78you0876ear1eallya2eacd62read77cadthis'

       error: unable to download 'https://gitlab.com/api/v4/projects/foo%2bar/repository/archive.tar.gz?sha= 87687do78you0876ear1eallya2eacd62read77cadthis': HTTP error 404

       response body:

       {"message":"404 Project Not Found"}
```



That is because nix drops the `host` parameter when serializing the locked flakeref to a url. The included patch adds the `?host` query back to the locked url.


## Release Notes

Fixes installing flakerefs pointing to custom github or gitlab instances via the `github:owner/name?host=internalgithub.company.com` format.

<!-- Many thanks! -->
