### PR TITLE
test: C++ includes work for manifest builds

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/start.bash
+++ b/assets/environment-interpreter/activate/activate.d/start.bash
@@ -4,6 +4,11 @@ _flox_activations="@flox_activations@"
 _sed="@gnused@/bin/sed"
 _sort="@coreutils@/bin/sort"
 
+# Run activate hook
+# If $1 is an empty string, the environment is not captured,
+# and the activation is not added to the activation registry.
+# If $1 is not empty, it is used to capture the environment changes made by the
+# hook.
 start() {
   _flox_activation_state_dir="${1?}"
   shift

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1411,7 +1411,7 @@ mod tests {
         let bin_name = String::from("links-against-libc");
         let source_name = String::from("main.go");
 
-        let (mut flox, _temp_dir_handle) = flox_instance();
+        let (flox, _temp_dir_handle) = flox_instance();
         let mut env =
             new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/go_gcc"));
         let env_path = env.parent_path().unwrap();
@@ -1454,7 +1454,6 @@ mod tests {
         "#};
         fs::write(env_path.join(source_name), source_code).unwrap();
 
-        reset_mocks_from_file(&mut flox.catalog_client, "envs/go_gcc.json");
         assert_build_status(&flox, &mut env, &package_name, None, true);
 
         let result_path = result_dir(&env_path, &package_name)

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -414,6 +414,19 @@ post_cmd = '''
     cp .flox/env/manifest.lock "$env_dir/manifest.lock"
 '''
 
+[envs.gcc_boost]
+skip_if_output_exists = "envs/gcc_boost"
+files = ["envs/gcc_boost/manifest.toml"]
+pre_cmd = "flox init"
+cmd = "flox edit -f manifest.toml"
+post_cmd = '''
+    envs_output_dir="$(dirname $RESPONSE_FILE)"
+    env_dir="$envs_output_dir/gcc_boost"
+    mkdir -p "$env_dir"
+    cp .flox/env/manifest.toml "$env_dir/manifest.toml"
+    cp .flox/env/manifest.lock "$env_dir/manifest.lock"
+'''
+
 [envs.kitchen_sink]
 skip_if_output_exists = "envs/kitchen_sink"
 files = ["envs/kitchen_sink/manifest.toml"]

--- a/test_data/generated/envs/gcc_boost.json
+++ b/test_data/generated/envs/gcc_boost.json
@@ -1,0 +1,340 @@
+[
+  [
+    {
+      "msgs": [],
+      "name": "toplevel",
+      "page": {
+        "complete": true,
+        "msgs": [],
+        "packages": [
+          {
+            "attr_path": "boost",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/ff5bi94rln1sn2sf2f94i9bf2hdvp3bp-boost-1.87.0.drv",
+            "description": "Collection of C++ libraries",
+            "insecure": false,
+            "install_id": "boost",
+            "license": "BSL-1.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "missing_builds": false,
+            "name": "boost-1.87.0",
+            "outputs": [
+              {
+                "name": "dev",
+                "store_path": "/nix/store/m0lbd92s17lv8acpx24bvkqlvcffnaay-boost-1.87.0-dev"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/9j9i692sqpwqhnnjijwqqcgy0s29jjnz-boost-1.87.0"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pkg_path": "boost",
+            "pname": "boost",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T04:19:28.064194Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "1.87.0"
+          },
+          {
+            "attr_path": "boost",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/qpg06681lmm4jqxqfxcax4lm5zswxsby-boost-1.87.0.drv",
+            "description": "Collection of C++ libraries",
+            "insecure": false,
+            "install_id": "boost",
+            "license": "BSL-1.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "missing_builds": false,
+            "name": "boost-1.87.0",
+            "outputs": [
+              {
+                "name": "dev",
+                "store_path": "/nix/store/v0ixxvl534xa0q92vwyfv82yq0s4gw4m-boost-1.87.0-dev"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/l5bpd8b0flqwdcg1y5b7nj0d19f8nzhv-boost-1.87.0"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pkg_path": "boost",
+            "pname": "boost",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T04:37:19.337222Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "1.87.0"
+          },
+          {
+            "attr_path": "boost",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/awlgym16vgbs5jc0m1684l79lbqdabwi-boost-1.87.0.drv",
+            "description": "Collection of C++ libraries",
+            "insecure": false,
+            "install_id": "boost",
+            "license": "BSL-1.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "missing_builds": false,
+            "name": "boost-1.87.0",
+            "outputs": [
+              {
+                "name": "dev",
+                "store_path": "/nix/store/wlyxcy9q7f84fwqn09i22hvrkck4dmfk-boost-1.87.0-dev"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/0jv6piv83bgg5hd1p66wqvzagarx4pix-boost-1.87.0"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pkg_path": "boost",
+            "pname": "boost",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T04:54:29.086426Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "1.87.0"
+          },
+          {
+            "attr_path": "boost",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/xd5xcp0wrs4gnz73dla4283qcvcpvynk-boost-1.87.0.drv",
+            "description": "Collection of C++ libraries",
+            "insecure": false,
+            "install_id": "boost",
+            "license": "BSL-1.0",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "missing_builds": false,
+            "name": "boost-1.87.0",
+            "outputs": [
+              {
+                "name": "dev",
+                "store_path": "/nix/store/ijdpzk8xcsq77k4g4fy19wr88d6s8pmg-boost-1.87.0-dev"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/32fx4d098fs4valykv92p41fkmfy1yc9-boost-1.87.0"
+              }
+            ],
+            "outputs_to_install": [
+              "out"
+            ],
+            "pkg_path": "boost",
+            "pname": "boost",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T05:15:54.133805Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "1.87.0"
+          },
+          {
+            "attr_path": "gcc",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/6r879yr3znvy5yjkirwjz5ahl9gdqa0g-gcc-wrapper-14.2.1.20250322.drv",
+            "description": "GNU Compiler Collection, version 14.2.1.20250322 (wrapper script)",
+            "insecure": false,
+            "install_id": "gcc",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "missing_builds": false,
+            "name": "gcc-wrapper-14.2.1.20250322",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/8wfzzn50wm0zdr14l8ri6fzhswdwsw6l-gcc-wrapper-14.2.1.20250322-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/xh3cx77w64nf1lwszik07vx2lan9l8jj-gcc-wrapper-14.2.1.20250322"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/agglx345hbig4x5frmj7mwwnhq8xlxlh-gcc-wrapper-14.2.1.20250322-info"
+              }
+            ],
+            "outputs_to_install": [
+              "man",
+              "out"
+            ],
+            "pkg_path": "gcc",
+            "pname": "gcc",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T04:19:29.090218Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-darwin",
+            "unfree": false,
+            "version": "14.2.1.20250322"
+          },
+          {
+            "attr_path": "gcc",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/mvq26ns0vkglyz35x6zd6jn1dvpr0wvx-gcc-wrapper-14.2.1.20250322.drv",
+            "description": "GNU Compiler Collection, version 14.2.1.20250322 (wrapper script)",
+            "insecure": false,
+            "install_id": "gcc",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "missing_builds": false,
+            "name": "gcc-wrapper-14.2.1.20250322",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/km6mm6rmh1p2av5vw37skaprgrd293vl-gcc-wrapper-14.2.1.20250322-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/rpxlridr3yn6mbmd34r0bya9qv91b79s-gcc-wrapper-14.2.1.20250322"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/7y6glm22qfb7sw1ybf0lgi5ml9ra278b-gcc-wrapper-14.2.1.20250322-info"
+              }
+            ],
+            "outputs_to_install": [
+              "man",
+              "out"
+            ],
+            "pkg_path": "gcc",
+            "pname": "gcc",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T04:37:20.415079Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "aarch64-linux",
+            "unfree": false,
+            "version": "14.2.1.20250322"
+          },
+          {
+            "attr_path": "gcc",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/awwvcwwanflz00ns50g61lyklg72cxm7-gcc-wrapper-14.2.1.20250322.drv",
+            "description": "GNU Compiler Collection, version 14.2.1.20250322 (wrapper script)",
+            "insecure": false,
+            "install_id": "gcc",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "missing_builds": false,
+            "name": "gcc-wrapper-14.2.1.20250322",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/skqvyhvi7mc2iyvcsi3jw9x5w1r2gw2k-gcc-wrapper-14.2.1.20250322-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/lvil1wrw3cgd8dbcjlvhm7728fhpq27k-gcc-wrapper-14.2.1.20250322"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/ldw9g57kj17ywcmwr2h7z4aw4rfr6438-gcc-wrapper-14.2.1.20250322-info"
+              }
+            ],
+            "outputs_to_install": [
+              "man",
+              "out"
+            ],
+            "pkg_path": "gcc",
+            "pname": "gcc",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T04:54:29.718062Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-darwin",
+            "unfree": false,
+            "version": "14.2.1.20250322"
+          },
+          {
+            "attr_path": "gcc",
+            "broken": false,
+            "catalog": "nixpkgs",
+            "derivation": "/nix/store/7chb1402lr3jgd7sxcbj3v01l97kvs3h-gcc-wrapper-14.2.1.20250322.drv",
+            "description": "GNU Compiler Collection, version 14.2.1.20250322 (wrapper script)",
+            "insecure": false,
+            "install_id": "gcc",
+            "license": "GPL-3.0-or-later",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "missing_builds": false,
+            "name": "gcc-wrapper-14.2.1.20250322",
+            "outputs": [
+              {
+                "name": "man",
+                "store_path": "/nix/store/1icxr998a24dfw4dk30v4n8kwdl0v29y-gcc-wrapper-14.2.1.20250322-man"
+              },
+              {
+                "name": "out",
+                "store_path": "/nix/store/f0m6caffiykyvsjim9376a3hx2yj2ghj-gcc-wrapper-14.2.1.20250322"
+              },
+              {
+                "name": "info",
+                "store_path": "/nix/store/rs9pvqy38dx84320sxf7ql4ppv2k4rhj-gcc-wrapper-14.2.1.20250322-info"
+              }
+            ],
+            "outputs_to_install": [
+              "man",
+              "out"
+            ],
+            "pkg_path": "gcc",
+            "pname": "gcc",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T05:15:55.338399Z",
+            "stabilities": [
+              "unstable"
+            ],
+            "system": "x86_64-linux",
+            "unfree": false,
+            "version": "14.2.1.20250322"
+          }
+        ],
+        "page": 793735,
+        "url": ""
+      }
+    }
+  ]
+]

--- a/test_data/generated/envs/gcc_boost/manifest.lock
+++ b/test_data/generated/envs/gcc_boost/manifest.lock
@@ -1,0 +1,265 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "boost": {
+        "pkg-path": "boost"
+      },
+      "gcc": {
+        "pkg-path": "gcc"
+      }
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "boost",
+      "broken": false,
+      "derivation": "/nix/store/ff5bi94rln1sn2sf2f94i9bf2hdvp3bp-boost-1.87.0.drv",
+      "description": "Collection of C++ libraries",
+      "install_id": "boost",
+      "license": "BSL-1.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "boost-1.87.0",
+      "pname": "boost",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:19:28.064194Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.87.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/m0lbd92s17lv8acpx24bvkqlvcffnaay-boost-1.87.0-dev",
+        "out": "/nix/store/9j9i692sqpwqhnnjijwqqcgy0s29jjnz-boost-1.87.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "boost",
+      "broken": false,
+      "derivation": "/nix/store/qpg06681lmm4jqxqfxcax4lm5zswxsby-boost-1.87.0.drv",
+      "description": "Collection of C++ libraries",
+      "install_id": "boost",
+      "license": "BSL-1.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "boost-1.87.0",
+      "pname": "boost",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:37:19.337222Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.87.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/v0ixxvl534xa0q92vwyfv82yq0s4gw4m-boost-1.87.0-dev",
+        "out": "/nix/store/l5bpd8b0flqwdcg1y5b7nj0d19f8nzhv-boost-1.87.0"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "boost",
+      "broken": false,
+      "derivation": "/nix/store/awlgym16vgbs5jc0m1684l79lbqdabwi-boost-1.87.0.drv",
+      "description": "Collection of C++ libraries",
+      "install_id": "boost",
+      "license": "BSL-1.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "boost-1.87.0",
+      "pname": "boost",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:54:29.086426Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.87.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/wlyxcy9q7f84fwqn09i22hvrkck4dmfk-boost-1.87.0-dev",
+        "out": "/nix/store/0jv6piv83bgg5hd1p66wqvzagarx4pix-boost-1.87.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "boost",
+      "broken": false,
+      "derivation": "/nix/store/xd5xcp0wrs4gnz73dla4283qcvcpvynk-boost-1.87.0.drv",
+      "description": "Collection of C++ libraries",
+      "install_id": "boost",
+      "license": "BSL-1.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "boost-1.87.0",
+      "pname": "boost",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T05:15:54.133805Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.87.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/ijdpzk8xcsq77k4g4fy19wr88d6s8pmg-boost-1.87.0-dev",
+        "out": "/nix/store/32fx4d098fs4valykv92p41fkmfy1yc9-boost-1.87.0"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gcc",
+      "broken": false,
+      "derivation": "/nix/store/6r879yr3znvy5yjkirwjz5ahl9gdqa0g-gcc-wrapper-14.2.1.20250322.drv",
+      "description": "GNU Compiler Collection, version 14.2.1.20250322 (wrapper script)",
+      "install_id": "gcc",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "gcc-wrapper-14.2.1.20250322",
+      "pname": "gcc",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:19:29.090218Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "14.2.1.20250322",
+      "outputs_to_install": [
+        "man",
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/agglx345hbig4x5frmj7mwwnhq8xlxlh-gcc-wrapper-14.2.1.20250322-info",
+        "man": "/nix/store/8wfzzn50wm0zdr14l8ri6fzhswdwsw6l-gcc-wrapper-14.2.1.20250322-man",
+        "out": "/nix/store/xh3cx77w64nf1lwszik07vx2lan9l8jj-gcc-wrapper-14.2.1.20250322"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gcc",
+      "broken": false,
+      "derivation": "/nix/store/mvq26ns0vkglyz35x6zd6jn1dvpr0wvx-gcc-wrapper-14.2.1.20250322.drv",
+      "description": "GNU Compiler Collection, version 14.2.1.20250322 (wrapper script)",
+      "install_id": "gcc",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "gcc-wrapper-14.2.1.20250322",
+      "pname": "gcc",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:37:20.415079Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "14.2.1.20250322",
+      "outputs_to_install": [
+        "man",
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/7y6glm22qfb7sw1ybf0lgi5ml9ra278b-gcc-wrapper-14.2.1.20250322-info",
+        "man": "/nix/store/km6mm6rmh1p2av5vw37skaprgrd293vl-gcc-wrapper-14.2.1.20250322-man",
+        "out": "/nix/store/rpxlridr3yn6mbmd34r0bya9qv91b79s-gcc-wrapper-14.2.1.20250322"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gcc",
+      "broken": false,
+      "derivation": "/nix/store/awwvcwwanflz00ns50g61lyklg72cxm7-gcc-wrapper-14.2.1.20250322.drv",
+      "description": "GNU Compiler Collection, version 14.2.1.20250322 (wrapper script)",
+      "install_id": "gcc",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "gcc-wrapper-14.2.1.20250322",
+      "pname": "gcc",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:54:29.718062Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "14.2.1.20250322",
+      "outputs_to_install": [
+        "man",
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/ldw9g57kj17ywcmwr2h7z4aw4rfr6438-gcc-wrapper-14.2.1.20250322-info",
+        "man": "/nix/store/skqvyhvi7mc2iyvcsi3jw9x5w1r2gw2k-gcc-wrapper-14.2.1.20250322-man",
+        "out": "/nix/store/lvil1wrw3cgd8dbcjlvhm7728fhpq27k-gcc-wrapper-14.2.1.20250322"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gcc",
+      "broken": false,
+      "derivation": "/nix/store/7chb1402lr3jgd7sxcbj3v01l97kvs3h-gcc-wrapper-14.2.1.20250322.drv",
+      "description": "GNU Compiler Collection, version 14.2.1.20250322 (wrapper script)",
+      "install_id": "gcc",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "gcc-wrapper-14.2.1.20250322",
+      "pname": "gcc",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T05:15:55.338399Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "14.2.1.20250322",
+      "outputs_to_install": [
+        "man",
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/rs9pvqy38dx84320sxf7ql4ppv2k4rhj-gcc-wrapper-14.2.1.20250322-info",
+        "man": "/nix/store/1icxr998a24dfw4dk30v4n8kwdl0v29y-gcc-wrapper-14.2.1.20250322-man",
+        "out": "/nix/store/f0m6caffiykyvsjim9376a3hx2yj2ghj-gcc-wrapper-14.2.1.20250322"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/test_data/generated/envs/gcc_boost/manifest.toml
+++ b/test_data/generated/envs/gcc_boost/manifest.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[install]
+gcc.pkg-path = "gcc"
+boost.pkg-path = "boost"

--- a/test_data/generated/init/go.json
+++ b/test_data/generated/init/go.json
@@ -11,7 +11,7 @@
             "attr_path": "go",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2vf3k8270h2781z477r88vswqvw8ykp0-go-1.24.2.drv",
+            "derivation": "/nix/store/rx127ahvvf4z52cla8v36vqkhxrj8ph7-go-1.24.2.drv",
             "description": "Go Programming language",
             "insecure": false,
             "install_id": "go",
@@ -22,7 +22,7 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/rv9g1p18w52vip6652svdgy138wgx7dj-go-1.24.2"
+                "store_path": "/nix/store/fd2s1z3why92qn8w7j6r0xlarikpv27v-go-1.24.2"
               }
             ],
             "outputs_to_install": [
@@ -33,11 +33,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:15:55.910259Z",
+            "scrape_date": "2025-05-05T04:19:29.232417Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "1.24.2"
           }

--- a/test_data/generated/init/node_npm.json
+++ b/test_data/generated/init/node_npm.json
@@ -10,7 +10,7 @@
         "pkg_path": "nodejs_14",
         "pname": "nodejs_14",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "14.21.3"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "nodejs_16",
         "pname": "nodejs_16",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "16.20.2"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "nodejs_18",
         "pname": "nodejs_18",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "18.20.8"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "nodejs_19",
         "pname": "nodejs_19",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "19.9.0"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "nodejs_20",
         "pname": "nodejs_20",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20.19.0"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "nodejs_21",
         "pname": "nodejs_21",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "21.7.3"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "nodejs_22",
         "pname": "nodejs_22",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.14.0"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "nodejs_23",
         "pname": "nodejs_23",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "nodejs_latest",
         "pname": "nodejs_latest",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "haxePackages.hxnodejs_4",
         "pname": "hxnodejs_4",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "4.0.9"
       },
       {
@@ -120,7 +120,7 @@
         "pkg_path": "haxePackages.hxnodejs_6",
         "pname": "hxnodejs_6",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "6.9.0"
       }
     ]

--- a/test_data/generated/init/nodejs_20.json
+++ b/test_data/generated/init/nodejs_20.json
@@ -10,7 +10,7 @@
         "pkg_path": "nodejs_14",
         "pname": "nodejs_14",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "14.21.3"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "nodejs_16",
         "pname": "nodejs_16",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "16.20.2"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "nodejs_18",
         "pname": "nodejs_18",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "18.20.8"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "nodejs_19",
         "pname": "nodejs_19",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "19.9.0"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "nodejs_20",
         "pname": "nodejs_20",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20.19.0"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "nodejs_21",
         "pname": "nodejs_21",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "21.7.3"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "nodejs_22",
         "pname": "nodejs_22",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.14.0"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "nodejs_23",
         "pname": "nodejs_23",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "nodejs_latest",
         "pname": "nodejs_latest",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "haxePackages.hxnodejs_4",
         "pname": "hxnodejs_4",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "4.0.9"
       },
       {
@@ -120,7 +120,7 @@
         "pkg_path": "haxePackages.hxnodejs_6",
         "pname": "hxnodejs_6",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "6.9.0"
       }
     ]
@@ -173,7 +173,7 @@
             "attr_path": "nodejs_20",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/d2vpc1aqk6iw3yzg1abk6jmqw7pfla58-nodejs-20.19.0.drv",
+            "derivation": "/nix/store/33i0rhflplwdjaxky0l9sqr1wcgks4qc-nodejs-20.19.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs_20",
@@ -184,15 +184,15 @@
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/rdhhmrq1qdzrpz7chg94la5xj8p88izq-nodejs-20.19.0-dev"
+                "store_path": "/nix/store/kslx73g14dmb5srlypnqapnlqqklv2pi-nodejs-20.19.0-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/g9i71gd4wm11a5hp4k5mimvsl8vx7jdw-nodejs-20.19.0"
+                "store_path": "/nix/store/fy4baj2727cz7yiaw51zyd8a0dkkdi5f-nodejs-20.19.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/avrrs9q3qh75cd0n2skpx4kp3sx9cnb7-nodejs-20.19.0-libv8"
+                "store_path": "/nix/store/gcflh0g2rqmnvzb1njcx8zc5m78h8w8k-nodejs-20.19.0-libv8"
               }
             ],
             "outputs_to_install": [
@@ -203,11 +203,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:07.167006Z",
+            "scrape_date": "2025-05-05T04:19:31.612979Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "20.19.0"
           }
