### PR TITLE
feat(envs): Show URLs for managed and remote

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -461,7 +461,7 @@ impl DotFlox {
 /// Unlike [ConcreteEnvironment], this type does not hold a concrete instance any environment,
 /// but rather fully qualified metadata to create an instance from.
 ///
-/// * for [PathEnvironment] and [ManagedEnvironment] that's the path to their `.flox` and `.flox/pointer.json`
+/// * for [PathEnvironment] and [ManagedEnvironment] that's the path to their `.flox` and `.flox/env.json`
 /// * for [RemoteEnvironment] that's the [ManagedPointer] to the remote environment
 ///
 /// Serialized as is into [FLOX_ACTIVE_ENVIRONMENTS_VAR] to be able to reopen environments.

--- a/cli/flox/src/commands/envs.rs
+++ b/cli/flox/src/commands/envs.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::path::Path;
@@ -8,7 +7,7 @@ use bpaf::Bpaf;
 use crossterm::style::Stylize;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::env_registry::{EnvRegistry, garbage_collect};
-use flox_rust_sdk::models::environment::DotFlox;
+use flox_rust_sdk::models::environment::{DotFlox, EnvironmentPointer, ManagedPointer};
 use serde_json::json;
 use tracing::instrument;
 
@@ -165,21 +164,50 @@ impl Display for DisplayEnvironments<'_> {
                 return Ok(());
             };
             let first_formatted =
-                format!("{:<widest$}  {}", first.name(), format_path(first.path())).bold();
+                format!("{:<widest$}  {}", first.name(), format_location(first)).bold();
             writeln!(f, "{first_formatted}")?;
         }
 
         for env in envs {
-            writeln!(f, "{:<widest$}  {}", env.name(), format_path(env.path()))?;
+            writeln!(f, "{:<widest$}  {}", env.name(), format_location(env))?;
         }
 
         Ok(())
     }
 }
 
-fn format_path(path: Option<&Path>) -> Cow<'_, str> {
-    path.map(|p| p.parent().unwrap_or(p).to_string_lossy())
-        .unwrap_or_else(|| "(remote)".into())
+/// Format the location (path and optional URL) of an environment.
+fn format_location(env: &UninitializedEnvironment) -> String {
+    match env {
+        UninitializedEnvironment::DotFlox(DotFlox { path, pointer }) => match pointer {
+            EnvironmentPointer::Path(_) => format_path(path),
+            EnvironmentPointer::Managed(managed_pointer) => {
+                format!("{} ({})", format_path(path), format_url(managed_pointer))
+            },
+        },
+        UninitializedEnvironment::Remote(managed_pointer) => {
+            format!("remote ({})", format_url(managed_pointer))
+        },
+    }
+}
+
+/// Format the URL of a FloxHub environment, logging any errors encountered.
+fn format_url(pointer: &ManagedPointer) -> String {
+    pointer.floxhub_url().map_or_else(
+        |err| {
+            // This is highly unlikely, given that most parse errors are
+            // modifications to the base (proto, host, port) which can only be
+            // done with `//` in the joined path and `EnvironmentOwner` and
+            // `EnvironmentName` prevent slashes.
+            tracing::warn!(?pointer, %err, "Failed to format URL for environment");
+            "unknown".into()
+        },
+        |url| url.to_string(),
+    )
+}
+
+fn format_path(path: &Path) -> String {
+    path.parent().unwrap_or(path).to_string_lossy().to_string()
 }
 
 fn get_registered_environments(
@@ -209,4 +237,55 @@ fn get_inactive_environments<'a>(
     };
 
     Ok(inactive)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use flox_rust_sdk::flox::{EnvironmentName, EnvironmentOwner, Floxhub};
+    use flox_rust_sdk::models::environment::PathPointer;
+    use indoc::formatdoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn display_environments() {
+        let floxhub = Floxhub::new("https://hub.example.com".parse().unwrap(), None).unwrap();
+        let owner = EnvironmentOwner::from_str("owner").unwrap();
+
+        let path_env = UninitializedEnvironment::DotFlox(DotFlox {
+            path: PathBuf::from("/envs/path/.flox"),
+            pointer: EnvironmentPointer::Path(PathPointer::new(
+                EnvironmentName::from_str("name_path").unwrap(),
+            )),
+        });
+
+        let managed_env = UninitializedEnvironment::DotFlox(DotFlox {
+            path: PathBuf::from("/envs/managed/.flox"),
+            pointer: EnvironmentPointer::Managed(ManagedPointer::new(
+                owner.clone(),
+                EnvironmentName::from_str("name_managed").unwrap(),
+                &floxhub,
+            )),
+        });
+
+        let remote_env = UninitializedEnvironment::Remote(ManagedPointer::new(
+            owner.clone(),
+            EnvironmentName::from_str("name_remote").unwrap(),
+            &floxhub,
+        ));
+
+        let envs = DisplayEnvironments {
+            envs: vec![&path_env, &managed_env, &remote_env],
+            format_active: false,
+        };
+        assert_eq!(envs.to_string(), formatdoc! {"
+            name_path                   /envs/path
+            name_managed                /envs/managed (https://hub.example.com/owner/name_managed)
+            name_remote                 remote (https://hub.example.com/owner/name_remote)
+        "});
+    }
 }


### PR DESCRIPTION
## Proposed Changes

So that it's easier to discover FloxHub functionality. This also
disambiguates the names of remote environments by including their owner.

There's an existing "bug" whereby remote environments that you're
currently or have previously used are listed with their
`~/.cache/flox/remote` directories and they aren't omitted if you
currently have one of them activated due to the way that we cache them
as managed environments.

I'm not attempting to fix that here because I think the fix belongs in
how we model the environments rather than applying fixes to the display
layer.

## Release Notes

`flox envs` now shows the FloxHub URLs of remote and managed environments.
