### PR TITLE
fix: stop using disallowedReferences for manifest builds

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1660,7 +1660,8 @@ mod tests {
                 mkdir -p $out/bin
                 cp {bin_name} $out/bin/{bin_name}
             """
-            runtime-packages = [ "boost" ]
+            # FIXME: replace with gcc.lib once we support outputs
+            runtime-packages = [ "boost", "gcc" ]
             sandbox = "{}"
             "#, if sandbox { "pure" } else { "off" }};
         env.edit(&flox, build_manifest).unwrap();
@@ -1742,7 +1743,8 @@ mod tests {
                 mkdir -p $out/bin
                 cp {bin_name} $out/bin/{bin_name}
             """
-            runtime-packages = []
+            # FIXME: replace with gcc.lib once we support outputs
+            runtime-packages = [ "gcc" ]
             sandbox = "{}"
             "#, if sandbox { "pure" } else { "off" }};
         env.edit(&flox, build_manifest).unwrap();

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -74,9 +74,12 @@ pkgs.runCommandNoCC name
         "log"
       ]
       ++ pkgs.lib.optionals (buildCache != null) [ "buildCache" ];
-    # We don't want to allow build outputs to reference the "develop" environment
-    # because they should get everything they need at runtime from the build wrapper env.
-    disallowedReferences = [ flox-env-package ]; # XXX too easy to leak into output.
+    # We previously used `disallowedReferences` to prevent builds from referencing
+    # the "develop" environment, but that was too strict and caused issues with
+    # the "log" and "buildCache" outputs in particular. Now we instead inspect the
+    # closure once the build is complete to ensure that it only contains packages
+    # found only in the build wrapper closure.
+    # disallowedReferences = [ flox-env-package ];
   }
   (
     (


### PR DESCRIPTION
## Proposed Changes

As observed in #3051 and discussed in #3020, our use of disallowedReferences was causing build failures based on otherwise-immaterial references from the log and buildCache outputs. This update replaces our use of that feature with an external check performed after the "successful" build, one advantage of which is that we can now display the exact "why-depends" reason for failing the build, rather than just reporting a failure with no way to examine the failed package to see what went wrong.

Closes #3051

## Release Notes

N/A