### PR TITLE
feat: Use a proper version number (0.0.0) as default for manifest builds

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -532,7 +532,6 @@ mod tests {
     #[test]
     fn build_no_dollar_out_sandbox_off() {
         let pname = String::from("foo");
-        let name = String::from("foo-unknown");
 
         let manifest = formatdoc! {r#"
             version = 1
@@ -548,11 +547,11 @@ mod tests {
         let output = assert_build_status(&flox, &mut env, &pname, None, false);
 
         let expected_output = formatdoc! {r#"
-            {name}> ❌  ERROR: Build command did not copy outputs to '$out'.
-            {name}>   - copy a single file with 'mkdir -p $out/bin && cp file $out/bin'
-            {name}>   - copy a bin directory with 'mkdir $out && cp -r bin $out'
-            {name}>   - copy multiple files with 'mkdir -p $out/bin && cp bin/* $out/bin'
-            {name}>   - copy files from an Autotools project with 'make install PREFIX=$out'
+            {pname}> ❌  ERROR: Build command did not copy outputs to '$out'.
+            {pname}>   - copy a single file with 'mkdir -p $out/bin && cp file $out/bin'
+            {pname}>   - copy a bin directory with 'mkdir $out && cp -r bin $out'
+            {pname}>   - copy multiple files with 'mkdir -p $out/bin && cp bin/* $out/bin'
+            {pname}>   - copy files from an Autotools project with 'make install PREFIX=$out'
         "#};
         assert!(
             output.stderr.contains(&expected_output),
@@ -563,7 +562,6 @@ mod tests {
     #[test]
     fn build_no_dollar_out_sandbox_pure() {
         let pname = String::from("foo");
-        let name = String::from("foo-unknown");
 
         let manifest = formatdoc! {r#"
             version = 1
@@ -582,11 +580,11 @@ mod tests {
         let output = assert_build_status(&flox, &mut env, &pname, None, false);
 
         let expected_output = formatdoc! {r#"
-            {name}> ❌  ERROR: Build command did not copy outputs to '$out'.
-            {name}>   - copy a single file with 'mkdir -p $out/bin && cp file $out/bin'
-            {name}>   - copy a bin directory with 'mkdir $out && cp -r bin $out'
-            {name}>   - copy multiple files with 'mkdir -p $out/bin && cp bin/* $out/bin'
-            {name}>   - copy files from an Autotools project with 'make install PREFIX=$out'
+            {pname}> ❌  ERROR: Build command did not copy outputs to '$out'.
+            {pname}>   - copy a single file with 'mkdir -p $out/bin && cp file $out/bin'
+            {pname}>   - copy a bin directory with 'mkdir $out && cp -r bin $out'
+            {pname}>   - copy multiple files with 'mkdir -p $out/bin && cp bin/* $out/bin'
+            {pname}>   - copy files from an Autotools project with 'make install PREFIX=$out'
         "#};
         assert!(
             output.stderr.contains(&expected_output),
@@ -606,7 +604,6 @@ mod tests {
     ///   including subdirectories of {bin,sbin,libexec}
     fn build_verify_sane_out(mode: &str) {
         let pname = String::from("foo");
-        let name = String::from("foo-unknown");
 
         let manifest = formatdoc! {r#"
             version = 1
@@ -639,18 +636,18 @@ mod tests {
         // [sic] newline before 'HINT: ...' ignored in 'nix build -L' output:
         // <https://github.com/NixOS/nix/issues/11991>
         let expected_output = formatdoc! {r#"
-            {name}> ⚠️  WARNING: $out/bin/not-executable is not executable.
-            {name}> ⚠️  WARNING: $out/bin/subdir is not a file.
-            {name}> ⚠️  WARNING: No executables found in '$out/bin'.
-            {name}> Only executables in '$out/bin' will be available on the PATH.
-            {name}> If your build produces executables, make sure they are copied to '$out/bin'.
-            {name}>   - copy a single file with 'mkdir -p $out/bin && cp file $out/bin'
-            {name}>   - copy a bin directory with 'mkdir $out && cp -r bin $out'
-            {name}>   - copy multiple files with 'mkdir -p $out/bin && cp bin/* $out/bin'
-            {name}>   - copy files from an Autotools project with 'make install PREFIX=$out'
-            {name}> HINT: The following executables were found outside of '$out/bin':
-            {name}>   - not-bin/hello
-            {name}>   - bin/subdir/executable-in-subdir
+            {pname}> ⚠️  WARNING: $out/bin/not-executable is not executable.
+            {pname}> ⚠️  WARNING: $out/bin/subdir is not a file.
+            {pname}> ⚠️  WARNING: No executables found in '$out/bin'.
+            {pname}> Only executables in '$out/bin' will be available on the PATH.
+            {pname}> If your build produces executables, make sure they are copied to '$out/bin'.
+            {pname}>   - copy a single file with 'mkdir -p $out/bin && cp file $out/bin'
+            {pname}>   - copy a bin directory with 'mkdir $out && cp -r bin $out'
+            {pname}>   - copy multiple files with 'mkdir -p $out/bin && cp bin/* $out/bin'
+            {pname}>   - copy files from an Autotools project with 'make install PREFIX=$out'
+            {pname}> HINT: The following executables were found outside of '$out/bin':
+            {pname}>   - not-bin/hello
+            {pname}>   - bin/subdir/executable-in-subdir
         "#};
         assert!(
             output.stderr.contains(&expected_output),

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -254,14 +254,14 @@ define BUILD_local_template =
   # environment can leak into the resulting build. For example, each of these
   # activations can prepend to a PYTHONPATH that gets embedded in the
   # build, which has the effect of pulling both environments into the closure.
-  
+
   # We can use `env -i` to prevent that leakage of the "develop" environment
   # path into the inner activation, but then that causes problems for compilers
   # that rely on NIX_CC* environment variables set in the outer activation. To
   # address this problem we maintain a list of ALLOW_OUTER_ENV_VARS allowed
   # to be propagated from the outer to the inner activation, and again use the
   # `env` command to let those through.
-  
+
   # The final result is approximately the following:
   #   $(FLOX_INTERPRETER)/activate ... -- \
   #     env -i $(foreach i,$(ALLOW_OUTER_ENV_VARS),$(i)="$$$$$(i)") \
@@ -483,7 +483,7 @@ $(foreach build,$(BUILDS), \
   $(eval _sandbox = $(shell \
     $(_jq) -r '.manifest.build."$(_pname)".sandbox' $(MANIFEST_LOCK))) \
   $(eval _version = $(shell \
-    $(_jq) -r '.manifest.build."$(_pname)".version // "unknown"' $(MANIFEST_LOCK))) \
+    $(_jq) -r '.manifest.build."$(_pname)".version // "0.0.0"' $(MANIFEST_LOCK))) \
   $(if $(filter null off,$(_sandbox)), \
     $(eval $(call BUILD_template,local)), \
     $(eval $(call BUILD_template,nix_sandbox))))


### PR DESCRIPTION
## Proposed Changes

Previously, the default version for manifest builds was `unknown`. While
technically valid, this leads to the string `unknown` appearing in
places like `flox show` where a version number is reasonably expected.

This changes the default to 0.0.0 which, while still being relatively
meaningless, at least looks and feels like a version number.

## Release Notes


<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->