### PR TITLE
fix: activate developer env in build mode for pure builds

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -167,8 +167,8 @@ while true; do
       ;;
     -m | --mode)
       shift
-      if [ -z "${1:-}" ] || ! { [ "$1" == "run" ] || [ "$1" == "dev" ] || [ "$1" == "build" ] || [ "$1" == "build-sandbox" ]; }; then
-        echo "Option --mode requires 'dev', 'run', 'build', or 'build-sandbox' as an argument." >&2
+      if [ -z "${1:-}" ] || ! { [ "$1" == "run" ] || [ "$1" == "dev" ] || [ "$1" == "build" ]; }; then
+        echo "Option --mode requires 'dev', 'run', or 'build' as an argument." >&2
         echo "$USAGE" >&2
         exit 1
       fi
@@ -258,7 +258,7 @@ case "$_flox_shell" in
     ;;
 esac
 
-if [ "$_FLOX_ENV_ACTIVATION_MODE" = "build" ] || [ "$_FLOX_ENV_ACTIVATION_MODE" = "build-sandbox" ]; then
+if [ "$_FLOX_ENV_ACTIVATION_MODE" = "build" ]; then
   if [ $# -eq 0 ]; then
     echo "build mode is only supported for running a command" >&2
     exit 1

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1978,12 +1978,10 @@ mod tests {
         boost_include_only(false);
     }
 
-    // TODO: currently failing since build-sandbox mode doesn't run etc-profiles
-    // for the outer activation
-    // #[test]
-    // fn boost_include_only_sandbox_pure() {
-    //     boost_include_only(true);
-    // }
+    #[test]
+    fn boost_include_only_sandbox_pure() {
+        boost_include_only(true);
+    }
 
     #[test]
     fn cleans_up_data_sandbox() {

--- a/package-builder/Makefile
+++ b/package-builder/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := all
 
-ALL = flox-build.mk build-manifest.nix nef/default.nix \
+ALL = env-filter flox-build.mk build-manifest.nix nef/default.nix \
   $(addprefix nef/lib/,default.nix dirToAttrs.nix extendAttrSet.nix mkOverlay.nix reflect.nix)
 
 OS := $(shell uname -s)
@@ -19,6 +19,10 @@ libsandbox.so: sandbox.c closure.o
 
 libsandbox.dylib: sandbox.c closure.o
 	$(CC) -pthread -dynamiclib $^ -o $@
+
+env-filter: env-filter.bash
+	cp $< $@
+	chmod +x $@
 
 .PHONY: all
 all: $(ALL)

--- a/package-builder/env-filter.bash
+++ b/package-builder/env-filter.bash
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 # env-filter: redact environment variables, apart from those expressly called out
 # with (-a|--allow) args or matching prefixes provided with (-p|--allow-prefix).

--- a/pkgs/flox-package-builder/default.nix
+++ b/pkgs/flox-package-builder/default.nix
@@ -26,6 +26,7 @@ let
   build-manifest-nix = substituteAll {
     name = "build-manifest.nix";
     src = ../../package-builder/build-manifest.nix;
+    inherit envFilter;
   };
   flox-build-mk = substituteAll {
     name = "flox-build.mk";


### PR DESCRIPTION
## Proposed Changes

Update pure manifest build to activate developer environment in build mode as is done in the sandbox off case. Also reorder arguments to exactly match the invocation as found in flox-build.mk.

Closes #3052 

## Release Notes

N/A