### PR TITLE
feat(ci): upload test reports to BuildKite

### DIFF
--- a/.github/scripts/remote-execute-integration-tests.sh
+++ b/.github/scripts/remote-execute-integration-tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+function render_remote_cmd() {
+  local -r flake_ref="github:flox/flox/$GITHUB_SHA#packages.$MATRIX_SYSTEM.flox-cli-tests"
+  local -r nix_args=(--accept-flake-config --extra-experimental-features '"nix-command flakes"' "$flake_ref")
+  local -r ci_args=(--ci-runner "flox-$MATRIX_SYSTEM")
+  local -r bats_args=(--filter-tags "$MATRIX_TEST_TAGS" --report-formatter junit)
+
+  # Don't actually run the command, just render it. We want the environment
+  # variables from this machine, not the remote builder.
+  echo nix run "${nix_args[@]}" -- "${ci_args[@]}" -- "${bats_args[@]}"
+}
+export -f render_remote_cmd
+
+function upload_report_to_buildkite() {
+  local -r report_path="$1"
+  local -r git_commit_message="$(git log -1 --pretty=format:"%s")"
+
+  curl \
+    -X POST \
+    --fail-with-body \
+    -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+    -F "data=@$report_path" \
+    -F "format=junit" \
+    -F "run_env[CI]=github_actions" \
+    -F "run_env[key]=$GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" \
+    -F "run_env[number]=$GITHUB_RUN_NUMBER" \
+    -F "run_env[branch]=$GITHUB_REF" \
+    -F "run_env[commit_sha]=$GITHUB_SHA" \
+    -F "run_env[message]=$git_commit_message" \
+    -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+    https://analytics-api.buildkite.com/v1/uploads
+}
+
+function main() {
+  git clean -xfd
+
+  # Execute the render_remote_cmd on the remote host, whilst also keeping a copy
+  # of stdout on this machine. We'll use that output.txt later to extract which
+  # temporary directory was used as WORKDIR when running the tests, since bats
+  # will output the JUnit report.xml there.
+  ssh "github@$REMOTE_SERVER_ADDRESS" \
+    -o LogLevel=ERROR \
+    -o "UserKnownHostsFile=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE" \
+    "$(render_remote_cmd)" \
+    | tee output.txt
+
+  # Upload the JUnit report if we're in the merge queue
+  if [[ 'merge_group' == "$GITHUB_EVENT_NAME" ]]; then
+    local -r report_path_on_remote="$(awk '{ if ($1 == "TESTS_DIR:") { print $2 } }' output.txt)/report.xml"
+    # Square bracket due to IPv6 being used to address the remote builderes via TailScale.
+    scp \
+      -6 \
+      -o "UserKnownHostsFile=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE" \
+      "github@[$REMOTE_SERVER_ADDRESS]:$report_path_on_remote" \
+      .
+    upload_report_to_buildkite "$(realpath ./report.xml)"
+  fi
+}
+main "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,27 @@ jobs:
           RUST_BACKTRACE: 1
         run: nix develop -L --no-update-lock-file --command just impure-tests
 
+      - name: "Upload CLI Unit Test Results"
+        if: ${{ (matrix.test-tags == '!activate,!containerize,!catalog') && (github.event_name == 'merge_group') }}
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_RUST_UNIT_TESTS_TOKEN }}
+        run: |
+          curl \
+            -X POST \
+            --fail-with-body \
+            -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+            -F "data=@cli/target/nextest/ci/junit.xml" \
+            -F "format=junit" \
+            -F "run_env[CI]=github_actions" \
+            -F "run_env[key]=$GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" \
+            -F "run_env[number]=$GITHUB_RUN_NUMBER" \
+            -F "run_env[branch]=$GITHUB_REF" \
+            -F "run_env[commit_sha]=$GITHUB_SHA" \
+            -F "run_env[message]=$(git log -1 --pretty=format:"%s")" \
+            -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            https://analytics-api.buildkite.com/v1/uploads
+
+
       # This differs from `nix-build-bats-tests` in that:
       #   - a cargo-built debug binary is used, like you would in local development
       #   - envrionment variables unskip some tests against live systems
@@ -401,14 +422,8 @@ jobs:
 
       - name: "Run Bats Tests (./#flox-cli-tests)"
         timeout-minutes: 30
-        run: |
-          git clean -xfd
-          ssh github@$REMOTE_SERVER_ADDRESS \
-            -oLogLevel=ERROR \
-            -oUserKnownHostsFile=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE \
-            nix run \
-                --accept-flake-config \
-                --extra-experimental-features '"nix-command flakes"' \
-                'github:flox/flox/${{ github.sha }}#packages.${{ matrix.system }}.flox-cli-tests' -- \
-                  --ci-runner '"flox-${{ matrix.system }}"' -- \
-                  --filter-tags '"${{ matrix.test-tags }}"'
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_INTEGRATION_TESTS_TOKEN }}
+          MATRIX_SYSTEM: ${{ matrix.system }}
+          MATRIX_TEST_TAGS: ${{ matrix.test-tags }}
+        run: ./.github/scripts/remote-execute-integration-tests.sh

--- a/Justfile
+++ b/Justfile
@@ -13,7 +13,7 @@
 nix_options := "--extra-experimental-features nix-command \
                 --extra-experimental-features flakes"
 INPUT_DATA := "${PWD}/test_data/input_data"
-cargo_test_invocation := "cargo nextest run --manifest-path ${PWD}/cli/Cargo.toml --workspace"
+cargo_test_invocation := "cargo nextest --profile ci run --manifest-path ${PWD}/cli/Cargo.toml --workspace"
 
 # Set the FLOX_VERSION variable so that it can be used in the build/runtime
 # It's important to add the git revision to the version string,

--- a/cli/.config/nextest.toml
+++ b/cli/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.ci.junit]
+path = "junit.xml"
+store-success-output = true
+store-failure-output = true


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
We'd like to monitor the flakiness and performance of our unit tests and
integration tests. I believe BuildKite's test suites offering brings what we
need. It can show us the test reliability, how long each test takes, and some
other interesting metrics.

BuildKite integrates well with their own CI (duh), but it also accepts JUnit XML
files to be uploaded and stored. Both Rust with nextest and bats support
generating JUnit files that BuildKite understands. So, this will be our
preferred way of uploading, since we're not planning on moving CI systems.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
