### PR TITLE
test: fix proptest flakey test

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -700,7 +700,7 @@ pub mod test_helpers {
 #[cfg(test)]
 pub mod tests {
 
-    use flox_test_utils::proptest::alphanum_string;
+    use flox_test_utils::proptest::{alphanum_string, lowercase_alphanum_string};
     use indoc::indoc;
     use itertools::izip;
     use proptest::collection::{hash_set as prop_hash_set, vec as prop_vec};
@@ -728,7 +728,10 @@ pub mod tests {
             (
                 prop_vec(manifest_without_install_or_include(), size..=size),
                 prop_hash_set(alphanum_string(2), size..=size),
-                prop_hash_set(alphanum_string(2), size..=size),
+                // macOS is case-insensitive,
+                // so only use lowercase directories so there isn't a collision
+                // between e.g. dir and DIR
+                prop_hash_set(lowercase_alphanum_string(2), size..=size),
             )
                 .prop_map(|(manifests, names, dirs)| {
                     let (mut flox, tempdir) = flox_instance();

--- a/cli/flox-test-utils/src/proptest.rs
+++ b/cli/flox-test-utils/src/proptest.rs
@@ -27,6 +27,15 @@ pub fn alphanum_string(max_size: usize) -> impl Strategy<Value = String> {
     .prop_map(|v| v.into_iter().collect())
 }
 
+pub fn lowercase_alphanum_string(max_size: usize) -> impl Strategy<Value = String> {
+    let ranges = vec!['a'..='z', '0'..='9'];
+    prop::collection::vec(
+        proptest::char::ranges(std::borrow::Cow::Owned(ranges)),
+        1..=max_size,
+    )
+    .prop_map(|v| v.into_iter().collect())
+}
+
 /// Produces strings that only contain alphanumeric characters.
 ///
 /// This is handy when you want to generate valid TOML keys without worrying about quoting


### PR DESCRIPTION
[test: don't drop proptest cases with izip](https://github.com/flox/flox/commit/8db6a33250d6c5ac77d0e3dbc952d71d0c233c61)

Instead of generating vectors and sets of potentially different sizes
and then zipping them together in a way that truncates extra cases, make
sure all vectors and sets are of the same length.

[test: fix proptest flakey test](https://github.com/flox/flox/commit/b3a10c854ec1849ff3fe343687bb3b63380ba825)

Use lowercase directory names in proptest helper function to avoid
directory collisions on macOS.

Previously, it was possible for two directory names to be generated that
had different casing but were otherwise equivalent, e.g. dir and DIR.
macOS is case insenstive, so this could cause test failures like
https://github.com/flox/flox/actions/runs/14041842973/job/39313629491

## Release Notes

NA