### PR TITLE
docs: Flox uppercase as noun

### DIFF
--- a/cli/flox/doc/doc-build/flox-build.md
+++ b/cli/flox/doc/doc-build/flox-build.md
@@ -32,7 +32,7 @@ and output build artifacts at `result-<package>` adjacent to the environment.
 
 Possible values for `<package>` are all keys under the `build` attribute
 in the `manifest.toml`.
-If no `<package>` is specified, flox will attempt to build all packages
+If no `<package>` is specified, Flox will attempt to build all packages
 that are defined in the environment.
 
 Packages are built by running the script defined in `build.<package>.command`

--- a/cli/flox/doc/doc-build/flox-publish.md
+++ b/cli/flox/doc/doc-build/flox-publish.md
@@ -41,7 +41,7 @@ This allows re-use of the package in other environments.
 
 Flox makes some assertions before publishing, specifically
 
-- The flox environment used to build the package is tracked as a git repository.
+- The Flox environment used to build the package is tracked as a git repository.
 - Tracked files in the repository are all clean.
 - The repository has a remote defined and the current revision has been pushed to it.
 - The build environment must have at least one package installed.
@@ -82,11 +82,11 @@ and defers authorization to the nix AWS provider.
 Flox uses nix's S3 provider to perform the uploads and downloads,
 so you need to be authenticated with AWS
 to allow for this.
-Using the `awscli2` package (as found in flox),
+Using the `awscli2` package (as found in Flox),
 you need to run `aws sso login`.
 If you are using non-default profiles (see `~/.aws/config`),
 you should set AWS_PROFILE in your shell
-so `aws` CLI and flox invocations
+so `aws` CLI and Flox invocations
 use the same AWS profile.
 
 Instructions for setting up the AWS CLI
@@ -96,7 +96,7 @@ can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-sta
 
 To simplify the command line during publish,
 you can set the `store_url` and `signing_key`
-in the flox config:
+in the Flox config:
 
 ``` bash
 flox config --set publish.store_url "s3://my-bucket-name"

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -134,7 +134,7 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
     and they will not persist when using a remote environment with `-r`.
 
 `$FLOX_ENV_PROJECT`
-:   `activate` sets this variable to the directory of the project using the flox
+:   `activate` sets this variable to the directory of the project using the Flox
     environment.
     For environments stored locally, this is the directory containing the
     environment.

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -78,17 +78,17 @@ flox config --set 'trusted_environments."owner/name"' trust
 # SUPPORTED CONFIGURATION OPTIONS
 
 `config_dir`
-:   Directory where flox should load its configuration file
+:   Directory where Flox should load its configuration file
     (default: `$XDG_CONFIG_HOME/flox`).
     This option will only take effect if set with `$FLOX_CONFIG_DIR`.
     `config_dir` is ignored.
 
 `cache_dir`
-:   Directory where flox should store ephemeral data
+:   Directory where Flox should store ephemeral data
     (default: `$XDG_CACHE_HOME/flox`).
 
 `data_dir`
-:   Directory where flox should store persistent data
+:   Directory where Flox should store persistent data
     (default: `$XDG_DATA_HOME/flox`).
 
 `disable_metrics`
@@ -117,7 +117,7 @@ flox config --set 'trusted_environments."owner/name"' trust
     * "hide-default": filters out environments named 'default' from the shell prompt
 
 `state_dir`
-:   Directory where flox should store data that's not critical but also
+:   Directory where Flox should store data that's not critical but also
     shouldn't be able to be freely deleted like data in the cache directory.
     (default: `$XDG_STATE_HOME/flox` e.g. `~/.local/state/flox`)
 

--- a/cli/flox/doc/flox-update.md
+++ b/cli/flox/doc/flox-update.md
@@ -23,7 +23,7 @@ flox [<general-options>] update
 Update an environment's base catalog,
 or update the global base catalog if `--global` is specified.
 
-The base catalog is a collection of packages used by various flox subcommands.
+The base catalog is a collection of packages used by various Flox subcommands.
 
 The global base catalog provides packages for
 [`flox-search(1)`](./flox-search.md) and [`flox-show(1)`](./flox-show.md) when

--- a/cli/flox/doc/flox.md
+++ b/cli/flox/doc/flox.md
@@ -20,7 +20,7 @@ flox [<general options>] <command>
 
 Flox is a virtual environment and package manager all in one.
 
-With flox you create environments that layer and provide dependencies just
+With Flox you create environments that layer and provide dependencies just
 where it matters,
 making them portable across the full software lifecycle.
 
@@ -35,7 +35,7 @@ These completions are installed alongside Flox.
 ./include/general-options.md
 ```
 
-## flox Options
+## Flox Options
 
 `--version`
 :   Print `flox` version.
@@ -107,7 +107,7 @@ sharing environments, and administration.
 :   Override the default editor used for editing environment manifests and commit messages.
 
 `$SSL_CERT_FILE`, `$NIX_SSL_CERT_FILE`
-:   If set, overrides the path to the default flox-provided SSL certificate bundle.
+:   If set, overrides the path to the default Flox provided SSL certificate bundle.
     Set `NIX_SSL_CERT_FILE` to only override packages built with Nix,
     and otherwise set `SSL_CERT_FILE` to override the value for all packages.
 


### PR DESCRIPTION
## Proposed Changes

I noticed some incorrect uses when editing `flox-config` in another PR and filtered the remaining offenders with:

    rg "[^./'\`]flox" cli/flox/doc

## Release Notes

N/A