### PR TITLE
chore: Remove unused Flox.uuid

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -79,8 +79,6 @@ pub struct Flox {
 
     pub system: String,
 
-    pub uuid: uuid::Uuid,
-
     pub floxhub: Floxhub,
 
     /// Token to authenticate with FloxHub.
@@ -330,7 +328,6 @@ pub mod test_helpers {
             temp_dir,
             config_dir,
             runtime_dir,
-            uuid: Default::default(),
             floxhub: Floxhub::new(
                 Url::from_str("https://hub.flox.dev").unwrap(),
                 git_url_override,

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -88,7 +88,6 @@ use crate::utils::errors::display_chain;
 use crate::utils::init::{
     init_catalog_client,
     init_telemetry_uuid,
-    init_uuid,
     telemetry_opt_out_needs_migration,
 };
 use crate::utils::metrics::{AWSDatalakeConnection, Client, Hub, METRICS_UUID_FILE_NAME};
@@ -353,7 +352,6 @@ impl FloxArgs {
             runtime_dir,
             temp_dir: temp_dir_path.clone(),
             system: env!("NIX_TARGET_SYSTEM").to_string(),
-            uuid: init_uuid(&config.flox.data_dir).await?,
             floxhub_token,
             floxhub,
             catalog_client,


### PR DESCRIPTION
## Proposed Changes

These two live in parallel with each other:

1. `init_uuid()` and `~/.local/share/flox/uuid`
2. `init_telemetry_uuid()` and `~/.local/share/flox/metrics-uuid`

However the former never appears to have been used since it was added in 2f0768b8 and occasionally causes race conditions when I run the integration tests locally:

    ✗ flox activate works with requirements.txt and pip [1005]
       tags: catalog end2end python python:activate:requirements
       (from function `assert_success' in file /nix/store/612z53vfi1py1qf2cii0nzrqcigfgbag-bats-with-libraries-1.11.1/share/bats/bats-assert/src/assert_success.bash, line 42,
        in test file lang-python.bats, line 115)
         `assert_success' failed
       ❌ ERROR: failed to parse a UUID
          0: std::backtrace_rs::backtrace::libunwind::trace
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
          1: std::backtrace_rs::backtrace::trace_unsynchronized
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
          2: std::backtrace::Backtrace::create
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/backtrace.rs:331:13
          3: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.98/src/backtrace.rs:27:14
          4: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
                    at /nix/store/lxvf527m0av7vv4gr8gc41qlgwxl5hk6-rust-stable-2025-03-18/lib/rustlib/src/rust/library/core/src/result.rs:2014:27
          5: flox::utils::init::metrics::init_uuid::{{closure}}
                    at /Users/dcarley/projects/flox/flox/cli/flox/src/utils/init/metrics.rs:106:16
          6: flox::commands::FloxArgs::handle::{{closure}}
                    at /Users/dcarley/projects/flox/flox/cli/flox/src/commands/mod.rs:356:52
          7: flox::run::{{closure}}
                    at /Users/dcarley/projects/flox/flox/cli/flox/src/main.rs:45:25
          8: <core::pin::Pin<P> as core::future::future::Future>::poll
                    at /nix/store/lxvf527m0av7vv4gr8gc41qlgwxl5hk6-rust-stable-2025-03-18/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
          9: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/park.rs:284:60
         10: tokio::task::coop::with_budget
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/coop/mod.rs:167:5
         11: tokio::task::coop::budget
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/coop/mod.rs:133:5
         12: tokio::runtime::park::CachedParkThread::block_on
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/park.rs:284:31
         13: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/context/blocking.rs:66:9
         14: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/multi_thread/mod.rs:87:13
         15: tokio::runtime::context::runtime::enter_runtime
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/context/runtime.rs:65:16
         16: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/multi_thread/mod.rs:86:9
         17: tokio::runtime::runtime::Runtime::block_on_inner
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/runtime.rs:370:45
         18: tokio::runtime::runtime::Runtime::block_on
                    at /Users/dcarley/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/runtime.rs:340:13
         19: flox::main
                    at /Users/dcarley/projects/flox/flox/cli/flox/src/main.rs:142:27
         20: core::ops::function::FnOnce::call_once
                    at /nix/store/lxvf527m0av7vv4gr8gc41qlgwxl5hk6-rust-stable-2025-03-18/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
         21: std::sys::backtrace::__rust_begin_short_backtrace
                    at /nix/store/lxvf527m0av7vv4gr8gc41qlgwxl5hk6-rust-stable-2025-03-18/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
         22: std::rt::lang_start::{{closure}}
                    at /nix/store/lxvf527m0av7vv4gr8gc41qlgwxl5hk6-rust-stable-2025-03-18/lib/rustlib/src/rust/library/std/src/rt.rs:195:18
         23: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/ops/function.rs:284:13
         24: std::panicking::try::do_call
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panicking.rs:584:40
         25: std::panicking::try
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panicking.rs:547:19
         26: std::panic::catch_unwind
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panic.rs:358:14
         27: std::rt::lang_start_internal::{{closure}}
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/rt.rs:174:48
         28: std::panicking::try::do_call
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panicking.rs:584:40
         29: std::panicking::try
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panicking.rs:547:19
         30: std::panic::catch_unwind
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panic.rs:358:14
         31: std::rt::lang_start_internal
                    at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/rt.rs:174:20
         32: std::rt::lang_start
                    at /nix/store/lxvf527m0av7vv4gr8gc41qlgwxl5hk6-rust-stable-2025-03-18/lib/rustlib/src/rust/library/std/src/rt.rs:194:17
         33: _main

## Release Notes

N/A