@@ -275,7 +275,7 @@
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/vw6hibpv5jfhpgak9x8j6jsrsl753jj8-nodejs-20.18.1.drv",
+            "derivation": "/nix/store/s6vvykdlbdnvxmwd9vwqn0mrh0pcz56r-nodejs-20.18.1.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs",
@@ -286,11 +286,11 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/wfxq6w9bkp5dcfr8yb6789b0w7128gnb-nodejs-20.18.1"
+                "store_path": "/nix/store/f0lm95g31vpknr8jj9xw53cx2rqly2nm-nodejs-20.18.1"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/6cpw80r57lyippnjl5knrvymcwalv1m2-nodejs-20.18.1-libv8"
+                "store_path": "/nix/store/l17919sgiw0i3awxlpic9z9a3g2d0rgv-nodejs-20.18.1-libv8"
               }
             ],
             "outputs_to_install": [
@@ -307,7 +307,7 @@
               "staging",
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "20.18.1"
           }

--- a/test_data/generated/init/nodejs_gt_20.json
+++ b/test_data/generated/init/nodejs_gt_20.json
@@ -10,7 +10,7 @@
         "pkg_path": "nodejs_14",
         "pname": "nodejs_14",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "14.21.3"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "nodejs_16",
         "pname": "nodejs_16",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "16.20.2"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "nodejs_18",
         "pname": "nodejs_18",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "18.20.8"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "nodejs_19",
         "pname": "nodejs_19",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "19.9.0"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "nodejs_20",
         "pname": "nodejs_20",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20.19.0"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "nodejs_21",
         "pname": "nodejs_21",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "21.7.3"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "nodejs_22",
         "pname": "nodejs_22",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.14.0"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "nodejs_23",
         "pname": "nodejs_23",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "nodejs_latest",
         "pname": "nodejs_latest",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "haxePackages.hxnodejs_4",
         "pname": "hxnodejs_4",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "4.0.9"
       },
       {
@@ -120,7 +120,7 @@
         "pkg_path": "haxePackages.hxnodejs_6",
         "pname": "hxnodejs_6",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "6.9.0"
       }
     ]
