### PR TITLE
feat(compose): Support includes of remote envs

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/fetcher.rs
+++ b/cli/flox-rust-sdk/src/models/environment/fetcher.rs
@@ -22,12 +22,6 @@ impl IncludeFetcher {
         flox: &Flox,
         include_environment: &IncludeDescriptor,
     ) -> Result<LockedInclude, EnvironmentError> {
-        if self.base_directory.is_none() {
-            return Err(EnvironmentError::Recoverable(
-                RecoverableMergeError::CannotIncludeInRemote,
-            ));
-        };
-
         let (manifest, name) = match include_environment {
             IncludeDescriptor::Local { dir, name } => self.fetch_local(flox, dir, name),
             IncludeDescriptor::Remote { remote, name } => self.fetch_remote(flox, remote, name),
@@ -47,6 +41,12 @@ impl IncludeFetcher {
         dir: impl AsRef<Path>,
         name: &Option<String>,
     ) -> Result<(Manifest, String), EnvironmentError> {
+        if self.base_directory.is_none() {
+            return Err(EnvironmentError::Recoverable(
+                RecoverableMergeError::RemoteCannotIncludeLocal,
+            ));
+        };
+
         let path = self
             .expand_include_dir(dir)
             .map_err(EnvironmentError::Recoverable)?;
@@ -120,7 +120,7 @@ impl IncludeFetcher {
         dir: impl AsRef<Path>,
     ) -> Result<PathBuf, RecoverableMergeError> {
         let Some(base_directory) = &self.base_directory else {
-            return Err(RecoverableMergeError::CannotIncludeInRemote);
+            return Err(RecoverableMergeError::RemoteCannotIncludeLocal);
         };
 
         let dir = dir.as_ref();

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -411,23 +411,14 @@ impl Environment for RemoteEnvironment {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::os::unix::fs::symlink;
-
-    use indoc::indoc;
+#[cfg(any(test, feature = "tests"))]
+pub mod test_helpers {
     use tempfile::tempdir_in;
 
     use super::*;
-    use crate::flox::test_helpers::flox_instance_with_optional_floxhub;
-    use crate::models::environment::managed_environment::test_helpers::{
-        mock_managed_environment_from_env_files,
-        mock_managed_environment_in,
-    };
-    use crate::models::lockfile::RecoverableMergeError;
-    use crate::providers::catalog::GENERATED_DATA;
+    use crate::models::environment::managed_environment::test_helpers::mock_managed_environment_in;
 
-    fn mock_remote_environment(
+    pub fn mock_remote_environment(
         flox: &Flox,
         contents: &str,
         owner: EnvironmentOwner,
@@ -447,6 +438,20 @@ mod tests {
         )
         .unwrap()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::symlink;
+
+    use indoc::indoc;
+
+    use super::test_helpers::mock_remote_environment;
+    use super::*;
+    use crate::flox::test_helpers::flox_instance_with_optional_floxhub;
+    use crate::models::environment::managed_environment::test_helpers::mock_managed_environment_from_env_files;
+    use crate::models::lockfile::RecoverableMergeError;
+    use crate::providers::catalog::GENERATED_DATA;
 
     #[test]
     fn migrate_remote_gcroot_link_to_dir() {

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -520,7 +520,7 @@ mod tests {
         let EnvironmentError::Recoverable(RecoverableMergeError::Fetch { err, .. }) = err else {
             panic!("expected Fetch error, got: {err:?}");
         };
-        let EnvironmentError::Recoverable(RecoverableMergeError::CannotIncludeInRemote) = *err
+        let EnvironmentError::Recoverable(RecoverableMergeError::RemoteCannotIncludeLocal) = *err
         else {
             panic!("expected CannotIncludeInRemote error, got: {err:?}");
         };

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -1709,8 +1709,8 @@ pub enum RecoverableMergeError {
     #[error("{0}")]
     Catchall(String),
 
-    #[error("cannot include environments in remote environments")]
-    CannotIncludeInRemote,
+    #[error("remote environments cannot include local environments")]
+    RemoteCannotIncludeLocal,
 }
 
 pub mod test_helpers {

--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -445,8 +445,14 @@ pub struct LockedInclude {
     #[cfg_attr(test, proptest(strategy = "alphanum_string(5)"))]
     pub name: String,
     pub descriptor: IncludeDescriptor,
-    // TODO: once we consider remote environments, add this field
-    // pub remote: Option<RemoteSource>
+    // TODO: Record generation if/when:
+    // 1. We have a need for it in presentation, e.g.
+    //   - https://github.com/flox/flox/issues/2948
+    // 2. Generations work has settled:
+    //   - https://github.com/flox/product/pull/881
+    //   - https://github.com/flox/product/pull/891
+    // 3. We've exposed it from `RemoteEnvironment`/`ManagedEnvironment`
+    // pub remote: Option<Generation>,
 }
 
 /// All the resolution failures for a single resolution request

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -490,17 +490,28 @@ of tables in the `include.environments` array. The schema for these "include
 descriptors" is shown below:
 
 ```
-IncludeDescriptor ::= {
+IncludeDescriptor ::= LocalIncludeDescriptor | RemoteIncludeDescriptor
+
+LocalIncludeDescriptor :: = {
   dir  = STRING
 , name = null | STRING
 }
+
+RemoteIncludeDescriptor :: = {
+  remote = STRING
+, name   = null | STRING
+}
 ```
 
-The fields in the include descriptor are as follows:
+The fields in these include descriptors are as follows:
 
 `dir`
-: The path to the environment to include. This has the same semantics as the
-  `--dir` flag passed to many Flox commands.
+: The local path to the environment to include. This has the same semantics as
+  the `--dir` flag passed to many Flox commands.
+
+`remote`
+: The remote name of an environment to include. This has the same semantics as
+  the `--remote` flag passed to many Flox commands.
 
 `name`
 : An optional override to the name of the included environment. This is useful
@@ -510,8 +521,6 @@ The fields in the include descriptor are as follows:
 Changes to the included environments aren't automatically reflected in the
 composing environment. You control when updates are pulled in by using
 [`flox include upgrade`](./flox-include-upgrade.md).
-
-Remote environments are not currently supported as includes.
 
 ### Merge semantics
 


### PR DESCRIPTION
## Proposed Changes

Tests are relatively light because most of the supporting work for this
was already done, so I've focused on the fetcher and the happy path for
`flox include upgrade`.

Similarly not much of the documentation needed updating because the
behaviour as described is the same for remote environments. I haven't
duplicated the `manifest.toml` descriptor docs because `name` is in both
and is the most wordy.

Follow-ups that don't need to be in-scope for initial release:

- https://github.com/flox/flox/issues/2948
- https://github.com/flox/flox/issues/2949

I considered using `env.lockfile().manifest` instead of `env.manifest()`
in the new `fetch_remote()` and existing `fetch_local()` but it doesn't
seem right that these could possibly lock if there's a race condition
between checking the lockfile is up-to-date and getting the lockfile.

Incidentally I'm growing less sure that 6828a50 was a good idea.

## Release Notes

Include of remote environments (if this doesn't make it to next week's release).