### PR TITLE
refactor: determine ingress_uri in publish provider

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -121,20 +121,15 @@ pub struct CheckedBuildMetadata {
     _private: (),
 }
 
-pub trait BinaryCache {
-    fn upload(&self, path: &str) -> Result<(), PublishError>;
-    fn cache_url(&self) -> &Url;
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct NixCopyCache {
     pub url: Url,
     pub key_file: PathBuf,
 }
 
-impl BinaryCache for NixCopyCache {
+impl NixCopyCache {
     #[instrument(skip(self), fields(progress = format!("Uploading '{path}' to '{}'", self.url)))]
-    fn upload(&self, path: &str) -> Result<(), PublishError> {
+    pub fn upload(&self, path: &str) -> Result<(), PublishError> {
         let mut url = self.url.clone();
         let url_with_key = url
             .query_pairs_mut()
@@ -167,29 +162,6 @@ impl BinaryCache for NixCopyCache {
             let stderr = String::from_utf8_lossy(&output.stderr);
             Err(PublishError::CacheUploadError(stderr.to_string()))
         }
-    }
-
-    fn cache_url(&self) -> &Url {
-        &self.url
-    }
-}
-
-pub struct MockCache {
-    pub url: Url,
-    pub error_msg: Option<String>,
-}
-
-impl BinaryCache for MockCache {
-    fn upload(&self, _path: &str) -> Result<(), PublishError> {
-        if let Some(msg) = &self.error_msg {
-            Err(PublishError::CacheUploadError(msg.to_string()))
-        } else {
-            Ok(())
-        }
-    }
-
-    fn cache_url(&self) -> &Url {
-        &self.url
     }
 }
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -275,7 +275,7 @@ fn determine_cache(
 
                You can supply a signing key by either:
                - Providing a path to a key with the '--signing-private-key' option.
-               - Setting it in the config via 'flox config --set publish.signing-key <path>'
+               - Setting it in the config via 'flox config --set publish.signing_private_key <path>'
 
                Or you can publish without uploading artifacts via the '--metadata-only' option.
             "}
@@ -825,7 +825,7 @@ pub mod tests {
 
                 You can supply a signing key by either:
                 - Providing a path to a key with the '--signing-private-key' option.
-                - Setting it in the config via 'flox config --set publish.signing-key <path>'
+                - Setting it in the config via 'flox config --set publish.signing_private_key <path>'
 
                 Or you can publish without uploading artifacts via the '--metadata-only' option.
             " }

--- a/cli/flox/doc/doc-build/flox-publish.md
+++ b/cli/flox/doc/doc-build/flox-publish.md
@@ -100,7 +100,7 @@ in the Flox config:
 
 ``` bash
 flox config --set publish.store_url "s3://my-bucket-name"
-flox config --set publish.signing_key "/home/<name>/.config/my-flox-catalog.key"
+flox config --set publish.signing_private_key "/home/<name>/.config/my-flox-catalog.key"
 ```
 
 ## Signing key

--- a/cli/flox/src/commands/upload.rs
+++ b/cli/flox/src/commands/upload.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::publish::{BinaryCache, NixCopyCache};
+use flox_rust_sdk::providers::publish::NixCopyCache;
 use tracing::instrument;
 use url::Url;
 


### PR DESCRIPTION
See this thread and linked notes for context on this change: https://flox-dev.slack.com/archives/C07GRNPFNJE/p1743702577025429?thread_ts=1743439226.018539&cid=C07GRNPFNJE

[refactor: determine ingress_uri in publish provider](https://github.com/flox/flox/pull/2926/commits/f193b8f693ff3c16e1983c0aaf9068cea8980f45)
It's been decided that the publish provider should communicate with the
catalog about where to publish a package, which includes determining the
store type (which could be meta-only in the near future) and the
ingress_uri.

Move the logic in the CLI and `merge_cache_options` into
`PublishProvider::publish` and `determine_cache`.

This meant that cache was removed from the `PublishProvider` struct.
This makes sense, since PublishProvider is now responsible for
determining if a cache should even be used.

I also dropped the generic `<Cache>` on `impl Publisher for
PublishProvider`. Currently it's allowing using a `MockCache` for a
single test that makes sure that if `upload()` returns an error,
`publish()` returns that error. Since that's essentially testing that
we're using `?`, I don't think it's worth the complexity. It also
doesn't make sense with this refactor to mock at that level - we may
need to test that `publish()` correctly decides which type of cache to
use, and then calls `upload()` with that cache, but completely overriding
the decision of what cache to use just sidesteps all the logic we need
to test.

I also dropped `test_merge_cache_options_success` which has multiple cases
in favor of two existing publish tests and a third test I added
`publish_errors_without_key`. I don't think it's worth unit testing
`determine_cache` as it's just an if + a match, and I don't think at
this point it's worth adding much broader tests that have to call
Publish::handle or something to test every single case.

[refactor: drop unused BinaryCache trait](https://github.com/flox/flox/pull/2926/commits/be2901840f0ae45a338757fecc26d40741f26eee)

We may need to bring something like this back, but it's unused for now.

## Release Notes

NA