### PR TITLE
WIP: fix: don't clear environment for build activation

### DIFF
--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -23,6 +23,10 @@ use self::errors::IoError;
 /// but for now just use the `CI` environment variable
 pub static IN_CI: LazyLock<bool> = LazyLock::new(|| env::var("CI").is_ok());
 
+pub static WATCHDOG_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
+    PathBuf::from(env::var("WATCHDOG_BIN").unwrap_or(env!("WATCHDOG_BIN").to_string()))
+});
+
 #[derive(Error, Debug)]
 pub enum FindAndReplaceError {
     #[error("walkdir error: {0}")]

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -24,6 +24,7 @@ use flox_rust_sdk::models::manifest::typed::{ActivateMode, IncludeDescriptor, In
 use flox_rust_sdk::providers::build::FLOX_RUNTIME_DIR_VAR;
 use flox_rust_sdk::providers::services::shutdown_process_compose_if_all_processes_stopped;
 use flox_rust_sdk::providers::upgrade_checks::UpgradeInformationGuard;
+use flox_rust_sdk::utils::WATCHDOG_BIN;
 use flox_rust_sdk::utils::logging::traceable_path;
 use indoc::{formatdoc, indoc};
 use itertools::Itertools;
@@ -57,9 +58,6 @@ pub static INTERACTIVE_BASH_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 pub const FLOX_ACTIVATE_START_SERVICES_VAR: &str = "FLOX_ACTIVATE_START_SERVICES";
 pub const FLOX_SERVICES_TO_START_VAR: &str = "_FLOX_SERVICES_TO_START";
-pub static WATCHDOG_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
-    PathBuf::from(env::var("WATCHDOG_BIN").unwrap_or(env!("WATCHDOG_BIN").to_string()))
-});
 pub static FLOX_INTERPRETER: LazyLock<PathBuf> = LazyLock::new(|| {
     PathBuf::from(env::var("FLOX_INTERPRETER").unwrap_or(env!("FLOX_INTERPRETER").to_string()))
 });

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -254,14 +254,14 @@ define BUILD_local_template =
   # environment can leak into the resulting build. For example, each of these
   # activations can prepend to a PYTHONPATH that gets embedded in the
   # build, which has the effect of pulling both environments into the closure.
-  
+
   # We can use `env -i` to prevent that leakage of the "develop" environment
   # path into the inner activation, but then that causes problems for compilers
   # that rely on NIX_CC* environment variables set in the outer activation. To
   # address this problem we maintain a list of ALLOW_OUTER_ENV_VARS allowed
   # to be propagated from the outer to the inner activation, and again use the
   # `env` command to let those through.
-  
+
   # The final result is approximately the following:
   #   $(FLOX_INTERPRETER)/activate ... -- \
   #     env -i $(foreach i,$(ALLOW_OUTER_ENV_VARS),$(i)="$$$$$(i)") \
