### PR TITLE
feat(init): sluggify inferred env name

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -839,6 +839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1065,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "shell-escape",
+ "slug",
  "supports-color",
  "sys-info",
  "sysinfo",
@@ -3601,6 +3608,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     "flox-watchdog",
     "flox-activations",
     "flox-core",
-    "flox-test-utils"
+    "flox-test-utils",
 ]
 default-members = ["flox", "flox-watchdog", "flox-activations"]
 
@@ -24,7 +24,7 @@ clap = { version = "4.5.38", features = ["derive"] }
 clap_derive = "4.5.4"
 close_fds = "0.3"
 # Pinned due to bug: https://github.com/rust-cli/config-rs/issues/531
-config = { version = "0.13.4", default-features = false, features = ["toml"]}
+config = { version = "0.13.4", default-features = false, features = ["toml"] }
 crossterm = "0.27"
 derive_more = "0.99.20"
 dirs = "5.0.0"
@@ -39,7 +39,10 @@ futures = "0.3"
 # git pending:
 # - https://github.com/alexliesenfeld/httpmock/issues/127
 # - https://github.com/alexliesenfeld/httpmock/pull/131
-httpmock = { git = "https://github.com/flox/httpmock.git", branch = "flox/remove_recording_struct", default-features = false , features = ["proxy", "record"] }
+httpmock = { git = "https://github.com/flox/httpmock.git", branch = "flox/remove_recording_struct", default-features = false, features = [
+    "proxy",
+    "record",
+] }
 indent = "0.1.1"
 indexmap = { version = "2.9.0", features = ["serde"] }
 indoc = "2.0.6"
@@ -47,7 +50,7 @@ inquire = "0.6.0"
 indicatif = "0.17"
 itertools = "0.12.1"
 jsonwebtoken = "9.3"
-log = { version = "0.4.27", features = ["kv"]}
+log = { version = "0.4.27", features = ["kv"] }
 nix = { version = "0.28", features = ["signal", "process", "user"] }
 oauth2 = "4.4"
 once_cell = "1.21.3"
@@ -71,6 +74,7 @@ serde_json = "1"
 serde_with = "3.12.0"
 serde_yaml = "0.9"
 shell-escape = "0.1.5"
+slug = "0.1"
 supports-color = "3.0.2"
 # provides process tools for shell detection
 sysinfo = "0.32.1"

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -37,6 +37,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true
 shell-escape.workspace = true
+slug.workspace = true
 supports-color.workspace = true
 sys-info.workspace = true
 sysinfo.workspace = true

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -108,7 +108,7 @@ impl Init {
                 .file_name()
                 .map(|n| n.to_string_lossy().to_string())
                 .context("Can't init in root")?;
-            EnvironmentName::from_str(&name)?
+            EnvironmentName::from_str(&slug::slugify(name))?
         };
 
         // Don't run language hooks for "default" environment

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -53,6 +53,19 @@ teardown() {
   assert_output --partial '"name": "test"'
 }
 
+@test "c2: flox init should normalize the current directory name when used to infer the environment name" {
+  mkdir -p "spa ce"
+  pushd "spa ce"
+
+  run "$FLOX_BIN" init
+  assert_success
+
+  run cat .flox/env.json
+  assert_success
+  assert_output --partial '"name": "spa-ce"'
+  popd
+}
+
 @test "c4: custom name option 1: flox init accepts -n for a user defined name" {
   run "$FLOX_BIN" init -n "other-test"
   assert_success
@@ -104,6 +117,7 @@ EOF
   run "$FLOX_BIN" init -n "na me"
   assert_failure
 }
+
 
 function check_with_dir() {
   run ls -A "$PROJECT_DIR"


### PR DESCRIPTION
`flox init` will fail creating flox environments when the current directory contains spaces. Instead, it will require an explicit name provided via `--name`. As suggested in <https://github.com/flox/flox/issues/1718> we can be a bit smarter wrt implicit names, by precautiously sluggifying the directory name.

As a side effect, other special characters are also trimmed to guarantee url-safe names. It's possible (although unclear whether thats desirable) to slug env names provided by `--name`, or even lower at parsing time of `EnvironmentName`.

## Proposed Changes

Inferred names of directories will be sluggified at initialization time, i.e. `/some/dir/with spaces` will result in an environment named `with-spaces` instead of failing to parse the inferred name.


