### PR TITLE
flox-cli-tests: Set version correctly, for realz

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -150,11 +150,12 @@ version:
         {{bats_args}}
 
 # Run the CLI integration test suite using Nix-built binaries
-@nix-integ-tests:
+@nix-integ-tests +bats_args="":
     nix run \
         --accept-flake-config \
         --extra-experimental-features 'nix-command flakes' \
-        .#flox-cli-tests
+        .#flox-cli-tests \
+        {{bats_args}}
 
 # Run the CLI unit tests
 @unit-tests regex="": build

--- a/Justfile
+++ b/Justfile
@@ -139,17 +139,15 @@ version:
 @test-nix-plugins: build-nix-plugins
     meson test -C nix-plugins/builddir
 
-# Run the CLI integration test suite
+# Run the CLI integration test suite using locally built binaries
+# This is equivalent to the "local" jobs in CI.
 @integ-tests +bats_args="": build
     flox-cli-tests \
-        --nix-plugins "$NIX_PLUGINS" \
-        --flox "$FLOX_BIN" \
-        --watchdog "$WATCHDOG_BIN" \
-        --input-data "{{INPUT_DATA}}" \
-        --generated-data "$GENERATED_DATA" \
+        --local-dev \
         {{bats_args}}
 
 # Run the CLI integration test suite using Nix-built binaries
