### PR TITLE
ci: check closure size in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,22 +264,16 @@ jobs:
                 --no-update-lock-file  \
                 --print-out-paths      \
                   "$package";
+              if [[ "$package" = *flox ]]; then
+                  CLOSURE_SIZE=$(nix path-info ./result -S | awk '{print $2}')
+                  echo "closure-size-${{ matrix.system }}=$CLOSURE_SIZE" >> "$GITHUB_OUTPUT"
+                  if [[ "$CLOSURE_SIZE" -gt 320000000 ]]; then # 320MB-ish
+                    echo "  -> $package is too large: $CLOSURE_SIZE";
+                    exit 1;
+                  fi
+              fi
             fi
           done
-
-      - name: "Get closure size"
-        id: "closure"
-        run: |
-          NIX="nix --accept-flake-config --experimental-features 'nix-command flakes'"
-          CLOSURE_SIZE=$(
-            ssh github@$REMOTE_SERVER \
-              -oLogLevel=ERROR \
-              -oUserKnownHostsFile=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE \
-                "$NIX build github:flox/flox/${{ github.sha }}#packages.${{ matrix.system }}.flox &&" \
-                "$NIX path-info -r --json ./result" \
-            | jq '[.[].narSize]|add'
-          )
-          echo "closure-size-${{ matrix.system }}=$CLOSURE_SIZE" >> "$GITHUB_OUTPUT"
 
       - name: "Get Flox version"
         id: "version"


### PR DESCRIPTION
## Proposed Changes
Check closure size in CI

https://github.com/flox/flox/actions/runs/14578433318/job/40889621855#step:5:343
```
/nix/store/j65z0bhyzwpf3wl8isp2hkfdrikvc8fc-flox-1.4.0-g6d5d7d9
  -> .#packages.x86_64-linux.flox is too large: 336151704
Error: Process completed with exit code 1.
```

Will need to merge a few PRs before this check will pass.

## Release Notes
The distribution of flox has been cut in size by more than half, resulting in faster installs, downloads, and overall happiness. 