@@ -137,7 +137,7 @@
             "attr_path": "nodejs_23",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/fmnz6133qxshnwm35j4hhbx8my3883n5-nodejs-23.11.0.drv",
+            "derivation": "/nix/store/1bppizga8azifl94c2ib9qr4s6w162qm-nodejs-23.11.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs_23",
@@ -148,15 +148,15 @@
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/37nmva83fc0idfd0xk7rq61zgxg0ywab-nodejs-23.11.0-dev"
+                "store_path": "/nix/store/g1c4jg5r4x6jg3zpirgmw9na2swv94sw-nodejs-23.11.0-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/farnym67jl2brs97ihsvziz7gm0yq26l-nodejs-23.11.0"
+                "store_path": "/nix/store/gdh7lnl6ksw2s9j65ah0jnr93cypq0zr-nodejs-23.11.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/3kx3gj5ix8nsp63kh3nkvxzbqcic85wx-nodejs-23.11.0-libv8"
+                "store_path": "/nix/store/yf4hi5pps1ciplvlrfdvmzdyv0z24l2x-nodejs-23.11.0-libv8"
               }
             ],
             "outputs_to_install": [
@@ -167,11 +167,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:07.168846Z",
+            "scrape_date": "2025-05-05T04:19:31.613884Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "23.11.0"
           }
