### PR TITLE
docs(manifest): Add link to build section

### DIFF
--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -31,6 +31,7 @@ tables:
 - [`[profile]`](#profile)
 - [`[services]`](#services)
 - [`[include]`](#include)
+- [`[build]`](#build)
 - [`[options]`](#options)
 - [`containerize`] - see [`flox-containerize(1)`](./flox-containerize.md)
 


### PR DESCRIPTION
## Proposed Changes

This is already linked on the right hand side of the rendered docs but we should list it here as well for consistency.

## Release Notes

N/A