### PR TITLE
feat: comment out options.systems in template

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -388,22 +388,37 @@ impl RawManifest {
         "#});
 
         // `systems` array with custom formatting
-        let mut systems_array = Array::new();
-        for system in systems {
-            let mut item = Value::from(system.to_string());
-            item.decor_mut().set_prefix("\n  "); // Indent each item with two spaces
-            if Some(system) == systems.last() {
-                item.decor_mut().set_suffix(",\n"); // Add a newline before the first item
+        if systems.len() != 4 {
+            // If somehow we init with something *other* than the default systems,
+            // add those.
+            let mut systems_array = Array::new();
+            for system in systems {
+                let mut item = Value::from(system.to_string());
+                item.decor_mut().set_prefix("\n  "); // Indent each item with two spaces
+                if Some(system) == systems.last() {
+                    item.decor_mut().set_suffix(",\n"); // Add a newline before the first item
+                }
+                systems_array.push_formatted(item);
             }
-            systems_array.push_formatted(item);
-        }
 
-        let systems_key = Key::new(MANIFEST_SYSTEMS_KEY);
-        options_table.insert(&systems_key, toml_edit::value(systems_array));
-        if let Some((mut key, _)) = options_table.get_key_value_mut(&systems_key) {
-            key.leaf_decor_mut().set_prefix(indoc! {r#"
+            let systems_key = Key::new(MANIFEST_SYSTEMS_KEY);
+            options_table.insert(&systems_key, toml_edit::value(systems_array));
+            if let Some((mut key, _)) = options_table.get_key_value_mut(&systems_key) {
+                key.leaf_decor_mut().set_prefix(indoc! {r#"
+                    # Systems that environment is compatible with
+                    "#});
+            }
+        } else {
+            // If we init with the default systems, we can omit those.
+            options_table.decor_mut().set_suffix(indoc! {r#"
+
                 # Systems that environment is compatible with
-                "#});
+                # systems = [
+                #   "aarch64-darwin",
+                #   "aarch64-linux",
+                #   "x86_64-darwin",
+                #   "x86_64-linux",
+                # ]"#});
         }
 
         let cuda_detection_key = Key::new("cuda-detection");
@@ -1188,12 +1203,12 @@ pub(super) mod test {
             ## Other Environment Options -----------------------------------------
             [options]
             # Systems that environment is compatible with
-            systems = [
-              "aarch64-darwin",
-              "aarch64-linux",
-              "x86_64-darwin",
-              "x86_64-linux",
-            ]
+            # systems = [
+            #   "aarch64-darwin",
+            #   "aarch64-linux",
+            #   "x86_64-darwin",
+            #   "x86_64-linux",
+            # ]
             # Uncomment to disable CUDA detection.
             # cuda-detection = false
         "#};
@@ -1297,12 +1312,12 @@ pub(super) mod test {
             ## Other Environment Options -----------------------------------------
             [options]
             # Systems that environment is compatible with
-            systems = [
-              "aarch64-darwin",
-              "aarch64-linux",
-              "x86_64-darwin",
-              "x86_64-linux",
-            ]
+            # systems = [
+            #   "aarch64-darwin",
+            #   "aarch64-linux",
+            #   "x86_64-darwin",
+            #   "x86_64-linux",
+            # ]
             # Uncomment to disable CUDA detection.
             # cuda-detection = false
         "#};

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -226,13 +226,6 @@ EOF
   FLOX_SHELL=zsh "$FLOX_BIN" activate --trust -r "$OWNER/$NAME" -- python -c "import requests"
 }
 
-# bats test_tags=init:catalog
-@test "init creates manifest with all 4 systems" {
-  "$FLOX_BIN" init
-  systems=$(tomlq -r -c '.options.systems' .flox/env/manifest.toml)
-  assert_equal "$systems" '["aarch64-darwin","aarch64-linux","x86_64-darwin","x86_64-linux"]'
-}
-
 # ---------------------------------------------------------------------------- #
 #
 #

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -95,7 +95,21 @@ function make_incompatible() {
   git clone "$FLOX_FLOXHUB_PATH/$OWNER/floxmeta" "$PROJECT_DIR/floxmeta"
   pushd "$PROJECT_DIR/floxmeta" >/dev/null || return
   git checkout "$ENV_NAME"
-  sed -i "s|$NIX_SYSTEM|$init_system|g" "${GENERATION}/env/manifest.toml" "${GENERATION}/env/manifest.lock"
+
+  # Remove any existing systems and append just the incompatible one
+  tmp_manifest="$(mktemp)"
+  cat "${GENERATION}/env/manifest.toml" | tomlq -t '.options = {}' > "$tmp_manifest"
+  mv "$tmp_manifest" "${GENERATION}/env/manifest.toml"
+  echo "$(cat << EOF
+systems = [ "$init_system" ]
+EOF
+)" >> "${GENERATION}/env/manifest.toml"
+
+  # Do the same thing for the lockfile: remove any existing systems and add in
+  # just the incompatible one
+  tmp_lockfile="$(mktemp)"
+  cat "${GENERATION}/env/manifest.lock" | jq ".manifest.options.systems = [\"$init_system\"]" > "$tmp_lockfile"
+  mv "$tmp_lockfile" "${GENERATION}/env/manifest.lock"
 
   git add .
   git \


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This comments out `options.systems` in the manifest template. When all of the systems are present, it's functionally equivalent to omitting this option entirely, so we might as well omit it. This has the added benefit of not generating a composition merge notification when one environment includes another without otherwise overriding anything.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
