### PR TITLE
feat: publish narinfo with publish metadata

### DIFF
--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -16,7 +16,6 @@ use flox_rust_sdk::providers::publish::{
 };
 use indoc::{formatdoc, indoc};
 use tracing::{debug, instrument};
-use url::Url;
 
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::ensure_floxhub_token;
@@ -46,11 +45,6 @@ pub struct Publish {
 
 #[derive(Debug, Bpaf, Clone, Default)]
 struct CacheArgs {
-    /// URL of store to copy packages to.
-    /// Takes precedence over a value from 'flox config'.
-    #[bpaf(long, argument("URL"), hide)]
-    store_url: Option<Url>,
-
     /// Which catalog to publish to.
     /// Takes precedence over the default value of the user's GitHub handle.
     #[bpaf(short, long, argument("NAME"))]
@@ -168,13 +162,7 @@ impl Publish {
 
         debug!("publishing package: {}", &package);
         match publish_provider
-            .publish(
-                &flox.catalog_client,
-                &catalog_name,
-                cache_args.store_url,
-                key_file,
-                metadata_only,
-            )
+            .publish(&flox.catalog_client, &catalog_name, key_file, metadata_only)
             .await
         {
             Ok(_) => message::updated(formatdoc! {"

--- a/cli/flox/src/commands/upload.rs
+++ b/cli/flox/src/commands/upload.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::publish::NixCopyCache;
+use flox_rust_sdk::providers::publish::ClientSideCatalogStoreConfig;
 use tracing::instrument;
 use url::Url;
 
@@ -40,16 +40,14 @@ impl Upload {
 
         subcommand_metric!("upload");
 
-        let store_path = validate_store_path(self.store_path)?;
+        let store_path = validate_store_path(self.store_path.clone())?;
 
-        let cache = NixCopyCache {
-            url: self.cache.store_url,
-            key_file: self.cache.signing_key,
-        };
-
-        cache
-            .upload(&store_path.to_string_lossy())
-            .context("Failed to upload artifact")?;
+        ClientSideCatalogStoreConfig::upload_store_path(
+            &self.cache.store_url,
+            &self.cache.signing_key,
+            &store_path.to_string_lossy(),
+        )
+        .context("Failed to upload artifact")?;
 
         message::updated(format!(
             "Store path {} uploaded successfully.",


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**feat: upload nar info with publish metadata**

We now format the raw JSON NAR info into the format expected by the
catalog server and include it as part of the upload process.

**feat: query nar info from catalog after upload**

Now after uploading artifacts to the Catalog Store we query the NAR info
from the egress URI so that we can later massage it (coming in a later
commit) and upload it to the Catalog.

**refactor: abstract over catalog store type**

The existing publish provider and publish command in several places
assume and/or hardcode a `nix copy` Catalog Store. I've refactored the
provider to use a generic `ClientSideCatalogStoreConfig` type instead
that internally handles the details of publishing to particular store
types.

**refactor: remove --store-url option**

This `flox publish` option only existed for testing purposes. It was
discussed synchronously and we decided to remove this option entirely
because it makes it confusing to determine which catalog config states
are invalid.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
