### PR TITLE
feat(compose): error for modified environments

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -117,7 +117,9 @@ impl<State> CoreEnvironment<State> {
 
     /// Return a [LockedManifest] if the environment is already locked and has
     /// the same manifest contents as the manifest, otherwise return None.
-    fn lockfile_if_up_to_date(&self) -> Result<Option<Lockfile>, CoreEnvironmentError> {
+    /// Note that the manifest could have whitespace or comment differences from
+    /// the lockfile.
+    pub fn lockfile_if_up_to_date(&self) -> Result<Option<Lockfile>, CoreEnvironmentError> {
         let lockfile_path = self.lockfile_path();
 
         let Ok(lockfile_path) = CanonicalPath::new(lockfile_path) else {

--- a/cli/flox-rust-sdk/src/models/environment/fetcher.rs
+++ b/cli/flox-rust-sdk/src/models/environment/fetcher.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use super::{open_path, EnvironmentError};
+use indoc::formatdoc;
+
+use super::{open_path, ConcreteEnvironment, EnvironmentError};
 use crate::flox::Flox;
 use crate::models::environment::Environment;
 use crate::models::lockfile::{LockedInclude, RecoverableMergeError};
@@ -25,18 +27,44 @@ impl IncludeFetcher {
                 ),
             ));
         };
-        let (name, environment) = match include_environment {
+        let (name, path) = match include_environment {
             IncludeDescriptor::Local { dir, name } => {
                 let path = if dir.is_absolute() {
-                    dir
+                    dir.clone()
                 } else {
-                    &base_directory.join(dir)
+                    base_directory.join(dir)
                 };
-                (name, open_path(flox, path).unwrap())
+                (name, path)
             },
         };
+        let environment = open_path(flox, &path)?;
 
-        // TODO: error if manifest and lock are not in sync
+        match &environment {
+            ConcreteEnvironment::Path(environment) => {
+                if !environment.lockfile_up_to_date()? {
+                    return Err(EnvironmentError::Recoverable(
+                        RecoverableMergeError::Catchall(
+                            "cannot include environment since its manifest and lockfile are out of sync".to_string()
+                        ),
+                    ));
+                }
+            },
+            ConcreteEnvironment::Managed(environment) => {
+                if environment.has_local_changes(flox)? {
+                    return Err(EnvironmentError::Recoverable(
+                        RecoverableMergeError::Catchall(formatdoc! {"
+                            cannot include environment since it has changes not yet synced to a generation.
+
+                            To resolve this issue, run either
+                            * 'flox edit -d {} --sync' to commit your local changes to a new generation
+                            * 'flox edit -d {} --reset' to discard your local changes and reset to the latest generation
+                        ", path.to_string_lossy(), path.to_string_lossy()}.to_string())));
+                }
+            },
+            ConcreteEnvironment::Remote(_) => {
+                unreachable!("opening a path cannot result in a remote environment");
+            },
+        }
 
         Ok(LockedInclude {
             manifest: environment.manifest(flox)?,
@@ -66,7 +94,8 @@ mod test {
     use indoc::indoc;
 
     use super::*;
-    use crate::flox::test_helpers::flox_instance;
+    use crate::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
+    use crate::models::environment::managed_environment::test_helpers::mock_managed_environment_in;
     use crate::models::environment::path_environment::test_helpers::new_path_environment_in;
     #[test]
     fn fetch_relative_path() {
@@ -79,7 +108,8 @@ mod test {
         let manifest = toml_edit::de::from_str(manifest_contents).unwrap();
 
         fs::create_dir(&environment_path).unwrap();
-        new_path_environment_in(&flox, manifest_contents, &environment_path);
+        let mut environment = new_path_environment_in(&flox, manifest_contents, &environment_path);
+        environment.lockfile(&flox).unwrap();
 
         let include_fetcher = IncludeFetcher {
             base_directory: Some(tempdir.path().to_path_buf()),
@@ -110,7 +140,8 @@ mod test {
         let manifest = toml_edit::de::from_str(manifest_contents).unwrap();
 
         fs::create_dir(&environment_path).unwrap();
-        new_path_environment_in(&flox, manifest_contents, &environment_path);
+        let mut environment = new_path_environment_in(&flox, manifest_contents, &environment_path);
+        environment.lockfile(&flox).unwrap();
 
         let include_fetcher = IncludeFetcher {
             base_directory: Some(tempdir.path().to_path_buf()),
@@ -128,5 +159,110 @@ mod test {
             name: "environment".to_string(),
             descriptor: include_descriptor,
         })
+    }
+
+    /// For fetching path environments:
+    /// - Fetching fails when not locked
+    /// - Fetching succeeds for trivial changes in the manifest (e.g. comments)
+    /// - Fetching fails when there are non-trivial changes in the manifest not
+    ///   reflected in the lockfile
+    #[test]
+    fn fetch_path_fails_if_out_of_sync() {
+        let (flox, tempdir) = flox_instance();
+
+        let environment_path = tempdir.path().join("environment");
+        let manifest_contents = indoc! {r#"
+        version = 1
+        "#};
+
+        fs::create_dir(&environment_path).unwrap();
+        let mut environment = new_path_environment_in(&flox, manifest_contents, &environment_path);
+
+        let include_fetcher = IncludeFetcher {
+            base_directory: Some(tempdir.path().to_path_buf()),
+        };
+
+        let include_descriptor = IncludeDescriptor::Local {
+            dir: environment_path.file_name().unwrap().into(),
+            name: None,
+        };
+
+        // Fetching should fail before locking
+        let err = include_fetcher
+            .fetch(&flox, &include_descriptor)
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "cannot include environment since its manifest and lockfile are out of sync"
+        );
+
+        // After locking, fetching should succeed
+        environment.lockfile(&flox).unwrap();
+        include_fetcher.fetch(&flox, &include_descriptor).unwrap();
+
+        // After writing a comment, fetching should succeed
+        fs::write(environment.manifest_path(&flox).unwrap(), indoc! {r#"
+        version = 1
+
+        # comment
+        "#})
+        .unwrap();
+        include_fetcher.fetch(&flox, &include_descriptor).unwrap();
+
+        // After writing an actual change, fetching should fail
+        fs::write(environment.manifest_path(&flox).unwrap(), indoc! {r#"
+        version = 1
+
+        # comment
+        [vars]
+        foo = "bar"
+        "#})
+        .unwrap();
+        let err = include_fetcher
+            .fetch(&flox, &include_descriptor)
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "cannot include environment since its manifest and lockfile are out of sync"
+        );
+    }
+
+    /// fetch() errors if attempting to fetch an out of sync managed environment
+    #[test]
+    fn fetch_managed_fails_if_out_of_sync() {
+        let owner = "owner".parse().unwrap();
+        let (flox, tempdir) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        let environment_path = tempdir.path().join("environment");
+        let manifest_contents = indoc! {r#"
+        version = 1
+        "#};
+
+        fs::create_dir(&environment_path).unwrap();
+        let environment =
+            mock_managed_environment_in(&flox, manifest_contents, owner, &environment_path, None);
+
+        let include_fetcher = IncludeFetcher {
+            base_directory: Some(tempdir.path().to_path_buf()),
+        };
+
+        let include_descriptor = IncludeDescriptor::Local {
+            dir: environment_path.file_name().unwrap().into(),
+            name: None,
+        };
+
+        // After writing a comment, fetching should fail
+        fs::write(environment.manifest_path(&flox).unwrap(), indoc! {r#"
+        version = 1
+
+        # comment
+        "#})
+        .unwrap();
+        let err = include_fetcher
+            .fetch(&flox, &include_descriptor)
+            .unwrap_err();
+        assert!(err.to_string().contains(
+            "cannot include environment since it has changes not yet synced to a generation"
+        ));
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1040,6 +1040,9 @@ impl ManagedEnvironment {
     /// if the environment is in sync with its current generation
     /// outside of the context of a specific operation.
     /// E.g. `flox edit`.
+    ///
+    /// Not having local changes means the environment has a lockfile, since we
+    /// only create generations with lockfiles
     pub fn has_local_changes(&self, flox: &Flox) -> Result<bool, ManagedEnvironmentError> {
         let mut generations = self.generations();
         let generations = generations

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1688,7 +1688,7 @@ pub(crate) mod tests {
         new_named_path_environment_in,
         new_path_environment_in,
     };
-    use crate::models::environment::path_environment::tests::generate_path_environments_without_install;
+    use crate::models::environment::path_environment::tests::generate_path_environments_without_install_or_include;
     use crate::models::environment::Environment;
     use crate::models::manifest::raw::RawManifest;
     use crate::models::manifest::typed::{Include, Manifest, Vars};
@@ -3233,9 +3233,7 @@ pub(crate) mod tests {
         /// Use manifests without [install] sections so we don't have to
         /// generate resolution responses
         #[test]
-        fn lock_manifest_noop_if_locked_without_install_section((mut flox, tempdir, environments_to_include) in generate_path_environments_without_install(2)) {
-
-            flox.features.compose = true;
+        fn lock_manifest_noop_if_locked_without_install_section((flox, tempdir, environments_to_include) in generate_path_environments_without_install_or_include(2)) {
 
             let manifest = Manifest {
                 version: Version,

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -918,11 +918,14 @@ pub mod test {
         version = 1
     "#};
 
-    // Generate a Manifest that has an empty install section
-    pub fn manifest_without_install() -> impl Strategy<Value = Manifest> {
-        any::<Manifest>().prop_filter("require an empty install section", |seed_manifest| {
-            seed_manifest.install.0.is_empty()
-        })
+    // Generate a Manifest that has empty install and include sections
+    pub fn manifest_without_install_or_include() -> impl Strategy<Value = Manifest> {
+        any::<Manifest>().prop_filter(
+            "require empty install and include sections",
+            |seed_manifest| {
+                seed_manifest.install.skip_serializing() && seed_manifest.include.skip_serializing()
+            },
+        )
     }
 
     #[test]

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -180,6 +180,10 @@ environments = [
 ]
 EOF
 
+  # Trigger a lock of included
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
+    "$FLOX_BIN" list -d included
+
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
     run --separate-stderr "$FLOX_BIN" list -c -d composer
   assert_success


### PR DESCRIPTION
When fetching included path environments, error if the environment has not been locked or has changes in the manifest not reflected in the serialized form of the manifest in the lockfile:
```
❌ ERROR: failed to fetch environment 'name': cannot include environment since its manifest and lockfile are out of sync
```

For managed environments, error if the environment is out of sync with floxmeta:
```
❌ ERROR: failed to fetch environment 'name': cannot include environment since it has changes not yet synced to a generation.

To resolve this issue, run either
* 'flox edit -d /path/to/name --sync' to commit your local changes to a new generation
* 'flox edit -d /path/to/name --reset' to discard your local changes and reset to the latest generation
```

I'm not sure if formatting the error with a partial error chain is necessarily the right way to go (as opposed to dropping `failed to fetch environment 'name'`), but it seems good enough for now.

## Release Notes

NA - behind feature flag