### PR TITLE
feat(containerize): Allow --runtime and --file

### DIFF
--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -20,17 +20,7 @@ flox [<general-options>] containerize
 # DESCRIPTION
 
 Export a Flox environment as a container image.
-The image is written to the specified output target.
-With `--file|-f <file>` a tarball is writtent to the specified file.
-When `-` is passed as `<file>` the image is instead written to stdout.
-The `--runtime <runtime>` flag supports `docker` and `podman`,
-and expects the selected runtime to be found in PATH.
-
-When neither option is provided,
-the container is loaded into a supported runtime,
-`docker` or `podman`, whichever is found first in PATH.
-If no supported runtime is found,
-the container is written to `./<env name>-container.tar` instead.
+The image can be written to a container runtime registry, a file, or another process.
 
 **Note**: Exporting a container from macOS requires a supported runtime
 because a proxy container is used to build the environment and image. You

--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -13,7 +13,7 @@ flox-containerize - export an environment as a container image
 ```
 flox [<general-options>] containerize
      [-d=<path> | -r=<owner/name>]
-     [-f=<file> | --runtime=<runtime>]
+     [-f=<file>] [--runtime=<runtime>]
      [--tag=<tag>]
 ```
 
@@ -32,8 +32,8 @@ the container is loaded into a supported runtime,
 If no supported runtime is found,
 the container is written to `./<env name>-container.tar` instead.
 
-**Note**: Exporting a container from macOS requires a supported runtime to be
-found because a proxy container is used to build the environment and image. You
+**Note**: Exporting a container from macOS requires a supported runtime
+because a proxy container is used to build the environment and image. You
 may be prompted for permissions to share files into the proxy container.
 Files used in the proxy container are cached using a `docker` or `podman`
 volume named `flox-nix`.
@@ -53,13 +53,15 @@ similar to `flox activate --`.
 # OPTIONS
 
 `-f`, `--file`
-:   Write the container image to `<file>`.
-    If `<output target>` is `-`, writes to `stdout`.
+:   File to write the container image to.
+    `-` to write to stdout.
+    Defaults to `{name}-container.tar` if `--runtime` isn't specified or detected.
 
 `--runtime`
-:   Load the image into the specified `<runtime>`.
-    `<runtime>` may bei either `docker` or `podman`.
-    The specified binary must be found in `PATH`.
+:   Container runtime to
+    store the image (when `--file` is not specified)
+    or build the image (when on macOS).
+    Defaults to detecting the first available on PATH.
 
 ```{.include}
 ./include/environment-options.md

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -346,7 +346,7 @@ impl FromStr for Runtime {
         match s {
             "docker" => Ok(Runtime::Docker),
             "podman" => Ok(Runtime::Podman),
-            _ => Err(anyhow!("Registry must be 'docker' or 'podman'")),
+            _ => Err(anyhow!("Runtime must be 'docker' or 'podman'")),
         }
     }
 }

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -30,11 +30,18 @@ pub struct Containerize {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
 
-    /// Output to write the container to.
-    /// Defaults to loading into container storage if docker or podman is present
-    /// or otherwise writes to a file '{name}-container.tar'
-    #[bpaf(external(output_target), optional)]
-    output: Option<OutputTarget>,
+    /// Container runtime to
+    /// store the image (when '--file' is not specified)
+    /// or build the image (when on macOS).
+    /// Defaults to detecting the first available on PATH.
+    #[bpaf(long, argument("docker|podman"))]
+    runtime: Option<Runtime>,
+
+    /// File to write the container image to.
+    /// '-` to write to stdout.
+    /// Defaults to '{name}-container.tar' if '--runtime' isn't specified or detected.
+    #[bpaf(short, long, argument("file"))]
+    file: Option<FileOrStdout>,
 
     /// Tag to apply to the container, defaults to 'latest'
     #[bpaf(short, long, argument("tag"))]
