### PR TITLE
chore(catalog): Remove publisher_url

### DIFF
--- a/cli/catalog-api-v1/src/lib.rs
+++ b/cli/catalog-api-v1/src/lib.rs
@@ -34,14 +34,14 @@ pub mod types {
     }
 
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-    pub struct CatalogStoreConfigPublisher {
-        pub publisher_url: String,
-    }
+    pub struct CatalogStoreConfigPublisher {}
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{CatalogStoreConfig, CatalogStoreConfigNixCopy, CatalogStoreConfigPublisher};
+    use crate::types::{
+        CatalogStoreConfig, CatalogStoreConfigNixCopy, CatalogStoreConfigPublisher,
+    };
 
     #[test]
     fn deserialize_catalog_store_config_null() {
@@ -84,15 +84,27 @@ mod tests {
     #[test]
     fn deserialize_catalog_store_config_publisher() {
         let response_string = r#"{
+           "store_type": "publisher"
+        }"#;
+
+        let store_config = serde_json::from_str::<CatalogStoreConfig>(response_string).unwrap();
+        assert_eq!(
+            store_config,
+            CatalogStoreConfig::Publisher(CatalogStoreConfigPublisher {})
+        )
+    }
+
+    #[test]
+    fn deserialize_catalog_store_config_publisher_ignores_deprecated_url() {
+        let response_string = r#"{
            "store_type": "publisher",
            "publisher_url": "s3://example"
         }"#;
 
         let store_config = serde_json::from_str::<CatalogStoreConfig>(response_string).unwrap();
-        assert_eq!(store_config, 
-            CatalogStoreConfig::Publisher( CatalogStoreConfigPublisher {
-                 publisher_url: "s3://example".into(),
-                })
-            )
+        assert_eq!(
+            store_config,
+            CatalogStoreConfig::Publisher(CatalogStoreConfigPublisher {})
+        )
     }
 }


### PR DESCRIPTION
## Proposed Changes

As described by the ticket:

> Currently we allow a catalog owner to set the publisher url to use for
> their catalog.  That was done with flexability in mind, perhaps
> running multiple instances of publishers ourselves for development and
> testing.  While potentially useful, we are not close to needing that
> and it leaves us vulnerable to token stealing.
>
> Bob could set his own catalog to use an arbitrary url as the publisher
> for _his_ catalog.  And then instruct someone else to use an
> environment using a package from his catalog.  Doing so will result in
> the CLI asking our catalog service to `get_store_info` with the user's
> floxhub token where the catalog service will pass that auth along to
> the url Bob configured (assuming it is a publisher).
>
> If we need this in the future, we'll need to address this.  But for
> now, let's configure the publisher url in the catalog service via
> infra provisioning (env var?) and omit it from the store config.  This
> has implications for `catalog-util` and possibly the CLI.

Removing it from the response would be a breaking change for the CLI which, although it doesn't currently use `publisher_url`, will attempt to deserialize it. So for now it is marked as optional and it will be removed from the CLI and `catalog-util`. Creating or changing the publisher store config for a catalog will require upgrading the CLI.

## Release Notes

N/A