### PR TITLE
refactor(env): Remove Environment::manifest()

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -89,7 +89,11 @@ impl<State> CoreEnvironment<State> {
         self.env_dir.join(LOCKFILE_FILENAME)
     }
 
-    /// Read the manifest file
+    /// Extract the current content of the manifest from disk.
+    ///
+    /// This may differ from the locked manifest, which should typically be used unless you need to:
+    /// - provide the latest editable contents to the user
+    /// - avoid double-locking
     pub fn manifest_contents(&self) -> Result<String, CoreEnvironmentError> {
         fs::read_to_string(self.manifest_path()).map_err(CoreEnvironmentError::OpenManifest)
     }

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -117,7 +117,7 @@ impl<State> CoreEnvironment<State> {
         }
     }
 
-    pub fn manifest(&self) -> Result<Manifest, CoreEnvironmentError> {
+    fn manifest(&self) -> Result<Manifest, CoreEnvironmentError> {
         toml::from_str(&self.manifest_contents()?)
             .map_err(CoreEnvironmentError::DeserializeManifest)
     }

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -426,12 +426,6 @@ impl Environment for ManagedEnvironment {
         Ok(manifest)
     }
 
-    /// Return the deserialized manifest
-    fn manifest(&self, flox: &Flox) -> Result<Manifest, EnvironmentError> {
-        Ok(toml::from_str(&self.manifest_contents(flox)?)
-            .map_err(CoreEnvironmentError::DeserializeManifest)?)
-    }
-
     /// This will lock if there is an out of sync local checkout
     fn rendered_env_links(
         &mut self,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -419,7 +419,11 @@ impl Environment for ManagedEnvironment {
         Ok(result)
     }
 
-    /// Extract the current content of the manifest
+    /// Extract the current content of the manifest from disk.
+    ///
+    /// This may differ from the locked manifest, which should typically be used unless you need to:
+    /// - provide the latest editable contents to the user
+    /// - avoid double-locking
     fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         let local_checkout = self.local_env_or_copy_current_generation(flox)?;
         let manifest = local_checkout.manifest_contents()?;

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -19,7 +19,7 @@ use super::env_registry::EnvRegistryError;
 use super::environment_ref::{EnvironmentName, EnvironmentOwner};
 use super::lockfile::{LockResult, LockedInclude, Lockfile, RecoverableMergeError, ResolveError};
 use super::manifest::raw::PackageToInstall;
-use super::manifest::typed::{ActivateMode, Manifest, ManifestError};
+use super::manifest::typed::{ActivateMode, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
 use crate::flox::{Flox, Floxhub};
 use crate::providers::buildenv::BuildEnvOutputs;
@@ -154,9 +154,6 @@ pub trait Environment: Send {
     /// Implementations may use process context from [Flox]
     /// to determine the current content of the manifest.
     fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError>;
-
-    /// Return the deserialized manifest
-    fn manifest(&self, flox: &Flox) -> Result<Manifest, EnvironmentError>;
 
     /// Return the path to rendered environment in the Nix store.
     ///

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -51,7 +51,7 @@ use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::lockfile::{DEFAULT_SYSTEMS_STR, LockResult, Lockfile};
 use crate::models::manifest::raw::{CatalogPackage, PackageToInstall, RawManifest};
-use crate::models::manifest::typed::{ActivateMode, Manifest};
+use crate::models::manifest::typed::ActivateMode;
 use crate::providers::buildenv::BuildEnvOutputs;
 
 /// Struct representing a local environment
@@ -311,12 +311,6 @@ impl Environment for PathEnvironment {
     /// Read the environment definition file as a string
     fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         fs::read_to_string(self.manifest_path(flox)?).map_err(EnvironmentError::ReadManifest)
-    }
-
-    /// Return the deserialized manifest
-    fn manifest(&self, _flox: &Flox) -> Result<Manifest, EnvironmentError> {
-        let env_view = self.as_core_environment()?;
-        env_view.manifest().map_err(EnvironmentError::Core)
     }
 
     /// Returns the environment name

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -308,7 +308,11 @@ impl Environment for PathEnvironment {
         Ok(result)
     }
 
-    /// Read the environment definition file as a string
+    /// Extract the current content of the manifest
+    ///
+    /// This may differ from the locked manifest, which should typically be used unless you need to:
+    /// - provide the latest editable contents to the user
+    /// - avoid double-locking
     fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         fs::read_to_string(self.manifest_path(flox)?).map_err(EnvironmentError::ReadManifest)
     }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -28,7 +28,6 @@ use crate::models::environment_ref::EnvironmentName;
 use crate::models::floxmeta::{FloxMeta, FloxMetaError};
 use crate::models::lockfile::{LockResult, Lockfile};
 use crate::models::manifest::raw::PackageToInstall;
-use crate::models::manifest::typed::Manifest;
 
 const REMOTE_ENVIRONMENT_BASE_DIR: &str = "remote";
 
@@ -339,11 +338,6 @@ impl Environment for RemoteEnvironment {
     /// Extract the current content of the manifest
     fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         self.inner.manifest_contents(flox)
-    }
-
-    /// Return the deserialized manifest
-    fn manifest(&self, flox: &Flox) -> Result<Manifest, EnvironmentError> {
-        self.inner.manifest(flox)
     }
 
     fn rendered_env_links(

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -336,6 +336,10 @@ impl Environment for RemoteEnvironment {
     }
 
     /// Extract the current content of the manifest
+    ///
+    /// This may differ from the locked manifest, which should typically be used unless you need to:
+    /// - provide the latest editable contents to the user
+    /// - avoid double-locking
     fn manifest_contents(&self, flox: &Flox) -> Result<String, EnvironmentError> {
         self.inner.manifest_contents(flox)
     }

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -413,7 +413,7 @@ fn build_repo_err_msg(msg: &str) -> String {
     "}
 }
 
-fn build_repo_err(msg: &str) -> PublishError {
+pub fn build_repo_err(msg: &str) -> PublishError {
     PublishError::UnsupportedEnvironmentState(build_repo_err_msg(msg))
 }
 
@@ -584,7 +584,7 @@ pub fn check_environment_metadata(
         .existing_lockfile(flox)
         .map_err(|e| PublishError::UnsupportedEnvironmentState(e.to_string()))?
     else {
-        return Err(build_repo_err("Environment must be locked."));
+        unreachable!("It should have been verified the environment was locked");
     };
 
     // Gather build repo info

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -25,11 +25,6 @@ use crate::utils::CommandExt;
 
 #[derive(Debug, Error)]
 pub enum PublishError {
-    #[error("This type of environment is not supported for publishing")]
-    UnsupportedEnvironment,
-    #[error("The environment must be locked to publish")]
-    UnlockedEnvironment,
-
     #[error("The outputs from the build do not exist: {0}")]
     NonexistentOutputs(String),
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -607,8 +607,8 @@ pub fn check_environment_metadata(
     let build_repo_meta = gather_build_repo_meta(&git)?;
     let base_repo_meta = gather_base_repo_meta(&lockfile)?;
 
-    let manifest = environment.manifest(flox)?;
-    let description = manifest
+    let description = lockfile
+        .manifest
         .build
         .inner()
         .get(pkg)

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
@@ -76,14 +76,11 @@ impl Publish {
         }
 
         environment_subcommand_metric!("publish", self.environment);
-        let env = self
+        let mut env = self
             .environment
             .detect_concrete_environment(&flox, "Publish")?;
-        let target = Self::get_publish_target(
-            &env.manifest(&flox)
-                .context("failed to get environment manifest")?,
-            &self.publish_target,
-        )?;
+        let lockfile: Lockfile = env.lockfile(&flox)?.into();
+        let target = Self::get_publish_target(&lockfile.manifest, &self.publish_target)?;
         Self::publish(config, flox, env, target, self.metadata_only, self.cache).await
     }
 


### PR DESCRIPTION
## Proposed Changes

So that we stop accidentally using the unlocked and unmerged manifest
which prevents other features from working with composition.

This is best reviewed commit-by-commit.

This branch (unfortunately, currently) depends on:

- https://github.com/flox/flox/pull/2962 (not reviewed)
- https://github.com/flox/flox/pull/2964 (merged only to RC branch)

## Release Notes

N/A
