### PR TITLE
feat: add zebra() to Environment trait

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -603,15 +603,10 @@ impl CoreEnvironment<ReadOnly> {
         // Create a seed lockfile by "unlocking" (i.e. removing the locked entries of)
         // all packages matching the given groups or iids.
         // If no groups or iids are provided, all packages are unlocked.
-        let seed_lockfile = if groups_or_iids.is_empty() {
-            debug!("no groups or iids provided, unlocking all packages");
-            None
-        } else {
-            existing_lockfile.clone().map(|mut lockfile| {
-                lockfile.unlock_packages_by_group_or_iid(groups_or_iids);
-                lockfile
-            })
-        };
+        let seed_lockfile = existing_lockfile.clone().map(|mut lockfile| {
+            lockfile.unlock_packages_by_group_or_iid(groups_or_iids);
+            lockfile
+        });
 
         let upgraded_lockfile = Lockfile::lock_manifest(
             flox,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -17,7 +17,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use self::remote_environment::RemoteEnvironmentError;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
-use super::lockfile::{Lockfile, RecoverableMergeError, ResolveError};
+use super::lockfile::{IncludeToZebra, Lockfile, RecoverableMergeError, ResolveError};
 use super::manifest::raw::PackageToInstall;
 use super::manifest::typed::{ActivateMode, Manifest, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
@@ -131,6 +131,13 @@ pub trait Environment: Send {
         &mut self,
         flox: &Flox,
         groups_or_iids: &[&str],
+    ) -> Result<UpgradeResult, EnvironmentError>;
+
+    // Zebra includes in the environment
+    fn zebra(
+        &mut self,
+        flox: &Flox,
+        to_zebra: Vec<IncludeToZebra>,
     ) -> Result<UpgradeResult, EnvironmentError>;
 
     /// Return the lockfile.

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1405,24 +1405,29 @@ impl Lockfile {
     }
 
     /// Filter out packages from the locked manifest by install_id or group
+    /// If groups_or_iids is empty, all packages are unlocked.
     ///
     /// This is used to create a seed lockfile to upgrade a subset of packages,
     /// as packages that are not in the seed lockfile will be re-resolved unconstrained.
     pub(crate) fn unlock_packages_by_group_or_iid(&mut self, groups_or_iids: &[&str]) -> &mut Self {
-        self.packages = std::mem::take(&mut self.packages)
-            .into_iter()
-            .filter(|package| {
-                if groups_or_iids.contains(&package.install_id()) {
-                    return false;
-                }
+        if groups_or_iids.is_empty() {
+            self.packages = Vec::new();
+        } else {
+            self.packages = std::mem::take(&mut self.packages)
+                .into_iter()
+                .filter(|package| {
+                    if groups_or_iids.contains(&package.install_id()) {
+                        return false;
+                    }
 
-                if let Some(catalog_package) = package.as_catalog_package_ref() {
-                    return !groups_or_iids.contains(&catalog_package.group.as_str());
-                }
+                    if let Some(catalog_package) = package.as_catalog_package_ref() {
+                        return !groups_or_iids.contains(&catalog_package.group.as_str());
+                    }
 
-                true
-            })
-            .collect();
+                    true
+                })
+                .collect();
+        }
         self
     }
 


### PR DESCRIPTION
[refactor: don't re-fetch includes for flox upgrade](https://github.com/flox/flox/commit/1b2c0435bc707fb2559fd71a19fe1bdc780d3bf5)

Currently upgrading all packages is implemented by completely removing the seed
lockfile. This will force all includes to be re-fetched.

Instead, only unlock packages when performing an upgrade.

[feat: add zebra() to Environment trait](https://github.com/flox/flox/commit/0557f55822401bb564f18d75dcac4dc100e0851f)

We haven't yet decided what to call the operation that re-fetched an
included environment, so I'm calling that zebra in this commit.

Add zebra() to Environment trait and implement it in CoreEnvironment and
Lockfile.

zebra() re-fetches all included environments or if specified, a list of
included environments.

I added some tests, but I plan to integration test the following after
this functionality is exposed with a flox subcommand:
- zebraing all included environments
- zebraing by name (and making sure nothing else is zebraed)
- zebraing by directory name

## Release Notes

NA