### PR TITLE
chore: don't print nix trace warnings unless running with `-v+`

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -80,14 +80,15 @@ endif
 # Path to Nix expession (NEF) library.
 _nef := $(_libexec_dir)/nef
 
-# Invoke nix with the required experimental features enabled.
-_nix := $(_nix) --extra-experimental-features "flakes nix-command"
-
 # Set makefile verbosity based on the value of _FLOX_PKGDB_VERBOSITY [sic]
 # as set in the environment by the flox CLI. First set it to 0 if not defined.
 ifeq (,$(_FLOX_PKGDB_VERBOSITY))
   _FLOX_PKGDB_VERBOSITY = 0
 endif
+
+# Invoke nix with the required experimental features enabled.
+_nix := $(_nix) --extra-experimental-features "flakes nix-command" $(intcmp 0,$(_FLOX_PKGDB_VERBOSITY),--trace-verbose)
+
 # Ensure we use the Nix-provided SHELL.
 SHELL := $(_bash) $(intcmp 2,$(_FLOX_PKGDB_VERBOSITY),-x)
 

--- a/package-builder/nef/lib/dirToAttrs.nix
+++ b/package-builder/nef/lib/dirToAttrs.nix
@@ -112,7 +112,7 @@
         if exists then
           entry
         else
-          builtins.trace "Not importing any attributes because the directory ${dir} doesn't exist" null;
+          builtins.traceVerbose "Not importing any attributes because the directory ${dir} doesn't exist" null;
 
       result = pathToEntries dir;
     in


### PR DESCRIPTION
Without a .flox/pkgs dir, `flox build` would emoit a stray `trace: Not importing any attributes because the directory ${dir} doesn't exist` message, originating from a `builtins.trace` call in `nef#dirToAttrs`.

`builtin.trace` is about the only mechanism `nix` provides for (non terminating) messages from nix expressions. Unfortuantely they always start with `trace:`.
In this case the message also doesnt serve a functional purpose, so both its decoration and existence were a bit unwarranted. Besides `builtins.trace` nix brovides a _second_ builtin, `builtins.traceVerbose`. Unlike the former its silent by default and requires a `--trace-verbose` flag to show. Here, we use this to now silence the message by default.

When shown, the message will still have the `trace: ` prefix, but at leat its not shown by default any longer.

