### PR TITLE
fix: don't say you can edit on FloxHub

### DIFF
--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -192,7 +192,7 @@ impl Push {
         Ok(formatdoc! {"
             {heading}
 
-            View or edit the environment at: {url}
+            View the environment at: {url}
             Use this environment from another machine: 'flox activate -r {owner}/{name}'
             Make a copy of this environment: 'flox pull {owner}/{name}'
         "})

--- a/cli/tests/floxhub-cross-systems.bats
+++ b/cli/tests/floxhub-cross-systems.bats
@@ -93,7 +93,7 @@ teardown() {
   assert_output - << EOF
 ✅ Updates to ${name} successfully force pushed to FloxHub
 
-View or edit the environment at: https://hub.preview.flox.dev/${OWNER}/${name}
+View the environment at: https://hub.preview.flox.dev/${OWNER}/${name}
 Use this environment from another machine: 'flox activate -r ${OWNER}/${name}'
 Make a copy of this environment: 'flox pull ${OWNER}/${name}'
 EOF


### PR DESCRIPTION
Editing on FloxHub has been deprecated

## Release Notes

Editing on FloxHub has been deprecated
