### PR TITLE
chore(pkgs): Disable doCheck for t3

### DIFF
--- a/pkgs/t3/default.nix
+++ b/pkgs/t3/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     "VERSION=${version}"
   ];
   nativeBuildInputs = [ help2man ];
-  doCheck = true;
+  doCheck = false;
 
   meta = with lib; {
     homepage = "https://github.com/flox/t3";


### PR DESCRIPTION
## Proposed Changes

We've had some intermittent failures from the t3 tests due to output ordering on faster machines.

Prevent these from blocking the installation of Flox as a flake by disabling `doCheck` for the package, as previously agreed in this thread:

- https://flox-dev.slack.com/archives/C05P6A5J6U8/p1739292017829209

The t3 repo runs these same tests in CI so we'll still get feedback when we make changes to t3 itself, which is the time that we're most likely to make breaking changes and be in a position to fix them.

## Release Notes

Make the installation of Flox from a flake more reliable.