### PR TITLE
style(list): render composed manifest with tables and sections

### DIFF
--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -188,13 +188,11 @@ EOF
   # TODO: Unspecified tables and empty vecs should be omitted.
   assert_equal "$output" 'version = 1
 
-[install.hello]
-pkg-path = "hello"
+[install]
+hello.pkg-path = "hello"
 
-[options.allow]
-licenses = []
-
-[options.semver]'
+[options]
+allow.licenses = []'
   assert_equal "$stderr" 'ℹ️ Displaying merged manifest.'
 }
 


### PR DESCRIPTION
## Proposed Changes

Implements a `toml_edit::visit_mut::VisitMut` visitor, that changes the layout of the printed to align closer to our preferred style (section table headers with dotted subtables).

The default serializer provided by the `toml` crate renders all tables as implicit non-dotted tables, e.g.:

```toml
version = 1

[install.curl]
pkg-path = "curl"

[install.hello]
pkg-path = "hello"

[options.allow]
licenses = []

[options.semver]

[services.sleep1]
command = "sleep 1"

[services.sleep2]
command = "sleep 2"
```

In our documentation we generally prefer non-implicit tables at the root/document level with dotted subtables.

```toml
version = 1

[include]
environments = [
  { dir = "some empty environment" }
]

[install]
curl.pkg-path = "curl"
hello.pkg-path = "hello"

[services]
sleep1.command = "sleep 1"
sleep2.command = "sleep 2"
```

Unlike `toml`, the lower level `toml_edit` crate allows editing the style of the printed document.
While by default it formats every table as an inline table (interestingly the opposite choice compared to its sibling), it provides a `VisitMut` trait,
that allows adjusting the document inplace.

Thee default behavior when instantiating with `Visitor::new_for_document` is to render toplevel tables as non-dotted, implicit, sections:

```toml
version = 1

[install]
# ... subtables

# empty tables are ignored
```

It then recursively replaces inline tables with dotted subtables:

```toml
version = 1

[install]
hello.pkg-path = "hello"
hello.pkg-group = "groupname"
```



## Release Notes