@@ -191,7 +191,7 @@
             "attr_path": "nodejs_22",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lvmx1yi282jmc8y01zz05vac8h554h34-nodejs-22.14.0.drv",
+            "derivation": "/nix/store/5cwk9l1iwpwcisih5ll7mc2i6w42y05m-nodejs-22.14.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs_22",
@@ -202,15 +202,15 @@
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/pyhz87g4xnb88rh372p7xxls49hivh57-nodejs-22.14.0-dev"
+                "store_path": "/nix/store/zbr4fi11j897pa9jikqpviz57kagvizv-nodejs-22.14.0-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/5z0wi8qwah6y9cv3na0fgjzbk9ihh1pz-nodejs-22.14.0"
+                "store_path": "/nix/store/2ribxb3gi87gj4331m6k0ydn0z90zfi7-nodejs-22.14.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/ac2187x84ggp1vpxnw4y81xy3caqz77s-nodejs-22.14.0-libv8"
+                "store_path": "/nix/store/9rp5sb2nb5549qqax4v6ly4glixjm6d5-nodejs-22.14.0-libv8"
               }
             ],
             "outputs_to_install": [
@@ -221,11 +221,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:07.167922Z",
+            "scrape_date": "2025-05-05T04:19:31.613428Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "22.14.0"
           }
@@ -245,7 +245,7 @@
             "attr_path": "nodejs_21",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/2vza1j6chgmfa1s77ws7c0li9cnzl0jq-nodejs-21.7.3.drv",
+            "derivation": "/nix/store/ndcy9jlzxviid8yxb4k7afcacsdbppq7-nodejs-21.7.3.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs_21",
@@ -256,11 +256,11 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/dfs59hwhc4mb4hdk77nc5dd39k2v2qs2-nodejs-21.7.3"
+                "store_path": "/nix/store/hxr5ziwxn72wxcrhxasdy542h6z0r9hg-nodejs-21.7.3"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/iq38acw88hl92vpwamfkzgk3pk3dsr0x-nodejs-21.7.3-libv8"
+                "store_path": "/nix/store/y6xj0m2n7mlzgx5mc62m0lb4h02dzklr-nodejs-21.7.3-libv8"
               }
             ],
             "outputs_to_install": [
@@ -277,7 +277,7 @@
               "staging",
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "21.7.3"
           }
@@ -297,7 +297,7 @@
             "attr_path": "nodejs_20",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/d2vpc1aqk6iw3yzg1abk6jmqw7pfla58-nodejs-20.19.0.drv",
+            "derivation": "/nix/store/33i0rhflplwdjaxky0l9sqr1wcgks4qc-nodejs-20.19.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs_20",
@@ -308,15 +308,15 @@
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/rdhhmrq1qdzrpz7chg94la5xj8p88izq-nodejs-20.19.0-dev"
+                "store_path": "/nix/store/kslx73g14dmb5srlypnqapnlqqklv2pi-nodejs-20.19.0-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/g9i71gd4wm11a5hp4k5mimvsl8vx7jdw-nodejs-20.19.0"
+                "store_path": "/nix/store/fy4baj2727cz7yiaw51zyd8a0dkkdi5f-nodejs-20.19.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/avrrs9q3qh75cd0n2skpx4kp3sx9cnb7-nodejs-20.19.0-libv8"
+                "store_path": "/nix/store/gcflh0g2rqmnvzb1njcx8zc5m78h8w8k-nodejs-20.19.0-libv8"
               }
             ],
             "outputs_to_install": [
@@ -327,11 +327,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:07.167006Z",
+            "scrape_date": "2025-05-05T04:19:31.612979Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "20.19.0"
           }
@@ -399,7 +399,7 @@
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lvmx1yi282jmc8y01zz05vac8h554h34-nodejs-22.14.0.drv",
+            "derivation": "/nix/store/5cwk9l1iwpwcisih5ll7mc2i6w42y05m-nodejs-22.14.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs",
@@ -410,15 +410,15 @@
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/pyhz87g4xnb88rh372p7xxls49hivh57-nodejs-22.14.0-dev"
+                "store_path": "/nix/store/zbr4fi11j897pa9jikqpviz57kagvizv-nodejs-22.14.0-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/5z0wi8qwah6y9cv3na0fgjzbk9ihh1pz-nodejs-22.14.0"
+                "store_path": "/nix/store/2ribxb3gi87gj4331m6k0ydn0z90zfi7-nodejs-22.14.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/ac2187x84ggp1vpxnw4y81xy3caqz77s-nodejs-22.14.0-libv8"
+                "store_path": "/nix/store/9rp5sb2nb5549qqax4v6ly4glixjm6d5-nodejs-22.14.0-libv8"
               }
             ],
             "outputs_to_install": [
@@ -429,11 +429,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:07.159642Z",
+            "scrape_date": "2025-05-05T04:19:31.609371Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "22.14.0"
           }

--- a/test_data/generated/init/python_poetry.json
+++ b/test_data/generated/init/python_poetry.json
@@ -11,7 +11,7 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/49xsrmwiipbwry9lwqrr5z23bf4zaqbf-python3-3.12.9.drv",
+            "derivation": "/nix/store/swlxpgwqf6aj57kfhnanv5fvfsjl61w5-python3-3.12.9.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
@@ -22,11 +22,7 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9"
-              },
-              {
-                "name": "debug",
-                "store_path": "/nix/store/m09w6hj3mciijfvaf2icqvc777kjd05f-python3-3.12.9-debug"
+                "store_path": "/nix/store/xzjghvsg4fhr2vv6h4scihsdrgk4i76w-python3-3.12.9"
               }
             ],
             "outputs_to_install": [
@@ -37,11 +33,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:20.017042Z",
+            "scrape_date": "2025-05-05T04:19:37.754154Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "3.12.9"
           }
@@ -63,22 +59,22 @@
             "attr_path": "poetry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/zczajl7p7h54g9scqwy9r1pzz8c2y3yf-python3.12-poetry-2.1.2.drv",
+            "derivation": "/nix/store/jxzlrp104gpnn1rj63lf16qymr76vxbg-python3.12-poetry-2.1.2.drv",
             "description": "Python dependency management and packaging made easy",
             "insecure": false,
             "install_id": "poetry",
             "license": "MIT",
-            "locked_url": "https://github.com/flox/nixpkgs?rev=f771eb401a46846c1aebd20552521b233dd7e18b",
+            "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "missing_builds": false,
             "name": "poetry-2.1.2",
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/n9xr05v822jgg1wzsypalg7ahr1viypr-python3.12-poetry-2.1.2"
+                "store_path": "/nix/store/nvjdpf7mzjhmdr1bra5lyi3f5z0yid3h-python3.12-poetry-2.1.2"
               },
               {
                 "name": "dist",
-                "store_path": "/nix/store/175pi3yvax9p1z7af9155fndhjljb2wc-python3.12-poetry-2.1.2-dist"
+                "store_path": "/nix/store/7sm681vkc1pw246nniynpha8ffmbpw35-python3.12-poetry-2.1.2-dist"
               }
             ],
             "outputs_to_install": [
@@ -86,19 +82,19 @@
             ],
             "pkg_path": "poetry",
             "pname": "poetry",
