### PR TITLE
feat: heuristics for publishing git remote

### DIFF
--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -109,7 +109,7 @@ pub trait GitProvider: Sized + std::fmt::Debug {
     fn push(&self, remote: &str, force: bool) -> Result<(), Self::PushError>;
     fn set_origin(&self, branch: &str, origin_name: &str) -> Result<(), Self::SetOriginError>;
 
-    fn get_origin(&self) -> Result<OriginInfo, Self::GetOriginError>;
+    fn get_current_branch_remote_info(&self) -> Result<OriginInfo, Self::GetOriginError>;
 
     fn workdir(&self) -> Option<&Path>;
     fn path(&self) -> &Path;
@@ -860,7 +860,7 @@ impl GitProvider for GitCommandProvider {
     ///   (remote_name, branch_name) = split_once "/" upstream_ref
     ///   upstream_url = git remote get-url ${remote_name}
     ///   upstream_rev = git ls-remote ${remote_name} ${branch_name}
-    fn get_origin(&self) -> Result<OriginInfo, Self::GetOriginError> {
+    fn get_current_branch_remote_info(&self) -> Result<OriginInfo, Self::GetOriginError> {
         let (remote_name, remote_branch) = {
             let reference = GitCommandProvider::run_command(
                 self.new_command()

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -403,7 +403,7 @@ pub fn check_build_metadata(
 
 fn gather_build_repo_meta(git: &impl GitProvider) -> Result<LockedUrlInfo, PublishError> {
     // Gather build repo info
-    let origin = git.get_origin().map_err(|_e| {
+    let origin = git.get_current_branch_remote_info().map_err(|_e| {
         PublishError::UnsupportedEnvironmentState(
             "Unable to identify repository origin info. Checkout a branch with 'git checkout -b' and set upstream with 'git branch --set-upstream-to origin/branch'".to_string(),
         )


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**refactor: rename GitProvider::get_origin**

I've renamed this method to make it clear that it's not retrieving a
remote named "origin". Furthermore, this method gets information about
the remote that the current branch is tracking, so the new name feels
more comprehensive and more accurate.

**feat: heuristics for publishing git remote**

Previously we required that the build repository be tracking a remote
branch, where the build repository and the remote repsository were both
on the latest revision. This is restrictive, and causes frustration when
running the `flox publish` command.

This change loosens those restrictions by additionally allowing the
build repository be on a revision that is present on a remote. When
multiple remotes are present we apply the following heuristics to choose
the remote URL to publish. The order of preference for choosing the
remote is as follows:
- The remote whose branch the build repo is tracking
- The remote that is configured if only one is configured
- If multiple remotes are configured, prefer one named "upstream", then
  one named "origin". If none of the remotes have those names, simply
  choose the first one listed by `git remote`.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
