### PR TITLE
fix: allow default catalogs for search

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -35,7 +35,6 @@ use crate::flox::FLOX_VERSION;
 use crate::models::search::{PackageDetails, ResultCount, SearchLimit, SearchResults};
 use crate::utils::logging::traceable_path;
 
-const NIXPKGS_CATALOG: &str = "nixpkgs";
 pub const FLOX_CATALOG_MOCK_DATA_VAR: &str = "_FLOX_USE_CATALOG_MOCK";
 pub const FLOX_CATALOG_DUMP_DATA_VAR: &str = "_FLOX_CATALOG_DUMP_RESPONSE_FILE";
 
@@ -552,7 +551,8 @@ impl ClientTrait for CatalogClient {
                 let response = self
                     .client
                     .search_api_v1_catalog_search_get(
-                        Some(NIXPKGS_CATALOG),
+                        // Default behavior for empty 'catalogs' is all catalogs.
+                        None,
                         Some(page_number),
                         Some(page_size),
                         &api_types::SearchTerm::from_str(search_term)


### PR DESCRIPTION
We were specifying `nixpkgs` as the search catalog but the service was not actually using that parameter and always search all catalogs.  Now we have implemented that on the service side, but are designating the base catalog `base` (not `nixpkgs`).  There is a workaround in the service to accommodate older CLI versions but we want to remove that code in the future.

This change removes specifying the catalog on the search call, allowing the service to determine the default behavior with the new handling of the catalog parameter.  The actual behavior should not change at all.