### PR TITLE
fix: don't print double ".." upon successful build

### DIFF
--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -233,7 +233,7 @@ impl Build {
             // or produces at least one link.
             // Handle anyway for completeness and to avoid erros in case the above changes.
             [] => message::info(format!("{success_prefix} No outputs created")),
-            [link] => message::created(format!("{success_prefix}. Output created: {link}",)),
+            [link] => message::created(format!("{success_prefix} Output created: {link}",)),
             links => message::created(formatdoc! {"
                 {success_prefix}
                 Outputs created: {}",


### PR DESCRIPTION
## Proposed Changes

Removing extra "." that resulted in a double ".." in the final comment following a successful build, e.g.:
```
> Completed build of flox-cri-0.1.0 in local mode
>
> ✨ Builds completed successfully.. Output created: ./result-flox-cri
                                  ^^
```

## Release Notes

N/A