### PR TITLE
build: backport fix host attribute in github/gitlab urls

### DIFF
--- a/pkgs/nix/default.nix
+++ b/pkgs/nix/default.nix
@@ -48,6 +48,13 @@ nixVersions."${nixVersion}".overrideAttrs (prev: {
     # Note: remove for Nix >= v2.29
     (builtins.path { path = ./patches/pr_12642_libfetchers_git_shallow_clone_cache.patch; })
 
+    # <https://github.com/NixOS/nix/pull/12580> was merged into master in february,
+    # but remained unreleased until Nix 2.29.
+    # For the same reason as the above,
+    # backport this until we bump our base packages to contain Nix >= 2.29 as stable.
+    #
+    # Note: remove for Nix >= v2.29
+    (builtins.path { path = ./patches/pr_12580_host-in-locked-github-url.2.24.11.patch; })
   ];
 
   postFixup = ''

--- a/pkgs/nix/patches/pr_12580_host-in-locked-github-url.2.24.11.patch
+++ b/pkgs/nix/patches/pr_12580_host-in-locked-github-url.2.24.11.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libfetchers/github.cc b/src/libfetchers/github.cc
+index 9cddd8571..ea4dbe338 100644
+--- a/src/libfetchers/github.cc
++++ b/src/libfetchers/github.cc
+@@ -149,6 +149,9 @@ struct GitArchiveInputScheme : InputScheme
+         };
+         if (auto narHash = input.getNarHash())
+             url.query.insert_or_assign("narHash", narHash->to_string(HashFormat::SRI, true));
++        auto host = maybeGetStrAttr(input.attrs, "host");
++        if (host)
++            url.query.insert_or_assign("host", *host);
+         return url;
+     }


### PR DESCRIPTION
Originally introduced in <https://github.com/flox/flox/pull/2789> the patch was merged upstream into master
in February via <https://github.com/NixOS/nix/pull/12580>. Assuming it was available via Nix in nixpkgs in late June, we removed the patch in <https://github.com/flox/flox/pull/3176>, which bumped our nix distribution to v2.28.2.

It turns out that the upstream patch was only released via nix **2.29.0**, thus by removing our patch we regressed that behavior.

This commit reintroduces the patch, while we use nix 2.28.3.
