### PR TITLE
feat: add history support to `AllGenerationsMetadata`

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -925,6 +925,7 @@ mod tests {
         use crate::models::environment::generations::{
             AllGenerationsMetadata,
             GenerationId,
+            GenerationsError,
             HistoryKind,
             SwitchGenerationOptions,
         };
@@ -1050,6 +1051,21 @@ mod tests {
                 first_gen_id,
                 second_gen_id,
             );
+        }
+
+        #[test]
+        fn switch_generation_does_not_allow_current_generation() {
+            let mut metadata = AllGenerationsMetadata::default();
+            let (generation_id, ..) = metadata.add_generation(default_add_generation_options());
+
+            let result =
+                metadata.switch_generation(default_switch_generation_options(generation_id));
+
+            assert!(
+                matches!(result, Err(GenerationsError::RollbackToCurrentGeneration)),
+                "unexpected result {:?}",
+                result
+            )
         }
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -605,7 +605,6 @@ pub struct AddGenerationOptions {
     pub hostname: String,
     pub timestamp: DateTime<Utc>,
     pub kind: HistoryKind,
-    pub summary: String,
 }
 
 #[derive(Debug, Clone)]
@@ -613,7 +612,6 @@ pub struct SwitchGenerationOptions {
     pub author: String,
     pub hostname: String,
     pub timestamp: DateTime<Utc>,
-    pub summary: String,
     pub next_generation: GenerationId,
 }
 
