### PR TITLE
docs(build): Add NEF to flox build --help

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -983,10 +983,9 @@ enum ShareCommands {
     /// Build packages for Flox
     #[bpaf(
         command,
-        // TODO: NEF
-        header(
-            "Build packages from the manifest's 'build' table, or run clean subcommand if specified."
-        ),
+        header(indoc!{"Build packages from the manifest's 'build' table, Nix
+                       expression files in '.flox/pkgs/', or run 'clean'
+                       subcommand if specified."}),
         footer("Run 'man flox-build' for more details.")
     )]
     Build(#[bpaf(external(build::build))] build::Build),


### PR DESCRIPTION
## Proposed Changes

We forgot to update this when releasing Nix expression builds.

New output:

    % flox build --help
    Build packages for Flox

    Usage: flox build [-d=<path>] (COMMAND ... | [--stability=<stability>] [
    <package>]...)

    Build packages from the manifest's 'build' table, Nix expression files in
    '.flox/pkgs/', or run 'clean' subcommand if specified.

    …

## Release Notes

N/A
