### PR TITLE
chore(ci): upload test results to buildkite when on main

### DIFF
--- a/.github/scripts/remote-execute-integration-tests.sh
+++ b/.github/scripts/remote-execute-integration-tests.sh
@@ -15,8 +15,8 @@ function render_remote_cmd() {
 export -f render_remote_cmd
 
 function upload_report_to_buildkite() {
-  # Don't do anything if we're not in the merge queue
-  [[ 'merge_group' != "$GITHUB_EVENT_NAME" ]] && return 0
+  # Don't do anything if we're not in the merge queue or on main
+  ! [[ 'merge_group' == "$GITHUB_EVENT_NAME" || 'main' == "$GITHUB_REF_NAME" ]] && return 0
 
   local -r git_commit_message="$(git log -1 --pretty=format:"%s")"
   local -r report_path_on_remote="$(awk '{ if ($1 == "TESTS_DIR:") { print $2 } }' output.txt)/report.xml"


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

I've seen a few tests fail on main right after they come out of the merge queue succesfully. So, I think it's a good idea to also upload the results for the tests that are run on the main branch.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
