### PR TITLE
feat(compose): Order override notices by env

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
@@ -68,12 +68,11 @@ impl<Key: Into<String>> FromIterator<Key> for KeyPath {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[must_use]
+// Currently, the only warning is that a value is being overridden,
+// but more warnings may be added in the future.
+#[non_exhaustive]
 pub enum Warning {
     Overriding(KeyPath),
-    /// Currently, the only warning is that a value is being overridden,
-    /// but more warnings may be added in the future. This placeholer prevents
-    /// linting from complaining about irrefutable matches and let statements.
-    Placeholder(),
 }
 
 /// A warning that occurred during the merge of two manifests,

--- a/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/mod.rs
@@ -12,6 +12,9 @@ use thiserror::Error;
 
 use super::typed::{ContainerizeConfig, Manifest};
 
+// TODO: Pass the actual name in.
+pub static COMPOSER_MANIFEST_ID: &str = "Current manifest";
+
 #[derive(Error, Debug)]
 pub enum MergeError {}
 
@@ -107,8 +110,7 @@ impl CompositeManifest {
         &self,
         merger: ManifestMerger,
     ) -> Result<(Manifest, Vec<WarningWithContext>), MergeError> {
-        // TODO: Surface the name of the current environment.
-        let current_manifest = &("Current manifest".to_string(), self.composer.clone());
+        let current_manifest = &(COMPOSER_MANIFEST_ID.to_string(), self.composer.clone());
 
         let mut merges = self.deps.iter().chain([current_manifest]);
         let (_, mut merged_manifest) = merges

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -901,7 +901,7 @@ mod tests {
         assert_eq!(writer.to_string(), indoc! {"
             ✅ Environment successfully updated.
             ℹ️ The following manifest fields were overridden during merging:
-            - Environment 'Current manifest' set:
+            - This environment set:
               - vars.foo
             ℹ️ Run 'flox list -c' to see merged manifest.
             "});

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4758,7 +4758,7 @@ EOF
   run --separate-stderr "$FLOX_BIN" activate -d composer -- echo "locking"
   assert_success
   assert_equal "$stderr" "ℹ️ The following manifest fields were overridden during merging:
-- Environment 'Current manifest' set:
+- This environment set:
   - vars.foo
 Sourcing .bashrc
 Setting PATH from .bashrc"

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -225,6 +225,6 @@ EOF
   assert_success
   assert_equal "$stderr" "ℹ️ Displaying merged manifest.
 ℹ️ The following manifest fields were overridden during merging:
-- Environment 'Current manifest' set:
+- This environment set:
   - vars.foo"
 }


### PR DESCRIPTION
## Proposed Changes

List the notices about overridden fields in the order that the environments were included and the composing environment last.

Changes the unit test to use real environments because it depends more heavily on the implementation of the `Compose` object; specifically the naming of the environments in `Compose.include` vs `Compose.warnings`.

Follow-up from:

- https://github.com/flox/flox/pull/2837#discussion_r2010346244
- https://github.com/flox/flox/pull/2837#discussion_r2010348329

## Release Notes

N/A