### PR TITLE
fix(manifest): Correct manifest package desc link

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -375,7 +375,7 @@ impl_into_inner!(Install, BTreeMap<String, ManifestPackageDescriptor>);
 #[serde(
     untagged,
     expecting = "Expected either a catalog package descriptor, a flake installable or a store path.
-See https://flox.dev/docs/concepts/manifest/#package-descriptors for more information."
+See https://flox.dev/docs/reference/command-reference/manifest.toml/#package-descriptors for more information."
 )]
 pub enum ManifestPackageDescriptor {
     Catalog(PackageDescriptorCatalog),


### PR DESCRIPTION
## Proposed Changes

This anchor no longer exists and we're about to redirect the page in:

- https://github.com/flox/floxdocs/pull/226

There's not much we can do about redirecting that specific anchor because it requires client-side redirects for anchors and they're not currently supported by `mkdocs-redirects` so we'll just have to accept that only newer releases will get the right error message.

## Release Notes

N/A, probably not worth mentioning.
