### PR TITLE
fix(pre-commit): Show rustfmt errors

### DIFF
--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -48,7 +48,7 @@ pre-commit-hooks.lib.${system}.run {
       in
       {
         enable = true;
-        entry = lib.mkForce "${wrapper}/bin/cargo-fmt fmt --all --manifest-path 'cli/Cargo.toml' -- --color always";
+        entry = lib.mkForce "${wrapper}/bin/cargo-fmt fmt --all --check --manifest-path 'cli/Cargo.toml' -- --color always";
       };
     clippy = {
       enable = true;


### PR DESCRIPTION
## Proposed Changes

Previously this would show failures as:

    % pre-commit run -a --hook-stage push
    clang-format.............................................................Passed
    clippy...................................................................Passed
    nixfmt-rfc-style.........................................................Passed
    rustfmt..................................................................Failed
    - hook id: rustfmt
    - files were modified by this hook

Now it shows the actual change:

    % pre-commit run -a --hook-stage push
    clang-format.............................................................Passed
    clippy...................................................................Passed
    nixfmt-rfc-style.........................................................Passed
    rustfmt..................................................................Failed
    - hook id: rustfmt
    - exit code: 1

    Diff in /Users/dcarley/projects/flox/flox/cli/flox/src/commands/init/mod.rs:839:
             };

             let toml_str = format_customization(&customization)?;
    -
    +
             // Use indoc to create the expected TOML with proper indentation
             let expected_toml = indoc! {r#"
                 version = 1

The option is described as:

    --check         Run in 'check' mode. Exits with 0 if input is
                    formatted correctly. Exits with 1 and prints a diff if
                    formatting is required.

## Release Notes

N/A
