### PR TITLE
fix: in-place activation for Bash 3

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/generate-bash-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-bash-startup-commands.bash
@@ -74,8 +74,8 @@ generate_bash_startup_commands() {
   # We already customized the PATH and MANPATH, but the user and system
   # dotfiles may have changed them, so finish by doing this again.
   # shellcheck disable=SC1090
-  echo "source <('$_flox_activations' set-env-dirs --shell bash --flox-env '$_FLOX_ENV' --env-dirs '${FLOX_ENV_DIRS:-}');"
-  echo "source <('$_flox_activations' fix-paths --shell bash --env-dirs '$FLOX_ENV_DIRS' --path '$PATH' --manpath '${MANPATH:-}');"
+  echo "eval \"\$('$_flox_activations' set-env-dirs --shell bash --flox-env '$_FLOX_ENV' --env-dirs '${FLOX_ENV_DIRS:-}')\";"
+  echo "eval \"\$('$_flox_activations' fix-paths --shell bash --env-dirs '$FLOX_ENV_DIRS' --path '$PATH' --manpath '${MANPATH:-}')\";"
 
   # Iterate over $FLOX_ENV_DIRS in reverse order and
   # source user-specified profile scripts if they exist.


### PR DESCRIPTION
In-place activation with Bash 3 currently errors with:
```
Error: Broken pipe (os error 32)
```

This is caused by using `source <(...)`, because Bash 3 does not support process substitution with source. See:
https://lists.gnu.org/archive/html/bug-bash/2006-01/msg00018.html

Fix this by using `eval` instead of `source`

## Release Notes

Fixed the error `Error: Broken pipe (os error 32)` for `eval "$(flox activate)"` when using Bash 3, which ships with macOS