### PR TITLE
feat: add `flox generations {rollback,switch}` commands

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -32,8 +32,14 @@ use super::core_environment::CoreEnvironment;
 use super::fetcher::IncludeFetcher;
 use super::managed_environment::ManagedEnvironment;
 use super::remote_environment::RemoteEnvironment;
-use super::{ConcreteEnvironment, ENV_DIR_NAME, LOCKFILE_FILENAME, copy_dir_recursive};
-use crate::flox::EnvironmentName;
+use super::{
+    ConcreteEnvironment,
+    ENV_DIR_NAME,
+    EnvironmentError,
+    LOCKFILE_FILENAME,
+    copy_dir_recursive,
+};
+use crate::flox::{EnvironmentName, Flox};
 use crate::models::environment::{MANIFEST_FILENAME, UninitializedEnvironment};
 use crate::providers::git::{
     GitCommandError,
@@ -519,6 +525,12 @@ fn write_metadata_file(
 pub trait GenerationsExt {
     /// Return all generations metadata for the environment.
     fn generations_metadata(&self) -> Result<AllGenerationsMetadata, GenerationsError>;
+
+    fn switch_generation(
+        &mut self,
+        flox: &Flox,
+        generation: GenerationId,
+    ) -> Result<(), EnvironmentError>;
 }
 
 /// Combined type for environments supporting generations,

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -396,7 +396,7 @@ impl Generations<ReadWrite<'_>> {
             return Err(GenerationsError::GenerationNotFound(*generation));
         };
 
-        metadata.current_gen = Some(generation.clone());
+        metadata.current_gen = Some(generation);
         write_metadata_file(metadata, self.repo.path())?;
 
         self.repo
@@ -638,6 +638,7 @@ impl SingleGenerationMetadata {
 #[derive(
     Debug,
     Clone,
+    Copy,
     PartialEq,
     Eq,
     PartialOrd,

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -84,30 +84,12 @@ impl Display for DisplayAllMetadata<'_> {
 #[cfg(test)]
 mod tests {
     use chrono::DateTime;
+    use flox_rust_sdk::models::environment::generations::SingleGenerationMetadata;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     use super::*;
-
-    fn mock_generations() -> AllGenerationsMetadata {
-        AllGenerationsMetadata::new(2.into(), [
-            (1.into(), SingleGenerationMetadata {
-                created: DateTime::default() + chrono::Duration::hours(1),
-                last_active: None,
-                description: "Generation 1 description".to_string(),
-            }),
-            (2.into(), SingleGenerationMetadata {
-                created: DateTime::default() + chrono::Duration::hours(2),
-                last_active: Some(DateTime::default() + chrono::Duration::hours(4)),
-                description: "Generation 2 description".to_string(),
-            }),
-            (3.into(), SingleGenerationMetadata {
-                created: DateTime::default() + chrono::Duration::hours(3),
-                last_active: Some(DateTime::default() + chrono::Duration::hours(3)),
-                description: "Generation 3 description".to_string(),
-            }),
-        ])
-    }
+    use crate::commands::generations::test_helpers::mock_generations;
 
     #[test]
     fn test_fmt_single_generation() {
@@ -151,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_fmt_generations() {
-        let actual = DisplayAllMetadata(&mock_generations()).to_string();
+        let actual = DisplayAllMetadata(&mock_generations(2.into())).to_string();
 
         let expected = indoc! {"
             * 1:

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -8,6 +8,7 @@ use crate::config::Config;
 
 mod list;
 mod rollback;
+mod switch;
 
 /// Generations Commands.
 #[derive(Debug, Clone, Bpaf)]
@@ -23,6 +24,10 @@ pub enum GenerationsCommands {
     /// Switch to the last active generation
     #[bpaf(command)]
     Rollback(#[bpaf(external(rollback::rollback))] rollback::Rollback),
+
+    /// Switch to the provided generation
+    #[bpaf(command)]
+    Switch(#[bpaf(external(switch::switch))] switch::Switch),
 }
 
 impl GenerationsCommands {
@@ -34,6 +39,7 @@ impl GenerationsCommands {
             },
             GenerationsCommands::List(args) => args.handle(flox)?,
             GenerationsCommands::Rollback(args) => args.handle(flox)?,
+            GenerationsCommands::Switch(args) => args.handle(flox)?,
         }
 
         Ok(())

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use list::List;
 use tracing::instrument;
 
 use super::display_help;
 use crate::config::Config;
 
 mod list;
+mod rollback;
 
 /// Generations Commands.
 #[derive(Debug, Clone, Bpaf)]
@@ -18,7 +18,11 @@ pub enum GenerationsCommands {
 
     /// List generations of the selected environment
     #[bpaf(command)]
-    List(#[bpaf(external(list::list))] List),
+    List(#[bpaf(external(list::list))] list::List),
+
+    /// Switch to the last active generation
+    #[bpaf(command)]
+    Rollback(#[bpaf(external(rollback::rollback))] rollback::Rollback),
 }
 
 impl GenerationsCommands {
@@ -29,6 +33,7 @@ impl GenerationsCommands {
                 display_help(Some("generations".to_string()));
             },
             GenerationsCommands::List(args) => args.handle(flox)?,
+            GenerationsCommands::Rollback(args) => args.handle(flox)?,
         }
 
         Ok(())

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -45,3 +45,43 @@ impl GenerationsCommands {
         Ok(())
     }
 }
+
+#[cfg(test)]
+pub(super) mod test_helpers {
+    use chrono::DateTime;
+    use flox_rust_sdk::models::environment::generations::{
+        AllGenerationsMetadata,
+        GenerationId,
+        SingleGenerationMetadata,
+    };
+
+    pub(super) fn mock_generations(active: GenerationId) -> AllGenerationsMetadata {
+        let active_ts = Some(DateTime::default() + chrono::Duration::hours(4));
+
+        AllGenerationsMetadata::new(active, [
+            (1.into(), SingleGenerationMetadata {
+                created: DateTime::default() + chrono::Duration::hours(1),
+                last_active: if active == 1.into() { active_ts } else { None },
+                description: "Generation 1 description".to_string(),
+            }),
+            (2.into(), SingleGenerationMetadata {
+                created: DateTime::default() + chrono::Duration::hours(2),
+                last_active: if active == 2.into() {
+                    active_ts
+                } else {
+                    Some(DateTime::default() + chrono::Duration::hours(2))
+                },
+                description: "Generation 2 description".to_string(),
+            }),
+            (3.into(), SingleGenerationMetadata {
+                created: DateTime::default() + chrono::Duration::hours(3),
+                last_active: if active == 3.into() {
+                    active_ts
+                } else {
+                    Some(DateTime::default() + chrono::Duration::hours(3))
+                },
+                description: "Generation 3 description".to_string(),
+            }),
+        ])
+    }
+}

--- a/cli/flox/src/commands/generations/rollback.rs
+++ b/cli/flox/src/commands/generations/rollback.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::generations::{GenerationsEnvironment, GenerationsExt};
+use itertools::Itertools;
+use tracing::{debug, instrument};
+
+use crate::commands::{EnvironmentSelect, environment_select};
+use crate::environment_subcommand_metric;
+use crate::utils::message;
+
+/// Arguments for the `flox generations rollback` command
+#[derive(Bpaf, Debug, Clone)]
+pub struct Rollback {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+}
+
+impl Rollback {
+    #[instrument(name = "rollback", skip_all)]
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        let env = self.environment.to_concrete_environment(&flox)?;
+
+        environment_subcommand_metric!("generations::rollback", env);
+        let mut env: GenerationsEnvironment = env.try_into()?;
+
+        debug!("determining previous generation");
+        let metadata = env.generations_metadata()?;
+
+        // (0, is the current active)
+        let Some((previously_active_generation_id, _meta)) = metadata
+            .generations
+            .iter()
+            .sorted_by_key(|(_id, meta)| meta.last_active)
+            .nth(1)
+        else {
+            message::warning("No previous generation to rollback to.");
+            return Ok(());
+        };
+
+        debug!(%previously_active_generation_id, "target generation determined, attempting rollback");
+        env.switch_generation(&flox, *previously_active_generation_id)?;
+        message::updated(format!(
+            "Switched to generation {previously_active_generation_id}"
+        ));
+
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/generations/switch.rs
+++ b/cli/flox/src/commands/generations/switch.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::generations::{
+    GenerationId,
+    GenerationsEnvironment,
+    GenerationsExt,
+};
+use tracing::{debug, instrument};
+
+use crate::commands::{EnvironmentSelect, environment_select};
+use crate::environment_subcommand_metric;
+use crate::utils::message;
+
+/// Arguments for the `flox generations switch` command
+#[derive(Bpaf, Debug, Clone)]
+pub struct Switch {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
+
+    #[bpaf(positional("generation"))]
+    target_generation: GenerationId,
+}
+
+impl Switch {
+    #[instrument(name = "switch", skip_all)]
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        let env = self.environment.to_concrete_environment(&flox)?;
+
+        environment_subcommand_metric!("generations::switch", env);
+        let mut env: GenerationsEnvironment = env.try_into()?;
+
+        let to = self.target_generation;
+        debug!(%to, "target generation provided, attempting rollback");
+        env.switch_generation(&flox, to)?;
+        message::updated(format!("Switched to generation {to}"));
+        return Ok(());
+    }
+}


### PR DESCRIPTION
Allow rollbacks to previous generations (specifically, the generation active before the currently active generation).
Also allow switching to an arbitrary generation via `flox generations switch`.
