### PR TITLE
fix(config): Parse unquoted TOML keys

### DIFF
--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -209,7 +209,7 @@ EOF
 @test "m10.2: 'activate --remote' succeeds if trusted by config" {
   make_empty_remote_env
 
-  run "$FLOX_BIN" config --set "trusted_environments.'$OWNER/test'" "trust"
+  run "$FLOX_BIN" config --set "trusted_environments.$OWNER/test" "trust"
   run "$FLOX_BIN" activate --remote "$OWNER/test" -- true
   assert_success
 }
@@ -217,7 +217,7 @@ EOF
 @test "m10.2: 'activate' succeeds if included remote environment is trusted by config" {
   make_composer_with_remote_include
 
-  run "$FLOX_BIN" config --set "trusted_environments.'$OWNER/test'" "trust"
+  run "$FLOX_BIN" config --set "trusted_environments.$OWNER/test" "trust"
   run "$FLOX_BIN" activate -- true
   assert_success
 }
@@ -226,7 +226,7 @@ EOF
 @test "m10.2: 'activate --remote' succeeds if trusted by config (case-sensitive)" {
   make_empty_remote_env CaseSensitive
 
-  run "$FLOX_BIN" config --set "trusted_environments.'$OWNER/CaseSensitive'" "trust"
+  run "$FLOX_BIN" config --set "trusted_environments.$OWNER/CaseSensitive" "trust"
   run "$FLOX_BIN" activate --remote "$OWNER/CaseSensitive" -- true
   assert_success
 }
@@ -237,7 +237,7 @@ EOF
 @test "m10.3: 'activate --remote' fails if denied by config, --trust overrides" {
   make_empty_remote_env
 
-  run "$FLOX_BIN" config --set "trusted_environments.'$OWNER/test'" "deny"
+  run "$FLOX_BIN" config --set "trusted_environments.$OWNER/test" "deny"
 
   run "$FLOX_BIN" activate --remote "$OWNER/test" -- true
   assert_failure
@@ -249,7 +249,7 @@ EOF
 @test "m10.0: 'activate' fails if included remote environment is denied by config" {
   make_composer_with_remote_include
 
-  run "$FLOX_BIN" config --set "trusted_environments.'$OWNER/test'" "deny"
+  run "$FLOX_BIN" config --set "trusted_environments.$OWNER/test" "deny"
   run "$FLOX_BIN" activate --trust -- true
   assert_failure
   assert_output --partial "The included environment $OWNER/test is not trusted."


### PR DESCRIPTION
## Proposed Changes

Allow TOML keys such as `trusted_environments.foo/bar` to be parsed without requiring any additional quoting from the user.

This fixes a regression that I introduced in 841d6b47 (not currently in a release version) where I accidentally dropped the quoting from some uses of the key, which prevented trust choices from being saved:

    % flox activate -r nicklewis/example
    ⚠️  The environment nicklewis/example is not trusted.

    flox environments do not run in a sandbox.
    Activation hooks can run arbitrary code on your machine.
    Thus, environments need to be trusted to be activated.
    > Do you trust the environment nicklewis/example? Trust, save choice
    ❌ ERROR: Could not write token to config: Could not parse key: TOML parse error at line 1, column 31
      |
    1 | trusted_environments.nicklewis/example
      |                               ^

It also fixes a longer standing bug from 1938 where the commands that we give for users to run don't work:

    % flox activate -r nicklewis/example
    ❌ ERROR: Environment nicklewis/example is not trusted.

    Run 'flox config --set trusted_environments.nicklewis/example trust' to trust it.
    % flox config --set trusted_environments.nicklewis/example trust
    ❌ ERROR: Could not parse key: TOML parse error at line 1, column 31
      |
    1 | trusted_environments.nicklewis/example
      |                               ^

## Release Notes

`flox config --set` accepts nested keys with non-alphanumeric characters without requiring quoting, such as saving trust for remote environments.