### PR TITLE
fix: report all result symlinks created by a build

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -718,7 +718,7 @@ define NIX_EXPRESSION_BUILD_template =
   # Harvest the logfile from the build.
   $($(_pvarname)_logfile): $($(_pvarname)_buildJSON) $(_pvarname)_CHECK_BUILD
 	$$(eval _drvPath = $$(shell $(_jq) -r '.[0].drvPath' $$<))
-	$(_V_) ( $(_nix) log $$(_drvPath) || echo "No logs available" ) > $($(_pvarname)_logfile)
+	$(_V_) ( $(_nix) log $$(_drvPath) 2>/dev/null || echo "No logs available" ) > $($(_pvarname)_logfile)
 
   # Add the log to the store and create a GCRoot for it.
   $($(_pvarname)_result)-log: $($(_pvarname)_logfile)


### PR DESCRIPTION
## Proposed Changes

PR3188 only reported the default "out" link created by a build rather than the result links created for all of its outputs. This patch updates the reporting to include all result links created, not just the "out" one.

## Release Notes

* N/A