### PR TITLE
fix: Force the use of coreutils/cp to copy static manifest chunks

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -23,3 +23,4 @@ yes,sschuberth,Sebastian Schuberth,<sschuberth@gmail.com>
 yes,oxcabe,Óscar Carrasco,<me@oxca.be>
 yes,crsche,Conor Scheidt,<me@crsche.com>
 yes,philiptaron,Philip Taron,<philip.taron@gmail.com>
+yes,RichardAlmanza,Richard Almanza,<al.vegari@gmail.com>

--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -76,8 +76,8 @@ let
       ''
         export PATH="${coreutils}/bin''${PATH:+:}''${PATH}"
         mkdir -p $out/activate.d
-        cp --no-preserve=mode ${manifestLockFile} $out/manifest.lock
-        cp --no-preserve=mode ${defaultEnvrc} $out/activate.d/envrc
+        "${coreutils}/bin/cp" --no-preserve=mode ${manifestLockFile} $out/manifest.lock
+        "${coreutils}/bin/cp" --no-preserve=mode ${defaultEnvrc} $out/activate.d/envrc
       ''
       # [vars] section
       (

--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -75,7 +75,7 @@ let
       # static chunks
       ''
         export PATH="${coreutils}/bin''${PATH:+:}''${PATH}"
-        mkdir -p $out/activate.d
+        "${coreutils}/bin/mkdir" -p $out/activate.d
         "${coreutils}/bin/cp" --no-preserve=mode ${manifestLockFile} $out/manifest.lock
         "${coreutils}/bin/cp" --no-preserve=mode ${defaultEnvrc} $out/activate.d/envrc
       ''
@@ -85,7 +85,7 @@ let
           ""
         else
           ''
-            cat ${vars} >> $out/activate.d/envrc
+            "${coreutils}/bin/cat" ${vars} >> $out/activate.d/envrc
           ''
       )
       # [hook] section
@@ -96,7 +96,7 @@ let
           in
           if (v != null) then
             ''
-              cp ${builtins.toFile "hook-on-activate" v} $out/activate.d/hook-on-activate
+              "${coreutils}/bin/cp" ${builtins.toFile "hook-on-activate" v} $out/activate.d/hook-on-activate
             ''
           else
             ""
@@ -115,7 +115,7 @@ let
             };
           in
           ''
-            cp ${serviceConfigYamlStorePath} $out/service-config.yaml
+            "${coreutils}/bin/cp" ${serviceConfigYamlStorePath} $out/service-config.yaml
           ''
       )
     ]
@@ -132,7 +132,9 @@ let
               let
                 f = builtins.toFile "profile-${i}" v;
               in
-              "cp ${f} $out/activate.d/profile-${i}\n"
+              ''
+                "${coreutils}/bin/cp" ${f} $out/activate.d/profile-${i}
+              ''
             else
               ""
           else
@@ -164,8 +166,8 @@ let
                   f = builtins.toFile "build-${i}" v;
                 in
                 ''
-                  mkdir -p $out/package-builds.d
-                  cp ${f} $out/package-builds.d/${i}
+                  "${coreutils}/bin/mkdir" -p $out/package-builds.d
+                  "${coreutils}/bin/cp" ${f} $out/package-builds.d/${i}
                 ''
               )
             else


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**fix: Force the use of coreutils/cp to copy static manifest chunks**
I just add `command` before `cp --no-preserve...` in the `createManifestChunks` section in buildenv/buildenv.nix

### Context


