### PR TITLE
refactor: lock() and ensure_locked() -> LockResult

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -23,7 +23,13 @@ use super::{
 };
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
-use crate::models::lockfile::{LockedPackage, Lockfile, ResolutionFailure, ResolveError};
+use crate::models::lockfile::{
+    LockResult,
+    LockedPackage,
+    Lockfile,
+    ResolutionFailure,
+    ResolveError,
+};
 use crate::models::manifest::raw::{
     PackageToInstall,
     TomlEditError,
@@ -151,10 +157,10 @@ impl<State> CoreEnvironment<State> {
     /// since pkgdb manifests can no longer be locked.
     ///
     /// TODO: consider removing this
-    pub fn ensure_locked(&mut self, flox: &Flox) -> Result<Lockfile, EnvironmentError> {
+    pub fn ensure_locked(&mut self, flox: &Flox) -> Result<LockResult, EnvironmentError> {
         match self.lockfile_if_up_to_date()? {
-            Some(lock) => Ok(lock),
-            None => self.lock(flox),
+            Some(lock) => Ok(LockResult::Unchanged(lock)),
+            None => Ok(LockResult::Changed(self.lock(flox)?)),
         }
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/fetcher.rs
+++ b/cli/flox-rust-sdk/src/models/environment/fetcher.rs
@@ -36,7 +36,7 @@ impl IncludeFetcher {
 
         match &environment {
             ConcreteEnvironment::Path(environment) => {
-                if !environment.lockfile_up_to_date(flox)? {
+                if !environment.lockfile_up_to_date()? {
                     return Err(EnvironmentError::Recoverable(
                         RecoverableMergeError::Catchall(
                             "cannot include environment since its manifest and lockfile are out of sync".to_string()

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -528,15 +528,6 @@ impl Environment for ManagedEnvironment {
         Ok(path)
     }
 
-    /// The environment is locked,
-    /// and the manifest in the lockfile matches that in the manifest.
-    /// Note that the manifest could have whitespace or comment differences from
-    /// the lockfile.
-    fn lockfile_up_to_date(&self, flox: &Flox) -> Result<bool, EnvironmentError> {
-        let local_checkout = self.local_env_or_copy_current_generation(flox)?;
-        Ok(local_checkout.lockfile_if_up_to_date()?.is_some())
-    }
-
     /// Returns the environment name
     fn name(&self) -> EnvironmentName {
         self.pointer.name.clone()

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -218,12 +218,6 @@ pub trait Environment: Send {
     /// may be located in different directories.
     fn lockfile_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError>;
 
-    /// The environment is locked,
-    /// and the manifest in the lockfile matches that in the manifest.
-    /// Note that the manifest could have whitespace or comment differences from
-    /// the lockfile.
-    fn lockfile_up_to_date(&self, flox: &Flox) -> Result<bool, EnvironmentError>;
-
     /// Returns the environment name
     fn name(&self) -> EnvironmentName;
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -17,7 +17,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use self::remote_environment::RemoteEnvironmentError;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
-use super::lockfile::{Lockfile, RecoverableMergeError, ResolveError};
+use super::lockfile::{LockResult, RecoverableMergeError, ResolveError};
 use super::manifest::raw::PackageToInstall;
 use super::manifest::typed::{ActivateMode, Manifest, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
@@ -144,7 +144,7 @@ pub trait Environment: Send {
     ///
     /// Some implementations error if the lock does not already exist, while
     /// others call lock.
-    fn lockfile(&mut self, flox: &Flox) -> Result<Lockfile, EnvironmentError>;
+    fn lockfile(&mut self, flox: &Flox) -> Result<LockResult, EnvironmentError>;
 
     /// Extract the current content of the manifest
     ///

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -401,15 +401,6 @@ impl Environment for PathEnvironment {
         Ok(self.path.join(ENV_DIR_NAME).join(LOCKFILE_FILENAME))
     }
 
-    /// The environment is locked,
-    /// and the manifest in the lockfile matches that in the manifest.
-    /// Note that the manifest could have whitespace or comment differences from
-    /// the lockfile.
-    fn lockfile_up_to_date(&self, _flox: &Flox) -> Result<bool, EnvironmentError> {
-        let env_view = self.as_core_environment()?;
-        Ok(env_view.lockfile_if_up_to_date()?.is_some())
-    }
-
     /// Return the path where the process compose socket for an environment
     /// should be created
     fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
@@ -574,6 +565,15 @@ impl PathEnvironment {
         }
 
         Ok(false)
+    }
+
+    /// The environment is locked,
+    /// and the manifest in the lockfile matches that in the manifest.
+    /// Note that the manifest could have whitespace or comment differences from
+    /// the lockfile.
+    pub fn lockfile_up_to_date(&self) -> Result<bool, EnvironmentError> {
+        let env_view = self.as_core_environment()?;
+        Ok(env_view.lockfile_if_up_to_date()?.is_some())
     }
 
     fn link(

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -387,14 +387,6 @@ impl Environment for RemoteEnvironment {
         self.inner.lockfile_path(flox)
     }
 
-    /// The environment is locked,
-    /// and the manifest in the lockfile matches that in the manifest.
-    /// Note that the manifest could have whitespace or comment differences from
-    /// the lockfile.
-    fn lockfile_up_to_date(&self, flox: &Flox) -> Result<bool, EnvironmentError> {
-        self.inner.lockfile_up_to_date(flox)
-    }
-
     /// Returns the environment name
     fn name(&self) -> EnvironmentName {
         self.inner.name()

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -26,7 +26,7 @@ use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::environment::RenderedEnvironmentLink;
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
-use crate::models::lockfile::Lockfile;
+use crate::models::lockfile::LockResult;
 use crate::models::manifest::raw::PackageToInstall;
 use crate::models::manifest::typed::Manifest;
 
@@ -245,7 +245,7 @@ impl RemoteEnvironment {
 impl Environment for RemoteEnvironment {
     /// Return the lockfile content,
     /// or error if the lockfile doesn't exist.
-    fn lockfile(&mut self, flox: &Flox) -> Result<Lockfile, EnvironmentError> {
+    fn lockfile(&mut self, flox: &Flox) -> Result<LockResult, EnvironmentError> {
         self.inner.lockfile(flox)
     }
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -80,6 +80,24 @@ pub struct Registry {
     _json: Value,
 }
 
+#[derive(Debug, Clone)]
+pub enum LockResult {
+    /// Locking produced a new Lockfile.
+    /// The change could be a minimal as whitespace.
+    Changed(Lockfile),
+    /// Locking did not produce a new Lockfile.
+    Unchanged(Lockfile),
+}
+
+impl From<LockResult> for Lockfile {
+    fn from(result: LockResult) -> Self {
+        match result {
+            LockResult::Changed(lockfile) => lockfile,
+            LockResult::Unchanged(lockfile) => lockfile,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct Lockfile {

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -232,7 +232,7 @@ impl Activate {
             path
         };
 
-        let lockfile_version = environment.lockfile(&flox)?.version();
+        let lockfile_version = lockfile.version();
         subcommand_metric!("activate#version", lockfile_version = lockfile_version);
 
         // read the currently active environments from the environment

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -90,8 +90,9 @@ impl Build {
 
         let base_dir = env.parent_path()?;
         let flox_env = env.rendered_env_links(&flox)?;
+        let lockfile = env.lockfile(&flox)?.into();
 
-        let packages_to_clean = available_packages(&env.lockfile(&flox)?, packages)?;
+        let packages_to_clean = available_packages(&lockfile, packages)?;
 
         let builder = FloxBuildMk;
         builder.clean(&flox, &base_dir, &flox_env.development, &packages_to_clean)?;
@@ -109,8 +110,9 @@ impl Build {
 
         let base_dir = env.parent_path()?;
         let built_environments = env.build(&flox)?;
+        let lockfile = env.lockfile(&flox)?.into();
 
-        let packages_to_build = available_packages(&env.lockfile(&flox)?, packages)?;
+        let packages_to_build = available_packages(&lockfile, packages)?;
 
         let builder = FloxBuildMk;
         let output = builder.build(

--- a/cli/flox/src/commands/check_for_upgrades.rs
+++ b/cli/flox/src/commands/check_for_upgrades.rs
@@ -84,7 +84,7 @@ impl CheckForUpgrades {
         // - has recently been fetched
         // Otherwise, run a dry-upgrade tof he environment and store the new information
         if let Some(info) = upgrade_information.info() {
-            let environment_lockfile = environment.lockfile(flox)?;
+            let environment_lockfile = environment.lockfile(flox)?.into();
 
             let is_information_for_current_lockfile =
                 info.result.old_lockfile == Some(environment_lockfile);
@@ -258,8 +258,8 @@ mod tests {
         let _ = locked.info_mut().insert(UpgradeInformation {
             last_checked: OffsetDateTime::now_utc(),
             result: UpgradeResult {
-                old_lockfile: Some(environment.lockfile(&flox).unwrap()),
-                new_lockfile: environment.lockfile(&flox).unwrap(),
+                old_lockfile: Some(environment.lockfile(&flox).unwrap().into()),
+                new_lockfile: environment.lockfile(&flox).unwrap().into(),
                 store_path: None,
             },
         });

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -10,6 +10,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
+use flox_rust_sdk::models::lockfile::Lockfile;
 use flox_rust_sdk::providers::container_builder::{ContainerBuilder, MkContainerNix};
 use flox_rust_sdk::utils::{ReaderExt, WireTap};
 use indoc::indoc;
@@ -64,7 +65,8 @@ impl Containerize {
 
         let built_environment = env.build(&flox)?;
         let env_name = env.name();
-        let manifest = env.lockfile(&flox)?.manifest;
+        let lockfile: Lockfile = env.lockfile(&flox)?.into();
+        let manifest = lockfile.manifest;
         let mode = manifest.options.activate.mode.unwrap_or_default();
 
         let source = if std::env::consts::OS == "linux" {

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -18,6 +18,7 @@ use flox_rust_sdk::models::environment::{
     Environment,
     EnvironmentError,
 };
+use flox_rust_sdk::models::lockfile::Lockfile;
 use flox_rust_sdk::providers::buildenv::BuildEnvError;
 use flox_rust_sdk::providers::services::ServiceError;
 use itertools::Itertools;
@@ -203,7 +204,7 @@ impl Edit {
 
                 warn_manifest_changes_for_services(flox, environment);
 
-                let lockfile = environment.lockfile(flox)?;
+                let lockfile: Lockfile = environment.lockfile(flox)?.into();
                 if lockfile.compose.is_some() {
                     message::print_overridden_manifest_fields(&lockfile);
                     message::info("Run 'flox list -c' to see merged manifest.");

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -61,7 +61,7 @@ impl List {
             .environment
             .detect_concrete_environment(&flox, "List using")?;
 
-        let lockfile = env.lockfile(&flox)?;
+        let lockfile = env.lockfile(&flox)?.into();
         if self.list_mode == ListMode::Config {
             Self::print_config(&flox, &mut env, &lockfile)?;
             return Ok(());
@@ -353,7 +353,7 @@ impl List {
             return Ok(None);
         };
 
-        let current_lockfile = environment.lockfile(flox)?;
+        let current_lockfile = environment.lockfile(flox)?.into();
 
         if Some(current_lockfile) != info.result.old_lockfile {
             // todo: delete the info file?

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -128,7 +128,8 @@ impl Publish {
         metadata_only: bool,
         cache_args: CacheArgs,
     ) -> Result<()> {
-        if !check_target_exists(&env.lockfile(&flox)?, &package)? {
+        let lockfile = env.lockfile(&flox)?.into();
+        if !check_target_exists(&lockfile, &package)? {
             bail!("Package '{}' not found in environment", package);
         }
 

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -5,6 +5,7 @@ use bpaf::Bpaf;
 use flox_rust_sdk::data::System;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
+use flox_rust_sdk::models::lockfile::Lockfile;
 use flox_rust_sdk::models::manifest::typed::{ActivateMode, Inner, Manifest, Services};
 use flox_rust_sdk::providers::services::{ProcessState, ProcessStates, new_services_to_start};
 use tracing::{debug, instrument};
@@ -285,7 +286,7 @@ pub async fn start_services_with_new_process_compose(
     names: &[String],
 ) -> Result<Vec<String>> {
     let environment = concrete_environment.dyn_environment_ref_mut();
-    let lockfile = environment.lockfile(&flox)?;
+    let lockfile: Lockfile = environment.lockfile(&flox)?.into();
     let system = flox.system.clone();
 
     for name in names {

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -236,7 +236,7 @@ mod tests {
             dep2_dir = dep2.parent_path().unwrap().to_string_lossy(),
         };
         let mut composer = new_path_environment(&flox, &composer_original_manifest);
-        let lockfile = composer.lockfile(&flox).unwrap();
+        let lockfile = composer.lockfile(&flox).unwrap().into();
 
         let (subscriber, writer) = test_subscriber_message_only();
         async {


### PR DESCRIPTION
## Proposed Changes

Review suggestion from https://github.com/flox/flox/pull/2837#discussion_r2010454197

Adds a `LockResult` enum which indicates whether an environment was
newly locked or an existing lock was used, matching the pattern of
`EditResult` and `UpgradeResult`.

It prevents callers like `activate` needing to `lockfile_up_to_date()` -
which I'll move off the `Environment` trait in a subsequent commit -
before calling `lock()` or `ensure_locked()`.

Into (via From) is provided for accessing the inner `Lockfile` if the
caller doesn't care about the operation. I wasn't sure whether to call
this `to_inner()`, `lockfile()`, or provide it on a struct, but settled
on this.

I'm not currently making any attempt to refactor `ensure_locked()` in
relation to the (slightly out of date) comments because it requires some
additional benchmarking and it seems alright to me at the moment, but I
don't have enough new information to warrant updating the comment.

## Release Notes

N/A