### PR TITLE
refactor: use flox-activations for zsh fpath

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -24,24 +24,31 @@ else
   unset ZDOTDIR
 fi
 
-# Modify dynamic zsh fpath in preference to FPATH in environment.
-# See https://github.com/flox/flox/pull/1299 for more details.
-declare -a fpath_prepend=()
-for i in "${(@s/:/)FLOX_ENV_DIRS}"; do
-  # Check if fpath already contains this env's site-functions directory.
-  # The trick here is that the "i" means inverse subscript, meaning that
-  # it returns the index of the value which follows, and "e" specifies an
-  # exact match. If the value is found it returns the index of the matching
-  # element, but if not it returns the length of the array + 1, hence we
-  # check for any value greater than the length of the array.
-  # TODO: apple puts their stuff first so re-sort fpath by putting flox envs
-  #       first by paring the latter appearances from fpath.
-  if [[ -n "$i" && $fpath[(ie)$i/share/zsh/site-functions] -gt ${#fpath} ]]; then
-    fpath_prepend+=( "$i"/share/zsh/site-functions "$i"/share/zsh/vendor-completions )
-  fi
-done
-if [ ${#fpath_prepend[@]} -gt 0 ]; then
-  fpath=( "${fpath_prepend[@]}" "${fpath[@]}" )
+# Save FPATH before and after rearranging it so we know whether we need to
+# reload completions below.
+old_fpath="$FPATH"
+
+# We use `FPATH` as input here so we can re-use machinery for rearranging
+# PATH-like variables, but we actually output code to set `fpath` instead.
+# 
+# Setting `FPATH` directly has different (e.g. surprising) behavior compared to
+# setting `fpath`. I haven't found first-party documentation stating that this
+# is the case, but FPATH/fpath aren't normal shell variables, and if zsh sees
+# that `FPATH` is set at startup time, it won't proceed with its normal shell
+# function loading procedures (it assumes that `FPATH` is set because you've
+# intentionally done so), which will remove completions already installed to
+# the system.
+#
+# For more details on `fpath` and `FPATH`, see:
+# - `man zshbuiltins`
+# - `man zshparam`
+# - https://zsh.sourceforge.io/Doc/Release/Functions.html
+
+# shellcheck disable=SC1090
+source <($_flox_activations fix-fpath --colon-separated-fpath "$FPATH" --env-dirs "${FLOX_ENV_DIRS:-}")
+new_fpath="$FPATH"
+
+if [ "$old_fpath" != "$new_fpath" ]; then
   autoload -U compinit
   declare -a _flox_compinit_args=()
 
@@ -81,7 +88,6 @@ if [ ${#fpath_prepend[@]} -gt 0 ]; then
     set -x
   fi
 fi
-unset fpath_prepend
 
 if [ "${_FLOX_ACTIVATION_PROFILE_ONLY:-}" != true ]; then
   # Restore environment variables set in the previous bash initialization.

--- a/cli/flox-activations/src/cli/fix_fpath.rs
+++ b/cli/flox-activations/src/cli/fix_fpath.rs
@@ -1,0 +1,60 @@
+use clap::Args;
+
+use super::fix_paths::prepend_dirs_to_pathlike_var;
+use super::separate_dir_list;
+
+#[derive(Debug, Args)]
+pub struct FixFpathArgs {
+    /// The contents of `$FLOX_ENV_DIRS`.
+    #[arg(long)]
+    pub env_dirs: String,
+    /// The contents of `$FPATH` (specifically `$FPATH` and not `$fpath`).
+    #[arg(long)]
+    pub colon_separated_fpath: String,
+}
+
+impl FixFpathArgs {
+    pub fn handle(&self) {
+        let output = Self::handle_inner(&self.env_dirs, &self.colon_separated_fpath);
+        println!("{output}");
+    }
+
+    fn handle_inner(env_dirs_joined: &str, colon_separated_fpath: &str) -> String {
+        let env_dirs = separate_dir_list(env_dirs_joined);
+        let path_dirs = separate_dir_list(colon_separated_fpath);
+        let suffixes = ["share/zsh/site-functions", "share/zsh/vendor-completions"];
+        let fixed_path_dirs = prepend_dirs_to_pathlike_var(&env_dirs, &suffixes, &path_dirs);
+        let as_strs = fixed_path_dirs
+            .into_iter()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        format_fpath_array(&as_strs)
+    }
+}
+
+fn format_fpath_array(dir_list: &[impl AsRef<str>]) -> String {
+    let quoted_dirs = dir_list
+        .iter()
+        .map(|s| format!("\"{}\"", s.as_ref()))
+        .collect::<Vec<_>>();
+    let space_separated = quoted_dirs.join(" ");
+    format!("fpath=({space_separated})")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Most of what we would test here is already covered by tests
+    // in `fix_paths.rs` since that's where `prepend_dirs_to_pathlike_var`
+    // is defined.
+
+    #[test]
+    fn makes_space_separated_array() {
+        let env_dirs = "foo:bar";
+        let fpath = "dir1:dir2";
+        let output = FixFpathArgs::handle_inner(env_dirs, fpath);
+        let expected = r#"fpath=("foo/share/zsh/site-functions" "foo/share/zsh/vendor-completions" "bar/share/zsh/site-functions" "bar/share/zsh/vendor-completions" "dir1" "dir2")"#;
+        assert_eq!(output.as_str(), expected);
+    }
+}

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -73,7 +73,7 @@ impl FixPathsArgs {
 /// If suffixes is empty, adds each dir in FLOX_ENV_DIRS directly.
 pub fn prepend_dirs_to_pathlike_var(
     flox_env_dirs: &[PathBuf],
-    suffixes: &[&str],
+    suffixes: &[impl AsRef<str>],
     existing_dirs: &[PathBuf],
 ) -> Vec<PathBuf> {
     let mut dir_set = HashSet::new();
@@ -91,7 +91,7 @@ pub fn prepend_dirs_to_pathlike_var(
             }
         } else {
             for suffix in suffixes.iter().rev() {
-                let new_dir = dir.join(suffix);
+                let new_dir = dir.join(suffix.as_ref());
                 // Insert returns `true` if the value was _newly_ inserted
                 if dir_set.insert(new_dir.clone()) {
                     dirs.push_front(new_dir)

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -71,6 +71,7 @@ impl FixPathsArgs {
 /// Adds subdirectories of FLOX_ENV_DIRS to the front of the provided list
 /// of directories.
 /// If suffixes is empty, adds each dir in FLOX_ENV_DIRS directly.
+/// Suffixes are expected *not* to contain a leading slash.
 pub fn prepend_dirs_to_pathlike_var(
     flox_env_dirs: &[PathBuf],
     suffixes: &[impl AsRef<str>],

--- a/cli/flox-activations/src/cli/mod.rs
+++ b/cli/flox-activations/src/cli/mod.rs
@@ -4,6 +4,7 @@ use attach::AttachArgs;
 use clap::{Parser, Subcommand};
 
 pub mod attach;
+mod fix_fpath;
 mod fix_paths;
 mod prepend_and_dedup;
 mod profile_scripts;
@@ -11,6 +12,7 @@ mod set_env_dirs;
 mod set_ready;
 mod start_or_attach;
 
+use fix_fpath::FixFpathArgs;
 use fix_paths::FixPathsArgs;
 use prepend_and_dedup::PrependAndDedupArgs;
 use profile_scripts::ProfileScriptsArgs;
@@ -47,6 +49,8 @@ pub enum Command {
         about = "Prepends and dedups environment dirs, optionally pruning directories that aren't from environments"
     )]
     PrependAndDedup(PrependAndDedupArgs),
+    #[command(about = "Print sourceable output fixing fpath/FPATH for zsh.")]
+    FixFpath(FixFpathArgs),
 }
 
 /// Splits PATH-like variables into individual paths, removing any empty strings.

--- a/cli/flox-activations/src/cli/prepend_and_dedup.rs
+++ b/cli/flox-activations/src/cli/prepend_and_dedup.rs
@@ -14,25 +14,20 @@ pub struct PrependAndDedupArgs {
     pub path_like: String,
     /// The suffix to append to each environment directory.
     #[arg(long)]
-    pub suffix: Option<String>,
+    pub suffix: Option<Vec<String>>,
 }
 
 impl PrependAndDedupArgs {
     pub fn handle(&self) {
-        let output = Self::handle_inner(&self.env_dirs, self.suffix.as_ref(), &self.path_like);
+        let output = Self::handle_inner(&self.env_dirs, self.suffix.as_deref(), &self.path_like);
         println!("{output}");
     }
 
-    fn handle_inner(env_dirs_joined: &str, suffix: Option<&String>, path_like: &str) -> String {
+    fn handle_inner(env_dirs_joined: &str, suffixes: Option<&[String]>, path_like: &str) -> String {
         let env_dirs = separate_dir_list(env_dirs_joined);
         let path_dirs = separate_dir_list(path_like);
-        let suffixes = if let Some(s) = suffix {
-            vec![s.as_str()]
-        } else {
-            vec![]
-        };
-        let fixed_path_dirs =
-            prepend_dirs_to_pathlike_var(&env_dirs, suffixes.as_slice(), &path_dirs);
+        let suffixes = suffixes.unwrap_or(&[]);
+        let fixed_path_dirs = prepend_dirs_to_pathlike_var(&env_dirs, suffixes, &path_dirs);
         join_dir_list(fixed_path_dirs)
     }
 }
@@ -49,7 +44,7 @@ mod tests {
     fn handles_empty_pathlike_var() {
         let env_dirs = "foo:bar";
         let suffix = "bin".to_string();
-        let output = PrependAndDedupArgs::handle_inner(env_dirs, Some(&suffix), "");
+        let output = PrependAndDedupArgs::handle_inner(env_dirs, Some(&[suffix]), "");
         assert_eq!(output, "foo/bin:bar/bin");
     }
 

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> Result<(), Error> {
         cli::Command::SetEnvDirs(args) => args.handle()?,
         cli::Command::ProfileScripts(args) => args.handle()?,
         cli::Command::PrependAndDedup(args) => args.handle(),
+        cli::Command::FixFpath(args) => args.handle(),
     }
     Ok(())
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**feat: allow appending multiple suffixes to var**

This extends `flox-activations prepend-and-dedup` to allow the
`--suffix` to take multiple values for the situations in which you need
to append multiple suffixes to an environment directory.

> Note: this ended up not being needed since we need to handle fpath/FPATH carefully, but it could still be useful in the future.

**refactor: use flox-activations for zsh fpath**

This change refactors our Zsh init script to use `flox-activations` to
set `fpath`/`FPATH` in a similar way that we use `flox-activations` to
set `PATH`, `MANPATH`, and other `PATH`-like variables.

The main thing to notice here is that since `flox-activations` operates
on colon-separated variables already, we take `FPATH` as an input, but
generate code that sets `fpath`. Setting `FPATH` directly has unexpected
behavior that causes completions installed to the system to be removed
from `fpath`/`FPATH`.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
