### PR TITLE
fix: allow build wrapper bash into the closure

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -625,13 +625,15 @@ define MANIFEST_BUILD_template =
 	@# Also fail the build if it contains packages not found in the build
 	@# wrapper's closure.
 	$$(eval _build_store_path = $$(shell $(_readlink) $($(_pvarname)_result)))
+	# Allow the use of bashNonInteractive (formerly bash on older nixpkgs revisions)
+	$$(eval _executable_wrapper_store_path = $$(shell $(_nix) path-info --offline '$$(BUILDTIME_NIXPKGS_URL)#bashNonInteractive^out' ||  $(_nix) path-info --offline '$$(BUILDTIME_NIXPKGS_URL)#bash^out'))
 	$$(eval _build_closure_requisites = $$(shell $(_nix_store) --query --requisites $($(_pvarname)_result)/.))
 	@# BUG: $$($(_pvarname)_build_wrapper_env)/requisites.txt missing libcxx on Darwin??? Repeat the hard way ...
 	$$(eval _build_wrapper_requisites = $$(shell $(_nix_store) --query --requisites $$($(_pvarname)_build_wrapper_env)/.))
 	$$(eval _nef_requisites = \
 	  $$(if $$($(_pvarname)_buildDeps),$$(shell $(_nix_store) --query --requisites $$($(_pvarname)_buildDeps))))
 	$$(eval _build_closure_extra_packages = $$(strip \
-	  $$(filter-out $$(_build_store_path) $$(_build_wrapper_requisites) $$(_nef_requisites), \
+	  $$(filter-out $$(_build_store_path) $$(_build_wrapper_requisites) $$(_nef_requisites) $$(_executable_wrapper_store_path), \
 	    $$(_build_closure_requisites))))
 	$$(eval _count = $$(words $$(_build_closure_extra_packages)))
 	$$(eval _space = $$(shell echo $$(_count) | $(_tr) '[0-9]' '-'))


### PR DESCRIPTION
Currently (manifest) builds that produce any executable in `$out/bin` fail to build with the following error:

```
❌ ERROR: Unexpected dependencies found in package 'quotes_app_cpp':

 1. Remove any unneeded references (e.g. debug symbols) from your build.
 2. If you're using package groups, move these packages into the 'toplevel' group.
 3. If you're using 'runtime-packages', make sure each package is listed both in
    'runtime-packages' and in the 'toplevel' group.

 1 packages found in /nix/store/6i593wmvszs4c2jmmcz0mi4i9bx7hs5a-quotes-app-cpp-0.0.1
 -      not found in /nix/store/qqmf6j5pb999vbdc8w9v8979svx5fxh9-environment-build-quotes-app-cpp

/nix/store/6i593wmvszs4c2jmmcz0mi4i9bx7hs5a-quotes-app-cpp-0.0.1
└───bin/.quotes-app-cpp-wrapped: …#!/nix/store/8ivrpmp3arvxbr6imdwm2d28q9cjsqvi-bash-5.2p37/bin/sh.export QUOTE…
    → /nix/store/8ivrpmp3arvxbr6imdwm2d28q9cjsqvi-bash-5.2p37
```

This error is produced if the closure of the build contains references to anything not in the closure of the the package's build environment. Generally, there is no bash from the toplevel page present in the environment. The bash that _is_ present in the closure comes from flox-interpreter, which generally does doesn't correspond to the page as its built and shipped with flox and not rebuilt at construction of the environment (generally to ensure consistent behavior rather than being downstream of whatever nixpkgs the environment locks onto).

This commit ensures that the bash used by the executable wrapper script is an allowed reference.

The alternatives to this were:

* we wrap with the known bash from the env which may not correspond to the page, but is already present for consistency
* we build flox-interpreter based on the toplevel page of the environment every time we build the environment, leaving us with more fragile environment builds and kinda requiring us to always have a toplevel page.

Both approaches depend on the invariant that there is _some_ bash in the environment. This second also implicates changes across environments builds and has far larger impact than this current change.

The only drawback of this (as far as i can tell) is the addition of a 2.5M bash binary.