@@ -629,7 +627,6 @@ impl AllGenerationsMetadata {
             hostname,
             timestamp,
             kind,
-            summary,
         }: AddGenerationOptions,
     ) -> (GenerationId, &SingleGenerationMetadata, &HistorySpec) {
         // prepare new values
@@ -656,7 +653,6 @@ impl AllGenerationsMetadata {
             hostname,
             timestamp,
             kind,
-            summary,
             previous_generation: current_generation,
             current_generation: next_generation,
         };
@@ -1063,6 +1059,21 @@ mod tests {
 
             assert!(
                 matches!(result, Err(GenerationsError::RollbackToCurrentGeneration)),
+                "unexpected result {:?}",
+                result
+            )
+        }
+
+        #[test]
+        fn switch_generation_requires_existing_generation() {
+            let mut metadata = AllGenerationsMetadata::default();
+            metadata.add_generation(default_add_generation_options());
+            let absent_gen_id = GenerationId(2);
+            let result =
+                metadata.switch_generation(default_switch_generation_options(absent_gen_id));
+
+            assert!(
+                matches!(result, Err(GenerationsError::GenerationNotFound(2))),
                 "unexpected result {:?}",
                 result
             )

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -584,6 +584,9 @@ impl TryFrom<ConcreteEnvironment> for GenerationsEnvironment {
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AllGenerationsMetadata {
+    #[serde(default, skip)]
+    pub history: History,
+
     /// None means the environment has been created but does not yet have any
     /// generations
     pub current_gen: Option<GenerationId>,
@@ -605,6 +608,7 @@ impl AllGenerationsMetadata {
         generations: impl IntoIterator<Item = (GenerationId, SingleGenerationMetadata)>,
     ) -> Self {
         AllGenerationsMetadata {
+            history: History::default(),
             current_gen: Some(current_gen),
             generations: BTreeMap::from_iter(generations),
             version: Default::default(),

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -916,6 +916,44 @@ mod tests {
         }
     }
 
+    mod metadata {
+
+        use pretty_assertions::assert_eq;
+
+        use crate::models::environment::generations::AllGenerationsMetadata;
+        use crate::models::environment::generations::tests::default_add_generation_options;
+
+        /// Adding a generation adds consisten metadata, ie.
+        ///
+        /// * adds new [SingleGenerationMetadata]
+        /// * updates the current generation
+        /// * adds a history entry for adding the generation
+        #[test]
+        fn add_generation_adds_metadata_and_history() {
+            let mut metadata = AllGenerationsMetadata::default();
+
+            let options = default_add_generation_options();
+
+            let (generation, generation_metadata, history) =
+                metadata.add_generation(options.clone());
+
+            let (generation_metadata, history) = (generation_metadata.clone(), history.clone());
+
+            assert_eq!(metadata.current_gen, Some(generation));
+            assert_eq!(generation_metadata.created, options.timestamp);
+            assert_eq!(generation_metadata.last_active, Some(options.timestamp));
+            assert_eq!(generation_metadata.description, options.summary);
+
+            assert_eq!(history.author, options.author);
+            assert_eq!(history.hostname, options.hostname);
+            assert_eq!(history.current_generation, generation);
+            assert_eq!(history.previous_generation, None);
+            assert_eq!(history.kind, options.kind);
+            assert_eq!(history.summary, options.summary);
+            assert_eq!(history.timestamp, options.timestamp);
+        }
+    }
+
     fn setup_two_generations() -> (Generations, TempDir) {
         let (flox, tempdir) = flox_instance();
         let env = new_path_environment(&flox, "version = 1");

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -597,6 +597,8 @@ pub struct AllGenerationsMetadata {
 }
 
 impl AllGenerationsMetadata {
+    /// Create a new object from its parts,
+    /// used in tests to create mocks.
     #[cfg(feature = "tests")]
     pub fn new(
         current_gen: GenerationId,
@@ -682,6 +684,7 @@ pub enum HistoryKind {
 /// The structure of a single change, tying together
 /// _who_ performed _what_ change, where and when.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HistorySpec {
     // change provided
     /// Type of the change

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -920,8 +920,9 @@ mod tests {
 
         use pretty_assertions::assert_eq;
 
-        use crate::models::environment::generations::AllGenerationsMetadata;
+        use super::default_switch_generation_options;
         use crate::models::environment::generations::tests::default_add_generation_options;
+        use crate::models::environment::generations::{AllGenerationsMetadata, GenerationId};
 
         /// Adding a generation adds consisten metadata, ie.
         ///
@@ -951,6 +952,30 @@ mod tests {
             assert_eq!(history.kind, options.kind);
             assert_eq!(history.summary, options.summary);
             assert_eq!(history.timestamp, options.timestamp);
+        }
+
+        #[test]
+        fn generation_counter_is_correctly_increased() {
+            let mut metadata = AllGenerationsMetadata::default();
+            let (first_generation, _, _) =
+                metadata.add_generation(default_add_generation_options());
+
+            let (second_generation, _, _) =
+                metadata.add_generation(default_add_generation_options());
+
+            assert_eq!(first_generation, GenerationId(1));
+            assert_eq!(second_generation, GenerationId(2));
+
+            metadata
+                .switch_generation(default_switch_generation_options(first_generation))
+                .unwrap();
+            assert_eq!(metadata.current_gen, Some(first_generation));
+
+            let (third_generation, _, _) =
+                metadata.add_generation(default_add_generation_options());
+
+            // generation counter continues at the current max (N=2) + 1
+            assert_eq!(third_generation, GenerationId(3));
         }
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -893,6 +893,29 @@ mod tests {
     const GEN_ID_1: GenerationId = GenerationId(1);
     const GEN_ID_2: GenerationId = GenerationId(2);
 
+    const AUTHOR: &str = "author";
+    const HOSTNAME: &str = "host";
+
+    fn default_add_generation_options() -> AddGenerationOptions {
+        AddGenerationOptions {
+            author: AUTHOR.into(),
+            hostname: HOSTNAME.into(),
+            timestamp: Utc::now(),
+            kind: HistoryKind::Other("mock".into()),
+            summary: "mock generation".into(),
+        }
+    }
+
+    fn default_switch_generation_options(next_generation: GenerationId) -> SwitchGenerationOptions {
+        SwitchGenerationOptions {
+            author: AUTHOR.into(),
+            hostname: HOSTNAME.into(),
+            timestamp: Utc::now(),
+            summary: "switch mock".into(),
+            next_generation,
+        }
+    }
+
     fn setup_two_generations() -> (Generations, TempDir) {
         let (flox, tempdir) = flox_instance();
         let env = new_path_environment(&flox, "version = 1");


### PR DESCRIPTION
This PR adds support for history tracking within the generation metadata file (`medatata.json`).
History is represented as a list of changes that describe the "who, where, when and what" of a change.
Modification of the history are only possible via the new methods on `AllGenerationsMetadata`, which preserve the internal consistency of the metadata.


