### PR TITLE
test: Move RUST_BACKTRACE to flox-cli-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,6 @@ jobs:
       - name: "CLI Integration Tests"
         timeout-minutes: 30
         env:
-          RUST_BACKTRACE: 1
           AUTH0_FLOX_DEV_CLIENT_SECRET: "${{ secrets.MANAGED_AUTH0_FLOX_DEV_CLIENT_SECRET }}"
           FLOX_CI_RUNNER: "github-${{ matrix.os }}"
         run: |

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -140,6 +140,10 @@ writeShellScriptBin PROJECT_NAME ''
   FLOX_LATEST_VERSION=${builtins.readFile ../../VERSION}
   export FLOX_LATEST_VERSION
 
+  # This makes test failures easier to debug, especially in CI, but requires
+  # explicitly disabling in tests that use `assert_failure` and `assert_output`.
+  export RUST_BACKTRACE=1
+
   # TODO: we shouldn't do this but rather use absolute paths
   # Look if we can use https://github.com/abathur/resholve
   export PATH="$PROJECT_PATH:${lib.makeBinPath paths}"


### PR DESCRIPTION
## Proposed Changes

So that it behaves the same locally as in CI. It's the second time this week I've modified a test that runs successfully locally and then fails in CI because the configuration is different, for example:

- https://github.com/flox/flox/actions/runs/14218087982/job/39839312599

## Release Notes

N/A
