### PR TITLE
Add more context to BuildKite uploads

### DIFF
--- a/.github/scripts/remote-execute-integration-tests.sh
+++ b/.github/scripts/remote-execute-integration-tests.sh
@@ -31,6 +31,9 @@ function upload_report_to_buildkite() {
     -F "run_env[commit_sha]=$GITHUB_SHA" \
     -F "run_env[message]=$git_commit_message" \
     -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+    -F "tags[architecture]=$MATRIX_SYSTEM" \
+    -F "tags[nix_flakeref]=github:flox/flox/$GITHUB_SHA" \
+    -F "tags[nix_attribute]=packages.$MATRIX_SYSTEM.flox-cli-tests" \
     https://analytics-api.buildkite.com/v1/uploads
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_RUST_UNIT_TESTS_TOKEN }}
         run: |
+          system="$(nix eval --raw --impure --expr 'builtins.currentSystem')"
           curl \
             -X POST \
             --fail-with-body \
@@ -172,6 +173,9 @@ jobs:
             -F "run_env[commit_sha]=$GITHUB_SHA" \
             -F "run_env[message]=$(git log -1 --pretty=format:"%s")" \
             -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            -F "tags[architecture]=$system" \
+            -F "tags[nix_flakeref]=github:flox/flox/$GITHUB_SHA" \
+            -F "tags[nix_attribute]=devShells.$system.default" \
             https://analytics-api.buildkite.com/v1/uploads
 
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Apparently, BuildKite allows us to set custom tags and filter on them. So, I thought It'd be a good idea to at least include the architecture the suite targeted, and the Nix falkeref and attribute. E.g.

    -F "tags[architecture]=$MATRIX_SYSTEM" \
    -F "tags[nix_flakeref]=github:flox/flox/$GITHUB_SHA" \
    -F "tags[nix_attribute]=packages.$MATRIX_SYSTEM.flox-cli-tests" \

These tags will then be visible in BuildKite, allowing us to reconstruct the original command that was run to execute the tests. In hopes to reproduce an error if we encounter one.

Ref: https://buildkite.com/docs/test-engine/importing-junit-xml

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
