### PR TITLE
feat: minimal perl for use with builder.pl

### DIFF
--- a/pkgs/flox-buildenv/default.nix
+++ b/pkgs/flox-buildenv/default.nix
@@ -1,12 +1,12 @@
 {
   cacert,
-  darwin,
+  callPackage,
   coreutils,
+  darwin,
   flox-interpreter,
   glibcLocalesUtf8,
   lib,
   nix,
-  perl,
   runCommandNoCC,
   stdenv,
   writeText,
@@ -46,6 +46,10 @@ let
       # Static environment variables
     ''
   );
+  perl = callPackage ./flox-perl.nix {
+    # Script which determines the modules to keep.
+    perlScript = ../../buildenv/builder.pl;
+  };
 in
 runCommandNoCC "${pname}-${version}"
   {

--- a/pkgs/flox-buildenv/flox-perl.nix
+++ b/pkgs/flox-buildenv/flox-perl.nix
@@ -1,0 +1,168 @@
+{
+  lib,
+  perl,
+  perlScript, # Script which determines the modules to keep.
+  stdenv,
+}:
+let
+  # Would like to disable the building of _all_ unnecessary extensions but
+  # found it was altogether too easy to break the build. This approach lets
+  # us avoid building extensions that we know we won't need, and then later
+  # we can use the "profiling" approach to pare back the package even further.
+  #
+  # Be sure to comment _out_ extensions we need in the list below.
+  noExtensions = [
+    "B"
+    "Compress/Raw/Bzip2"
+    "Compress/Raw/Zlib"
+    # "Cwd" # Required by builder.pl.
+    "DB_File"
+    "Data/Dumper"
+    "Devel/PPPort"
+    "Devel/Peek"
+    "Digest/MD5"
+    "Digest/SHA"
+    "Encode"
+    "Fcntl"
+    "File/DosGlob"
+    # "File/Glob" # Required for `./perl -Ilib -I. installperl`.
+    "Filter/Util/Call"
+    "Hash/Util"
+    "Hash/Util/FieldHash"
+    "I18N/Langinfo"
+    # "IO" # Required by builder.pl for IO/Handle.pm.
+    "IPC/SysV"
+    # "List/Util" # Required for Scalar/Util.pm.
+    "MIME/Base64"
+    "Math/BigInt/FastCalc"
+    "NDBM_File"
+    "Opcode"
+    "POSIX"
+    "PerlIO/encoding"
+    "PerlIO/mmap"
+    "PerlIO/via"
+    "SDBM_File"
+    "Socket"
+    "Storable"
+    "Sys/Hostname"
+    "Sys/Syslog"
+    # "Time/HiRes" # Required by builder.pl.
+    "Time/Piece"
+    "Unicode/Collate"
+    "Unicode/Normalize"
+    "XS/APItest"
+    "XS/Typemap"
+    "attributes"
+    "mro"
+    "re" # Required when building pods, but we have disabled.
+    "threads"
+    "threads/shared"
+  ];
+
+in
+perl.overrideAttrs (oldAttrs: {
+  pname = "flox-perl";
+  # No need for man or devdoc outputs.
+  outputs = [ "out" ];
+
+  # Update configureFlags to minimize build.
+  configureFlags = oldAttrs.configureFlags ++ [
+    # Disable shared libperl
+    "-Uuseshrplib"
+    # Optimize for size
+    "-Doptimize=-Os"
+    # No man pages
+    "-Uman1dir"
+    "-Uman3dir"
+    # Disable building of unnecessary extensions.
+    "-Dnoextensions='${lib.concatStringsSep " " noExtensions}'"
+  ];
+
+  # Disable building and installation of pods, strip binaries.
+  makeFlags = (oldAttrs.makeFlags or [ ]) ++ [
+    "generated_pods=" # Disable building of pods.
+    "INSTALLFLAGS=-p" # Don't attempt to install the pod files.
+    "STRIPFLAGS=-s" # Run strip on installed binaries.
+  ];
+
+  postInstall =
+    ''
+      # The upstream hook depends upon $man being defined.
+      man="/no-such-path"
+    ''
+    + oldAttrs.postInstall
+
+    # Can remove once https://github.com/NixOS/nixpkgs/pull/386700
+    # has flowed through to our build (hence the use of --replace-quiet).
+    + (lib.optionalString ((stdenv.cc.fallback_sdk or null) != null) ''
+      substituteInPlace "$out"/lib/perl5/*/*/Config_heavy.pl \
+        --replace-quiet "${stdenv.cc.fallback_sdk}" /no-such-path;
+    '')
+
+    + ''
+      (
+        set -x
+
+        # Remove dependencies in Config_heavy.pl.
+        sed -e '/incpth=/s/.nix.store.[^-]*-/\/no-such-path-/g' \
+          -e 's/\/nix\/store\/[^/]*-coreutils-[^/]*\/bin\///g' \
+          -i "$out"/lib/perl5/*/*/Config_heavy.pl
+
+        # Remove dependency on coreutils in Cwd.pm.
+        sed -e 's/\/nix\/store\/[^/]*-coreutils-[^/]*//g' \
+          -i "$out"/lib/perl5/*/*/Cwd.pm
+
+        # Move over all modules required by the build. The following command
+        # prints out all module files exercised by way of the command, which
+        # itself exercises all of the same inputs used by builder.pl.
+        keeplibs=$(mktemp)
+        $out/bin/perl -MConfig \
+          -e 'do "${perlScript}"; END {
+            foreach my $lib (keys %INC) {
+              next if $lib eq "${perlScript}";
+              if ( -e "$Config{archlib}/$lib" ) {
+                print "$Config{version}/$Config{archname}/$lib\n";
+                my $libBasename = $lib;
+                $libBasename =~ s/\.pm$//;
+                if ( -d "$Config{archlib}/auto/$libBasename" ) {
+                  print "$Config{version}/$Config{archname}/auto/$libBasename\n";
+                }
+              } else {
+                print "$Config{version}/$lib\n";
+              }
+            };
+            print "$Config{version}/$Config{archname}/Config_heavy.pl\n";
+          }' > $keeplibs
+
+        # Create new lib directory.
+        mv $out/lib/perl5 $out/lib/perl5.orig
+        mkdir $out/lib/perl5
+        tar -C $out/lib/perl5.orig -cf - --files-from $keeplibs | tar -C $out/lib/perl5 -xvf -
+        rm -rf $out/lib/perl5.orig
+
+        # Create new bin directory.
+        mv $out/bin $out/bin.orig
+        mkdir $out/bin
+        mv $out/bin.orig/perl $out/bin
+        rm -rf $out/bin.orig
+      )
+    '';
+
+  postFixup = ''
+    (
+      set -x
+      # Remove nix-support.
+      rm -rf $out/nix-support
+    )
+  '';
+
+  # Check only the functionality we actually need.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # The following command exercises the same modules used by builder.pl.
+    (
+      set -x
+      $out/bin/perl -e 'do "${perlScript}"'
+    )
+  '';
+})


