### PR TITLE
feat: use /publish endpoint as intended

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -494,10 +494,12 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "futures",
+ "httpmock",
  "openapiv3",
  "prettyplease",
  "progenitor",
  "progenitor-client",
+ "regex",
  "regress 0.9.1",
  "reqwest 0.11.27",
  "serde",

--- a/cli/catalog-api-v1/Cargo.toml
+++ b/cli/catalog-api-v1/Cargo.toml
@@ -11,6 +11,8 @@ serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 regress.workspace = true
+regex = { workspace = true, optional = true }
+httpmock = { workspace = true, optional = true }
 
 [build-dependencies]
 prettyplease.workspace = true
@@ -18,3 +20,11 @@ progenitor.workspace = true
 serde_json.workspace = true
 syn.workspace = true
 openapiv3.workspace = true
+
+[dev-dependencies]
+httpmock.workspace = true
+regex.workspace = true
+
+[features]
+# allow exporting test helpers in dev mode only
+tests = ["httpmock", "regex"]

--- a/cli/catalog-api-v1/build.rs
+++ b/cli/catalog-api-v1/build.rs
@@ -9,17 +9,31 @@ fn main() {
     let spec_src = PathBuf::from("openapi.json");
 
     let file = std::fs::File::open(&spec_src).unwrap();
-    let spec = serde_json::from_reader(file).expect("Failed to parse openapi spec");
+    let mut spec_json: serde_json::Value =
+        serde_json::from_reader(file).expect("Failed to parse openapi spec");
+    // This endpoint is causing the generated mock code to fail,
+    // and we're not using /metrics/ anyways, so drop it.
+    spec_json["paths"]
+        .as_object_mut()
+        .unwrap()
+        .remove("/metrics/")
+        .unwrap();
+    let spec = serde_json::from_value(spec_json).expect("Failed to parse openapi spec");
 
     let client = generate_client(&spec);
     let client_dst = generate_dir.join("client.rs");
     fs::write(client_dst, client).unwrap();
 
+    let mock = generate_mock(&spec);
+    let mock_dst = generate_dir.join("mock.rs");
+    fs::write(&mock_dst, mock).unwrap();
+
     // rerun if the spec changed
     println!("cargo:rerun-if-changed={}", spec_src.display());
+    println!("cargo:rerun-if-changed={}", mock_dst.display());
 }
 
-fn generate_client(spec: &OpenAPI) -> String {
+fn generator() -> progenitor::Generator {
     let mut settings = progenitor::GenerationSettings::default();
     settings.with_derive("PartialEq");
     settings.with_replacement(
@@ -37,8 +51,17 @@ fn generate_client(spec: &OpenAPI) -> String {
         "crate::types::CatalogStoreConfigNixCopy",
         vec![].into_iter(),
     );
-    let mut generator = progenitor::Generator::new(&settings);
-    let tokens = generator.generate_tokens(spec).unwrap();
+    progenitor::Generator::new(&settings)
+}
+
+fn generate_client(spec: &OpenAPI) -> String {
+    let tokens = generator().generate_tokens(spec).unwrap();
+    let ast = syn::parse2(tokens).unwrap();
+    prettyplease::unparse(&ast)
+}
+
+fn generate_mock(spec: &OpenAPI) -> String {
+    let tokens = generator().httpmock(spec, "crate").unwrap();
     let ast = syn::parse2(tokens).unwrap();
     prettyplease::unparse(&ast)
 }

--- a/cli/catalog-api-v1/build.rs
+++ b/cli/catalog-api-v1/build.rs
@@ -27,6 +27,16 @@ fn generate_client(spec: &OpenAPI) -> String {
         "crate::error::MessageType",
         ["Default".parse().unwrap()].into_iter(),
     );
+    settings.with_replacement(
+        "CatalogStoreConfig",
+        "crate::types::CatalogStoreConfig",
+        vec![].into_iter(),
+    );
+    settings.with_replacement(
+        "CatalogStoreConfigNixCopy",
+        "crate::types::CatalogStoreConfigNixCopy",
+        vec![].into_iter(),
+    );
     let mut generator = progenitor::Generator::new(&settings);
     let tokens = generator.generate_tokens(spec).unwrap();
     let ast = syn::parse2(tokens).unwrap();

--- a/cli/catalog-api-v1/openapi.json
+++ b/cli/catalog-api-v1/openapi.json
@@ -1268,7 +1268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RootModel_Annotated_Union_CatalogStoreConfigNull__CatalogStoreConfigMetaOnly__CatalogStoreConfigNixCopy__CatalogStoreConfigPublisher___FieldInfo_annotation_NoneType__required_True__title__CatalogStoreConfig___discriminator__store_type____BeforeValidator__"
+                  "$ref": "#/components/schemas/CatalogStoreConfig"
                 }
               }
             }
@@ -1324,7 +1324,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RootModel_Annotated_Union_CatalogStoreConfigNull__CatalogStoreConfigMetaOnly__CatalogStoreConfigNixCopy__CatalogStoreConfigPublisher___FieldInfo_annotation_NoneType__required_True__title__CatalogStoreConfig___discriminator__store_type____BeforeValidator__"
+                "$ref": "#/components/schemas/CatalogStoreConfig"
               }
             }
           }
@@ -1335,7 +1335,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RootModel_Annotated_Union_CatalogStoreConfigNull__CatalogStoreConfigMetaOnly__CatalogStoreConfigNixCopy__CatalogStoreConfigPublisher___FieldInfo_annotation_NoneType__required_True__title__CatalogStoreConfig___discriminator__store_type____BeforeValidator__"
+                  "$ref": "#/components/schemas/CatalogStoreConfig"
                 }
               }
             }
@@ -1651,6 +1651,32 @@
           "tags"
         ],
         "title": "CatalogStatus"
+      },
+      "CatalogStoreConfig": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CatalogStoreConfigNull"
+          },
+          {
+            "$ref": "#/components/schemas/CatalogStoreConfigMetaOnly"
+          },
+          {
+            "$ref": "#/components/schemas/CatalogStoreConfigNixCopy"
+          },
+          {
+            "$ref": "#/components/schemas/CatalogStoreConfigPublisher"
+          }
+        ],
+        "title": "CatalogStoreConfig",
+        "discriminator": {
+          "propertyName": "store_type",
+          "mapping": {
+            "meta-only": "#/components/schemas/CatalogStoreConfigMetaOnly",
+            "nix-copy": "#/components/schemas/CatalogStoreConfigNixCopy",
+            "null": "#/components/schemas/CatalogStoreConfigNull",
+            "publisher": "#/components/schemas/CatalogStoreConfigPublisher"
+          }
+        }
       },
       "CatalogStoreConfigMetaOnly": {
         "properties": {
@@ -2306,9 +2332,15 @@
             "title": "Ingress Uri",
             "nullable": true,
             "type": "string"
+          },
+          "catalog_store_config": {
+            "$ref": "#/components/schemas/CatalogStoreConfig"
           }
         },
         "type": "object",
+        "required": [
+          "catalog_store_config"
+        ],
         "title": "PublishResponse"
       },
       "ResolutionMessageGeneral": {
@@ -2547,32 +2579,6 @@
           "items"
         ],
         "title": "ResolvedPackageGroups"
