### PR TITLE
feat: poll for publish completion

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -82,6 +82,7 @@ pub enum Response {
     Packages(PackageDetails),
     Search(SearchResults),
     GetStoreInfo(StoreInfoResponse),
+    GetStorepathStatus(StorepathStatusResponse),
     Error(GenericResponse<ErrorResponse>),
     Publish(PublishResponse),
     CreatePackage,
@@ -405,6 +406,7 @@ pub type UserBuildPublish = api_types::UserBuildPublish;
 pub type UserDerivationInfo = api_types::UserDerivationInput;
 pub type StoreInfoRequest = api_types::StoreInfoRequest;
 pub type StoreInfoResponse = api_types::StoreInfoResponse;
+pub type StorepathStatusResponse = api_types::StorepathStatusResponse;
 pub type StoreInfo = api_types::StoreInfo;
 pub type CatalogStoreConfig = api_types::CatalogStoreConfig;
 pub type CatalogStoreConfigNixCopy = api_types::CatalogStoreConfigNixCopy;
@@ -473,6 +475,10 @@ pub trait ClientTrait {
         &self,
         _derivations: Vec<String>,
     ) -> Result<HashMap<String, Vec<StoreInfo>>, CatalogClientError>;
+
+    /// Checks whether the provided package has been successfully published.
+    async fn is_publish_complete(&self, req: &StoreInfoRequest)
+    -> Result<bool, CatalogClientError>;
 }
 
 impl ClientTrait for CatalogClient {
@@ -728,6 +734,34 @@ impl ClientTrait for CatalogClient {
             })?;
         let store_info = response.into_inner();
         Ok(store_info.items)
+    }
+
+    /// Checks whether the store paths for a package have made it into the catalog store yet.
+    async fn is_publish_complete(
+        &self,
+        req: &StoreInfoRequest,
+    ) -> Result<bool, CatalogClientError> {
+        let statuses = self
+            .client
+            .get_storepath_status_api_v1_catalog_store_status_post(req)
+            .await
+            .map_err(|e| match e {
+                APIError::ErrorResponse(err) => {
+                    CatalogClientError::APIError(APIError::ErrorResponse(err))
+                },
+                _ => CatalogClientError::APIError(e),
+            })?;
+        // TODO(zmitchell): We currently throw away _progress_ because the status is reported
+        //                  by store path, and what we're reporting here is all or nothing.
+        //                  In the future we can provide more detail using the statuses here,
+        //                  which could be used to indicate to the user that *something* is
+        //                  happening.
+        let all_narinfo_available = statuses.items.values().all(|storepath_statuses_for_drv| {
+            storepath_statuses_for_drv
+                .iter()
+                .all(|status| status.narinfo_known)
+        });
+        Ok(all_narinfo_available)
     }
 }
 
@@ -1004,6 +1038,27 @@ impl ClientTrait for MockClient {
             Some(Response::GetStoreInfo(resp)) => Ok(resp.items),
             _ => panic!("expected get_store_info response, found {:?}", &mock_resp),
         }
+    }
+
+    async fn is_publish_complete(
+        &self,
+        _req: &StoreInfoRequest,
+    ) -> Result<bool, CatalogClientError> {
+        let mock_resp = self
+            .mock_responses
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .pop_front();
+        let statuses = match mock_resp {
+            Some(Response::GetStorepathStatus(resp)) => resp,
+            _ => panic!("expected get_store_info response, found {:?}", &mock_resp),
+        };
+        let all_narinfo_available = statuses.items.values().all(|storepath_statuses_for_drv| {
+            storepath_statuses_for_drv
+                .iter()
+                .all(|status| status.narinfo_known)
+        });
+        Ok(all_narinfo_available)
     }
 }
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -41,7 +41,7 @@ use crate::models::lockfile::Lockfile;
 use crate::models::manifest::typed::Inner;
 use crate::providers::auth::catalog_auth_to_envs;
 use crate::providers::build;
-use crate::providers::catalog::{CatalogStoreConfig, CatalogStoreConfigNixCopy};
+use crate::providers::catalog::{CatalogStoreConfig, CatalogStoreConfigNixCopy, StoreInfoRequest};
 use crate::providers::git::GitProvider;
 use crate::providers::nix::nix_base_command;
 use crate::utils::CommandExt;
@@ -93,6 +93,9 @@ pub enum PublishError {
 
     #[error(transparent)]
     Auth(#[from] AuthError),
+
+    #[error("Timed out waiting for publish completion")]
+    PublishTimeout,
 }
 
 /// The `Publish` trait describes the high level behavior of publishing a package to a catalog.
@@ -106,6 +109,12 @@ pub trait Publisher {
         catalog_name: &str,
         key_file: Option<PathBuf>,
         metadata_only: bool,
+    ) -> Result<(), PublishError>;
+    async fn wait_for_publish_completion(
+        &self,
+        client: &Client,
+        poll_interval_millis: u64,
+        timeout_millis: u64,
     ) -> Result<(), PublishError>;
 }
 
