### PR TITLE
style: make catalog connection errors less noisy

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1630,6 +1630,91 @@ mod tests {
         mock.assert();
     }
 
+    // region: Error response handling
+    //
+    // Client errors and response error handling of the progenitor generated client
+    // follows the client spec.
+    // For example the pacakge version API is expected
+    // to return 404 and 422 error responses with a json body
+    // of the form `{ "detail": <String> }`.
+    // Errorneous responses (!= 200) _not_ mathcing these two cases,
+    // are represented as `APIError::UnexpectedResponse`s.
+    // Responses with expected status but not matching the expected body schema,
+    // will turn into `APIError::InvalidResponsePayload`.
+
+    /// 404 errors are mapped to [VersionsError::NotFound],
+    /// so consumers dont need to inspect raw error response
+    #[tokio::test]
+    async fn versions_error_response_not_found() {
+        let server = MockServer::start_async().await;
+
+        let mock = server.mock(|_, then| {
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json! ({"detail" : "(╯°□°)╯︵ ┻━┻ "}));
+        });
+
+        let client = CatalogClient::new(client_config(server.base_url().as_str()));
+        let result = client.package_versions("some-package").await;
+        assert!(
+            matches!(result, Err(VersionsError::NotFound)),
+            "expected VersionsError::NotFound, found: {result:?}"
+        );
+        mock.assert()
+    }
+
+    /// Other known error responses are detected
+    #[tokio::test]
+    async fn version_error_response() {
+        let server = MockServer::start_async().await;
+
+        let mock = server.mock(|_, then| {
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json! ({"detail" : "(╯°□°)╯︵ ┻━┻ "}));
+        });
+
+        let client = CatalogClient::new(client_config(server.base_url().as_str()));
+        let result = client.package_versions("some-package").await;
+        assert!(
+            matches!(
+                result,
+                Err(VersionsError::CatalogClientError(
+                    CatalogClientError::APIError(APIError::ErrorResponse(_))
+                ))
+            ),
+            "expected ErrorResponse, found: {result:?}"
+        );
+        mock.assert()
+    }
+
+    /// Other unknown error responses are [APIError::UnexpectedResponse]s
+    #[tokio::test]
+    async fn version_unknown_response() {
+        let server = MockServer::start_async().await;
+
+        let mock = server.mock(|_, then| {
+            then.status(418)
+                .header("content-type", "application/json")
+                .json_body(json! ({"detail" : "ceramic"}));
+        });
+
+        let client = CatalogClient::new(client_config(server.base_url().as_str()));
+        let result = client.package_versions("some-package").await;
+        assert!(
+            matches!(
+                result,
+                Err(VersionsError::CatalogClientError(
+                    CatalogClientError::APIError(APIError::UnexpectedResponse(_))
+                ))
+            ),
+            "expected APIError::UnexpectedResponse, found: {result:?}"
+        );
+        mock.assert()
+    }
+
+    // endregion
+
     /// make_depaging_stream collects items from multiple pages
     #[tokio::test]
     async fn depage_multiple_pages() {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1052,12 +1052,9 @@ pub enum VersionsError {
 /// APIError.
 /// We should find something cleaner.
 fn fmt_info(error_response: &ApiErrorResponseValue) -> String {
-    format!(
-        "status: {}; headers: {:?}; value: {:?}",
-        error_response.status(),
-        error_response.headers(),
-        error_response.as_ref()
-    )
+    let status = error_response.status();
+    let details = &error_response.detail;
+    format!("{status} {details}")
 }
 
 impl TryFrom<PackageGroup> for api_types::PackageGroup {

--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -34,7 +34,7 @@ impl Show {
             // didn't match a package.
             // So translate 404 into an empty vec![].
             // Once we drop the pkgdb code path, we can clean this up.
-            Err(VersionsError::Versions(e)) if e.status() == 404 => PackageDetails {
+            Err(VersionsError::NotFound) => PackageDetails {
                 results: vec![],
                 count: None::<u64>,
             },

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -608,11 +608,7 @@ pub fn format_resolve_error(err: &ResolveError) -> String {
     trace!("formatting locked_manifest_error: {err:?}");
     match err {
         // region: errors from the catalog locking
-        ResolveError::CatalogResolve(err) => formatdoc! {"
-            Failed to lock the manifest.
-
-            {err}
-        "},
+        ResolveError::CatalogResolve(err) => display_chain(err),
         // endregion
         ResolveError::UnrecognizedSystem(system) => formatdoc! {"
             Unrecognized system in manifest: {system}


### PR DESCRIPTION
Instead of `Debug` representations of status header and contents, only render status and details using their `Display` format:

    /// known server errors
    ❌ ERROR: catalog error: 422 Unprocessable Entity: something bad
    ❌ ERROR: catalog error: 404 Not Found

    /// Special handling for 404 `flox show`
    ❌ ERROR: no packages matched this pkg-path: 'foo'
