### PR TITLE
chore: ensure install targets composing env

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -690,7 +690,7 @@ impl Lockfile {
             ));
         }
 
-        debug!("Composing included environments");
+        debug!("composing included environments");
 
         // Fetch included manifests we don't already have in seed_lockfile.
         // Note that we have to preserve the order of the includes in the
@@ -701,6 +701,10 @@ impl Lockfile {
             .map(|to_upgrade| to_upgrade.is_empty())
             .unwrap_or(false);
         for include_environment in &manifest.include.environments {
+            debug!(
+                name = include_environment.to_string(),
+                "inspecting included environment"
+            );
             let existing_locked_include = 'existing: {
                 // Don't use existing locked includes if we're upgradeing all
                 // includes
@@ -750,7 +754,10 @@ impl Lockfile {
                         .unwrap_or(false);
 
                     if should_refetch {
-                        debug!("upgrading included environment {include_environment}");
+                        debug!(
+                            name = include_environment.to_string(),
+                            "upgrading included environment"
+                        );
                         include_fetcher
                             .fetch(flox, include_environment)
                             .map_err(|e| RecoverableMergeError::Fetch {
@@ -759,15 +766,18 @@ impl Lockfile {
                             })?
                     } else {
                         debug!(
-                            "using existing locked include from lockfile for {}",
-                            include_environment
+                            name = include_environment.to_string(),
+                            "using existing locked include from lockfile"
                         );
 
                         locked_include
                     }
                 },
                 None => {
-                    debug!("fetching included environment {include_environment}");
+                    debug!(
+                        name = include_environment.to_string(),
+                        "fetching included environment"
+                    );
 
                     let locked_include =
                         include_fetcher

--- a/cli/flox-rust-sdk/src/models/manifest/composite/shallow.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/composite/shallow.rs
@@ -1,4 +1,5 @@
 use flox_core::Version;
+use tracing::{debug, instrument, trace};
 
 use super::{
     KeyPath,
@@ -34,6 +35,7 @@ use crate::models::manifest::typed::{
 pub(crate) struct ShallowMerger;
 
 impl ShallowMerger {
+    #[instrument(skip_all)]
     fn merge_version(
         low_priority: &Version<1>,
         high_priority: &Version<1>,
@@ -45,6 +47,7 @@ impl ShallowMerger {
         Ok(high_priority.clone())
     }
 
+    #[instrument(skip_all)]
     fn merge_install(
         low_priority: &Install,
         high_priority: &Install,
@@ -58,6 +61,7 @@ impl ShallowMerger {
     }
 
     /// Keys in `manifest2` overwrite keys in `manifest1`.
+    #[instrument(skip_all)]
     fn merge_vars(
         low_priority: &Vars,
         high_priority: &Vars,
@@ -70,6 +74,7 @@ impl ShallowMerger {
         Ok((Vars(merged), warnings))
     }
 
+    #[instrument(skip_all)]
     fn merge_hook(
         low_priority: Option<&Hook>,
         high_priority: Option<&Hook>,
@@ -87,6 +92,7 @@ impl ShallowMerger {
         }
     }
 
+    #[instrument(skip_all)]
     fn merge_profile(
         low_priority: Option<&Profile>,
         high_priority: Option<&Profile>,
@@ -125,6 +131,7 @@ impl ShallowMerger {
         }
     }
 
+    #[instrument(skip_all)]
     fn merge_options(
         low_priority: &Options,
         high_priority: &Options,
@@ -208,6 +215,7 @@ impl ShallowMerger {
         Ok((merged, warnings))
     }
 
+    #[instrument(skip_all)]
     fn merge_services(
         low_priority: &Services,
         high_priority: &Services,
@@ -220,6 +228,7 @@ impl ShallowMerger {
         Ok((Services(merged), warnings))
     }
 
+    #[instrument(skip_all)]
     fn merge_build(
         low_priority: &Build,
         high_priority: &Build,
@@ -232,6 +241,7 @@ impl ShallowMerger {
         Ok((Build(merged), warnings))
     }
 
+    #[instrument(skip_all)]
     fn merge_containerize(
         low_priority: Option<&Containerize>,
         high_priority: Option<&Containerize>,
@@ -260,24 +270,34 @@ impl ManifestMergeTrait for ShallowMerger {
         low_priority: &Manifest,
         high_priority: &Manifest,
     ) -> Result<(Manifest, Vec<Warning>), MergeError> {
+        trace!(section = "versions", "merging manifest section");
         let version = Self::merge_version(&low_priority.version, &high_priority.version)?;
+        trace!(section = "install", "merging manifest section");
         let (install, install_warnings) =
             Self::merge_install(&low_priority.install, &high_priority.install)?;
+        trace!(section = "vars", "merging manifest section");
         let (vars, vars_warnings) = Self::merge_vars(&low_priority.vars, &high_priority.vars)?;
+        trace!(section = "hook", "merging manifest section");
         let hook = Self::merge_hook(low_priority.hook.as_ref(), high_priority.hook.as_ref())?;
+        trace!(section = "profile", "merging manifest section");
         let profile = Self::merge_profile(
             low_priority.profile.as_ref(),
             high_priority.profile.as_ref(),
         )?;
+        trace!(section = "options", "merging manifest section");
         let (options, options_warnings) =
             Self::merge_options(&low_priority.options, &high_priority.options)?;
+        trace!(section = "services", "merging manifest section");
         let (services, services_warnings) =
             Self::merge_services(&low_priority.services, &high_priority.services)?;
+        trace!(section = "build", "merging manifest section");
         let (build, build_warnings) = Self::merge_build(&low_priority.build, &high_priority.build)?;
+        trace!(section = "containerize", "merging manifest section");
         let (containerize, containerize_warnings) = Self::merge_containerize(
             low_priority.containerize.as_ref(),
             high_priority.containerize.as_ref(),
         )?;
+        debug!("manifest pair merged successfully");
 
         let manifest = Manifest {
             version,

--- a/cli/flox-rust-sdk/src/models/manifest/mod.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/mod.rs
@@ -1,3 +1,4 @@
 pub mod composite;
 pub mod raw;
+#[macro_use]
 pub mod typed;

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -59,6 +59,8 @@ macro_rules! impl_into_inner {
     };
 }
 
+pub(crate) use impl_into_inner;
+
 /// An interface for the type of function that serde's skip_serializing_if
 /// method takes.
 pub(crate) trait SkipSerializing {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -324,6 +324,17 @@ impl MockClient {
             .push_back(Response::Resolve(resp));
     }
 
+    /// Push a new response into the list of mock responses given a name under
+    /// the `test_data/generated/resolve` directory.
+    pub fn push_named_resolve_response(&mut self, name: &str) {
+        let msg = format!("couldn't read resolve response named '{name}'");
+        let resp = read_mock_responses((*GENERATED_DATA).join("resolve").join(name)).expect(&msg);
+        self.mock_responses
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .extend(resp);
+    }
+
     /// Push a new response into the list of mock responses
     pub fn push_search_response(&mut self, resp: SearchResults) {
         self.mock_responses

--- a/cli/flox-test-utils/src/manifests.rs
+++ b/cli/flox-test-utils/src/manifests.rs
@@ -6,3 +6,13 @@ pub const EMPTY_ALL_SYSTEMS: &str = r#"
     [options]
     systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]
 "#;
+
+pub const HELLO: &str = r#"
+    version = 1
+
+    [install]
+    hello.pkg-path = "hello"
+
+    [options]
+    systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]
+"#;

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -119,6 +119,27 @@ pub(crate) fn packages_already_installed(pkgs: &[PackageToInstall], environment_
     }
 }
 
+/// Display a message for packages that are newly overridden by the composing manifest
+pub(crate) fn packages_newly_overridden_by_composer(pkgs: &[String]) {
+    let already_installed_msg = match pkgs {
+        [] => None,
+        [pkg] => Some(format!(
+            "This environment now overrides package with id '{}'",
+            pkg
+        )),
+        pkgs => {
+            let joined = pkgs.iter().map(|p| format!("'{}'", p)).collect::<Vec<_>>();
+            let joined = joined.join(", ");
+            Some(format!(
+                "This environment now overrides packages with ids {joined}"
+            ))
+        },
+    };
+    if let Some(msg) = already_installed_msg {
+        info(msg)
+    }
+}
+
 /// Format a list of overridden fields for an environment.
 fn format_overridden_fields(fields: &[String]) -> String {
     fields


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

**chore: add logging to composition operations**

**feat: push resolve responses by name**

This change makes it easier to populate the mock catalog client by
allowing you to push a response by name rather than path.

**chore: ensure install targets composing env**

This doesn't actually change any behavior. Instead, it adds a test to
ensure that when attempting to install a package that's already present
in an included environment, the package is installed to the composing
environment and an override warning is shown about the new override

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
