### PR TITLE
test: avoid upgrade check race condition in bats tests 

### DIFF
--- a/cli/flox/src/commands/check_for_upgrades.rs
+++ b/cli/flox/src/commands/check_for_upgrades.rs
@@ -159,6 +159,15 @@ pub fn spawn_detached_check_for_upgrades_process(
     log_dir: &Path,
     check_timeout: Option<u64>,
 ) -> Result<()> {
+    // Avoid race copnditions in integration tests
+    if let Ok(true) = std::env::var("_FLOX_TESTING_DISABLE_BG_SIDE_EFFECTS")
+        .unwrap_or_default()
+        .parse()
+    {
+        debug!("Skipping background job for tests");
+        return Ok(());
+    }
+
     // Get the path to the current executable
     let self_executable = match self_executable {
         Some(path) => path,

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4768,3 +4768,18 @@ Setting PATH from .bashrc"
   assert_equal "$stderr" "Sourcing .bashrc
 Setting PATH from .bashrc"
 }
+
+# bats test_tags=activate:upgrade-checks
+@test "runs upgrade checks in the background on activate" {
+    project_setup_common
+    unset _FLOX_TESTING_DISABLE_BG_SIDE_EFFECTS # allow background checks for this test
+    "$FLOX_BIN" init
+    _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/old_hello.json" "$FLOX_BIN" install hello
+    _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.json" "$FLOX_BIN" activate -- true
+
+    timeout 5s bash -c "while [ ! -f .flox/cache/upgrade-checks.json ]; do sleep 0.1; done"
+
+    run jq '.result.new_lockfile == .result.old_lockfile'  .flox/cache/upgrade-checks.json
+    assert_success
+    assert_output false # lockfile content should differ due to upgrade
+}

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -184,6 +184,7 @@ misc_vars_setup() {
 flox_cli_vars_setup() {
   unset FLOX_PROMPT_ENVIRONMENTS _FLOX_ACTIVE_ENVIRONMENTS
   export FLOX_DISABLE_METRICS='true'
+  export _FLOX_TESTING_DISABLE_BG_SIDE_EFFECTS='true'
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

* Allow skipping upgrade checks in tests to avoid some of the race conditions mentioned in #2903

* Add a specific test for upgrade checks on activation

## Release Notes

(testing infrastructure)