-            "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
-            "rev_count": 789333,
-            "rev_date": "2025-04-24T20:20:57Z",
-            "scrape_date": "2025-04-27T05:14:40.145676Z",
+            "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+            "rev_count": 793735,
+            "rev_date": "2025-05-04T03:14:55Z",
+            "scrape_date": "2025-05-05T04:19:36.826888Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "2.1.2"
           }
         ],
-        "page": 789333,
+        "page": 793735,
         "url": ""
       }
     }
@@ -115,7 +111,7 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/49xsrmwiipbwry9lwqrr5z23bf4zaqbf-python3-3.12.9.drv",
+            "derivation": "/nix/store/swlxpgwqf6aj57kfhnanv5fvfsjl61w5-python3-3.12.9.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
@@ -126,11 +122,7 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9"
-              },
-              {
-                "name": "debug",
-                "store_path": "/nix/store/m09w6hj3mciijfvaf2icqvc777kjd05f-python3-3.12.9-debug"
+                "store_path": "/nix/store/xzjghvsg4fhr2vv6h4scihsdrgk4i76w-python3-3.12.9"
               }
             ],
             "outputs_to_install": [
@@ -141,11 +133,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:20.017042Z",
+            "scrape_date": "2025-05-05T04:19:37.754154Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "3.12.9"
           }

--- a/test_data/generated/init/python_pyproject_pip.json
+++ b/test_data/generated/init/python_pyproject_pip.json
@@ -11,7 +11,7 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/49xsrmwiipbwry9lwqrr5z23bf4zaqbf-python3-3.12.9.drv",
+            "derivation": "/nix/store/swlxpgwqf6aj57kfhnanv5fvfsjl61w5-python3-3.12.9.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
@@ -22,11 +22,7 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9"
-              },
-              {
-                "name": "debug",
-                "store_path": "/nix/store/m09w6hj3mciijfvaf2icqvc777kjd05f-python3-3.12.9-debug"
+                "store_path": "/nix/store/xzjghvsg4fhr2vv6h4scihsdrgk4i76w-python3-3.12.9"
               }
             ],
             "outputs_to_install": [
@@ -37,11 +33,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:20.017042Z",
+            "scrape_date": "2025-05-05T04:19:37.754154Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "3.12.9"
           }

--- a/test_data/generated/init/python_requests.json
+++ b/test_data/generated/init/python_requests.json
@@ -11,7 +11,7 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/49xsrmwiipbwry9lwqrr5z23bf4zaqbf-python3-3.12.9.drv",
+            "derivation": "/nix/store/swlxpgwqf6aj57kfhnanv5fvfsjl61w5-python3-3.12.9.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
@@ -22,11 +22,7 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9"
-              },
-              {
-                "name": "debug",
-                "store_path": "/nix/store/m09w6hj3mciijfvaf2icqvc777kjd05f-python3-3.12.9-debug"
+                "store_path": "/nix/store/xzjghvsg4fhr2vv6h4scihsdrgk4i76w-python3-3.12.9"
               }
             ],
             "outputs_to_install": [
@@ -37,11 +33,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:20.017042Z",
+            "scrape_date": "2025-05-05T04:19:37.754154Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "3.12.9"
           }

--- a/test_data/generated/init/python_requirements.json
+++ b/test_data/generated/init/python_requirements.json
@@ -11,7 +11,7 @@
             "attr_path": "python3",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/49xsrmwiipbwry9lwqrr5z23bf4zaqbf-python3-3.12.9.drv",
+            "derivation": "/nix/store/swlxpgwqf6aj57kfhnanv5fvfsjl61w5-python3-3.12.9.drv",
             "description": "High-level dynamically-typed programming language",
             "insecure": false,
             "install_id": "python3",
@@ -22,11 +22,7 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9"
-              },
-              {
-                "name": "debug",
-                "store_path": "/nix/store/m09w6hj3mciijfvaf2icqvc777kjd05f-python3-3.12.9-debug"
+                "store_path": "/nix/store/xzjghvsg4fhr2vv6h4scihsdrgk4i76w-python3-3.12.9"
               }
             ],
             "outputs_to_install": [
@@ -37,11 +33,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:20.017042Z",
+            "scrape_date": "2025-05-05T04:19:37.754154Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "3.12.9"
           }

--- a/test_data/generated/init/yarn_1x.json
+++ b/test_data/generated/init/yarn_1x.json
@@ -10,7 +10,7 @@
         "pkg_path": "nodejs_14",
         "pname": "nodejs_14",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "14.21.3"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "nodejs_16",
         "pname": "nodejs_16",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "16.20.2"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "nodejs_18",
         "pname": "nodejs_18",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "18.20.8"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "nodejs_19",
         "pname": "nodejs_19",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "19.9.0"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "nodejs_20",
         "pname": "nodejs_20",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20.19.0"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "nodejs_21",
         "pname": "nodejs_21",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "21.7.3"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "nodejs_22",
         "pname": "nodejs_22",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.14.0"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "nodejs_23",
         "pname": "nodejs_23",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "nodejs_latest",
         "pname": "nodejs_latest",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "haxePackages.hxnodejs_4",
         "pname": "hxnodejs_4",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "4.0.9"
       },
       {
@@ -120,7 +120,7 @@
         "pkg_path": "haxePackages.hxnodejs_6",
         "pname": "hxnodejs_6",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "6.9.0"
       }
     ]
@@ -137,7 +137,7 @@
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lvmx1yi282jmc8y01zz05vac8h554h34-nodejs-22.14.0.drv",
+            "derivation": "/nix/store/5cwk9l1iwpwcisih5ll7mc2i6w42y05m-nodejs-22.14.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs",
@@ -148,15 +148,15 @@
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/pyhz87g4xnb88rh372p7xxls49hivh57-nodejs-22.14.0-dev"
+                "store_path": "/nix/store/zbr4fi11j897pa9jikqpviz57kagvizv-nodejs-22.14.0-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/5z0wi8qwah6y9cv3na0fgjzbk9ihh1pz-nodejs-22.14.0"
+                "store_path": "/nix/store/2ribxb3gi87gj4331m6k0ydn0z90zfi7-nodejs-22.14.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/ac2187x84ggp1vpxnw4y81xy3caqz77s-nodejs-22.14.0-libv8"
+                "store_path": "/nix/store/9rp5sb2nb5549qqax4v6ly4glixjm6d5-nodejs-22.14.0-libv8"
               }
             ],
             "outputs_to_install": [
@@ -167,11 +167,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:07.159642Z",
+            "scrape_date": "2025-05-05T04:19:31.609371Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "22.14.0"
           }
@@ -205,7 +205,7 @@
             "attr_path": "yarn",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/5g4mcmy6hq1j7nx43dnzajqysimg5xp2-yarn-1.22.22.drv",
+            "derivation": "/nix/store/waqkpmm4r7l0gc6ndmyibyzvsjpzhlx8-yarn-1.22.22.drv",
             "description": "Fast, reliable, and secure dependency management for javascript",
             "insecure": false,
             "install_id": "yarn",
@@ -216,7 +216,7 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/bn868hy4v171i58jx25bls555jspbhl9-yarn-1.22.22"
+                "store_path": "/nix/store/2ii4afii0xlaljyzd8lm5y5n7xdj836j-yarn-1.22.22"
               }
             ],
             "outputs_to_install": [
@@ -227,11 +227,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:17:45.439836Z",
+            "scrape_date": "2025-05-05T04:20:32.785737Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "1.22.22"
           }

--- a/test_data/generated/init/yarn_berry.json
+++ b/test_data/generated/init/yarn_berry.json
@@ -10,7 +10,7 @@
         "pkg_path": "nodejs_14",
         "pname": "nodejs_14",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "14.21.3"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "nodejs_16",
         "pname": "nodejs_16",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "16.20.2"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "nodejs_18",
         "pname": "nodejs_18",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "18.20.8"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "nodejs_19",
         "pname": "nodejs_19",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "19.9.0"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "nodejs_20",
         "pname": "nodejs_20",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20.19.0"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "nodejs_21",
         "pname": "nodejs_21",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "21.7.3"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "nodejs_22",
         "pname": "nodejs_22",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.14.0"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "nodejs_23",
         "pname": "nodejs_23",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "nodejs_latest",
         "pname": "nodejs_latest",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "haxePackages.hxnodejs_4",
         "pname": "hxnodejs_4",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "4.0.9"
       },
       {
@@ -120,7 +120,7 @@
         "pkg_path": "haxePackages.hxnodejs_6",
         "pname": "hxnodejs_6",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "6.9.0"
       }
     ]
