### PR TITLE
fix(upgrade-check): Propagate version

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -12,6 +12,8 @@ use crate::data::FloxVersion;
 pub use crate::models::environment_ref::{self, *};
 use crate::providers::{catalog, flake_installable_locker};
 
+pub const FLOX_VERSION_VAR: &str = "FLOX_VERSION";
+
 /// The Flox version, this is crate is part of.
 /// This is _also_ used to determine the version of the CLI.
 /// The version is determined by the following rules:
@@ -26,11 +28,12 @@ use crate::providers::{catalog, flake_installable_locker};
 pub static FLOX_VERSION_STRING: LazyLock<String> = LazyLock::new(|| {
     // Runtime provided version,
     // i.e. the flox cli wrapper of the nix built production flox package.
-    if let Ok(version) = std::env::var("FLOX_VERSION") {
+    if let Ok(version) = std::env::var(FLOX_VERSION_VAR) {
         return version;
     };
 
     // Buildtime provided version, i.e. `just build-flox`.
+    // Macro requires string literal rather than const.
     if let Some(version) = option_env!("FLOX_VERSION") {
         return version.to_string();
     }

--- a/cli/flox/src/commands/check_for_upgrades.rs
+++ b/cli/flox/src/commands/check_for_upgrades.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 use anyhow::{Context, Result, bail};
 use bpaf::{Bpaf, Parser};
 use flox_core::log_file_format_upgrade_check;
-use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::flox::{FLOX_VERSION_STRING, FLOX_VERSION_VAR, Flox};
 use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::providers::catalog::{self, CatalogQoS};
 use flox_rust_sdk::providers::upgrade_checks::{UpgradeInformation, UpgradeInformationGuard};
@@ -172,8 +172,12 @@ pub fn spawn_detached_check_for_upgrades_process(
     };
 
     let environment_json = serde_json::to_string(&environment)?;
-
     let mut command = Command::new(self_executable);
+
+    // Propagate the version which is set by the bypassed wrapper script and
+    // then gets unset when the CLI starts.
+    command.env(FLOX_VERSION_VAR, &*FLOX_VERSION_STRING);
+
     command.arg("check-for-upgrades");
     command.arg(environment_json);
 

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -6,7 +6,7 @@ use std::process::ExitCode;
 use anyhow::{Context, Result};
 use bpaf::{Args, Parser};
 use commands::{EnvironmentSelectError, FloxArgs, FloxCli, Prefix, Version};
-use flox_rust_sdk::flox::{FLOX_VERSION, FLOX_VERSION_STRING};
+use flox_rust_sdk::flox::{FLOX_VERSION, FLOX_VERSION_STRING, FLOX_VERSION_VAR};
 use flox_rust_sdk::models::environment::EnvironmentError;
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironmentError;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironmentError;
@@ -56,7 +56,7 @@ fn main() -> ExitCode {
     // not to look up the env concurrently,
     // because at this point the program is still single threaded.
     unsafe {
-        env::remove_var("FLOX_VERSION");
+        env::remove_var(FLOX_VERSION_VAR);
     }
 
     // Quit early if `--prefix` is present


### PR DESCRIPTION
## Proposed Changes

Upgrade checks were incorrectly reporting version `0.0.0-dirty` because
we were re-execing the Rust binary directly and not passing on the
`FLOX_VERSION` environment variable:

- https://flox-dev.sentry.io/traces/?field=id&field=span.op&field=span.description&field=span.duration&field=transaction&field=timestamp&groupBy=transaction.op&mode=aggregate&query=release%3Aflox-cli%400.0.0-dirty&sort=-timestamp&statsPeriod=30d&visualize=%7B%22chartType%22%3A0%2C%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D
- https://flox-dev.slack.com/archives/C05FFKDRRJA/p1744058246181009?thread_ts=1743957066.653269&cid=C05FFKDRRJA

This is awkward to test because:

- you need to use the wrapper script, not the cargo binary from the
  devShell which uses a different version heuristic
- it's hard to inspect the `upgrade-check` sub-process

So I've verified the fix by observing the `user-agent` header on the
catalog request using `flox build .#flox`, `./result/bin/flox activate`,
and `mitmproxy`.

Before:
![image](https://github.com/user-attachments/assets/f47775a2-608b-4e87-90b9-9d23ef326fc4)

After:
![image](https://github.com/user-attachments/assets/09fa2635-e4eb-4f23-b589-22b6968e58ae)

## Release Notes

N/A
