### PR TITLE
feat(generations): Expose meta w/new env trait

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -501,6 +501,12 @@ fn write_metadata_file(
     Ok(())
 }
 
+/// Environments that support generations.
+pub trait GenerationsEnvironment {
+    /// Return all generations metadata for the environment.
+    fn generations_metadata(&self) -> Result<AllGenerationsMetadata, GenerationsError>;
+}
+
 /// flox environment metadata for managed environments
 ///
 /// Managed environments support rolling back to previous generations.

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -9,7 +9,12 @@ use tracing::{debug, instrument};
 
 use super::core_environment::{CoreEnvironment, UpgradeResult};
 use super::fetcher::IncludeFetcher;
-use super::generations::{Generations, GenerationsError};
+use super::generations::{
+    AllGenerationsMetadata,
+    Generations,
+    GenerationsEnvironment,
+    GenerationsError,
+};
 use super::path_environment::PathEnvironment;
 use super::{
     CACHE_DIR_NAME,
@@ -556,6 +561,12 @@ impl Environment for ManagedEnvironment {
     /// should be created
     fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
         services_socket_path(&self.path_hash(), flox)
+    }
+}
+
+impl GenerationsEnvironment for ManagedEnvironment {
+    fn generations_metadata(&self) -> Result<AllGenerationsMetadata, GenerationsError> {
+        self.generations().metadata()
     }
 }
 
@@ -1142,7 +1153,7 @@ impl ManagedEnvironment {
         &self.pointer
     }
 
-    fn generations(&self) -> Generations {
+    pub(crate) fn generations(&self) -> Generations {
         Generations::new(
             self.floxmeta.git.clone(),
             branch_name(&self.pointer, &self.path),

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -6,6 +6,7 @@ use tracing::{debug, instrument};
 
 use super::core_environment::UpgradeResult;
 use super::fetcher::IncludeFetcher;
+use super::generations::{AllGenerationsMetadata, GenerationsEnvironment, GenerationsError};
 use super::managed_environment::{ManagedEnvironment, ManagedEnvironmentError};
 use super::{
     CanonicalPath,
@@ -408,6 +409,12 @@ impl Environment for RemoteEnvironment {
 
     fn services_socket_path(&self, flox: &Flox) -> Result<PathBuf, EnvironmentError> {
         self.inner.services_socket_path(flox)
+    }
+}
+
+impl GenerationsEnvironment for RemoteEnvironment {
+    fn generations_metadata(&self) -> Result<AllGenerationsMetadata, GenerationsError> {
+        self.inner.generations_metadata()
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

Add a new environment trait for generations and expose metadata for managed and remote environments.

Currently this returns `GenerationsError` rather than wrapping it in something like `EnvironmentError`. We might want to change that in the future, but right now it's hard to predict without wiring up all of the functionality.

## Release Notes

N/A
