### PR TITLE
feat(compose): Add support to list --config

### DIFF
--- a/cli/flox/doc/doc-compose/flox-list.md
+++ b/cli/flox/doc/doc-compose/flox-list.md
@@ -1,0 +1,48 @@
+---
+title: FLOX-LIST
+section: 1
+header: "Flox User Manuals"
+...
+
+
+# NAME
+
+flox-list - list packages installed in an environment
+
+# SYNOPSIS
+
+```
+flox [<general-options>] list
+     [-d=<path> | -r=<owner/name>]
+     [-e | -c | -n | -a]
+```
+
+# DESCRIPTION
+
+List packages installed in an environment.
+The options `-n`, `-e`, and `-a` exist to provide varying levels of detail in
+the output.
+
+# OPTIONS
+
+## List Options
+
+`-e`, `--extended`
+:   Show the install ID, pkg-path, and version of each package (default).
+
+`-c`, `--config`
+:   Show the raw contents of the manifest.
+
+`-n`, `--name`
+:   Show only the install ID of each package.
+
+`-a`, `--all`
+:   Show all available package information including priority and license.
+
+```{.include}
+./include/environment-options.md
+./include/general-options.md
+```
+
+# SEE ALSO
+[`flox-install(1)`](./flox-install.md)

--- a/cli/flox/doc/doc-compose/flox-list.md
+++ b/cli/flox/doc/doc-compose/flox-list.md
@@ -32,6 +32,8 @@ the output.
 
 `-c`, `--config`
 :   Show the raw contents of the manifest.
+    When using composition, the merged manifest will be shown without any
+    commented lines.
 
 `-n`, `--name`
 :   Show only the install ID of each package.

--- a/cli/flox/doc/doc-compose/manifest.toml.md
+++ b/cli/flox/doc/doc-compose/manifest.toml.md
@@ -474,6 +474,8 @@ priority that should be used when merging the manifests. Descriptors later in
 the array take higher priority than those earlier in the array, and manifest
 fields in the composing manifest take the highest priority.
 
+The merged manifest can be viewed with `flox list --config`.
+
 ### Syntax
 
 An example `[include]` section is shown below:

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -66,7 +66,7 @@ impl List {
         }
 
         let system = &flox.system;
-        let lockfile = Self::get_lockfile(&flox, &mut env)?;
+        let lockfile = env.lockfile(&flox)?;
         let packages = lockfile.list_packages(system)?;
 
         if packages.is_empty() {
@@ -289,22 +289,6 @@ impl List {
             }
         }
         Ok(())
-    }
-
-    /// Read existing lockfile or lock to create a new [LockedManifest].
-    ///
-    /// This may write the lockfile depending on the type of environment;
-    /// path and managed environments with local checkouts will lock if there
-    /// isn't a lockfile or it has different manifest contents than the
-    /// manifest.
-    ///
-    /// Check the implementation docs of [Environment::lockfile] for more
-    /// information.
-    fn get_lockfile(flox: &Flox, env: &mut ConcreteEnvironment) -> Result<Lockfile> {
-        // TODO: it would be better if we knew when a lock was actually happening
-        let lockfile = env.lockfile(flox)?;
-
-        Ok(lockfile)
     }
 
     fn get_cached_upgrades_for_current_system(

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -38,6 +38,9 @@ pub(crate) fn deleted(v: impl Display) {
 pub(crate) fn updated(v: impl Display) {
     print_message(std::format_args!("✅ {v}"));
 }
+pub(crate) fn info(v: impl Display) {
+    print_message(std::format_args!("ℹ️ {v}"));
+}
 /// double width character, add an additional space for alignment
 pub(crate) fn warning(v: impl Display) {
     print_message(std::format_args!("⚠️  {v}"));

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -140,12 +140,17 @@ EOF
   "$FLOX_BIN" init
   MANIFEST_CONTENTS="$(
     cat <<-EOF
-    version = 1
+version = 1
 
-    [install]
+[hook]
+on-activate = "something suspicious"
 
-    [hook]
-    on-activate = "something suspicious"
+[profile]
+
+[options.allow]
+licenses = []
+
+[options.semver]
 EOF
   )"
 

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -121,10 +121,7 @@ EOF
   assert_output "influxdb2: influxdb2 (influxdb2)"
 }
 
-# ------------------------------ Catalog Tests ------------------------------- #
-# ---------------------------------------------------------------------------- #
-
-# bats test_tags=list,list:catalog
+# bats test_tags=list
 @test "'flox list' lists packages of environment in the current dir; One package from nixpkgs" {
   "$FLOX_BIN" init
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
@@ -135,7 +132,7 @@ EOF
   assert_output --regexp 'hello: hello \([0-9]+\.[0-9]+(\.[0-9]+)?\)'
 }
 
-# bats test_tags=list,list:catalog,list:config
+# bats test_tags=list,list:config
 @test "'flox list --config' shows manifest content" {
   "$FLOX_BIN" init
   MANIFEST_CONTENTS="$(
@@ -160,5 +157,3 @@ EOF
   assert_success
   assert_output "$MANIFEST_CONTENTS"
 }
-
-# ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

Update `flox list --config` to print the merged manifest with a notice
when using composition.

We now lock early, which we didn't previously for `list -c`, in order to
detect composition and for a more consistent experience between composed
and non-composed environments.

We have to re-serialize merged manifests from `typed::Manifest` which
means that we lose comments and add some defaults that the user may not
have specified. We'll improve on this in later commits and tickets.

## Release Notes

N/A
