### PR TITLE
fix(catalog): Attempt to parse unexpected errors

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1131,6 +1131,7 @@ dependencies = [
  "flox-test-utils",
  "fslock",
  "futures",
+ "http 1.3.1",
  "httpmock",
  "indent",
  "indexmap 2.9.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,6 +36,7 @@ flox-test-utils = { path = "flox-test-utils" }
 fslock = "0.2.1"
 fs_extra = "1.3.0"
 futures = "0.3"
+http = "1.3.1"
 # git pending:
 # - https://github.com/alexliesenfeld/httpmock/issues/127
 # - https://github.com/alexliesenfeld/httpmock/pull/131

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -45,6 +45,7 @@ serial_test = { workspace = true, features = ["file_locks"] }
 tracing-subscriber = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
+http.workspace = true
 httpmock.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Proposed Changes

So that we report the `detail` from any error message where possible such as the recently added permission errors.

There's a discrepancy with us reporting read permissions before write permissions which will be fixed separately in https://github.com/flox/catalog-server/pull/382

Before:

    % flox publish -o billlevine
    …
    Completed build of quotes-app-go-0.0.1 in local mode

    ❌ ERROR: Failed to publish package: 403 Forbidden

After:

    % flox publish -o billlevine -d ~/projects/flox/flox-manifest-build-examples/quotes-app-go
    …
    Completed build of quotes-app-go-0.0.1 in local mode

    ❌ ERROR: Failed to publish package: 403 Forbidden: You are not permitted to read this catalog.

The other way to solve this case is to explicitly enumerate a 403 response for each of the endpoints that are doing permission checking, which will add explicit handling at the end of the generated methods, that look like this:

    let result = self.client.execute(request).await;
    let response = result?;
    match response.status().as_u16() {
        200u16 => ResponseValue::from_response(response).await,
        201u16 => ResponseValue::from_response(response).await,
        404u16 => {
            Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
        }
        409u16 => {
            Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
        }
        422u16 => {
            Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
        }
        _ => Err(Error::UnexpectedResponse(response)),
    }

However we're not always going to remember to do that, especially for cross-cutting concerns like authentication, so instead attempt to parse them as best effort.

This can't be done within `map_err` because parsing requires consuming the response body which is an async operation. So I've implemented it as a trait that be used in all of the existing catalog provider methods instead.

The `version_unknown_response` test needed modifying because it was now behaving the same as `version_error_response` due to having a `detail` field.

## Release Notes

N/A, probably.
