### PR TITLE
test: drop PanickingClient

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -84,6 +84,8 @@ pub enum Response {
     GetStoreInfo(StoreInfoResponse),
     Error(GenericResponse<ErrorResponse>),
     Publish(PublishResponse),
+    CreatePackage,
+    PublishBuild,
 }
 
 #[derive(Debug, Error)]
@@ -949,7 +951,16 @@ impl ClientTrait for MockClient {
         _package_name: impl AsRef<str> + Send + Sync,
         _original_url: impl AsRef<str> + Send + Sync,
     ) -> Result<(), CatalogClientError> {
-        Ok(())
+        let mock_resp = self
+            .mock_responses
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .pop_front();
+        match mock_resp {
+            Some(Response::CreatePackage) => Ok(()),
+            // We don't need to test errors at the moment
+            _ => panic!("expected create package response, found {:?}", &mock_resp),
+        }
     }
 
     async fn publish_build(
@@ -958,7 +969,16 @@ impl ClientTrait for MockClient {
         _package_name: impl AsRef<str> + Send + Sync,
         _build_info: &UserBuildPublish,
     ) -> Result<(), CatalogClientError> {
-        Ok(())
+        let mock_resp = self
+            .mock_responses
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .pop_front();
+        match mock_resp {
+            Some(Response::PublishBuild) => Ok(()),
+            // We don't need to test errors at the moment
+            _ => panic!("expected create package response, found {:?}", &mock_resp),
+        }
     }
 
     async fn get_store_info(

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -899,12 +899,14 @@ pub mod tests {
             env_metadata,
         };
 
-        reset_mocks(&mut flox.catalog_client, vec![Response::Publish(
-            PublishResponse {
+        reset_mocks(&mut flox.catalog_client, vec![
+            Response::CreatePackage,
+            Response::Publish(PublishResponse {
                 ingress_uri: None,
                 catalog_store_config: CatalogStoreConfig::MetaOnly,
-            },
-        )]);
+            }),
+            Response::PublishBuild,
+        ]);
 
         let res = publish_provider
             .publish(&flox.catalog_client, &catalog_name, None, None, false)
@@ -967,13 +969,16 @@ pub mod tests {
             env_metadata,
         };
 
-        reset_mocks(&mut client, vec![Response::Publish(PublishResponse {
-            ingress_uri: Some("https://example.com".to_string()),
-            catalog_store_config: CatalogStoreConfig::NixCopy(CatalogStoreConfigNixCopy {
-                ingress_uri: "https://example.com".to_string(),
-                egress_uri: "https://example.com".to_string(),
+        reset_mocks(&mut client, vec![
+            Response::CreatePackage,
+            Response::Publish(PublishResponse {
+                ingress_uri: Some("https://example.com".to_string()),
+                catalog_store_config: CatalogStoreConfig::NixCopy(CatalogStoreConfigNixCopy {
+                    ingress_uri: "https://example.com".to_string(),
+                    egress_uri: "https://example.com".to_string(),
+                }),
             }),
-        })]);
+        ]);
 
         let result = publish_provider
             .publish(&client, &catalog_name, None, None, false)
@@ -1091,15 +1096,17 @@ pub mod tests {
         let cache_path = cache.url.to_file_path().unwrap();
         assert!(std::fs::read_dir(&cache_path).is_err());
 
-        reset_mocks(&mut flox.catalog_client, vec![Response::Publish(
-            PublishResponse {
+        reset_mocks(&mut flox.catalog_client, vec![
+            Response::CreatePackage,
+            Response::Publish(PublishResponse {
                 ingress_uri: Some(cache.url.to_string()),
                 catalog_store_config: CatalogStoreConfig::NixCopy(CatalogStoreConfigNixCopy {
                     ingress_uri: cache.url.to_string(),
                     egress_uri: cache.url.to_string(),
                 }),
-            },
-        )]);
+            }),
+            Response::PublishBuild,
+        ]);
 
         publish_provider
             .publish(


### PR DESCRIPTION
Our normal MockClient should panic by default. It's confusing to have two different mock clients that do the same thing.

It was also making it harder for me to tell where catalog types were being used throughout the codebase.

Fix cases where MockClient wasn't panicking when it should be.

## Release Notes
NA