### PR TITLE
chore: make nef nixpkgs evaluations more permissive

### DIFF
--- a/package-builder/nef/default.nix
+++ b/package-builder/nef/default.nix
@@ -6,7 +6,11 @@
 }:
 let
   nixpkgs = import nixpkgs-flake {
-    inherit system; # todo set config
+    inherit system;
+    config = {
+      allowUnfree = true;
+      allowInsecure = true;
+    };
   };
   pkgsDir = pkgs-dir;
 


### PR DESCRIPTION
Allow evaluating (and building) unfree and insecure packages. It's the responsibility of the catalog to deny _installation_ downstream. For builds, provide a more user friendly, i.e. permissive experience.

This keeps denying broken and unsupported packages, as building or using those is unlikely
to be resulting in a working build.
