### PR TITLE
fix(installer_channel): Document and restrict vals

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1032,6 +1032,8 @@ dependencies = [
  "path-dedot",
  "pollster",
  "pretty_assertions",
+ "proptest",
+ "proptest-derive",
  "regex",
  "reqwest 0.11.27",
  "semver",

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -58,6 +58,8 @@ flox-core.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+proptest.workspace = true
+proptest-derive.workspace = true
 serde_with.workspace = true
 serial_test.workspace = true
 temp-env.workspace = true

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -101,6 +101,11 @@ flox config --set 'trusted_environments."owner/name"' trust
 :   Hide environments named 'default' from the shell prompt,
     and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: true).
 
+`installer_channel`
+:   Release channel to use when checking for updates to Flox.
+    Valid values are `stable`, `nightly`, or `qa`.
+    (default: `stable`)
+
 `search_limit`
 :   How many items `flox search` should show by default.
 


### PR DESCRIPTION
## Proposed Changes

We had a Sentry report for a failed update check against the path `by-env/nixos-24.05/LATEST_VERSION` which looks like someone set the `installer_channel` config option to represent a Nix channel:

- https://flox-dev.sentry.io/issues/6421529049/?alert_rule_id=15667377&alert_type=issue&environment=stable&notification_uuid=cb2bb2c3-3b62-4c88-b17a-fb67d0426310&project=4506548241825792&referrer=slack

Prevent this from happening by restricting and documenting the values that can be provided. If you try to set an incorrect value imperatively:

    % flox config --set installer_channel nixos-24.05
    ❌ ERROR: unknown variant `nixos-24.05`, expected one of `stable`, `nightly`, `qa`

If you set an incorrect value declaratively, as that user has:

    % flox list
    ❌ ERROR: Could not parse config: unknown variant `nixos-24.05`, expected one of `stable`, `nightly`, `qa`

Unfortunately the errors don't include the path of the invalid key but in this case it should be clear enough where the problem lies. I looked briefly at whether `serde_path_to_error` would help here but it doesn't appear to give anything for errors in top-level keys like this.

## Release Notes

Document the use of `installer_channel` to receive more frequent update notifications and prevent invalid values.