### PR TITLE
fix(mk-data): Catch errors in cmds

### DIFF
--- a/cli/mk_data/src/generate.rs
+++ b/cli/mk_data/src/generate.rs
@@ -324,6 +324,9 @@ fn run_pre_cmd(
     ignore_errors: bool,
 ) -> Result<(), Error> {
     let mut cmd = Command::new("bash");
+    if !ignore_errors {
+        cmd.arg("-eu");
+    }
     cmd.arg("-c").arg(pre_cmd);
     cmd.current_dir(dir);
     if let Some(vars) = vars {
@@ -392,8 +395,10 @@ pub fn run_cmd(
     ignore_errors: bool,
 ) -> Result<(), Error> {
     let mut cmd = Command::new("bash");
-    cmd.arg("-c");
-    cmd.arg(gen_cmd);
+    if !ignore_errors {
+        cmd.arg("-eu");
+    }
+    cmd.arg("-c").arg(gen_cmd);
     cmd.current_dir(dir);
     if let Some(vars) = vars {
         for (key, value) in vars.iter() {
@@ -420,8 +425,10 @@ pub fn run_post_cmd(
     ignore_errors: bool,
 ) -> Result<(), Error> {
     let mut cmd = Command::new("bash");
-    cmd.arg("-c");
-    cmd.arg(post_cmd);
+    if !ignore_errors {
+        cmd.arg("-eu");
+    }
+    cmd.arg("-c").arg(post_cmd);
     cmd.current_dir(dir);
     if let Some(vars) = vars {
         for (key, value) in vars.iter() {


### PR DESCRIPTION
## Proposed Changes

Catch errors in all commands of `pre_cmd`, `cmd`, and `post_cmd` scripts
when `ignore_errors` is not set. Previously only the exit code of the
last command was used to detect errors.

This makes `RESPONSE_FILE` manipulation safer because we won't
accidentally end up with an empty file or field if there's a problem
with a `jq` query.

I tested running `just gen-data -f` locally which completed and verified
that we don't have any current errors. I haven't included it in this
commit though because it's very noisy and will conflict with the
`httpmock` work.

## Release Notes

N/A
