### PR TITLE
fix: patch Nix for better single user error

### DIFF
--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -55,6 +55,8 @@ nixVersions."${nixVersion}".overrideAttrs (prev: {
     #
     # Note: remove for Nix >= v2.29
     (builtins.path { path = ./patches/pr_12580_host-in-locked-github-url.2.24.11.patch; })
+
+    (builtins.path { path = ./patches/pr_13340_db_lock_permission_error.patch; })
   ];
 
   postFixup = ''

--- a/pkgs/nix/patches/pr_13340_db_lock_permission_error.patch
+++ b/pkgs/nix/patches/pr_13340_db_lock_permission_error.patch
@@ -1,0 +1,54 @@
+From 9252001342a6717a71633b578f9f1aaf86c313a9 Mon Sep 17 00:00:00 2001
+From: Matthew Kenigsberg <matthew@floxdev.com>
+Date: Mon, 9 Jun 2025 16:46:20 -0600
+Subject: [PATCH] Improve database lock permission error context
+
+Add helpful context when opening the Nix database lock fails due to
+permission errors. Instead of just showing "Permission denied", now
+provides guidance about possible causes:
+- Running as non-root in a single-user Nix installation
+- Nix daemon may have crashed
+---
+ src/libstore/local-store.cc         | 11 ++++++++++-
+ tests/functional/read-only-store.sh |  3 ++-
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/libstore/local-store.cc b/src/libstore/local-store.cc
+index 949f0f74f..1608dba81 100644
+--- a/src/libstore/local-store.cc
++++ b/src/libstore/local-store.cc
+@@ -223,7 +223,16 @@ LocalStore::LocalStore(
+        schema upgrade is in progress. */
+     if (!readOnly) {
+         Path globalLockPath = dbDir + "/big-lock";
+-        globalLock = openLockFile(globalLockPath.c_str(), true);
++        try {
++            globalLock = openLockFile(globalLockPath.c_str(), true);
++        } catch (SysError & e) {
++            if (e.errNo == EACCES || e.errNo == EPERM) {
++                e.addTrace({},
++                    "This command may have been run as non-root in a single-user Nix installation,\n"
++                    "or the Nix daemon may have crashed.");
++            }
++            throw;
++        }
+     }
+ 
+     if (!readOnly && !lockFile(globalLock.get(), ltRead, false)) {
+diff --git a/tests/functional/read-only-store.sh b/tests/functional/read-only-store.sh
+index f6b6eaf32..ea96bba41 100755
+--- a/tests/functional/read-only-store.sh
++++ b/tests/functional/read-only-store.sh
+@@ -42,7 +42,8 @@ chmod -R -w $TEST_ROOT/var
+ 
+ # Make sure we fail on add operations on the read-only store
+ # This is only for adding files that are not *already* in the store
+-expectStderr 1 nix-store --add eval.nix | grepQuiet "error: opening lock file '$(readlink -e $TEST_ROOT)/var/nix/db/big-lock'"
++# Should show enhanced error message with helpful context
++expectStderr 1 nix-store --add eval.nix | grepQuiet "This command may have been run as non-root in a single-user Nix installation"
+ expectStderr 1 nix-store --store local?read-only=true --add eval.nix | grepQuiet "Permission denied"
+ 
+ # Test the same operations from before should again succeed
+-- 
+2.49.0
+


### PR DESCRIPTION
I have an upstream PR applying this patch, but it hasn't merged yet, and
even if it does we can apply it in the meantime.

When running as a non-root user using a single-user installation of Nix,
or when the nix daemon crashes, the current error Nix provides doesn't
give much hint for how to solve the issue. The current error for a
`flox install` is:
```
❌ ERROR: Failed to build environment:

Failed to realise 'hello':
error: opening lock file '/nix/var/nix/db/big-lock': Permission denied
```

Prior to our most recent update of Nix, the error included

```
error: could not set permissions on '/nix/var/nix/profiles/per-user' to 755: Operation not permitted
```

Modify the error to provide some hints at how to solve the problem.
After this patch, the error is:
```
❌ ERROR: Failed to build environment:

Failed to realise 'hello':
error:
       … This command may have been run as non-root in a single-user Nix installation,
       or the Nix daemon may have crashed.

       error: opening lock file '/nix/var/nix/db/big-lock': Permission denied
```