### PR TITLE
feat(build): nixpkgs url for dependency expression builds

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -149,7 +149,7 @@ pub struct FloxBuildMk<'args> {
 
     // common build components
     base_dir: &'args Path,
-    expression_dir: Option<&'args Path>,
+    expression_dir: &'args Path,
     built_environments: &'args BuildEnvOutputs,
 }
 
@@ -157,7 +157,7 @@ impl FloxBuildMk<'_> {
     pub fn new<'args>(
         flox: &'args Flox,
         base_dir: &'args Path,
-        expression_dir: Option<&'args Path>,
+        expression_dir: &'args Path,
         built_environments: &'args BuildEnvOutputs,
     ) -> FloxBuildMk<'args> {
         FloxBuildMk {
@@ -231,10 +231,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         ));
 
         // TODO: modify flox-build.mk to allow missing expression dirs
-        let expression_dir = match self.expression_dir {
-            Some(dir) => &*dir.to_string_lossy(),
-            None => "/absolutely/nowhere",
-        };
+        let expression_dir = self.expression_dir.to_string_lossy();
         command.arg(format!("NIX_EXPRESSION_DIR={expression_dir}"));
         command.arg(format!("FLOX_INTERPRETER={}", flox_interpreter.display()));
 
@@ -352,11 +349,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         ));
 
         // TODO: is this even necessary, or can we detect build outputs instead?
-        // TODO: modify flox-build.mk to allow missing expression dirs
-        let expression_dir = match self.expression_dir {
-            Some(dir) => &*dir.to_string_lossy(),
-            None => "/absolutely/nowhere",
-        };
+        let expression_dir = self.expression_dir.to_string_lossy();
         command.arg(format!("NIX_EXPRESSION_DIR={expression_dir}"));
 
         // Add clean target arguments by prefixing the package names with "clean/".
@@ -689,7 +682,7 @@ pub mod test_helpers {
     pub fn assert_build_status_with_nix_expr(
         flox: &Flox,
         env: &mut PathEnvironment,
-        expression_dir: Option<&Path>,
+        expression_dir: &Path,
         package: &str,
         build_cache: Option<bool>,
         expect_success: bool,
@@ -754,7 +747,7 @@ pub mod test_helpers {
         assert_build_status_with_nix_expr(
             flox,
             env,
-            None,
+            &nix_expression_dir(env),
             package_name,
             build_cache,
             expect_success,
@@ -765,7 +758,7 @@ pub mod test_helpers {
         let err = FloxBuildMk::new(
             flox,
             &env.parent_path().unwrap(),
-            None,
+            &nix_expression_dir(env),
             &env.build(flox).unwrap(),
         )
         .clean(
@@ -2371,7 +2364,7 @@ mod nef_tests {
         let collected = assert_build_status_with_nix_expr(
             &flox,
             &mut env,
-            Some(&expressions_dir),
+            &expressions_dir,
             &pname,
             None,
             true,
@@ -2413,7 +2406,7 @@ mod nef_tests {
         let collected = assert_build_status_with_nix_expr(
             &flox,
             &mut env,
-            Some(&expressions_dir),
+            &expressions_dir,
             &pname,
             None,
             true,

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -695,15 +695,10 @@ pub fn check_build_metadata(
 
     let mut clean_build_env = PathEnvironment::open(flox, path_pointer, dot_flox_path)?;
     let base_dir = clean_build_env.parent_path()?;
-    let expression_dir = Some(nix_expression_dir(&clean_build_env));
+    let expression_dir = nix_expression_dir(&clean_build_env);
     let built_environments = clean_build_env.build(flox)?;
 
-    let builder = FloxBuildMk::new(
-        flox,
-        &base_dir,
-        expression_dir.as_deref(),
-        &built_environments,
-    );
+    let builder = FloxBuildMk::new(flox, &base_dir, &expression_dir, &built_environments);
 
     // Build the package and collect the outputs
     let output_stream = builder.build(

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -106,12 +106,7 @@ impl Build {
             .map(|target| target.name())
             .collect::<Vec<_>>();
 
-        let builder = FloxBuildMk::new(
-            &flox,
-            &base_dir,
-            Some(&expression_dir),
-            &flox_env_build_outputs,
-        );
+        let builder = FloxBuildMk::new(&flox, &base_dir, &expression_dir, &flox_env_build_outputs);
         builder.clean(&target_names)?;
 
         message::created("Clean completed successfully");
@@ -137,8 +132,7 @@ impl Build {
             .map(|target| target.name())
             .collect::<Vec<_>>();
 
-        let builder =
-            FloxBuildMk::new(&flox, &base_dir, Some(&expression_dir), &built_environments);
+        let builder = FloxBuildMk::new(&flox, &base_dir, &expression_dir, &built_environments);
         let output = builder.build(
             &mock_base_catalog_url().as_flake_ref()?,
             find_toplevel_group_nixpkgs(&lockfile)

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -14,6 +14,7 @@ use flox_rust_sdk::providers::build::{
     PackageTarget,
     PackageTargets,
     build_symlink_path,
+    find_toplevel_group_nixpkgs,
     nix_expression_dir,
 };
 use flox_rust_sdk::providers::catalog::mock_base_catalog_url;
@@ -140,6 +141,10 @@ impl Build {
             FloxBuildMk::new(&flox, &base_dir, Some(&expression_dir), &built_environments);
         let output = builder.build(
             &mock_base_catalog_url().as_flake_ref()?,
+            find_toplevel_group_nixpkgs(&lockfile)
+                .map(|catalog_ref| catalog_ref.as_flake_ref())
+                .transpose()?
+                .as_ref(),
             &FLOX_INTERPRETER,
             &target_names,
             None,

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -139,6 +139,7 @@ impl Publish {
         let package_metadata = check_package_metadata(
             &env_metadata.lockfile,
             &mock_base_catalog_url(), // TODO: Replace with actual locked URL info from catalog server
+            env_metadata.toplevel_catalog_ref.as_ref(),
             package,
         )?;
 


### PR DESCRIPTION
In order to provide better compatibility with manifest builds,
we need to allow building nix expressions with a compatible set of nixpkgs.
Generally this will the "latest available" set of nixpkgs used when building,
nix expressions can't be expected to be compatible.
Instead we will use the nixpkgs revision referenced by the toplevel group (if available).

This implements the finding of toplevel nixpkgs for dependency expression builds.
I.e. IF there are packages in the toplevel group, make will be called with an additional variable `TOPLEVEL_NIXPKGS_URL`.
I guess if we're building without anything in the toplevel group using whats currently `BUILDTIME_NIXPKGS_URL` is should be good enough.
Publishing _manifest builds_ still requires packages in `toplevel`.