### PR TITLE
test: enable boost build test on Linux

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1891,15 +1891,7 @@ mod tests {
         boost_runtime(false);
     }
 
-    // TODO: currently failing on Linux since the built artifact depends on the
-    // environment store path
-    // If I comment out disallowedReferences in order to see why the artifact
-    // depends on the environment store path, I'm seeing:
-    // $ ldd result-test_boost/bin/.test_boost-wrapped
-    // ...
-    // libboost_system.so.1.87.0 => /nix/store/rfrdr79nk2l0s01zzpfzczjlscimawvl-environment-develop/lib/libboost_system.so.1.87.0 (0x00007fafcf2ed000)
     #[test]
-    #[cfg(target_os = "macos")]
     fn boost_runtime_sandbox_pure() {
         boost_runtime(true);
     }


### PR DESCRIPTION
This test was previously failing but can be enabled since 3a7b184ee175ec11fae4bc058c2a4945a918f509

## Release Notes

NA