### PR TITLE
fix: don't hardcode gc roots tempdir

### DIFF
--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -312,6 +312,8 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
 
             This is likely due to a corrupt environment.
         "},
+
+        CoreEnvironmentError::CreateTempdir(_) => display_chain(err),
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This is meant to address an issue we've seen in CI where a hardcoded temporary directory used to store GC roots during a build is owned by the wrong user.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
