### PR TITLE
refactor(publish): Use open_path()

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -761,7 +761,7 @@ pub enum UninstallError {
     PackageOnlyIncluded(String, String),
 }
 
-/// Open an environment defined in `{path}/.flox`
+/// Open an environment defined in `path` that has a `.flox` within.
 pub fn open_path(
     flox: &Flox,
     path: impl AsRef<Path>,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -379,10 +379,9 @@ impl EnvironmentPointer {
     /// the function returns an [EnvironmentPointer] containing information about the environment.
     /// If reading or parsing fails, an [EnvironmentError] is returned.
     ///
-    /// Use this method to determine the type of an environment at a given path.
-    /// The result should be used to call the appropriate `open` method
-    /// on either [path_environment::PathEnvironment] or [managed_environment::ManagedEnvironment].
-    pub fn open(dot_flox_path: &CanonicalPath) -> Result<EnvironmentPointer, EnvironmentError> {
+    /// If you want to operate on the [Environment] at the given path then use
+    /// [open_path] on a project path instead.
+    fn open(dot_flox_path: &CanonicalPath) -> Result<EnvironmentPointer, EnvironmentError> {
         let pointer_path = dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME);
         let pointer_contents = match fs::read(&pointer_path) {
             Ok(contents) => contents,


### PR DESCRIPTION
## Proposed Changes

Partial revert of https://github.com/flox/flox/commit/7b990aa7215e11f2c212459c7da2bca0db682474 which made `EnvironmentPointer::open` public.

The typo of "environment" originally caught my attention and then it
occurred to me that the `unreachable!()` message was inverted because it
would only be triggered when opening a non-path environment.

We can use `open_path()` instead, as already used by `providers::build`,
and then just call trait methods on `Environment` without having to
explicitly convert to `ConcreteEnviroment::Path` or similar.

Track the project path in `CheckedEnvironmentMetadata`, rather than the
`.flox` path and working backwards, to make this easier. This doesn't
lessen our guarantees about what's in the tracked repo because we're
still opening an environment.

## Release Notes

N/A