### PR TITLE
Prep patches for https://github.com/flox/flox/issues/2879

### DIFF
--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -395,7 +395,7 @@ mod tests {
             version = 1
 
             [install]
-            hello.pkg-path = "hello" 
+            hello.pkg-path = "hello"
 
             [build.hello]
             command = '''
@@ -413,7 +413,7 @@ mod tests {
             version = 1
 
             [install]
-            hello.pkg-path = "hello" 
+            hello.pkg-path = "hello"
         "#};
         let manifest = Manifest::from_str(&manifest_str).unwrap();
         let res = Publish::get_publish_target(&manifest, &None);
@@ -426,7 +426,7 @@ mod tests {
             version = 1
 
             [install]
-            hello.pkg-path = "hello" 
+            hello.pkg-path = "hello"
 
             [build.hello]
             command = '''
@@ -449,7 +449,7 @@ mod tests {
             version = 1
 
             [install]
-            hello.pkg-path = "hello" 
+            hello.pkg-path = "hello"
 
             [build.hello]
             command = '''
@@ -478,7 +478,7 @@ mod tests {
             version = 1
 
             [install]
-            hello.pkg-path = "hello" 
+            hello.pkg-path = "hello"
 
             [build.hello]
             command = '''


### PR DESCRIPTION
[test: support mock responses for get_ingress_uri](https://github.com/flox/flox/commit/60b1ebd1ee502f0683b1288d396a24a02a2c48b5)

Move the implementation of get_ingress_uri to ClientTrait since it
should be identical for both CatalogClient and MockClient.

Add a helper function to push responses that can be used by
create_catalog/get_ingress_uri

[refactor: consolidate merge_cache_options logic](https://github.com/flox/flox/commit/71e40940cb617ecd8a7aa302ade3a035365323d2)

Consolidate logic for handling cache options instead of splitting it
between publish() and merge_cache_options().

This is more readable, allows unit testing all related logic at the same
time, and skips an unnecessary request to the catalog server when
--store-url is passed.

A test case was added to very that the error for
```
if catalog_has_ingress_uri && no_key_supplied && !metadata_only
```
was not regressed.

[test: remove trailing whitespace in test cases](https://github.com/flox/flox/commit/3f46e786d431adb2080b947731f60d18c501c17f)

## Release Notes

NA