### PR TITLE
fix: ensure FLOX_ENV present in env set by build wrapper

### DIFF
--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -117,6 +117,9 @@ if [ -z "${FLOX_ENV-}" ]; then
   exit 1
 fi
 
+# Propagate required variables that are documented as exposed.
+export FLOX_ENV
+
 # prepend path
 export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin:$PATH"
 


### PR DESCRIPTION
## Proposed Changes

The `FLOX_ENV` variable was being set but not exported by the build `wrapper` script. This meant that it was set for the benefit of `etc/profile.d` and `hook.on-activate` scripts that are _sourced_, but not present for the executables that are subsequently exec'd, e.g. for any of the `profile.*` scripts.

Do not merge ... still a WIP, and very possibly the wrong approach.

## Release Notes

N/A