@@ -274,9 +274,8 @@ define BUILD_local_template =
 	$(_V_) \
 	  $(if $(_virtualSandbox),$(PRELOAD_VARS) FLOX_SRC_DIR=$$$$($(_pwd)) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
 	  $(FLOX_INTERPRETER)/activate --env $(FLOX_ENV) --mode dev --turbo --env-project $$$$($(_pwd)) -- \
-	    $(_env) -i out=$(_out) $(foreach i,$(ALLOW_OUTER_ENV_VARS),$(i)="$$$$$(i)") \
-	      $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) --set-vars -- \
-	        $(_t3) $($(_pvarname)_logfile) -- $(_bash) -e $($(_pvarname)_buildScript)
+	    env out=$(_out) $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) --set-vars -- \
+	      $(_t3) $($(_pvarname)_logfile) -- $(_bash) -e $($(_pvarname)_buildScript)
 	$(_V_) $(_nix) build -L `$(_nix) store add-file "$(shell $(_realpath) "$($(_pvarname)_logfile)")"` \
 	  --out-link "result-$(_pname)-log"
 	$(_V_) set -o pipefail && \

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -274,7 +274,7 @@ define BUILD_local_template =
 	$(_V_) \
 	  $(if $(_virtualSandbox),$(PRELOAD_VARS) FLOX_SRC_DIR=$$$$($(_pwd)) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
 	  $(FLOX_INTERPRETER)/activate --env $(FLOX_ENV) --mode dev --turbo --env-project $$$$($(_pwd)) -- \
-	    env out=$(_out) $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) --set-vars -- \
+	    env -u LIBRARY_PATH out=$(_out) $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) --set-vars -- \
 	      $(_t3) $($(_pvarname)_logfile) -- $(_bash) -e $($(_pvarname)_buildScript)
 	$(_V_) $(_nix) build -L `$(_nix) store add-file "$(shell $(_realpath) "$($(_pvarname)_logfile)")"` \
 	  --out-link "result-$(_pname)-log"

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -273,7 +273,7 @@ define BUILD_local_template =
 	$(_VV_) $(_rm) -rf $(_out)
 	$(_V_) \
 	  $(if $(_virtualSandbox),$(PRELOAD_VARS) FLOX_SRC_DIR=$$$$($(_pwd)) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
-	  $(FLOX_INTERPRETER)/activate --env $(FLOX_ENV) --mode dev --turbo --env-project $$$$($(_pwd)) -- \
+	  $(FLOX_INTERPRETER)/activate --env $(FLOX_ENV) --mode dev --turbo --env-project $$$$($(_pwd)) --watchdog $(WATCHDOG_BIN) -- \
 	    env -u LIBRARY_PATH out=$(_out) $(_build_wrapper_env)/wrapper --env $(_build_wrapper_env) --set-vars -- \
 	      $(_t3) $($(_pvarname)_logfile) -- $(_bash) -e $($(_pvarname)_buildScript)
 	$(_V_) $(_nix) build -L `$(_nix) store add-file "$(shell $(_realpath) "$($(_pvarname)_logfile)")"` \


### PR DESCRIPTION
WIP: needs more discussion, some additional changes if we do settle on this approach, and a test case

Clearing the environment is preventing variables set by the outer activation from getting in to the inner activation.

More specifically, when trying to `flox build`
https://github.com/flox/flox-manifest-build-examples/tree/f8285e85c90144328b5540cbf596fb9c4f138770/quotes-app-cpp we get the error:
```
Rendering quotes-cpp build script to /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T//9b780511-quotes-cpp-build.bash
Building quotes-cpp-0.0.1 in local mode
00:00:00.003944 + mkdir -p /tmp/store_9b780511826ebac591134b75268ca2e1-quotes-cpp-0.0.1/bin /tmp/store_9b780511826ebac591134b75268ca2e1-quotes-cpp-0.0.1/lib /tmp/store_9b780511826ebac591134b75268ca2e1-quotes-cpp-0.0.1/libexec
00:00:00.038850 clang++ -O3 -std=c++17 quotes_server.cpp -o quotes-cpp -lboost_system -lboost_json -pthread
00:00:00.005831 + make
00:00:01.635954 quotes_server.cpp:1:10: fatal error: 'boost/beast.hpp' file not found
00:00:01.635977     1 | #include <boost/beast.hpp>
00:00:01.635979       |          ^~~~~~~~~~~~~~~~~
00:00:01.927974 1 error generated.
00:00:01.929584 make: *** [all] Error 1
make: *** [/nix/store/z99p3mq6fqhajls0fcisdnqlay2jwcpq-package-builder-1.0.0/libexec/flox-build.mk:456: quotes_cpp_local_build] Error 2
❌ ERROR: Build failed with status: exit status: 2
```

Includes cannot be found because "$FLOX_ENV/include" only exists for the outer activation, not the inner one, but we're clearing the environment between the two activations.

TODO: need more discussion about whether we want to choose what parts of outer activation to allow in, or if there are parts of outer activation that we want to keep out

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
