### PR TITLE
fix(install): Prevent '=' and ' ' in pkg-path

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -751,6 +751,14 @@ impl FromStr for CatalogPackage {
             None
         };
 
+        let disallowed_chars = ['=', ' '];
+        if disallowed_chars.iter().any(|c| attr_path.contains(*c)) {
+            return Err(RawManifestError::MalformedStringDescriptor {
+                msg: format! {"pkg-path cannot contain characters: {:?}", disallowed_chars},
+                desc: descriptor.to_string(),
+            });
+        }
+
         let install_id = install_id_from_attr_path(&attr_path, descriptor)?;
 
         Ok(Self {
@@ -1885,6 +1893,13 @@ pub(super) mod test {
             version: None,
             systems: None,
         });
+        let parsed: CatalogPackage = "foo.bar@>=2.10 <=2.12".parse().unwrap();
+        assert_eq!(parsed, CatalogPackage {
+            id: "bar".to_string(),
+            pkg_path: "foo.bar".to_string(),
+            version: Some(">=2.10 <=2.12".to_string()),
+            systems: None,
+        });
         let parsed: CatalogPackage = "foo.bar@=1.2.3".parse().unwrap();
         assert_eq!(parsed, CatalogPackage {
             id: "bar".to_string(),
@@ -1940,6 +1955,20 @@ pub(super) mod test {
         CatalogPackage::from_str("foo.\"bar.baz.qux@1.2.3")
             .expect_err("missing closing quote should cause failure");
         CatalogPackage::from_str("foo@").expect_err("missing version should cause failure");
+
+        let err =
+            CatalogPackage::from_str("foo=bar").expect_err("= in pkg-path should cause failure");
+        assert_eq!(
+            err.to_string(),
+            "couldn't parse descriptor 'foo=bar': pkg-path cannot contain characters: ['=', ' ']",
+        );
+
+        let err = CatalogPackage::from_str("foo bar")
+            .expect_err("whitespace in pkg-path should cause failure");
+        assert_eq!(
+            err.to_string(),
+            "couldn't parse descriptor 'foo bar': pkg-path cannot contain characters: ['=', ' ']",
+        );
     }
 
     /// Determines whether to have a branch and/or revision in the URL


### PR DESCRIPTION
## Proposed Changes

Prevent malformed pkg-paths from `flox install` commands from causing exceptions in `catalog-server` by checking for characters that should never appear after parsing out the `@version` requirement.

This exception:

- https://flox-dev.sentry.io/issues/6777203580/?project=4507306107273216&referrer=github_integration

Appears to have been caused by the equivalent (values changed for anonymity but structure preserved) of:

    flox install 'foo.pkg_group = "bar_group"'

Which could either be an attempt to imperatively install to a group, a copy/paste mistake from a manifest, or an LLM agent.

We have to be relatively flexible about the strings that we accept here because, unlike the typed manifest, the `@version` specifier can contain equals and whitespace. However the `pkg-path` never should.

## Release Notes

`flox install` now prevents invalid `=` and ` ` characters outside of any `@version` requirement string.