### PR TITLE
fix: unable to create gc-roots directory

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -109,12 +109,14 @@ impl RemoteEnvironment {
             // `.flox/run` used to be a link until flox versions 1.3.3!
             // If we find a symlink, we need to delete it to create a directory
             // with symlinked files in the following step.
-            if gcroots_dir.exists() && gcroots_dir.is_symlink() {
+            if gcroots_dir.is_symlink() {
+                // returns true if the file exists and is a symlink
                 debug!(gcroot=?gcroots_dir, "removing symlink");
                 fs::remove_file(&gcroots_dir).map_err(RemoteEnvironmentError::CreateGcRootDir)?;
             }
 
             if !gcroots_dir.exists() {
+                debug!(path = %gcroots_dir.display(), "creating gc roots directory");
                 std::fs::create_dir_all(&gcroots_dir)
                     .map_err(RemoteEnvironmentError::CreateGcRootDir)?;
             }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
When running `flox list -r` we create a remote environment in a temporary directory, or pull the latest updates to it if it already exists. In the past the `.flox/run` path was a symlink to what is now the `dev` mode environment. That was changed with v1.3.3, and now that path is a directory that contains the `*.dev` and `*.run` symlinks. This command attempts to migrate from the old path to the new path, but failed to do so because of a misunderstanding of the `Path::exists` method.

The `Path::exists` method traverses symlinks to determine whether the real file exists. On my system the `.flox/run` symlink was dangling, so `Path::exists` returned false even though the symlink itself existed. This caused the `create_dir_all` function to fail to create the new `.flox/run` directory. We now use the `Path::is_symlink` method to check whether the symlink exists because it returns true if the path exists and is a symlink (without traversing it).

Closes #3039

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users will no longer encounter an error running the `flox list -r` command if Nix garbage collection has deleted a stale copy of an environment, leaving a dangling symlink at `~/.cache/flox/<owner>/<name>/.flox/run`.

<!-- Many thanks! -->