+# This is equivalent to the "remote" jobs in CI.
 @nix-integ-tests +bats_args="":
     nix run \
         --accept-flake-config \

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -200,7 +200,6 @@ impl ContainerizeProxy {
             "{}/{}",
             FLOX_FLAKE,
             // Use a more specific commit if available, e.g. pushed to GitHub.
-            // TODO: Doesn't always work: https://github.com/flox/flox/issues/2502
             (*FLOX_CONTAINERIZE_FLAKE_REF_OR_REV)
                 .clone()
                 .unwrap_or(flox_version.commit_sha().unwrap_or(flox_version_tag))

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -416,7 +416,7 @@ EOF
 
   TAG="cmd-runs-in-activation"
 
-  bash -c "_FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
+  bash -c "$FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 
   run podman run --rm "test:$TAG"
   assert_success
@@ -440,7 +440,7 @@ EOF
 
   TAG="whoami-in-container"
 
-  bash -c "_FLOX_CONTAINERIZE_FLAKE_REF_OR_REV=main $FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
+  bash -c "$FLOX_BIN containerize --tag $TAG --runtime podman" 3>&- # TODO: why close FD 3?
 
   run podman run --rm "test:$TAG" 'whoami'
   assert_success

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -92,6 +92,7 @@ reals_setup() {
   xdg_reals_setup
   git_reals_setup
   {
+    print_var _FLOX_LOCAL_DEV
     print_var FLOX_BIN
     print_var BUILDENV_BIN
     print_var WATCHDOG_BIN

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -93,6 +93,11 @@ reals_setup() {
   git_reals_setup
   {
     print_var FLOX_BIN
+    print_var BUILDENV_BIN
+    print_var WATCHDOG_BIN
+    print_var FLOX_ACTIVATIONS_BIN
+    print_var FLOX_INTERPRETER
+    print_var NIX_PLUGINS
     print_var NIX_BIN
     print_var NIX_STORE
     print_var REAL_GIT_CONFIG_GLOBAL
@@ -103,7 +108,9 @@ reals_setup() {
     print_var REAL_XDG_DATA_HOME
     print_var REAL_XDG_STATE_HOME
     print_var TESTS_DIR
+    print_var INPUT_DATA
     print_var GENERATED_DATA
+    print_var MANUALLY_GENERATED
   } >&3
 }
 

--- a/cli/tests/version.bats
+++ b/cli/tests/version.bats
@@ -44,6 +44,22 @@ teardown() {
   common_test_teardown
 }
 
+function is_local_dev() {
+  [[ "${_FLOX_LOCAL_DEV}" == "true" ]]
+}
+
+function skip_if_local_dev() {
+  if is_local_dev; then
+    skip "Skipping test in local development mode"
+  fi
+}
+
+function skip_if_not_local_dev() {
+  if ! is_local_dev; then
+    skip "Skipping test not in local development mode"
+  fi
+}
+
 # We can't easily or safely predict the buildtime version so assert that the two
 # different formats never appear at the same time. When running in CI remote
 # builders it will fallback to "0.0.0-dirty".
@@ -60,32 +76,23 @@ function assert_buildtime_version() {
   refute_output --partial "$MOCK_RUNTIME_VERSION"
 }
 
-@test "version: accepts runtime version from wrapper derivation" {
+@test "version: binary accepts runtime version from wrapper derivation" {
+  skip_if_not_local_dev
   FLOX_VERSION="$MOCK_RUNTIME_VERSION" run "$FLOX_BIN" --version
   assert_success
   assert_runtime_version
 }
 
-@test "version: doesn't propagate runtime version into activations" {
-  run bash <(
-    cat << EOF
-export FLOX_VERSION="$MOCK_RUNTIME_VERSION"
-$FLOX_BIN activate -- $FLOX_BIN --version
-EOF
-  )
+@test "version: wrapper derivation ignores runtime FLOX_VERSION" {
+  skip_if_local_dev
+  FLOX_VERSION="$MOCK_RUNTIME_VERSION" run "$FLOX_BIN" --version
   assert_success
   assert_buildtime_version
 }
 
-@test "version: uses buildtime version in absence of wrapper derivation" {
+@test "version: doesn't leak FLOX_VERSION into activation" {
   project_setup
-
-  run bash <(
-    cat << EOF
-unset FLOX_VERSION
-$FLOX_BIN --version
-EOF
-  )
-  assert_success
-  assert_buildtime_version
+  FLOX_VERSION="$MOCK_RUNTIME_VERSION" run "$FLOX_BIN" activate -- printenv FLOX_VERSION
+  assert_failure
+  assert_output ""
 }

--- a/flake.nix
+++ b/flake.nix
@@ -146,12 +146,6 @@
 
           flox-cli-tests = prev.flox-cli-tests.override {
             PROJECT_TESTS_DIR = "/cli/tests";
-            NIX_PLUGINS = null;
-            FLOX_BIN = null;
-            WATCHDOG_BIN = null;
-            FLOX_ACTIVATIONS_BIN = null;
-            BUILDENV_BIN = null;
-            flox-interpreter = null;
           };
         });
       };

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -296,16 +296,7 @@ writeShellScriptBin PROJECT_NAME ''
 
   {
     echo "''${0##*/}: Running test suite with:";
-    echo "  FLOX_BIN:                 $FLOX_BIN";
-    echo "  WATCHDOG_BIN:             $WATCHDOG_BIN";
-    echo "  BUILDENV_BIN:             $BUILDENV_BIN";
-    echo "  FLOX_ACTIVATIONS_BIN:     $FLOX_ACTIVATIONS_BIN";
-    echo "  NIX_PLUGINS:                $NIX_PLUGINS";
-    echo "  NIX_BIN:                  $NIX_BIN";
-    echo "  FLOX_INTERPRETER:         $FLOX_INTERPRETER";
     echo "  PROJECT_TESTS_DIR:        $PROJECT_TESTS_DIR";
-    echo "  INPUT_DATA:               $INPUT_DATA";
-    echo "  GENERATED_DATA:           $GENERATED_DATA";
     echo "  bats                      ${batsWith}/bin/bats";
     echo "  bats options              ''${_BATS_ARGS[*]}";
     echo "  bats tests                ''${_FLOX_TESTS[*]}";

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -19,7 +19,7 @@
   flox-buildenv,
   flox-nix-plugins,
   flox-watchdog,
-  flox-cli,
+  flox,
   flox-interpreter,
   gawk,
   git,
@@ -201,7 +201,7 @@ writeShellScriptBin PROJECT_NAME ''
     export MANUALLY_GENERATED='${./../../test_data/manually_generated}'
     export INPUT_DATA='${./../../test_data/input_data}'
 
-    export FLOX_BIN="${flox-cli}/bin/flox"
+    export FLOX_BIN="${flox}/bin/flox"
     export NIX_BIN="${nix}/bin/nix"
     export BUILDENV_BIN="${flox-buildenv}/bin/buildenv"
     export NIX_PLUGINS="${flox-nix-plugins}/lib/nix-plugins"

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -190,6 +190,7 @@ writeShellScriptBin PROJECT_NAME ''
     shift;
   done
 
+  export _FLOX_LOCAL_DEV
   if [[ "''${_FLOX_LOCAL_DEV}" != "true" ]]; then
     # Override any local mutable paths set by the devShell.
     export GENERATED_DATA='${./../../test_data/generated}'

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -139,11 +139,6 @@ writeShellScriptBin PROJECT_NAME ''
   FLOX_LATEST_VERSION=${builtins.readFile ../../VERSION}
   export FLOX_LATEST_VERSION
 
-  # if FLOX_VERSION is not set, use the latest released version
-  # otherwise use the provided version
-  # when running tests with just, just will set FLOX_VERSION.
-  export FLOX_VERSION="''${FLOX_VERSION:-$FLOX_LATEST_VERSION}"
-
   # TODO: we shouldn't do this but rather use absolute paths
   # Look if we can use https://github.com/abathur/resholve
   export PATH="$PROJECT_PATH:${lib.makeBinPath paths}"

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -42,17 +42,8 @@
   which,
   writeShellScriptBin,
   process-compose,
-  GENERATED_DATA ? ./../../test_data/generated,
-  MANUALLY_GENERATED ? ./../../test_data/manually_generated,
-  INPUT_DATA ? ./../../test_data/input_data,
   PROJECT_NAME ? "flox-cli-tests",
   PROJECT_TESTS_DIR ? ./../../cli/tests,
-  NIX_BIN ? "${nix}/bin/nix",
-  BUILDENV_BIN ? "${flox-buildenv}/bin/buildenv",
-  NIX_PLUGINS ? "${flox-nix-plugins}/lib/nix-plugins",
-  FLOX_BIN ? "${flox-cli}/bin/flox",
-  WATCHDOG_BIN ? "${flox-watchdog}/libexec/flox-watchdog",
-  FLOX_ACTIVATIONS_BIN ? "${flox-activations}/bin/flox-activations",
 }:
 let
   batsWith = bats.withLibraries (p: [
@@ -123,11 +114,6 @@ writeShellScriptBin PROJECT_NAME ''
   set -eu;
   set -o pipefail;
 
-  # Set the test data location
-  export GENERATED_DATA='${GENERATED_DATA}'
-  export MANUALLY_GENERATED='${MANUALLY_GENERATED}'
-  export INPUT_DATA='${INPUT_DATA}'
-
   # Find root of the subproject if not specified
   PROJECT_TESTS_DIR='${PROJECT_TESTS_DIR}';
   # Find top level of the project
@@ -167,65 +153,15 @@ writeShellScriptBin PROJECT_NAME ''
   cp -RL "$PROJECT_TESTS_DIR/"* "$WORKDIR";
   cd "$WORKDIR"||exit;
 
-  # Declare project specific dependencies
-  ${if NIX_BIN == null then "export NIX_BIN='nix';" else "export NIX_BIN='${NIX_BIN}';"}
-  ${
-    if BUILDENV_BIN == null then
-      ''export BUILDENV_BIN="$PROJECT_ROOT_DIR/build/flox-buildenv/bin/buildenv";''
-    else
-      "export BUILDENV_BIN='${BUILDENV_BIN}';"
-  }
-  ${
-    if NIX_PLUGINS == null then
-      ''export NIX_PLUGINS="$PROJECT_ROOT_DIR/build/nix-plugins/lib/nix-plugins";''
-    else
-      "export NIX_PLUGINS='${NIX_PLUGINS}';"
-  }
-  ${
-    if WATCHDOG_BIN == null then
-      # We pass this to daemonize which requires an absolute path
-      "export WATCHDOG_BIN=\"$(command -v flox-watchdog)\";"
-    else
-      "export WATCHDOG_BIN='${WATCHDOG_BIN}';"
-  }
-  ${
-    if FLOX_ACTIVATIONS_BIN == null then
-      ''export FLOX_ACTIVATIONS_BIN="$(command -v flox-activations)";''
-    else
-      "export FLOX_ACTIVATIONS_BIN='${FLOX_ACTIVATIONS_BIN}';"
-  }
-  # TODO: we should probably make this an absolute path to avoid having to call
-  # which "$FLOX_BIN" in user_dotfiles_setup
-  ${if FLOX_BIN == null then "export FLOX_BIN='flox';" else "export FLOX_BIN='${FLOX_BIN}';"}
-  export PROCESS_COMPOSE_BIN='${process-compose}/bin/process-compose';
-  ${
-    if flox-interpreter == null then
-      ''export FLOX_INTERPRETER="$PROJECT_ROOT_DIR/build/flox-interpreter";''
-    else
-      ''export FLOX_INTERPRETER='${flox-interpreter}';''
-  }
-
   usage() {
         cat << EOF
-  Usage: $0 [--flox <FLOX BINARY>| -F <FLOX BINARY>] \
-            [--watchdog <WATCHDOG BINARY | -K <WATCHDOG BINARY>] \
-            [--flox-activations <FLOX ACTIVATIONS BINARY>] \
-            [--nix-plugins <PLUGINS DIR>| -P <PLUGINS DIR>] \
-            [--nix <NIX BINARY>| -N <NIX BINARY>] \
-            [--input-data <INPUT DATA> | -I <INPUT DATA>] \
-            [--generated-data <GENERATED DATA> | -G <GENERATED DATA>] \
+  Usage: $0 [--local-dev] \
             [--tests <TESTS_DIR>| -T <TESTS_DIR>] \
             [--watch | -W] \
             [--help | -h] -- [BATS ARGUMENTS]
 
   Available options:
-      -F, --flox           Path to flox binary (Default: $FLOX_BIN)
-      -K, --watchdog       Path to the watchdog binary (Default: $WATCHDOG_BIN)
-      -B, --buildenv       Path to buildenv binary (Default: $BUILDENV_BIN)
-      -P, --nix-plugins    Path to dir with flox nix-plugins (Default: $NIX_PLUGINS)
-      -N, --nix            Path to nix binary (Default: $NIX_BIN)
-      -I, --input-data     Path to the input data directory (Default: $INPUT_DATA)
-      -G, --generated-data Path to the generated data directory (Default: $GENERATED_DATA)
+      --local-dev          Use local (rather than Nix) built dependencies (Default: false)
       -T, --tests          Path to folder of tests (Default: $PROJECT_TESTS_DIR)
       -c, --ci-runner      Which runner this job is on, if any
       -W, --watch          Run tests in a continuous watch mode
@@ -237,16 +173,10 @@ writeShellScriptBin PROJECT_NAME ''
   WATCH=;
   declare -a _FLOX_TESTS;
   _FLOX_TESTS=();
+  _FLOX_LOCAL_DEV=false
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
-      -[fF]|--flox)           export FLOX_BIN="''${2?}"; shift; ;;
-      -[kK]|--watchdog)       export WATCHDOG_BIN="''${2?}"; shift; ;;
-      -[bB]|--buildenv)       export BUILDENV_BIN="''${2?}"; shift; ;;
-      --flox-activations)     export FLOX_ACTIVATIONS_BIN="''${2?}"; shift; ;;
-      -[pP]|--nix-plugins)    export NIX_PLUGINS="''${2?}"; shift; ;;
-      -[nN]|--nix)            export NIX_BIN="''${2?}"; shift; ;;
-      -[iI]|--input-data)     export INPUT_DATA="''${2?}"; shift; ;;
-      -[gG]|--generated-data) export GENERATED_DATA="''${2?}"; shift; ;;
+      --local-dev)            _FLOX_LOCAL_DEV=true; ;;
       -[tT]|--tests)          export TESTS_DIR="''${2?}"; shift; ;;
       -[cC]|--ci-runner)      export FLOX_CI_RUNNER="''${2?}"; shift; ;;
       -[wW]|--watch)          WATCH=:; ;;
