### PR TITLE
refactor: flox-activations profile-scripts for zsh

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -77,25 +77,11 @@ fi
 source <("$_flox_activations" set-env-dirs --shell zsh --flox-env "$FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
 source <("$_flox_activations" fix-paths --shell zsh --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")
 
-# Source user-specified profile scripts if they exist.
-# Iterate over $FLOX_ENV_DIRS in reverse order using zsh-specific "(Oa)".
-# See: https://www.zsh.org/mla/workers/2003/msg00413.html
-  # Our ZDOTDIR startup files source user RC files that may modify FLOX_ENV_DIRS,
-  # and then _flox_env_helper may fix it up.
-  # If this happens, we want to respect those modifications,
-  # so we use FLOX_ENV_DIRS from the environment
-IFS=':' read -r -A _flox_env_dirs <<< "$FLOX_ENV_DIRS"
-for _flox_env in ${(Oa)_flox_env_dirs[@]}; do
-  for i in profile-common profile-zsh hook-script; do
-    if [ -e "$_flox_env/activate.d/$i" ]; then
-      "$_flox_activate_tracer" "$_flox_env/activate.d/$i" START
-      source "$_flox_env/activate.d/$i"
-      "$_flox_activate_tracer" "$_flox_env/activate.d/$i" END
-    else
-      "$_flox_activate_tracer" "$_flox_env/activate.d/$i" NOT FOUND
-    fi
-  done
-done
+# Our ZDOTDIR startup files source user RC files that may modify FLOX_ENV_DIRS,
+# and then _flox_env_helper may fix it up.
+# If this happens, we want to respect those modifications,
+# so we use FLOX_ENV_DIRS from the environment
+source <("$_flox_activations" profile-scripts --shell zsh --env-dirs "$FLOX_ENV_DIRS")
 
 # Disable command hashing to allow for newly installed flox packages
 # to be found immediately. We do this as the very last thing because


### PR DESCRIPTION
We should use flox-activations profile-scripts to be consistent with all other shells

## Release Notes

NA