### PR TITLE
fix: only run profile scripts once per shell

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/generate-bash-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-bash-startup-commands.bash
@@ -79,7 +79,7 @@ generate_bash_startup_commands() {
   # RC files to perform activations.
   echo "eval \"\$('$_flox_activations' set-env-dirs --shell bash --flox-env \"$_FLOX_ENV\" --env-dirs \"\${FLOX_ENV_DIRS:-}\")\";"
   echo "eval \"\$('$_flox_activations' fix-paths --shell bash --env-dirs \"\$FLOX_ENV_DIRS\" --path \"\$PATH\" --manpath \"\${MANPATH:-}\")\";"
-  echo "eval \"\$('$_flox_activations' profile-scripts --shell bash --env-dirs \"\${FLOX_ENV_DIRS:-}\")\";"
+  echo "eval \"\$('$_flox_activations' profile-scripts --shell bash --already-sourced-env-dirs \"\${_FLOX_SOURCED_PROFILE_SCRIPTS:-}\" --env-dirs \"\${FLOX_ENV_DIRS:-}\")\";"
 
   # Disable command hashing to allow for newly installed flox packages
   # to be found immediately. We do this as the very last thing because

--- a/assets/environment-interpreter/activate/activate.d/generate-fish-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-fish-startup-commands.bash
@@ -75,7 +75,8 @@ generate_fish_startup_commands() {
   echo "$_flox_activations set-env-dirs --shell fish --flox-env \"$_FLOX_ENV\" --env-dirs \"\$FLOX_ENV_DIRS\" | source;"
   echo "set -gx MANPATH (if set -q MANPATH; echo \"\$MANPATH\"; else; echo empty; end);"
   echo "$_flox_activations fix-paths --shell fish --env-dirs \"\$FLOX_ENV_DIRS\" --path \"\$PATH\" --manpath \"\$MANPATH\" | source;"
-  echo "$_flox_activations profile-scripts --shell fish --env-dirs \"\$FLOX_ENV_DIRS\" | source;"
+  echo "set -g  _FLOX_SOURCED_PROFILE_SCRIPTS (if set -q _FLOX_SOURCED_PROFILE_SCRIPTS; echo \"\$_FLOX_SOURCED_PROFILE_SCRIPTS\"; else; echo ""; end);"
+  echo "$_flox_activations profile-scripts --shell fish --already-sourced-env-dirs  \"\$_FLOX_SOURCED_PROFILE_SCRIPTS\" --env-dirs \"\$FLOX_ENV_DIRS\" | source;"
 
   # fish does not use hashing in the same way bash does, so there's
   # nothing to be done here by way of that requirement.

--- a/assets/environment-interpreter/activate/activate.d/generate-tcsh-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-tcsh-startup-commands.bash
@@ -76,7 +76,10 @@ generate_tcsh_startup_commands() {
   echo "eval \"\`'$_flox_activations' set-env-dirs --shell tcsh --flox-env '$_FLOX_ENV' --env-dirs \$FLOX_ENV_DIRS:q\`\";"
   echo 'if (! $?MANPATH) setenv MANPATH "empty";'
   echo "eval \"\`'$_flox_activations' fix-paths --shell tcsh --env-dirs \$FLOX_ENV_DIRS:q --path \$PATH:q --manpath \$MANPATH:q\`\";"
-  echo "eval \"\`'$_flox_activations' profile-scripts --shell tcsh --env-dirs \$FLOX_ENV_DIRS:q\`\";"
+  echo 'if (! $?_FLOX_SOURCED_PROFILE_SCRIPTS) set _FLOX_SOURCED_PROFILE_SCRIPTS = "";'
+  # Quote _FLOX_SOURCED_PROFILE_SCRIPTS instead of quoting since tcsh doesn't
+  # pass an argument at all for an unquoted empty string
+  echo "eval \"\`'$_flox_activations' profile-scripts --shell tcsh --already-sourced-env-dirs \"\$_FLOX_SOURCED_PROFILE_SCRIPTS\" --env-dirs \$FLOX_ENV_DIRS:q\`\";"
 
   # Disable command hashing to allow for newly installed flox packages
   # to be found immediately. We do this as the very last thing because

--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -81,7 +81,7 @@ source <("$_flox_activations" fix-paths --shell zsh --env-dirs "$FLOX_ENV_DIRS" 
 # and then _flox_env_helper may fix it up.
 # If this happens, we want to respect those modifications,
 # so we use FLOX_ENV_DIRS from the environment
-source <("$_flox_activations" profile-scripts --shell zsh --env-dirs "$FLOX_ENV_DIRS")
+source <("$_flox_activations" profile-scripts --shell zsh --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}" --env-dirs "$FLOX_ENV_DIRS")
 
 # Disable command hashing to allow for newly installed flox packages
 # to be found immediately. We do this as the very last thing because

--- a/cli/flox-activations/src/cli/profile_scripts.rs
+++ b/cli/flox-activations/src/cli/profile_scripts.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use log::debug;
 
 use super::separate_dir_list;
-use crate::shell_gen::source_file;
+use crate::shell_gen::{Shell, source_file};
 
 #[derive(Debug, Args)]
 pub struct ProfileScriptsArgs {
@@ -15,7 +15,7 @@ pub struct ProfileScriptsArgs {
     )]
     pub env_dirs: String,
     #[arg(short, long, help = "Which shell syntax to emit")]
-    pub shell: String,
+    pub shell: Shell,
 }
 
 impl ProfileScriptsArgs {
@@ -45,7 +45,7 @@ impl ProfileScriptsArgs {
 /// This is mostly useful so that you don't need to specifically create files to test this functionality.
 fn source_profile_scripts_cmds(
     env_dirs: &str,
-    shell: &str,
+    shell: &Shell,
     path_predicate: impl Fn(&Path) -> bool,
 ) -> Vec<String> {
     let dirs = separate_dir_list(env_dirs);
@@ -74,7 +74,7 @@ mod test {
     #[test]
     fn bash_all_exist_correct_order() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, "bash", |_| true);
+        let cmds = source_profile_scripts_cmds(dirs, &Shell::Bash, |_| true);
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-bash';".to_string(),
@@ -87,7 +87,7 @@ mod test {
     #[test]
     fn zsh_all_exist_correct_order() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, "zsh", |_| true);
+        let cmds = source_profile_scripts_cmds(dirs, &Shell::Zsh, |_| true);
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-zsh';".to_string(),
@@ -100,7 +100,7 @@ mod test {
     #[test]
     fn tcsh_all_exist_correct_order() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, "tcsh", |_| true);
+        let cmds = source_profile_scripts_cmds(dirs, &Shell::Tcsh, |_| true);
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-tcsh';".to_string(),
@@ -113,7 +113,7 @@ mod test {
     #[test]
     fn fish_all_exist_correct_order() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, "fish", |_| true);
+        let cmds = source_profile_scripts_cmds(dirs, &Shell::Fish, |_| true);
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-fish';".to_string(),
@@ -126,7 +126,7 @@ mod test {
     #[test]
     fn bash_some_exist() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, "bash", |p| {
+        let cmds = source_profile_scripts_cmds(dirs, &Shell::Bash, |p| {
             p != Path::new("newer/activate.d/profile-common")
         });
         let expected = vec![
@@ -140,7 +140,7 @@ mod test {
     #[test]
     fn zsh_some_exist() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, "zsh", |p| {
+        let cmds = source_profile_scripts_cmds(dirs, &Shell::Zsh, |p| {
             p != Path::new("newer/activate.d/profile-common")
         });
         let expected = vec![
@@ -154,7 +154,7 @@ mod test {
     #[test]
     fn tcsh_some_exist() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, "tcsh", |p| {
+        let cmds = source_profile_scripts_cmds(dirs, &Shell::Tcsh, |p| {
             p != Path::new("newer/activate.d/profile-common")
         });
         let expected = vec![
@@ -168,7 +168,7 @@ mod test {
     #[test]
     fn fish_some_exist() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, "fish", |p| {
+        let cmds = source_profile_scripts_cmds(dirs, &Shell::Fish, |p| {
             p != Path::new("newer/activate.d/profile-common")
         });
         let expected = vec![

--- a/cli/flox-activations/src/cli/profile_scripts.rs
+++ b/cli/flox-activations/src/cli/profile_scripts.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use clap::Args;
 use log::debug;
 
-use super::separate_dir_list;
+use super::{join_dir_list, separate_dir_list};
 use crate::shell_gen::{Shell, source_file};
 
 #[derive(Debug, Args)]
@@ -16,6 +16,11 @@ pub struct ProfileScriptsArgs {
     pub env_dirs: String,
     #[arg(short, long, help = "Which shell syntax to emit")]
     pub shell: Shell,
+    #[arg(
+        long,
+        help = "A list of FLOX_ENV directories that have already been sourced"
+    )]
+    pub already_sourced_env_dirs: String,
 }
 
 impl ProfileScriptsArgs {
@@ -29,42 +34,52 @@ impl ProfileScriptsArgs {
             "producing profile script commands, FLOX_ENV_DIRS={}",
             self.env_dirs
         );
-        let individual_cmds =
-            source_profile_scripts_cmds(&self.env_dirs, &self.shell, Path::exists);
+        let individual_cmds = source_profile_scripts_cmds(
+            &self.env_dirs,
+            &self.already_sourced_env_dirs,
+            &self.shell,
+            Path::exists,
+        );
         let all_cmds = format!("{}\n", individual_cmds.join("\n"));
         output.write_all(all_cmds.as_bytes())?;
         Ok(())
     }
 }
 
-/// Returns a list of commands for sourcing the user's profile scripts in the correct order.
+/// Returns a list of commands for sourcing the user's profile scripts in the correct order and updating _FLOX_SOURCED_PROFILE_SCRIPTS.
 ///
-/// The output also contains comment lines indicating any errors or files that didn't exist.
 /// The `path_predicate` is used to determine which paths should actually be sourced. In production
 /// this is just any of the profile scripts that exist on disk, but in testing it can be anything.
 /// This is mostly useful so that you don't need to specifically create files to test this functionality.
 fn source_profile_scripts_cmds(
     env_dirs: &str,
+    already_sourced_env_dirs: &str,
     shell: &Shell,
     path_predicate: impl Fn(&Path) -> bool,
 ) -> Vec<String> {
     let dirs = separate_dir_list(env_dirs);
-    dirs.into_iter()
-        .rev()
-        .flat_map(|path| {
-            let common = path.join("activate.d/profile-common");
-            let shell_specific = path.join(format!("activate.d/profile-{shell}"));
-            [common, shell_specific]
-        })
-        .filter_map(|path| {
-            if path_predicate(&path) {
-                Some(source_file(&path))
-            } else {
-                debug!(path:display = path.display(); "script did not exist");
-                None
+    let already_sourced_dirs = separate_dir_list(already_sourced_env_dirs);
+    let mut new_sourced_dirs = already_sourced_dirs.clone();
+    let mut cmds = vec![];
+    for dir in dirs.into_iter().rev() {
+        if !already_sourced_dirs.contains(&dir) {
+            let common = dir.join("activate.d/profile-common");
+            let shell_specific = dir.join(format!("activate.d/profile-{shell}"));
+            for path in [common, shell_specific] {
+                if path_predicate(&path) {
+                    cmds.push(source_file(&path));
+                } else {
+                    debug!(path:display = path.display(); "script did not exist");
+                }
             }
-        })
-        .collect::<Vec<_>>()
+            new_sourced_dirs.insert(0, dir)
+        }
+    }
+    cmds.push(shell.set_var_not_exported(
+        "_FLOX_SOURCED_PROFILE_SCRIPTS",
+        &join_dir_list(new_sourced_dirs),
+    ));
+    cmds
 }
 
 #[cfg(test)]
@@ -74,12 +89,13 @@ mod test {
     #[test]
     fn bash_all_exist_correct_order() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, &Shell::Bash, |_| true);
+        let cmds = source_profile_scripts_cmds(dirs, "", &Shell::Bash, |_| true);
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-bash';".to_string(),
             "source 'newer/activate.d/profile-common';".to_string(),
             "source 'newer/activate.d/profile-bash';".to_string(),
+            "_FLOX_SOURCED_PROFILE_SCRIPTS='newer:older';".to_string(),
         ];
         assert_eq!(expected, cmds);
     }
@@ -87,12 +103,13 @@ mod test {
     #[test]
     fn zsh_all_exist_correct_order() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, &Shell::Zsh, |_| true);
+        let cmds = source_profile_scripts_cmds(dirs, "", &Shell::Zsh, |_| true);
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-zsh';".to_string(),
             "source 'newer/activate.d/profile-common';".to_string(),
             "source 'newer/activate.d/profile-zsh';".to_string(),
+            "typeset -g _FLOX_SOURCED_PROFILE_SCRIPTS='newer:older';".to_string(),
         ];
         assert_eq!(expected, cmds);
     }
@@ -100,12 +117,13 @@ mod test {
     #[test]
     fn tcsh_all_exist_correct_order() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, &Shell::Tcsh, |_| true);
+        let cmds = source_profile_scripts_cmds(dirs, "", &Shell::Tcsh, |_| true);
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-tcsh';".to_string(),
             "source 'newer/activate.d/profile-common';".to_string(),
             "source 'newer/activate.d/profile-tcsh';".to_string(),
+            "set _FLOX_SOURCED_PROFILE_SCRIPTS = 'newer:older';".to_string(),
         ];
         assert_eq!(expected, cmds);
     }
@@ -113,12 +131,13 @@ mod test {
     #[test]
     fn fish_all_exist_correct_order() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, &Shell::Fish, |_| true);
+        let cmds = source_profile_scripts_cmds(dirs, "", &Shell::Fish, |_| true);
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-fish';".to_string(),
             "source 'newer/activate.d/profile-common';".to_string(),
             "source 'newer/activate.d/profile-fish';".to_string(),
+            "set -g _FLOX_SOURCED_PROFILE_SCRIPTS 'newer:older';".to_string(),
         ];
         assert_eq!(expected, cmds);
     }
@@ -126,13 +145,14 @@ mod test {
     #[test]
     fn bash_some_exist() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, &Shell::Bash, |p| {
+        let cmds = source_profile_scripts_cmds(dirs, "", &Shell::Bash, |p| {
             p != Path::new("newer/activate.d/profile-common")
         });
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-bash';".to_string(),
             "source 'newer/activate.d/profile-bash';".to_string(),
+            "_FLOX_SOURCED_PROFILE_SCRIPTS='newer:older';".to_string(),
         ];
         assert_eq!(expected, cmds);
     }
@@ -140,13 +160,14 @@ mod test {
     #[test]
     fn zsh_some_exist() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, &Shell::Zsh, |p| {
+        let cmds = source_profile_scripts_cmds(dirs, "", &Shell::Zsh, |p| {
             p != Path::new("newer/activate.d/profile-common")
         });
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-zsh';".to_string(),
             "source 'newer/activate.d/profile-zsh';".to_string(),
+            "typeset -g _FLOX_SOURCED_PROFILE_SCRIPTS='newer:older';".to_string(),
         ];
         assert_eq!(expected, cmds);
     }
@@ -154,13 +175,14 @@ mod test {
     #[test]
     fn tcsh_some_exist() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, &Shell::Tcsh, |p| {
+        let cmds = source_profile_scripts_cmds(dirs, "", &Shell::Tcsh, |p| {
             p != Path::new("newer/activate.d/profile-common")
         });
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-tcsh';".to_string(),
             "source 'newer/activate.d/profile-tcsh';".to_string(),
+            "set _FLOX_SOURCED_PROFILE_SCRIPTS = 'newer:older';".to_string(),
         ];
         assert_eq!(expected, cmds);
     }
@@ -168,14 +190,37 @@ mod test {
     #[test]
     fn fish_some_exist() {
         let dirs = "newer:older";
-        let cmds = source_profile_scripts_cmds(dirs, &Shell::Fish, |p| {
+        let cmds = source_profile_scripts_cmds(dirs, "", &Shell::Fish, |p| {
             p != Path::new("newer/activate.d/profile-common")
         });
         let expected = vec![
             "source 'older/activate.d/profile-common';".to_string(),
             "source 'older/activate.d/profile-fish';".to_string(),
             "source 'newer/activate.d/profile-fish';".to_string(),
+            "set -g _FLOX_SOURCED_PROFILE_SCRIPTS 'newer:older';".to_string(),
         ];
+        assert_eq!(expected, cmds);
+    }
+
+    #[test]
+    fn one_already_sourced_script_is_skipped() {
+        let dirs = "newer:older";
+        let already_sourced = "older";
+        let cmds = source_profile_scripts_cmds(dirs, already_sourced, &Shell::Bash, |_| true);
+        let expected = vec![
+            "source 'newer/activate.d/profile-common';".to_string(),
+            "source 'newer/activate.d/profile-bash';".to_string(),
+            "_FLOX_SOURCED_PROFILE_SCRIPTS='newer:older';".to_string(),
+        ];
+        assert_eq!(expected, cmds);
+    }
+
+    #[test]
+    fn all_already_sourced_scripts_are_skipped() {
+        let dirs = "newer:older";
+        let already_sourced = "newer:older";
+        let cmds = source_profile_scripts_cmds(dirs, already_sourced, &Shell::Bash, |_| true);
+        let expected = vec!["_FLOX_SOURCED_PROFILE_SCRIPTS='newer:older';".to_string()];
         assert_eq!(expected, cmds);
     }
 }

--- a/cli/flox-activations/src/cli/profile_scripts.rs
+++ b/cli/flox-activations/src/cli/profile_scripts.rs
@@ -20,6 +20,9 @@ pub struct ProfileScriptsArgs {
         long,
         help = "A list of FLOX_ENV directories that have already been sourced"
     )]
+    // If not provided, defaults to an empty string. This is required for tcsh in
+    // particular that is unable to pass empty arguments on the command line.
+    #[clap(default_value = "")]
     pub already_sourced_env_dirs: String,
 }
 

--- a/cli/flox-activations/src/shell_gen.rs
+++ b/cli/flox-activations/src/shell_gen.rs
@@ -35,6 +35,17 @@ impl fmt::Display for Shell {
         }
     }
 }
+impl Shell {
+    /// Set a shell variable that is not exported
+    pub fn set_var_not_exported(&self, var: &str, value: &str) -> String {
+        match self {
+            Self::Bash => format!("{var}='{value}';"),
+            Self::Fish => format!("set -g {var} '{value}';"),
+            Self::Tcsh => format!("set {var} = '{value}';"),
+            Self::Zsh => format!("typeset -g {var}='{value}';"),
+        }
+    }
+}
 
 pub fn source_file(path: &Path) -> String {
     format!("source '{}';", path.display())

--- a/cli/flox-activations/src/shell_gen.rs
+++ b/cli/flox-activations/src/shell_gen.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::Path;
 
 /// The shells that we support generating code for
@@ -19,6 +20,18 @@ impl std::str::FromStr for Shell {
             "tcsh" => Ok(Self::Tcsh),
             "fish" => Ok(Self::Fish),
             _ => Err(anyhow::anyhow!("Invalid shell: '{s}'")),
+        }
+    }
+}
+
+impl fmt::Display for Shell {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Bash => write!(f, "bash"),
+            Self::Zsh => write!(f, "zsh"),
+            Self::Tcsh => write!(f, "tcsh"),
+            Self::Fish => write!(f, "fish"),
         }
     }
 }


### PR DESCRIPTION
[refactor: use typed Shell for --shell arg](https://github.com/flox/flox/pull/3413/commits/b6f26160060c2508d7080defe2ad00e70e0c1f06)
[b6f2616](https://github.com/flox/flox/pull/3413/commits/b6f26160060c2508d7080defe2ad00e70e0c1f06)

This will error early if an unsupported arg is passed to --shell.
This will make it so upcoming commits that need a Shell object don't
have to add error handling deeper within the logic of flox-activations
profile-scripts

[fix: only run profile scripts once per shell](https://github.com/flox/flox/pull/3413/commits/35a5eec5219b93943e905e60c9c17feda4426998)
[35a5eec](https://github.com/flox/flox/pull/3413/commits/35a5eec5219b93943e905e60c9c17feda4426998)

Use a _FLOX_SOURCED_PROFILE_SCRIPTS shell variable to track when
environment's profile scripts have been run, and run them at most once.

This fixes double printing from profile scripts in the case:
- There's an in-place activation in dotfiles
- A second environment is activated

It also reduces overhead of running profile scripts more than we need
to.

Some cases this isn't ideal:
- eval "$(flox activate)" && flox edit && eval "$(flox activate)"
  In that case a user won't get any edits to profile scripts reflected.
  In that sense modifying the test case "activate runs profile twice in
  nested activation" is a minor regression in behavior, but I think it's
  pretty minor since I don't think repeat in-place activations will be
  very common.
- In the scenario where there's an activation in a dotfile and a user
  runs flox activate -d project, the project's profile script is run by
  the activation that is in the dotfile, rather than once the project's
  activation has taken back control. Ideally I think it would be the
  other way around, but I don't think that breaks any use cases except
  for cases that are contrived.

[fix: don't pass --already-sourced-env-dirs flag at bootstrap](https://github.com/flox/flox/pull/3413/commits/514ffddce34f51c13a2835a5fa3c809028342eda)
[514ffdd](https://github.com/flox/flox/pull/3413/commits/514ffddce34f51c13a2835a5fa3c809028342eda)

Modern versions of tcsh support the ":Q" modifier for passing empty args
on the command line, but versions prior to 6.23 do not have a way to do
that, so to support these versions we will instead avoid passing the
--already-sourced-env-dirs argument altogether when there is no default
value to be passed. This will in turn require updating flox-activations
to provide a default [empty] value for `already_sourced_env_dirs` when
not provided/overridden by CLI args.