### PR TITLE
fix: remove nix substituter settings from flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,6 @@
 {
   description = "flox - Harness the power of Nix";
 
-  nixConfig.extra-substituters = [ "https://cache.flox.dev" ];
-  nixConfig.extra-trusted-public-keys = [
-    "flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs="
-  ];
-
   # Roll forward monthly as **our** stable branch advances. Note that we also
   # build against the staging branch in CI to detect regressions before they
   # reach stable.


### PR DESCRIPTION
## Proposed Changes

The presence of nix substituter settings always elicits errors for users that have not added themselves as trusted users:
```
flox [limeytexan/default] Michaels-MBP% nix build
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
```

Substituter settings are handled on a system-wide basis by both the Flox installer and the (relatively new) Nix modules so their presence in the flake is unnecessary for anyone who has installed Flox, and presumably everyone developing Flox will have already done that.

Most importantly, we do not want to give the impression that users ought to be adding themselves as trusted users, because that is a well-known way of obtaining root on a system. Our developers should also avoid running as a trusted user so that they will observe / be exposed to the same experience that potential contributers will see when using (and building) Flox.

## Release Notes

N/A