### PR TITLE
fix: correctly detect need for mock regen

### DIFF
--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -852,6 +852,7 @@ myhello.runtime-packages = [ "hello", "goodbye" ]
 '''
 
 [build.hello]
+skip_if_output_exists = "build/hello"
 files = ["build/hello/hello.c", "build/hello/.flox"]
 pre_cmd = '''
     rm .flox/env/manifest.lock

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -243,7 +243,6 @@ pre_cmd = '''
 cmd = "flox install krb5"
 
 [resolve.ld_floxlib]
-skip_if_output_exists = "envs/ld_floxlib"
 files = ["envs/ld_floxlib/manifest.toml"]
 pre_cmd = "flox init"
 ignore_cmd_errors = true


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**fix: skip extra mock regen: build/hello**

This job moves the response file at the end of the job, but the
presence of that response is what's used by default for checking
whether to re-run the job. This change adjusts the job to check
for the presence of the output directory instead.

**fix: skip extra mock regen: ld_floxlib**

This job specifies a path to check to determine when the job should be
re-run, but does not create that path at the end of the job, so it is
always re-run.

**fix: correctly detect mock regen**

Previously we were preferring the presence of the response file when
determining whether to re-run a job and not honoring the
`skip_if_output_exists` field in all cases. Now we use this field to
completely override which path to check when determining whether to
re-run a job.

This change addresses a bug in which deleting an `env/*` directory
wouldn't regenerate the mock if the corresponding `*.yaml` file still
existed

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
