### PR TITLE
fix: runtime expansion for fish and tcsh

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ inquire = "0.6.0"
 indicatif = "0.17"
 itertools = "0.12.1"
 jsonwebtoken = "9.3"
-log = "0.4.27"
+log = { version = "0.4.27", features = ["kv"]}
 nix = { version = "0.28", features = ["signal", "process", "user"] }
 oauth2 = "4.4"
 once_cell = "1.21.3"

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -286,9 +286,17 @@ mod test {
     }
 
     #[test]
-    fn handles_empty_manpath() {
+    fn handles_blank_manpath() {
         let env_dirs = "/env1:/env2";
         let manpath = "";
+        let fixed = fix_manpath_var(env_dirs, manpath);
+        assert_eq!(fixed, "/env1/share/man:/env2/share/man:");
+    }
+
+    #[test]
+    fn handles_empty_manpath() {
+        let env_dirs = "/env1:/env2";
+        let manpath = "empty";
         let fixed = fix_manpath_var(env_dirs, manpath);
         assert_eq!(fixed, "/env1/share/man:/env2/share/man:");
     }

--- a/cli/flox-activations/src/cli/mod.rs
+++ b/cli/flox-activations/src/cli/mod.rs
@@ -45,6 +45,7 @@ pub enum Command {
 
 /// Splits PATH-like variables into individual paths, removing any empty strings.
 fn separate_dir_list(joined: &str) -> Vec<PathBuf> {
+    let joined = if joined == "empty" { "" } else { joined };
     let split = std::env::split_paths(joined).collect::<Vec<_>>();
     if (split.len() == 1) && (split[0] == PathBuf::from("")) {
         vec![]

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4796,7 +4796,7 @@ nested_activation_get_output() {
 # are present in PATH, and the outer environment appears first.
 nested_activation_assertions() {
   # Check that PATH is repaired
-  assert_output --partial "PATH is $outer_stub/bin:$outer_stub/sbin:$default_stub/bin:$default_stub/sbin:before_path:$original_path"
+  assert_output --partial "PATH is $outer_stub/bin:$outer_stub/sbin:$default_stub/bin:$default_stub/sbin:before_path"
   # Check that MANPATH is repaired
   assert_output --partial "MANPATH is $outer_stub/share/man:$default_stub/share/man"
 }

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4844,19 +4844,16 @@ check_nested_activation_repairs_path_and_manpath() {
 
 # bats test_tags=activate:fish,activate:nested
 @test "fish: command: nested activation repairs (MAN)PATH" {
-  skip "fixme"
   check_nested_activation_repairs_path_and_manpath fish -c
 }
 
 # bats test_tags=activate:fish,activate:nested
 @test "fish: interactive: nested activation repairs (MAN)PATH" {
-  skip "fixme"
   check_nested_activation_repairs_path_and_manpath fish -ic
 }
 
 # bats test_tags=activate:fish,activate:nested
 @test "fish: in-place: nested activation repairs (MAN)PATH" {
-  skip "fixme"
   check_nested_activation_repairs_path_and_manpath fish eval
 }
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3765,7 +3765,7 @@ EOF
   )"
   echo "$MANIFEST_CONTENTS_PROJECT" | "$FLOX_BIN" edit -d project -f -
 
-  echo "eval \`$FLOX_BIN activate -d '$PROJECT_DIR/default'\`" > "$HOME/.tcshrc.extra"
+  echo "eval \"\`'$FLOX_BIN' activate -d '$PROJECT_DIR/default'\`\"" >> "$HOME/.tcshrc.extra"
 
   # It would be better use tcsh -i to source .tcshrc,
   # but that causes the tests to background because tcsh -i tries to open
@@ -4829,19 +4829,16 @@ check_nested_activation_repairs_path_and_manpath() {
 
 # bats test_tags=activate:tcsh,activate:nested
 @test "tcsh: command: nested activation repairs (MAN)PATH" {
-  skip "fixme"
   check_nested_activation_repairs_path_and_manpath tcsh -c
 }
 
 # bats test_tags=activate:tcsh,activate:nested
 @test "tcsh: interactive: nested activation repairs (MAN)PATH" {
-  skip "fixme"
   check_nested_activation_repairs_path_and_manpath tcsh -ic
 }
 
 # bats test_tags=activate:tcsh,activate:nested
 @test "tcsh: in-place: nested activation repairs (MAN)PATH" {
-  skip "fixme"
   check_nested_activation_repairs_path_and_manpath tcsh eval
 }
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**fix(fish): runtime expansion in generated script**

This uses much of the same strategy as for tcsh since fish also doesn't
have `${foo:-}` syntax.

**fix(tcsh): runtime expansion in generated script**

This has a number of changes.
1) Expand variables at runtime rather than temp-rc-file-generation-time.
   This prevents environment directories from mysteriously going missing
   from PATH, MANPATH, etc.
2) Use if-statements to determine whether FLOX_ENV_DIRS and MANPATH are
   unset. Tcsh doesn't have an equivalent of "${foo:-}" as in Bash and
   Zsh, so you need to explicitly check first.
3) Rather than expanding FLOX_ENV_DIRS and MANPATH to empty strings,
   expand them to the sentinel value "empty". This is necessary because
   the empty string just becomes whitespace during one of the parsing
   stages and causes the argument passed to `--env-dirs` to simply
   disappear in tcsh.
4) When expanding variables that need to be quoted, use the `:q`
   modifier to avoid another set of nested quote characters, which can
   be very hard to read. See * below for the exact language from the
   tcsh manual.
5) Iterate over profile scripts at runtime via the `profile-scripts`
   subcommand.
6) Edit the `profile-scripts` command to no longer print comment lines
   when scripts aren't found. This is necessary because when eval-ing
   commands, tcsh doesn't terminate a comment at a newline character,
   so subsequent commands are effectively commented out. 
7) Use `setenv` to set a default value for `MANPATH` instead of `set`.

* When the ':q' modifier is applied to a substitution the variable will
  expand to multiple words with each word separated by a blank and
  quoted to prevent later command or filename substitution.

**test: weaken nested activation PATH assertion**

Somewhere in `PATH` there is a `::`, and it turns out that shells often
expand this to `:.:` e.g. they turn a `::` into a path component that
represents the current directory. The nested activation tests rely on
knowing the explicit `PATH` before and after the nested activation so
that we can ensure that the original `PATH` hasn't been somehow mangled
or dropped.

I only observed this behavior with integration tests run against a
Nix-built flox binary, and only for Fish and tcsh.

Since the shell is doing this `::` -> `:.:` expansion, we can no longer
rely on knowing the exact value of `PATH`. To make the tests pass, we'll
make the assertion weaker by only asserting that `PATH` is prefixed by
the Flox environment directories and `before_path:`, which is explicitly
prepended to `PATH` by the test helpers. The idea is that if we see
`before_path`, we're seeing *all* of `PATH`, and we don't need to check
the exact value of `PATH`.

**chore: enable structured logging in log crate**

Structured logging was one of the reasons I preferred the `tracing`
crate over the `log` crate, but I recently learned that the `log` crate
also has support for structured logging via the `kv` feature. Enabling
this allows us to use structured logging in `flox-activations`.


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
