### PR TITLE
fix: honor _FLOX_NIX_STORE_URL when invoking `nix path-info`

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -793,6 +793,17 @@ fn check_store_paths(
     command.stdin(Stdio::piped());
     command.stderr(Stdio::null());
     command.stdout(Stdio::piped());
+
+    match std::env::var("_FLOX_NIX_STORE_URL").ok().as_deref() {
+        None | Some("") => {
+            debug!("using 'auto' store");
+        },
+        Some(store_url) => {
+            debug!(%store_url, "overriding Nix store URL");
+            command.args(["--option", "store", store_url]);
+        },
+    }
+
     command.args(["path-info", "--offline", "--stdin"]);
 
     let mut child = command.spawn().map_err(BuildEnvError::CallNixBuild)?;

--- a/cli/flox-rust-sdk/src/providers/flake_installable_locker.rs
+++ b/cli/flox-rust-sdk/src/providers/flake_installable_locker.rs
@@ -208,6 +208,16 @@ impl InstallableLocker for Nix {
         let mut command = nix_base_command();
         command.args(["--option", "extra-plugin-files", &*NIX_PLUGINS]);
 
+        match std::env::var("_FLOX_NIX_STORE_URL").ok().as_deref() {
+            None | Some("") => {
+                debug!("using 'auto' store");
+            },
+            Some(store_url) => {
+                debug!(%store_url, "overriding Nix store URL");
+                command.args(["--option", "store", store_url]);
+            },
+        }
+
         command.args(["--option", "pure-eval", "false"]);
         command.arg("eval");
         command.arg("--no-update-lock-file");


### PR DESCRIPTION
## Proposed Changes

When honoring _FLOX_NIX_STORE_URL for invoking buildenv on a remote store, similarly honor it when invoking `nix path-info` to take inventory of that same remote store.

## Release Notes

N/A