### PR TITLE
chore: check that pushed  environments do not refer to local includes

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -2960,13 +2960,10 @@ mod test {
         );
 
         // Create composer, which locks implicitly
+        // Create environment _without_ including `dep`,
+        // because _pushing_ an environment with local imports is not allowed.
         let composer_manifest_contents = indoc! {r#"
         version = 1
-
-        [include]
-        environments = [
-          { dir = "dep" },
-        ]
         "#};
 
         let mut composer = mock_managed_environment_in(
@@ -2976,6 +2973,20 @@ mod test {
             tempdir.path(),
             Some("composer"),
         );
+
+        // Add an include of an environment by local path
+        let composer_manifest_contents_with_include = indoc! {r#"
+        version = 1
+
+        [include]
+        environments = [
+          { dir = "dep" },
+        ]
+        "#};
+
+        composer
+            .edit(&flox, composer_manifest_contents_with_include.to_string())
+            .unwrap();
 
         // Check lockfile
         let lockfile = composer.lockfile(&flox).unwrap();

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -103,6 +103,7 @@ impl Push {
         force: bool,
     ) -> Result<()> {
         let mut env = ManagedEnvironment::open(flox, managed_pointer.clone(), dot_flox_dir)?;
+
         env.push(flox, force).map_err(|err| {
             Self::convert_error(
                 EnvironmentError::ManagedEnvironment(err),

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -468,6 +468,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
         },
         // access denied is caught early as ManagedEnvironmentError::AccessDenied
         ManagedEnvironmentError::Push(_) => display_chain(err),
+        ManagedEnvironmentError::PushWithLocalIncludes => display_chain(err),
         ManagedEnvironmentError::DeleteBranch(_) => display_chain(err),
         ManagedEnvironmentError::DeleteEnvironment(path, err) => formatdoc! {"
             Failed to delete remote environment at {path:?}: {err}


### PR DESCRIPTION
Local includes be it by absolute or relative path are unlikely to impossible to reproduce when pulling the environment on another machine.

This PR checks the current manifest whether for local includes and bails the push command if that is the case.
