### PR TITLE
feat(generations): Unhide from --help and update description

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -855,7 +855,7 @@ enum UseCommands {
     )]
     Activate(#[bpaf(external(activate::activate))] activate::Activate),
 
-    /// Interact with services
+    /// Manage services in an environment
     #[bpaf(command)]
     Services(
         #[bpaf(

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -172,7 +172,7 @@ EOF
 
     RUST_LOG=debug run "$FLOX_BIN" services
     assert_success
-    assert_output --partial "Interact with services"
+    assert_output --partial "Manage services in an environment"
 }
 
 @test "all imperative commands error when no services are defined" {

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -84,7 +84,7 @@ Manage environments
 
 Use environments
     activate       Enter the environment, type 'exit' to leave
-    services       Interact with services
+    services       Manage services in an environment
 
 Discover packages
     search         Search for system or library packages to install


### PR DESCRIPTION
## Proposed Changes

**feat(generations): Unhide from --help**

In preparation for upcoming v1.7.0 release.

**docs(gen/serv): Replace "interact" descriptions**

The word "interact" doesn't tell you much and the description for
"generations" did help you to understand what they were if you hadn't
already read about them somewhere else (docs or FloxHub).

## Release Notes

N/A