### PR TITLE
fix: tweak post edit message

### DIFF
--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -187,7 +187,7 @@ impl Edit {
         let reactivate_required_note = indoc::indoc! {"
             Your manifest has changes that cannot be automatically applied.
 
-            Please 'exit' the environment and run 'flox activate' to see these changes.
+            Please 'exit' the shell and run 'flox activate' to see these changes.
        "};
 
         match result {


### PR DESCRIPTION
Change `environment` -> `shell`.
For an in-place activation, I think it would be surprising to read this message, type exit, and then have your Terminal close if you thought you were somehow only going to exit a Flox started shell.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