@@ -137,7 +137,7 @@
             "attr_path": "nodejs",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/lvmx1yi282jmc8y01zz05vac8h554h34-nodejs-22.14.0.drv",
+            "derivation": "/nix/store/5cwk9l1iwpwcisih5ll7mc2i6w42y05m-nodejs-22.14.0.drv",
             "description": "Event-driven I/O framework for the V8 JavaScript engine",
             "insecure": false,
             "install_id": "nodejs",
@@ -148,15 +148,15 @@
             "outputs": [
               {
                 "name": "dev",
-                "store_path": "/nix/store/pyhz87g4xnb88rh372p7xxls49hivh57-nodejs-22.14.0-dev"
+                "store_path": "/nix/store/zbr4fi11j897pa9jikqpviz57kagvizv-nodejs-22.14.0-dev"
               },
               {
                 "name": "out",
-                "store_path": "/nix/store/5z0wi8qwah6y9cv3na0fgjzbk9ihh1pz-nodejs-22.14.0"
+                "store_path": "/nix/store/2ribxb3gi87gj4331m6k0ydn0z90zfi7-nodejs-22.14.0"
               },
               {
                 "name": "libv8",
-                "store_path": "/nix/store/ac2187x84ggp1vpxnw4y81xy3caqz77s-nodejs-22.14.0-libv8"
+                "store_path": "/nix/store/9rp5sb2nb5549qqax4v6ly4glixjm6d5-nodejs-22.14.0-libv8"
               }
             ],
             "outputs_to_install": [
@@ -167,11 +167,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:16:07.159642Z",
+            "scrape_date": "2025-05-05T04:19:31.609371Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "22.14.0"
           }
@@ -193,7 +193,7 @@
             "attr_path": "yarn-berry",
             "broken": false,
             "catalog": "nixpkgs",
-            "derivation": "/nix/store/7vhp5j4dyby2qwvs3qzc12fvj6mim7yc-yarn-berry-4.9.1.drv",
+            "derivation": "/nix/store/8h1m6v8w381y6g365jbw1jd3ld5x1532-yarn-berry-4.9.1.drv",
             "description": "Fast, reliable, and secure dependency management",
             "insecure": false,
             "install_id": "yarn-berry",
@@ -204,7 +204,7 @@
             "outputs": [
               {
                 "name": "out",
-                "store_path": "/nix/store/gsgwbbrjzmkq2jjvwk3fz00wpy10al7w-yarn-berry-4.9.1"
+                "store_path": "/nix/store/y39hy99i2h4iqvm2r6p9m1aw2jxi32sw-yarn-berry-4.9.1"
               }
             ],
             "outputs_to_install": [
@@ -215,11 +215,11 @@
             "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
             "rev_count": 793735,
             "rev_date": "2025-05-04T03:14:55Z",
-            "scrape_date": "2025-05-05T05:17:45.445187Z",
+            "scrape_date": "2025-05-05T04:20:32.789721Z",
             "stabilities": [
               "unstable"
             ],
-            "system": "x86_64-linux",
+            "system": "aarch64-darwin",
             "unfree": false,
             "version": "4.9.1"
           }

--- a/test_data/generated/resolve/node_suggestions.json
+++ b/test_data/generated/resolve/node_suggestions.json
@@ -26,7 +26,7 @@
         "pkg_path": "nodejs",
         "pname": "nodejs",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.14.0"
       },
       {
@@ -37,7 +37,7 @@
         "pkg_path": "nodejs_14",
         "pname": "nodejs_14",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "14.21.3"
       },
       {
@@ -48,7 +48,7 @@
         "pkg_path": "nodejs_16",
         "pname": "nodejs_16",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "16.20.2"
       }
     ]

--- a/test_data/generated/resolve/package_suggestions.json
+++ b/test_data/generated/resolve/package_suggestions.json
@@ -26,7 +26,7 @@
         "pkg_path": "packagekit",
         "pname": "packagekit",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.3.0"
       },
       {
@@ -37,7 +37,7 @@
         "pkg_path": "psc-package",
         "pname": "psc-package",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.6.2"
       },
       {
@@ -48,7 +48,7 @@
         "pkg_path": "patch-package",
         "pname": "patch-package",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "8.0.0"
       }
     ]

