### PR TITLE
chore: bump publish timeout

### DIFF
--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -28,7 +28,7 @@ use crate::utils::errors::display_chain;
 use crate::utils::message;
 
 const PUBLISH_COMPLETION_POLL_INTERVAL_MILLIS: u64 = 2_000; // 1s
-const PUBLISH_COMPLETION_TIMEOUT_MILLIS: u64 = 5 * 60 * 1_000; // 5 min
+const PUBLISH_COMPLETION_TIMEOUT_MILLIS: u64 = 30 * 60 * 1_000; // 30 min
 
 #[derive(Bpaf, Clone)]
 pub struct Publish {


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
We've seen the publish command time out while waiting for processing on the Publisher side. The current timeout is 5 minutes, and a recent 1.5GiB closure took 15 minutes to process. Bump this to 30 minutes so that we don't give up before the user does.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
