### PR TITLE
fix(activate): Fix error from _profile_scripts

### DIFF
--- a/assets/environment-interpreter/common/activate.d/source-profile-d.bash
+++ b/assets/environment-interpreter/common/activate.d/source-profile-d.bash
@@ -12,14 +12,11 @@ function source_profile_d {
   }
 
   declare -a _profile_scripts
-  # TODO: figure out why this is needed
-  set +e
-  read -r -d '' -a _profile_scripts < <(
+  read -r -a _profile_scripts < <(
     cd "$_profile_d" || exit
     shopt -s nullglob
     echo *.sh
   )
-  set -e
   for profile_script in "${_profile_scripts[@]}"; do
     # shellcheck disable=SC1090 # from rendered environment
     source "$_profile_d/$profile_script"


### PR DESCRIPTION
## Proposed Changes

I noticed this error while looking at reporting activation errors with traps for #3101. The `-d ''` argument specified that we expected a NUL char after the space delimited values but the command we run never provides one:

    read [-ers] [-a aname] [-d delim] [-i text] [-n nchars] [-N nchars] [-p prompt] [-t timeout] [-u fd] [name ...]
        …
        -d delim
                The first character of delim is used to terminate the input line, rather than newline.  If delim is the empty string, read will terminate a line when it reads a NUL character.

Before:

    % bash -xc 'declare -a _var; read -r -d "" -a _var < <(echo foo bar); echo "${_var[@]}"'
    + declare -a _var
    + read -r -d '' -a _var ++ echo foo bar
    + echo foo bar foo bar

    % bash -exc 'declare -a _var; read -r -d "" -a _var < <(echo foo bar); echo "${_var[@]}"'
    + declare -a _var
    + read -r -d '' -a _var ++ echo foo bar

After:

    % bash -exc 'declare -a _var; read -r -a _var < <(echo foo bar); echo "${_var[@]}"'
    + declare -a _var
    + read -r -a _var ++ echo foo bar
    + echo foo bar foo bar

The `nullglob` option also does not produce a NUL char:

    % bash -c 'shopt -s nullglob; echo *.nomatch | cat -ev'
    $

There are other ways that we could write this function but then we have to do more work to restore `nullglob` so it doesn't seem worth it.

## Release Notes

N/A
