### PR TITLE
feat: add `generations` category and `generation list` subcommand

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -528,6 +528,20 @@ pub struct AllGenerationsMetadata {
     version: Version<1>,
 }
 
+impl AllGenerationsMetadata {
+    #[cfg(feature = "tests")]
+    pub fn new(
+        current_gen: GenerationId,
+        generations: impl IntoIterator<Item = (GenerationId, SingleGenerationMetadata)>,
+    ) -> Self {
+        AllGenerationsMetadata {
+            current_gen: Some(current_gen),
+            generations: BTreeMap::from_iter(generations),
+            version: Default::default(),
+        }
+    }
+}
+
 /// Metadata for a single generation of an environment
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -9,12 +9,7 @@ use tracing::{debug, instrument};
 
 use super::core_environment::{CoreEnvironment, UpgradeResult};
 use super::fetcher::IncludeFetcher;
-use super::generations::{
-    AllGenerationsMetadata,
-    Generations,
-    GenerationsEnvironment,
-    GenerationsError,
-};
+use super::generations::{AllGenerationsMetadata, Generations, GenerationsError, GenerationsExt};
 use super::path_environment::PathEnvironment;
 use super::{
     CACHE_DIR_NAME,
@@ -564,7 +559,7 @@ impl Environment for ManagedEnvironment {
     }
 }
 
