### PR TITLE
feat(template): Add build to manifest template

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -342,11 +342,11 @@ impl RawManifest {
         services_table.decor_mut().set_prefix(indoc! {r#"
 
 
-                ## Services ----------------------------------------------------------
+                ## Services ---------------------------------------------------------
                 ##  $ flox services start             <- Starts all services
                 ##  $ flox services status            <- Status of running services
                 ##  $ flox activate --start-services  <- Activates & starts all
-                ## -------------------------------------------------------------------
+                ## ------------------------------------------------------------------
             "#});
 
         services_table.decor_mut().set_suffix(indoc! {r#"
@@ -1215,11 +1215,11 @@ pub(super) mod test {
             # fish = ...
 
 
-            ## Services ----------------------------------------------------------
+            ## Services ---------------------------------------------------------
             ##  $ flox services start             <- Starts all services
             ##  $ flox services status            <- Status of running services
             ##  $ flox activate --start-services  <- Activates & starts all
-            ## -------------------------------------------------------------------
+            ## ------------------------------------------------------------------
             [services]
             # myservice.command = "python3 -m http.server"
 
@@ -1339,11 +1339,11 @@ pub(super) mod test {
             # fish = ...
 
 
-            ## Services ----------------------------------------------------------
+            ## Services ---------------------------------------------------------
             ##  $ flox services start             <- Starts all services
             ##  $ flox services status            <- Status of running services
             ##  $ flox activate --start-services  <- Activates & starts all
-            ## -------------------------------------------------------------------
+            ## ------------------------------------------------------------------
             [services]
             # myservice.command = "python3 -m http.server"
 
@@ -1466,11 +1466,11 @@ pub(super) mod test {
             # fish = ...
 
 
-            ## Services ----------------------------------------------------------
+            ## Services ---------------------------------------------------------
             ##  $ flox services start             <- Starts all services
             ##  $ flox services status            <- Status of running services
             ##  $ flox activate --start-services  <- Activates & starts all
-            ## -------------------------------------------------------------------
+            ## ------------------------------------------------------------------
             [services]
             # myservice.command = "python3 -m http.server"
 
@@ -1581,11 +1581,11 @@ pub(super) mod test {
             """
 
 
-            ## Services ----------------------------------------------------------
+            ## Services ---------------------------------------------------------
             ##  $ flox services start             <- Starts all services
             ##  $ flox services status            <- Status of running services
             ##  $ flox activate --start-services  <- Activates & starts all
-            ## -------------------------------------------------------------------
+            ## ------------------------------------------------------------------
             [services]
             # myservice.command = "python3 -m http.server"
 
@@ -1698,11 +1698,11 @@ pub(super) mod test {
             # fish = ...
 
 
-            ## Services ----------------------------------------------------------
+            ## Services ---------------------------------------------------------
             ##  $ flox services start             <- Starts all services
             ##  $ flox services status            <- Status of running services
             ##  $ flox activate --start-services  <- Activates & starts all
-            ## -------------------------------------------------------------------
+            ## ------------------------------------------------------------------
             [services]
             # myservice.command = "python3 -m http.server"
 

--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -34,6 +34,8 @@ pub const MANIFEST_OPTIONS_KEY: &str = "options";
 pub const MANIFEST_SYSTEMS_KEY: &str = "systems";
 /// Represents the `[include]` table key in manifest.toml
 pub const MANIFEST_INCLUDE_KEY: &str = "include";
+/// Represents the `[build]` table key in manifest.toml
+pub const MANIFEST_BUILD_KEY: &str = "build";
 
 /// A wrapper around a [`toml_edit::DocumentMut`]
 /// that allows modifications of the raw manifest document,
@@ -61,6 +63,7 @@ impl RawManifest {
         Self::add_profile_section(&mut manifest, customization, true);
         Self::add_services_section(&mut manifest);
         Self::add_include_section(&mut manifest);
+        Self::add_build_section(&mut manifest);
         Self::add_options_section(&mut manifest, systems, customization);
 
         RawManifest(manifest)
@@ -351,6 +354,33 @@ impl RawManifest {
                 # myservice.command = "python3 -m http.server""#});
 
         manifest.insert(MANIFEST_SERVICES_KEY, Item::Table(services_table));
+    }
+
+    /// Populates an example build section.
+    fn add_build_section(manifest: &mut DocumentMut) {
+        let mut build_table = Table::new();
+
+        build_table.decor_mut().set_prefix(indoc! {r#"
+
+
+                 ## Build and publish your own packages ------------------------------
+                 ##  $ flox build
+                 ##  $ flox publish
+                 ## ------------------------------------------------------------------
+            "#});
+
+        build_table.decor_mut().set_suffix(indoc! {r#"
+
+                # [build.myproject]
+                # description = "The coolest project ever"
+                # version = "0.0.1"
+                # command = """
+                #   mkdir -p $out/bin
+                #   cargo build --release
+                #   cp target/release/myproject $out/bin/myproject
+                # """"#});
+
+        manifest.insert(MANIFEST_BUILD_KEY, Item::Table(build_table));
     }
 
     /// Populates an example include section.
@@ -1203,6 +1233,21 @@ pub(super) mod test {
             # ]
 
 
+            ## Build and publish your own packages ------------------------------
+            ##  $ flox build
+            ##  $ flox publish
+            ## ------------------------------------------------------------------
+            [build]
+            # [build.myproject]
+            # description = "The coolest project ever"
+            # version = "0.0.1"
+            # command = """
+            #   mkdir -p $out/bin
+            #   cargo build --release
+            #   cp target/release/myproject $out/bin/myproject
+            # """
+
+
             ## Other Environment Options -----------------------------------------
             [options]
             # Systems that environment is compatible with
@@ -1310,6 +1355,21 @@ pub(super) mod test {
             # environments = [
             #     { dir = "../common" }
             # ]
+
+
+            ## Build and publish your own packages ------------------------------
+            ##  $ flox build
+            ##  $ flox publish
+            ## ------------------------------------------------------------------
+            [build]
+            # [build.myproject]
+            # description = "The coolest project ever"
+            # version = "0.0.1"
+            # command = """
+            #   mkdir -p $out/bin
+            #   cargo build --release
+            #   cp target/release/myproject $out/bin/myproject
+            # """
 
 
             ## Other Environment Options -----------------------------------------
@@ -1424,6 +1484,21 @@ pub(super) mod test {
             # ]
 
 
+            ## Build and publish your own packages ------------------------------
+            ##  $ flox build
+            ##  $ flox publish
+            ## ------------------------------------------------------------------
+            [build]
+            # [build.myproject]
+            # description = "The coolest project ever"
+            # version = "0.0.1"
+            # command = """
+            #   mkdir -p $out/bin
+            #   cargo build --release
+            #   cp target/release/myproject $out/bin/myproject
+            # """
+
+
             ## Other Environment Options -----------------------------------------
             [options]
             # Systems that environment is compatible with
@@ -1522,6 +1597,21 @@ pub(super) mod test {
             # environments = [
             #     { dir = "../common" }
             # ]
+
+
+            ## Build and publish your own packages ------------------------------
+            ##  $ flox build
+            ##  $ flox publish
+            ## ------------------------------------------------------------------
+            [build]
+            # [build.myproject]
+            # description = "The coolest project ever"
+            # version = "0.0.1"
+            # command = """
+            #   mkdir -p $out/bin
+            #   cargo build --release
+            #   cp target/release/myproject $out/bin/myproject
+            # """
 
 
             ## Other Environment Options -----------------------------------------
@@ -1624,6 +1714,21 @@ pub(super) mod test {
             # environments = [
             #     { dir = "../common" }
             # ]
+
+
+            ## Build and publish your own packages ------------------------------
+            ##  $ flox build
+            ##  $ flox publish
+            ## ------------------------------------------------------------------
+            [build]
+            # [build.myproject]
+            # description = "The coolest project ever"
+            # version = "0.0.1"
+            # command = """
+            #   mkdir -p $out/bin
+            #   cargo build --release
+            #   cp target/release/myproject $out/bin/myproject
+            # """
 
 
             ## Other Environment Options -----------------------------------------


### PR DESCRIPTION
## Proposed Changes

I've taken the shortest but complete example I can from the concept docs
because we don't want to clutter up everyone's environments with a
really long command.

It's a little odd to have `[build]` and `[build.myproject]` next to each
other when uncommented but it both matches the style of the other
headings and makes the project specific build easier to read.

I've signposted the build and publish commands so that users know what
to do next but there's not much more to say about them like we do for
services beacuse they're pretty self explanatory.

## Release Notes

N/A
