### PR TITLE
fix(ci): Remove control characters from XML test report before uploading

### DIFF
--- a/.github/scripts/remote-execute-integration-tests.sh
+++ b/.github/scripts/remote-execute-integration-tests.sh
@@ -28,7 +28,12 @@ function upload_report_to_buildkite() {
     "github@[$REMOTE_SERVER_ADDRESS]:$report_path_on_remote" \
     ./report.xml
 
-  local -r report_path="$PWD/report.xml"
+  # Strip control characters from report to make sure it's a valid XML file.
+  # Stolen from here:
+  # https://github.com/bats-core/bats-core/issues/311#issuecomment-627807346
+  sed "s,\x1B\[[0-9;]*[a-zA-Z],,g" ./report.xml > report-stripped.xml
+
+  local -r report_path="$PWD/report-stripped.xml"
 
   curl \
     -X POST \


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Apparently, XML files can only contain a certain set of characters, of which some control characters are not included. We appear to have one (or multiple, I honestly don't know) of these control characters in the output of our CLI and bats test suite. Bats doesn't seem to clear out these characters, so we'll just do it in an extra step.

Ref: https://www.w3.org/TR/REC-xml/#charsets

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