@@ -265,9 +195,21 @@ writeShellScriptBin PROJECT_NAME ''
     shift;
   done
 
-  # Set the test data location
-  export GENERATED_DATA=''${GENERATED_DATA:-'${GENERATED_DATA}'}
-  export INPUT_DATA=''${INPUT_DATA:-'${INPUT_DATA}'}
+  if [[ "''${_FLOX_LOCAL_DEV}" != "true" ]]; then
+    # Override any local mutable paths set by the devShell.
+    export GENERATED_DATA='${./../../test_data/generated}'
+    export MANUALLY_GENERATED='${./../../test_data/manually_generated}'
+    export INPUT_DATA='${./../../test_data/input_data}'
+
+    export FLOX_BIN="${flox-cli}/bin/flox"
+    export NIX_BIN="${nix}/bin/nix"
+    export BUILDENV_BIN="${flox-buildenv}/bin/buildenv"
+    export NIX_PLUGINS="${flox-nix-plugins}/lib/nix-plugins"
+    export WATCHDOG_BIN="${flox-watchdog}/libexec/flox-watchdog"
+    export FLOX_ACTIVATIONS_BIN="${flox-activations}/bin/flox-activations"
+    export PROCESS_COMPOSE_BIN='${process-compose}/bin/process-compose'
+    export FLOX_INTERPRETER='${flox-interpreter}'
+  fi
 
   # Default flag values
   : "''${TESTS_DIR:=$WORKDIR}";

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -47,7 +47,6 @@ symlinkJoin {
       --set NIX_BIN             "${nix}/bin/nix" \
       --set BUILDENV_NIX        "${flox-buildenv}/lib/buildenv.nix" \
       --set NIX_PLUGINS         "${flox-nix-plugins}/lib/nix-plugins" \
-      --set FLOX_BIN            "${flox-cli}/bin/flox" \
       --set WATCHDOG_BIN        "${flox-watchdog}/libexec/flox-watchdog" \
       --set PROCESS_COMPOSE_BIN "${process-compose}/bin/process-compose" \
       --set FLOX_VERSION        "${version}"

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -22,10 +22,10 @@ let
   version =
     if (FLOX_VERSION != null) then
       FLOX_VERSION
-    else if !(self ? revCount || self ? shortRev) then
-      "${fileVersion}-dirty"
-    else if !(self ? revCount) then
+    else if (self ? shortRev) then
       "${fileVersion}-g${self.shortRev}"
+    else if (self ? dirtyShortRev) then
+      "${fileVersion}-g${self.dirtyShortRev}"
     else
       fileVersion;
 in

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -124,6 +124,7 @@ mkShell (
         define_dev_env_var FLOX_ACTIVATIONS_BIN "''${REPO_ROOT}/cli/target/debug/flox-activations";
 
         # make built binaries
+        define_dev_env_var BUILDENV_BIN "''${REPO_ROOT}/build/flox-buildenv/bin/buildenv";
         define_dev_env_var NIX_PLUGINS "''${REPO_ROOT}/build/nix-plugins/lib/nix-plugins";
 
         # static nix files
@@ -138,6 +139,7 @@ mkShell (
         define_dev_env_var FLOX_MANPAGES "''${REPO_ROOT}/build/flox-manpages";
 
         # test data
+        define_dev_env_var INPUT_DATA "''${REPO_ROOT}/test_data/input_data";
         define_dev_env_var GENERATED_DATA "''${REPO_ROOT}/test_data/generated";
         define_dev_env_var MANUALLY_GENERATED "''${REPO_ROOT}/test_data/manually_generated";
 


### PR DESCRIPTION
## Proposed Changes

Make it possible to determine the correct version when testing:

- `flox --version`
- `flox containerize` on macOS

Split out of https://github.com/flox/flox/pull/2769

This is best reviewed commit-by-commit.

## Release Notes

N/A, not user facing.
