### PR TITLE
Composition messaging tweaks

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -992,7 +992,7 @@ impl SkipSerializing for Include {
 #[serde(deny_unknown_fields)]
 #[serde(
     untagged,
-    expecting = "Expected either a local or remote include descriptor."
+    expecting = "Must specify included environment as { dir = <dir>, [name = <name>] }"
 )]
 pub enum IncludeDescriptor {
     Local {

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -974,6 +974,7 @@ pub enum ManifestError {
 /// The section where users can declare dependencies on other environments.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+#[serde(deny_unknown_fields)]
 pub struct Include {
     #[serde(default)]
     pub environments: Vec<IncludeDescriptor>,
@@ -988,6 +989,7 @@ impl SkipSerializing for Include {
 /// The structure for how a user is able to declare a dependency on an environment.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+#[serde(deny_unknown_fields)]
 #[serde(
     untagged,
     expecting = "Expected either a local or remote include descriptor."

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -686,11 +686,11 @@ fn notify_upgrade_if_available(flox: &Flox, environment: &mut ConcreteEnvironmen
 
     // Update this message in flox-config.md if you change it here
     let message = formatdoc! {"
-        ℹ️  Upgrades are available for packages in {description}.
+        Upgrades are available for packages in {description}.
         Use 'flox upgrade --dry-run' for details.
     "};
 
-    message::plain(message);
+    message::info(message);
 
     Ok(())
 }

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -860,7 +860,7 @@ mod tests {
 
         assert_eq!(writer.to_string(), indoc! {"
             ✅ Environment successfully updated.
-            ℹ️ Run 'flox list -c' to see merged manifest.
+            ℹ️  Run 'flox list -c' to see merged manifest.
             "});
     }
 
@@ -915,10 +915,10 @@ mod tests {
         // - hint to see the merged manifest is shown.
         assert_eq!(writer.to_string(), indoc! {"
             ✅ Environment successfully updated.
-            ℹ️ The following manifest fields were overridden during merging:
+            ℹ️  The following manifest fields were overridden during merging:
             - This environment set:
               - vars.foo
-            ℹ️ Run 'flox list -c' to see merged manifest.
+            ℹ️  Run 'flox list -c' to see merged manifest.
             "});
     }
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -110,7 +110,7 @@ static FLOX_DESCRIPTION: &'_ str = indoc! {"
 
 /// Manually documented commands that are to keep the help text short
 const ADDITIONAL_COMMANDS: &str = indoc! {"
-    auth, config, envs, gc, upgrade
+    auth, config, envs, gc, include, upgrade
 "};
 
 fn vec_len<T>(x: Vec<T>) -> usize {
@@ -943,7 +943,13 @@ enum AdditionalCommands {
 
     /// Interact with included environments
     #[bpaf(command, hide)]
-    Include(#[bpaf(external(include::include_commands))] include::IncludeCommands),
+    Include(
+        #[bpaf(
+            external(include::include_commands),
+            fallback(include::IncludeCommands::Help)
+        )]
+        include::IncludeCommands,
+    ),
 }
 
 impl AdditionalCommands {

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -43,8 +43,9 @@ pub(crate) fn deleted(v: impl Display) {
 pub(crate) fn updated(v: impl Display) {
     print_message(std::format_args!("✅ {v}"));
 }
+/// double width character, add an additional space for alignment
 pub(crate) fn info(v: impl Display) {
-    print_message(std::format_args!("ℹ️ {v}"));
+    print_message(std::format_args!("ℹ️  {v}"));
 }
 /// double width character, add an additional space for alignment
 pub(crate) fn warning(v: impl Display) {
@@ -269,7 +270,7 @@ mod tests {
         // - composer environment is listed last
         // - environment `dep_one` doesn't appear because its fields are overridden later
         assert_eq!(writer.to_string(), indoc! {"
-            ℹ️ The following manifest fields were overridden during merging:
+            ℹ️  The following manifest fields were overridden during merging:
             - Environment 'dep_two' set:
               - vars.overridden_by_dep2
             - This environment set:

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4798,7 +4798,7 @@ EOF
 
   run --separate-stderr "$FLOX_BIN" activate -d composer -- echo "locking"
   assert_success
-  assert_equal "$stderr" "ℹ️ The following manifest fields were overridden during merging:
+  assert_equal "$stderr" "ℹ️  The following manifest fields were overridden during merging:
 - This environment set:
   - vars.foo
 Sourcing .bashrc

--- a/cli/tests/include.bats
+++ b/cli/tests/include.bats
@@ -138,7 +138,7 @@ EOF
   setup_composer_and_two_includes
   run "$FLOX_BIN" include upgrade -d composer
   assert_success
-  assert_output "ℹ️ No included environments have changes."
+  assert_output "ℹ️  No included environments have changes."
 }
 
 @test "include upgrade reports no changes when non-upgraded environment changes" {
@@ -146,7 +146,7 @@ EOF
   edit_included1
   run "$FLOX_BIN" include upgrade -d composer included2
   assert_success
-  assert_output "ℹ️ Included environment 'included2' has no changes."
+  assert_output "ℹ️  Included environment 'included2' has no changes."
 }
 
 @test "include upgrade defaults to upgrading all" {
@@ -193,7 +193,7 @@ EOF
   assert_output - <<EOF
 ✅ Upgraded 'composer' with latest changes to:
 - 'included1'
-ℹ️ Included environment 'included2' has no changes.
+ℹ️  Included environment 'included2' has no changes.
 EOF
 
   run "$FLOX_BIN" list -c -d composer

--- a/cli/tests/list.bats
+++ b/cli/tests/list.bats
@@ -183,7 +183,7 @@ EOF
 
 [install]
 hello.pkg-path = "hello"'
-  assert_equal "$stderr" 'ℹ️ Displaying merged manifest.'
+  assert_equal "$stderr" 'ℹ️  Displaying merged manifest.'
 }
 
 # bats test_tags=list,list:config
@@ -211,8 +211,8 @@ EOF
 
   run --separate-stderr "$FLOX_BIN" list -c -d composer
   assert_success
-  assert_equal "$stderr" "ℹ️ Displaying merged manifest.
-ℹ️ The following manifest fields were overridden during merging:
+  assert_equal "$stderr" "ℹ️  Displaying merged manifest.
+ℹ️  The following manifest fields were overridden during merging:
 - This environment set:
   - vars.foo"
 }

--- a/cli/tests/uninstall.bats
+++ b/cli/tests/uninstall.bats
@@ -225,6 +225,6 @@ EOF
   assert_success
   assert_output - << EOF
 🗑️  'hello' uninstalled from environment 'composer'
-ℹ️ 'hello' is still installed by environment 'included'
+ℹ️  'hello' is still installed by environment 'included'
 EOF
 }

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -92,7 +92,7 @@ EOF
   run "$FLOX_BIN" --help
   assert_output --partial - << EOF
 Additional Commands. Use "flox COMMAND --help" for more info
-    auth, config, envs, gc, upgrade
+    auth, config, envs, gc, include, upgrade
 EOF
 }
 


### PR DESCRIPTION
[fix: deny unknown fields in [include]](https://github.com/flox/flox/commit/876856adffb45590b5b7403b4d291a15a916a10b)

We should error if environments gets mistyped or if name in an include
descriptor gets mistyped.

[feat: improve error for IncludeDescriptor](https://github.com/flox/flox/commit/e2c79d05b172caee76ed82a48207877a606ed9c8)

For an invalid IncludeDescriptor, error with:
```
❌ ERROR: Failed to parse manifest:

Must specify included environment as { dir = <dir>, [name = <name>] }
```

Instead of:
```
❌ ERROR: Failed to parse manifest:

Expected either a local or remote include descriptor.
```

[feat: improve include help](https://github.com/flox/flox/pull/2959/commits/b09c410bbd83805ac6ba53bcb6d01876f7499004)

- Show help when `flox include` is run without any arguments
- Add include to `flox help` output

[fix: add second space after ℹ️](https://github.com/flox/flox/pull/2959/commits/5f11d553cba9c6b511692d3ac4d7483ccf82886d)

ℹ️ is double width so there should be two spaces after it

## Release Notes

NA