### PR TITLE
feat: set (temp) gc roots during environment builds

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -39,6 +39,7 @@ use crate::models::manifest::raw::{
 };
 use crate::models::manifest::typed::{Manifest, ManifestError};
 use crate::providers::buildenv::{
+    self,
     BuildEnv,
     BuildEnvError,
     BuildEnvNix,
@@ -274,7 +275,7 @@ impl CoreEnvironment<()> {
         out_link_path: impl AsRef<Path>,
         store_path: &BuiltStorePath,
     ) -> Result<(), CoreEnvironmentError> {
-        BuildEnvNix.link(out_link_path, store_path)?;
+        buildenv::create_gc_root_in([store_path.as_path()], out_link_path)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Proposed Changes

Our goal is to avoid garbage collection of store paths between realisation
and the eventual nix build producing a flox environment path.
To that end we are going to create gc-roots for all paths going into the environment build.

Since all realisation steps are going to produce gc-roots,
the base paths for gc roots is ubiquitously needed.
In order to avoid passing paths as arguments around, we can use the ambient `BuildEnvNix` instance
to hold a basepath and provide further functionality to format prefixes.


[feat: add function to create gc_roots. i.e. link store paths](https://github.com/flox/flox/commit/5f12026da87e8b4fd2f740c5016a09ccd5b067d7)

Essentially runs `nix build <store path> --out-link <prefix>`.
To avoid accidental building or substitution of this command,
we also pass `--offline -j 0`.
In support of bulk operations, we pass path arguments via stdin.

[refactor: remove BuildEnv::link in favor of gc_root function](https://github.com/flox/flox/commit/bb3be33bb29fb9eb194908cde86d72225f9e1b95)

Since the command to set gc_roots, is essentially equivalent to the existing implementation of `BuildEnv::link`,
we can drop the less general one in and use the new function as is.

## Release Notes

GC roots should prevent failures of ennvironment builds during active GC jobs.