### PR TITLE
feat(push): alias `--org` to `--owner`

### DIFF
--- a/cli/flox/doc/flox-push.md
+++ b/cli/flox/doc/flox-push.md
@@ -49,7 +49,7 @@ FloxHub with local changes to the environment.
 `-d`, `--dir`
 :   Directory to push the environment from (default: current directory).
 
-`-o`, `--owner`
+`-o`, `--owner`, `--org`
 :   FloxHub owner to push environment to (default: current FloxHub user).
 
 `-f`, `--force`

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -33,8 +33,9 @@ pub struct Push {
     #[bpaf(long, short, argument("path"))]
     dir: Option<PathBuf>,
 
-    /// FloxHub owner to push environment to (default: current FloxHub user)
-    #[bpaf(long, short, argument("owner"))]
+    /// FloxHub account to push environment to (default: current FloxHub user).
+    /// Organizations may use either '--owner=<orgname>' or alias '--org=<orgname>'.
+    #[bpaf(long("owner"), long("org"), short, argument("owner"))]
     owner: Option<EnvironmentOwner>,
 
     /// Forcibly overwrite the remote copy of the environment


### PR DESCRIPTION
Accept `flox push --owner <>` or `flox push --org <>` with the same effect.
