### PR TITLE
fix(publish): remove upload destination on spinner

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -323,7 +323,7 @@ impl ClientSideCatalogStoreConfig {
     ///
     /// Note: this is only public because it's used in the private `flox upload`
     ///       command.
-    #[instrument(skip_all, fields(progress = format!("Uploading '{store_path}' to '{}'", destination_url)))]
+    #[instrument(skip_all, fields(progress = format!("Uploading '{store_path}'")))]
     pub fn upload_store_path(
         destination_url: &Url,
         signing_key_path: Option<&Path>,


### PR DESCRIPTION
While uploading during publish, we don't need to show the full destination location in the spinner message.  Removed that and confirmed the full upload destination with query parameters are available in debug logs with `-vv`.

