### PR TITLE
fix: align spinner vocab with guidelines

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -708,7 +708,7 @@ impl Lockfile {
     /// re-fetched.
     /// If to_upgrade is None, only included environments not in the seed lockfile
     /// are fetched.
-    #[instrument(skip_all, fields(progress = "Merging environment includes"))]
+    #[instrument(skip_all, fields(progress = "Composing environments"))]
     fn merge_manifest(
         flox: &Flox,
         manifest: &Manifest,


### PR DESCRIPTION
We try to avoid using `includes`

## Release Notes

Spinner wording change so probably NA