### PR TITLE
test(cuda): Catch error from find on non-NixOS

### DIFF
--- a/assets/environment-interpreter/common/etc/profile.d/0800_cuda.sh
+++ b/assets/environment-interpreter/common/etc/profile.d/0800_cuda.sh
@@ -44,7 +44,7 @@ activate_cuda() {
   if [ -z "$SYSTEM_LIBS" ]; then
     # shellcheck disable=SC2016
     SYSTEM_LIBS=$(
-      "$_find" "${fhs_root_prefix}/run/opengl-driver" -type f -print 2> /dev/null \
+      { "$_find" "${fhs_root_prefix}/run/opengl-driver" -type f -print 2> /dev/null || echo; } \
         | "$_nawk" -v lib_pattern="${lib_pattern}" \
           'BEGIN {files=""} $0 ~ lib_pattern {files = ( files == "" ? $NF : files ":" $NF)} END {print files}'
     )

--- a/cli/tests/cuda.bats
+++ b/cli/tests/cuda.bats
@@ -33,7 +33,6 @@ project_setup() {
   export FAKE_FHS_ROOT="${PROJECT_DIR}/fake_fhs_root"
   mkdir "$FAKE_FHS_ROOT"
   mkdir -p "${FAKE_FHS_ROOT}/dev"
-  mkdir -p "${FAKE_FHS_ROOT}/run/opengl-driver"
 }
 
 project_teardown() {
@@ -77,6 +76,7 @@ teardown() {
 
 @test "cuda disabled when nvidia0 device present but libcuba absent on NixOS" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
+  mkdir -p "${FAKE_FHS_ROOT}/run/opengl-driver"
 
   run "$FLOX_BIN" activate -- bash \
     "$TESTS_DIR/cuda/cuda-disabled.sh" \
@@ -124,6 +124,7 @@ teardown() {
 
 @test "cuda enabled when nvidia0 device present and libcuda present on NixOS" {
   touch "${FAKE_FHS_ROOT}/dev/nvidia0"
+  mkdir -p "${FAKE_FHS_ROOT}/run/opengl-driver"
   touch "${FAKE_FHS_ROOT}/run/opengl-driver/libcuda.so"
   touch "${FAKE_FHS_ROOT}/run/opengl-driver/libcuda.so.1"
   touch "${FAKE_FHS_ROOT}/run/opengl-driver/libcudart.so"


### PR DESCRIPTION
## Proposed Changes

The CUDA script would fail on the last `find | nawk` command when:

1. `/dev/nvidia0` is present
2. `ldconfig` returns no matching libs
3. `/run/opengl-driver` doesn't exist (ie. not NixOS)

This caused the `find` to fail on a non-existent directory and caused activations to fail because it runs the script with `set -e`.

It's reproduced by not automatically creating the directory for every test in the suite. It's now only created for the two tests that exercise NixOS behaviour. It's fixed by catching the error from `find` and returning an empty result like we did previously for `ldconfig` in 5c3cf9b1.

Failure with the change to the test and not the script:

    ✗ cuda disabled when nvidia0 device present but libcuba absent [1327]
       tags: cuda
       (from function `assert_success' in file /nix/store/612z53vfi1py1qf2cii0nzrqcigfgbag-bats-with-libraries-1.11.1/share/bats/bats-assert/src/assert_success.bash, line 42,
        in test file cuda.bats, line 73)
         `assert_success' failed
    …
    ++ /nix/store/vsia946b1b3bqz3j9cznlibc5l834n5f-findutils-4.10.0/bin/find /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.ub27qI/bats-run-cmTBoC/test/2/project-2/fake_fhs_root/run/opengl-driver -type f -print
       ++ /nix/store/328armcjagvyjz2iczccz9jn3s3zb0g2-nawk-20250116/bin/nawk -v 'lib_pattern=lib(cuda|nvidia|dxcore).*\.so.*' 'BEGIN {files=""} $0 ~ lib_pattern {files = ( files == "" ? $NF : files ":" $NF)} END {print files}'
       + SYSTEM_LIBS=

I think this script is still a good candidate for rewriting in Rust because we can be more explicit about handling exit codes and error output from individual commands (currently we have to swallow because everything ends up in the activation), there's less chance of common quoting and piping mistakes that we get from shell script, and it's possible to test each part independently. We should consider when to prioritise that separate from this ticket though, he says hoping that this is the last of these bugs for now.

## Release Notes

Fixed a bug in `flox activate` on machines that have CUDA hardware but no available libraries.
