### PR TITLE
fix: prepend environment dirs to PYTHONPATH

### DIFF
--- a/assets/environment-interpreter/common/etc/profile.d/0500_python.sh
+++ b/assets/environment-interpreter/common/etc/profile.d/0500_python.sh
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 _cat="@coreutils@/bin/cat"
 _realpath="@coreutils@/bin/realpath"
+_flox_activations="@flox_activations@"
 
 # ============================================================================ #
 #
@@ -11,15 +12,11 @@ _realpath="@coreutils@/bin/realpath"
 # Only run if `python3' is in `PATH'
 if [[ -x "$FLOX_ENV/bin/python3" ]]; then
   # Get the major/minor version from `python3' to determine the correct path.
-  _env_pypath="$FLOX_ENV/lib/python$(
-    "$FLOX_ENV/bin/python3" -c 'import sys
-print( "{}.{}".format( sys.version_info[0], sys.version_info[1] ) )'
-  )/site-packages"
-  # Only add the path if its missing
-  case ":${PYTHONPATH:-}:" in
-    *:"$_env_pypath":*) : ;;
-    *) PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$_env_pypath" ;;
-  esac
+  _python_version="$("$FLOX_ENV/bin/python3" -c 'import sys; print( "{}.{}".format( sys.version_info[0], sys.version_info[1] ) )')"
+  # This will be appended to each environment directory to form an entry in the
+  # PATH-like variable.
+  _env_suffix="lib/python${_python_version}/site-packages"
+  PYTHONPATH="$($_flox_activations prepend-and-dedup --env-dirs "$FLOX_ENV_DIRS" --suffix "$_env_suffix" --path-like "${PYTHONPATH:-}")"
   export PYTHONPATH
 fi
 

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -70,7 +70,7 @@ impl FixPathsArgs {
 
 /// Adds subdirectories of FLOX_ENV_DIRS to the front of the provided list
 /// of directories.
-fn prepend_dirs_to_pathlike_var(
+pub fn prepend_dirs_to_pathlike_var(
     flox_env_dirs: &[PathBuf],
     suffixes: &[&str],
     existing_dirs: &[PathBuf],

--- a/cli/flox-activations/src/cli/mod.rs
+++ b/cli/flox-activations/src/cli/mod.rs
@@ -5,12 +5,14 @@ use clap::{Parser, Subcommand};
 
 pub mod attach;
 mod fix_paths;
+mod prepend_and_dedup;
 mod profile_scripts;
 mod set_env_dirs;
 mod set_ready;
 mod start_or_attach;
 
 use fix_paths::FixPathsArgs;
+use prepend_and_dedup::PrependAndDedupArgs;
 use profile_scripts::ProfileScriptsArgs;
 use set_env_dirs::SetEnvDirsArgs;
 pub use set_ready::SetReadyArgs;
@@ -41,6 +43,10 @@ pub enum Command {
     SetEnvDirs(SetEnvDirsArgs),
     #[command(about = "Print sourceable output that sources the user's profile scripts.")]
     ProfileScripts(ProfileScriptsArgs),
+    #[command(
+        about = "Prepends and dedups environment dirs, optionally pruning directories that aren't from environments"
+    )]
+    PrependAndDedup(PrependAndDedupArgs),
 }
 
 /// Splits PATH-like variables into individual paths, removing any empty strings.

--- a/cli/flox-activations/src/cli/prepend_and_dedup.rs
+++ b/cli/flox-activations/src/cli/prepend_and_dedup.rs
@@ -1,0 +1,49 @@
+use clap::Args;
+
+use super::fix_paths::prepend_dirs_to_pathlike_var;
+use super::{join_dir_list, separate_dir_list};
+
+#[derive(Debug, Args)]
+pub struct PrependAndDedupArgs {
+    /// The contents of `$FLOX_ENV_DIRS`.
+    #[arg(long)]
+    pub env_dirs: String,
+    /// The contents of a `PATH`-like variable e.g. a colon-delimited
+    /// list of directories.
+    #[arg(long)]
+    pub path_like: String,
+    /// The suffix to append to each environment directory.
+    #[arg(long)]
+    pub suffix: String,
+}
+
+impl PrependAndDedupArgs {
+    pub fn handle(&self) {
+        let output = Self::handle_inner(&self.env_dirs, &self.suffix, &self.path_like);
+        println!("{output}");
+    }
+
+    fn handle_inner(env_dirs_joined: &str, suffix: &str, path_like: &str) -> String {
+        let env_dirs = separate_dir_list(env_dirs_joined);
+        let path_dirs = separate_dir_list(path_like);
+        let fixed_path_dirs = prepend_dirs_to_pathlike_var(&env_dirs, &[suffix], &path_dirs);
+        join_dir_list(fixed_path_dirs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Most of what we would test here is already covered by tests
+    // in `fix_paths.rs` since that's where `prepend_dirs_to_pathlike_var`
+    // is defined.
+
+    #[test]
+    fn handles_empty_pathlike_var() {
+        let env_dirs = "foo:bar";
+        let suffix = "bin";
+        let output = PrependAndDedupArgs::handle_inner(env_dirs, suffix, "");
+        assert_eq!(output, "foo/bin:bar/bin");
+    }
+}

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), Error> {
         cli::Command::FixPaths(args) => args.handle()?,
         cli::Command::SetEnvDirs(args) => args.handle()?,
         cli::Command::ProfileScripts(args) => args.handle()?,
+        cli::Command::PrependAndDedup(args) => args.handle(),
     }
     Ok(())
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**fix: prepend environment dirs to PYTHONPATH**

Previously we appended environment directories to `PYTHONPATH`, which
is incorrect because in nested activations you'll end up preferring
modules from earlier activations instead of newer activations.

**feat: add generic path fixing command**

We already have functionality for prepending and deduplicating
environment directories as we add them to a `PATH`-like variable. This
change just exposes that functionalty as a generic command that prints
out the modified `PATH`-like variable. This means that it's up to the
caller to properly _set_ a variable to this output and then export it.
This is done on purpose to keep the command generic.

Closes #3225 

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Fixes a bug that causes Python modules from outside the environment to be preferred when `PYTHONPATH` is set prior to activation. Also fixes a bug that caused Python modules from earlier activations to be preferred to those in later activations when more than one environment is activated at a time.

<!-- Many thanks! -->
