### PR TITLE
feat: flox include upgrade

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -23,13 +23,7 @@ use super::{
 };
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
-use crate::models::lockfile::{
-    IncludeToUpgrade,
-    LockedPackage,
-    Lockfile,
-    ResolutionFailure,
-    ResolveError,
-};
+use crate::models::lockfile::{LockedPackage, Lockfile, ResolutionFailure, ResolveError};
 use crate::models::manifest::raw::{
     PackageToInstall,
     TomlEditError,
@@ -646,7 +640,7 @@ impl CoreEnvironment<ReadOnly> {
     pub fn include_upgrade(
         &mut self,
         flox: &Flox,
-        to_upgrade: Vec<IncludeToUpgrade>,
+        to_upgrade: Vec<String>,
     ) -> Result<UpgradeResult, EnvironmentError> {
         tracing::debug!(
             includes = to_upgrade.iter().join(","),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -42,7 +42,7 @@ use crate::models::floxmeta::{
     FloxMetaError,
     floxmeta_git_options,
 };
-use crate::models::lockfile::{IncludeToUpgrade, Lockfile};
+use crate::models::lockfile::Lockfile;
 use crate::models::manifest::raw::PackageToInstall;
 use crate::models::manifest::typed::Manifest;
 use crate::providers::buildenv::BuildEnvOutputs;
@@ -371,7 +371,7 @@ impl Environment for ManagedEnvironment {
     fn include_upgrade(
         &mut self,
         flox: &Flox,
-        to_upgrade: Vec<IncludeToUpgrade>,
+        to_upgrade: Vec<String>,
     ) -> Result<UpgradeResult, EnvironmentError> {
         let mut generations = self.generations();
         let mut generations = generations

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -42,7 +42,7 @@ use crate::models::floxmeta::{
     FloxMetaError,
     floxmeta_git_options,
 };
-use crate::models::lockfile::{IncludeToZebra, Lockfile};
+use crate::models::lockfile::{IncludeToUpgrade, Lockfile};
 use crate::models::manifest::raw::PackageToInstall;
 use crate::models::manifest::typed::Manifest;
 use crate::providers::buildenv::BuildEnvOutputs;
@@ -367,11 +367,11 @@ impl Environment for ManagedEnvironment {
         Ok(result)
     }
 
-    // Zebra includes in the environment
-    fn zebra(
+    /// Upgrade environments included in the environment
+    fn include_upgrade(
         &mut self,
         flox: &Flox,
-        to_zebra: Vec<IncludeToZebra>,
+        to_upgrade: Vec<IncludeToUpgrade>,
     ) -> Result<UpgradeResult, EnvironmentError> {
         let mut generations = self.generations();
         let mut generations = generations
@@ -386,13 +386,16 @@ impl Environment for ManagedEnvironment {
             ))?
         }
 
-        let metadata = if to_zebra.is_empty() {
-            "zebraed all includes".to_string()
+        let metadata = if to_upgrade.is_empty() {
+            "upgraded all included environments".to_string()
         } else {
-            format!("zebraed includes: {}", to_zebra.iter().join(", "))
+            format!(
+                "upgraded included environments: {}",
+                to_upgrade.iter().join(", ")
+            )
         };
 
-        let result = local_checkout.zebra(flox, to_zebra)?;
+        let result = local_checkout.include_upgrade(flox, to_upgrade)?;
 
         generations
             .add_generation(&mut local_checkout, metadata)

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -17,7 +17,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use self::remote_environment::RemoteEnvironmentError;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
-use super::lockfile::{IncludeToUpgrade, Lockfile, RecoverableMergeError, ResolveError};
+use super::lockfile::{Lockfile, RecoverableMergeError, ResolveError};
 use super::manifest::raw::PackageToInstall;
 use super::manifest::typed::{ActivateMode, Manifest, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
@@ -137,7 +137,7 @@ pub trait Environment: Send {
     fn include_upgrade(
         &mut self,
         flox: &Flox,
-        to_upgrade: Vec<IncludeToUpgrade>,
+        to_upgrade: Vec<String>,
     ) -> Result<UpgradeResult, EnvironmentError>;
 
     /// Return the lockfile.

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -17,7 +17,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use self::remote_environment::RemoteEnvironmentError;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
-use super::lockfile::{IncludeToZebra, Lockfile, RecoverableMergeError, ResolveError};
+use super::lockfile::{IncludeToUpgrade, Lockfile, RecoverableMergeError, ResolveError};
 use super::manifest::raw::PackageToInstall;
 use super::manifest::typed::{ActivateMode, Manifest, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
@@ -133,11 +133,11 @@ pub trait Environment: Send {
         groups_or_iids: &[&str],
     ) -> Result<UpgradeResult, EnvironmentError>;
 
-    // Zebra includes in the environment
-    fn zebra(
+    /// Upgrade environments included in the environment
+    fn include_upgrade(
         &mut self,
         flox: &Flox,
-        to_zebra: Vec<IncludeToZebra>,
+        to_upgrade: Vec<IncludeToUpgrade>,
     ) -> Result<UpgradeResult, EnvironmentError>;
 
     /// Return the lockfile.

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -26,7 +26,7 @@ use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::environment::RenderedEnvironmentLink;
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
-use crate::models::lockfile::{IncludeToUpgrade, Lockfile};
+use crate::models::lockfile::Lockfile;
 use crate::models::manifest::raw::PackageToInstall;
 use crate::models::manifest::typed::Manifest;
 
@@ -320,7 +320,7 @@ impl Environment for RemoteEnvironment {
     fn include_upgrade(
         &mut self,
         flox: &Flox,
-        to_upgrade: Vec<IncludeToUpgrade>,
+        to_upgrade: Vec<String>,
     ) -> Result<UpgradeResult, EnvironmentError> {
         let result = self.inner.include_upgrade(flox, to_upgrade)?;
         self.inner

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -26,7 +26,7 @@ use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::environment::RenderedEnvironmentLink;
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
-use crate::models::lockfile::{IncludeToZebra, Lockfile};
+use crate::models::lockfile::{IncludeToUpgrade, Lockfile};
 use crate::models::manifest::raw::PackageToInstall;
 use crate::models::manifest::typed::Manifest;
 
@@ -316,13 +316,13 @@ impl Environment for RemoteEnvironment {
         Ok(result)
     }
 
-    // Zebra includes in the environment
-    fn zebra(
+    /// Upgrade environments included in the environment
+    fn include_upgrade(
         &mut self,
         flox: &Flox,
-        to_zebra: Vec<IncludeToZebra>,
+        to_upgrade: Vec<IncludeToUpgrade>,
     ) -> Result<UpgradeResult, EnvironmentError> {
-        let result = self.inner.zebra(flox, to_zebra)?;
+        let result = self.inner.include_upgrade(flox, to_upgrade)?;
         self.inner
             .push(flox, false)
             .map_err(|e| RemoteEnvironmentError::UpdateUpstream(e).into())

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -678,15 +678,18 @@ impl Lockfile {
         // Note that we have to preserve the order of the includes in the
         // manifest.
         let mut locked_includes: Vec<LockedInclude> = vec![];
+        let upgrade_all = to_upgrade
+            .as_ref()
+            .map(|to_upgrade| to_upgrade.is_empty())
+            .unwrap_or(false);
         for include_environment in &manifest.include.environments {
             let existing_locked_include = 'existing: {
                 // Don't use existing locked includes if we're upgradeing all
                 // includes
-                if let Some(to_upgrade) = &to_upgrade {
-                    if to_upgrade.is_empty() {
-                        break 'existing None;
-                    }
+                if upgrade_all {
+                    break 'existing None;
                 }
+
                 // If there's a seed_lockfile
                 let Some(seed_lockfile) = seed_lockfile else {
                     break 'existing None;
@@ -706,6 +709,7 @@ impl Lockfile {
 
             let locked_include = match existing_locked_include {
                 Some(locked_include) => {
+                    debug!("found existing locked include for {include_environment}");
                     // The following is a weird edge case,
                     // but I don't think it's too much of a problem:
                     // Suppose composer includes ./dir1 which has name A in

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -732,6 +732,7 @@ impl Lockfile {
                         .unwrap_or(false);
 
                     if should_refetch {
+                        debug!("upgrading included environment {include_environment}");
                         include_fetcher
                             .fetch(flox, include_environment)
                             .map_err(|e| RecoverableMergeError::Fetch {
@@ -748,7 +749,7 @@ impl Lockfile {
                     }
                 },
                 None => {
-                    debug!("fetching included environment {}", include_environment);
+                    debug!("fetching included environment {include_environment}");
 
                     let locked_include =
                         include_fetcher

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -13,8 +13,8 @@ use tracing::instrument;
 
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::activate::FLOX_INTERPRETER;
+use crate::environment_subcommand_metric;
 use crate::utils::message;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[allow(unused)] // remove when we implement the command
 #[derive(Bpaf, Clone)]

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -17,9 +17,9 @@ use macos_containerize_proxy::ContainerizeProxy;
 use tracing::{debug, info, instrument};
 
 use super::{EnvironmentSelect, environment_select};
+use crate::environment_subcommand_metric;
 use crate::utils::message;
 use crate::utils::openers::first_in_path;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 mod macos_containerize_proxy;
 

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -7,9 +7,9 @@ use tracing::instrument;
 
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::environment_description;
+use crate::environment_subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::message;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Delete an environment
 #[derive(Bpaf, Clone)]

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -31,10 +31,10 @@ use super::{
     environment_select,
 };
 use crate::commands::{EnvironmentSelectError, ensure_floxhub_token};
+use crate::environment_subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::errors::format_error;
 use crate::utils::message;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Edit declarative environment configuration
 #[derive(Bpaf, Clone)]

--- a/cli/flox/src/commands/include.rs
+++ b/cli/flox/src/commands/include.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::Environment;
+use indoc::indoc;
+use tracing::{info_span, instrument};
+
+use super::EnvironmentSelect;
+use crate::commands::{display_help, environment_description, environment_select};
+use crate::environment_subcommand_metric;
+use crate::utils::message;
+
+/// Include Commands.
+#[derive(Debug, Clone, Bpaf)]
+pub enum IncludeCommands {
+    /// Prints help information
+    #[bpaf(command, hide)]
+    Help,
+    /// Upgrade environments included in an environment
+    #[bpaf(command, header(indoc! {"
+        Get the latest contents of included environments and merge them with the
+        composing environment.
+
+        The included environments to upgrade can be specified by name,
+        or if none are specified, all included environments will be upgraded.
+    "}))]
+    Upgrade(#[bpaf(external(upgrade))] Upgrade),
+}
+
+#[derive(Bpaf, Debug, Clone)]
+pub struct Upgrade {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+
+    /// Included environments to upgrade
+    #[bpaf(positional("included environment"))]
+    to_upgrade: Vec<String>,
+}
+
+impl IncludeCommands {
+    #[instrument(name = "include", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        match self {
+            IncludeCommands::Help => {
+                display_help(Some("include".to_string()));
+            },
+            IncludeCommands::Upgrade(args) => args.handle(flox).await?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Upgrade {
+    #[instrument(name = "upgrade", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        environment_subcommand_metric!("include::upgrade", self.environment);
+
+        let mut environment = self
+            .environment
+            .detect_concrete_environment(&flox, "Upgrade included environments in")?;
+
+        let description = environment_description(&environment)?;
+
+        let span = info_span!(
+            "include upgrade",
+            progress = format!("Upgrading included environments in environment {description}...")
+        );
+        let result =
+            span.in_scope(|| environment.include_upgrade(&flox, self.to_upgrade.clone()))?;
+
+        let include_diff = result.include_diff();
+        if include_diff.is_empty() {
+            if self.to_upgrade.is_empty() {
+                message::info("No included environments have changes.");
+            } else {
+                for name in self.to_upgrade {
+                    message::info(format!("Included environment '{name}' has no changes."))
+                }
+            }
+        } else {
+            for upgraded in include_diff {
+                message::updated(format!("Upgraded included environment '{upgraded}'"));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -16,9 +16,9 @@ use itertools::Itertools;
 use tracing::{debug, instrument};
 
 use super::{EnvironmentSelect, environment_select};
+use crate::environment_subcommand_metric;
 use crate::utils::message;
 use crate::utils::tracing::sentry_set_tag;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 // List packages installed in an environment
 #[derive(Bpaf, Clone)]

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod edit;
 mod envs;
 mod gc;
 mod general;
+mod include;
 mod init;
 mod install;
 mod list;
@@ -939,6 +940,10 @@ enum AdditionalCommands {
     /// Garbage collect data for deleted environments
     #[bpaf(command, hide, footer("Run 'man flox-gc' for more details."))]
     Gc(#[bpaf(external(gc::gc))] gc::Gc),
+
+    /// Interact with included environments
+    #[bpaf(command, hide)]
+    Include(#[bpaf(external(include::include_commands))] include::IncludeCommands),
 }
 
 impl AdditionalCommands {
@@ -956,6 +961,7 @@ impl AdditionalCommands {
             AdditionalCommands::Update(args) => args.handle(flox).await?,
             AdditionalCommands::Upgrade(args) => args.handle(flox).await?,
             AdditionalCommands::Gc(args) => args.handle(flox)?,
+            AdditionalCommands::Include(args) => args.handle(flox).await?,
         }
         Ok(())
     }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -21,8 +21,8 @@ use url::Url;
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::ensure_floxhub_token;
 use crate::config::{Config, PublishConfig};
+use crate::environment_subcommand_metric;
 use crate::utils::message;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Clone)]
 pub struct Publish {

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 
 use crate::commands::services::{ServicesEnvironment, guard_service_commands_available};
 use crate::commands::{EnvironmentSelect, environment_select};
-use crate::{environment_subcommand_metric, subcommand_metric};
+use crate::environment_subcommand_metric;
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Logs {

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -22,8 +22,8 @@ use crate::commands::services::{
 };
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::config::Config;
+use crate::environment_subcommand_metric;
 use crate::utils::message;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Restart {

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -21,8 +21,8 @@ use crate::commands::services::{
 };
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::config::Config;
+use crate::environment_subcommand_metric;
 use crate::utils::message;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Start {

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 
 use crate::commands::services::{ServicesEnvironment, guard_service_commands_available};
 use crate::commands::{EnvironmentSelect, environment_select};
-use crate::{environment_subcommand_metric, subcommand_metric};
+use crate::environment_subcommand_metric;
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Status {

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -6,8 +6,8 @@ use tracing::instrument;
 
 use crate::commands::services::{ServicesEnvironment, guard_service_commands_available};
 use crate::commands::{EnvironmentSelect, environment_select};
+use crate::environment_subcommand_metric;
 use crate::utils::message;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Stop {

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -9,9 +9,9 @@ use tracing::{debug, info_span, instrument};
 use super::services::warn_manifest_changes_for_services;
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::{EnvironmentSelectError, ensure_floxhub_token, environment_description};
+use crate::environment_subcommand_metric;
 use crate::utils::message;
 use crate::utils::tracing::sentry_set_tag;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Uninstall installed packages from an environment
 #[derive(Bpaf, Clone)]

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -9,8 +9,8 @@ use tracing::{info_span, instrument};
 use super::services::warn_manifest_changes_for_services;
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::{ensure_floxhub_token, environment_description};
+use crate::environment_subcommand_metric;
 use crate::utils::message;
-use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Upgrade packages in an environment
 #[derive(Bpaf, Clone)]

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -54,9 +54,9 @@ macro_rules! subcommand_metric {
 macro_rules! environment_subcommand_metric {
     ($subcommand:tt, $environment_select:expr $(, $key:tt = $value:expr)*) => {{
         if let EnvironmentSelect::Remote(environment_ref) = &$environment_select {
-            subcommand_metric!($subcommand, remote_environment = environment_ref.to_string() $(, $key = $value)*);
+            $crate::subcommand_metric!($subcommand, remote_environment = environment_ref.to_string() $(, $key = $value)*);
         } else {
-            subcommand_metric!($subcommand $(, $key = $value)*);
+            $crate::subcommand_metric!($subcommand $(, $key = $value)*);
         }
     }};
 }

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -48,20 +48,6 @@ teardown() {
   common_test_teardown
 }
 
-# create a deprecated v0 environment from prepared data
-setup_pkgdb_env() {
-  NAME=$1
-  shift
-
-  mkdir -p "$PROJECT_DIR/.flox/env"
-  cp --no-preserve=mode "$MANUALLY_GENERATED"/empty_v0/* "$PROJECT_DIR/.flox/env"
-
-  echo '{
-    "name": "'$NAME'",
-    "version": 1
-  }' >>"$PROJECT_DIR/.flox/env.json"
-}
-
 # ---------------------------------------------------------------------------- #
 # catalog tests
 


### PR DESCRIPTION
See commit messages for first few commits. Primary change is:

[feat: flox include upgrade](https://github.com/flox/flox/commit/61da141790c13af7d199818ead4cbf5a2b3b8766)

Add command `flox include upgrade`.

This exposes functionality already implemented on the Environment trait.

Help text for the new command:
```
Upgrade environments included in an environment

Usage: flox include upgrade [-d=<path> | -r=<owner>/<name>] [<included
environment>]...

Get the latest contents of included environments and merge them with the
composing environment.
The included environments to upgrade can be specified by name, or if none are
specified, all included environments will be upgraded.

Available positional items:
    <included environment>  Included environments to upgrade

Available options:
    -d, --dir=<path>        Path containing a .flox/ directory
    -r, --remote=<owner>/<name>  A remote environment on FloxHub
    -h, --help              Prints help information
```
## Release Notes

NA - behind feature flag