### PR TITLE
fix(nef/cli): check the right outLink

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -120,6 +120,8 @@ pub struct BuildResult {
     pub version: String,
     pub system: Option<String>,
     pub log: BuiltStorePath,
+    #[serde(rename = "outLink")]
+    pub out_link: PathBuf,
 }
 
 /// Output received from an ongoing build process.


### PR DESCRIPTION
As in the result link is named after the target name/attrPath (.flox/pkgs/foo/bar.nix -> flox build foo.bar -> ./result-foo.bar). With manifest builds that attrPath becomes the pname (hence probably the var name `$(_pvarname)_result = result-$(_pname))`). Expression builds also link to `$(_pvarname)_result`, irrespective of thweir actual pname (as defined in the nix expression). Thus when we look for `result-(build_output.pname)` after the build, we falsely claim that the build of nix expressions failed.

This commit adds an `out_link` field to the buildOutput json and changes the cli to check that instead of guessing the outlink.
