### PR TITLE
feat(compose): Print overrides for edit, list, and activate

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -836,23 +836,6 @@ impl EditResult {
             },
         }
     }
-
-    pub fn include_modified(&self) -> bool {
-        match self {
-            Self::Unchanged => false,
-            Self::Changed {
-                old_lockfile,
-                new_lockfile,
-                ..
-            } => {
-                old_lockfile
-                    .as_ref()
-                    .map(|lockfile| lockfile.user_manifest().include.clone())
-                    .unwrap_or_default()
-                    != new_lockfile.user_manifest().include
-            },
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/cli/flox-rust-sdk/src/models/environment/fetcher.rs
+++ b/cli/flox-rust-sdk/src/models/environment/fetcher.rs
@@ -41,7 +41,7 @@ impl IncludeFetcher {
 
         match &environment {
             ConcreteEnvironment::Path(environment) => {
-                if !environment.lockfile_up_to_date()? {
+                if !environment.lockfile_up_to_date(flox)? {
                     return Err(EnvironmentError::Recoverable(
                         RecoverableMergeError::Catchall(
                             "cannot include environment since its manifest and lockfile are out of sync".to_string()

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -479,6 +479,15 @@ impl Environment for ManagedEnvironment {
         Ok(path)
     }
 
+    /// The environment is locked,
+    /// and the manifest in the lockfile matches that in the manifest.
+    /// Note that the manifest could have whitespace or comment differences from
+    /// the lockfile.
+    fn lockfile_up_to_date(&self, flox: &Flox) -> Result<bool, EnvironmentError> {
+        let local_checkout = self.local_env_or_copy_current_generation(flox)?;
+        Ok(local_checkout.lockfile_if_up_to_date()?.is_some())
+    }
+
     /// Returns the environment name
     fn name(&self) -> EnvironmentName {
         self.pointer.name.clone()

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -211,6 +211,12 @@ pub trait Environment: Send {
     /// may be located in different directories.
     fn lockfile_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError>;
 
+    /// The environment is locked,
+    /// and the manifest in the lockfile matches that in the manifest.
+    /// Note that the manifest could have whitespace or comment differences from
+    /// the lockfile.
+    fn lockfile_up_to_date(&self, flox: &Flox) -> Result<bool, EnvironmentError>;
+
     /// Returns the environment name
     fn name(&self) -> EnvironmentName;
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -381,6 +381,15 @@ impl Environment for PathEnvironment {
         Ok(self.path.join(ENV_DIR_NAME).join(LOCKFILE_FILENAME))
     }
 
+    /// The environment is locked,
+    /// and the manifest in the lockfile matches that in the manifest.
+    /// Note that the manifest could have whitespace or comment differences from
+    /// the lockfile.
+    fn lockfile_up_to_date(&self, _flox: &Flox) -> Result<bool, EnvironmentError> {
+        let env_view = self.as_core_environment()?;
+        Ok(env_view.lockfile_if_up_to_date()?.is_some())
+    }
+
     /// Return the path where the process compose socket for an environment
     /// should be created
     fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
@@ -545,15 +554,6 @@ impl PathEnvironment {
         }
 
         Ok(false)
-    }
-
-    /// The environment is locked,
-    /// and the manifest in the lockfile matches that in the manifest.
-    /// Note that the manifest could have whitespace or comment differences from
-    /// the lockfile.
-    pub fn lockfile_up_to_date(&self) -> Result<bool, EnvironmentError> {
-        let env_view = self.as_core_environment()?;
-        Ok(env_view.lockfile_if_up_to_date()?.is_some())
     }
 
     fn link(

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -372,6 +372,14 @@ impl Environment for RemoteEnvironment {
         self.inner.lockfile_path(flox)
     }
 
+    /// The environment is locked,
+    /// and the manifest in the lockfile matches that in the manifest.
+    /// Note that the manifest could have whitespace or comment differences from
+    /// the lockfile.
+    fn lockfile_up_to_date(&self, flox: &Flox) -> Result<bool, EnvironmentError> {
+        self.inner.lockfile_up_to_date(flox)
+    }
+
     /// Returns the environment name
     fn name(&self) -> EnvironmentName {
         self.inner.name()

--- a/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
@@ -77,8 +77,8 @@ pub enum Warning {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct WarningWithContext {
-    warning: Warning,
-    higher_priority_name: String,
+    pub warning: Warning,
+    pub higher_priority_name: String,
 }
 
 /// A collection of manifests to be merged with a `ManifestMergeTrait`.

--- a/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
@@ -6,6 +6,7 @@ mod shallow;
 use enum_dispatch::enum_dispatch;
 #[cfg(test)]
 use proptest::prelude::*;
+use serde::{Deserialize, Serialize};
 pub(crate) use shallow::ShallowMerger;
 use thiserror::Error;
 
@@ -21,7 +22,8 @@ pub enum MergeError {}
 /// where [`KeyPath::push`] and [`KeyPath::extend`] return a new `KeyPath`
 /// with the new key(s) added to the top of the stack,
 /// leaving the original `KeyPath` unchanged.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct KeyPath(Vec<String>);
 impl KeyPath {
     /// Create a new empty `KeyPath`.
@@ -63,7 +65,8 @@ impl<Key: Into<String>> FromIterator<Key> for KeyPath {
 ///
 /// Currently, the only warning is that a value is being overridden,
 /// but more warnings may be added in the future.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[must_use]
 pub enum Warning {
     Overriding(KeyPath),
@@ -71,7 +74,8 @@ pub enum Warning {
 
 /// A warning that occurred during the merge of two manifests,
 /// along with the names of the two manifests involved.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct WarningWithContext {
     warning: Warning,
     higher_priority_name: String,

--- a/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
@@ -62,14 +62,15 @@ impl<Key: Into<String>> FromIterator<Key> for KeyPath {
 ///
 /// Warnings are not errors, but they may indicate
 /// that the user should review the merged manifest or its dependencies.
-///
-/// Currently, the only warning is that a value is being overridden,
-/// but more warnings may be added in the future.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[must_use]
 pub enum Warning {
     Overriding(KeyPath),
+    /// Currently, the only warning is that a value is being overridden,
+    /// but more warnings may be added in the future. This placeholer prevents
+    /// linting from complaining about irrefutable matches and let statements.
+    Placeholder(),
 }
 
 /// A warning that occurred during the merge of two manifests,

--- a/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
@@ -106,6 +106,7 @@ impl CompositeManifest {
         &self,
         merger: ManifestMerger,
     ) -> Result<(Manifest, Vec<WarningWithContext>), MergeError> {
+        // TODO: Surface the name of the current environment.
         let current_manifest = &("Current manifest".to_string(), self.composer.clone());
 
         let mut merges = self.deps.iter().chain([current_manifest]);

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -204,9 +204,8 @@ impl Edit {
                 warn_manifest_changes_for_services(flox, environment);
 
                 let lockfile = environment.lockfile(flox)?;
-                message::print_overridden_manifest_fields(&lockfile);
-
-                if result.include_modified() {
+                if lockfile.compose.is_some() {
+                    message::print_overridden_manifest_fields(&lockfile);
                     message::info("Run 'flox list -c' to see merged manifest.");
                 }
             },
@@ -904,6 +903,7 @@ mod tests {
             ℹ️ The following manifest fields were overridden during merging:
             - Environment 'Current manifest' set:
               - vars.foo
+            ℹ️ Run 'flox list -c' to see merged manifest.
             "});
     }
 }

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -114,6 +114,7 @@ impl List {
         println!("{manifest_contents}");
         if is_composed {
             message::info("Displaying merged manifest.");
+            message::print_overridden_manifest_fields(lockfile);
         }
 
         Ok(())

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -135,6 +135,7 @@ pub(crate) fn print_overridden_manifest_fields(lockfile: &Lockfile) {
                 field.to_string(),
                 warning_context.higher_priority_name.clone(),
             )),
+            _ => None,
         })
         .collect();
 

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -197,3 +197,34 @@ licenses = []
 [options.semver]'
   assert_equal "$stderr" 'ℹ️ Displaying merged manifest.'
 }
+
+# bats test_tags=list,list:config
+@test "'flox list --config' shows notices about overrides" {
+  "$FLOX_BIN" init -d included
+  "$FLOX_BIN" edit -d included -f - <<- EOF
+version = 1
+
+[vars]
+foo = "included"
+EOF
+
+  "$FLOX_BIN" init -d composer
+  "$FLOX_BIN" edit -d composer -f - <<- EOF
+version = 1
+
+[vars]
+foo = "composer"
+
+[include]
+environments = [
+  { dir = "../included" },
+]
+EOF
+
+  run --separate-stderr "$FLOX_BIN" list -c -d composer
+  assert_success
+  assert_equal "$stderr" "ℹ️ Displaying merged manifest.
+ℹ️ The following manifest fields were overridden during merging:
+- Environment 'Current manifest' set:
+  - vars.foo"
+}


### PR DESCRIPTION
## Proposed Changes

Best reviewed commit-by-commit.

I've matched the locations of the existing "integration" tests in BATS
and Rust because both commands use a different pattern and I still can't
decide which I prefer.

This surfaces the name `Current manifest` which isn't ideal but we don't
currently have a way for the `ComposesiteManifest` to know the name of
the environment that it came from.

## Release Notes

N/A
