### PR TITLE
fix: seekable http

### DIFF
--- a/cli/flox-rust-sdk/src/providers/auth.rs
+++ b/cli/flox-rust-sdk/src/providers/auth.rs
@@ -7,7 +7,7 @@ use tempfile::{NamedTempFile, TempDir, TempPath, tempdir_in};
 use crate::flox::{Flox, FloxhubToken};
 
 /// Hostnames that are authenticated with FloxHub credentials.
-const FLOXHUB_AUTHENTICATED_HOSTNAMES: [&str; 7] = [
+const FLOXHUB_AUTHENTICATED_HOSTNAMES: [&str; 8] = [
     "publisher.flox.dev",
     "publisher.preview.flox.dev",
     "api.preview2.flox.dev",
@@ -16,6 +16,7 @@ const FLOXHUB_AUTHENTICATED_HOSTNAMES: [&str; 7] = [
     "experimental-publisher.preview.flox.dev",
     "experimental-publisher.preview2.flox.dev", // deltaops
     "cache.floxware.com",                       // Tom
+    "localhost",
 ];
 
 pub trait AuthProvider {

--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -30,6 +30,7 @@ nixVersions."${nixVersion}".overrideAttrs (prev: {
   # Apply patch files.
   patches = prev.patches ++ [
     (builtins.path { path = ./patches/multiple-github-tokens.2.24.9.patch; })
+    (builtins.path { path = ./patches/seekable_http.patch; })
     # Backport of upstream PR targeting nix >= 2.27
     # <https://github.com/NixOS/nix/pull/12580>
     (builtins.path {

--- a/pkgs/nix/patches/seekable_http.patch
+++ b/pkgs/nix/patches/seekable_http.patch
@@ -1,0 +1,50 @@
+From bb56ff51f095d7ed3225ad3ee53e279b0486c737 Mon Sep 17 00:00:00 2001
+From: Thomas Bereknyei <tomberek@gmail.com>
+Date: Thu, 1 May 2025 02:28:17 -0400
+Subject: [PATCH] fix: allow redirected HTTP uploads
+
+When a PUT is redirected, some of the data can be sent by curl before headers are read. This means the subsequent PUT operation needs to seek back to origin.
+---
+ src/libstore/filetransfer.cc | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/src/libstore/filetransfer.cc b/src/libstore/filetransfer.cc
+index 8fc4f14f2..ca19011ca 100644
+--- a/src/libstore/filetransfer.cc
++++ b/src/libstore/filetransfer.cc
+@@ -312,6 +312,23 @@ struct curlFileTransfer : public FileTransfer
+         }
+         #endif
+ 
++        size_t seekCallback(curl_off_t offset, int origin)
++        {
++            if (origin == SEEK_SET) {
++            readOffset = offset;
++            } else if (origin == SEEK_CUR) {
++            readOffset += offset;
++            } else if (origin == SEEK_END) {
++            readOffset = request.data->length() + offset;
++            }
++            return CURL_SEEKFUNC_OK;
++        }
++
++        static size_t seekCallbackWrapper(void *clientp, curl_off_t offset, int origin)
++        {
++            return ((TransferItem *) clientp)->seekCallback(offset, origin);
++        }
++
+         void init()
+         {
+             if (!req) req = curl_easy_init();
+@@ -364,6 +381,8 @@ struct curlFileTransfer : public FileTransfer
+                 curl_easy_setopt(req, CURLOPT_READFUNCTION, readCallbackWrapper);
+                 curl_easy_setopt(req, CURLOPT_READDATA, this);
+                 curl_easy_setopt(req, CURLOPT_INFILESIZE_LARGE, (curl_off_t) request.data->length());
++                curl_easy_setopt(req, CURLOPT_SEEKFUNCTION, seekCallbackWrapper);
++                curl_easy_setopt(req, CURLOPT_SEEKDATA, this);
+             }
+ 
+             if (request.verifyTLS) {
+-- 
+2.49.0
+


### PR DESCRIPTION
## Proposed Changes
Support PUT operations that are redirected. Currently they are broken because the http implementation in Nix didn't/couldn't rewind the data.

The patch is merged upstream at: https://github.com/NixOS/nix/pull/13121 , available in 2.28

Also adds localhost for sending netrc auth, useful for testing. 

## Release Notes
N/A
