### PR TITLE
fix: consistent formatting for auto-setup pkgs

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -139,7 +139,11 @@ impl RawManifest {
 
             table
         } else {
-            Table::from_iter(packages.iter().map(|pkg| (&pkg.id, InlineTable::from(pkg))))
+            Table::from_iter(packages.iter().map(|pkg| {
+                let mut table = InlineTable::from(pkg);
+                table.set_dotted(true);
+                (&pkg.id, table)
+            }))
         };
 
         install_table.decor_mut().set_prefix(indoc! {r#"
@@ -1177,7 +1181,8 @@ pub(super) mod test {
             ##  $ flox show gum     <- show all versions of a package
             ## -------------------------------------------------------------------
             [install]
-            python3 = { pkg-path = "python3", version = "3.11.6" }
+            python3.pkg-path = "python3"
+            python3.version = "3.11.6"
 
 
             ## Environment Variables ---------------------------------------------


### PR DESCRIPTION


## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Previously when you run a `flox init` that does auto setup, it would add the package to the manifest in "inline table" form e.g.:
```toml
hello = { pkg-path = "hello" }
```
This change fixes it to use the dotted form that we use elsewhere.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Packages installed by auto-setup will now use the same formatting in the manifest as packages installed via `flox install`.

<!-- Many thanks! -->
