### PR TITLE
chore(nef): improve messages and add error breadcrumbs

### DIFF
--- a/package-builder/nef/default.nix
+++ b/package-builder/nef/default.nix
@@ -62,8 +62,10 @@ in
   #
   # nix eval -f <nef> --argstr pkgs-dir <PATH> --argstr system <SYSTEM> pkgs.<attrPath>
   pkgs =
-    assert lib.assertMsg (system != null)
-      "system missing, needs top be provided with `--argstr system <SYSTEM>` or by running with `--impure`";
+    assert lib.assertMsg (system != null) ''
+      'system' argument missing.
+      Evaluate with `--argstr system <SYSTEM>` or with `--impure` to use the current system.
+    '';
     extendedNixpkgs;
 
 }

--- a/package-builder/nef/lib/extendAttrSet.nix
+++ b/package-builder/nef/lib/extendAttrSet.nix
@@ -13,8 +13,31 @@
 
     [1]: <https://noogle.dev/f/lib/makeExtensible>
     [2]: <https://noogle.dev/f/lib/makeScope>
+
+    # Type
+
+    ```
+    extendAttrSet :: [ String ] -> Attrs -> Attrs -> Attrs -> Attrs
+
+    # Arguments
+
+    `attrPath`
+    : Current attrPath of the set is extended, used for messaging
+
+    `currentScope`
+    : Current scope, i.e. the union of all parent attr sets.
+      Used as a fallback by `nef.mkOverlay`.
+
+    `packageSet`
+    : The value at `attrPath`, required to be a package set,
+      i.e. defined via either `makeExtensible`[1] or `makeScope`[2].
+
+    `extensions`
+    : The extensions structure for the current attrPath,
+      a Directory value produced by nef.dirToAttrs
   */
   extendAttrSet =
+
     attrPath: currentScope: packageSet: extensions:
     let
       overlay = nef.mkOverlay attrPath currentScope extensions;

--- a/package-builder/nef/lib/extendAttrSet.nix
+++ b/package-builder/nef/lib/extendAttrSet.nix
@@ -60,5 +60,5 @@
             Package sets must be attrsets created with `makeScope` or `makeExtensible`.
           '';
     in
-    extendedAttrSet;
+    builtins.addErrorContext "while extending package set '${lib.showAttrPath attrPath}'" extendedAttrSet;
 }

--- a/package-builder/nef/lib/extendAttrSet.nix
+++ b/package-builder/nef/lib/extendAttrSet.nix
@@ -32,7 +32,10 @@
         else if packageSet ? extend then
           packageSet.extend overlay
         else
-          throw "dont know how to extend ${lib.showAttrPath attrPath}";
+          throw ''
+            Cannot extend '${lib.showAttrPath attrPath}', since it is not a supported package set.
+            Package sets must be attrsets created with `makeScope` or `makeExtensible`.
+          '';
     in
     extendedAttrSet;
 }

--- a/package-builder/nef/lib/mkOverlay.nix
+++ b/package-builder/nef/lib/mkOverlay.nix
@@ -57,7 +57,15 @@
         {
           "nix" =
             let
-              recursionGuardError = (throw "'${lib.showAttrPath attrPath'}' defines itself");
+              recursionGuardError =
+                let
+                  attrPathStr = lib.showAttrPath attrPath';
+                in
+                throw ''
+                  Circular dependency on '${attrPathStr}' detected.
+                  '${attrPathStr}' transitively imports itself
+                  and there was no previous value that could be provided.
+                '';
 
               # Find or build a `callPackage` function that replaces infinite recursion erros with an error
               callPackage =

--- a/package-builder/nef/lib/mkOverlay.nix
+++ b/package-builder/nef/lib/mkOverlay.nix
@@ -39,7 +39,7 @@
   mkOverlay =
     # current attr path for messaging
     attrPath:
-    # Current scope, i.e. the unionm of all parent attr sets
+    # Current scope, i.e. the union of all parent attr sets
     # Used to create a `callPackage` function when nixpkgs does not
     # via either `makeScope` or a custom `callPackage`.
     currentScope:
@@ -52,20 +52,18 @@
         name: value:
         let
           attrPath' = attrPath ++ [ name ];
+          attrPathStr = lib.showAttrPath attrPath';
         in
 
         {
           "nix" =
             let
-              recursionGuardError =
-                let
-                  attrPathStr = lib.showAttrPath attrPath';
-                in
-                throw ''
-                  Circular dependency on '${attrPathStr}' detected.
-                  '${attrPathStr}' transitively imports itself
-                  and there was no previous value that could be provided.
-                '';
+              recursionGuardError = throw ''
+                Circular dependency detected.
+                The package '${attrPathStr}' defined in ${value.path} directly or transitively imports itself.
+                For example by requesting a dependency '${name}'.
+                An expression can only access its own attribute path to override its existing value.
+              '';
 
               # Find or build a `callPackage` function that replaces infinite recursion erros with an error
               callPackage =
@@ -109,13 +107,20 @@
                       ${name} = prev.${name} or recursionGuardError;
                     }
                   );
+
+              errorContext =
+                let
+                  replacingOrDefining = if builtins.hasAttr name prev then "replacing" else "defining";
+                in
+                "while ${replacingOrDefining} '${attrPathStr}' by evaluating '${value.path}'";
             in
-            callPackage value.path { };
+            builtins.addErrorContext errorContext (callPackage value.path { });
 
           "directory" =
             # Try extend an existing attrset or create a new scope
             let
-              attrSet = if builtins.hasAttr name prev then prev.${name} else lib.makeScope prev.newScope (_: { });
+              attrSet =
+                if builtins.hasAttr name prev then prev.${name} else lib.makeScope final.newScope (_: { });
             in
             nef.extendAttrSet attrPath' (currentScope // final) attrSet value;
         }


### PR DESCRIPTION
## Proposed Changes

* Improve two user facing error messages originating in the NEF library.
* Add breadcrumbs to error traces pointing potentially helping to better pinpoint evaluation errors.
* Improve function documentation for `nef.extendAttrSet`
