### PR TITLE
refactor: skip serializing optional fields

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -27,6 +27,8 @@ use crate::providers::services::ServiceError;
 pub(crate) const DEFAULT_GROUP_NAME: &str = "toplevel";
 pub const DEFAULT_PRIORITY: u64 = 5;
 
+/// An interface codifying how to access types that are just semantic wrappers
+/// around inner types. This impl may be generated with a macro.
 pub trait Inner {
     type Inner;
 
@@ -35,6 +37,7 @@ pub trait Inner {
     fn into_inner(self) -> Self::Inner;
 }
 
+/// A macro that generates a `Inner` impl.
 macro_rules! impl_into_inner {
     ($wrapper:ty, $inner_type:ty) => {
         impl Inner for $wrapper {
@@ -53,6 +56,12 @@ macro_rules! impl_into_inner {
             }
         }
     };
+}
+
+/// An interface for the type of function that serde's skip_serializing_if
+/// method takes.
+pub(crate) trait SkipSerializing {
+    fn skip_serializing(&self) -> bool;
 }
 
 /// Not meant for writing manifest files, only for reading them.
@@ -277,7 +286,7 @@ pub struct Install(
     pub(crate) BTreeMap<String, ManifestPackageDescriptor>,
 );
 
-impl Install {
+impl SkipSerializing for Install {
     fn skip_serializing(&self) -> bool {
         self.0.is_empty()
     }
@@ -477,7 +486,7 @@ pub struct Vars(
     pub(crate)  BTreeMap<String, String>,
 );
 
-impl Vars {
+impl SkipSerializing for Vars {
     fn skip_serializing(&self) -> bool {
         self.0.is_empty()
     }
@@ -596,7 +605,7 @@ pub struct ActivateOptions {
     pub mode: Option<ActivateMode>,
 }
 
-impl ActivateOptions {
+impl SkipSerializing for ActivateOptions {
     /// Don't write a struct of None's into the lockfile but also don't
     /// explicitly check fields which we might forget to update.
     fn skip_serializing(&self) -> bool {
@@ -645,7 +654,7 @@ pub struct Services(
     pub(crate) BTreeMap<String, ServiceDescriptor>,
 );
 
-impl Services {
+impl SkipSerializing for Services {
     fn skip_serializing(&self) -> bool {
         self.0.is_empty()
     }
@@ -746,7 +755,7 @@ pub struct Build(
 
 impl_into_inner!(Build, BTreeMap<String,BuildDescriptor>);
 
-impl Build {
+impl SkipSerializing for Build {
     fn skip_serializing(&self) -> bool {
         self.0.is_empty()
     }
@@ -866,7 +875,7 @@ pub struct Include {
     pub environments: Vec<IncludeDescriptor>,
 }
 
-impl Include {
+impl SkipSerializing for Include {
     pub(crate) fn skip_serializing(&self) -> bool {
         self.environments.is_empty()
     }

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -13,7 +13,6 @@ use flox_test_utils::proptest::{
     optional_btree_set,
     optional_string,
     optional_vec_of_strings,
-    vec_of_strings,
 };
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -573,8 +572,8 @@ pub struct Allows {
     pub broken: Option<bool>,
     /// A list of license descriptors that are allowed
     #[serde(default)]
-    #[cfg_attr(test, proptest(strategy = "vec_of_strings(3, 4)"))]
-    pub licenses: Vec<String>,
+    #[cfg_attr(test, proptest(strategy = "optional_vec_of_strings(3, 4)"))]
+    pub licenses: Option<Vec<String>>,
 }
 
 #[skip_serializing_none]
@@ -1031,7 +1030,6 @@ pub mod test {
             version = 1
 
             [options.allow]
-            licenses = []
 
             [options.semver]
         "#};
@@ -1059,7 +1057,6 @@ pub mod test {
             [profile]
 
             [options.allow]
-            licenses = []
 
             [options.semver]
         "#};

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -189,10 +189,7 @@ EOF
   assert_equal "$output" 'version = 1
 
 [install]
-hello.pkg-path = "hello"
-
-[options]
-allow.licenses = []'
+hello.pkg-path = "hello"'
   assert_equal "$stderr" 'ℹ️ Displaying merged manifest.'
 }
 

--- a/test_data/generated/envs/build-noop/manifest.lock
+++ b/test_data/generated/envs/build-noop/manifest.lock
@@ -3,9 +3,7 @@
   "manifest": {
     "version": 1,
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     },
     "build": {

--- a/test_data/generated/envs/build-noop/manifest.lock
+++ b/test_data/generated/envs/build-noop/manifest.lock
@@ -2,10 +2,7 @@
   "lockfile-version": 1,
   "manifest": {
     "version": 1,
-    "options": {
-      "allow": {},
-      "semver": {}
-    },
+    "options": {},
     "build": {
       "hello": {
         "command": "echo hello"

--- a/test_data/generated/envs/build-runtime-all-toplevel.json
+++ b/test_data/generated/envs/build-runtime-all-toplevel.json
@@ -15,9 +15,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     },
     "build": {

--- a/test_data/generated/envs/build-runtime-all-toplevel.json
+++ b/test_data/generated/envs/build-runtime-all-toplevel.json
@@ -14,10 +14,7 @@
         "pkg-group": "not-toplevel"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    },
+    "options": {},
     "build": {
       "myhello": {
         "command": "    mkdir -p $out/bin\n    echo echo hello foo > $out/bin/hello\n    echo exec hello >> $out/bin/hello\n    chmod +x $out/bin/hello\n"

--- a/test_data/generated/envs/build-runtime-packages-not-found.json
+++ b/test_data/generated/envs/build-runtime-packages-not-found.json
@@ -7,10 +7,7 @@
         "pkg-path": "hello"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    },
+    "options": {},
     "build": {
       "myhello": {
         "command": "  mkdir -p $out/bin\n  echo echo hello foo > $out/bin/hello\n  echo exec hello >> $out/bin/hello\n  chmod +x $out/bin/hello\n",

--- a/test_data/generated/envs/build-runtime-packages-not-found.json
+++ b/test_data/generated/envs/build-runtime-packages-not-found.json
@@ -8,9 +8,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     },
     "build": {

--- a/test_data/generated/envs/build-runtime-packages-not-toplevel.json
+++ b/test_data/generated/envs/build-runtime-packages-not-toplevel.json
@@ -15,9 +15,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     },
     "build": {

--- a/test_data/generated/envs/build-runtime-packages-not-toplevel.json
+++ b/test_data/generated/envs/build-runtime-packages-not-toplevel.json
@@ -14,10 +14,7 @@
         "pkg-group": "not-toplevel"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    },
+    "options": {},
     "build": {
       "myhello": {
         "command": "  mkdir -p $out/bin\n  echo echo hello foo > $out/bin/hello\n  echo exec hello >> $out/bin/hello\n  chmod +x $out/bin/hello\n",

--- a/test_data/generated/envs/build-runtime-packages-only-hello.json
+++ b/test_data/generated/envs/build-runtime-packages-only-hello.json
@@ -15,9 +15,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     },
     "build": {

--- a/test_data/generated/envs/build-runtime-packages-only-hello.json
+++ b/test_data/generated/envs/build-runtime-packages-only-hello.json
@@ -14,10 +14,7 @@
         "pkg-group": "not-toplevel"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    },
+    "options": {},
     "build": {
       "myhello": {
         "command": "    mkdir -p $out/bin\n    echo echo hello foo > $out/bin/hello\n    echo exec hello >> $out/bin/hello\n    chmod +x $out/bin/hello\n",

--- a/test_data/generated/envs/go_gcc/manifest.lock
+++ b/test_data/generated/envs/go_gcc/manifest.lock
@@ -15,9 +15,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/go_gcc/manifest.lock
+++ b/test_data/generated/envs/go_gcc/manifest.lock
@@ -14,10 +14,7 @@
         "pkg-path": "go"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    }
+    "options": {}
   },
   "packages": [
     {

--- a/test_data/generated/envs/hello-unfree-lock.json
+++ b/test_data/generated/envs/hello-unfree-lock.json
@@ -7,10 +7,7 @@
         "pkg-path": "hello-unfree"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    }
+    "options": {}
   },
   "packages": [
     {

--- a/test_data/generated/envs/hello-unfree-lock.json
+++ b/test_data/generated/envs/hello-unfree-lock.json
@@ -8,9 +8,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/hello/manifest.lock
+++ b/test_data/generated/envs/hello/manifest.lock
@@ -15,9 +15,7 @@
         "aarch64-linux",
         "x86_64-darwin",
         "x86_64-linux"
-      ],
-      "allow": {},
-      "semver": {}
+      ]
     }
   },
   "packages": [

--- a/test_data/generated/envs/hello/manifest.lock
+++ b/test_data/generated/envs/hello/manifest.lock
@@ -16,9 +16,7 @@
         "x86_64-darwin",
         "x86_64-linux"
       ],
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/hello/manifest.toml
+++ b/test_data/generated/envs/hello/manifest.toml
@@ -67,6 +67,15 @@ hello.pkg-path = "hello"
 # myservice.command = "python3 -m http.server"
 
 
+## Include ----------------------------------------------------------
+## ... environments to create a composed environment
+## ------------------------------------------------------------------
+[include]
+# environments = [
+#     { dir = "../common" }
+# ]
+
+
 ## Other Environment Options -----------------------------------------
 [options]
 # Systems that environment is compatible with

--- a/test_data/generated/envs/hello_and_htop_for_no_system/manifest.lock
+++ b/test_data/generated/envs/hello_and_htop_for_no_system/manifest.lock
@@ -18,9 +18,7 @@
         "aarch64-linux",
         "x86_64-linux"
       ],
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/hello_and_htop_for_no_system/manifest.lock
+++ b/test_data/generated/envs/hello_and_htop_for_no_system/manifest.lock
@@ -17,9 +17,7 @@
         "x86_64-darwin",
         "aarch64-linux",
         "x86_64-linux"
-      ],
-      "allow": {},
-      "semver": {}
+      ]
     }
   },
   "packages": [

--- a/test_data/generated/envs/hello_as_greeting/manifest.lock
+++ b/test_data/generated/envs/hello_as_greeting/manifest.lock
@@ -14,9 +14,7 @@
         "x86_64-darwin",
         "x86_64-linux"
       ],
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/hello_as_greeting/manifest.lock
+++ b/test_data/generated/envs/hello_as_greeting/manifest.lock
@@ -13,9 +13,7 @@
         "aarch64-linux",
         "x86_64-darwin",
         "x86_64-linux"
-      ],
-      "allow": {},
-      "semver": {}
+      ]
     }
   },
   "packages": [

--- a/test_data/generated/envs/influxdb2/manifest.lock
+++ b/test_data/generated/envs/influxdb2/manifest.lock
@@ -14,9 +14,7 @@
         "x86_64-darwin",
         "x86_64-linux"
       ],
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/influxdb2/manifest.lock
+++ b/test_data/generated/envs/influxdb2/manifest.lock
@@ -13,9 +13,7 @@
         "aarch64-linux",
         "x86_64-darwin",
         "x86_64-linux"
-      ],
-      "allow": {},
-      "semver": {}
+      ]
     }
   },
   "packages": [

--- a/test_data/generated/envs/kitchen_sink/manifest.lock
+++ b/test_data/generated/envs/kitchen_sink/manifest.lock
@@ -20,10 +20,7 @@
       "fish": "    alias profile_alias=\"echo fish\"\n    set -gx PROFILE_SECTION_VAR profile-fish\n",
       "tcsh": "    alias profile_alias \"echo tcsh\"\n    export PROFILE_SECTION_VAR=\"profile-tcsh\"\n"
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    }
+    "options": {}
   },
   "packages": [
     {

--- a/test_data/generated/envs/kitchen_sink/manifest.lock
+++ b/test_data/generated/envs/kitchen_sink/manifest.lock
@@ -21,9 +21,7 @@
       "tcsh": "    alias profile_alias \"echo tcsh\"\n    export PROFILE_SECTION_VAR=\"profile-tcsh\"\n"
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/krb5_prereqs/manifest.lock
+++ b/test_data/generated/envs/krb5_prereqs/manifest.lock
@@ -56,9 +56,7 @@
         "aarch64-linux",
         "x86_64-linux"
       ],
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/krb5_prereqs/manifest.lock
+++ b/test_data/generated/envs/krb5_prereqs/manifest.lock
@@ -55,9 +55,7 @@
         "x86_64-darwin",
         "aarch64-linux",
         "x86_64-linux"
-      ],
-      "allow": {},
-      "semver": {}
+      ]
     }
   },
   "packages": [

--- a/test_data/generated/envs/pip/manifest.lock
+++ b/test_data/generated/envs/pip/manifest.lock
@@ -13,9 +13,7 @@
         "x86_64-darwin",
         "aarch64-linux",
         "x86_64-linux"
-      ],
-      "allow": {},
-      "semver": {}
+      ]
     }
   },
   "packages": [

--- a/test_data/generated/envs/pip/manifest.lock
+++ b/test_data/generated/envs/pip/manifest.lock
@@ -14,9 +14,7 @@
         "aarch64-linux",
         "x86_64-linux"
       ],
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/publish-simple/manifest.lock
+++ b/test_data/generated/envs/publish-simple/manifest.lock
@@ -7,10 +7,7 @@
         "pkg-path": "hello"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    },
