### PR TITLE
refactor: use RawManifest helpers

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -77,7 +77,7 @@ pub struct PathEnvironment {
 }
 
 /// A profile script or list of packages to install when initializing an environment
-#[derive(Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct InitCustomization {
     pub hook_on_activate: Option<String>,
     pub profile_common: Option<String>,


### PR DESCRIPTION
Rather than re-implementing toml_edit logic in format_customization, add
a RawManifest::new_minimal method that calls RawManifest helpers. It
also avoids doing unnecessary work by calling insert_packages, which is
designed to operate on a pre-existing manifest.

In hindsight I'm not sure it was worth the effort, added conditionals in
RawManifest, and weird newline handling. But it's probably slightly less likely
that we'll end up with accidentally different behavior between new_documented
and format_customization with this approach.

Closes #2806 
