### PR TITLE
fix(ci): allow buildkite uploads to fail

### DIFF
--- a/.github/scripts/remote-execute-integration-tests.sh
+++ b/.github/scripts/remote-execute-integration-tests.sh
@@ -50,7 +50,8 @@ function upload_report_to_buildkite() {
     -F "tags[architecture]=$MATRIX_SYSTEM" \
     -F "tags[nix_flakeref]=github:flox/flox/$GITHUB_SHA" \
     -F "tags[nix_attribute]=packages.$MATRIX_SYSTEM.flox-cli-tests" \
-    https://analytics-api.buildkite.com/v1/uploads
+    https://analytics-api.buildkite.com/v1/uploads \
+    || true
 }
 trap 'upload_report_to_buildkite' EXIT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,8 @@ jobs:
             -F "tags[architecture]=$system" \
             -F "tags[nix_flakeref]=github:flox/flox/$GITHUB_SHA" \
             -F "tags[nix_attribute]=devShells.$system.default" \
-            https://analytics-api.buildkite.com/v1/uploads
+            https://analytics-api.buildkite.com/v1/uploads \
+            || true
 
 
       # This differs from `nix-build-bats-tests` in that:


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Apparently we hit the monthly limit of test suite execution uploads. Doesn't make sense to fail the whole pipeline for this.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
