### PR TITLE
fix:inform user of no changes on push

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1485,7 +1485,11 @@ impl ManagedEnvironment {
             }
         }
 
-        let prior_remote_hash = self.floxmeta.git.get_origin().unwrap().revision;
+        let prior_remote_hash = self
+            .floxmeta
+            .git
+            .get_remote_revision("dynamicorigin", &sync_branch)
+            .map_err(ManagedEnvironmentError::Git)?;
 
         self.floxmeta
             .git
@@ -1499,9 +1503,13 @@ impl ManagedEnvironment {
                 _ => ManagedEnvironmentError::Push(err),
             })?;
 
-        let subsequnt_remote_hash = self.floxmeta.git.get_origin().unwrap().revision;
+        let subsequnt_remote_hash = self
+            .floxmeta
+            .git
+            .get_remote_revision("dynamicorigin", &sync_branch)
+            .map_err(ManagedEnvironmentError::Git)?;
 
-        if prior_remote_hash == subsequnt_remote_hash && prior_remote_hash != None {
+        if prior_remote_hash == subsequnt_remote_hash && prior_remote_hash.is_some() {
             Err(ManagedEnvironmentError::NoUpdatesToPush)?
         }
 

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -77,7 +77,7 @@ impl Push {
                     EnvironmentOwner::from_str(
                         flox.floxhub_token
                             .as_ref()
-                            .context("Need to be loggedin")?
+                            .context("Need to be logged in")?
                             .handle(),
                     )?
                 };

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -468,6 +468,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
         // access denied is caught early as ManagedEnvironmentError::AccessDenied
         ManagedEnvironmentError::Push(_) => display_chain(err),
         ManagedEnvironmentError::PushWithLocalIncludes => display_chain(err),
+        ManagedEnvironmentError::NoUpdatesToPush => display_chain(err),
         ManagedEnvironmentError::DeleteBranch(_) => display_chain(err),
         ManagedEnvironmentError::DeleteEnvironment(path, err) => formatdoc! {"
             Failed to delete remote environment at {path:?}: {err}


### PR DESCRIPTION
## Proposed Changes

We can inform the user that there are actually no changes to push (sync) to their Flox origin.

## Release Notes

- Fix issue where CLI would tell you that there were changes pushed, but there actually weren't. Now, you will see an error if you pushed but there was nothing to push.
