### PR TITLE
fix(ci): strip control characters, again

### DIFF
--- a/.github/scripts/remote-execute-integration-tests.sh
+++ b/.github/scripts/remote-execute-integration-tests.sh
@@ -28,10 +28,9 @@ function upload_report_to_buildkite() {
     "github@[$REMOTE_SERVER_ADDRESS]:$report_path_on_remote" \
     ./report.xml
 
-  # Strip control characters from report to make sure it's a valid XML file.
-  # Stolen from here:
-  # https://github.com/bats-core/bats-core/issues/311#issuecomment-627807346
-  sed "s,\x1B\[[0-9;]*[a-zA-Z],,g" ./report.xml > report-stripped.xml
+  # Remove all non-valid XML characters. We set -CSDA to make Perl use UTF8 for
+  # its I/O and -p to make it loop over the whole file.
+  perl -CSDA -pe 's/[^\P{C}\t\n\r]//g' ./report.xml > ./report-stripped.xml
 
   local -r report_path="$PWD/report-stripped.xml"
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

The solution in flox/flox@cc0b421 apparently wasn't aggresive enough, so I'm brining out the big guns for this one. Running xmllint on the XML output of the failed job reveals the following.

    $ xmllint report.xml 2>&1
    report.xml:222: parser error : PCDATA invalid Char value 27
    %
     ^
    report.xml:222: parser error : PCDATA invalid Char value 27
    %
        ^
    report.xml:222: parser error : PCDATA invalid Char value 27
    flox [project-177] myprompt&gt; 2004h</failure>
    ^
    report.xml:222: parser error : PCDATA invalid Char value 27
    flox [project-177] myprompt&gt; 2004h</failure>
       ^
    report.xml:222: parser error : PCDATA invalid Char value 27
    flox [project-177] myprompt&gt; 2004h</failure>
          ^
    report.xml:222: parser error : PCDATA invalid Char value 27
    flox [project-177] myprompt&gt; 2004h</failure>
             ^
    report.xml:222: parser error : PCDATA invalid Char value 27
    flox [project-177] myprompt&gt; 2004h</failure>
                                                ^
    report.xml:222: parser error : PCDATA invalid Char value 27
    flox [project-177] myprompt&gt; 2004h</failure>
                                                   ^

Running that document through the perl command from this commit makes it a valid XML document.

    $ perl -CSDA -pe 's/[^\P{C}\t\n\r]//g' report.xml > cleaned.xml
    $ xmllint --noout cleaned.xml

Ref: https://github.com/flox/flox/actions/runs/14381165149/job/40325259387#step:5:686
Ref: https://buildkite.com/organizations/flox/analytics/suites/bats-integration-tests/uploads/01961fd8-4188-767a-bfe5-95ce86506916

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
