### PR TITLE
feat: create .flox/.gitignore for for pull --copy

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -18,7 +18,6 @@ use std::fs::{self};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use indoc::formatdoc;
 use itertools::Itertools;
 use tracing::debug;
 
@@ -35,7 +34,6 @@ use super::{
     EnvironmentPointer,
     GCROOTS_DIR_NAME,
     InstallationAttempt,
-    LIB_DIR_NAME,
     LOCKFILE_FILENAME,
     LOG_DIR_NAME,
     PathPointer,
@@ -47,7 +45,7 @@ use super::{
 use crate::data::{CanonicalPath, System};
 use crate::flox::Flox;
 use crate::models::env_registry::{deregister, ensure_registered};
-use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME};
+use crate::models::environment::{ENV_DIR_NAME, MANIFEST_FILENAME, create_dot_flox_gitignore};
 use crate::models::environment_ref::EnvironmentName;
 use crate::models::lockfile::{DEFAULT_SYSTEMS_STR, LockResult, Lockfile};
 use crate::models::manifest::raw::{CatalogPackage, PackageToInstall, RawManifest};
@@ -526,14 +524,7 @@ impl PathEnvironment {
         }
 
         // Write stateful directories to .flox/.gitignore
-        fs::write(dot_flox_path.join(".gitignore"), formatdoc! {"
-            {GCROOTS_DIR_NAME}/
-            {CACHE_DIR_NAME}/
-            {LIB_DIR_NAME}/
-            {LOG_DIR_NAME}/
-            !{ENV_DIR_NAME}/
-            "})
-        .map_err(EnvironmentError::WriteGitignore)?;
+        create_dot_flox_gitignore(&dot_flox_path)?;
 
         let dot_flox_path = CanonicalPath::new(dot_flox_path).expect("the directory just created");
 

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -18,6 +18,7 @@ use flox_rust_sdk::models::environment::{
     EnvironmentError,
     EnvironmentPointer,
     ManagedPointer,
+    create_dot_flox_gitignore,
 };
 use flox_rust_sdk::models::manifest::raw::add_system;
 use flox_rust_sdk::providers::buildenv::BuildEnvError;
@@ -291,10 +292,15 @@ impl Pull {
 
         if copy {
             debug!("Converting environment to path environment");
-            if let Err(e) = env.into_path_environment(flox) {
-                fs::remove_dir_all(&dot_flox_path)
-                    .context("Could not clean up .flox/ directory")?;
-                bail!(e);
+            match env.into_path_environment(flox) {
+                Err(e) => {
+                    fs::remove_dir_all(&dot_flox_path)
+                        .context("Could not clean up .flox/ directory")?;
+                    bail!(e);
+                },
+                Ok(env) => {
+                    create_dot_flox_gitignore(env.dot_flox_path())?;
+                },
             }
         }
 

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -419,6 +419,7 @@ function add_incompatible_package() {
   assert [ ! -e ".flox/env.lock" ]
   assert [ $(cat .flox/env.json | jq -r '.name') == "name" ]
   assert [ $(cat .flox/env.json | jq -r '.owner') == "null" ]
+  assert [ -f .flox/.gitignore ]
   assert_output --partial "Created path environment from owner/name"
 }
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Previously if you ran a `flox pull --copy` you would not get the `.flox/.gitignore` file that you get if you run `flox init`. This meant that logs from services and the watchdog would not be ignored in environments created via `flox pull --copy`. Now we generate that file and the logs are ignored.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Environments created via `flox pull --copy` will now ignore the correct files in the `.flox` directory.

<!-- Many thanks! -->
