### PR TITLE
fix: populate $(BUILD_OUTPUTS) prior to constructing manifest build DAG

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1538,14 +1538,14 @@ mod tests {
 
     #[test]
     fn build_depending_on_another_build() {
-        let package_name = String::from("foo");
-        let file_name = String::from("bar");
+        let package_name = String::from("app-with-dashes");
+        let file_name = String::from("foo");
         let file_content = String::from("some content");
 
         let manifest = formatdoc! {r#"
             version = 1
 
-            [build.dep]
+            [build.dep-with-dashes]
             command = """
                 mkdir $out
                 echo -n "{file_content}" > $out/{file_name}
@@ -1554,7 +1554,7 @@ mod tests {
             [build.{package_name}]
             command = """
                 mkdir $out
-                cp ${{dep}}/{file_name} $out/{file_name}
+                cp ${{dep-with-dashes}}/{file_name} $out/{file_name}
             """
         "#};
 


### PR DESCRIPTION
## Proposed Changes

Issue #3217 documents an instance where the manifest build script preparation failed to substitute a package reference prior to invoking the build. Turns out this was caused by a combination of the order of processing and not attempting substitution for all known builds, and splitting the processing of all known `$(MANIFEST_BUILDS)` into two passes addresses the problem.

Also updated existing test to confirm ability to build dependency containing multiple dashes, as we initially thought that was the origin of the bug.

Closes #3217.

## Release Notes

N/A