### PR TITLE
test(services): Remove LD_AUDIT for Redis

### DIFF
--- a/cli/tests/services/redis.toml
+++ b/cli/tests/services/redis.toml
@@ -1,8 +1,6 @@
 version = 1
 
 [vars]
-# https://github.com/flox/flox/issues/1341
-LD_AUDIT = ""
 # Redis requires this but it's unset on some of our runners/builders.
 LANG = "en_US.UTF-8"
 


### PR DESCRIPTION
## Proposed Changes

We worked around this by setting `GLIBC_TUNABLES` for all activations in 463db712c872d66570f706c879f7db6fe6d3d8b0.

## Release Notes

N/A