@@ -561,6 +570,58 @@ where
             .await
             .map_err(PublishError::CatalogError)?;
 
+        Ok(())
+    }
+
+    /// Waits until the narinfos for all store paths are present in the catalog,
+    /// or errors on timeout.
+    async fn wait_for_publish_completion(
+        &self,
+        client: &Client,
+        poll_interval_millis: u64,
+        timeout_millis: u64,
+    ) -> Result<(), PublishError> {
+        let store_paths = self
+            .build_metadata
+            .outputs
+            .0
+            .iter()
+            .map(|output| output.store_path.clone())
+            .collect::<Vec<_>>();
+        let drv_path = self.build_metadata.drv_path.clone();
+        let request = StoreInfoRequest {
+            drv_paths: Some(vec![drv_path]),
+            outpaths: store_paths,
+        };
+        let loop_poll_and_wait = async {
+            let start = tokio::time::Instant::now();
+            let wait_duration = tokio::time::Duration::from_millis(poll_interval_millis);
+            loop {
+                let now = tokio::time::Instant::now();
+                let elapsed = now.duration_since(start);
+                debug!(
+                    elapsed_millis = elapsed.as_millis(),
+                    "polling publish completion"
+                );
+                if client
+                    .is_publish_complete(&request)
+                    .await
+                    .map_err(PublishError::CatalogError)?
+                {
+                    break;
+                }
+                debug!("not complete, sleeping");
+                tokio::time::sleep(wait_duration).await;
+            }
+            let now = tokio::time::Instant::now();
+            let elapsed = now.duration_since(start);
+            debug!(elapsed_millis = elapsed.as_millis(), "publish complete");
+            Ok::<_, PublishError>(())
+        };
+        let timeout = tokio::time::Duration::from_millis(timeout_millis);
+        tokio::time::timeout(timeout, loop_poll_and_wait)
+            .await
+            .map_err(|_| PublishError::PublishTimeout)??;
         Ok(())
     }
 }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
@@ -17,7 +17,7 @@ use flox_rust_sdk::providers::publish::{
     check_package_metadata,
 };
 use indoc::formatdoc;
-use tracing::{debug, instrument};
+use tracing::{debug, info_span, instrument};
 
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::build::packages_to_build;
@@ -26,6 +26,9 @@ use crate::config::Config;
 use crate::environment_subcommand_metric;
 use crate::utils::errors::display_chain;
 use crate::utils::message;
+
+const PUBLISH_COMPLETION_POLL_INTERVAL_MILLIS: u64 = 1_000; // 1s
+const PUBLISH_COMPLETION_TIMEOUT_MILLIS: u64 = 5 * 60 * 1_000; // 5 min
 
 #[derive(Bpaf, Clone)]
 pub struct Publish {
@@ -161,14 +164,32 @@ impl Publish {
             .publish(&flox.catalog_client, &catalog_name, key_file, metadata_only)
             .await
         {
-            Ok(_) => message::updated(formatdoc! {"
-                Package published successfully.
-
-                Use 'flox install {catalog_name}/{package}' to install it.
-                ", package = &publish_provider.package_metadata.package,}),
+            Ok(_) => {
+                let span = info_span!(
+                    "publish",
+                    progress = "Waiting for confirmation of successful publish..."
+                );
+                {
+                    // Using a block here instead of `span.in_scope()` because
+                    // that's not an async context.
+                    let _ = span.enter();
+                    publish_provider
+                        .wait_for_publish_completion(
+                            &flox.catalog_client,
+                            PUBLISH_COMPLETION_POLL_INTERVAL_MILLIS,
+                            PUBLISH_COMPLETION_TIMEOUT_MILLIS,
+                        )
+                        .await
+                        .context("Failed while waiting for publish confirmation")?;
+                }
+            },
             Err(e) => bail!("Failed to publish package: {}", display_chain(&e)),
         }
+        message::updated(formatdoc! {"
+            Package published successfully.
 
+            Use 'flox install {catalog_name}/{package}' to install it.
+            ", package = &publish_provider.package_metadata.package,});
         Ok(())
     }
 }


### PR DESCRIPTION
## Proposed Changes

> Note: this is in draft because the endpoint this relies on is only deployed to `preview`, and there is remaining work to populate the `narinfo_exists` field on the server side. Once those are deployed, we can create tests/mocks to ensure that timeouts don't last forever, etc.

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

**feat: poll for publish completion**

Uses the new `/store_path/status` endpoint to poll for the completion
of the publish process. The publish process doesn't end with uploading
the artifacts, since there is a signing process and propagation of
metadata to the catalog server. If something fails after uploading
artifacts, we need to inform the user so that they don't mistakenly
think that the publish was a success.

Closes #3098

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
