### PR TITLE
fix: use older flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,9 +4,9 @@
 let
   src = ./.;
   flake-compat = builtins.fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/9100a0f413b0c601e0533d1d94ffd501ce2e7885.tar.gz";
-    sha256 = "sha256:09m84vsz1py50giyfpx0fpc7a4i0r1xsb54dh0dpdg308lp4p188";
+    url = "https://github.com/edolstra/flake-compat/archive/baa7aa7bd0a570b3b9edd0b8da859fee3ffaa4d4.tar.gz";
+    sha256 = "sha256:002mjvf08z3vm1djzgb2b95d89kn526fas0lagjwr38jmmf7ign6";
   };
   flake = import flake-compat { inherit src; };
 in
-flake.outputs.packages.${system}.flox
+flake.defaultNix.packages.${system}.flox


### PR DESCRIPTION
## Proposed Changes
Use older variant that doesn't assume flakes.