### PR TITLE
test(manifest): Update comments about options

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -1140,12 +1140,15 @@ pub mod test {
     }
 
     // A serialized manifest shouldn't contain any tables that aren't specified
-    // or required. This makes the lockfile and presentation of merged manifests
-    // (which have to come from `Manifest` rather than `RawManifest`) tidier.
+    // or required, with the exception of `options` which is fiddly to implement
+    // `skip_serializing_if` for such a mixture of fields.
+    //
+    // This makes the lockfile tidier and improve cross-version compatibility.
+    // It doesn't affect the presentation of composed manifests because `flox
+    // list` uses a different serializer.
     #[test]
     fn serialize_omits_unspecified_fields() {
         let manifest = Manifest::default();
-        // TODO: omit `options` in https://github.com/flox/flox/issues/2812
         let expected = indoc! {r#"
             version = 1
 
@@ -1166,7 +1169,6 @@ pub mod test {
             profile: Some(Profile::default()),
             ..Default::default()
         };
-        // TODO: omit `options` in https://github.com/flox/flox/issues/2812
         let expected = indoc! {r#"
             version = 1
 

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -141,13 +141,6 @@ version = 1
 
 [hook]
 on-activate = "something suspicious"
-
-[profile]
-
-[options.allow]
-licenses = []
-
-[options.semver]
 EOF
   )"
 


### PR DESCRIPTION
## Proposed Changes

Final clean-up to close https://github.com/flox/flox/issues/2812 which I took from @zmitchell because I have some context and spare cycles.

**test(manifest): Update comments about options**

It no longer matters that `options` is serialized here because we have
decoupled the presentation format since:

- 945da12
- b1e8464

I think there's still value in keeping the tests though because we
shouldn't be rendering other unspecified tables. Similar, but not the
same, as the test for not rendering null fields.

**test(list): Remove unused manifest content**

I accidentally added these tables in 29dd849 when I was considering
re-purposing this test for something else. That commit should have only
been a whitespace change.

## Release Notes

N/A