--- a/test_data/generated/search/ello_all.json
+++ b/test_data/generated/search/ello_all.json
@@ -1,7 +1,18 @@
 [
   {
-    "count": 68,
+    "count": 69,
     "results": [
+      {
+        "attr_path": "hello",
+        "catalog": "mkenigs",
+        "description": "Not Provided",
+        "name": "hello-0.0.0",
+        "pkg_path": "mkenigs/hello",
+        "pname": "hello",
+        "stabilities": [],
+        "system": "aarch64-darwin",
+        "version": "0.0.0"
+      },
       {
         "attr_path": "hello",
         "catalog": null,
@@ -10,7 +21,7 @@
         "pkg_path": "hello",
         "pname": "hello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.12.1"
       },
       {
@@ -21,7 +32,7 @@
         "pkg_path": "jello",
         "pname": "jello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.6.0"
       },
       {
@@ -32,7 +43,7 @@
         "pkg_path": "hello-go",
         "pname": "hello-go",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "hello-go"
       },
       {
@@ -43,7 +54,7 @@
         "pkg_path": "libcello",
         "pname": "libcello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.1.0"
       },
       {
@@ -54,7 +65,7 @@
         "pkg_path": "hello-cpp",
         "pname": "hello-cpp",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "hello-cpp"
       },
       {
@@ -65,7 +76,7 @@
         "pkg_path": "nwg-hello",
         "pname": "nwg-hello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.3.1"
       },
       {
@@ -76,7 +87,7 @@
         "pkg_path": "cannelloni",
         "pname": "cannelloni",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.2.1"
       },
       {
@@ -87,7 +98,7 @@
         "pkg_path": "hello-unfree",
         "pname": "hello-unfree",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.0"
       },
       {
@@ -98,7 +109,7 @@
         "pkg_path": "mellowplayer",
         "pname": "mellowplayer",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.6.8"
       },
       {
@@ -109,7 +120,7 @@
         "pkg_path": "hello-wayland",
         "pname": "hello-wayland",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2024-03-04"
       },
       {
@@ -120,7 +131,7 @@
         "pkg_path": "marwaita-yellow",
         "pname": "marwaita-yellow",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23"
       },
       {
@@ -131,7 +142,7 @@
         "pkg_path": "libsForQt5.umbrello",
         "pname": "umbrello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.08.5"
       },
       {
@@ -142,7 +153,7 @@
         "pkg_path": "fcitx5-mellow-themes",
         "pname": "fcitx5-mellow-themes",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2024-11-11"
       },
       {
@@ -153,7 +164,7 @@
         "pkg_path": "kdePackages.umbrello",
         "pname": "umbrello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "25.04.0"
       },
       {
@@ -164,7 +175,7 @@
         "pkg_path": "libsForQt512.umbrello",
         "pname": "umbrello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.08.3"
       },
       {
@@ -175,7 +186,7 @@
         "pkg_path": "libsForQt514.umbrello",
         "pname": "umbrello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.08.3"
       },
       {
@@ -186,7 +197,7 @@
         "pkg_path": "libsForQt515.umbrello",
         "pname": "umbrello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.08.3"
       },
       {
@@ -197,7 +208,7 @@
         "pkg_path": "emacsPackages.ellocate",
         "pname": "ellocate",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20200112.1931"
       },
       {
@@ -208,7 +219,7 @@
         "pkg_path": "python310Packages.jello",
         "pname": "jello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.6.0"
       },
       {
@@ -219,7 +230,7 @@
         "pkg_path": "python311Packages.jello",
         "pname": "jello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.6.0"
       },
       {
@@ -230,7 +241,7 @@
         "pkg_path": "python312Packages.jello",
         "pname": "jello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.6.0"
       },
       {
@@ -241,7 +252,7 @@
         "pkg_path": "python313Packages.jello",
         "pname": "jello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.6.0"
       },
       {
@@ -252,7 +263,7 @@
         "pkg_path": "sbclPackages.hello-clog",
         "pname": "hello-clog",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20241012-git"
       },
       {
@@ -263,7 +274,7 @@
         "pkg_path": "texlivePackages.othello",
         "pname": "othello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "15878"
       },
       {
@@ -274,7 +285,7 @@
         "pkg_path": "emacsPackages.org-trello",
         "pname": "org-trello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20210314.1901"
       },
       {
@@ -285,7 +296,7 @@
         "pkg_path": "plasma5Packages.umbrello",
         "pname": "umbrello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.08.5"
       },
       {
@@ -296,7 +307,7 @@
         "pkg_path": "python37Packages.bellows",
         "pname": "bellows",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.21.0"
       },
       {
@@ -307,7 +318,7 @@
         "pkg_path": "python38Packages.bellows",
         "pname": "bellows",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.26.0"
       },
       {
@@ -318,7 +329,7 @@
         "pkg_path": "python39Packages.bellows",
         "pname": "bellows",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.34.5"
       },
       {
@@ -329,7 +340,7 @@
         "pkg_path": "python39Packages.pynello",
         "pname": "pynello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.0.3"
       },
       {
@@ -340,7 +351,7 @@
         "pkg_path": "python310Packages.bellows",
         "pname": "bellows",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.37.6"
       },
       {
@@ -351,7 +362,7 @@
         "pkg_path": "python310Packages.pynello",
         "pname": "pynello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.0.3"
       },
       {
@@ -362,7 +373,7 @@
         "pkg_path": "python311Packages.bellows",
         "pname": "bellows",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.42.0"
       },
       {
@@ -373,7 +384,7 @@
         "pkg_path": "python311Packages.pynello",
         "pname": "pynello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.0.3"
       },
       {
@@ -384,7 +395,7 @@
         "pkg_path": "python312Packages.bellows",
         "pname": "bellows",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.44.1"
       },
       {
@@ -395,7 +406,7 @@
         "pkg_path": "python312Packages.pynello",
         "pname": "pynello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.0.3"
       },
       {
@@ -406,7 +417,7 @@
         "pkg_path": "python313Packages.bellows",
         "pname": "bellows",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.44.1"
       },
       {
@@ -417,7 +428,7 @@
         "pkg_path": "python313Packages.pynello",
         "pname": "pynello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.0.3"
       },
       {
@@ -428,7 +439,7 @@
         "pkg_path": "emacsPackages.mellow-theme",
         "pname": "mellow-theme",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20170808.1317"
       },
       {
@@ -439,7 +450,7 @@
         "pkg_path": "perlPackages.ParallelLoops",
         "pname": "ParallelLoops",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.12"
       },
       {
@@ -450,7 +461,7 @@
         "pkg_path": "sbclPackages.hello-builder",
         "pname": "hello-builder",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20241012-git"
       },
       {
@@ -461,7 +472,7 @@
         "pkg_path": "javaPackages.mavenHello_1_0",
         "pname": "mavenHello_1_0",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.0"
       },
       {
@@ -472,7 +483,7 @@
         "pkg_path": "javaPackages.mavenHello_1_1",
         "pname": "mavenHello_1_1",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.1"
       },
       {
@@ -483,7 +494,7 @@
         "pkg_path": "texlivePackages.othelloboard",
         "pname": "othelloboard",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.2"
       },
       {
@@ -494,7 +505,7 @@
         "pkg_path": "emacsPackages.sly-hello-world",
         "pname": "sly-hello-world",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20200225.1755"
       },
       {
@@ -505,7 +516,7 @@
         "pkg_path": "perl536Packages.ParallelLoops",
         "pname": "ParallelLoops",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.12"
       },
       {
@@ -516,7 +527,7 @@
         "pkg_path": "perl538Packages.ParallelLoops",
         "pname": "ParallelLoops",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.12"
       },
       {
@@ -527,7 +538,7 @@
         "pkg_path": "perl540Packages.ParallelLoops",
         "pname": "ParallelLoops",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.12"
       },
       {
@@ -538,7 +549,7 @@
         "pkg_path": "sbclPackages.qtools-helloworld",
         "pname": "qtools-helloworld",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20230214-git"
       },
       {
@@ -549,7 +560,7 @@
         "pkg_path": "libsForQt5_openssl_1_1.umbrello",
         "pname": "umbrello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.08.1"
       },
       {
@@ -560,7 +571,7 @@
         "pkg_path": "apacheHttpdPackages.mod_auth_mellon",
         "pname": "mod_auth_mellon",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.19.1"
       },
       {
@@ -571,7 +582,7 @@
         "pkg_path": "wordpressPackages.plugins.hello-dolly",
         "pname": "hello-dolly",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.7.2"
       },
       {
@@ -582,7 +593,7 @@
         "pkg_path": "apacheHttpdPackages_2_4.mod_auth_mellon",
         "pname": "mod_auth_mellon",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.19.1"
       },
       {
@@ -593,7 +604,7 @@
         "pkg_path": "lispPackages_new.sbclPackages.hello-clog",
         "pname": "hello-clog",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20221106-git"
       },
       {
@@ -604,7 +615,7 @@
         "pkg_path": "lispPackages_new.sbclPackages.hello-builder",
         "pname": "hello-builder",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20221106-git"
       },
       {
@@ -615,7 +626,7 @@
         "pkg_path": "lispPackages_new.sbclPackages.qtools-helloworld",
         "pname": "qtools-helloworld",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20200427-git"
       },
       {
@@ -626,7 +637,7 @@
         "pkg_path": "sbclPackages.cl-mw_dot_examples_dot_hello-world",
         "pname": "cl-mw_dot_examples_dot_hello-world",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20150407-git"
       },
       {
@@ -637,7 +648,7 @@
         "pkg_path": "home-assistant-component-tests.homeassistant_yellow",
         "pname": "homeassistant_yellow",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2025.4.4"
       },
       {
@@ -648,7 +659,7 @@
         "pkg_path": "lispPackages_new.sbclPackages.cl-mw_dot_examples_dot_hello-world",
         "pname": "cl-mw_dot_examples_dot_hello-world",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20150407-git"
       },
       {
@@ -659,7 +670,7 @@
         "pkg_path": "_3llo",
         "pname": "_3llo",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.3.1"
       },
       {
@@ -670,7 +681,7 @@
         "pkg_path": "iagno",
         "pname": "iagno",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.38.1"
       },
       {
@@ -681,7 +692,7 @@
         "pkg_path": "gerbolyze",
         "pname": "gerbolyze",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.1.9"
       },
       {
@@ -692,7 +703,7 @@
         "pkg_path": "gnome.iagno",
         "pname": "iagno",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.38.1"
       },
       {
@@ -703,7 +714,7 @@
         "pkg_path": "gnome3.iagno",
         "pname": "iagno",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.38.1"
       },
       {
@@ -714,7 +725,7 @@
         "pkg_path": "texlivePackages.songs",
         "pname": "songs",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.1"
       },
       {
@@ -725,7 +736,7 @@
         "pkg_path": "python311Packages.gerbonara",
         "pname": "gerbonara",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.4.0"
       },
       {
@@ -736,7 +747,7 @@
         "pkg_path": "python312Packages.gerbonara",
         "pname": "gerbonara",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.4.0"
       },
       {
@@ -747,7 +758,7 @@
         "pkg_path": "python313Packages.gerbonara",
         "pname": "gerbonara",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.4.0"
       }
     ]

--- a/test_data/generated/search/exactly_ten.json
+++ b/test_data/generated/search/exactly_ten.json
@@ -10,7 +10,7 @@
         "pkg_path": "python",
         "pname": "python",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.7.18.8"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "gpython",
         "pname": "gpython",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.2.0"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "python2",
         "pname": "python2",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.7.18.8"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "python3",
         "pname": "python3",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.12.9"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "python27",
         "pname": "python27",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.7.18.8"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "python36",
         "pname": "python36",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "python3-3.6.14"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "python37",
         "pname": "python37",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "python3-3.7.16"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "python38",
         "pname": "python38",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "python3-3.8.18"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "python39",
         "pname": "python39",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "python3-3.9.21"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "python-qt",
         "pname": "python-qt",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.6.0"
       }
     ]

