### PR TITLE
feat: allow publishing of nix expression builds

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -382,7 +382,7 @@ impl EnvironmentPointer {
     /// Use this method to determine the type of an environment at a given path.
     /// The result should be used to call the appropriate `open` method
     /// on either [path_environment::PathEnvironment] or [managed_environment::ManagedEnvironment].
-    fn open(dot_flox_path: &CanonicalPath) -> Result<EnvironmentPointer, EnvironmentError> {
+    pub fn open(dot_flox_path: &CanonicalPath) -> Result<EnvironmentPointer, EnvironmentError> {
         let pointer_path = dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME);
         let pointer_contents = match fs::read(&pointer_path) {
             Ok(contents) => contents,

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -6,6 +6,7 @@ use std::sync::LazyLock;
 use std::sync::mpsc::Receiver;
 use std::{env, thread};
 
+use chrono::{DateTime, Utc};
 use indoc::{formatdoc, indoc};
 use serde::Deserialize;
 use tempfile::NamedTempFile;
@@ -563,6 +564,28 @@ impl<'origins> PackageTargets<'origins> {
 
     pub fn expression_dir(&self) -> &Path {
         self.expression_dir
+    }
+}
+
+/// Simple struct to hold the information of a locked URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockedUrlInfo {
+    pub url: String,
+    pub rev: String,
+    pub rev_count: u64,
+    pub rev_date: DateTime<Utc>,
+}
+
+/// Hardcoded locked URL for publishes of expression builds
+///
+/// Outisde of tests this should be replaced by a mechanism that fetches an actual locked URL,
+/// in correspondence with the catalog server.
+pub fn mock_locked_url_info() -> LockedUrlInfo {
+    LockedUrlInfo {
+        url: "https://github.com/flox/nixpkgs?ref=refs/heads/stable&rev=698214a32beb4f4c8e3942372c694f40848b360d".to_string(),
+        rev: "698214a32beb4f4c8e3942372c694f40848b360d".to_string(),
+        rev_count: 773904,
+        rev_date: chrono::DateTime::from_timestamp(1742889210, 0).unwrap(),
     }
 }
 

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -6,7 +6,6 @@ use std::sync::LazyLock;
 use std::sync::mpsc::Receiver;
 use std::{env, thread};
 
-use chrono::{DateTime, Utc};
 use indoc::{formatdoc, indoc};
 use serde::Deserialize;
 use tempfile::NamedTempFile;
@@ -79,9 +78,6 @@ pub enum ManifestBuilderError {
 
     #[error("failed to list available nix expressions to build: {0}")]
     ListNixExpressions(String),
-
-    #[error("invalid nixpkgs base url")]
-    InvalidNixpkgsBaseUrl(url::ParseError),
 
     #[error("failed to clean up build artifacts: {stderr}")]
     RunClean {
@@ -578,35 +574,6 @@ impl<'origins> PackageTargets<'origins> {
 
     pub fn expression_dir(&self) -> &Path {
         self.expression_dir
-    }
-}
-
-/// Simple struct to hold the information of a locked URL.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LockedUrlInfo {
-    pub url: String,
-    pub rev: String,
-    pub rev_count: u64,
-    pub rev_date: DateTime<Utc>,
-}
-
-impl LockedUrlInfo {
-    pub fn as_flake_ref(&self) -> Result<Url, ManifestBuilderError> {
-        Url::parse(&format!("git+{}", self.url))
-            .map_err(ManifestBuilderError::InvalidNixpkgsBaseUrl)
-    }
-}
-
-/// Hardcoded locked URL for publishes of expression builds
-///
-/// Outisde of tests this should be replaced by a mechanism that fetches an actual locked URL,
-/// in correspondence with the catalog server.
-pub fn mock_locked_url_info() -> LockedUrlInfo {
-    LockedUrlInfo {
-        url: "https://github.com/flox/nixpkgs?ref=refs/heads/stable&rev=698214a32beb4f4c8e3942372c694f40848b360d".to_string(),
-        rev: "698214a32beb4f4c8e3942372c694f40848b360d".to_string(),
-        rev_count: 773904,
-        rev_date: chrono::DateTime::from_timestamp(1742889210, 0).unwrap(),
     }
 }
 

--- a/cli/flox-rust-sdk/src/providers/container_builder.rs
+++ b/cli/flox-rust-sdk/src/providers/container_builder.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, instrument};
 use super::buildenv::BuiltStorePath;
 use crate::flox::Flox;
 use crate::models::manifest::typed::{ActivateMode, ContainerizeConfig};
-use crate::providers::build::BUILDTIME_NIXPKGS_URL;
+use crate::providers::build::COMMON_NIXPKGS_URL;
 use crate::providers::nix::nix_base_command;
 use crate::utils::gomap::GoMap;
 use crate::utils::{CommandExt, ReaderExt};
@@ -145,7 +145,7 @@ impl ContainerBuilder for MkContainerNix {
         command.arg("--json");
         command.arg("--no-link");
         command.arg("--file").arg(&*MK_CONTAINER_NIX);
-        command.args(["--argstr", "nixpkgsFlakeRef", &*BUILDTIME_NIXPKGS_URL]);
+        command.args(["--argstr", "nixpkgsFlakeRef", COMMON_NIXPKGS_URL.as_str()]);
         command.args(["--argstr", "containerSystem", env!("NIX_TARGET_SYSTEM")]);
         command.args(["--argstr", "system", env!("NIX_TARGET_SYSTEM")]);
         command.args([

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -675,7 +675,7 @@ pub fn check_build_metadata(
                 .rendered_env_links(flox)
                 .unwrap()
                 .development,
-            &[pkg.to_owned()],
+            &[pkg],
             Some(false),
         )
         .map_err(|e| PublishError::BuildError(e.to_string()))?;

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -23,7 +23,7 @@ use super::git::{GitCommandError, GitCommandProvider, StatusInfo};
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
 use crate::models::environment::path_environment::PathEnvironment;
-use crate::models::environment::{Environment, EnvironmentError, PathPointer};
+use crate::models::environment::{Environment, EnvironmentError, EnvironmentPointer};
 use crate::models::lockfile::Lockfile;
 use crate::models::manifest::typed::Inner;
 use crate::providers::auth::catalog_auth_to_envs;
@@ -97,21 +97,16 @@ pub struct LockedUrlInfo {
 
 /// Ensures that the required metadata for publishing is consistent from the environment
 #[allow(clippy::manual_non_exhaustive)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CheckedEnvironmentMetadata {
+    pub lockfile: Lockfile,
     // This is the local root path of the repo containing the environment
     pub repo_root_path: PathBuf,
     // This is the path to the .flox for the build environment relative to the repo_root_path
     pub rel_dotflox_path: PathBuf,
 
-    // There may or may not be a locked base catalog reference in the environment
-    pub base_catalog_ref: LockedUrlInfo,
     // The build repo reference is always present
     pub build_repo_ref: LockedUrlInfo,
-
-    // These are collected from the environment manifest
-    pub package: String,
-    pub description: String,
 
     // This field isn't "pub", so no one outside this module can construct this struct. That helps
     // ensure that we can only make this struct as a result of doing the "right thing."
@@ -131,6 +126,21 @@ pub struct CheckedBuildMetadata {
     pub system: SystemEnum,
 
     pub version: Option<String>,
+
+    // This field isn't "pub", so no one outside this module can construct this struct. That helps
+    // ensure that we can only make this struct as a result of doing the "right thing."
+    _private: (),
+}
+
+#[allow(clippy::manual_non_exhaustive)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct PackageMetadata {
+    // There may or may not be a locked base catalog reference in the environment
+    pub base_catalog_ref: LockedUrlInfo,
+
+    // These are collected from the environment manifest
+    pub package: String,
+    pub description: String,
 
     // This field isn't "pub", so no one outside this module can construct this struct. That helps
     // ensure that we can only make this struct as a result of doing the "right thing."
@@ -417,6 +427,7 @@ impl ClientSideCatalogStoreConfig {
 pub struct PublishProvider<A> {
     pub env_metadata: CheckedEnvironmentMetadata,
     pub build_metadata: CheckedBuildMetadata,
+    pub package_metadata: PackageMetadata,
     auth: A,
 }
 
@@ -424,11 +435,13 @@ impl<A> PublishProvider<A> {
     pub fn new(
         env_metadata: CheckedEnvironmentMetadata,
         build_metadata: CheckedBuildMetadata,
+        package_metadata: PackageMetadata,
         auth: A,
     ) -> Self {
         Self {
             env_metadata,
             build_metadata,
+            package_metadata,
             auth,
         }
     }
@@ -455,7 +468,7 @@ where
         client
             .create_package(
                 &catalog_name,
-                &self.env_metadata.package,
+                &self.package_metadata.package,
                 &self.env_metadata.build_repo_ref.url,
             )
             .await
@@ -470,7 +483,7 @@ where
         // needed.
         tracing::debug!("Beginning publish of package...");
         let publish_response = client
-            .publish_info(catalog_name, &self.env_metadata.package)
+            .publish_info(catalog_name, &self.package_metadata.package)
             .await
             .map_err(PublishError::CatalogError)?;
 
@@ -486,7 +499,7 @@ where
         let build_info = UserBuildPublish {
             derivation: UserDerivationInfo {
                 broken: Some(false),
-                description: self.env_metadata.description.clone(),
+                description: self.package_metadata.description.clone(), // TODO: extract from expr build result
                 drv_path: self.build_metadata.drv_path.clone(),
                 license: None,
                 name: self.build_metadata.name.clone(),
@@ -497,7 +510,7 @@ where
                 unfree: None,
                 version: self.build_metadata.version.clone(),
             },
-            locked_base_catalog_url: Some(self.env_metadata.base_catalog_ref.url.clone()),
+            locked_base_catalog_url: Some(self.package_metadata.base_catalog_ref.url.clone()),
             url: self.env_metadata.build_repo_ref.url.clone(),
             rev: self.env_metadata.build_repo_ref.rev.clone(),
             rev_count: self.env_metadata.build_repo_ref.rev_count as i64,
@@ -515,7 +528,7 @@ where
 
         tracing::debug!("Publishing build in catalog...");
         client
-            .publish_build(&catalog_name, &self.env_metadata.package, &build_info)
+            .publish_build(&catalog_name, &self.package_metadata.package, &build_info)
             .await
             .map_err(PublishError::CatalogError)?;
 
@@ -618,7 +631,6 @@ pub fn check_build_metadata_from_build_result(
 pub fn check_build_metadata(
     flox: &Flox,
     env_metadata: &CheckedEnvironmentMetadata,
-    env: &PathEnvironment,
     builder: &impl ManifestBuilder,
     pkg: &str,
 ) -> Result<CheckedBuildMetadata, PublishError> {
@@ -645,8 +657,13 @@ pub fn check_build_metadata(
                 .to_string(),
         )
     })?;
-    let mut clean_build_env =
-        PathEnvironment::open(flox, PathPointer::new(env.name()), dot_flox_path)?;
+    let EnvironmentPointer::Path(path_pointer) = EnvironmentPointer::open(&dot_flox_path)
+        .map_err(|e| PublishError::UnsupportedEnvironmentState(e.to_string()))?
+    else {
+        unreachable!("Cloned environment contained a path environmentonment")
+    };
+
+    let mut clean_build_env = PathEnvironment::open(flox, path_pointer, dot_flox_path)?;
 
     // Build the package and collect the outputs
     let output_stream = builder
@@ -877,7 +894,6 @@ fn gather_base_repo_meta(lockfile: &Lockfile) -> Result<LockedUrlInfo, PublishEr
 pub fn check_environment_metadata(
     flox: &Flox,
     environment: &impl Environment,
-    pkg: &str,
 ) -> Result<CheckedEnvironmentMetadata, PublishError> {
     // We want to make sure we don't incur a lock operation, it must be locked and committed to the repo
     // So we do so with an immutable Environment reference.
@@ -901,22 +917,34 @@ pub fn check_environment_metadata(
     })?;
 
     let build_repo_meta = gather_build_repo_meta(&git)?;
-    let base_repo_meta = gather_base_repo_meta(&lockfile)?;
+
+    Ok(CheckedEnvironmentMetadata {
+        lockfile,
+        build_repo_ref: build_repo_meta,
+        repo_root_path: git.path().to_path_buf(),
+        rel_dotflox_path: rel_dotflox_path.to_path_buf(),
+        _private: (),
+    })
+}
+
+pub fn check_package_metadata(
+    lockfile: &Lockfile,
+    pkg: &str,
+) -> Result<PackageMetadata, PublishError> {
+    let base_catalog_ref = gather_base_repo_meta(lockfile)?;
 
     let description = lockfile
         .manifest
         .build
         .inner()
         .get(pkg)
-        .and_then(|desc| desc.description.clone());
+        .and_then(|desc| desc.description.clone())
+        .unwrap_or_default();
 
-    Ok(CheckedEnvironmentMetadata {
-        base_catalog_ref: base_repo_meta,
-        build_repo_ref: build_repo_meta,
+    Ok(PackageMetadata {
         package: pkg.to_string(),
-        repo_root_path: git.path().to_path_buf(),
-        rel_dotflox_path: rel_dotflox_path.to_path_buf(),
-        description: description.unwrap_or_else(|| "Not Provided".to_string()),
+        description,
+        base_catalog_ref,
         _private: (),
     })
 }
@@ -934,7 +962,6 @@ pub mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::data::CanonicalPath;
     use crate::flox::FloxhubToken;
     use crate::flox::test_helpers::{create_test_token, flox_instance};
     use crate::models::environment::path_environment::PathEnvironment;
@@ -1031,7 +1058,7 @@ pub mod tests {
         let (flox, _temp_dir_handle) = flox_instance();
         let (env, _git) = example_path_environment(&flox, None);
 
-        let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME);
+        let meta = check_environment_metadata(&flox, &env);
         meta.expect_err("Should fail due to not being a git repo");
     }
 
@@ -1041,13 +1068,13 @@ pub mod tests {
         let (_tempdir_handle, _remote_repo, remote_uri) = example_git_remote_repo();
         let (env, _git) = example_path_environment(&flox, Some(&remote_uri));
 
-        let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME);
+        let meta = check_environment_metadata(&flox, &env);
         assert!(meta.is_ok());
 
         std::fs::write(env.manifest_path(&flox).unwrap(), "dirty content")
             .expect("to write some additional text to the .flox");
 
-        let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME);
+        let meta = check_environment_metadata(&flox, &env);
         match meta {
             Err(PublishError::UnsupportedEnvironmentState(_msg)) => {},
             _ => panic!("Expected error to be of type UnsupportedEnvironmentState"),
@@ -1060,7 +1087,7 @@ pub mod tests {
         let (_tempdir_handle, _remote_repo, remote_uri) = example_git_remote_repo();
         let (env, git) = example_path_environment(&flox, Some(&remote_uri));
 
-        let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME);
+        let meta = check_environment_metadata(&flox, &env);
         assert!(meta.is_ok());
 
         let manifest_path = env
@@ -1075,7 +1102,7 @@ pub mod tests {
             .expect("adding flox files");
         git.commit("dirty comment").expect("be able to commit");
 
-        let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME);
+        let meta = check_environment_metadata(&flox, &env);
         match meta {
             Err(PublishError::UnsupportedEnvironmentState(_msg)) => {},
             _ => panic!("Expected error to be of type UnsupportedEnvironmentState"),
@@ -1088,8 +1115,7 @@ pub mod tests {
         let (_tempdir_handle, _remote_repo, remote_uri) = example_git_remote_repo();
         let (env, build_repo) = example_path_environment(&flox, Some(&remote_uri));
 
-        let meta = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME).unwrap();
-        let description_in_manifest = "Some sample package description from our tests";
+        let meta = check_environment_metadata(&flox, &env).unwrap();
 
         let build_repo_meta = meta.build_repo_ref;
         assert!(build_repo_meta.url.contains(&remote_uri));
@@ -1099,9 +1125,19 @@ pub mod tests {
                 .is_ok()
         );
         assert_eq!(build_repo_meta.rev_count, 1);
+    }
 
-        let lockfile_path = CanonicalPath::new(env.lockfile_path(&flox).unwrap());
-        let lockfile = Lockfile::read_from_file(&lockfile_path.unwrap()).unwrap();
+    #[test]
+    fn test_check_package_meta_nominal() {
+        let (flox, _temp_dir_handle) = flox_instance();
+        let (_tempdir_handle, _remote_repo, remote_uri) = example_git_remote_repo();
+        let (mut env, _) = example_path_environment(&flox, Some(&remote_uri));
+
+        let lockfile = env.lockfile(&flox).unwrap().into();
+
+        let meta = check_package_metadata(&lockfile, EXAMPLE_PACKAGE_NAME).unwrap();
+        let description_in_manifest = "Some sample package description from our tests";
+
         // Only the toplevel group in this example, so we can grab the first package
         let locked_base_pkg = lockfile.packages[0].as_catalog_package_ref().unwrap();
         assert_eq!(meta.base_catalog_ref.url, locked_base_pkg.locked_url);
@@ -1123,11 +1159,11 @@ pub mod tests {
 
         let (env, _build_repo) = example_path_environment(&flox, Some(&remote_uri));
 
-        let env_metadata = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME).unwrap();
+        let env_metadata = check_environment_metadata(&flox, &env).unwrap();
 
         // This will actually run the build
-        let meta = check_build_metadata(&flox, &env_metadata, &env, &builder, EXAMPLE_PACKAGE_NAME)
-            .unwrap();
+        let meta =
+            check_build_metadata(&flox, &env_metadata, &builder, EXAMPLE_PACKAGE_NAME).unwrap();
 
         let version_in_manifest = "1.0.2a";
 
@@ -1151,13 +1187,16 @@ pub mod tests {
         let catalog_name = token.handle().to_string();
         flox.floxhub_token = Some(token);
 
-        let env_metadata = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME).unwrap();
+        let env_metadata = check_environment_metadata(&flox, &env).unwrap();
         let build_metadata =
-            check_build_metadata(&flox, &env_metadata, &env, &builder, EXAMPLE_PACKAGE_NAME)
-                .unwrap();
+            check_build_metadata(&flox, &env_metadata, &builder, EXAMPLE_PACKAGE_NAME).unwrap();
+
+        let package_metadata =
+            check_package_metadata(&env_metadata.lockfile, EXAMPLE_PACKAGE_NAME).unwrap();
 
         let auth = Auth::from_flox(&flox).unwrap();
-        let publish_provider = PublishProvider::new(env_metadata, build_metadata, auth);
+        let publish_provider =
+            PublishProvider::new(env_metadata, build_metadata, package_metadata, auth);
 
         reset_mocks(&mut flox.catalog_client, vec![
             Response::CreatePackage,
@@ -1180,7 +1219,11 @@ pub mod tests {
     /// can be passed to publish()
     ///
     /// It is dummy in the sense that no human thought about it ;)
-    fn dummy_publish_metadata() -> (CheckedBuildMetadata, CheckedEnvironmentMetadata) {
+    fn dummy_publish_metadata() -> (
+        CheckedBuildMetadata,
+        CheckedEnvironmentMetadata,
+        PackageMetadata,
+    ) {
         let build_metadata = CheckedBuildMetadata {
             name: "dummy".to_string(),
             pname: "dummy".to_string(),
@@ -1193,15 +1236,22 @@ pub mod tests {
         };
 
         let env_metadata = CheckedEnvironmentMetadata {
+            lockfile: Lockfile::default(),
             repo_root_path: PathBuf::new(),
             rel_dotflox_path: PathBuf::new(),
-            base_catalog_ref: LockedUrlInfo {
+
+            build_repo_ref: LockedUrlInfo {
                 url: "dummy".to_string(),
                 rev: "dummy".to_string(),
                 rev_count: 0,
                 rev_date: Utc::now(),
             },
-            build_repo_ref: LockedUrlInfo {
+
+            _private: (),
+        };
+
+        let package_metadata = PackageMetadata {
+            base_catalog_ref: LockedUrlInfo {
                 url: "dummy".to_string(),
                 rev: "dummy".to_string(),
                 rev_count: 0,
@@ -1212,7 +1262,7 @@ pub mod tests {
             _private: (),
         };
 
-        (build_metadata, env_metadata)
+        (build_metadata, env_metadata, package_metadata)
     }
 
     #[tokio::test]
@@ -1225,10 +1275,11 @@ pub mod tests {
         flox.floxhub_token = Some(token);
 
         // Don't do a build because it's slow
-        let (build_metadata, env_metadata) = dummy_publish_metadata();
+        let (build_metadata, env_metadata, package_metadata) = dummy_publish_metadata();
 
         let auth = Auth::from_flox(&flox).unwrap();
-        let publish_provider = PublishProvider::new(env_metadata, build_metadata, auth);
+        let publish_provider =
+            PublishProvider::new(env_metadata, build_metadata, package_metadata, auth);
 
         reset_mocks(&mut client, vec![
             Response::CreatePackage,
@@ -1340,14 +1391,16 @@ pub mod tests {
         let catalog_name = token.handle().to_string();
         flox.floxhub_token = Some(token.clone());
 
-        let env_metadata = check_environment_metadata(&flox, &env, EXAMPLE_PACKAGE_NAME).unwrap();
+        let env_metadata = check_environment_metadata(&flox, &env).unwrap();
         let build_metadata =
-            check_build_metadata(&flox, &env_metadata, &env, &builder, EXAMPLE_PACKAGE_NAME)
-                .unwrap();
+            check_build_metadata(&flox, &env_metadata, &builder, EXAMPLE_PACKAGE_NAME).unwrap();
+        let package_metadata =
+            check_package_metadata(&env_metadata.lockfile, EXAMPLE_PACKAGE_NAME).unwrap();
 
         let (_key_file, cache) = local_nix_cache(&token);
         let auth = Auth::from_flox(&flox).unwrap();
-        let publish_provider = PublishProvider::new(env_metadata, build_metadata, auth);
+        let publish_provider =
+            PublishProvider::new(env_metadata, build_metadata, package_metadata, auth);
 
         // the 'cache' should be non existent before the publish
         let cache_url = cache.upload_url().unwrap();

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -4,7 +4,6 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 
 use catalog_api_v1::types::{NarInfo, NarInfos, Output, Outputs, PublishResponse, SystemEnum};
-use chrono::{DateTime, Utc};
 use indoc::{formatdoc, indoc};
 use thiserror::Error;
 use tracing::{debug, instrument};
@@ -95,28 +94,6 @@ pub trait Publisher {
         key_file: Option<PathBuf>,
         metadata_only: bool,
     ) -> Result<(), PublishError>;
-}
-
-/// Simple struct to hold the information of a locked URL.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LockedUrlInfo {
-    pub url: String,
-    pub rev: String,
-    pub rev_count: u64,
-    pub rev_date: DateTime<Utc>,
-}
-
-/// Hardcoded locked URL for publishes of expression builds
-///
-/// Outisde of tests this should be replaced by a mechanism that fetches an actual locked URL,
-/// in correspondence with the catalog server.
-pub fn mock_locked_url_info() -> LockedUrlInfo {
-    LockedUrlInfo {
-        url: "https://github.com/flox/nixpkgs?ref=refs/heads/stable&rev=698214a32beb4f4c8e3942372c694f40848b360d".to_string(),
-        rev: "698214a32beb4f4c8e3942372c694f40848b360d".to_string(),
-        rev_count: 773904,
-        rev_date: chrono::DateTime::from_timestamp(1742889210, 0).unwrap(),
-    }
 }
 
 /// Ensures that the required metadata for publishing is consistent from the environment
@@ -999,7 +976,9 @@ pub mod tests {
 
     use std::io::Write;
 
+    use build::mock_locked_url_info;
     use catalog_api_v1::types::CatalogStoreConfigNixCopy;
+    use chrono::Utc;
     use pretty_assertions::assert_eq;
 
     use super::*;

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -12,9 +12,9 @@ use flox_rust_sdk::providers::build::{
     Output,
     PackageTargets,
     build_symlink_path,
-    mock_locked_url_info,
     nix_expression_dir,
 };
+use flox_rust_sdk::providers::catalog::mock_base_catalog_url;
 use indoc::formatdoc;
 use tracing::instrument;
 
@@ -129,7 +129,7 @@ impl Build {
         let builder =
             FloxBuildMk::new(&flox, &base_dir, Some(&expression_dir), &built_environments);
         let output = builder.build(
-            &mock_locked_url_info().as_flake_ref()?,
+            &mock_base_catalog_url().as_flake_ref()?,
             &FLOX_INTERPRETER,
             &packages_to_build.target_names(),
             None,

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -12,6 +12,7 @@ use flox_rust_sdk::providers::build::{
     Output,
     PackageTargets,
     build_symlink_path,
+    mock_locked_url_info,
     nix_expression_dir,
 };
 use indoc::formatdoc;
@@ -130,6 +131,7 @@ impl Build {
             &base_dir,
             &built_environments,
             Some(&expression_dir),
+            &mock_locked_url_info().as_flake_ref()?,
             &FLOX_INTERPRETER,
             &packages_to_build.target_names(),
             None,

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -6,18 +6,16 @@ use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::models::lockfile::Lockfile;
-use flox_rust_sdk::models::manifest::typed::Inner;
 use flox_rust_sdk::providers::build::{
     FloxBuildMk,
     ManifestBuilder,
     Output,
+    PackageTargets,
     build_symlink_path,
-    get_nix_expression_targets,
     nix_expression_dir,
 };
-use indoc::{formatdoc, indoc};
-use itertools::Itertools;
-use tracing::{debug, instrument};
+use indoc::formatdoc;
+use tracing::instrument;
 
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::activate::FLOX_INTERPRETER;
@@ -93,20 +91,19 @@ impl Build {
         if let ConcreteEnvironment::Remote(_) = &env {
             bail!("Cannot build from a remote environment");
         };
-
         let base_dir = env.parent_path()?;
         let expression_dir = nix_expression_dir(&env); // TODO: decouple from env
         let flox_env = env.rendered_env_links(&flox)?;
         let lockfile = env.lockfile(&flox)?.into();
 
-        let packages_to_clean = available_packages(&lockfile, &expression_dir, packages)?;
+        let packages_to_clean = packages_to_build(&lockfile, &expression_dir, &packages)?;
 
         let builder = FloxBuildMk::new(&flox);
         builder.clean(
             &base_dir,
             &flox_env.development,
             Some(&expression_dir),
-            &packages_to_clean,
+            &packages_to_clean.target_names(),
         )?;
 
         message::created("Clean completed successfully");
@@ -126,7 +123,7 @@ impl Build {
 
         let lockfile = env.lockfile(&flox)?.into();
 
-        let packages_to_build = available_packages(&lockfile, &expression_dir, packages)?;
+        let packages_to_build = packages_to_build(&lockfile, &expression_dir, &packages)?;
 
         let builder = FloxBuildMk::new(&flox);
         let output = builder.build(
@@ -134,7 +131,7 @@ impl Build {
             &built_environments,
             Some(&expression_dir),
             &FLOX_INTERPRETER,
-            &packages_to_build,
+            &packages_to_build.target_names(),
             None,
         )?;
 
@@ -142,16 +139,20 @@ impl Build {
             match message {
                 Output::Stdout(line) => println!("{line}"),
                 Output::Stderr(line) => eprintln!("{line}"),
-                Output::Success { .. } => {
+                Output::Success(results) => {
                     let current_dir = env::current_dir()
                         .context("could not get current directory")?
                         .canonicalize()
                         .context("could not canonicalize current directory")?;
-                    let links_to_print = packages_to_build
+
+                    let links_to_print = results
                         .iter()
-                        .map(|package| Self::check_and_display_symlink(&env, package, &current_dir))
+                        .map(|package| {
+                            Self::check_and_display_symlink(&env, &package.pname, &current_dir)
+                        })
                         .collect::<Result<Vec<_>, _>>()?;
-                    if packages_to_build.len() > 1 {
+
+                    if links_to_print.len() > 1 {
                         message::created(formatdoc!(
                             "Builds completed successfully.
                             Outputs created: {}",
@@ -211,55 +212,18 @@ impl Build {
     }
 }
 
-fn available_packages(
-    lockfile: &Lockfile,
-    expression_dir: &Path,
-    packages: Vec<String>,
-) -> Result<Vec<String>> {
-    let environment_packages = &lockfile.manifest.build;
-    let nix_expression_packages =
-        get_nix_expression_targets(expression_dir).map_err(anyhow::Error::msg)?;
+pub(crate) fn packages_to_build<'o>(
+    lockfile: &'o Lockfile,
+    expression_dir: &'o Path,
+    packages: &[impl AsRef<str>],
+) -> Result<PackageTargets<'o>> {
+    let mut available_targets = PackageTargets::new(lockfile, expression_dir)?;
 
-    if environment_packages.inner().is_empty() && nix_expression_packages.is_empty() {
-        bail!(indoc! {"
-        No builds found.
-
-        Add a build by modifying the '[build]' section of the manifest with 'flox edit'
-        "});
+    if !packages.is_empty() {
+        available_targets.select(packages)?;
     }
 
-    let packages_to_build = if packages.is_empty() {
-        environment_packages
-            .inner()
-            .keys()
-            .chain(nix_expression_packages.iter())
-            .cloned()
-            .dedup()
-            .collect()
-    } else {
-        packages
-    };
-
-    for package in &packages_to_build {
-        let is_nix_expression = nix_expression_packages.contains(package);
-        let is_manifest_build = environment_packages.inner().contains_key(package);
-
-        match (is_nix_expression, is_manifest_build) {
-            (true, true) => {
-                bail!(formatdoc! {"
-                    Package '{package}' is defined in the manifest and as a Nix expression.
-                
-                    Rename or delete either the package definition in {expression_dir}
-                    or the '[build]' section in the manifest.
-                ", expression_dir = expression_dir.display()})
-            },
-            (true, false) => debug!(%package, "found nix expression"),
-            (false, true) => debug!(%package, "found manifest_build"),
-            (false, false) => bail!("Package '{}' not found in environment", package),
-        }
-    }
-
-    Ok(packages_to_build)
+    Ok(available_targets)
 }
 
 #[cfg(test)]
@@ -326,11 +290,8 @@ mod test {
                 {{runCommand}}: runCommand "{pname}" {{}} ""
             "#})]);
 
-        let result = available_packages(
-            &env.lockfile(&flox).unwrap().into(),
-            &expressions_dir,
-            vec![],
-        );
+        let lockfile = env.lockfile(&flox).unwrap().into();
+        let result = packages_to_build(&lockfile, &expressions_dir, &Vec::<String>::new());
         assert!(result.is_err());
     }
 }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -6,7 +6,8 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::models::manifest::typed::{Inner, Manifest};
 use flox_rust_sdk::providers::auth::Auth;
-use flox_rust_sdk::providers::build::{mock_locked_url_info, nix_expression_dir};
+use flox_rust_sdk::providers::build::nix_expression_dir;
+use flox_rust_sdk::providers::catalog::mock_base_catalog_url;
 use flox_rust_sdk::providers::publish::{
     PublishProvider,
     Publisher,
@@ -144,7 +145,7 @@ impl Publish {
         let package_metadata = check_package_metadata(
             &env_metadata.lockfile,
             &nix_expression_dir(&path_env),
-            mock_locked_url_info(), // TODO: Replace with actual locked URL info from catalog server
+            &mock_base_catalog_url(), // TODO: Replace with actual locked URL info from catalog server
             &package,
         )?;
 

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -180,22 +180,10 @@ impl Publish {
     }
 }
 
-fn check_target_exists(lockfile: &Lockfile, package: &str) -> Result<bool> {
-    let environment_packages = &lockfile.manifest.build;
-
-    if environment_packages.inner().is_empty() {
-        bail!(indoc! {"
-        No builds found.
-
-        Add a build by modifying the '[build]' section of the manifest with 'flox edit'
-        "});
-    }
-
-    if !environment_packages.inner().contains_key(package) {
-        bail!("Package '{}' not found in environment", package);
-    }
-
-    Ok(true)
+fn check_target_exists(lockfile: &Lockfile, expression_dir: &Path, package: &str) -> Result<()> {
+    // returns the same Vec iff `package` is avalable
+    build::packages_to_build(lockfile, expression_dir, &vec![package])?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -6,7 +6,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::models::manifest::typed::{Inner, Manifest};
 use flox_rust_sdk::providers::auth::Auth;
-use flox_rust_sdk::providers::build::{FloxBuildMk, nix_expression_dir};
+use flox_rust_sdk::providers::build::{FloxBuildMk, mock_locked_url_info, nix_expression_dir};
 use flox_rust_sdk::providers::publish::{
     PublishProvider,
     Publisher,
@@ -14,7 +14,6 @@ use flox_rust_sdk::providers::publish::{
     check_build_metadata,
     check_environment_metadata,
     check_package_metadata,
-    mock_locked_url_info,
 };
 use indoc::formatdoc;
 use tracing::{debug, instrument};

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -6,7 +6,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::models::manifest::typed::{Inner, Manifest};
 use flox_rust_sdk::providers::auth::Auth;
-use flox_rust_sdk::providers::build::{FloxBuildMk, mock_locked_url_info, nix_expression_dir};
+use flox_rust_sdk::providers::build::{mock_locked_url_info, nix_expression_dir};
 use flox_rust_sdk::providers::publish::{
     PublishProvider,
     Publisher,
@@ -148,8 +148,7 @@ impl Publish {
             &package,
         )?;
 
-        let build_metadata =
-            check_build_metadata(&flox, &env_metadata, &FloxBuildMk::new(&flox), &package)?;
+        let build_metadata = check_build_metadata(&flox, &env_metadata, &package)?;
 
         // CLI args take precedence over config
         let key_file = cache_args.signing_private_key.or(config

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -118,7 +118,7 @@ ifeq (,$(NIX_EXPRESSION_DIR))
 endif
 NIX_EXPRESSION_BUILDS := \
   $(shell $(_nix) eval \
-    --argstr nixpkgs-url $(BUILDTIME_NIXPKGS_URL) \
+    --argstr nixpkgs-url '$(BUILDTIME_NIXPKGS_URL)' \
     --argstr system $(NIX_SYSTEM) \
     --argstr pkgs-dir $(NIX_EXPRESSION_DIR) \
     --file $(_nef) \

--- a/test_data/generated/build/hello/hello.c
+++ b/test_data/generated/build/hello/hello.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 
-int main()
-{
+int main() {
   printf("Hello world\n");
   return 0;
 }

--- a/test_data/input_data/build/hello/hello.c
+++ b/test_data/input_data/build/hello/hello.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 
-int main()
-{
+int main() {
   printf("Hello world\n");
   return 0;
 }


### PR DESCRIPTION
Allow `flox publish` to distinguish between manifest and expression builds.
Determine locked nixpkgs for expression builds
independent from the current catalog page of the `top-level` group.

For that we split the `check_environment_metadata` routine of the publish process into `check_environment_metadata` and `check_package_metadata`, where the latter primarily deals with the differences between manifest and expression builds.

Changes in determining available builds further motivated unifying this for reuse in builds and publishes.

Finally while dynamically resolving the nixpkgs page to publish for
will be addressed separately,
we add support to build nix expressions with arbitrary nixpkgs flakerefs.
