### PR TITLE
refactor(catalog): Don't shadow store_type variant

### DIFF
--- a/cli/catalog-api-v1/build.rs
+++ b/cli/catalog-api-v1/build.rs
@@ -41,11 +41,6 @@ fn generator() -> progenitor::Generator {
         "crate::types::CatalogStoreConfig",
         vec![].into_iter(),
     );
-    settings.with_replacement(
-        "CatalogStoreConfigNixCopy",
-        "crate::types::CatalogStoreConfigNixCopy",
-        vec![].into_iter(),
-    );
     progenitor::Generator::new(&settings)
 }
 

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -379,6 +379,48 @@ pub mod types {
             value.clone()
         }
     }
+    ///CatalogStoreConfigNixCopy
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "CatalogStoreConfigNixCopy",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "egress_uri",
+    ///    "ingress_uri"
+    ///  ],
+    ///  "properties": {
+    ///    "egress_uri": {
+    ///      "title": "Egress Uri",
+    ///      "type": "string"
+    ///    },
+    ///    "ingress_uri": {
+    ///      "title": "Ingress Uri",
+    ///      "type": "string"
+    ///    },
+    ///    "store_type": {
+    ///      "title": "Store Type",
+    ///      "default": "nix-copy",
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    pub struct CatalogStoreConfigNixCopy {
+        pub egress_uri: String,
+        pub ingress_uri: String,
+        #[serde(default = "defaults::catalog_store_config_nix_copy_store_type")]
+        pub store_type: String,
+    }
+    impl From<&CatalogStoreConfigNixCopy> for CatalogStoreConfigNixCopy {
+        fn from(value: &CatalogStoreConfigNixCopy) -> Self {
+            value.clone()
+        }
+    }
     ///CatalogStoreConfigNull
     ///
     /// <details><summary>JSON schema</summary>
@@ -3281,6 +3323,9 @@ pub mod types {
         }
         pub(super) fn catalog_store_config_meta_only_store_type() -> String {
             "meta-only".to_string()
+        }
+        pub(super) fn catalog_store_config_nix_copy_store_type() -> String {
+            "nix-copy".to_string()
         }
         pub(super) fn catalog_store_config_null_store_type() -> String {
             "null".to_string()

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -541,6 +541,7 @@ fn get_client_side_catalog_store_config(
             let CatalogStoreConfigNixCopy {
                 ingress_uri,
                 egress_uri,
+                ..
             } = nix_copy_config;
             if let Some(path) = key_file {
                 ClientSideCatalogStoreConfig::NixCopy {
@@ -1237,6 +1238,7 @@ pub mod tests {
                 catalog_store_config: CatalogStoreConfig::NixCopy(CatalogStoreConfigNixCopy {
                     ingress_uri: "https://example.com".to_string(),
                     egress_uri: "https://example.com".to_string(),
+                    store_type: "nix-copy".to_string(),
                 }),
             }),
         ]);
@@ -1360,6 +1362,7 @@ pub mod tests {
                 catalog_store_config: CatalogStoreConfig::NixCopy(CatalogStoreConfigNixCopy {
                     ingress_uri: cache_url.to_string(),
                     egress_uri: cache_url.to_string(),
+                    store_type: "nix-copy".to_string(),
                 }),
             }),
             Response::PublishBuild,


### PR DESCRIPTION
## Proposed Changes

Supersedes https://github.com/flox/flox/pull/3096

So that..

1. We automatically get changes from the upstream schema, such as making `CatalogStoreConfigPublisher.publisher_url` optional. Previously we would have to remember to make those changes manually.

2. We don't have two types of the same name available like we did for `CatalogStoreconfigMetaOnly` or `CatalogStoreConfigPublisher` because we didn't add `settings.with_replacement()` call for them.

This leaves us with an extraneous `store_type` field but I think that's the lesser of evils.

## Release Notes

N/A
