### PR TITLE
fix(compose): Use lockfile for services

### DIFF
--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -110,13 +110,16 @@ pub struct ServicesEnvironment {
 impl ServicesEnvironment {
     /// Create a [ServicesEnvironment] from a [ConcreteEnvironment].
     ///
+    /// Will lock the environment if it's not already locked.
+    ///
     /// Returns an error if the environment doesn't support services.
     pub fn from_concrete_environment(
         flox: &Flox,
-        environment: ConcreteEnvironment,
+        mut environment: ConcreteEnvironment,
     ) -> Result<Self> {
         let socket = environment.services_socket_path(flox)?;
-        let manifest = environment.manifest(flox)?;
+        let lockfile: Lockfile = environment.lockfile(flox)?.into();
+        let manifest = lockfile.manifest;
 
         Ok(Self {
             environment,


### PR DESCRIPTION
~ℹ️ I've not raised this against the RC branch whilst we're still deciding on the release. We can cherry-pick it in, if necessary.~
@mkenigs note: we decided to release 1.4.0 so I changed the base branch

## Proposed Changes

So that services are found from the merged manifest.

Before:

    % flox services status -d ~/demo/composed
    ❌ ERROR: Environment does not have any services defined.

After:

    % flox services status -d ~/demo/composed
    NAME       STATUS       PID
    hello      Stopped

Not adding an explicit test for composition with services because it requires a lot of boilerplate and we're unlikely to regress this particular case.

I'm going to look into (or ticket if I run out of time) ways to prevent us from using the unlocked typed manifest, independent from us making a decision about changing the user facing behaviour in:

- https://github.com/flox/flox/issues/2892

## Release Notes

N/A when combined in services release.
