### PR TITLE
test: improve proptest generator performance

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -3227,13 +3227,14 @@ pub(crate) mod tests {
     proptest! {
         // This probably isn't the best suited for proptest as there are lots of
         // writes to disk.
-        // 8 cases takes about 1-1.5 seconds for me
-        #![proptest_config(ProptestConfig::with_cases(8))]
+        // 32 cases takes .1-.2 seconds for me
+        #![proptest_config(ProptestConfig::with_cases(32))]
         /// If we lock twice, the second lockfile should be the same as the first
         /// Use manifests without [install] sections so we don't have to
         /// generate resolution responses
         #[test]
-        fn lock_manifest_noop_if_locked_without_install_section((flox, tempdir, environments_to_include) in generate_path_environments_without_install_or_include(2)) {
+        fn lock_manifest_noop_if_locked_without_install_section((mut flox, tempdir, environments_to_include) in generate_path_environments_without_install_or_include(3)) {
+            flox.features.compose = true;
 
             let manifest = Manifest {
                 version: Version,

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -916,12 +916,30 @@ pub mod test {
 
     // Generate a Manifest that has empty install and include sections
     pub fn manifest_without_install_or_include() -> impl Strategy<Value = Manifest> {
-        any::<Manifest>().prop_filter(
-            "require empty install and include sections",
-            |seed_manifest| {
-                seed_manifest.install.skip_serializing() && seed_manifest.include.skip_serializing()
-            },
+        (
+            any::<Version<1>>(),
+            any::<Vars>(),
+            any::<Option<Hook>>(),
+            any::<Option<Profile>>(),
+            any::<Options>(),
+            any::<Services>(),
+            any::<Build>(),
+            any::<Option<Containerize>>(),
         )
+            .prop_map(
+                |(version, vars, hook, profile, options, services, build, containerize)| Manifest {
+                    version,
+                    install: Install::default(),
+                    vars,
+                    hook,
+                    profile,
+                    options,
+                    services,
+                    build,
+                    containerize,
+                    include: Include::default(),
+                },
+            )
     }
 
     #[test]


### PR DESCRIPTION
Improve the performance of `manifest_without_install_or_include()`

`lock_manifest_noop_if_locked_without_install_section` has been consistently taking more than 60 seconds for me.

The issue seems to be the `prop_filter()` calls in `manifest_without_install_or_include()`. I assume that many manifests are being generated and then rejected. Instead of using prop_filter, create a valid manifest by construction.

This massively improves the speed of
`lock_manifest_noop_if_locked_without_install_section`, so increase the number of cases we're running.

## Release Notes

NA