+    "options": {},
     "build": {
       "mypkg": {
         "command": "    mkdir -p $out/bin\n    echo -n \"!#/bin/sh\" > $out/bin/mypkg\n    echo -n \"echo Happy Floxing!\" > $out/bin/mypkg\n    chmod +x $out/bin/mypkg\n",

--- a/test_data/generated/envs/publish-simple/manifest.lock
+++ b/test_data/generated/envs/publish-simple/manifest.lock
@@ -8,9 +8,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     },
     "build": {

--- a/test_data/generated/envs/tabula-lock.json
+++ b/test_data/generated/envs/tabula-lock.json
@@ -10,8 +10,7 @@
     "options": {
       "allow": {
         "broken": true
-      },
-      "semver": {}
+      }
     }
   },
   "packages": [

--- a/test_data/generated/envs/tabula-lock.json
+++ b/test_data/generated/envs/tabula-lock.json
@@ -9,8 +9,7 @@
     },
     "options": {
       "allow": {
-        "broken": true,
-        "licenses": []
+        "broken": true
       },
       "semver": {}
     }

--- a/test_data/generated/envs/vim-vim-full-conflict-resolved.json
+++ b/test_data/generated/envs/vim-vim-full-conflict-resolved.json
@@ -12,9 +12,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/vim-vim-full-conflict-resolved.json
+++ b/test_data/generated/envs/vim-vim-full-conflict-resolved.json
@@ -11,10 +11,7 @@
         "pkg-path": "vim-full"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    }
