### PR TITLE
feat(compose): Implement trust for remote includes

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -118,7 +118,13 @@ impl Activate {
 
         if let ConcreteEnvironment::Remote(ref env) = concrete_environment {
             if !self.trust {
-                ensure_environment_trust(&mut config, &flox, env).await?;
+                ensure_environment_trust(
+                    &mut config,
+                    &flox,
+                    &env.env_ref(),
+                    &env.manifest_contents(&flox)?,
+                )
+                .await?;
             }
         }
 

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -13,11 +13,10 @@ use flox_rust_sdk::providers::flake_installable_locker::LockedInstallable;
 use flox_rust_sdk::providers::upgrade_checks::UpgradeInformationGuard;
 use indoc::formatdoc;
 use itertools::Itertools;
-use toml_edit::visit_mut::VisitMut;
-use toml_edit::{Item, KeyMut, Value};
 use tracing::{debug, instrument};
 
 use super::{EnvironmentSelect, environment_select};
+use crate::commands::render_composition_manifest;
 use crate::environment_subcommand_metric;
 use crate::utils::message;
 use crate::utils::tracing::sentry_set_tag;
@@ -114,44 +113,12 @@ impl List {
         lockfile: &Lockfile,
     ) -> Result<String> {
         let is_composed = lockfile.compose.is_some();
-
-        // A visitor that converts inline tables to proper tables
-        // Nested tables are rendered as `dotted` tables.
-        // The default behavior when instantiating with `Visitor::new_for_document`,
-        // is to render toplevel tables as non-dotted, sections.
-        struct Visitor {
-            dotted: bool,
-        }
-        impl Visitor {
-            fn new_for_document() -> Self {
-                Visitor { dotted: false }
-            }
-        }
-        impl VisitMut for Visitor {
-            fn visit_table_like_kv_mut(&mut self, _key: KeyMut<'_>, node: &mut Item) {
-                if let toml_edit::Item::Value(Value::InlineTable(inline_table)) = node {
-                    let mut table = std::mem::take(inline_table).into_table();
-                    table.set_implicit(true);
-                    table.set_dotted(self.dotted);
-                    toml_edit::visit_mut::visit_table_mut(
-                        &mut Visitor { dotted: true },
-                        &mut table,
-                    );
-                    *node = toml_edit::Item::Table(table);
-                }
-            }
-        }
-
         let manifest_contents = if is_composed {
-            let mut document = toml_edit::ser::to_document(&lockfile.manifest)?;
-            toml_edit::visit_mut::visit_document_mut(
-                &mut Visitor::new_for_document(),
-                &mut document,
-            );
-            document.to_string()
+            render_composition_manifest(&lockfile.manifest)?
         } else {
             env.manifest_contents(flox)?
         };
+
         Ok(manifest_contents)
     }
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1379,6 +1379,7 @@ pub(super) async fn ensure_environment_trust(
     manifest_contents: &String,
 ) -> Result<()> {
     let trust = config.flox.trusted_environments.get(env_ref);
+    let env_config_key = format!("trusted_environments.{env_ref}");
     let env_prefixed_name = match env_included {
         true => format!("included environment {env_ref}"),
         false => format!("environment {env_ref}"),
@@ -1410,7 +1411,7 @@ pub(super) async fn ensure_environment_trust(
         let message = formatdoc! {"
             The {env_prefixed_name} is not trusted.
 
-            Run 'flox config --set trusted_environments.{env_ref} trust' to trust it."};
+            Run 'flox config --set {env_config_key} trust' to trust it."};
         bail!("{message}");
     }
 
@@ -1474,7 +1475,7 @@ pub(super) async fn ensure_environment_trust(
                 update_config(
                     &flox.config_dir,
                     &flox.temp_dir,
-                    format!("trusted_environments.'{env_ref}'"),
+                    &env_config_key,
                     Some(EnvironmentTrust::Trust),
                 )
                 .context("Could not write token to config")?;
@@ -1486,7 +1487,7 @@ pub(super) async fn ensure_environment_trust(
                 update_config(
                     &flox.config_dir,
                     &flox.temp_dir,
-                    format!("trusted_environments.'{env_ref}'"),
+                    &env_config_key,
                     Some(EnvironmentTrust::Deny),
                 )
                 .context("Could not write token to config")?;

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1373,11 +1373,10 @@ fn activated_environments() -> ActiveEnvironments {
 pub(super) async fn ensure_environment_trust(
     config: &mut Config,
     flox: &Flox,
-    environment: &RemoteEnvironment,
+    env_ref: &EnvironmentRef,
+    manifest_contents: &String,
 ) -> Result<()> {
-    let env_ref = EnvironmentRef::new_from_parts(environment.owner().clone(), environment.name());
-
-    let trust = config.flox.trusted_environments.get(&env_ref);
+    let trust = config.flox.trusted_environments.get(env_ref);
 
     // Official Flox environments are trusted by default
     // Only applies to the current flox owned FloxHub,
@@ -1493,7 +1492,7 @@ pub(super) async fn ensure_environment_trust(
                 return Ok(());
             },
             Choices::Abort => bail!("Denied {env_ref} (temporary)"),
-            Choices::ShowConfig => eprintln!("{}", environment.manifest_contents(flox)?),
+            Choices::ShowConfig => eprintln!("{}", manifest_contents),
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Check for trust when running `flox activate` against a composed
environment that includes remote environments.

This mimics the behaviour of `flox activate -r` for a non-composed
environment and reduces (or shifts responsibility for) the risk of
running arbitrary hooks from external sources by requiring the user to
review and accept them first.

It's also easier to implement it at `activate` rather than when the
remotes are fetched and merged because that happens deep within the SDK
for several callpaths and we don't have an easy way to surface that
messaging in the CLI.

This check has to be done after locking because, although we have the
names of the remotes from the unlocked manifest, we don't have the
manifest contents of the remotes. This means that the environment will
still be built locally, but we're considering the risk of that being
misused as low compared to running hooks.

I don't like using `assert_output --partial` in tests but the fake
FloxHub generates a bunch of output that makes the tests noisy and I'd
prefer to match the existing style for now.

## Release Notes

`flox activate` will now check remote included environments for trust when using composition.