### PR TITLE
test(publish): wip: Convert to httpmock

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1581,6 +1581,51 @@ pub mod test_helpers {
 
         client.reset_mocks(responses);
     }
+
+    /// Create a catalog with the given name and config.
+    ///
+    /// Will continue with config and not return an error if the catalog already exists.
+    pub async fn create_catalog_with_config(
+        client: &Client,
+        name: &str,
+        config: &CatalogStoreConfig,
+    ) -> Result<(), CatalogClientError> {
+        let Client::Catalog(client) = client else {
+            panic!("can only be used with a CatalogClient");
+        };
+
+        // TODO: Change `catalog-server` to use `CatalogName` instead of `Name`.
+        let name_name = api_types::Name::from_str(name).map_err(|_e| {
+            CatalogClientError::APIError(APIError::InvalidRequest(
+                format!("catalog name {} does not meet API requirements.", name).to_string(),
+            ))
+        })?;
+        let catalog_name = str_to_catalog_name(name)?;
+
+        match client
+            .client
+            .create_catalog_api_v1_catalog_catalogs_post(&name_name)
+            .await
+        {
+            Ok(_) => {},
+            // Continue if already exists.
+            Err(e) if e.status() == Some(StatusCode::CONFLICT) => {},
+            Err(e) => {
+                return Err(CatalogClientError::APIError(e));
+            },
+        }
+
+        client
+            .client
+            .set_catalog_store_config_api_v1_catalog_catalogs_catalog_name_store_config_put(
+                &catalog_name,
+                config,
+            )
+            .await
+            .map_err(CatalogClientError::APIError)?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -1492,7 +1492,12 @@ pub fn mock_base_catalog_url() -> BaseCatalogUrl {
 }
 
 pub mod test_helpers {
+    use tempfile::TempDir;
+
     use super::*;
+    use crate::flox::test_helpers::create_test_token;
+    use crate::flox::{Flox, FloxhubToken};
+    use crate::providers::auth::{Auth, AuthProvider};
 
     pub static UNIT_TEST_GENERATED: LazyLock<PathBuf> =
         LazyLock::new(|| PathBuf::from(std::env::var("UNIT_TEST_GENERATED").unwrap()));
@@ -1520,15 +1525,38 @@ pub mod test_helpers {
     /// Tests must be run with `#[tokio::test(flavor = "multi_thread")]` to
     /// allow the `MockServer` to run in another thread.
     pub fn auto_recording_catalog_client(filename: &str) -> Client {
+        let auth = Auth::from_tempdir_and_token(TempDir::new().unwrap(), None);
+        _auto_recording_catalog_client(filename, DEFAULT_CATALOG_URL, &auth)
+    }
+
+    /// Similar to [auto_recording_catalog_client] but authenticates against a dev
+    /// instance of the catalog-server using a token from
+    /// `_FLOX_UNIT_TEST_RECORD_TOKEN` and updates [Flox] to have the
+    /// appropriate token and client.
+    ///
+    /// Should only be used for tests that require authentication.
+    pub fn auto_recording_catalog_client_authed_dev(flox: &mut Flox, filename: &str) -> Auth {
+        let token = if std::env::var("_FLOX_UNIT_TEST_RECORD") == Ok("true".to_string()) {
+            FloxhubToken::from_str(&std::env::var("_FLOX_UNIT_TEST_RECORD_TOKEN").unwrap()).unwrap()
+        } else {
+            create_test_token("test")
+        };
+
+        flox.floxhub_token = Some(token);
+        let auth = Auth::from_flox(flox).unwrap();
+        let base_url = "http://localhost:8000";
+        let client = _auto_recording_catalog_client(filename, base_url, &auth);
+        flox.catalog_client = client;
+
+        auth
+    }
+
+    fn _auto_recording_catalog_client(filename: &str, base_url: &str, auth: &Auth) -> Client {
         let mut path = UNIT_TEST_GENERATED.join(filename);
         path.set_extension("yaml");
         let (mock_mode, catalog_url) =
             if std::env::var("_FLOX_UNIT_TEST_RECORD") == Ok("true".to_string()) {
-                // Generate against prod
-                (
-                    CatalogMockMode::Record(path),
-                    DEFAULT_CATALOG_URL.to_string(),
-                )
+                (CatalogMockMode::Record(path), base_url.to_string())
             } else {
                 (
                     CatalogMockMode::Replay(path),
@@ -1538,7 +1566,7 @@ pub mod test_helpers {
 
         let catalog_config = CatalogClientConfig {
             catalog_url,
-            floxhub_token: None,
+            floxhub_token: auth.token().map(|token| token.secret().to_string()),
             extra_headers: Default::default(),
             mock_mode,
         };

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1277,7 +1277,7 @@ pub mod tests {
                 url: "dummy".to_string(),
                 rev: "dummy".to_string(),
                 rev_count: 0,
-                rev_date: Utc::now(),
+                rev_date: "2025-01-01T12:00:00Z".parse::<DateTime<Utc>>().unwrap(),
             },
 
             _private: (),

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1250,6 +1250,12 @@ pub mod tests {
         CheckedEnvironmentMetadata,
         PackageMetadata,
     ) {
+        // TODO: https://github.com/flox/flox/issues/3179
+        // Use a page available available on whichever catalog-server instance we're using.
+        let base_ref = BaseCatalogUrl::from(
+            "https://github.com/flox/nixpkgs?rev=693bc46d169f5af9c992095736e82c3488bf7dbb",
+        );
+
         let build_metadata = CheckedBuildMetadata {
             name: "dummy".to_string(),
             pname: "dummy".to_string(),
@@ -1266,7 +1272,7 @@ pub mod tests {
             repo_root_path: PathBuf::new(),
             rel_project_path: PathBuf::new(),
 
-            toplevel_catalog_ref: Some(mock_base_catalog_url()),
+            toplevel_catalog_ref: Some(base_ref.clone()),
             build_repo_ref: LockedUrlInfo {
                 url: "dummy".to_string(),
                 rev: "dummy".to_string(),
@@ -1278,7 +1284,7 @@ pub mod tests {
         };
 
         let package_metadata = PackageMetadata {
-            base_catalog_ref: mock_base_catalog_url(),
+            base_catalog_ref: base_ref,
             package: EXAMPLE_MANIFEST_PACKAGE_TARGET.clone(),
             description: "dummy".to_string(),
             _private: (),

--- a/test_data/unit_test_generated/publish_errors_without_key.yaml
+++ b/test_data/unit_test_generated/publish_errors_without_key.yaml
@@ -1,0 +1,66 @@
+when:
+  path: /api/v1/catalog/catalogs/
+  method: POST
+then:
+  status: 409
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '74'
+  - name: content-type
+    value: application/json
+  body: '{"detail":"The catalog with name flox-unit-tests-nix-copy already exists"}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-nix-copy/store/config
+  method: PUT
+  body: '{"store_type":"meta-only"}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '26'
+  - name: content-type
+    value: application/json
+  body: '{"store_type":"meta-only"}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-nix-copy/packages
+  method: POST
+  body: '{"original_url":"dummy"}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '73'
+  - name: content-type
+    value: application/json
+  body: '{"catalog":"flox-unit-tests-nix-copy","name":"mypkg","original_url":null}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-nix-copy/packages/mypkg/publish/info
+  method: POST
+  body: '{}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '369'
+  - name: content-type
+    value: application/json
+  body: '{"ingress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","ingress_auth":null,"catalog_store_config":{"store_type":"nix-copy","ingress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","egress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD"}}'

--- a/test_data/unit_test_generated/publish_meta_only.yaml
+++ b/test_data/unit_test_generated/publish_meta_only.yaml
@@ -1,0 +1,83 @@
+when:
+  path: /api/v1/catalog/catalogs/
+  method: POST
+then:
+  status: 409
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '75'
+  - name: content-type
+    value: application/json
+  body: '{"detail":"The catalog with name flox-unit-tests-meta-only already exists"}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-meta-only/store/config
+  method: PUT
+  body: '{"store_type":"meta-only"}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '26'
+  - name: content-type
+    value: application/json
+  body: '{"store_type":"meta-only"}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-meta-only/packages
+  method: POST
+  body: '{"original_url":"dummy"}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '74'
+  - name: content-type
+    value: application/json
+  body: '{"catalog":"flox-unit-tests-meta-only","name":"mypkg","original_url":null}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-meta-only/packages/mypkg/publish/info
+  method: POST
+  body: '{}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '90'
+  - name: content-type
+    value: application/json
+  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"meta-only"}}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-meta-only/packages/mypkg/builds
+  method: POST
+  body: '{"derivation":{"broken":false,"description":"dummy","drv_path":"dummy","name":"dummy","outputs":[{"name":"out","store_path":"/nix/store/fnswpav9ywgmndy2mangxrzvgld1yviw-nix-2.24.12/bin/nix"}],"outputs_to_install":[],"pname":"dummy","system":"x86_64-linux","version":"1.0.0"},"locked_base_catalog_url":"https://github.com/flox/nixpkgs?rev=693bc46d169f5af9c992095736e82c3488bf7dbb","rev":"dummy","rev_count":0,"rev_date":"2025-01-01T12:00:00Z","url":"dummy"}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '14'
+  - name: content-type
+    value: application/json
+  body: '{"store":null}'

--- a/test_data/unit_test_generated/upload_to_local_cache.yaml
+++ b/test_data/unit_test_generated/upload_to_local_cache.yaml
@@ -1,0 +1,83 @@
+when:
+  path: /api/v1/catalog/catalogs/
+  method: POST
+then:
+  status: 409
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '74'
+  - name: content-type
+    value: application/json
+  body: '{"detail":"The catalog with name flox-unit-tests-nix-copy already exists"}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-nix-copy/store/config
+  method: PUT
+  body: '{"store_type":"nix-copy","egress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","ingress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","store_type":"nix-copy"}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '224'
+  - name: content-type
+    value: application/json
+  body: '{"store_type":"nix-copy","ingress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","egress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD"}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-nix-copy/packages
+  method: POST
+  body: '{"original_url":"dummy"}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '73'
+  - name: content-type
+    value: application/json
+  body: '{"catalog":"flox-unit-tests-nix-copy","name":"mypkg","original_url":null}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-nix-copy/packages/mypkg/publish/info
+  method: POST
+  body: '{}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:34 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '369'
+  - name: content-type
+    value: application/json
+  body: '{"ingress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","ingress_auth":null,"catalog_store_config":{"store_type":"nix-copy","ingress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","egress_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD"}}'
+---
+when:
+  path: /api/v1/catalog/catalogs/flox-unit-tests-nix-copy/packages/mypkg/builds
+  method: POST
+  body: '{"cache_uri":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","derivation":{"broken":false,"description":"dummy","drv_path":"dummy","name":"dummy","outputs":[{"name":"out","store_path":"/nix/store/fnswpav9ywgmndy2mangxrzvgld1yviw-nix-2.24.12/bin/nix"}],"outputs_to_install":[],"pname":"dummy","system":"x86_64-linux","version":"1.0.0"},"locked_base_catalog_url":"https://github.com/flox/nixpkgs?rev=693bc46d169f5af9c992095736e82c3488bf7dbb","narinfos":{"out":{}},"narinfos_source_url":"file:///var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.fiJmxP/.tmpdM2xrD","rev":"dummy","rev_count":0,"rev_date":"2025-01-01T12:00:00Z","url":"dummy"}'
+then:
+  status: 200
+  header:
+  - name: date
+    value: Thu, 12 Jun 2025 15:56:36 GMT
+  - name: server
+    value: uvicorn
+  - name: content-length
+    value: '14'
+  - name: content-type
+    value: application/json
+  body: '{"store":null}'


### PR DESCRIPTION
These mocks were recorded using the functionality from the preceding
commits.

We're not merging this yet because of two blockers:

1. It's currently hard to standup and auth against a dev catalog-server
2. The mock request bodies contain tempdir paths that don't match
   subsequent test runs