Since I updated the [nix package](https://archlinux.org/packages/extra/x86_64/nix/) in Arch Linux from 2.24.11-10 to 2.26.3-1 the process to update the manifest breaks with the following error:

```
$ flox edit
❌ ERROR: Failed to build environment:

Failed to constructed environment: these 2 derivations will be built:
  /nix/store/q8ibksg63fx49qz541by1mm9k79c1zlk-manifest.drv
  /nix/store/mf2lsq6dbllqdh4w79k8fi16wrl6dhng-environment.drv
building '/nix/store/q8ibksg63fx49qz541by1mm9k79c1zlk-manifest.drv'...
manifest> + export 'PATH=/nix/store/b1wvkjx96i3s7wblz38ya0zr8i93zbc5-coreutils-9.5/bin:/path-not-set'
manifest> + mkdir -p /nix/store/30sr643jvnvfkdd7bmnf7sqd5vm8534g-manifest/activate.d
manifest> + cp '--no-preserve=mode' /nix/store/2ys931f53vdqqcfc4xi87r73n03fazcz-manifest.lock /nix/store/30sr643jvnvfkdd7bmnf7sqd5vm8534g-manifest/manifest.lock
manifest> cp: unrecognized option: no-preserve=mode
manifest> BusyBox v1.36.1 () multi-call binary.
manifest> Usage: cp [-arPLHpfinlsTu] SOURCE DEST
manifest> or: cp [-arPLHpfinlsu] SOURCE... { -t DIRECTORY | DIRECTORY }
manifest> Copy SOURCEs to DEST
manifest>       -a      Same as -dpR
manifest>       -R,-r   Recurse
manifest>       -d,-P   Preserve symlinks (default if -R)
manifest>       -L      Follow all symlinks
manifest>       -H      Follow symlinks on command line
manifest>       -p      Preserve file attributes if possible
manifest>       -f      Overwrite
manifest>       -i      Prompt before overwrite
manifest>       -n      Don't overwrite
manifest>       -l,-s   Create (sym)links
manifest>       -T      Refuse to copy if DEST is a directory
manifest>       -t DIR  Copy all SOURCEs into DIR
manifest>       -u      Copy only newer files
error: builder for '/nix/store/q8ibksg63fx49qz541by1mm9k79c1zlk-manifest.drv' failed with exit code 1;
       last 24 log lines:
       > + export 'PATH=/nix/store/b1wvkjx96i3s7wblz38ya0zr8i93zbc5-coreutils-9.5/bin:/path-not-set'
       > + mkdir -p /nix/store/30sr643jvnvfkdd7bmnf7sqd5vm8534g-manifest/activate.d
       > + cp '--no-preserve=mode' /nix/store/2ys931f53vdqqcfc4xi87r73n03fazcz-manifest.lock /nix/store/30sr643jvnvfkdd7bmnf7sqd5vm8534g-manifest/manifest.lock
       > cp: unrecognized option: no-preserve=mode
       > BusyBox v1.36.1 () multi-call binary.
       >
       > Usage: cp [-arPLHpfinlsTu] SOURCE DEST
       > or: cp [-arPLHpfinlsu] SOURCE... { -t DIRECTORY | DIRECTORY }
       >
       > Copy SOURCEs to DEST
       >
       >    -a      Same as -dpR
       >   -R,-r   Recurse
       >        -d,-P   Preserve symlinks (default if -R)
       >      -L      Follow all symlinks
       >    -H      Follow symlinks on command line
       >        -p      Preserve file attributes if possible
       >   -f      Overwrite
       >      -i      Prompt before overwrite
       >        -n      Don't overwrite
       >        -l,-s   Create (sym)links
       >      -T      Refuse to copy if DEST is a directory
       >  -t DIR  Copy all SOURCEs into DIR
       >      -u      Copy only newer files
       For full logs, run:
         nix log /nix/store/q8ibksg63fx49qz541by1mm9k79c1zlk-manifest.drv
error: 1 dependencies of derivation '/nix/store/mf2lsq6dbllqdh4w79k8fi16wrl6dhng-environment.drv' failed to build


> Continue editing? No
❌ ERROR: Environment editing cancelled
```

I don't have any idea about the reason or what changed the previous behavior, but it seems like "nix defined `cp` as an alias pointing to the `cp` of **busybox** or something like that, because it completely ignores the `cp` of **coreutils** defined in `PATH`  except when I added `command`"

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A (If you use Arch Linux BTW, it just works again)

<!-- Many thanks! -->
