### PR TITLE
refactor: add existing_lockfile method

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -283,9 +283,8 @@ impl CoreEnvironment<()> {
 /// even if the concrete [super::Environment] tracks the files in a different way
 /// such as a git repository or a database.
 impl CoreEnvironment<ReadOnly> {
-    /// Create a new environment view for the given directory
-    ///
-    /// This assumes that the directory contains a valid manifest.
+    /// Create a new environment view given the path to a directory that
+    /// contains a valid manifest.
     pub fn new(env_dir: impl AsRef<Path>, include_fetcher: IncludeFetcher) -> Self {
         CoreEnvironment {
             env_dir: env_dir.as_ref().to_path_buf(),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -42,7 +42,7 @@ use crate::models::floxmeta::{
     FloxMetaError,
     floxmeta_git_options,
 };
-use crate::models::lockfile::LockResult;
+use crate::models::lockfile::{LockResult, Lockfile};
 use crate::models::manifest::raw::PackageToInstall;
 use crate::models::manifest::typed::{IncludeDescriptor, Manifest};
 use crate::providers::buildenv::BuildEnvOutputs;
@@ -225,6 +225,13 @@ impl Environment for ManagedEnvironment {
     fn lockfile(&mut self, flox: &Flox) -> Result<LockResult, EnvironmentError> {
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
         self.ensure_locked(flox, &mut local_checkout)
+    }
+
+    /// Returns the lockfile if it already exists.
+    fn existing_lockfile(&self, flox: &Flox) -> Result<Option<Lockfile>, EnvironmentError> {
+        self.local_env_or_copy_current_generation(flox)?
+            .existing_lockfile()
+            .map_err(EnvironmentError::Core)
     }
 
     /// Install packages to the environment atomically

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -17,7 +17,7 @@ use self::managed_environment::ManagedEnvironmentError;
 use self::remote_environment::RemoteEnvironmentError;
 use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
-use super::lockfile::{LockResult, LockedInclude, RecoverableMergeError, ResolveError};
+use super::lockfile::{LockResult, LockedInclude, Lockfile, RecoverableMergeError, ResolveError};
 use super::manifest::raw::PackageToInstall;
 use super::manifest::typed::{ActivateMode, Manifest, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
@@ -220,6 +220,9 @@ pub trait Environment: Send {
     /// [Environment::manifest_path] and [Environment::lockfile_path]
     /// may be located in different directories.
     fn lockfile_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError>;
+
+    /// Returns the lockfile if it already exists.
+    fn existing_lockfile(&self, flox: &Flox) -> Result<Option<Lockfile>, EnvironmentError>;
 
     /// Returns the environment name
     fn name(&self) -> EnvironmentName;

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -49,7 +49,7 @@ use crate::flox::Flox;
 use crate::models::env_registry::{deregister, ensure_registered};
 use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
-use crate::models::lockfile::{DEFAULT_SYSTEMS_STR, LockResult};
+use crate::models::lockfile::{DEFAULT_SYSTEMS_STR, LockResult, Lockfile};
 use crate::models::manifest::raw::{CatalogPackage, PackageToInstall, RawManifest};
 use crate::models::manifest::typed::{ActivateMode, Manifest};
 use crate::providers::buildenv::BuildEnvOutputs;
@@ -196,6 +196,13 @@ impl Environment for PathEnvironment {
     fn lockfile(&mut self, flox: &Flox) -> Result<LockResult, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
         env_view.ensure_locked(flox)
+    }
+
+    /// Returns the lockfile if it already exists.
+    fn existing_lockfile(&self, _flox: &Flox) -> Result<Option<Lockfile>, EnvironmentError> {
+        self.as_core_environment()?
+            .existing_lockfile()
+            .map_err(EnvironmentError::Core)
     }
 
     /// Install packages to the environment atomically

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -26,7 +26,7 @@ use crate::flox::{EnvironmentOwner, EnvironmentRef, Flox};
 use crate::models::environment::RenderedEnvironmentLink;
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
-use crate::models::lockfile::LockResult;
+use crate::models::lockfile::{LockResult, Lockfile};
 use crate::models::manifest::raw::PackageToInstall;
 use crate::models::manifest::typed::Manifest;
 
@@ -247,6 +247,11 @@ impl Environment for RemoteEnvironment {
     /// or error if the lockfile doesn't exist.
     fn lockfile(&mut self, flox: &Flox) -> Result<LockResult, EnvironmentError> {
         self.inner.lockfile(flox)
+    }
+
+    /// Returns the lockfile if it exists.
+    fn existing_lockfile(&self, flox: &Flox) -> Result<Option<Lockfile>, EnvironmentError> {
+        self.inner.existing_lockfile(flox)
     }
 
     /// Install packages to the environment atomically


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
It's a common operation to get the lockfile if one already exists. This method has already existed on CoreEnvironment and this change simply exposes it on the Environment trait. The new method is used in the `flox install` command to check the composition override warnings before and after an installation.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
