### PR TITLE
fix(activate): quote arguments in generated fish activation commands

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/generate-fish-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-fish-startup-commands.bash
@@ -72,10 +72,10 @@ generate_fish_startup_commands() {
   # (foo_with_default) that is either the runtime (not generation-time) value
   # or the string 'empty'.
   echo "set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo \"\$FLOX_ENV_DIRS\"; else; echo empty; end);"
-  echo "$_flox_activations set-env-dirs --shell fish --flox-env $_FLOX_ENV --env-dirs \$FLOX_ENV_DIRS | source;"
+  echo "$_flox_activations set-env-dirs --shell fish --flox-env \"$_FLOX_ENV\" --env-dirs \"\$FLOX_ENV_DIRS\" | source;"
   echo "set -gx MANPATH (if set -q MANPATH; echo \"\$MANPATH\"; else; echo empty; end);"
-  echo "$_flox_activations fix-paths --shell fish --env-dirs \$FLOX_ENV_DIRS --path \"\$PATH\" --manpath \"\$MANPATH\" | source;"
-  echo "$_flox_activations profile-scripts --shell fish --env-dirs \$FLOX_ENV_DIRS | source;"
+  echo "$_flox_activations fix-paths --shell fish --env-dirs \"\$FLOX_ENV_DIRS\" --path \"\$PATH\" --manpath \"\$MANPATH\" | source;"
+  echo "$_flox_activations profile-scripts --shell fish --env-dirs \"\$FLOX_ENV_DIRS\" | source;"
 
   # fish does not use hashing in the same way bash does, so there's
   # nothing to be done here by way of that requirement.


### PR DESCRIPTION
Avoid spaces or other shell-significant characters breaking activation by being misinterpreted at activation time. As mentioned in <https://github.com/flox/flox/issues/1719> this can lead to errors at activation time. This commit adds quoting to the generated fish commands. bash, and tcsh already took care of this quoting, zsh is being initialized differently but does include quoting as well.