### PR DESCRIPTION
## Proposed Changes

A recent packaging regression caused the size of the perl closure to balloon to more than 1GB on Darwin, but even without such bugs the size of perl is much larger than it needs to be.

This patch introduces the new `flox-perl` package which is a build of perl customized as follows:

- reduce the size of the build itself
    - disable shared perl library so that perl remains a single executable
    - added `"-Doptimize='-Os'"` Configure option to optimize for size
    - disable building of man pages
    - disable building of pod files
    - disable building of unnecessary extensions
- reduce the size of the installed package
    - implemented [perl] code to identify modules loaded when invoking `builder.pl`
    - used that file listing to drive a `tar` copy of only the necessary files and remove all others
- remove unnecessary dependencies in the closure
    - `Config_heavy.pl` contained unnecessary package references
    - removed coreutils dependency from `Cwd.pm`

... and now with these changes the flox-perl package has a closure size of less than 5MB on `aarch64-darwin` and can still support the needs of `builder.pl`.

```
flox [limeytexan/default] Michaels-MBP% nix-store -qR `nix-store -qR result | grep flox.perl` | xargs du -sc
160     /nix/store/3s1airkm7ajidqkvyj4x3cxqki38n6nl-libxcrypt-4.4.38
4080    /nix/store/1jbin5q80r6gm4zkqvndi70hvizm4yyy-flox-perl-5.40.0
4240    total
```

## Release Notes

N/A