### PR TITLE
feat(compose): Add errors and notices to uninstall

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -321,9 +321,7 @@ impl CoreEnvironment<ReadOnly> {
 
     /// Uninstall packages from the environment atomically
     ///
-    /// Returns true if the environment was modified and false otherwise.
-    /// TODO: this should return a list of packages that were actually
-    /// uninstalled rather than a bool.
+    /// Returns the modified environment if there were no errors.
     pub fn uninstall(
         &mut self,
         packages: Vec<String>,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -17,7 +17,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use self::remote_environment::RemoteEnvironmentError;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
-use super::lockfile::{LockResult, RecoverableMergeError, ResolveError};
+use super::lockfile::{LockResult, LockedInclude, RecoverableMergeError, ResolveError};
 use super::manifest::raw::PackageToInstall;
 use super::manifest::typed::{ActivateMode, Manifest, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
@@ -95,6 +95,9 @@ pub struct InstallationAttempt {
 #[derive(Debug)]
 pub struct UninstallationAttempt {
     pub new_manifest: Option<String>,
+    /// Packages that were requested to be uninstalled but are stilled provided
+    /// by included environments.
+    pub still_included: HashMap<String, LockedInclude>,
     /// The store path of environment that was built to validate the uninstall.
     /// This is used as an optimization to skip builds that we've already done.
     pub built_environment_store_paths: Option<BuildEnvOutputs>,

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -278,6 +278,7 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
             Please ensure that you have write permissions to '.flox/env/manifest.toml'.
         "},
         CoreEnvironmentError::PackageNotFound(_) => display_chain(err),
+        CoreEnvironmentError::PackageOnlyIncluded(_, _) => display_chain(err),
         CoreEnvironmentError::MultiplePackagesMatch(_, _) => display_chain(err),
 
         // internal error, a bug if this happens to users!

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -363,18 +363,18 @@ EOF
 @test "changes to the local environment block 'flox uninstall'"  {
   make_empty_remote_env
 
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/vim.json" \
-    "$FLOX_BIN" install vim
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
+    "$FLOX_BIN" install hello
 
-  tomlq -i -t '.install.hello."pkg-path" = "hello"' .flox/env/manifest.toml
+  tomlq -i -t '.install.curl."pkg-path" = "curl"' .flox/env/manifest.toml
 
-  run "$FLOX_BIN" uninstall vim
+  run "$FLOX_BIN" uninstall hello
   assert_failure
 
-  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/curl_hello.json" \
     "$FLOX_BIN" edit --sync
 
-  run "$FLOX_BIN" uninstall vim
+  run "$FLOX_BIN" uninstall hello
   assert_success
 }
 

--- a/cli/tests/uninstall.bats
+++ b/cli/tests/uninstall.bats
@@ -1,0 +1,132 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test rust impl of `flox uninstall`
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+# bats file_tags=uninstall
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_NAME="test"
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" > /dev/null || return
+  export LOCKFILE_PATH="$PROJECT_DIR/.flox/env/manifest.lock"
+  export MANIFEST_PATH="$PROJECT_DIR/.flox/env/manifest.toml"
+}
+
+project_teardown() {
+  popd > /dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+  unset LOCKFILE_PATH
+  unset MANIFEST_PATH
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  setup_isolated_flox
+  project_setup
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.json"
+}
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+@test "uninstall: confirmation message" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install hello
+  assert_success
+  assert_output "✅ 'hello' installed to environment 'test'"
+
+  run "$FLOX_BIN" uninstall hello
+  assert_success
+  # Note that there's TWO spaces between the emoji and the package name
+  assert_output "🗑️  'hello' uninstalled from environment 'test'"
+}
+
+@test "uninstall: errors (without proceeding) for already uninstalled packages" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install hello
+  assert_success
+
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 run "$FLOX_BIN" uninstall hello curl
+  assert_failure
+  assert_output "❌ ERROR: couldn't uninstall 'curl', wasn't previously installed"
+}
+
+@test "uninstall: edits manifest" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install hello
+  assert_success
+  run "$FLOX_BIN" uninstall hello
+  run grep '^hello.pkg-path = "hello"' "$PROJECT_DIR/.flox/env/manifest.toml"
+  assert_failure
+}
+
+@test "uninstall: reports error when package not found" {
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" uninstall not-a-package
+  assert_failure
+  assert_output --partial "couldn't uninstall 'not-a-package', wasn't previously installed"
+}
+
+@test "uninstall: removes link to installed binary" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install hello
+  assert_success
+  assert_output --partial "✅ 'hello' installed to environment"
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello" ]
+  assert_success
+  run "$FLOX_BIN" uninstall hello
+  assert_success
+  run [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello" ]
+  assert_success
+}
+
+@test "uninstall: has helpful error message with no packages installed" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json"
+  # If the [install] table is missing entirely we don't want to report a TOML
+  # parse error, we want to report that there's nothing to uninstall.
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" uninstall hello
+  assert_failure
+  assert_output --partial "couldn't uninstall 'hello', wasn't previously installed"
+}
+
+@test "uninstall: can uninstall packages with dotted att_paths" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/rubyPackages_3_2.rails.json"
+  run "$FLOX_BIN" init
+  assert_success
+  # Install a dotted package
+  run "$FLOX_BIN" install rubyPackages_3_2.rails
+  assert_success
+
+  # The package should be in the manifest
+  manifest_after_install=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
+  assert_regex "$manifest_after_install" 'rails\.pkg-path = "rubyPackages_3_2\.rails"'
+
+  # Flox can uninstall the dotted package
+  run "$FLOX_BIN" uninstall rubyPackages_3_2.rails
+  assert_success
+
+  # The package should be removed from the manifest
+  manifest_after_uninstall=$(cat "$PROJECT_DIR/.flox/env/manifest.toml")
+  ! assert_regex "$manifest_after_uninstall" 'rails\.pkg-path = "rubyPackages_3_2\.rails"'
+}


### PR DESCRIPTION
## Proposed Changes

An imperative uninstall command on a composed environment only operates
on the composing environment's manifest rather than the merged
manifest (which is essentially a read-only view) or the included
environments (which are also read-only locks).

So return an error if you attempt to uninstall a package that is only
provided by an included environment.

Also print a notice if you uninstall a package from the composing
environment but the package is still provided by an include, which could
be surprising to the user if we said it was removed but it's still
visible.

Only the highest priority include is returned, rather than listing all
of the possible matches, for user-facing simplicity and to match how we
handle warnings for overridden manifest fields. This could result in
whack-a-mole where you have to remove a package from multiple
environments but it seems like the less common scenario.

It's worth noting that we have to lock in order to detect composition
and this could potentially cause the environment to be built twice if it
was unlocked prior running `flox uninstall`.

## Release Notes

N/A until feature release.
