### PR TITLE
feat: add authentication for publisher

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -114,15 +114,20 @@ pub struct Features {
 pub static DEFAULT_FLOXHUB_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://hub.flox.dev").unwrap());
 
+/// Assertions about the owner of this token
 #[derive(Debug, Clone, Deserialize)]
 struct FloxTokenClaims {
+    /// The FloxHub handle of the user this token belongs to
     #[serde(rename = "https://flox.dev/handle")]
     handle: String,
 }
 
+/// A token authenticating a user with FloxHub
 #[derive(Debug, Clone, DeserializeFromStr)]
 pub struct FloxhubToken {
+    /// The entire token as a string
     token: String,
+    /// Assertions about the identity of the token's owner
     token_data: FloxTokenClaims,
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -23,6 +23,7 @@ use super::manifest::raw::PackageToInstall;
 use super::manifest::typed::{ActivateMode, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
 use crate::flox::{Flox, Floxhub};
+use crate::providers::auth::AuthError;
 use crate::providers::buildenv::BuildEnvOutputs;
 use crate::providers::git::{
     GitCommandDiscoverError,
@@ -734,6 +735,9 @@ pub enum EnvironmentError {
     /// An error flox edit can recover from
     #[error(transparent)]
     Recoverable(RecoverableMergeError),
+
+    #[error("authentication error")]
+    Auth(#[source] AuthError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/cli/flox-rust-sdk/src/providers/auth.rs
+++ b/cli/flox-rust-sdk/src/providers/auth.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use crate::flox::FloxhubToken;
+
+/// Handles authentication with catalog stores during build and publish.
+#[derive(Debug)]
+pub struct Auth {
+    /// The directory in which we'll create an ad-hoc netrc file if needed.
+    netrc_tempdir: TempDir,
+    /// The user's FloxHub authentication token.
+    floxhub_token: Option<FloxhubToken>,
+}
+
+impl Auth {
+    /// Get a reference to the user's token (which may be expired).
+    pub fn token(&self) -> Option<&FloxhubToken> {
+        self.floxhub_token.as_ref()
+    }
+
+    /// Get the location of the tempdir in which an ad-hoc netrc
+    /// can be created.
+    pub fn tempdir_path(&self) -> &Path {
+        self.netrc_tempdir.path()
+    }
+}

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod build;
 pub mod buildenv;
 pub mod catalog;

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -6,6 +6,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::models::lockfile::Lockfile;
 use flox_rust_sdk::models::manifest::typed::{Inner, Manifest};
+use flox_rust_sdk::providers::auth::write_floxhub_netrc;
 use flox_rust_sdk::providers::build::FloxBuildMk;
 use flox_rust_sdk::providers::publish::{
     PublishProvider,
@@ -13,7 +14,6 @@ use flox_rust_sdk::providers::publish::{
     build_repo_err,
     check_build_metadata,
     check_environment_metadata,
-    write_floxhub_netrc,
 };
 use indoc::{formatdoc, indoc};
 use tracing::{debug, instrument};

--- a/cli/flox/src/commands/upload.rs
+++ b/cli/flox/src/commands/upload.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::publish::{ClientSideCatalogStoreConfig, write_floxhub_netrc};
+use flox_rust_sdk::providers::auth::write_floxhub_netrc;
+use flox_rust_sdk::providers::publish::ClientSideCatalogStoreConfig;
 use tracing::instrument;
 use url::Url;
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -312,8 +312,8 @@ pub fn format_core_error(err: &CoreEnvironmentError) -> String {
 
             This is likely due to a corrupt environment.
         "},
-
         CoreEnvironmentError::CreateTempdir(_) => display_chain(err),
+        CoreEnvironmentError::Auth(err) => display_chain(err),
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

**feat: use auth provider in publish**

This simply replaces the existing calls to `write_floxhub_netrc` with
calls to the auth provider.

**feat: use auth provider in buildenv**

The tricky part in buildenv is that we don't know which stores need auth
beforehand aside from two hardcoded cases:
- `https://cache.nixos.org`
- `daemon`

I don't *really* understand the second one, but Tom claims that it's a
valid value, so I've hardcoded that as well (some of our tests use it,
but without comments on those tests it's hard to tell if those are just
test values or something real).

The existing logic does a pre-build check to make sure that all of the
store paths required to build the environment are substitutable.
Different store paths may be on different stores, so we iterate over
the store paths and the list of stores they can be found in just in case
one store isn't available and another is.

The problem comes from the fact that with build and publish, some stores
require authentication. If you need an auth token and don't have one,
that's an error *for this store*, but there might be another store that
doesn't require auth. So, this adds some complexity to handle that we
don't want to look up an auth token until we have to, and after that
we don't want to error immediately if the token is missing.

**refactor: move write_floxhub_netrc**

Since this function is only going to be used from the auth provider, it
makes sense to move this here. I'm hoping that we can move _all_ auth
logic to this provider over time.

**feat: add auth provider to buildenv**

This adds the `AuthError` type and an `AuthProvider` trait so that we
can mock this with a dummy provider at some point if we want to. At some
point we will need to come up with a solution for bubbling up auth
errors that arise in buildenv and publish. Right now we require a token
for publish, which makes sense, and since we require it we can check for
it early. That's not really the case for buildenv since you don't need
to be logged in just to build an environment.

**feat: add auth provider**

This adds an `Auth` provider that will be passed to the buildenv and
publish providers. Since this is supposed to be added to those providers
unconditionally, it needs to be constructible without a FloxHub token
in order to support someone building an environment without being logged
in.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
