### PR TITLE
fix: detect build deps

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -265,7 +265,6 @@ define MANIFEST_BUILD_DEPENDS_template =
     $(if $(shell $(_grep) '\$${$(_output)[.}]' $(build)), \
       $(eval _ovarname = $(subst -,_,$(_output))) \
       $(eval $(_pvarname)_deps_buildMetaJSON_files += $($(_ovarname)_buildMetaJSON)) \
-      # N.B. need newline after following line
       $($(_pvarname)_buildScript): $($(_ovarname)_buildMetaJSON)
     )
   )


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
We make an attempt to detect build dependencies written with the typical Nix syntax in the user's manifest builds. However, the comment in this diff breaks the command being run by the Makefile because the previous line has a line continuation.

Without this fix, the Go pure build example was not able to complete a multi-stage build where the first stage vendors dependencies and the second stage uses the output of that build.

Closes #3250 

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
