### PR TITLE
feat(build/publish): Remove feature flags

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -100,10 +100,6 @@ impl Flox {}
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Default)]
 pub struct Features {
     #[serde(default)]
-    pub build: bool,
-    #[serde(default)]
-    pub publish: bool,
-    #[serde(default)]
     pub upload: bool,
     #[serde(default)]
     pub qa: bool,

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -63,11 +63,6 @@ enum SubcommandOrBuildTargets {
 
 impl Build {
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        if !flox.features.build {
-            message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
-            bail!("'build' feature is not enabled.");
-        }
-
         match self.subcommand_or_targets {
             SubcommandOrBuildTargets::Clean { targets } => {
                 let env = self

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -367,8 +367,8 @@ impl FloxArgs {
             verbosity: self.verbosity.to_i32(),
         };
         debug!(
-            "features enabled, build={}, publish={}, upload={}",
-            flox.features.build, flox.features.publish, flox.features.upload,
+            configured = ?flox.features,
+            "feature flags"
         );
 
         // in debug mode keep the tempdir to reproduce nix commands

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -78,11 +78,6 @@ struct PublishTarget {
 
 impl Publish {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
-        if !flox.features.publish {
-            message::plain("🚧 👷 heja, a new command is in construction here, stay tuned!");
-            bail!("'publish' feature is not enabled.");
-        }
-
         let env = self
             .environment
             .detect_concrete_environment(&flox, "Publish")?;


### PR DESCRIPTION
## Proposed Changes

In preparation for 1.5 release.

We aren't using these anywhere else in code or tests, via the struct or
environment variables, so there is nothing else to change. The
`doc-build` directory mentioned in the ticket was already merged in
https://github.com/flox/flox/commit/c9d0d16949e1d5349be14288e6e30c943ee41552.

I've left the feature flag on `upload` because we're not exposing this
to users and perhaps(?) it will be removed in the near future.

## Release Notes

N/A by itself.
