### PR TITLE
chore: add composition breadcrumb metrics

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -173,6 +173,10 @@ impl Activate {
         };
         let manifest = &lockfile.manifest;
 
+        // breadcrumb metric to estimate use of composition
+        let has_includes = lockfile.compose.is_some();
+        subcommand_metric!("activate", "has_includes" = has_includes);
+
         let in_place = self.print_script || (!stdout().is_tty() && self.run_args.is_empty());
         let interactive = !in_place && self.run_args.is_empty();
 


### PR DESCRIPTION
* Upon successful edits, record a `subcommand_metric` containing whether includes changed during the edit.
* Upon activation, record whether the activated environment performs composition.
