### PR TITLE
fix: detect environment for generations cmds

### DIFF
--- a/cli/flox/src/commands/generations/history.rs
+++ b/cli/flox/src/commands/generations/history.rs
@@ -25,7 +25,9 @@ pub struct History {
 impl History {
     #[instrument(name = "history", skip_all)]
     pub fn handle(self, flox: Flox) -> Result<()> {
-        let env = self.environment.to_concrete_environment(&flox)?;
+        let env = self
+            .environment
+            .detect_concrete_environment(&flox, "Show history for")?;
         environment_subcommand_metric!("generations::history", env);
 
         let env: GenerationsEnvironment = env.try_into()?;

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -24,7 +24,9 @@ pub struct List {
 impl List {
     #[instrument(name = "list", skip_all)]
     pub fn handle(self, flox: Flox) -> Result<()> {
-        let env = self.environment.to_concrete_environment(&flox)?;
+        let env = self
+            .environment
+            .detect_concrete_environment(&flox, "List using")?;
         environment_subcommand_metric!("generations::list", env);
 
         let env: GenerationsEnvironment = env.try_into()?;

--- a/cli/flox/src/commands/generations/rollback.rs
+++ b/cli/flox/src/commands/generations/rollback.rs
@@ -25,7 +25,13 @@ pub struct Rollback {
 impl Rollback {
     #[instrument(name = "rollback", skip_all)]
     pub fn handle(self, flox: Flox) -> Result<()> {
-        let env = self.environment.to_concrete_environment(&flox)?;
+        // TODO(zmitchell, 2025-20-12): `detect_concrete_environment` will prompt
+        // which environment to use even when one of the choices is a path
+        // environment (which fails when selected). We could be smarter about
+        // this in the future.
+        let env = self
+            .environment
+            .detect_concrete_environment(&flox, "Rollback using")?;
 
         environment_subcommand_metric!("generations::rollback", env);
         let mut env: GenerationsEnvironment = env.try_into()?;

--- a/cli/flox/src/commands/generations/switch.rs
+++ b/cli/flox/src/commands/generations/switch.rs
@@ -25,7 +25,9 @@ pub struct Switch {
 impl Switch {
     #[instrument(name = "switch", skip_all)]
     pub fn handle(self, flox: Flox) -> Result<()> {
-        let env = self.environment.to_concrete_environment(&flox)?;
+        let env = self
+            .environment
+            .detect_concrete_environment(&flox, "Switch using")?;
 
         environment_subcommand_metric!("generations::switch", env);
         let mut env: GenerationsEnvironment = env.try_into()?;


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This appears to be a simple typo where `to_concrete_environment` was used in place of `detect_concrete_environment`. The latter does more complete resolution when deciding which environment to perform an action on by considering currently activated environments and handling the default environment specially.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