--- a/test_data/generated/search/hello.json
+++ b/test_data/generated/search/hello.json
@@ -1,7 +1,18 @@
 [
   {
-    "count": 23,
+    "count": 24,
     "results": [
+      {
+        "attr_path": "hello",
+        "catalog": "mkenigs",
+        "description": "Not Provided",
+        "name": "hello-0.0.0",
+        "pkg_path": "mkenigs/hello",
+        "pname": "hello",
+        "stabilities": [],
+        "system": "aarch64-darwin",
+        "version": "0.0.0"
+      },
       {
         "attr_path": "hello",
         "catalog": null,
@@ -10,7 +21,7 @@
         "pkg_path": "hello",
         "pname": "hello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.12.1"
       },
       {
@@ -21,7 +32,7 @@
         "pkg_path": "hello-go",
         "pname": "hello-go",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "hello-go"
       },
       {
@@ -32,7 +43,7 @@
         "pkg_path": "hello-cpp",
         "pname": "hello-cpp",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "hello-cpp"
       },
       {
@@ -43,7 +54,7 @@
         "pkg_path": "nwg-hello",
         "pname": "nwg-hello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.3.1"
       },
       {
@@ -54,7 +65,7 @@
         "pkg_path": "hello-unfree",
         "pname": "hello-unfree",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.0"
       },
       {
@@ -65,7 +76,7 @@
         "pkg_path": "hello-wayland",
         "pname": "hello-wayland",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2024-03-04"
       },
       {
@@ -76,7 +87,7 @@
         "pkg_path": "sbclPackages.hello-clog",
         "pname": "hello-clog",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20241012-git"
       },
       {
@@ -87,7 +98,7 @@
         "pkg_path": "texlivePackages.othello",
         "pname": "othello",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "15878"
       },
       {
@@ -98,19 +109,8 @@
         "pkg_path": "sbclPackages.hello-builder",
         "pname": "hello-builder",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20241012-git"
-      },
-      {
-        "attr_path": "javaPackages.mavenHello_1_0",
-        "catalog": null,
-        "description": "Maven Hello World",
-        "name": "maven-hello-1.0",
-        "pkg_path": "javaPackages.mavenHello_1_0",
-        "pname": "mavenHello_1_0",
-        "stabilities": [],
-        "system": "x86_64-linux",
-        "version": "1.0"
       }
     ]
   }

--- a/test_data/generated/search/java_suggestions.json
+++ b/test_data/generated/search/java_suggestions.json
@@ -10,7 +10,7 @@
         "pkg_path": "javacc",
         "pname": "javacc",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "7.0.13"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "javaCup",
         "pname": "javaCup",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20160615"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "hdf_java",
         "pname": "hdf_java",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.3.2"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "dbus_java",
         "pname": "dbus_java",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.7"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "geoipjava",
         "pname": "geoipjava",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.2.5"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "tabula-java",
         "pname": "tabula-java",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "1.0.5"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "erlang_javac",
         "pname": "erlang_javac",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "25.3.2.12"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "swigWithJava",
         "pname": "swigWithJava",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "4.2.1"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "yourkit-java",
         "pname": "yourkit-java",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2025.3-b135"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "java-hamcrest",
         "pname": "java-hamcrest",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.0"
       }
     ]
@@ -125,7 +125,7 @@
         "pkg_path": "jdk",
         "pname": "jdk",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "21.0.4"
       },
       {
@@ -136,7 +136,7 @@
         "pkg_path": "jdk8",
         "pname": "jdk8",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "8u442-b06"
       },
       {
@@ -147,7 +147,7 @@
         "pkg_path": "jdk11",
         "pname": "jdk11",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "11.0.26+4"
       }
     ]

--- a/test_data/generated/search/nodejs_all.json
+++ b/test_data/generated/search/nodejs_all.json
@@ -10,7 +10,7 @@
         "pkg_path": "nodejs_14",
         "pname": "nodejs_14",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "14.21.3"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "nodejs_16",
         "pname": "nodejs_16",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "16.20.2"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "nodejs_18",
         "pname": "nodejs_18",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "18.20.8"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "nodejs_19",
         "pname": "nodejs_19",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "19.9.0"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "nodejs_20",
         "pname": "nodejs_20",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "20.19.0"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "nodejs_21",
         "pname": "nodejs_21",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "21.7.3"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "nodejs_22",
         "pname": "nodejs_22",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "22.14.0"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "nodejs_23",
         "pname": "nodejs_23",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "nodejs_latest",
         "pname": "nodejs_latest",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "23.11.0"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "haxePackages.hxnodejs_4",
         "pname": "hxnodejs_4",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "4.0.9"
       },
       {
@@ -120,7 +120,7 @@
         "pkg_path": "haxePackages.hxnodejs_6",
         "pname": "hxnodejs_6",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "6.9.0"
       }
     ]

--- a/test_data/generated/search/python.json
+++ b/test_data/generated/search/python.json
@@ -10,7 +10,7 @@
         "pkg_path": "python",
         "pname": "python",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.7.18.8"
       },
       {
@@ -21,7 +21,7 @@
         "pkg_path": "gpython",
         "pname": "gpython",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "0.2.0"
       },
       {
@@ -32,7 +32,7 @@
         "pkg_path": "python2",
         "pname": "python2",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.7.18.8"
       },
       {
@@ -43,7 +43,7 @@
         "pkg_path": "python3",
         "pname": "python3",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.12.9"
       },
       {
@@ -54,7 +54,7 @@
         "pkg_path": "python27",
         "pname": "python27",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "2.7.18.8"
       },
       {
@@ -65,7 +65,7 @@
         "pkg_path": "python36",
         "pname": "python36",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "python3-3.6.14"
       },
       {
@@ -76,7 +76,7 @@
         "pkg_path": "python37",
         "pname": "python37",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "python3-3.7.16"
       },
       {
@@ -87,7 +87,7 @@
         "pkg_path": "python38",
         "pname": "python38",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "python3-3.8.18"
       },
       {
@@ -98,7 +98,7 @@
         "pkg_path": "python39",
         "pname": "python39",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "python3-3.9.21"
       },
       {
@@ -109,7 +109,7 @@
         "pkg_path": "python-qt",
         "pname": "python-qt",
         "stabilities": [],
-        "system": "x86_64-linux",
+        "system": "aarch64-darwin",
         "version": "3.6.0"
       }
     ]

--- a/test_data/input_data/envs/gcc_boost/manifest.toml
+++ b/test_data/input_data/envs/gcc_boost/manifest.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[install]
+gcc.pkg-path = "gcc"
+boost.pkg-path = "boost"


### PR DESCRIPTION
Test building a C++ program that uses an `#include` of a library
provided by Flox.

Tests correspond to the issue described in
https://github.com/flox/flox/issues/2992,
but the reproducer in that issue was technically not a valid reproducer
since in the example given, boost is actually needed at both buildtime
and runtime.
quotes-app-cpp has since been changed accordingly in
https://github.com/flox/flox-manifest-build-examples/pull/6

This commit adds two tests: one that requires boost just at build time,
and one that requires boost at both build time and runtime.

The test that only requires boost at build time fails prior to
https://github.com/flox/flox/commit/5a8e106b30e86ed0e5d8e668f860157e7e81d3d0.
The other one does not, because adding boost to runtime-packages means
that the include of boost can be found via the build-wrapper closure
even though it isn't available via the full development environment
closure.

I originally added a test with zlib, but zlib is present on macOS by
default so we'd have to make assertions about which zlib library was
used, which seems harder than just using boost.

## Release Notes

NA