### PR TITLE
build: update `config` crate `v0.13.4 - > v0.15`

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -602,16 +602,14 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.13.4"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
 dependencies = [
- "async-trait",
- "lazy_static",
- "nom",
  "pathdiff",
  "serde",
- "toml 0.5.11",
+ "toml",
+ "winnow",
 ]
 
 [[package]]
@@ -1064,7 +1062,7 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "toml_edit",
  "tracing",
  "tracing-indicatif",
@@ -1158,7 +1156,7 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "toml_edit",
  "tracing",
  "tracing-subscriber",
@@ -2138,12 +2136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,7 +2179,7 @@ dependencies = [
  "indicatif",
  "serde",
  "tempfile",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2228,16 +2220,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -4022,15 +4004,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,8 +23,7 @@ chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.40", features = ["derive"] }
 clap_derive = "4.5.4"
 close_fds = "0.3"
-# Pinned due to bug: https://github.com/rust-cli/config-rs/issues/531
-config = { version = "0.13.4", default-features = false, features = ["toml"] }
+config = { version = "0.15", default-features = false, features = ["toml"] }
 crossterm = "0.27"
 derive_more = "0.99.20"
 dirs = "5.0.0"


### PR DESCRIPTION
Follow up on #3301

* We previously pinned the config crate to the latest `v0.13` release due to a bug introduced in `v0.14`[1], which appears to have since been addressed.

[1]: https://github.com/rust-cli/config-rs/issues/531


