### PR TITLE
fix: invoke `version.command` string from activated environment

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -683,7 +683,9 @@ define JSON_VERSION_TO_COMMAND_jq =
     if type == "object" then (
       to_entries[] | \
       if .key == "file" then "$(_cat) \(.value)" else (
-        if .key == "command" then .value else (
+        if .key == "command" then (
+          "$(FLOX_ENV)/activate -c \(.value | @sh)"
+        ) else (
           "unknown version type: \(.key)" | halt_error(1)
         ) end
       ) end


### PR DESCRIPTION
## Proposed Changes

Issue #3308 documents the issue of attempting to use a command installed from the manifest in the process of using the `version.command` attribute to set the version string for a build, and finding that the command is not found.

This patch updates the code to always invoke the command string from within an invocation of `$(FLOX_ENV)/activate -c '<string>'`, which brings the full context of the activation into scope for running the command. It also adds an additional check to the existing suite of version checks to exercise this use case.

## Release Notes

* Fixed bug to allow use of manifest-installed packages from within the `version.command` manifest build attribute