### PR TITLE
fix: use cpio for serializing directory contents

### DIFF
--- a/pkgs/flox-package-builder/default.nix
+++ b/pkgs/flox-package-builder/default.nix
@@ -1,6 +1,7 @@
 {
   bashInteractive,
   coreutils,
+  cpio,
   daemonize,
   findutils,
   getopt,
@@ -28,6 +29,7 @@ stdenv.mkDerivation {
     for i in build-manifest.nix flox-build.mk validate-build.bash; do
       bashInteractive=${bashInteractive} \
       coreutils=${coreutils} \
+      cpio=${cpio} \
       daemonize=${daemonize} \
       findutils=${findutils} \
       getopt=${getopt} \


### PR DESCRIPTION
## Proposed Changes

Issue #3310 documents problems encountered using `gnutar` and `sed` to serialize and modify directory contents in the process of copying the manifest build output from a temporary directory to `$out`. This approach had the effect of modifying the destination of symbolic links as embedded in the gnutar control stream, which in turn corrupted its own validation checksums.

Fortunately, `cpio` archives do not suffer from this issue and are tolerant of binary substitutions that have the effect of rewriting symlink destinations, and this PR documents the effort to switch from the use of `tar` to `cpio` for copying and modifying manifest build outputs.

Closes #3310.

## Release Notes

* Fixed bug triggered by symbolic links in manifest build outputs referring to `$FLOX_ENV` 