### PR TITLE
refactor: remove `into_dyn_enviroment` and use `Box::new()` directly

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -254,14 +254,6 @@ pub enum ConcreteEnvironment {
 }
 
 impl ConcreteEnvironment {
-    pub fn into_dyn_environment(self) -> Box<dyn Environment> {
-        match self {
-            ConcreteEnvironment::Path(path_env) => Box::new(path_env),
-            ConcreteEnvironment::Managed(managed_env) => Box::new(managed_env),
-            ConcreteEnvironment::Remote(remote_env) => Box::new(remote_env),
-        }
-    }
-
     pub fn dyn_environment_ref(&self) -> &dyn Environment {
         match self {
             ConcreteEnvironment::Path(path_env) => path_env,

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -86,7 +86,7 @@ impl Build {
             bail!("Cannot build from a remote environment");
         };
 
-        let mut env = env.into_dyn_environment();
+        let mut env = Box::new(env);
 
         let base_dir = env.parent_path()?;
         let flox_env = env.rendered_env_links(&flox)?;


### PR DESCRIPTION
## Proposed Changes

Addresses #2381 as requested.

## Release Notes

N/A.
