### PR TITLE
fix(edit): Ensure lock for noop edits and improve include locking error

### DIFF
--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -212,7 +212,21 @@ EOF
   run "$FLOX_BIN" edit -f "$TESTS_DIR/edit/manifest.toml"
   assert_success
   assert_output "⚠️  No changes made to environment."
+}
 
+# bats test_tags=edit:unlocked
+@test "'flox edit' locks when there are no changes and no lockfile" {
+  "$FLOX_BIN" init
+
+  # Lock once and delete the lock.
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
+    run "$FLOX_BIN" edit -f "$TESTS_DIR/edit/manifest.toml"
+  rm .flox/env/manifest.lock
+
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" \
+    run "$FLOX_BIN" edit -f "$TESTS_DIR/edit/manifest.toml"
+  assert_success
+  assert_output "✅ Environment successfully updated."
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

**fix(edit): Ensure lock for noop edits**

Change the behaviour of `flox edit` so that it locks and builds an
environment when there are no changes to the manifest and it's not
already locked.

The primary motivation for this is so that we can provide a single
command for users to run in the error message when a composed
environment has unlocked includes. The alternatives are much more janky,
such as:

- `flox edit` with a whitespace change
- `flox activate -- true`

I think it also provides a more consistent experience and better
feedback loop because if you're editing an unlocked environment then
you'll want to know that it builds rather than deferring to the next
time it's activated.

For this reason I think it's also better irrespective of whether we
choose to implement `flox edit --sync` for local environments in:

- #2892

Prior to this change the new test would have failed with:

    -- output differs --
    expected : ✅ Environment successfully updated.
    actual   : ⚠️  No changes made to environment.
    --

**fix(compose): Error cmds for locked include**

Provide a command to run when a composed environment can't be locked
because one of its includes is unlocked. Similar to the error message we
provide for out-of-sync managed environments. This depends on the `flox
edit` changes in the preceding commit.

## Release Notes

`flox edit` will now lock and build an environment when there are no changes to the manifest and it's not
already locked.