-      },
-      "RootModel_Annotated_Union_CatalogStoreConfigNull__CatalogStoreConfigMetaOnly__CatalogStoreConfigNixCopy__CatalogStoreConfigPublisher___FieldInfo_annotation_NoneType__required_True__title__CatalogStoreConfig___discriminator__store_type____BeforeValidator__": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CatalogStoreConfigNull"
-          },
-          {
-            "$ref": "#/components/schemas/CatalogStoreConfigMetaOnly"
-          },
-          {
-            "$ref": "#/components/schemas/CatalogStoreConfigNixCopy"
-          },
-          {
-            "$ref": "#/components/schemas/CatalogStoreConfigPublisher"
-          }
-        ],
-        "title": "CatalogStoreConfig",
-        "discriminator": {
-          "propertyName": "store_type",
-          "mapping": {
-            "meta-only": "#/components/schemas/CatalogStoreConfigMetaOnly",
-            "nix-copy": "#/components/schemas/CatalogStoreConfigNixCopy",
-            "null": "#/components/schemas/CatalogStoreConfigNull",
-            "publisher": "#/components/schemas/CatalogStoreConfigPublisher"
-          }
-        }
       },
       "ServiceStatus": {
         "properties": {

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -351,6 +351,63 @@ pub mod types {
             value.clone()
         }
     }
+    ///CatalogStoreConfig
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "CatalogStoreConfig",
+    ///  "oneOf": [
+    ///    {
+    ///      "$ref": "#/components/schemas/CatalogStoreConfigNull"
+    ///    },
+    ///    {
+    ///      "$ref": "#/components/schemas/CatalogStoreConfigMetaOnly"
+    ///    },
+    ///    {
+    ///      "$ref": "#/components/schemas/CatalogStoreConfigNixCopy"
+    ///    },
+    ///    {
+    ///      "$ref": "#/components/schemas/CatalogStoreConfigPublisher"
+    ///    }
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[serde(untagged)]
+    pub enum CatalogStoreConfig {
+        Null(CatalogStoreConfigNull),
+        MetaOnly(CatalogStoreConfigMetaOnly),
+        NixCopy(CatalogStoreConfigNixCopy),
+        Publisher(CatalogStoreConfigPublisher),
+    }
+    impl From<&CatalogStoreConfig> for CatalogStoreConfig {
+        fn from(value: &CatalogStoreConfig) -> Self {
+            value.clone()
+        }
+    }
+    impl From<CatalogStoreConfigNull> for CatalogStoreConfig {
+        fn from(value: CatalogStoreConfigNull) -> Self {
+            Self::Null(value)
+        }
+    }
+    impl From<CatalogStoreConfigMetaOnly> for CatalogStoreConfig {
+        fn from(value: CatalogStoreConfigMetaOnly) -> Self {
+            Self::MetaOnly(value)
+        }
+    }
+    impl From<CatalogStoreConfigNixCopy> for CatalogStoreConfig {
+        fn from(value: CatalogStoreConfigNixCopy) -> Self {
+            Self::NixCopy(value)
+        }
+    }
+    impl From<CatalogStoreConfigPublisher> for CatalogStoreConfig {
+        fn from(value: CatalogStoreConfigPublisher) -> Self {
+            Self::Publisher(value)
+        }
+    }
     ///CatalogStoreConfigMetaOnly
     ///
     /// <details><summary>JSON schema</summary>
@@ -1683,7 +1740,13 @@ pub mod types {
     ///{
     ///  "title": "PublishResponse",
     ///  "type": "object",
+    ///  "required": [
+    ///    "catalog_store_config"
+    ///  ],
     ///  "properties": {
+    ///    "catalog_store_config": {
+    ///      "$ref": "#/components/schemas/CatalogStoreConfig"
+    ///    },
     ///    "ingress_uri": {
     ///      "title": "Ingress Uri",
     ///      "type": [
@@ -1697,6 +1760,7 @@ pub mod types {
     /// </details>
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PublishResponse {
+        pub catalog_store_config: CatalogStoreConfig,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ingress_uri: Option<String>,
     }
@@ -2059,72 +2123,6 @@ pub mod types {
     impl From<&ResolvedPackageGroups> for ResolvedPackageGroups {
         fn from(value: &ResolvedPackageGroups) -> Self {
             value.clone()
-        }
-    }
-    ///RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "title": "CatalogStoreConfig",
-    ///  "oneOf": [
-    ///    {
-    ///      "$ref": "#/components/schemas/CatalogStoreConfigNull"
-    ///    },
-    ///    {
-    ///      "$ref": "#/components/schemas/CatalogStoreConfigMetaOnly"
-    ///    },
-    ///    {
-    ///      "$ref": "#/components/schemas/CatalogStoreConfigNixCopy"
-    ///    },
-    ///    {
-    ///      "$ref": "#/components/schemas/CatalogStoreConfigPublisher"
-    ///    }
-    ///  ]
-    ///}
-    /// ```
-    /// </details>
-    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-    #[serde(untagged)]
-    pub enum RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator {
-        Null(CatalogStoreConfigNull),
-        MetaOnly(CatalogStoreConfigMetaOnly),
-        NixCopy(CatalogStoreConfigNixCopy),
-        Publisher(CatalogStoreConfigPublisher),
-    }
-    impl From<
-        &RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator,
-    >
-    for RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator {
-        fn from(
-            value: &RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator,
-        ) -> Self {
-            value.clone()
-        }
-    }
-    impl From<CatalogStoreConfigNull>
-    for RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator {
-        fn from(value: CatalogStoreConfigNull) -> Self {
-            Self::Null(value)
-        }
-    }
-    impl From<CatalogStoreConfigMetaOnly>
-    for RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator {
-        fn from(value: CatalogStoreConfigMetaOnly) -> Self {
-            Self::MetaOnly(value)
-        }
-    }
-    impl From<CatalogStoreConfigNixCopy>
-    for RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator {
-        fn from(value: CatalogStoreConfigNixCopy) -> Self {
-            Self::NixCopy(value)
-        }
-    }
-    impl From<CatalogStoreConfigPublisher>
-    for RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator {
-        fn from(value: CatalogStoreConfigPublisher) -> Self {
-            Self::Publisher(value)
         }
     }
     ///SearchTerm
@@ -4176,12 +4174,7 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/store/config`
     >(
         &'a self,
         catalog_name: &'a types::CatalogName,
-    ) -> Result<
-        ResponseValue<
-            types::RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator,
-        >,
-        Error<types::ErrorResponse>,
-    > {
+    ) -> Result<ResponseValue<types::CatalogStoreConfig>, Error<types::ErrorResponse>> {
         let url = format!(
             "{}/api/v1/catalog/catalogs/{}/store/config", self.baseurl, encode_path(&
             catalog_name.to_string()),
@@ -4220,13 +4213,8 @@ Sends a `PUT` request to `/api/v1/catalog/catalogs/{catalog_name}/store/config`
     >(
         &'a self,
         catalog_name: &'a types::CatalogName,
-        body: &'a types::RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator,
-    ) -> Result<
-        ResponseValue<
-            types::RootModelAnnotatedUnionCatalogStoreConfigNullCatalogStoreConfigMetaOnlyCatalogStoreConfigNixCopyCatalogStoreConfigPublisherFieldInfoAnnotationNoneTypeRequiredTrueTitleCatalogStoreConfigDiscriminatorStoreTypeBeforeValidator,
-        >,
-        Error<types::ErrorResponse>,
-    > {
+        body: &'a types::CatalogStoreConfig,
+    ) -> Result<ResponseValue<types::CatalogStoreConfig>, Error<types::ErrorResponse>> {
         let url = format!(
             "{}/api/v1/catalog/catalogs/{}/store/config", self.baseurl, encode_path(&
             catalog_name.to_string()),

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -351,63 +351,6 @@ pub mod types {
             value.clone()
         }
     }
-    ///CatalogStoreConfig
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "title": "CatalogStoreConfig",
-    ///  "oneOf": [
-    ///    {
-    ///      "$ref": "#/components/schemas/CatalogStoreConfigNull"
-    ///    },
-    ///    {
-    ///      "$ref": "#/components/schemas/CatalogStoreConfigMetaOnly"
-    ///    },
-    ///    {
-    ///      "$ref": "#/components/schemas/CatalogStoreConfigNixCopy"
-    ///    },
-    ///    {
-    ///      "$ref": "#/components/schemas/CatalogStoreConfigPublisher"
-    ///    }
-    ///  ]
-    ///}
-    /// ```
-    /// </details>
-    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-    #[serde(untagged)]
-    pub enum CatalogStoreConfig {
-        Null(CatalogStoreConfigNull),
-        MetaOnly(CatalogStoreConfigMetaOnly),
-        NixCopy(CatalogStoreConfigNixCopy),
-        Publisher(CatalogStoreConfigPublisher),
-    }
-    impl From<&CatalogStoreConfig> for CatalogStoreConfig {
-        fn from(value: &CatalogStoreConfig) -> Self {
-            value.clone()
-        }
-    }
-    impl From<CatalogStoreConfigNull> for CatalogStoreConfig {
-        fn from(value: CatalogStoreConfigNull) -> Self {
-            Self::Null(value)
-        }
-    }
-    impl From<CatalogStoreConfigMetaOnly> for CatalogStoreConfig {
-        fn from(value: CatalogStoreConfigMetaOnly) -> Self {
-            Self::MetaOnly(value)
-        }
-    }
-    impl From<CatalogStoreConfigNixCopy> for CatalogStoreConfig {
-        fn from(value: CatalogStoreConfigNixCopy) -> Self {
-            Self::NixCopy(value)
-        }
-    }
-    impl From<CatalogStoreConfigPublisher> for CatalogStoreConfig {
-        fn from(value: CatalogStoreConfigPublisher) -> Self {
-            Self::Publisher(value)
-        }
-    }
     ///CatalogStoreConfigMetaOnly
     ///
     /// <details><summary>JSON schema</summary>
@@ -433,48 +376,6 @@ pub mod types {
     }
     impl From<&CatalogStoreConfigMetaOnly> for CatalogStoreConfigMetaOnly {
         fn from(value: &CatalogStoreConfigMetaOnly) -> Self {
-            value.clone()
-        }
-    }
-    ///CatalogStoreConfigNixCopy
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "title": "CatalogStoreConfigNixCopy",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "egress_uri",
-    ///    "ingress_uri"
-    ///  ],
-    ///  "properties": {
-    ///    "egress_uri": {
-    ///      "title": "Egress Uri",
-    ///      "type": "string"
-    ///    },
-    ///    "ingress_uri": {
-    ///      "title": "Ingress Uri",
-    ///      "type": "string"
-    ///    },
-    ///    "store_type": {
-    ///      "title": "Store Type",
-    ///      "default": "nix-copy",
-    ///      "type": "string"
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-    pub struct CatalogStoreConfigNixCopy {
-        pub egress_uri: String,
-        pub ingress_uri: String,
-        #[serde(default = "defaults::catalog_store_config_nix_copy_store_type")]
-        pub store_type: String,
-    }
-    impl From<&CatalogStoreConfigNixCopy> for CatalogStoreConfigNixCopy {
-        fn from(value: &CatalogStoreConfigNixCopy) -> Self {
             value.clone()
         }
     }
@@ -1760,7 +1661,7 @@ pub mod types {
     /// </details>
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct PublishResponse {
-        pub catalog_store_config: CatalogStoreConfig,
+        pub catalog_store_config: crate::types::CatalogStoreConfig,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ingress_uri: Option<String>,
     }
@@ -3114,9 +3015,6 @@ pub mod types {
         pub(super) fn catalog_store_config_meta_only_store_type() -> String {
             "meta-only".to_string()
         }
-        pub(super) fn catalog_store_config_nix_copy_store_type() -> String {
-            "nix-copy".to_string()
-        }
         pub(super) fn catalog_store_config_null_store_type() -> String {
             "null".to_string()
         }
@@ -4174,7 +4072,10 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/store/config`
     >(
         &'a self,
         catalog_name: &'a types::CatalogName,
-    ) -> Result<ResponseValue<types::CatalogStoreConfig>, Error<types::ErrorResponse>> {
+    ) -> Result<
+        ResponseValue<crate::types::CatalogStoreConfig>,
+        Error<types::ErrorResponse>,
+    > {
         let url = format!(
             "{}/api/v1/catalog/catalogs/{}/store/config", self.baseurl, encode_path(&
             catalog_name.to_string()),
@@ -4213,8 +4114,11 @@ Sends a `PUT` request to `/api/v1/catalog/catalogs/{catalog_name}/store/config`
     >(
         &'a self,
         catalog_name: &'a types::CatalogName,
-        body: &'a types::CatalogStoreConfig,
-    ) -> Result<ResponseValue<types::CatalogStoreConfig>, Error<types::ErrorResponse>> {
+        body: &'a crate::types::CatalogStoreConfig,
+    ) -> Result<
+        ResponseValue<crate::types::CatalogStoreConfig>,
+        Error<types::ErrorResponse>,
+    > {
         let url = format!(
             "{}/api/v1/catalog/catalogs/{}/store/config", self.baseurl, encode_path(&
             catalog_name.to_string()),

--- a/cli/catalog-api-v1/src/lib.rs
+++ b/cli/catalog-api-v1/src/lib.rs
@@ -8,6 +8,81 @@ mod error;
 pub use client::*;
 
 pub mod types {
-    pub use crate::error::MessageType;
     pub use crate::client::types::*;
+    pub use crate::error::MessageType;
+
+    use serde::{Deserialize, Serialize};
+    /// Progenitor doesn't know how to use a discriminator as a tag, so add this
+    /// enum manually.
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[serde(tag = "store_type", rename_all = "kebab-case")]
+    pub enum CatalogStoreConfig {
+        /// The catalog store has not yet been configured
+        Null,
+        /// The user has configured the catalog for metadata only publishes
+        MetaOnly,
+        /// Store to copy to with `nix copy`
+        NixCopy(CatalogStoreConfigNixCopy),
+        /// Not yet supported
+        Publisher,
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    pub struct CatalogStoreConfigNixCopy {
+        pub egress_uri: String,
+        pub ingress_uri: String,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::{CatalogStoreConfig, CatalogStoreConfigNixCopy};
+
+    #[test]
+    fn deserialize_catalog_store_config_null() {
+        let response_string = r#"{
+            "store_type": "null"
+        }"#;
+
+        let store_config = serde_json::from_str::<CatalogStoreConfig>(response_string).unwrap();
+        assert_eq!(store_config, CatalogStoreConfig::Null)
+    }
+
+    #[test]
+    fn deserialize_catalog_store_config_meta_only() {
+        let response_string = r#"{
+            "store_type": "meta-only"
+        }"#;
+
+        let store_config = serde_json::from_str::<CatalogStoreConfig>(response_string).unwrap();
+        assert_eq!(store_config, CatalogStoreConfig::MetaOnly)
+    }
+
+    #[test]
+    fn deserialize_catalog_store_config_nix_copy() {
+        let response_string = r#"{
+           "store_type": "nix-copy",
+           "ingress_uri": "s3://example",
+           "egress_uri": "s3://example"
+        }"#;
+
+        let store_config = serde_json::from_str::<CatalogStoreConfig>(response_string).unwrap();
+        assert_eq!(
+            store_config,
+            CatalogStoreConfig::NixCopy(CatalogStoreConfigNixCopy {
+                ingress_uri: "s3://example".into(),
+                egress_uri: "s3://example".into()
+            })
+        )
+    }
+
+    #[test]
+    fn deserialize_catalog_store_config_publisher() {
+        let response_string = r#"{
+           "store_type": "publisher"
+        }"#;
+
+        let store_config = serde_json::from_str::<CatalogStoreConfig>(response_string).unwrap();
+        assert_eq!(store_config, CatalogStoreConfig::Publisher)
+    }
 }

--- a/cli/catalog-api-v1/src/lib.rs
+++ b/cli/catalog-api-v1/src/lib.rs
@@ -7,6 +7,10 @@ mod client;
 mod error;
 pub use client::*;
 
+#[cfg(any(test, feature = "tests"))]
+#[allow(clippy::all)]
+pub mod mock;
+
 pub mod types {
     pub use crate::client::types::*;
     pub use crate::error::MessageType;

--- a/cli/catalog-api-v1/src/mock.rs
+++ b/cli/catalog-api-v1/src/mock.rs
@@ -1,0 +1,2253 @@
+pub mod operations {
+    //! [`When`](httpmock::When) and [`Then`](httpmock::Then)
+    //! wrappers for each operation. Each can be converted to
+    //! its inner type with a call to `into_inner()`. This can
+    //! be used to explicitly deviate from permitted values.
+    use crate::*;
+    pub struct CreateCatalogApiV1CatalogCatalogsPostWhen(httpmock::When);
+    impl CreateCatalogApiV1CatalogCatalogsPostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/catalogs/$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn name(self, value: &types::Name) -> Self {
+            Self(self.0.query_param("name", value.to_string()))
+        }
+    }
+    pub struct CreateCatalogApiV1CatalogCatalogsPostThen(httpmock::Then);
+    impl CreateCatalogApiV1CatalogCatalogsPostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn created(self, value: &types::UserCatalog) -> Self {
+            Self(
+                self
+                    .0
+                    .status(201u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn conflict(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(409u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetCatalogApiV1CatalogCatalogsCatalogNameGetWhen(httpmock::When);
+    impl GetCatalogApiV1CatalogCatalogsCatalogNameGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/catalogs/[^/]*$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!("^/api/v1/catalog/catalogs/{}$", value.to_string()),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+    }
+    pub struct GetCatalogApiV1CatalogCatalogsCatalogNameGetThen(httpmock::Then);
+    impl GetCatalogApiV1CatalogCatalogsCatalogNameGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::UserCatalog) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteWhen(httpmock::When);
+    impl DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::DELETE)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/catalogs/[^/]*$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!("^/api/v1/catalog/catalogs/{}$", value.to_string()),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+    }
+    pub struct DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteThen(httpmock::Then);
+    impl DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &serde_json::Value) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_implemented(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(501u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetWhen(
+        httpmock::When,
+    );
+    impl GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/catalogs/[^/]*/packages$")
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!("^/api/v1/catalog/catalogs/{}/packages$", value.to_string()),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+    }
+    pub struct GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetThen(
+        httpmock::Then,
+    );
+    impl GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::UserPackageList) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostWhen(
+        httpmock::When,
+    );
+    impl CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/catalogs/[^/]*/packages$")
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!("^/api/v1/catalog/catalogs/{}/packages$", value.to_string()),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn name(self, value: &types::Name) -> Self {
+            Self(self.0.query_param("name", value.to_string()))
+        }
+        pub fn body(self, value: &types::UserPackageCreate) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+    pub struct CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostThen(
+        httpmock::Then,
+    );
+    impl CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::UserPackage) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn created(self, value: &types::UserPackage) -> Self {
+            Self(
+                self
+                    .0
+                    .status(201u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn conflict(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(409u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetWhen(
+        httpmock::When,
+    );
+    impl GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new(
+                                "^/api/v1/catalog/catalogs/[^/]*/packages/[^/]*$",
+                            )
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/{}/packages/.*$", value.to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn package_name(self, value: &types::PackageName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/.*/packages/{}$", value.to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+    }
+    pub struct GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetThen(
+        httpmock::Then,
+    );
+    impl GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::UserPackage) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetWhen(
+        httpmock::When,
+    );
+    impl GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new(
+                                "^/api/v1/catalog/catalogs/[^/]*/packages/[^/]*/builds$",
+                            )
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/{}/packages/.*/builds$", value
+                        .to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn package_name(self, value: &types::PackageName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/.*/packages/{}/builds$", value
+                        .to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+    }
+    pub struct GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetThen(
+        httpmock::Then,
+    );
+    impl GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::UserBuildList) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostWhen(
+        httpmock::When,
+    );
+    impl CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(
+                        regex::Regex::new(
+                                "^/api/v1/catalog/catalogs/[^/]*/packages/[^/]*/builds$",
+                            )
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/{}/packages/.*/builds$", value
+                        .to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn package_name(self, value: &types::PackageName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/.*/packages/{}/builds$", value
+                        .to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn body(self, value: &types::UserBuildPublish) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+    pub struct CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostThen(
+        httpmock::Then,
+    );
+    impl CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::UserBuildCreationResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn created(self, value: &types::UserBuildCreationResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(201u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn bad_request(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(400u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostWhen(
+        httpmock::When,
+    );
+    impl PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(
+                        regex::Regex::new(
+                                "^/api/v1/catalog/catalogs/[^/]*/packages/[^/]*/publish$",
+                            )
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/{}/packages/.*/publish$", value
+                        .to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn package_name(self, value: &types::PackageName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/.*/packages/{}/publish$", value
+                        .to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn body(self, value: &types::PublishRequest) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+    pub struct PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostThen(
+        httpmock::Then,
+    );
+    impl PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::PublishResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn bad_request(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(400u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetWhen(
+        httpmock::When,
+    );
+    impl GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/catalogs/[^/]*/sharing$")
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!("^/api/v1/catalog/catalogs/{}/sharing$", value.to_string()),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+    }
+    pub struct GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetThen(
+        httpmock::Then,
+    );
+    impl GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::CatalogShareInfo) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostWhen(
+        httpmock::When,
+    );
+    impl AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(
+                        regex::Regex::new(
+                                "^/api/v1/catalog/catalogs/[^/]*/sharing/add-read-users$",
+                            )
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/{}/sharing/add-read-users$", value
+                        .to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn body(self, value: &types::CatalogShareInfo) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+    pub struct AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostThen(
+        httpmock::Then,
+    );
+    impl AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::CatalogShareInfo) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostWhen(
+        httpmock::When,
+    );
+    impl RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(
+                        regex::Regex::new(
+                                "^/api/v1/catalog/catalogs/[^/]*/sharing/remove-read-users$",
+                            )
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/{}/sharing/remove-read-users$", value
+                        .to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn body(self, value: &types::CatalogShareInfo) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+    pub struct RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostThen(
+        httpmock::Then,
+    );
+    impl RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::CatalogShareInfo) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetWhen(
+        httpmock::When,
+    );
+    impl GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new(
+                                "^/api/v1/catalog/catalogs/[^/]*/store/config$",
+                            )
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/{}/store/config$", value.to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+    }
+    pub struct GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetThen(
+        httpmock::Then,
+    );
+    impl GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &crate::types::CatalogStoreConfig) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutWhen(
+        httpmock::When,
+    );
+    impl SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::PUT)
+                    .path_matches(
+                        regex::Regex::new(
+                                "^/api/v1/catalog/catalogs/[^/]*/store/config$",
+                            )
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalog_name(self, value: &types::CatalogName) -> Self {
+            let re = regex::Regex::new(
+                    &format!(
+                        "^/api/v1/catalog/catalogs/{}/store/config$", value.to_string()
+                    ),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn body(self, value: &crate::types::CatalogStoreConfig) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+    pub struct SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutThen(
+        httpmock::Then,
+    );
+    impl SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &crate::types::CatalogStoreConfig) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetPkgPathsApiV1CatalogInfoPkgPathsGetWhen(httpmock::When);
+    impl GetPkgPathsApiV1CatalogInfoPkgPathsGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/info/pkg-paths$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn page<T>(self, value: T) -> Self
+        where
+            T: Into<Option<i64>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("page", value.to_string()))
+            } else {
+                Self(
+                    self
+                        .0
+                        .matches(|req| {
+                            req.query_params
+                                .as_ref()
+                                .and_then(|qs| { qs.iter().find(|(key, _)| key == "page") })
+                                .is_none()
+                        }),
+                )
+            }
+        }
+        pub fn page_size<T>(self, value: T) -> Self
+        where
+            T: Into<Option<i64>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("page_size", value.to_string()))
+            } else {
+                Self(
+                    self
+                        .0
+                        .matches(|req| {
+                            req.query_params
+                                .as_ref()
+                                .and_then(|qs| {
+                                    qs.iter().find(|(key, _)| key == "page_size")
+                                })
+                                .is_none()
+                        }),
+                )
+            }
+        }
+    }
+    pub struct GetPkgPathsApiV1CatalogInfoPkgPathsGetThen(httpmock::Then);
+    impl GetPkgPathsApiV1CatalogInfoPkgPathsGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::PkgPathsResult) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct PackagesApiV1CatalogPackagesAttrPathGetWhen(httpmock::When);
+    impl PackagesApiV1CatalogPackagesAttrPathGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/packages/[^/]*$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn attr_path(self, value: &str) -> Self {
+            let re = regex::Regex::new(
+                    &format!("^/api/v1/catalog/packages/{}$", value.to_string()),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn page<T>(self, value: T) -> Self
+        where
+            T: Into<Option<i64>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("page", value.to_string()))
+            } else {
+                Self(
+                    self
+                        .0
+                        .matches(|req| {
+                            req.query_params
+                                .as_ref()
+                                .and_then(|qs| { qs.iter().find(|(key, _)| key == "page") })
+                                .is_none()
+                        }),
+                )
+            }
+        }
+        pub fn page_size<T>(self, value: T) -> Self
+        where
+            T: Into<Option<i64>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("page_size", value.to_string()))
+            } else {
+                Self(
+                    self
+                        .0
+                        .matches(|req| {
+                            req.query_params
+                                .as_ref()
+                                .and_then(|qs| {
+                                    qs.iter().find(|(key, _)| key == "page_size")
+                                })
+                                .is_none()
+                        }),
+                )
+            }
+        }
+    }
+    pub struct PackagesApiV1CatalogPackagesAttrPathGetThen(httpmock::Then);
+    impl PackagesApiV1CatalogPackagesAttrPathGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::PackagesResult) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn not_found(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(404u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct ResolveApiV1CatalogResolvePostWhen(httpmock::When);
+    impl ResolveApiV1CatalogResolvePostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/resolve$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn body(self, value: &types::PackageGroups) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+    pub struct ResolveApiV1CatalogResolvePostThen(httpmock::Then);
+    impl ResolveApiV1CatalogResolvePostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::ResolvedPackageGroups) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct SearchApiV1CatalogSearchGetWhen(httpmock::When);
+    impl SearchApiV1CatalogSearchGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(regex::Regex::new("^/api/v1/catalog/search$").unwrap()),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn catalogs<'a, T>(self, value: T) -> Self
+        where
+            T: Into<Option<&'a str>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("catalogs", value.to_string()))
+            } else {
+                Self(
+                    self
+                        .0
+                        .matches(|req| {
+                            req.query_params
+                                .as_ref()
+                                .and_then(|qs| {
+                                    qs.iter().find(|(key, _)| key == "catalogs")
+                                })
+                                .is_none()
+                        }),
+                )
+            }
+        }
+        pub fn page<T>(self, value: T) -> Self
+        where
+            T: Into<Option<i64>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("page", value.to_string()))
+            } else {
+                Self(
+                    self
+                        .0
+                        .matches(|req| {
+                            req.query_params
+                                .as_ref()
+                                .and_then(|qs| { qs.iter().find(|(key, _)| key == "page") })
+                                .is_none()
+                        }),
+                )
+            }
+        }
+        pub fn page_size<T>(self, value: T) -> Self
+        where
+            T: Into<Option<i64>>,
+        {
+            if let Some(value) = value.into() {
+                Self(self.0.query_param("page_size", value.to_string()))
+            } else {
+                Self(
+                    self
+                        .0
+                        .matches(|req| {
+                            req.query_params
+                                .as_ref()
+                                .and_then(|qs| {
+                                    qs.iter().find(|(key, _)| key == "page_size")
+                                })
+                                .is_none()
+                        }),
+                )
+            }
+        }
+        pub fn search_term(self, value: &types::SearchTerm) -> Self {
+            Self(self.0.query_param("search_term", value.to_string()))
+        }
+        pub fn system(self, value: types::SystemEnum) -> Self {
+            Self(self.0.query_param("system", value.to_string()))
+        }
+    }
+    pub struct SearchApiV1CatalogSearchGetThen(httpmock::Then);
+    impl SearchApiV1CatalogSearchGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::PackageSearchResult) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct SettingsApiV1CatalogSettingsKeyPostWhen(httpmock::When);
+    impl SettingsApiV1CatalogSettingsKeyPostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/settings/[^/]*$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn key(self, value: &str) -> Self {
+            let re = regex::Regex::new(
+                    &format!("^/api/v1/catalog/settings/{}$", value.to_string()),
+                )
+                .unwrap();
+            Self(self.0.path_matches(re))
+        }
+        pub fn value(self, value: &str) -> Self {
+            Self(self.0.query_param("value", value.to_string()))
+        }
+    }
+    pub struct SettingsApiV1CatalogSettingsKeyPostThen(httpmock::Then);
+    impl SettingsApiV1CatalogSettingsKeyPostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &serde_json::Value) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetCatalogStatusApiV1CatalogStatusCatalogGetWhen(httpmock::When);
+    impl GetCatalogStatusApiV1CatalogStatusCatalogGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/status/catalog$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+    }
+    pub struct GetCatalogStatusApiV1CatalogStatusCatalogGetThen(httpmock::Then);
+    impl GetCatalogStatusApiV1CatalogStatusCatalogGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::CatalogStatus) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn internal_server_error(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(500u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetWhen(httpmock::When);
+    impl GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/status/healthcheck$")
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+    }
+    pub struct GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetThen(httpmock::Then);
+    impl GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::HealthCheck) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn internal_server_error(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(500u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct TriggerErrorApiV1CatalogStatusSentryDebugGetWhen(httpmock::When);
+    impl TriggerErrorApiV1CatalogStatusSentryDebugGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/status/sentry-debug$")
+                            .unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+    }
+    pub struct TriggerErrorApiV1CatalogStatusSentryDebugGetThen(httpmock::Then);
+    impl TriggerErrorApiV1CatalogStatusSentryDebugGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &serde_json::Value) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetServiceStatusApiV1CatalogStatusServiceGetWhen(httpmock::When);
+    impl GetServiceStatusApiV1CatalogStatusServiceGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(
+                        regex::Regex::new("^/api/v1/catalog/status/service$").unwrap(),
+                    ),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+    }
+    pub struct GetServiceStatusApiV1CatalogStatusServiceGetThen(httpmock::Then);
+    impl GetServiceStatusApiV1CatalogStatusServiceGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::ServiceStatus) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn internal_server_error(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(500u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+    pub struct GetStoreInfoApiV1CatalogStorePostWhen(httpmock::When);
+    impl GetStoreInfoApiV1CatalogStorePostWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::POST)
+                    .path_matches(regex::Regex::new("^/api/v1/catalog/store$").unwrap()),
+            )
+        }
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+        pub fn body(self, value: &types::StoreInfoRequest) -> Self {
+            Self(self.0.json_body_obj(value))
+        }
+    }
+    pub struct GetStoreInfoApiV1CatalogStorePostThen(httpmock::Then);
+    impl GetStoreInfoApiV1CatalogStorePostThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+        pub fn ok(self, value: &types::StoreInfoResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(200u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+        pub fn unprocessable_entity(self, value: &types::ErrorResponse) -> Self {
+            Self(
+                self
+                    .0
+                    .status(422u16)
+                    .header("content-type", "application/json")
+                    .json_body_obj(value),
+            )
+        }
+    }
+}
+/// An extension trait for [`MockServer`](httpmock::MockServer) that
+/// adds a method for each operation. These are the equivalent of
+/// type-checked [`mock()`](httpmock::MockServer::mock) calls.
+pub trait MockServerExt {
+    fn create_catalog_api_v1_catalog_catalogs_post<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::CreateCatalogApiV1CatalogCatalogsPostWhen,
+            operations::CreateCatalogApiV1CatalogCatalogsPostThen,
+        );
+    fn get_catalog_api_v1_catalog_catalogs_catalog_name_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogApiV1CatalogCatalogsCatalogNameGetWhen,
+            operations::GetCatalogApiV1CatalogCatalogsCatalogNameGetThen,
+        );
+    fn delete_catalog_api_v1_catalog_catalogs_catalog_name_delete<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteWhen,
+            operations::DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteThen,
+        );
+    fn get_catalog_packages_api_v1_catalog_catalogs_catalog_name_packages_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetWhen,
+            operations::GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetThen,
+        );
+    fn create_catalog_package_api_v1_catalog_catalogs_catalog_name_packages_post<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostWhen,
+            operations::CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostThen,
+        );
+    fn get_catalog_package_api_v1_catalog_catalogs_catalog_name_packages_package_name_get<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetWhen,
+            operations::GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetThen,
+        );
+    fn get_package_builds_api_v1_catalog_catalogs_catalog_name_packages_package_name_builds_get<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetWhen,
+            operations::GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetThen,
+        );
+    fn create_package_build_api_v1_catalog_catalogs_catalog_name_packages_package_name_builds_post<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostWhen,
+            operations::CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostThen,
+        );
+    fn publish_request_api_v1_catalog_catalogs_catalog_name_packages_package_name_publish_post<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostWhen,
+            operations::PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostThen,
+        );
+    fn get_catalog_sharing_api_v1_catalog_catalogs_catalog_name_sharing_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetWhen,
+            operations::GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetThen,
+        );
+    fn add_catalog_sharing_api_v1_catalog_catalogs_catalog_name_sharing_add_read_users_post<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostWhen,
+            operations::AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostThen,
+        );
+    fn remove_catalog_sharing_api_v1_catalog_catalogs_catalog_name_sharing_remove_read_users_post<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostWhen,
+            operations::RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostThen,
+        );
+    fn get_catalog_store_config_api_v1_catalog_catalogs_catalog_name_store_config_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetWhen,
+            operations::GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetThen,
+        );
+    fn set_catalog_store_config_api_v1_catalog_catalogs_catalog_name_store_config_put<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutWhen,
+            operations::SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutThen,
+        );
+    fn get_pkg_paths_api_v1_catalog_info_pkg_paths_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetPkgPathsApiV1CatalogInfoPkgPathsGetWhen,
+            operations::GetPkgPathsApiV1CatalogInfoPkgPathsGetThen,
+        );
+    fn packages_api_v1_catalog_packages_attr_path_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::PackagesApiV1CatalogPackagesAttrPathGetWhen,
+            operations::PackagesApiV1CatalogPackagesAttrPathGetThen,
+        );
+    fn resolve_api_v1_catalog_resolve_post<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::ResolveApiV1CatalogResolvePostWhen,
+            operations::ResolveApiV1CatalogResolvePostThen,
+        );
+    fn search_api_v1_catalog_search_get<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::SearchApiV1CatalogSearchGetWhen,
+            operations::SearchApiV1CatalogSearchGetThen,
+        );
+    fn settings_api_v1_catalog_settings_key_post<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::SettingsApiV1CatalogSettingsKeyPostWhen,
+            operations::SettingsApiV1CatalogSettingsKeyPostThen,
+        );
+    fn get_catalog_status_api_v1_catalog_status_catalog_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogStatusApiV1CatalogStatusCatalogGetWhen,
+            operations::GetCatalogStatusApiV1CatalogStatusCatalogGetThen,
+        );
+    fn get_catalog_health_check_api_v1_catalog_status_healthcheck_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetWhen,
+            operations::GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetThen,
+        );
+    fn trigger_error_api_v1_catalog_status_sentry_debug_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::TriggerErrorApiV1CatalogStatusSentryDebugGetWhen,
+            operations::TriggerErrorApiV1CatalogStatusSentryDebugGetThen,
+        );
+    fn get_service_status_api_v1_catalog_status_service_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetServiceStatusApiV1CatalogStatusServiceGetWhen,
+            operations::GetServiceStatusApiV1CatalogStatusServiceGetThen,
+        );
+    fn get_store_info_api_v1_catalog_store_post<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetStoreInfoApiV1CatalogStorePostWhen,
+            operations::GetStoreInfoApiV1CatalogStorePostThen,
+        );
+}
+impl MockServerExt for httpmock::MockServer {
+    fn create_catalog_api_v1_catalog_catalogs_post<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::CreateCatalogApiV1CatalogCatalogsPostWhen,
+            operations::CreateCatalogApiV1CatalogCatalogsPostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::CreateCatalogApiV1CatalogCatalogsPostWhen::new(when),
+                operations::CreateCatalogApiV1CatalogCatalogsPostThen::new(then),
+            )
+        })
+    }
+    fn get_catalog_api_v1_catalog_catalogs_catalog_name_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogApiV1CatalogCatalogsCatalogNameGetWhen,
+            operations::GetCatalogApiV1CatalogCatalogsCatalogNameGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetCatalogApiV1CatalogCatalogsCatalogNameGetWhen::new(when),
+                operations::GetCatalogApiV1CatalogCatalogsCatalogNameGetThen::new(then),
+            )
+        })
+    }
+    fn delete_catalog_api_v1_catalog_catalogs_catalog_name_delete<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteWhen,
+            operations::DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteWhen::new(
+                    when,
+                ),
+                operations::DeleteCatalogApiV1CatalogCatalogsCatalogNameDeleteThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn get_catalog_packages_api_v1_catalog_catalogs_catalog_name_packages_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetWhen,
+            operations::GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetWhen::new(
+                    when,
+                ),
+                operations::GetCatalogPackagesApiV1CatalogCatalogsCatalogNamePackagesGetThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn create_catalog_package_api_v1_catalog_catalogs_catalog_name_packages_post<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostWhen,
+            operations::CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostWhen::new(
+                    when,
+                ),
+                operations::CreateCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPostThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn get_catalog_package_api_v1_catalog_catalogs_catalog_name_packages_package_name_get<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetWhen,
+            operations::GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetWhen::new(
+                    when,
+                ),
+                operations::GetCatalogPackageApiV1CatalogCatalogsCatalogNamePackagesPackageNameGetThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn get_package_builds_api_v1_catalog_catalogs_catalog_name_packages_package_name_builds_get<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetWhen,
+            operations::GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetWhen::new(
+                    when,
+                ),
+                operations::GetPackageBuildsApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsGetThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn create_package_build_api_v1_catalog_catalogs_catalog_name_packages_package_name_builds_post<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostWhen,
+            operations::CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostWhen::new(
+                    when,
+                ),
+                operations::CreatePackageBuildApiV1CatalogCatalogsCatalogNamePackagesPackageNameBuildsPostThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn publish_request_api_v1_catalog_catalogs_catalog_name_packages_package_name_publish_post<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostWhen,
+            operations::PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostWhen::new(
+                    when,
+                ),
+                operations::PublishRequestApiV1CatalogCatalogsCatalogNamePackagesPackageNamePublishPostThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn get_catalog_sharing_api_v1_catalog_catalogs_catalog_name_sharing_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetWhen,
+            operations::GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetWhen::new(
+                    when,
+                ),
+                operations::GetCatalogSharingApiV1CatalogCatalogsCatalogNameSharingGetThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn add_catalog_sharing_api_v1_catalog_catalogs_catalog_name_sharing_add_read_users_post<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostWhen,
+            operations::AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostWhen::new(
+                    when,
+                ),
+                operations::AddCatalogSharingApiV1CatalogCatalogsCatalogNameSharingAddReadUsersPostThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn remove_catalog_sharing_api_v1_catalog_catalogs_catalog_name_sharing_remove_read_users_post<
+        F,
+    >(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostWhen,
+            operations::RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostWhen::new(
+                    when,
+                ),
+                operations::RemoveCatalogSharingApiV1CatalogCatalogsCatalogNameSharingRemoveReadUsersPostThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn get_catalog_store_config_api_v1_catalog_catalogs_catalog_name_store_config_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetWhen,
+            operations::GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetWhen::new(
+                    when,
+                ),
+                operations::GetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigGetThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn set_catalog_store_config_api_v1_catalog_catalogs_catalog_name_store_config_put<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutWhen,
+            operations::SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutWhen::new(
+                    when,
+                ),
+                operations::SetCatalogStoreConfigApiV1CatalogCatalogsCatalogNameStoreConfigPutThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn get_pkg_paths_api_v1_catalog_info_pkg_paths_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetPkgPathsApiV1CatalogInfoPkgPathsGetWhen,
+            operations::GetPkgPathsApiV1CatalogInfoPkgPathsGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetPkgPathsApiV1CatalogInfoPkgPathsGetWhen::new(when),
+                operations::GetPkgPathsApiV1CatalogInfoPkgPathsGetThen::new(then),
+            )
+        })
+    }
+    fn packages_api_v1_catalog_packages_attr_path_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::PackagesApiV1CatalogPackagesAttrPathGetWhen,
+            operations::PackagesApiV1CatalogPackagesAttrPathGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::PackagesApiV1CatalogPackagesAttrPathGetWhen::new(when),
+                operations::PackagesApiV1CatalogPackagesAttrPathGetThen::new(then),
+            )
+        })
+    }
+    fn resolve_api_v1_catalog_resolve_post<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::ResolveApiV1CatalogResolvePostWhen,
+            operations::ResolveApiV1CatalogResolvePostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::ResolveApiV1CatalogResolvePostWhen::new(when),
+                operations::ResolveApiV1CatalogResolvePostThen::new(then),
+            )
+        })
+    }
+    fn search_api_v1_catalog_search_get<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::SearchApiV1CatalogSearchGetWhen,
+            operations::SearchApiV1CatalogSearchGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::SearchApiV1CatalogSearchGetWhen::new(when),
+                operations::SearchApiV1CatalogSearchGetThen::new(then),
+            )
+        })
+    }
+    fn settings_api_v1_catalog_settings_key_post<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::SettingsApiV1CatalogSettingsKeyPostWhen,
+            operations::SettingsApiV1CatalogSettingsKeyPostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::SettingsApiV1CatalogSettingsKeyPostWhen::new(when),
+                operations::SettingsApiV1CatalogSettingsKeyPostThen::new(then),
+            )
+        })
+    }
+    fn get_catalog_status_api_v1_catalog_status_catalog_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogStatusApiV1CatalogStatusCatalogGetWhen,
+            operations::GetCatalogStatusApiV1CatalogStatusCatalogGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetCatalogStatusApiV1CatalogStatusCatalogGetWhen::new(when),
+                operations::GetCatalogStatusApiV1CatalogStatusCatalogGetThen::new(then),
+            )
+        })
+    }
+    fn get_catalog_health_check_api_v1_catalog_status_healthcheck_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetWhen,
+            operations::GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetWhen::new(
+                    when,
+                ),
+                operations::GetCatalogHealthCheckApiV1CatalogStatusHealthcheckGetThen::new(
+                    then,
+                ),
+            )
+        })
+    }
+    fn trigger_error_api_v1_catalog_status_sentry_debug_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::TriggerErrorApiV1CatalogStatusSentryDebugGetWhen,
+            operations::TriggerErrorApiV1CatalogStatusSentryDebugGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::TriggerErrorApiV1CatalogStatusSentryDebugGetWhen::new(when),
+                operations::TriggerErrorApiV1CatalogStatusSentryDebugGetThen::new(then),
+            )
+        })
+    }
+    fn get_service_status_api_v1_catalog_status_service_get<F>(
+        &self,
+        config_fn: F,
+    ) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetServiceStatusApiV1CatalogStatusServiceGetWhen,
+            operations::GetServiceStatusApiV1CatalogStatusServiceGetThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetServiceStatusApiV1CatalogStatusServiceGetWhen::new(when),
+                operations::GetServiceStatusApiV1CatalogStatusServiceGetThen::new(then),
+            )
+        })
+    }
+    fn get_store_info_api_v1_catalog_store_post<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(
+            operations::GetStoreInfoApiV1CatalogStorePostWhen,
+            operations::GetStoreInfoApiV1CatalogStorePostThen,
+        ),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::GetStoreInfoApiV1CatalogStorePostWhen::new(when),
+                operations::GetStoreInfoApiV1CatalogStorePostThen::new(then),
+            )
+        })
+    }
+}

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -55,6 +55,7 @@ proptest-derive.workspace = true
 serial_test.workspace = true
 tracing-subscriber.workspace = true
 flox-test-utils.workspace = true
+catalog-api-v1 = { workspace = true, features = ["tests"] }
 
 [features]
 # allow exporting test helpers in dev mode only

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1925,7 +1925,7 @@ pub(crate) mod tests {
     use crate::models::manifest::raw::RawManifest;
     use crate::models::manifest::typed::{Include, Manifest, Vars};
     use crate::models::search::{PackageDetails, SearchLimit, SearchResults};
-    use crate::providers::catalog::{Client, PublishError};
+    use crate::providers::catalog::Client;
     use crate::providers::flake_installable_locker::{
         FlakeInstallableError,
         InstallableLockerMock,
@@ -1970,7 +1970,7 @@ pub(crate) mod tests {
             &self,
             _catalog_name: impl AsRef<str> + Send + Sync,
             _package_name: impl AsRef<str> + Send + Sync,
-        ) -> Result<PublishResponse, PublishError> {
+        ) -> Result<PublishResponse, CatalogClientError> {
             unreachable!("publish should not be called");
         }
 

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1908,7 +1908,6 @@ pub(crate) mod tests {
         fake_flake_installable_lock,
         fake_store_path_lock,
     };
-    use url::Url;
 
     use self::catalog::PackageResolutionInfo;
     use super::*;
@@ -1926,7 +1925,7 @@ pub(crate) mod tests {
     use crate::models::manifest::raw::RawManifest;
     use crate::models::manifest::typed::{Include, Manifest, Vars};
     use crate::models::search::{PackageDetails, SearchLimit, SearchResults};
-    use crate::providers::catalog::Client;
+    use crate::providers::catalog::{Client, PublishError};
     use crate::providers::flake_installable_locker::{
         FlakeInstallableError,
         InstallableLockerMock,
@@ -1967,18 +1966,12 @@ pub(crate) mod tests {
             unreachable!("package_versions should not be called");
         }
 
-        async fn create_catalog(
+        async fn publish(
             &self,
             _catalog_name: impl AsRef<str> + Send + Sync,
-        ) -> Result<PublishResponse, CatalogClientError> {
-            unreachable!("create_catalog should not be called");
-        }
-
-        async fn get_ingress_uri(
-            &self,
-            _catalog_name: impl AsRef<str> + Send + Sync,
-        ) -> Result<Option<Url>, CatalogClientError> {
-            unreachable!("create_catalog should not be called");
+            _package_name: impl AsRef<str> + Send + Sync,
+        ) -> Result<PublishResponse, PublishError> {
+            unreachable!("publish should not be called");
         }
 
         async fn create_package(

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -729,7 +729,7 @@ impl ClientTrait for CatalogClient {
 
 /// Converts a catalog name to a semantic type and performs validation that it
 /// meets the expected format.
-fn str_to_catalog_name(
+pub fn str_to_catalog_name(
     name: impl AsRef<str>,
 ) -> Result<api_types::CatalogName, CatalogClientError> {
     api_types::CatalogName::from_str(name.as_ref()).map_err(|_e| {
@@ -745,7 +745,7 @@ fn str_to_catalog_name(
 
 /// Converts a package name to a semantic type and performs validation that it
 /// meets the expected format.
-fn str_to_package_name(
+pub fn str_to_package_name(
     name: impl AsRef<str>,
 ) -> Result<api_types::PackageName, CatalogClientError> {
     api_types::PackageName::from_str(name.as_ref()).map_err(|_e| {

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -995,9 +995,9 @@ pub mod tests {
         );
     }
 
-    /// publish() errors for an unconfigured catalog
+    /// publish() passes the error details from the server through
     #[tokio::test]
-    async fn publish_errors_for_unconfigured_catalog() {
+    async fn publish_passes_error_details_through() {
         let server = MockServer::start();
 
         let token = create_test_token("test");
@@ -1024,7 +1024,7 @@ pub mod tests {
         let publish_mock = server.publish_request_api_v1_catalog_catalogs_catalog_name_packages_package_name_publish_post(|when, then| {
             when.catalog_name(&str_to_catalog_name(&catalog_name).unwrap())
                 .package_name(&str_to_package_name(package_name).unwrap());
-            then.bad_request(&ErrorResponse { detail: "unconfigured store".to_string() });
+            then.unprocessable_entity(&ErrorResponse { detail: "Some\nlong\nresponse\nfrom\nthe\nserver".to_string() });
         });
 
         let client = Client::Catalog(CatalogClient::new(CatalogClientConfig {
@@ -1055,17 +1055,14 @@ pub mod tests {
         let err = result.unwrap_err();
         assert_eq!(
             err.to_string(),
-            formatdoc! {"
-                Catalog '{0}' must be configured for whether to upload build artifacts.
-
-                To configure the catalog to skip uploading artifacts, run:
-                  $ catalog-util store --catalog {0} set meta-only
-
-                To configure the catalog to upload artifacts, run:
-                  $ catalog-util store --catalog {0} set nixcopy --ingress-uri <uri> --egress-uri <uri>
-            ", &catalog_name }
+            indoc! {"
+                422 Unprocessable Entity: Some
+                long
+                response
+                from
+                the
+                server"}
             .to_string()
-
         );
     }
 

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -22,6 +22,7 @@ use super::{EnvironmentSelect, environment_select};
 use crate::commands::ensure_floxhub_token;
 use crate::config::Config;
 use crate::environment_subcommand_metric;
+use crate::utils::errors::display_chain;
 use crate::utils::message;
 
 #[derive(Bpaf, Clone)]
@@ -181,7 +182,7 @@ impl Publish {
 
                 Use 'flox install {catalog_name}/{package}' to install it.
                 "}),
-            Err(e) => bail!("Failed to publish package: {}", e.to_string()),
+            Err(e) => bail!("Failed to publish package: {}", display_chain(&e)),
         }
 
         Ok(())

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -36,7 +36,7 @@ pub struct Publish {
     /// itself.
     ///
     /// With this option present, a signing key is not required.
-    #[bpaf(long)]
+    #[bpaf(long, hide)]
     metadata_only: bool,
 
     #[bpaf(external(publish_target), optional)]


### PR DESCRIPTION
This is blocked on serverside changes

See this thread and linked notes for context on this change: https://flox-dev.slack.com/archives/C07GRNPFNJE/p1743702577025429?thread_ts=1743439226.018539&cid=C07GRNPFNJE

See commits for more detail. Most significant change:

We've decided that the `/publish` endpoint should be used as a required
step in the publish process. We want to error if a catalog has an
unconfigured store, and we want to use the `/publish` endpoint to get
info required to carry out the publish. For now we need `ingress_uri`,
but we'll likely need `egress_uri` soon as well.

Catalogs are created implicitly server sided when they're needed, so we
can drop `create_catalog` in our client. And we can drop
`get_ingress_uri` in our client in favor of a method named `publish`
since that more clearly represents the underlying endpoint and how we
intend to use it in the future.

We're deliberately changing behavior such that even if `--metadata-only`
is passed, we error for an unconfigured store. We expect users to
configure their catalog for meta-only publishes rather than using
`--metadata-only`, so that option is hidden for now. Since we don't
currently support building from source, if a catalog is configured for
NixCopy but someone publishes with `--metadata-only`, there won't be any
way to build the required store paths.

## Release Notes

NA