### PR TITLE
fix: service-level variables not applied

### DIFF
--- a/cli/flox-rust-sdk/proptest-regressions/providers/services.txt
+++ b/cli/flox-rust-sdk/proptest-regressions/providers/services.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ae24b2728fb0cc0f7dbbbf096b84c5fc6da95b8f1042a796484325e3735595fc # shrinks to config = ProcessComposeConfig { log_level: Debug, log_configuration: ProcessComposeLoggerConfig { no_color: false }, processes: {"": ProcessConfig { command: "", vars: Some({}), is_daemon: None, shutdown: None }} }
+cc 2b4150f7eb0709284e1eed7667ce769f0218e283d8c8cecdb224ac3e66b7937f # shrinks to config = ProcessComposeConfig { log_level: Debug, log_configuration: ProcessComposeLoggerConfig { no_color: false }, disable_env_expansion: false, processes: {"": ProcessConfig { command: "", vars: Some({}), is_daemon: None, shutdown: None }} }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
You can set environment variables at both the environment level (via the `[vars]` section) or the service level via
`services.<name>.vars.<name>`. Previously the service level variables were not applied. There are two bugs involved.

The first bug is caused by the fact that `process-compose` has an internal templating engine that allows interpolating variables defined in the `vars` section of the config file. These variables are _not_ environment variables, and are only used for templating purposes. However, the manifest uses `vars` as the name of the environment variables section, and so when the service configuration is serialized to YAML we end up translating environment variables to template variables. This explains why it was possible to use template syntax by mistake in the service configuration.

The second bug is that by default, which is an extremely questionable decision, `process-compose` will expand shell variables in the config file _at load time_. This means that if the command for your service is `echo "hello $user"`, the value of `$user` will be looked up in the environment of `process-compose` (or an empty string if it's not found) and substituted into the config file as a pre-processing step before running your command. This means that if `$user` isn't present in the environment, the command used to spawn your service actually becomes `echo "hello "`. Disabling this behavior is done via the top level `disable_env_expansion` option.

Closes #2431 

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Service-specific environment variables will now be correctly applied.

<!-- Many thanks! -->
