### PR TITLE
fix: turn catalog git urls into shallow flakerefs

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1456,7 +1456,7 @@ pub struct BaseCatalogUrl(String);
 
 impl BaseCatalogUrl {
     pub fn as_flake_ref(&self) -> Result<Url, BaseCatalogUrlError> {
-        Url::parse(&format!("git+{}", self.0.as_str())).map_err(BaseCatalogUrlError)
+        Url::parse(&format!("git+{}&shallow=1", self.0.as_str())).map_err(BaseCatalogUrlError)
     }
 }
 


### PR DESCRIPTION
The catalog currently provides psude git flakerefs, e.g. `https://github.com/flox/nixpkgs?rev=<rev>`.
`BaseCatalogUrl::as_flake_ref` attemps to turn these urls into valid flake-refs, i.e. `git+<url>`.
However, `git+<url>` results in a full clone of the nixpkgs repo, which can take several minutes depending on I/O.
The fastest alternative would be fetching a tarball via the API, i.e. turning the url into `github:flox/nixpgks`,
or `file+https://github.com/flox/nixpkgs/tarball/<rev>`, or equivalent.
Alternatively, `?shallow=1` can be provided with any `git+<url>` flakeref to avoid full clones.
While possibly slower, it
1. does not require as much url rewriting,
2. uses the same protocol (git), and thus
3. avoids api limits on api.github.com.
