### PR TITLE
fix(buildenv): Don't outdent null script fields

### DIFF
--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -90,16 +90,16 @@ let
       )
       # [hook] section
       (
-        if (builtins.hasAttr "on-activate" hookSection) then
+        if
+          (builtins.hasAttr "on-activate" hookSection && (builtins.getAttr "on-activate" hookSection) != null)
+        then
           let
             contents = outdentScript (builtins.getAttr "on-activate" hookSection);
+            scriptFile = builtins.toFile "hook-on-activate" contents;
           in
-          if (contents != null) then
-            ''
-              "${coreutils}/bin/cp" ${builtins.toFile "hook-on-activate" contents} $out/activate.d/hook-on-activate
-            ''
-          else
-            ""
+          ''
+            "${coreutils}/bin/cp" ${scriptFile} $out/activate.d/hook-on-activate
+          ''
         else
           ""
       )
@@ -124,19 +124,16 @@ let
       builtins.map
         (
           shellType:
-          if (builtins.hasAttr shellType profileSection) then
+          if
+            (builtins.hasAttr shellType profileSection && (builtins.getAttr shellType profileSection) != null)
+          then
             let
               contents = outdentScript (builtins.getAttr shellType profileSection);
+              scriptFile = builtins.toFile "profile-${shellType}" contents;
             in
-            if (contents != null) then
-              let
-                scriptFile = builtins.toFile "profile-${shellType}" contents;
-              in
-              ''
-                "${coreutils}/bin/cp" ${scriptFile} $out/activate.d/profile-${shellType}
-              ''
-            else
-              ""
+            ''
+              "${coreutils}/bin/cp" ${scriptFile} $out/activate.d/profile-${shellType}
+            ''
           else
             ""
         )
@@ -156,22 +153,15 @@ let
           build = builtins.getAttr buildId buildSection;
         in
         (
-          if (builtins.hasAttr "command" build) then
+          if (builtins.hasAttr "command" build && (builtins.getAttr "command" build) != null) then
             let
               contents = outdentScript (builtins.getAttr "command" build);
+              scriptFile = builtins.toFile "build-${buildId}" contents;
             in
-            if (contents != null) then
-              (
-                let
-                  scriptFile = builtins.toFile "build-${buildId}" contents;
-                in
-                ''
-                  "${coreutils}/bin/mkdir" -p $out/package-builds.d
-                  "${coreutils}/bin/cp" ${scriptFile} $out/package-builds.d/${buildId}
-                ''
-              )
-            else
-              ""
+            ''
+              "${coreutils}/bin/mkdir" -p $out/package-builds.d
+              "${coreutils}/bin/cp" ${scriptFile} $out/package-builds.d/${buildId}
+            ''
           else
             ""
         )

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1829,6 +1829,21 @@ mod buildenv_tests {
         );
     }
 
+    /// Older versions of Flox rendered unspecified script fields as `null` in
+    /// the lockfile, which we should still support building and re-locking.
+    #[test]
+    fn null_script_fields() {
+        let buildenv = buildenv_instance();
+        let lockfile_path = MANUALLY_GENERATED.join("buildenv/lockfiles/null_fields/manifest.lock");
+        let client = MockClient::new();
+        let result = buildenv.build(&client, &lockfile_path, None);
+        assert!(
+            result.is_ok(),
+            "environment should render succesfully: {}",
+            result.unwrap_err()
+        );
+    }
+
     /// Single quotes in variables should be escaped.
     /// Similarly accidentally escaped single quotes like
     ///

--- a/test_data/manually_generated/buildenv/lockfiles/null_fields/manifest.lock
+++ b/test_data/manually_generated/buildenv/lockfiles/null_fields/manifest.lock
@@ -1,0 +1,18 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "hook": {
+      "on-activate": null
+    },
+    "profile": {
+      "common": null,
+      "bash": null,
+      "zsh": null,
+      "fish": null,
+      "tcsh": null
+    },
+    "options": {}
+  },
+  "packages": []
+}


### PR DESCRIPTION
## Proposed Changes

Don't call `outdentScript` on `null` fields as rendered by older versions of Flox. This doubles up the `getAttr` call but I think that's preferable to more nested conditionals.

I was unable to pull this older environment with Flox versions v1.5.0 and later, but pulls with v1.4.2 and earlier still worked, and so did `activate -r` presumably because it hadn't need to rebuild:

    % nix run github:flox/flox/v1.5.0 -- pull dcarley/tailscale
    ❌ ERROR: Failed to build environment:

    Failed to constructed environment: error:
           … while calling the 'derivationStrict' builtin
             at <nix/derivation-internal.nix>:37:12:
               36|
               37|   strict = derivationStrict drvAttrs;
                 |            ^
               38|

           … while evaluating derivation 'environment'
             whose name attribute is located at /nix/store/ffh0da5n98rmmrsqd1l3z1janlck84l3-flox-buildenv-0.0.1/lib/buildenv.nix:252:11

           … while evaluating attribute 'exportReferencesGraph' of derivation 'environment'
             at /nix/store/ffh0da5n98rmmrsqd1l3z1janlck84l3-flox-buildenv-0.0.1/lib/buildenv.nix:325:3:
              324|   # the contents of requisites.txt for each output.
              325|   exportReferencesGraph.graph = inputSrcs ++ [
                 |   ^
              326|     interpreter_out

           (stack trace truncated; use '--show-trace' to show the full, detailed trace)

           error: expected a string but found null: null

I ~~couldn't figure~~ gave up figuring out exactly which version of Flox that environment was last locked with and when we stopped rendering those specific fields, so I just generated the lockfile manually.

I don't think that `build` is technically susceptible to the same problem or worth testing because `build.command` isn't optional.

## Release Notes

Fixed a compatibility issue that was introduced in Flox v1.5.0 that caused environments that were locked with much older Flox versions to no longer build.