### PR TITLE
chore: add gitattributes when `flox init` runs

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -644,6 +644,8 @@ pub enum EnvironmentError {
     EnvironmentExists(PathBuf),
     #[error("could not write .gitignore file")]
     WriteGitignore(#[source] std::io::Error),
+    #[error("could not write .gitattributes file")]
+    WriteGitattributes(#[source] std::io::Error),
     // endregion
 
     // todo: move pointer related errors somewhere else?

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -18,6 +18,7 @@ use std::fs::{self};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use indoc::formatdoc;
 use itertools::Itertools;
 use tracing::debug;
 
@@ -525,6 +526,12 @@ impl PathEnvironment {
 
         // Write stateful directories to .flox/.gitignore
         create_dot_flox_gitignore(&dot_flox_path)?;
+
+        // Write (configure) Git attributes to ./flox/.gitattributes
+        fs::write(dot_flox_path.join(".gitattributes"), formatdoc! {"
+            {ENV_DIR_NAME}/{LOCKFILE_FILENAME} linguist-generated=true linguist-language=JSON
+            "})
+        .map_err(EnvironmentError::WriteGitattributes)?;
 
         let dot_flox_path = CanonicalPath::new(dot_flox_path).expect("the directory just created");
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -76,9 +76,10 @@ pub fn format_error(err: &EnvironmentError) -> String {
             delete the existing environment using 'flox delete -d {path:?}' and try again.
         "},
 
-        // This should rarely happen.
-        // At this point we already proved that we can write to the directory.
+        // These errors should rarely happen.
+        // At this point, we already proved that we can write to the directory.
         EnvironmentError::WriteGitignore(_) => display_chain(err),
+        EnvironmentError::WriteGitattributes(_) => display_chain(err),
 
         // todo: enrich with a path?
         EnvironmentError::ReadEnvironmentMetadata(error) => formatdoc! {"

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -172,6 +172,13 @@ EOF
   assert_line "run/"
 }
 
+@test "c9: flox init adds .gitattributes" {
+  "$FLOX_BIN" init
+  run cat .flox/.gitattributes
+  assert_success
+  assert_line "env/manifest.lock linguist-generated=true linguist-language=JSON"
+}
+
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=init:python:requirements

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -165,7 +165,7 @@ EOF
 }
 
 # bats test_tags=init:gitignore
-@test "c9: flox init adds .gitingore that ignores run/ directory" {
+@test "c9: flox init adds .gitignore that ignores run/ directory" {
   "$FLOX_BIN" init
   run cat .flox/.gitignore
   assert_success


### PR DESCRIPTION
## Proposed Changes

Addresses #781 , but follows the latter suggestion of putting the file at `.flox/.gitattributes` instead of `.flox/env/.gitattributes`.

## Release Notes

- The `flox init` command now creates a `.gitattributes` file in the `.flox` directory.
