### PR TITLE
feat: use ingress URI from catalog response

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1799,6 +1799,7 @@ pub(crate) mod tests {
         MsgAttrPathNotFoundSystemsNotOnSamePage,
         MsgGeneral,
         MsgUnknown,
+        PublishResponse,
         ResolutionMessage,
         SearchError,
         UserBuildPublish,
@@ -1814,6 +1815,7 @@ pub(crate) mod tests {
         fake_flake_installable_lock,
         fake_store_path_lock,
     };
+    use url::Url;
 
     use self::catalog::PackageResolutionInfo;
     use super::*;
@@ -1872,7 +1874,14 @@ pub(crate) mod tests {
         async fn create_catalog(
             &self,
             _catalog_name: impl AsRef<str> + Send + Sync,
-        ) -> Result<(), CatalogClientError> {
+        ) -> Result<PublishResponse, CatalogClientError> {
+            unreachable!("create_catalog should not be called");
+        }
+
+        async fn get_ingress_uri(
+            &self,
+            _catalog_name: impl AsRef<str> + Send + Sync,
+        ) -> Result<Option<Url>, CatalogClientError> {
             unreachable!("create_catalog should not be called");
         }
 

--- a/cli/flox/doc/doc-build/flox-publish.md
+++ b/cli/flox/doc/doc-build/flox-publish.md
@@ -20,7 +20,7 @@ flox-publish - Publish local packages for Flox
 flox [<general-options>] publish
      [-d=<path>]
      [--store-url]
-     [--signing-key]
+     [--signing-private-key]
      [<package>]...
 ```
 
@@ -53,7 +53,7 @@ This ensures that all files
 required to build the package are included in the git repo.
 
 Upon completion,
-the package closure is signed with the key file provided in `--signing-key`
+the package closure is signed with the key file provided in `--signing-private-key`
 and uploaded to the location specified in `--store_url`.
 
 ## After publishing
@@ -120,7 +120,7 @@ where you intend to install this packages
 signed by it.
 
 ``` bash
-# This is the key file you pass to --signing-key
+# This is the key file you pass to --signing-private-key
 nix key generate-secret --key-name mytest > mytest.key
 
 # Put this public key in `/etc/nix/nix.conf` as an `extra-trusted-public-keys` and restart the nix-daemon
@@ -154,7 +154,7 @@ for additional details.
     Currently this must be an S3 bucket like
     `s3://my-bucket`.
 
-`--signing-key <path>`
+`--signing-private-key <path>`
 :   The private key to use in signing the packge
     during upload.  This is a local file path.
 

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -51,7 +51,7 @@ struct CacheArgs {
     /// Path of the key file used to sign packages before copying.
     /// Takes precedence over a value from 'flox config'.
     #[bpaf(long, argument("FILE"))]
-    signing_key: Option<PathBuf>,
+    signing_private_key: Option<PathBuf>,
 }
 
 #[derive(Debug, Bpaf, Clone)]
@@ -167,7 +167,7 @@ fn merge_cache_options(
         .or(ingress_uri);
     let key_file = args
         .as_ref()
-        .and_then(|args| args.signing_key.clone())
+        .and_then(|args| args.signing_private_key.clone())
         .or(config.as_ref().and_then(|cfg| cfg.signing_key.clone()));
 
     match (url, key_file) {
@@ -211,7 +211,7 @@ mod tests {
                 config: None,
                 args: Some(CacheArgs {
                     store_url: Some(url_args.clone()),
-                    signing_key: Some(key_args.clone()),
+                    signing_private_key: Some(key_args.clone()),
                 }),
                 ingress_uri: None,
                 expected: Some(NixCopyCache {
@@ -238,7 +238,7 @@ mod tests {
                 }),
                 args: Some(CacheArgs {
                     store_url: Some(url_args.clone()),
-                    signing_key: Some(key_args.clone()),
+                    signing_private_key: Some(key_args.clone()),
                 }),
                 ingress_uri: Some(url_response.clone()),
                 expected: Some(NixCopyCache {
@@ -251,7 +251,7 @@ mod tests {
                 config: Some(PublishConfig { signing_key: None }),
                 args: Some(CacheArgs {
                     store_url: None,
-                    signing_key: Some(key_args.clone()),
+                    signing_private_key: Some(key_args.clone()),
                 }),
                 ingress_uri: Some(url_response.clone()),
                 expected: Some(NixCopyCache {

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -51,6 +51,11 @@ struct CacheArgs {
     #[bpaf(long, argument("URL"), hide)]
     store_url: Option<Url>,
 
+    /// Which catalog to publish to.
+    /// Takes precedence over the default value of the user's GitHub handle.
+    #[bpaf(short, long, argument("NAME"))]
+    catalog: Option<String>,
+
     /// Path of the key file used to sign packages before copying.
     /// Takes precedence over a value from 'flox config'.
     #[bpaf(long, argument("FILE"))]
@@ -97,7 +102,10 @@ impl Publish {
         // Fail as early as possible if the user isn't authenticated or doesn't
         // belong to an org with a catalog.
         let token = ensure_floxhub_token(&mut flox).await?;
-        let catalog_name = token.handle().to_string();
+        let catalog_name = cache_args
+            .catalog
+            .clone()
+            .unwrap_or(token.handle().to_string());
 
         let path_env = match env {
             ConcreteEnvironment::Path(path_env) => path_env,
@@ -232,6 +240,7 @@ mod tests {
                 config: None,
                 args: CacheArgs {
                     store_url: None,
+                    catalog: None,
                     signing_private_key: None,
                 },
                 ingress_uri: None,
@@ -242,6 +251,7 @@ mod tests {
                 config: None,
                 args: CacheArgs {
                     store_url: Some(url_args.clone()),
+                    catalog: None,
                     signing_private_key: Some(key_args.clone()),
                 },
                 ingress_uri: None,
@@ -257,6 +267,7 @@ mod tests {
                 }),
                 args: CacheArgs {
                     store_url: None,
+                    catalog: None,
                     signing_private_key: None,
                 },
                 ingress_uri: Some(url_response.clone()),
@@ -272,6 +283,7 @@ mod tests {
                 }),
                 args: CacheArgs {
                     store_url: Some(url_args.clone()),
+                    catalog: None,
                     signing_private_key: Some(key_args.clone()),
                 },
                 ingress_uri: Some(url_response.clone()),
@@ -285,6 +297,7 @@ mod tests {
                 config: Some(PublishConfig { signing_key: None }),
                 args: CacheArgs {
                     store_url: None,
+                    catalog: None,
                     signing_private_key: Some(key_args.clone()),
                 },
                 ingress_uri: Some(url_response.clone()),

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -134,9 +134,6 @@ pub enum EnvironmentPromptConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PublishConfig {
-    /// Default URL of the store used by 'flox publish'
-    pub store_url: Option<Url>,
-
     /// Default path of the signing key used by 'flox publish'
     pub signing_key: Option<PathBuf>,
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**feat: create catalog and retrieve ingress uri**

This adds a method to retrieve the ingress URI for a catalog, and
implements the method that idempotently creates a catalog at the same
time since this endoint is also the one that responds with the ingress
uri.

**refactor: remove store_url from config**

This argument will only be used in the future for testing, so it doesn't
need to be persisted in user config. This change also uses the ingress
uri from the catalog response instead of the CLI argument.

**refactor: rename signing key option**

The signing key required during publishing is the *private* key, not the
public key. Renaming this option makes that clearer to the user.

**refactor: rename the no-store option, make public**

This option is renamed to `--metadata-only` and allows a user to publish
the metadata of a package without uploading the artifact itself. This is
the same behavior as before the rename, but it is now explicitly public
so that a user doesn't need to provide a signing key. The change that
makes the signing key optional is forethcoming.

**feat: error with ingress uri and no signing key**

This change makes the store URL and signing key options independent.
The signing key argument is now only required under these conditions:
- The custom catalog has a store configured e.g. the `ingress_uri` is
  populated in the response.
- The user has not passed the `--metadata-only` option.

It is a hard error if the user attempts to publish to a catalog with a
configured store, and has not passed the `--metadata-only` flag.

This change also makes the store-url field optional and hides it. This
field will only be used for testing purposes going forward.



## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
