### PR TITLE
test: fix race in httpmock recording

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -250,7 +250,19 @@ impl Drop for MockRecorder {
         // https://github.com/alexliesenfeld/httpmock/issues/115
         let tempfile = self
             .server
-            .record_save(&self.recording, "httpmock")
+            .record_save(
+                &self.recording,
+                // We need something unique in the name otherwise parallel
+                // threads can race each other
+                format!(
+                    "httpmock_{}",
+                    self.path
+                        .file_name()
+                        .expect("path should have filename")
+                        .to_str()
+                        .expect("path should be unicode")
+                ),
+            )
             .expect("failed to save mock recording");
         fs::rename(&tempfile, &self.path).expect("failed to rename recorded mock file");
         debug!(


### PR DESCRIPTION
Make temporary mock filename unique to avoid tests running in parallel conflicting and using the same file.

Generating mocks was flaking with:
```
failed to rename recorded mock file: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

A little println debugging showed two tests running in parallel could add the same timestamp to the temporary file:
```
saved mock file /Users/matthew/.cargo/git/checkouts/httpmock-7a2fab464d0fd253/84956ea/target/httpmock/recordings/httpmock_1747852294.yaml
saved mock file /Users/matthew/.cargo/git/checkouts/httpmock-7a2fab464d0fd253/84956ea/target/httpmock/recordings/httpmock_1747852294.yaml
```

Presumably one test beats the other to renaming the file, and the second fails because the expected file no longer exists.

## Release Notes

NA