### PR TITLE
fix: clarify behavior of empty licenses list

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -962,6 +962,10 @@ impl Lockfile {
     ) -> Result<(), ResolveError> {
         for package in locked_packages {
             if let Some(ref licenses) = allow.licenses {
+                // If licenses is empty, allow any license.
+                // There isn't any reason to disallow all licenses,
+                // and setting licenses to [] is the only way with composition
+                // currently to allow all licenses if an included environment has licenses.
                 if !licenses.is_empty() {
                     let Some(ref license) = package.license else {
                         continue;
@@ -3709,6 +3713,23 @@ pub(crate) mod tests {
                 unfree: None,
                 broken: None,
                 licenses: Some(vec!["allowed".to_string()])
+            })
+            .is_ok()
+        );
+    }
+
+    /// [Lockfile::check_packages_are_allowed] allows any license if allowed
+    /// licenses is empty
+    #[test]
+    fn check_packages_are_allowed_for_empty_licenses() {
+        let (_, _, mut foo_locked) = fake_catalog_package_lock("foo", None);
+        foo_locked.license = Some("allowed".to_string());
+
+        assert!(
+            Lockfile::check_packages_are_allowed(&vec![foo_locked], &Allows {
+                unfree: None,
+                broken: None,
+                licenses: Some(vec![]),
             })
             .is_ok()
         );

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -530,6 +530,7 @@ Semver ::= {
 `allow.licenses`
 :   An allowlist of software licenses to allow in search results in installs.
     Valid entries are [SPDX Identifiers](https://spdx.org/licenses).
+    An empty list allows all licenses.
 
 `semver.allow-pre-releases`
 :   Whether to allow pre-release software for package installations.


### PR DESCRIPTION
Add a test/comment/documentation for the behavior that an empty list of licenses allows any license

## Release Notes

NA - just documented existing behavior