### PR TITLE
fix: do not relay stdout/err coming from builder

### DIFF
--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -174,7 +174,7 @@ impl WireTap<()> {
                     Ok(0) => break,
                     Ok(_) => {
                         let line = String::from_utf8_lossy(&line_buf).into_owned();
-                        tap_fn(&mut context, line.trim_end());
+                        tap_fn(&mut context, line.trim_end_matches("\n"));
 
                         line_buf.clear();
                     },

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -215,17 +215,20 @@ impl Build {
             .flatten_ok()
             .collect::<Result<Vec<_>, _>>()?;
 
-        if links_to_print.len() > 1 {
-            message::created(formatdoc!(
-                "Builds completed successfully.
-                            Outputs created: {}",
-                links_to_print.join(", ")
-            ));
-        } else {
-            message::created(format!(
-                "Build completed successfully. Output created: {}",
-                links_to_print[0]
-            ));
+        let success_prefix = "Builds completed successfully.";
+
+        match links_to_print.as_slice() {
+            // This case shouldnt occur with the current FloxBuildMk backend,
+            // which either errors earlier if nothing will be built,
+            // or produces at least one link.
+            // Handle anyway for completeness and to avoid erros in case the above changes.
+            [] => message::info(format!("{success_prefix} No outputs created")),
+            [link] => message::created(format!("{success_prefix}. Output created: {link}",)),
+            links => message::created(formatdoc! {"
+                {success_prefix}
+                Outputs created: {}",
+                links.join(", ")
+            }),
         }
 
         Ok(())


### PR DESCRIPTION
## Proposed Changes

Unlike Nix builds which solely write to stderr, the manifest builder emits lines to both stdout and stderr, which presents the possibility of getting the ordering wrong when printing those lines to the tty. We wrote `t3` specifically to address this issue while at the same time providing color highlighting and timestamping, but then undid all that by again reading and writing each line of output from flox, thereby re-introducing the possibility that lines can come out of order.

This patch updates `FloxBuildMk::{clean,build}` to inherit stdio rather than relaying output and streaming possibly out of order at the CLI level. For the use in tests, or other deliberate use where the output should be suppressed and collected instead, `FloxBuildMk::new_with_buffers`, was added to provide `&mut String` references that will be filled with the the output instead.

Closes #3118 

## Release Notes

* Fixed bug that can cause lines of manifest build output to appear out of order on the terminal