### PR TITLE
Add [include] section to description

### DIFF
--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -30,6 +30,7 @@ tables:
 - [`[hook]`](#hook)
 - [`[profile]`](#profile)
 - [`[services]`](#services)
+- [`[include]`](#include)
 - [`[options]`](#options)
 - [`containerize`] - see [`flox-containerize(1)`](./flox-containerize.md)
 


### PR DESCRIPTION
## Proposed Changes
Add the [include] section to the high-level description of the manifest.toml man page

## Release Notes
N/A
