### PR TITLE
feat(publish): FloxHub auth on remote stores

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -147,6 +147,7 @@ pub struct CheckedBuildMetadata {
 }
 
 /// Configuration for uploading to or downloading from a catalog store.
+#[allow(clippy::large_enum_variant)] // TODO: Remove after implementing `Publisher`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ClientSideCatalogStoreConfig {
     /// A `nix copy`-compatible Catalog Store (typically an S3 bucket).


### PR DESCRIPTION
## Proposed Changes

**feat(publish): FloxHub auth on nix-copy to ingress**

Pass a FloxHub token on `nix copy` calls to known FloxHub authenticated
store hostnames. These hostnames are currently hardcoded whilst we
figure out how we will provide multi-tenancy.

I've provided a helper function and then passed the file into the
publisher, rather than passing the token in, so that we don't have to
thread `flox.temp_dir` all the way through and it has symmetry with the
existing signing key argument.

It isn't wrapped in an `Option<>` because it's subject to change (as
above), may cause mistakes if it's sometimes not passed, and has no
effect for non-FloxHub store URIs.

Support for reading narinfo from the egress URI with auth will follow in
a separate commit.

**feat(publish): FloxHub auth on narinfo from egress**

Apply the same auth when fetching narinfo from an egress URI as we do
for `nix copy` to an ingress URI.

You won't however yet be able to substitute from one of these FloxHub
authenticated stores, which will need to be implemented in buildenv.

## Testing

It's hard to test this at the moment because we're still exploring automated testing in https://github.com/flox/catalog-server/issues/304 and the infra isn't quite setup to test this manually. You can follow the `catalog-util` instructions in https://github.com/flox/floxhub/issues/15#issuecomment-2814377554 and then run `flox publish` (without any `NIX_CONFIG` options) but there's a server-side issue being discussed in https://flox-dev.slack.com/archives/C08E9HSS6TV/p1745582551775389

## Release Notes

N/A
