### PR TITLE
fix(python): use poetry activation command

### DIFF
--- a/cli/flox/src/commands/init/python.rs
+++ b/cli/flox/src/commands/init/python.rs
@@ -415,7 +415,7 @@ impl Provider for PoetryPyProject {
                 # Quietly activate venv and install packages in a subshell so
                 # that the venv can be freshly activated in the profile section.
                 (
-                  source "$(poetry env info --path)/bin/activate"
+                  eval "$(poetry env activate)"
                   poetry install --quiet
                 )"#}
                 .to_string(),
@@ -423,25 +423,25 @@ impl Provider for PoetryPyProject {
             profile_bash: Some(
                 indoc! {r#"
                 echo "Activating poetry virtual environment" >&2
-                source "$(poetry env info --path)/bin/activate""#}
+                eval "$(poetry env activate)""#}
                 .to_string(),
             ),
             profile_fish: Some(
                 indoc! {r#"
                 echo "Activating poetry virtual environment" >&2
-                source "$(poetry env info --path)/bin/activate.fish""#}
+                eval (poetry env activate)"#}
                 .to_string(),
             ),
             profile_tcsh: Some(
                 indoc! {r#"
                 echo "Activating poetry virtual environment" >&2
-                source "$(poetry env info --path)/bin/activate.csh""#}
+                eval "`poetry env activate`""#}
                 .to_string(),
             ),
             profile_zsh: Some(
                 indoc! {r#"
                 echo "Activating poetry virtual environment" >&2
-                source "$(poetry env info --path)/bin/activate""#}
+                eval "$(poetry env activate)""#}
                 .to_string(),
             ),
             packages: Some(vec![


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
We use the `poetry env info --path` command to get the location of the Python virtual environment built by Poetry. However, if Poetry fails to find a suitable Python version (e.g. one that matches a version requirement in `pyproject.toml`) activation will fail and the output of this command will be empty.

Poetry has its own activation command that we can `eval` instead, and this command displays an error when one is encountered rather than silently failing.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users will now see an error when activating a Poetry virtual environment via the auto-setup hooks from `flox init` if Poetry can't find an appropriate Python version at activation time.

<!-- Many thanks! -->
