### PR TITLE
chore(manifest): Make hook and profile optional

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
@@ -298,14 +298,16 @@ fn deep_merge_optional_containerize_config(
 mod tests {
     use super::shallow::ShallowMerger;
     use super::*;
-    use crate::models::manifest::typed::Inner;
+    use crate::models::manifest::typed::{Inner, Profile, Vars};
 
     #[test]
     fn composite_manifest_runs_merger() {
-        let composer = {
-            let mut manifest = Manifest::default();
-            manifest.profile.common = Some("composer".to_string());
-            manifest
+        let composer = Manifest {
+            profile: Some(Profile {
+                common: Some("composer".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
         };
         let manifest1 = {
             let mut manifest = Manifest::default();
@@ -315,14 +317,16 @@ mod tests {
                 .insert("var1".to_string(), "manifest1".to_string());
             manifest
         };
-        let manifest2 = {
-            let mut manifest = Manifest::default();
-            manifest
-                .vars
-                .inner_mut()
-                .insert("var2".to_string(), "manifest2".to_string());
-            manifest.profile.common = Some("manifest2".to_string());
-            manifest
+        let manifest2 = Manifest {
+            vars: Vars(BTreeMap::from([(
+                "var2".to_string(),
+                "manifest2".to_string(),
+            )])),
+            profile: Some(Profile {
+                common: Some("manifest2".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
         };
         let composite = CompositeManifest {
             composer,
@@ -337,8 +341,11 @@ mod tests {
         assert_eq!(merged.vars.inner()["var1"], "manifest1");
         assert_eq!(merged.vars.inner()["var2"], "manifest2");
         assert_eq!(
-            merged.profile.common,
-            Some("manifest2\ncomposer".to_string())
+            merged.profile,
+            Some(Profile {
+                common: Some("manifest2\ncomposer".to_string()),
+                ..Default::default()
+            })
         );
     }
 }

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -193,10 +193,6 @@ EOF
 [install.hello]
 pkg-path = "hello"
 
-[hook]
-
-[profile]
-
 [options.allow]
 licenses = []
 


### PR DESCRIPTION
⚠️ Split from and based on #2813 to make it easier to review

## Proposed Changes

So that they don't get rendered as empty tables when `flox list -c`
serializes a merged manifest that didn't explicitly specify values. They
are still kept if they were explicitly set though, per the additional
test. The remaining options are deferred to 2812.

## Release Notes

N/A
