### PR TITLE
feat: message after `[include]` is modified

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -836,6 +836,23 @@ impl EditResult {
             },
         }
     }
+
+    pub fn include_modified(&self) -> bool {
+        match self {
+            Self::Unchanged => false,
+            Self::Changed {
+                old_lockfile,
+                new_lockfile,
+                ..
+            } => {
+                old_lockfile
+                    .as_ref()
+                    .map(|lockfile| lockfile.user_manifest().include.clone())
+                    .unwrap_or_default()
+                    != new_lockfile.user_manifest().include
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -242,10 +242,14 @@ impl Environment for PathEnvironment {
     fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
         let result = env_view.edit(flox, contents)?;
-        if result != EditResult::Unchanged {
-            if let Some(ref store_paths) = result.built_environment_store_paths() {
-                self.link(flox, store_paths)?;
-            };
+        match &result {
+            EditResult::Changed {
+                built_environment_store_paths,
+                ..
+            } => {
+                self.link(flox, built_environment_store_paths)?;
+            },
+            EditResult::Unchanged => {},
         }
         Ok(result)
     }

--- a/cli/flox-rust-sdk/src/utils/logging.rs
+++ b/cli/flox-rust-sdk/src/utils/logging.rs
@@ -65,4 +65,15 @@ pub mod test_helpers {
 
         (subscriber, writer)
     }
+
+    #[cfg(any(test, feature = "tests"))]
+    pub fn test_subscriber_message_only() -> (impl tracing::Subscriber, CollectingWriter) {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let (subscriber, writer) = test_subscriber();
+        let subscriber = subscriber.with(tracing_subscriber::filter::FilterFn::new(|metadata| {
+            metadata.target() == "flox::utils::message"
+        }));
+        (subscriber, writer)
+    }
 }

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -821,27 +821,16 @@ mod upgrade_notification_tests {
     use flox_rust_sdk::models::lockfile::LockedPackage;
     use flox_rust_sdk::providers::catalog::GENERATED_DATA;
     use flox_rust_sdk::providers::upgrade_checks::UpgradeInformation;
-    use flox_rust_sdk::utils::logging::test_helpers::CollectingWriter;
+    use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use time::OffsetDateTime;
-    use tracing::Subscriber;
-    use tracing_subscriber::filter::FilterFn;
-    use tracing_subscriber::layer::SubscriberExt;
 
     use super::*;
     use crate::commands::ActiveEnvironments;
 
-    fn test_subscriber() -> (impl Subscriber, CollectingWriter) {
-        let (subscriber, writer) = flox_rust_sdk::utils::logging::test_helpers::test_subscriber();
-        let subscriber = subscriber.with(FilterFn::new(|metadata| {
-            metadata.target() == "flox::utils::message"
-        }));
-        (subscriber, writer)
-    }
-
     #[test]
     fn no_notification_printed_if_absent() {
         let (flox, _tempdir) = flox_instance();
-        let (subscriber, writer) = test_subscriber();
+        let (subscriber, writer) = test_subscriber_message_only();
 
         let environment =
             new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
@@ -890,7 +879,7 @@ mod upgrade_notification_tests {
     #[test]
     fn no_notification_printed_if_already_active() {
         let (flox, _tempdir) = flox_instance();
-        let (subscriber, writer) = test_subscriber();
+        let (subscriber, writer) = test_subscriber_message_only();
 
         let environment =
             new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
@@ -921,7 +910,7 @@ mod upgrade_notification_tests {
     #[test]
     fn notification_printed_if_present() {
         let (flox, _tempdir) = flox_instance();
-        let (subscriber, writer) = test_subscriber();
+        let (subscriber, writer) = test_subscriber_message_only();
 
         let environment = new_named_path_environment_from_env_files(
             &flox,
@@ -948,7 +937,7 @@ mod upgrade_notification_tests {
     #[test]
     fn no_notification_printed_if_outdated() {
         let (flox, _tempdir) = flox_instance();
-        let (subscriber, writer) = test_subscriber();
+        let (subscriber, writer) = test_subscriber_message_only();
 
         let environment =
             new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
@@ -987,7 +976,7 @@ mod upgrade_notification_tests {
     #[test]
     fn no_notification_printed_if_no_diff() {
         let (flox, _tempdir) = flox_instance();
-        let (subscriber, writer) = test_subscriber();
+        let (subscriber, writer) = test_subscriber_message_only();
 
         let environment =
             new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -373,12 +373,15 @@ impl Edit {
 mod tests {
     use std::fs;
 
-    use flox_rust_sdk::flox::test_helpers::flox_instance_with_optional_floxhub;
+    use flox_rust_sdk::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
     use flox_rust_sdk::models::environment::managed_environment::test_helpers::mock_managed_environment_unlocked;
+    use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment_in;
     use flox_rust_sdk::models::lockfile::{ResolutionFailures, ResolveError};
+    use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use indoc::indoc;
     use serde::de::Error;
     use tempfile::tempdir;
+    use tracing::instrument::WithSubscriber;
 
     use super::*;
 

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -192,19 +192,16 @@ impl Edit {
             EditResult::Unchanged => {
                 message::warning("No changes made to environment.");
             },
-            EditResult::ReActivateRequired { .. }
-                if activated_environments().is_active(&active_environment) =>
-            {
-                message::warning(reactivate_required_note)
+            EditResult::Changed { .. } => {
+                if result.reactivate_required()
+                    && activated_environments().is_active(&active_environment)
+                {
+                    message::warning(reactivate_required_note);
+                } else {
+                    message::updated("Environment successfully updated.")
+                }
+                warn_manifest_changes_for_services(flox, environment);
             },
-            EditResult::ReActivateRequired { .. } => {
-                message::updated("Environment successfully updated.")
-            },
-            EditResult::Success { .. } => message::updated("Environment successfully updated."),
-        }
-
-        if result != EditResult::Unchanged {
-            warn_manifest_changes_for_services(flox, environment);
         }
 
         Ok(())

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -168,29 +168,18 @@ mod tests {
     use flox_rust_sdk::models::manifest::raw::PackageToInstall;
     use flox_rust_sdk::providers::catalog::test_helpers::reset_mocks_from_file;
     use flox_rust_sdk::providers::catalog::GENERATED_DATA;
-    use flox_rust_sdk::utils::logging::test_helpers::CollectingWriter;
+    use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use indoc::indoc;
     use tracing::instrument::WithSubscriber;
-    use tracing::Subscriber;
-    use tracing_subscriber::filter::FilterFn;
-    use tracing_subscriber::layer::SubscriberExt;
 
     use super::*;
     use crate::commands::EnvironmentSelect;
-
-    fn test_subscriber() -> (impl Subscriber, CollectingWriter) {
-        let (subscriber, writer) = flox_rust_sdk::utils::logging::test_helpers::test_subscriber();
-        let subscriber = subscriber.with(FilterFn::new(|metadata| {
-            metadata.target() == "flox::utils::message"
-        }));
-        (subscriber, writer)
-    }
 
     /// Check message printed when there are no upgrades available
     #[tokio::test]
     async fn confirmation_when_up_to_date() {
         let (mut flox, _tempdir) = flox_instance();
-        let (subscriber, writer) = test_subscriber();
+        let (subscriber, writer) = test_subscriber_message_only();
 
         let environment = new_named_path_environment_from_env_files(
             &flox,
@@ -217,7 +206,7 @@ mod tests {
     /// Run an upgrade of an environment that only has upgrades on other systems
     async fn run_upgrade_with_upgrades_on_other_system(dry_run: bool) -> String {
         let (mut flox, _tempdir) = flox_instance();
-        let (subscriber, writer) = test_subscriber();
+        let (subscriber, writer) = test_subscriber_message_only();
 
         let mut environment = new_named_path_environment(&flox, "version = 1", "name");
 


### PR DESCRIPTION
[fix: use lockfile to detect changes for edit](https://github.com/flox/flox/commit/4afa51d834ead251a7ece964be51e6506ba55da3)

Currently, if `flox edit` modifies `[include]` in a way that leads to a
change in e.g. hook.on-activate for the merged manifest, we don't print
the warning that a user may need to reactivate.

Fix this by using the manifest in the lockfile rather than the user
manifest.

This also refactors EditResult to only have two variants, Unchanged and
Changed. Upcoming changes will require warning when `[include]` is
modified, which isn't mutually exclusive with ReActivateRequired and
Success, so the enum would start to become a truth table. Using a method
EditResult::reactivate_required will be simpler.

[test: factor out test_subscriber_message_only](https://github.com/flox/flox/commit/907d0d5d0bb5506762d02f3a17ef134de02bb50c)

The code is already duplicated twice, and I'll need to use it a third
time.

[feat: message after [include] is modified](https://github.com/flox/flox/commit/6dd48abcdd9393f318c22dc669d8fbd40c3a2178)

After a `flox edit` that modifies `[include]`, print:
```
ℹ️ Run 'flox list -c' to see merged manifest.
```

## Release Notes

NA - behind feature flag