### PR TITLE
refactor: Move uninstall package helpers

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -652,6 +652,8 @@ pub enum EnvironmentError {
     ManifestNotFound,
 
     // endregion
+    #[error(transparent)]
+    ManifestError(#[from] ManifestError),
 
     // todo: candidate for impl specific error
     // * only path env implements init
@@ -768,6 +770,17 @@ pub enum UpgradeError {
     PkgNotFound(#[from] ManifestError),
     #[error("'{pkg}' is a package in the group '{group}' with multiple packages")]
     NonEmptyNamedGroup { pkg: String, group: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UninstallError {
+    #[error(transparent)]
+    ManifestError(#[from] ManifestError),
+    #[error(
+        "Cannot remove included package '{0}'\n\
+         Remove the package from environment '{1}' and then run 'flox include upgrade'"
+    )]
+    PackageOnlyIncluded(String, String),
 }
 
 /// Open an environment defined in `{path}/.flox`

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -277,9 +277,6 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
 
             Please ensure that you have write permissions to '.flox/env/manifest.toml'.
         "},
-        CoreEnvironmentError::PackageNotFound(_) => display_chain(err),
-        CoreEnvironmentError::PackageOnlyIncluded(_, _) => display_chain(err),
-        CoreEnvironmentError::MultiplePackagesMatch(_, _) => display_chain(err),
 
         // internal error, a bug if this happens to users!
         CoreEnvironmentError::BadLockfilePath(_) => display_chain(err),
@@ -304,6 +301,7 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
                     $ flox upgrade
             "},
         },
+        CoreEnvironmentError::UninstallError(_) => display_chain(err),
         // User facing
         CoreEnvironmentError::Services(err) => display_chain(err),
 

--- a/cli/tests/uninstall.bats
+++ b/cli/tests/uninstall.bats
@@ -81,9 +81,10 @@ teardown() {
 
 @test "uninstall: reports error when package not found" {
   "$FLOX_BIN" init
-  run "$FLOX_BIN" uninstall not-a-package
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 run "$FLOX_BIN" uninstall not-a-package
   assert_failure
-  assert_output --partial "couldn't uninstall 'not-a-package', wasn't previously installed"
+  assert_output "❌ ERROR: couldn't uninstall 'not-a-package', wasn't previously installed"
 }
 
 @test "uninstall: removes link to installed binary" {
@@ -105,9 +106,10 @@ teardown() {
   # If the [install] table is missing entirely we don't want to report a TOML
   # parse error, we want to report that there's nothing to uninstall.
   "$FLOX_BIN" init
-  run "$FLOX_BIN" uninstall hello
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 run "$FLOX_BIN" uninstall hello
   assert_failure
-  assert_output --partial "couldn't uninstall 'hello', wasn't previously installed"
+  assert_output "❌ ERROR: couldn't uninstall 'hello', wasn't previously installed"
 }
 
 @test "uninstall: can uninstall packages with dotted att_paths" {

--- a/cli/tests/uninstall.bats
+++ b/cli/tests/uninstall.bats
@@ -66,7 +66,7 @@ teardown() {
   # disable backtrace; we expect this to fail and assert output
   RUST_BACKTRACE=0 run "$FLOX_BIN" uninstall hello curl
   assert_failure
-  assert_output "❌ ERROR: couldn't uninstall 'curl', wasn't previously installed"
+  assert_output "❌ ERROR: no package named 'curl' in the manifest"
 }
 
 @test "uninstall: edits manifest" {
@@ -84,7 +84,7 @@ teardown() {
   # disable backtrace; we expect this to fail and assert output
   RUST_BACKTRACE=0 run "$FLOX_BIN" uninstall not-a-package
   assert_failure
-  assert_output "❌ ERROR: couldn't uninstall 'not-a-package', wasn't previously installed"
+  assert_output "❌ ERROR: no package named 'not-a-package' in the manifest"
 }
 
 @test "uninstall: removes link to installed binary" {
@@ -109,7 +109,7 @@ teardown() {
   # disable backtrace; we expect this to fail and assert output
   RUST_BACKTRACE=0 run "$FLOX_BIN" uninstall hello
   assert_failure
-  assert_output "❌ ERROR: couldn't uninstall 'hello', wasn't previously installed"
+  assert_output "❌ ERROR: no package named 'hello' in the manifest"
 }
 
 @test "uninstall: can uninstall packages with dotted att_paths" {


### PR DESCRIPTION
## Proposed Changes

Follow-up from the review of https://github.com/flox/flox/pull/2883

Moves `get_install_ids` onto `Manifest` in parallel with
`Manifest.install`.

The errors `PackageNotFound` and `MultiplePackagesMatch` have been moved
further down into `ManifestError` to match. These are distinct from
`PkgOrGroupNotFound` because we only handle package names for
`uninstall` and `get_install_ids`, unlike `upgrade`. I've changed the
user facing message in order to match `upgrade` and because we don't
know that the operation is `uninstall` this far down.

Moves `get_includes_for_packages` and `get_include_for_package` onto
`Compose` in parallel with `Compose.include`.

The error `PackageOnlyIncluded` has been grouped in `UninstallError`
which is then wrapped by `CoreEnvironmentError` in the same way as
`UpgradeError`.

The wrapping of error messages still feels complicated but I'm not sure
there's much more to do prior #1965.

## Release Notes

N/A