+    "options": {}
   },
   "packages": [
     {

--- a/test_data/generated/envs/vim-vim-full-conflict.json
+++ b/test_data/generated/envs/vim-vim-full-conflict.json
@@ -11,9 +11,7 @@
       }
     },
     "options": {
-      "allow": {
-        "licenses": []
-      },
+      "allow": {},
       "semver": {}
     }
   },

--- a/test_data/generated/envs/vim-vim-full-conflict.json
+++ b/test_data/generated/envs/vim-vim-full-conflict.json
@@ -10,10 +10,7 @@
         "pkg-path": "vim-full"
       }
     },
-    "options": {
-      "allow": {},
-      "semver": {}
-    }
+    "options": {}
   },
   "packages": [
     {

--- a/test_data/generated/search/java_suggestions.json
+++ b/test_data/generated/search/java_suggestions.json
@@ -1,6 +1,6 @@
 [
   {
-    "count": 868,
+    "count": 881,
     "results": [
       {
         "attr_path": "javacc",
@@ -115,29 +115,29 @@
     ]
   },
   {
-    "count": 136,
+    "count": 135,
     "results": [
       {
         "attr_path": "jdk",
         "catalog": null,
-        "description": "Certified builds of OpenJDK",
-        "name": "zulu-ca-jdk-21.0.4",
+        "description": "Open-source Java Development Kit",
+        "name": "openjdk-21.0.5+11",
         "pkg_path": "jdk",
         "pname": "jdk",
         "stabilities": [],
         "system": "aarch64-darwin",
-        "version": "21.0.4"
+        "version": "21.0.5+11"
       },
       {
         "attr_path": "jdk8",
         "catalog": null,
-        "description": "Certified builds of OpenJDK",
-        "name": "zulu-ca-jdk-8.0.422",
+        "description": "Open-source Java Development Kit",
+        "name": "openjdk-8u432-b06",
         "pkg_path": "jdk8",
         "pname": "jdk8",
         "stabilities": [],
         "system": "aarch64-darwin",
-        "version": "8.0.422"
+        "version": "8u432-b06"
       },
       {
         "attr_path": "jdk11",


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

**refactor: make allow.licenses optional**

This change makes `allow.licenses` optional so that its merge semantics
are clearer. This field is a `Vec`, which means that it defaults to
empty. At merge time it was unclear whether an empty `Vec` was present
as a default vs. explicitly set by the user, so we've made this more
explicit by making the field optional.

Since this field is optional, it will no longer be included in the
lockfile by default. This means that the test data needed to be
regenerated.

**refactor: add SkipSerializing trait**

This doesn't do much, it just adds a standardized way of writing down
these methods so that it doesn't seem like each `skip_serializing`
method is a one-off.

**feat: skip serializing options.{allow,semver}**

This changes omits `options.allow` and `options.semver` when their
sub-fields are `None`. This prevents `options.allow` and
`options.semver` from appearing in the merged manifest when they weren't
present in any of the composed manifests.

The reason they appeared in the first place is that they were
unconditionally serialized into the lockfile, so a manifest taken from a
lockfile would always contain these tables even though they were empty.

Since this changes the contents of the lockfile the test data needed to
be regenerated.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