-impl GenerationsEnvironment for ManagedEnvironment {
+impl GenerationsExt for ManagedEnvironment {
     fn generations_metadata(&self) -> Result<AllGenerationsMetadata, GenerationsError> {
         self.generations().metadata()
     }

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -23,6 +23,7 @@ use super::manifest::raw::PackageToInstall;
 use super::manifest::typed::{ActivateMode, ManifestError};
 use crate::data::{CanonicalPath, CanonicalizeError, System};
 use crate::flox::{Flox, Floxhub};
+use crate::models::environment::generations::GenerationsEnvironment;
 use crate::providers::auth::AuthError;
 use crate::providers::buildenv::BuildEnvOutputs;
 use crate::providers::git::{

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -6,7 +6,7 @@ use tracing::{debug, instrument};
 
 use super::core_environment::UpgradeResult;
 use super::fetcher::IncludeFetcher;
-use super::generations::{AllGenerationsMetadata, GenerationsEnvironment, GenerationsError};
+use super::generations::{AllGenerationsMetadata, GenerationsError, GenerationsExt};
 use super::managed_environment::{ManagedEnvironment, ManagedEnvironmentError};
 use super::{
     CanonicalPath,
@@ -412,7 +412,7 @@ impl Environment for RemoteEnvironment {
     }
 }
 
-impl GenerationsEnvironment for RemoteEnvironment {
+impl GenerationsExt for RemoteEnvironment {
     fn generations_metadata(&self) -> Result<AllGenerationsMetadata, GenerationsError> {
         self.inner.generations_metadata()
     }

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -1,0 +1,170 @@
+use std::fmt::Display;
+
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::generations::{
+    AllGenerationsMetadata,
+    SingleGenerationMetadata,
+};
+use tracing::instrument;
+
+use super::try_get_generations_metadata;
+use crate::commands::{EnvironmentSelect, environment_select};
+use crate::environment_subcommand_metric;
+
+/// Arguments for the `flox generations list` command
+#[derive(Bpaf, Debug, Clone)]
+pub struct List {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+}
+
+impl List {
+    #[instrument(name = "list", skip_all)]
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        let env = self.environment.to_concrete_environment(&flox)?;
+        environment_subcommand_metric!("generations::list", env);
+        let metadata = try_get_generations_metadata(&env)?;
+        println!("{}", DisplayAllMetadata(&metadata));
+        Ok(())
+    }
+}
+
+/// Formatter container for [SingleGenerationMetadata].
+/// Implements CLI/command specific formatting.
+struct DisplayMetadata<'m> {
+    metadata: &'m SingleGenerationMetadata,
+}
+impl Display for DisplayMetadata<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Description: {}", self.metadata.description)?;
+        write!(f, "Created: {}", self.metadata.created)?;
+        if let Some(last_active) = self.metadata.last_active {
+            writeln!(f)?;
+            write!(f, "Last Active: {last_active}")?;
+        };
+        Ok(())
+    }
+}
+
+/// Formatter container for [AllGenerationsMetadata].
+/// List formatting of generation data, following the template
+///
+/// ```text
+/// * <generation id>[ (current)]:
+///   <generation metadata>          # implemented by [DisplayMetadata] above
+/// ```
+struct DisplayAllMetadata<'m>(&'m AllGenerationsMetadata);
+impl Display for DisplayAllMetadata<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut iter = self.0.generations.iter().peekable();
+        while let (Some((id, metadata)), peek) = (iter.next(), iter.peek()) {
+            write!(f, "* {id}")?;
+            if Some(id) == self.0.current_gen.as_ref() {
+                write!(f, " (current)")?;
+            }
+            writeln!(f, ":")?;
+
+            let next = DisplayMetadata { metadata };
+            write!(f, "{}", indent::indent_all_by(2, next.to_string()))?;
+            if peek.is_some() {
+                writeln!(f)?;
+                writeln!(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::DateTime;
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    fn mock_generations() -> AllGenerationsMetadata {
+        AllGenerationsMetadata::new(2.into(), [
+            (1.into(), SingleGenerationMetadata {
+                created: DateTime::default() + chrono::Duration::hours(1),
+                last_active: None,
+                description: "Generation 1 description".to_string(),
+            }),
+            (2.into(), SingleGenerationMetadata {
+                created: DateTime::default() + chrono::Duration::hours(2),
+                last_active: Some(DateTime::default() + chrono::Duration::hours(4)),
+                description: "Generation 2 description".to_string(),
+            }),
+            (3.into(), SingleGenerationMetadata {
+                created: DateTime::default() + chrono::Duration::hours(3),
+                last_active: Some(DateTime::default() + chrono::Duration::hours(3)),
+                description: "Generation 3 description".to_string(),
+            }),
+        ])
+    }
+
+    #[test]
+    fn test_fmt_single_generation() {
+        let actual = DisplayMetadata {
+            metadata: &SingleGenerationMetadata {
+                created: DateTime::default(),
+                last_active: Some(DateTime::default()),
+                description: "Generation description".to_string(),
+            },
+        }
+        .to_string();
+
+        let expected = indoc! {"
+            Description: Generation description
+            Created: 1970-01-01 00:00:00 UTC
+            Last Active: 1970-01-01 00:00:00 UTC"
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    /// Currently prevented by the implementation
+    #[test]
+    fn test_fmt_single_generation_never_active() {
+        let actual = DisplayMetadata {
+            metadata: &SingleGenerationMetadata {
+                created: DateTime::default(),
+                last_active: None,
+                description: "Generation description".to_string(),
+            },
+        }
+        .to_string();
+
+        let expected = indoc! {"
+            Description: Generation description
+            Created: 1970-01-01 00:00:00 UTC"
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_fmt_generations() {
+        let actual = DisplayAllMetadata(&mock_generations()).to_string();
+
+        let expected = indoc! {"
+            * 1:
+              Description: Generation 1 description
+              Created: 1970-01-01 01:00:00 UTC
+
+            * 2 (current):
+              Description: Generation 2 description
+              Created: 1970-01-01 02:00:00 UTC
+              Last Active: 1970-01-01 04:00:00 UTC
+
+            * 3:
+              Description: Generation 3 description
+              Created: 1970-01-01 03:00:00 UTC
+              Last Active: 1970-01-01 03:00:00 UTC"
+        };
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -5,11 +5,12 @@ use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::{
     AllGenerationsMetadata,
+    GenerationsEnvironment,
+    GenerationsExt,
     SingleGenerationMetadata,
 };
 use tracing::instrument;
 
-use super::try_get_generations_metadata;
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
 
@@ -25,7 +26,10 @@ impl List {
     pub fn handle(self, flox: Flox) -> Result<()> {
         let env = self.environment.to_concrete_environment(&flox)?;
         environment_subcommand_metric!("generations::list", env);
-        let metadata = try_get_generations_metadata(&env)?;
+
+        let env: GenerationsEnvironment = env.try_into()?;
+        let metadata = env.generations_metadata()?;
+
         println!("{}", DisplayAllMetadata(&metadata));
         Ok(())
     }

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+use super::display_help;
+use crate::config::Config;
+
+/// Generations Commands.
+#[derive(Debug, Clone, Bpaf)]
+pub enum GenerationsCommands {
+    /// Prints help information
+    #[bpaf(command, hide)]
+    Help,
+}
+
+impl GenerationsCommands {
+    #[instrument(name = "generations", skip_all)]
+    pub fn handle(self, _config: Config, flox: Flox) -> Result<()> {
+        match self {
+            GenerationsCommands::Help => {
+                display_help(Some("generations".to_string()));
+            },
+        }
+
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -1,17 +1,10 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::ConcreteEnvironment;
-use flox_rust_sdk::models::environment::generations::{
-    AllGenerationsMetadata,
-    GenerationsEnvironment,
-};
-use indoc::formatdoc;
 use list::List;
 use tracing::instrument;
 
 use super::display_help;
-use crate::commands::environment_description;
 use crate::config::Config;
 
 mod list;
@@ -40,19 +33,4 @@ impl GenerationsCommands {
 
         Ok(())
     }
-}
-
-fn try_get_generations_metadata(env: &ConcreteEnvironment) -> Result<AllGenerationsMetadata> {
-    let metadata = match env {
-        ConcreteEnvironment::Path(_) => {
-            let description = environment_description(env)?;
-            bail!(formatdoc! {"
-                Generations are only available for environments pushed to floxhub.
-                The environment {description} is a local only environment.
-            "})
-        },
-        ConcreteEnvironment::Managed(env) => env.generations_metadata()?,
-        ConcreteEnvironment::Remote(env) => env.generations_metadata()?,
-    };
-    Ok(metadata)
 }

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -1,10 +1,20 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::ConcreteEnvironment;
+use flox_rust_sdk::models::environment::generations::{
+    AllGenerationsMetadata,
+    GenerationsEnvironment,
+};
+use indoc::formatdoc;
+use list::List;
 use tracing::instrument;
 
 use super::display_help;
+use crate::commands::environment_description;
 use crate::config::Config;
+
+mod list;
 
 /// Generations Commands.
 #[derive(Debug, Clone, Bpaf)]
@@ -12,6 +22,10 @@ pub enum GenerationsCommands {
     /// Prints help information
     #[bpaf(command, hide)]
     Help,
+
+    /// List generations of the selected environment
+    #[bpaf(command)]
+    List(#[bpaf(external(list::list))] List),
 }
 
 impl GenerationsCommands {
@@ -21,8 +35,24 @@ impl GenerationsCommands {
             GenerationsCommands::Help => {
                 display_help(Some("generations".to_string()));
             },
+            GenerationsCommands::List(args) => args.handle(flox)?,
         }
 
         Ok(())
     }
+}
+
+fn try_get_generations_metadata(env: &ConcreteEnvironment) -> Result<AllGenerationsMetadata> {
+    let metadata = match env {
+        ConcreteEnvironment::Path(_) => {
+            let description = environment_description(env)?;
+            bail!(formatdoc! {"
+                Generations are only available for environments pushed to floxhub.
+                The environment {description} is a local only environment.
+            "})
+        },
+        ConcreteEnvironment::Managed(env) => env.generations_metadata()?,
+        ConcreteEnvironment::Remote(env) => env.generations_metadata()?,
+    };
+    Ok(metadata)
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod edit;
 mod envs;
 mod gc;
 mod general;
+mod generations;
 mod include;
 mod init;
 mod install;
@@ -390,7 +391,7 @@ impl FloxArgs {
             Commands::Manage(args) => args.handle(flox).await,
             Commands::Use(args) => args.handle(config, flox).await,
             Commands::Discover(args) => args.handle(config, flox).await,
-            Commands::Modify(args) => args.handle(flox).await,
+            Commands::Modify(args) => args.handle(config, flox).await,
             Commands::Share(args) => args.handle(config, flox).await,
             Commands::Admin(args) => args.handle(config, flox).await,
             Commands::Internal(args) => args.handle(flox).await,
@@ -949,10 +950,20 @@ enum ModifyCommands {
         footer("Run 'man flox-uninstall' for more details.")
     )]
     Uninstall(#[bpaf(external(uninstall::uninstall))] uninstall::Uninstall),
+
+    /// Interact with environment generations
+    #[bpaf(command, hide)]
+    Generations(
+        #[bpaf(
+            external(generations::generations_commands),
+            fallback(generations::GenerationsCommands::Help)
+        )]
+        generations::GenerationsCommands,
+    ),
 }
 
 impl ModifyCommands {
-    async fn handle(self, flox: Flox) -> Result<()> {
+    async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
             ModifyCommands::Install(args) => args.handle(flox).await?,
             ModifyCommands::List(args) => args.handle(flox).await?,
@@ -960,6 +971,7 @@ impl ModifyCommands {
             ModifyCommands::Include(args) => args.handle(flox).await?,
             ModifyCommands::Upgrade(args) => args.handle(flox).await?,
             ModifyCommands::Uninstall(args) => args.handle(flox).await?,
+            ModifyCommands::Generations(args) => args.handle(config, flox)?,
         }
         Ok(())
     }


### PR DESCRIPTION
Allows to run `flox generations list [<environment>]` to get a listing of all generations of the selected environment.

The generations are currently formatted as

```
* {generation_id}[ (current)]:
   Description: {description}
   Created: {created}
   Last Active: {last_active}
```
