### PR TITLE
chore: improve search error message

### DIFF
--- a/cli/tests/search.bats
+++ b/cli/tests/search.bats
@@ -67,6 +67,11 @@ setup_file() {
 @test "'flox search' error with no search term" {
   run "$FLOX_BIN" search
   assert_failure
+  assert_output <<EOF
+❌  No search term provided.
+
+Try searching with a search term. For example, 'flox search curl'
+EOF
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

Fixes #2051, as requested.

Unfortunately, `bpaf` doesn't give much to flexibility of error messages, lest you implement your own parser. The path of least resistance here, though, was just to mark the string as optional, and then bail if it is not provided with our desired error message.

## Release Notes

Added better search error message if the search term is not provided.
