### PR TITLE
test(containerize): Use main for proxy flake

### DIFF
--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -132,6 +132,8 @@ setup() {
 }
 
 setup_file() {
+  export _FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main
+
   echo "FLOX_CI_RUNNER: '${FLOX_CI_RUNNER}'" >&3
   common_file_setup
   # The individual tests run faster this way because podman doesn't need to
@@ -416,7 +418,7 @@ EOF
 
   TAG="cmd-runs-in-activation"
 
-  bash -c "_FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
+  bash -c "$FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 
   run podman run --rm "test:$TAG"
   assert_success
@@ -440,7 +442,7 @@ EOF
 
   TAG="whoami-in-container"
 
-  bash -c "_FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
+  bash -c "$FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 
   run podman run --rm "test:$TAG" 'whoami'
   assert_success


### PR DESCRIPTION
## Proposed Changes

Fix these failing tests on the release branch by always testing the flake from `main` within the proxy container:

- https://github.com/flox/flox/actions/runs/13594323337/job/38007994931

This is a temporary solution while I attempt to untangle the correct `flox --version` used by both locally built and Nix built binaries from `flox-cli-tests` out of:

- https://github.com/flox/flox/pull/2769

This can be merged back to `main` from `release-1.3.16` (@stahnma @mkenigs is that the direction you were going to document?)

## Release Notes

N/A
