### PR TITLE
fix(compose): include.environments serde default and test with FLOX_FEATURES_COMPOSE=true

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -863,6 +863,7 @@ pub enum ManifestError {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct Include {
+    #[serde(default)]
     pub environments: Vec<IncludeDescriptor>,
 }
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4722,7 +4722,7 @@ EOF
     foo = "highest precedence"
 EOF
   )"
-  echo "$MANIFEST_CONTENTS_HIGHEST_PRECEDENCE" | FLOX_FEATURES_COMPOSE=true "$FLOX_BIN" edit -f -
+  echo "$MANIFEST_CONTENTS_HIGHEST_PRECEDENCE" | "$FLOX_BIN" edit -f -
 
   run "$FLOX_BIN" activate -- echo 'foo: $foo; bar: $bar'
   assert_success

--- a/cli/tests/compose.bats
+++ b/cli/tests/compose.bats
@@ -76,4 +76,6 @@ project_teardown() {
   project_setup
   RUST_LOG=debug FLOX_FEATURES_COMPOSE=true run "$FLOX_BIN" activate -- true
   assert_output --partial "compose=true"
+  RUST_LOG=debug FLOX_FEATURES_COMPOSE=false run "$FLOX_BIN" activate -- true
+  assert_output --partial "compose=false"
 }

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -160,8 +160,6 @@ EOF
 
 # bats test_tags=list,list:config
 @test "'flox list --config' shows manifest content for composed environments" {
-  export FLOX_FEATURES_COMPOSE=true
-
   "$FLOX_BIN" init -d included
   cat > included/.flox/env/manifest.toml <<-EOF
 version = 1

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -394,6 +394,8 @@ home_setup() {
 # `{setup,teardown}_suite' functions must be defined in `setup_suite.bash'
 # files, AND keep in mind that `SET_TESTS_DIR' will likely differ.
 common_suite_setup() {
+  export FLOX_FEATURES_COMPOSE='true'
+
   unset_flox_env_setup
   # Backup real env vars.
   reals_setup


### PR DESCRIPTION
## Proposed Changes

**test(integ): Default to FLOX_FEATURES_COMPOSE=true**

Run all integration tests with the composition feature flag enabled so
that we get early feedback in preparation for turning it on for
everywhere when the feature is launched.

Ideally it would be nice to run a matrix of the tests with and without
the feature flag but it's complicated to configure and expensive to run,
so it doesn't seem worth it.

It's worth noting that the feature flags for composition and services
affect manifest parsing in various places and we mostly switch on the
presence of includes rather than the flag, unlike pkgdb vs catalog which
took completely different setups and codepaths.

This change highlights an issue with `flox list` which will be fixed in
a subsequent commit.

**fix(compose): include.environments serde default**

Set a deserialization default of an empty vec so that a manifest with an
empty `[include]` table, as generated by the `flox init` template, can
be read back. Problem demonstated by this test failure:

    ✗ 'flox list' lists packages of environment in the current dir; One package from nixpkgs [49]
       tags: list
       (in test file list.bats, line 127)
         `_FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \' failed
       ✨ Created environment 'test' (aarch64-darwin)

       Next:
         $ flox search <package>    <- Search for a package
         $ flox install <package>   <- Install a package into an environment
         $ flox activate            <- Enter the environment
         $ flox edit                <- Add environment variables and shell hooks

       ❌ ERROR: Failed to modify manifest.

       couldn't parse manifest contents: missing field `environments`
       in `include`

## Release Notes

N/A