### PR TITLE
Revert "fix(install): Prevent '=' and ' ' in pkg-path"

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -751,14 +751,6 @@ impl FromStr for CatalogPackage {
             None
         };
 
-        let disallowed_chars = ['=', ' '];
-        if disallowed_chars.iter().any(|c| attr_path.contains(*c)) {
-            return Err(RawManifestError::MalformedStringDescriptor {
-                msg: format! {"pkg-path cannot contain characters: {:?}", disallowed_chars},
-                desc: descriptor.to_string(),
-            });
-        }
-
         let install_id = install_id_from_attr_path(&attr_path, descriptor)?;
 
         Ok(Self {
@@ -1893,13 +1885,6 @@ pub(super) mod test {
             version: None,
             systems: None,
         });
-        let parsed: CatalogPackage = "foo.bar@>=2.10 <=2.12".parse().unwrap();
-        assert_eq!(parsed, CatalogPackage {
-            id: "bar".to_string(),
-            pkg_path: "foo.bar".to_string(),
-            version: Some(">=2.10 <=2.12".to_string()),
-            systems: None,
-        });
         let parsed: CatalogPackage = "foo.bar@=1.2.3".parse().unwrap();
         assert_eq!(parsed, CatalogPackage {
             id: "bar".to_string(),
@@ -1955,20 +1940,6 @@ pub(super) mod test {
         CatalogPackage::from_str("foo.\"bar.baz.qux@1.2.3")
             .expect_err("missing closing quote should cause failure");
         CatalogPackage::from_str("foo@").expect_err("missing version should cause failure");
-
-        let err =
-            CatalogPackage::from_str("foo=bar").expect_err("= in pkg-path should cause failure");
-        assert_eq!(
-            err.to_string(),
-            "couldn't parse descriptor 'foo=bar': pkg-path cannot contain characters: ['=', ' ']",
-        );
-
-        let err = CatalogPackage::from_str("foo bar")
-            .expect_err("whitespace in pkg-path should cause failure");
-        assert_eq!(
-            err.to_string(),
-            "couldn't parse descriptor 'foo bar': pkg-path cannot contain characters: ['=', ' ']",
-        );
     }
 
     /// Determines whether to have a branch and/or revision in the URL


### PR DESCRIPTION
## Proposed Changes

This reverts commit 0ae5c95b4275a6dd347281f5fc8e59fbea1cc095.

We now have a server-side fix in `catalog-server` which prevents badly formed pkg/attr paths from causing errors. They are now treated as literal strings which don't match any known package:

    % FLOX_CATALOG_URL=https://api.preview.flox.dev/ nix run github:flox/flox/v1.6.0 -- install -d ~/tmp 'foo.pkg_group = "bar_group"'
    ❌ ERROR: resolution failed:
    Could not find package 'foo.pkg_group = "bar_group"'.
    Try 'flox search' with a broader search term.

Implemented in:

- https://github.com/flox/floxhub/pull/303

To be deployed to production in:

- https://github.com/flox/floxhub/pull/305

CLI validation would still be useful if we could do it consistently in `manifest::typed` to handle both imperative and declarative installs, but since we can't do that because serde untagged enums swallow any deserialization errors from further down the stack, I think it's better not to special case validation for imperative installs and instead just rely on `catalog-server`.

## Release Notes

N/A
