### PR TITLE
docs: drop stale reference to abs-path

### DIFF
--- a/cli/flox/doc/doc-build/manifest.toml.md
+++ b/cli/flox/doc/doc-build/manifest.toml.md
@@ -179,8 +179,6 @@ Each option is described below:
     and `["python310Packages", "pip"]` are equivalent for the `pkg-path`
     option.
 
-    This option is mutually exclusive with `abs-path`.
-
 `priority`
 :   A priority used to resolve file conflicts where lower values indicate
     higher priority.

--- a/cli/flox/doc/doc-compose/manifest.toml.md
+++ b/cli/flox/doc/doc-compose/manifest.toml.md
@@ -180,8 +180,6 @@ Each option is described below:
     and `["python310Packages", "pip"]` are equivalent for the `pkg-path`
     option.
 
-    This option is mutually exclusive with `abs-path`.
-
 `priority`
 :   A priority used to resolve file conflicts where lower values indicate
     higher priority.

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -180,8 +180,6 @@ Each option is described below:
     and `["python310Packages", "pip"]` are equivalent for the `pkg-path`
     option.
 
-    This option is mutually exclusive with `abs-path`.
-
 `priority`
 :   A priority used to resolve file conflicts where lower values indicate
     higher priority.


### PR DESCRIPTION
`abs-path` is a relic of pkgdb

## Release Notes

Minor doc cleanup