### PR TITLE
fix(fish): restore $status and $pipestatus

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/set-prompt.fish
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.fish
@@ -2,7 +2,7 @@
 
 if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS" && [ "$_FLOX_SET_PROMPT" != false ]
     if not set -q FLOX_PROMPT
-        set FLOX_PROMPT "flox"
+        set FLOX_PROMPT flox
     end
 
     if set -q NO_COLOR
@@ -20,8 +20,8 @@ if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS" && [ "
     end
 
     function fish_prompt
-        echo -n $_flox ""
-        flox_saved_fish_prompt
+        set -l original_prompt (flox_saved_fish_prompt | string collect --no-trim-newlines)
+        printf "%s %s\n" $_flox $original_prompt
     end
 end
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Our `set-prompt.fish` script injects a command before running the previously defined `fish_prompt` function. That command (`echo`) succeeds, which sets `$status` and `$pipestatus` to 0. The default prompt in fish only displays exit codes when they're nonzero, so by running our `echo` command we prevent `$status` and `$pipestatus` from being reported.

There were two solutions that I considered:
- Mimic the exit codes
- Mimic how Python virtualenv does this

### The virtualenv method

The fish prompt is produced by running the `fish_prompt` function, the output of which is taken as the format string for the prompt. In this method you immediately save the original prompt, and the print out a format string that just places ours in front e.g.

```
function fish_prompt
  set -l original_prompt (flox_saved_fish_prompt | string collect --no-trim-newlines)
  printf "%s %s\n" $_flox $original_prompt
end
```

This was suggested by GitHub user `krobelus`, and is the solution I've decided to go with.

### Mimic the exit codes

The `$status` and `$pipestatus` variables are read-only, so we can't save and restore them. What we can do instead is generate a command that produces the same exit code(s).

This solution saves `$pipestatus` at the beginning of the function, then maps it to create a pipeline that produces the same exit codes. This is accomplished with an `exit_code` function that simply returns the provided exit code:

```
function exit_code
  return $argv[1]
end
```

A string is built-up dynamically that when sourced will execute a pipeline with the same exit codes as the original `$pipestatus`:

```
build_exit_code_pipeline "0 0 123"
-> "exit_code 0 | exit_code 0 | exit_code 123"
```

When this command is sourced, the pipeline is executed and the original `$status` and `$pipestatus` are restored.

It's important to note that these commands need to be piped to `source` and *not* `eval`ed, because the `eval` command doesn't treat this as a pipeline and will therefore only populate `$status`, not `$pipestatus`.

### Testing

Note that commands run in `fish_prompt` do not effect the values of `$status` and `$pipestatus` outside of generating the prompt, so writing a test for this would involve writing an interactive test via `expect`, which I've elected not to do because it sucks.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Previously when running `flox activate` in Fish, `$status` and `$pipestatus` would always be set to 0 when computing the shell prompt. Fish users with shell prompts that make use of these variables will now see them in their prompts after running `flox activate`.

<!-- Many thanks! -->
