### PR TITLE
test(publish): Small debugging improvements

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1255,7 +1255,7 @@ pub mod tests {
             .publish(&flox.catalog_client, &catalog_name, None, false)
             .await;
 
-        assert!(res.is_ok());
+        assert!(res.is_ok(), "Expected publish to succeed, got: {:?}", res);
     }
 
     /// Generate dummy CheckedBuildMetadata and CheckedEnvironmentMetadata that


### PR DESCRIPTION
## Proposed Changes

Some small improvements that came out https://github.com/flox/flox/issues/3074

**test(publish): Add dummy output**

With a store path that we known to already exist so that we can test
`nix-copy` with this metadata. I was previously surprised that doing so
was a noop because there were no outputs.

**fix(publish): Improve copy outputs debugging**

Improve debug output for copying outputs and explicitly skip copying
when there are no outputs. This was already a noop when
`upload_build_outputs` iterates over an empty vec.

This helped me to debug a test where it was copying to the wrong path
because of a replayed mock from a previous test invocation and when some
handcrafted metadata didn't contain any outputs at all.

**test(publish): Show error on test assert fail**

So that we get the reason for the failure rather than just a bool.

## Release Notes

N/A
