### PR TITLE
fix(ci): Allow revert commits in merge queue

### DIFF
--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -96,7 +96,8 @@ pre-commit-hooks.lib.${system}.run {
                 ALLOWED_PREFIXES_FLAG=""
                 ALLOWED_PREFIXES=("Revert")
                 if [ "$IS_MERGE_QUEUE" = "1" ]; then
-                  ALLOWED_PREFIXES_FLAG="--allowed-prefixes \"''${ALLOWED_PREFIXES[@]}\""
+                  ALLOWED_PREFIXES_ESCAPED=$(printf "%q " "''${ALLOWED_PREFIXES[@]}")
+                  ALLOWED_PREFIXES_FLAG="--allowed-prefixes $ALLOWED_PREFIXES_ESCAPED"
                 fi
 
                 ${config.hooks.commitizen.package}/bin/cz check \


### PR DESCRIPTION
## Proposed Changes

I wasn't able to merge a branch that contained a revert commit:

- https://github.com/flox/flox/actions/runs/13948656774/job/39042042563#step:9:84
- https://github.com/flox/flox/pull/2769/commits/737558e4cf35ad0b01a94ea9a8379d09efed6760

Adding `-x` to this script revealed that it was double quoting the args:

    + ALLOWED_PREFIXES_FLAG=
    + ALLOWED_PREFIXES=("Revert")
    + '[' 1 = 1 ']'
    + ALLOWED_PREFIXES_FLAG='--allowed-prefixes "Revert"'
    + /nix/store/cpwhg2mjgbpyq1ll286kxr2s55mncs81-python3.12-commitizen-4.0.0/bin/cz check --allowed-prefixes '"Revert"' --rev-range 7907112422299d8eb310ee20c86c50994896201b..737558e4cf35ad0b01a94ea9a8379d09efed6760

It now looks like this, when tested with some additional values:

    + ALLOWED_PREFIXES_FLAG=
    + ALLOWED_PREFIXES=("Revert" "something else" "another thing too")
    + '[' 1 = 1 ']' ++ printf '%q ' Revert 'something else' 'another thing too'
    + ALLOWED_PREFIXES_ESCAPED='Revert something\ else another\ thing\ too '
    + ALLOWED_PREFIXES_FLAG='--allowed-prefixes Revert something\ else another\ thing\ too '
    + /nix/store/cpwhg2mjgbpyq1ll286kxr2s55mncs81-python3.12-commitizen-4.0.0/bin/cz check --allowed-prefixes Revert 'something\' else 'another\' 'thing\' too --rev-range 7907112422299d8eb310ee20c86c50994896201b..737558e4cf35ad0b01a94ea9a8379d09efed6760

The quoting and escaping still looks a bit odd in the trace output of the final command but it does the right thing and this is an intended use of `printf %q`:

- https://www.gnu.org/software/bash/manual/bash.html#index-printf

## Release Notes

N/A
