### PR TITLE
fix: update error with remote environments

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -993,7 +993,7 @@ impl SkipSerializing for Include {
 #[serde(deny_unknown_fields)]
 #[serde(
     untagged,
-    expecting = "Must specify included environment as { dir = <dir>, [name = <name>] }"
+    expecting = "expected { dir = <dir>, [name = <name>] } OR { remote = <owner/name>, [name = <name>] }"
 )]
 pub enum IncludeDescriptor {
     Local {


### PR DESCRIPTION
Remote environments can now be included but the error message was never updated
