### PR TITLE
docs(manifest): Update link in template

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/raw.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/raw.rs
@@ -125,7 +125,7 @@ impl RawManifest {
             ##
             ##   _Everything_ you need to know about the _manifest_ is here:
             ##
-            ##               https://flox.dev/docs/concepts/manifest
+            ##   https://flox.dev/docs/reference/command-reference/manifest.toml/
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
@@ -1160,7 +1160,7 @@ pub(super) mod test {
             ##
             ##   _Everything_ you need to know about the _manifest_ is here:
             ##
-            ##               https://flox.dev/docs/concepts/manifest
+            ##   https://flox.dev/docs/reference/command-reference/manifest.toml/
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
@@ -1284,7 +1284,7 @@ pub(super) mod test {
             ##
             ##   _Everything_ you need to know about the _manifest_ is here:
             ##
-            ##               https://flox.dev/docs/concepts/manifest
+            ##   https://flox.dev/docs/reference/command-reference/manifest.toml/
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
@@ -1412,7 +1412,7 @@ pub(super) mod test {
             ##
             ##   _Everything_ you need to know about the _manifest_ is here:
             ##
-            ##               https://flox.dev/docs/concepts/manifest
+            ##   https://flox.dev/docs/reference/command-reference/manifest.toml/
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
@@ -1533,7 +1533,7 @@ pub(super) mod test {
             ##
             ##   _Everything_ you need to know about the _manifest_ is here:
             ##
-            ##               https://flox.dev/docs/concepts/manifest
+            ##   https://flox.dev/docs/reference/command-reference/manifest.toml/
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
@@ -1643,7 +1643,7 @@ pub(super) mod test {
             ##
             ##   _Everything_ you need to know about the _manifest_ is here:
             ##
-            ##               https://flox.dev/docs/concepts/manifest
+            ##   https://flox.dev/docs/reference/command-reference/manifest.toml/
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI


### PR DESCRIPTION
## Proposed Changes

The redirect without the trailing slash is broken.

We'll need to fix this for existing manifests that have been generated by `flox init`, but it's not trivial right now, and we can avoid the indirection for newer versions:

- https://github.com/flox/floxdocs/issues/307

We moved the manifest concept to the environments concept for reasons described in the following PR, which I still think make sense:

- https://github.com/flox/floxdocs/pull/226

But if you want to learn more about the manifest then it's probably better that you go to the reference page for that specifically.

## Release Notes

N/A
