### PR TITLE
feat: show build output during publish

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use catalog_api_v1::types::{Output, Outputs, SystemEnum};
 use chrono::{DateTime, Utc};
 use thiserror::Error;
-use tracing::{info, instrument};
+use tracing::instrument;
 use url::Url;
 
 use super::build::{BuildResult, BuildResults, ManifestBuilder};
@@ -346,10 +346,10 @@ pub fn check_build_metadata(
                 panic!("expected build to succeed");
             },
             build::Output::Stdout(line) => {
-                info!("stdout: {line}");
+                println!("{line}");
             },
             build::Output::Stderr(line) => {
-                info!("stderr: {line}");
+                eprintln!("{line}");
             },
         }
     }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**fix: show build output during publish**

This change passes the build output through to stdout/stderr during
publish to match the behavior during the build as well. The previous
behavior was going through tracing::info, which I suspect was not being
passed through.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
