### PR TITLE
feat(init): Add push hint when not in git

### DIFF
--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -96,7 +96,26 @@ teardown() {
   run "$FLOX_BIN" init
   assert_success
 
-  assert_output - <<EOF
+  assert_output - << EOF
+✨ Created environment 'test' ($NIX_SYSTEM)
+
+Next:
+  $ flox search <package>    <- Search for a package
+  $ flox install <package>   <- Install a package into an environment
+  $ flox activate            <- Enter the environment
+  $ flox edit                <- Add environment variables and shell hooks
+  $ flox push                <- Use the environment from other machines or
+                                share it with someone on FloxHub
+EOF
+
+}
+
+@test "c7: tips omit 'flox push' when within a git repo" {
+  git init --quiet
+  run "$FLOX_BIN" init
+  assert_success
+
+  assert_output - << EOF
 ✨ Created environment 'test' ($NIX_SYSTEM)
 
 Next:


### PR DESCRIPTION
## Proposed Changes

So that people can discover the benefits of using FloxHub when creating
new environments. With the exception of environments that are within
existing git repos - detailed in the code comment.

The check is performed early in the `init` command so that traverse
directories to find the git parent doesn't add a noticeable delay
between printing parts of the result message. It shouldn't take long
enough to warrant a spinner though.

The original criteria was to print this notice on the first invocation
of `activate` for an environment and to also exclude temporary
environments (within `$TMPDIR` or name `tmp.*`) but that would have
required adding detection and state tracking to `flox activate` which is
much more sensitive to latency.

We don't need the temporary environment logic in this implementation
because it's part of an existing message that can be suppressed with
`--quiet` for automation.

The additional `message::plain("")` is necessary to preserve the
trailing newline that we had before, now that we don't know which
message will be last. Unfortunately it seems that Bats can't assert
whether it's there or not though.

## Release Notes

N/A