### PR TITLE
fix(pull/push): Better current_dir error

### DIFF
--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -55,7 +55,10 @@ impl Push {
         let span = tracing::info_span!("post-auth");
         let _guard = span.enter();
 
-        let dir = self.dir.unwrap_or_else(|| std::env::current_dir().unwrap());
+        let dir = match self.dir {
+            Some(d) => d,
+            None => std::env::current_dir().context("could not get current directory")?,
+        };
 
         let dot_flox = DotFlox::open_in(dir)?;
         let canonical_dot_flox_path =


### PR DESCRIPTION
## Proposed Changes

We got a Sentry panic from `flox pull`:

- https://flox-dev.sentry.io/issues/6648555991

`current_dir` can return an error if the dir was deleted or you no longer have permissions to access it. The former can be reproduced with:

    % mkdir tmp && cd tmp && rmdir ../tmp && flox pull dcarley/tailscale

    thread 'main' panicked at flox/src/commands/pull.rs:109:78:
    called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Now it returns:

    % mkdir tmp && cd tmp && rmdir ../tmp && flox pull dcarley/tailscale
    ❌ ERROR: Failed to get current directory: No such file or directory (os error 2)

`into_dir` needed moving up because of the partially borrowed value. The two match statements could have been combined but the resulting code was less readable.

I also fixed `flox push` which had the same issue.

## Release Notes

Improved error message when `flox pull` and `flox push` can't get the current directory.