### PR TITLE
fix: correctly set pip.ini path in builds

### DIFF
--- a/assets/environment-interpreter/common/etc/profile.d/0500_python.sh
+++ b/assets/environment-interpreter/common/etc/profile.d/0500_python.sh
@@ -23,9 +23,11 @@ print( "{}.{}".format( sys.version_info[0], sys.version_info[1] ) )'
   export PYTHONPATH
 fi
 
-# Only run if `pip' is in `PATH'
-if [[ -x "$FLOX_ENV/bin/pip3" ]]; then
-  PIP_CONFIG_FILE="$("$_realpath" --no-symlinks "$FLOX_ENV/../../pip.ini")"
+# Only run if `pip' is in `PATH' for non-containerize activations.
+# FLOX_ENV_PROJECT is unset in `containerize`, but *is* set for builds and
+# other activations. We don't need a virtual environment inside a container.
+if [[ (-x "$FLOX_ENV/bin/pip3") && (-n "${FLOX_ENV_PROJECT:-}") ]]; then
+  PIP_CONFIG_FILE="$FLOX_ENV_PROJECT/.flox/pip.ini"
   export PIP_CONFIG_FILE
   "$_cat" > "$PIP_CONFIG_FILE" << EOF
 [global]

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -162,7 +162,7 @@ pkgs.runCommandNoCC name
                 # N.B. not using t3 --forcecolor option because Nix sandbox
                 # strips color codes from output anyway.
                 FLOX_SRC_DIR=$(pwd) FLOX_RUNTIME_DIR="$TMP" \
-                  ${flox-env-package}/activate --env ${flox-env-package} --mode run --turbo -- \
+                  ${flox-env-package}/activate --env ${flox-env-package} --env-project $(pwd) --mode run --turbo -- \
                     ${build-wrapper-env-package}/wrapper --env ${build-wrapper-env-package} --set-vars -- \
                       t3 --relative $log -- bash -e ${buildScript-contents}
               ''
@@ -192,7 +192,7 @@ pkgs.runCommandNoCC name
                 # and we're not using env -i like we are in the impure build
 
                 FLOX_SRC_DIR=$(pwd) FLOX_RUNTIME_DIR="$TMP" \
-                  ${flox-env-package}/activate --env ${flox-env-package} --mode run --turbo -- \
+                  ${flox-env-package}/activate --env ${flox-env-package} --env-project $(pwd) --mode run --turbo -- \
                     ${build-wrapper-env-package}/wrapper --env ${build-wrapper-env-package} --set-vars -- \
                       t3 --relative $log -- bash -e ${buildScript-contents} || \
                 ( rm -rf $out && echo "flox build failed (caching build dir)" | tee $out 1>&2 )

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -273,7 +273,7 @@ define BUILD_local_template =
 	$(_VV_) $(_rm) -rf $(_out)
 	$(_V_) \
 	  $(if $(_virtualSandbox),$(PRELOAD_VARS) FLOX_SRC_DIR=$$$$($(_pwd)) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
-	  $(FLOX_INTERPRETER)/activate --env $(FLOX_ENV) --mode dev --turbo -- \
+	  $(FLOX_INTERPRETER)/activate --env $(FLOX_ENV) --mode dev --turbo --env-project $$$$($(_pwd)) -- \
 	    $(_env) -i out=$(_out) $(foreach i,$(ALLOW_OUTER_ENV_VARS),$(i)="$$$$$(i)") \
 	      $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) --set-vars -- \
 	        $(_t3) $($(_pvarname)_logfile) -- $(_bash) -e $($(_pvarname)_buildScript)


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Previously the Python etc/profile.d script would refer to the location of the `pip.ini` file (necessary to enforce a virtual environment) via a path relative to `$FLOX_ENV`. This doesn't work in builds because the relative path is in the Nix store e.g. `/nix/pip.ini`.

This change refactors the `/etc/profile.d` script and the build script to set and use the `$FLOX_ENV_PROJECT` variable instead of a relative path.

I tested this interactively but didn't create a test for it because it didn't seem worth it. To test it I created an environment with a simple Python project created via Claude. In the build logs you can see that it correctly creates binary wheels from the project.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