@@ -49,9 +56,15 @@ impl Containerize {
             .environment
             .detect_concrete_environment(&flox, "Containerize")?;
 
-        let output = self
-            .output
-            .unwrap_or_else(|| OutputTarget::detect_or_default(env.name().as_ref()));
+        let runtime = self.runtime.or_else(Runtime::detect_from_path);
+        let output = match (&runtime, self.file) {
+            // Specified file.
+            (_, Some(dest)) => OutputTarget::File(dest),
+            // Or specified or detected runtime.
+            (Some(runtime), None) => OutputTarget::Runtime(runtime.clone()),
+            // Or default file.
+            (None, None) => OutputTarget::default_file(env.name().as_ref()),
+        };
 
         let output_tag: &str = match self.tag {
             Some(tag) => &tag.to_string(),
@@ -82,14 +95,14 @@ impl Containerize {
             builder.create_container_source(&flox, env_name.as_ref(), output_tag)?
         } else {
             let env_path = env.parent_path()?;
-            let Some(container_runtime) = Runtime::detect_from_path() else {
+            let Some(proxy_runtime) = runtime else {
                 bail!(indoc! {r#"
                     No container runtime found in PATH.
 
                     Exporting a container on macOS requires Docker or Podman to be installed.
                 "#});
             };
-            let builder = ContainerizeProxy::new(env_path, container_runtime);
+            let builder = ContainerizeProxy::new(env_path, proxy_runtime);
             builder.create_container_source(&flox, env_name.as_ref(), output_tag)?
         };
 
@@ -100,27 +113,6 @@ impl Containerize {
         message::created(format!("'{env_name}:{output_tag}' written to {output}"));
         Ok(())
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Bpaf)]
-enum OutputTarget {
-    File(
-        #[bpaf(
-            long("file"),
-            short('f'),
-            argument("file"),
-            help("File to write the container image to. '-' to write to stdout.")
-        )]
-        FileOrStdout,
-    ),
-    Runtime(
-        #[bpaf(
-            long("runtime"),
-            argument("runtime"),
-            help("Container runtime to load the image into. 'docker' or 'podman'")
-        )]
-        Runtime,
-    ),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,19 +133,18 @@ impl FromStr for FileOrStdout {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Bpaf)]
+enum OutputTarget {
+    File(FileOrStdout),
+    Runtime(Runtime),
+}
+
 impl OutputTarget {
-    fn detect_or_default(env_name: impl AsRef<str>) -> Self {
-        let default_to_file = OutputTarget::File(FileOrStdout::File(PathBuf::from(format!(
+    fn default_file(env_name: impl AsRef<str>) -> Self {
+        OutputTarget::File(FileOrStdout::File(PathBuf::from(format!(
             "{}-container.tar",
             env_name.as_ref()
-        ))));
-
-        let Some(runtime) = Runtime::detect_from_path() else {
-            debug!("No container runtime found in PATH, defaulting to file");
-            return default_to_file;
-        };
-
-        OutputTarget::Runtime(runtime)
+        ))))
     }
 
     fn to_writer(&self) -> Result<Box<dyn ContainerSink + '_>> {
@@ -362,17 +353,12 @@ mod tests {
         assert!("invalid".parse::<Runtime>().is_err());
     }
 
-    /// Test that the default output target is one of the supported runtimes
-    /// which is found first in the PATH, or a file with the environment name,
-    /// if no supported runtime is found in the PATH.
     #[test]
     fn detect_runtime_in_path() {
         let tempdir = tempfile::tempdir().unwrap();
 
-        let default_target =
-            OutputTarget::File(FileOrStdout::File(PathBuf::from("test-container.tar")));
-        let docker_target = OutputTarget::Runtime(Runtime::Docker);
-        let podman_target = OutputTarget::Runtime(Runtime::Podman);
+        let docker_target = Runtime::Docker;
+        let podman_target = Runtime::Podman;
 
         let docker_bin = tempdir.path().join("docker-bin");
         let podman_bin = tempdir.path().join("podman-bin");
@@ -389,32 +375,33 @@ mod tests {
         fs::write(combined_bin.join("docker"), "").unwrap();
         fs::write(combined_bin.join("podman"), "").unwrap();
 
-        let target = temp_env::with_var(
-            "PATH",
-            Some(std::env::join_paths([&docker_bin, &podman_bin, &combined_bin]).unwrap()),
-            || OutputTarget::detect_or_default("test"),
-        );
-        assert_eq!(target, docker_target);
+        let docker_first_path =
+            Some(std::env::join_paths([&docker_bin, &podman_bin, &combined_bin]).unwrap());
+        let podman_first_path =
+            Some(std::env::join_paths([&podman_bin, &docker_bin, &combined_bin]).unwrap());
+        let combined_path =
+            Some(std::env::join_paths([&combined_bin, &podman_bin, &docker_bin]).unwrap());
+        let neither_path = Some(std::env::join_paths([neither_bin]).unwrap());
 
-        let target = temp_env::with_var(
-            "PATH",
-            Some(std::env::join_paths([&podman_bin, &docker_bin, &combined_bin]).unwrap()),
-            || OutputTarget::detect_or_default("test"),
-        );
-        assert_eq!(target, podman_target);
+        // Check that a Runtime can be detected in PATH.
+        let target = temp_env::with_var("PATH", docker_first_path.as_ref(), || {
+            Runtime::detect_from_path()
+        });
+        assert_eq!(target, Some(docker_target.clone()));
 
-        let target = temp_env::with_var(
-            "PATH",
-            Some(std::env::join_paths([&combined_bin, &podman_bin, &docker_bin]).unwrap()),
-            || OutputTarget::detect_or_default("test"),
-        );
-        assert_eq!(target, docker_target);
+        let target = temp_env::with_var("PATH", podman_first_path.as_ref(), || {
+            Runtime::detect_from_path()
+        });
+        assert_eq!(target, Some(podman_target.clone()));
 
-        let target = temp_env::with_var(
-            "PATH",
-            Some(std::env::join_paths([neither_bin]).unwrap()),
-            || OutputTarget::detect_or_default("test"),
-        );
-        assert_eq!(target, default_target);
+        let target = temp_env::with_var("PATH", combined_path.as_ref(), || {
+            Runtime::detect_from_path()
+        });
+        assert_eq!(target, Some(docker_target.clone()));
+
+        let target = temp_env::with_var("PATH", neither_path.as_ref(), || {
+            Runtime::detect_from_path()
+        });
+        assert_eq!(target, None);
     }
 }

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -252,7 +252,7 @@ function skip_if_linux() {
 Exporting a container on macOS requires Docker or Podman to be installed."
 }
 
-# bats test_tags=containerize:default-to-file
+# bats test_tags=containerize:default-to-runtime
 @test "container is written to a runtime by default" {
   env_setup_catalog
 
@@ -286,7 +286,7 @@ Exporting a container on macOS requires Docker or Podman to be installed."
   assert_line "✨ 'test:sometag' written to Podman runtime"
 }
 
-# bats test_tags=containerize:piped-to-runtime
+# bats test_tags=containerize:runtime
 @test "container is written to runtime when '--runtime <runtime>' is passed" {
   env_setup_catalog
 

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -238,9 +238,6 @@ function skip_if_linux() {
 
 # ---------------------------------------------------------------------------- #
 
-# TODO: Implement happy path tests for macOS in
-# https://github.com/flox/flox/issues/2466
-
 # bats test_tags=containerize:macos
 @test "runtime is required for proxy container on macos" {
   skip_if_linux

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -270,6 +270,7 @@ Exporting a container on macOS requires Docker or Podman to be installed."
   env_setup_catalog
 
   PATH= run "$FLOX_BIN" containerize
+  assert_line "✨ 'test:latest' written to file 'test-container.tar'"
   assert_success
   assert [ -f "test-container.tar" ] # <env-name>-container.tar by default
 }
@@ -296,6 +297,16 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 
   run --separate-stderr podman run -q -i "localhost/test:runtime" -c 'echo $foo'
   assert_success
+}
+
+# bats test_tags=containerize:file-and-runtime
+@test "container is written to file when '--runtime' and '--file' are passed" {
+  env_setup_catalog
+
+  run bash -c '"$FLOX_BIN" containerize --runtime podman --file podman-container.tar' 3>&-
+  assert_success
+  assert_line "✨ 'test:latest' written to file 'podman-container.tar'"
+  assert [ -f "podman-container.tar" ]
 }
 
 # bats test_tags=containerize:runtime-not-in-path

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -310,13 +310,13 @@ Exporting a container on macOS requires Docker or Podman to be installed."
 }
 
 # bats test_tags=containerize:runtime-not-in-path
-@test "error if runtime not in PATH" {
-  skip_if_not_linux # macOS checks for the container runtime earlier.
+@test "error if specified runtime not in PATH" {
   env_setup_catalog
 
-  run bash -c 'PATH= "$FLOX_BIN" containerize --runtime podman' 3>&-
+  # disable backtrace; we expect this to fail and assert output
+  RUST_BACKTRACE=0 run bash -c 'PATH= "$FLOX_BIN" containerize --runtime podman' 3>&-
   assert_failure
-  assert_line --partial "Failed to call runtime"
+  assert_output "❌ ERROR: Container runtime 'podman' not found in PATH."
 }
 
 function assert_container_output() {


### PR DESCRIPTION
## Proposed Changes

Allow both `--runtime` and `--file` arguments to be specified rather
than being mutually exclusive, so that macOS users with both `docker`
and `podman` on their PATH can choose which proxy runtime they want to
use, whilst still being able to write to a file outside the proxy.

I'm not convinced that `--file` is actually that useful since we added
the ability to write to runtime registries but it's hard work to get
usage metrics and removing it would be a breaking change.

The new logic is:

1. No args
  a. Detect proxy runtime, and
  b. Detect output runtime or write to default file
2. --runtime foo
  a. Use foo for the proxy and output runtime
3. --file bar
  a. Detect proxy runtime and write to file bar
4. --runtime foo --file bar
  a. Use foo for the proxy runtime and write to file bar

I considered putting the `output` match statement as a method on
`OutputTarget` so that it could be unit tested but I don't think it
provides much value given the readability of the statement, the coverage
we have from integration tests, and it's slightly harder to reason about
the args outside the context of the handler.

## Release Notes

`flox containerize` now allows `--runtime` and `--file` to be specified individually, allowing you to override the container runtime detection when building on macOS.
