### PR TITLE
fix: make generations switch error more clear

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -20,6 +20,7 @@
 use std::collections::BTreeMap;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::{env, fs};
 
 use chrono::{DateTime, Utc};
@@ -802,11 +803,20 @@ impl SingleGenerationMetadata {
     derive_more::DerefMut,
     derive_more::From,
     derive_more::Display,
-    derive_more::FromStr,
     DeserializeFromStr,
     SerializeDisplay,
 )]
 pub struct GenerationId(usize);
+
+impl FromStr for GenerationId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(GenerationId(s.parse::<usize>().map_err(|_| {
+            "generations must be referenced by number".to_string()
+        })?))
+    }
+}
 
 /// The type of history event that is associated with a change.
 /// These are generation _creating_ changes (such as install, edit, etc.)


### PR DESCRIPTION
Make the error when a generation number can't be parsed slightly more friendly.

Before:
```
> flox generations switch foo
❌ ERROR: couldn't parse `foo`: invalid digit found in string
```

After:
```
> flox generations switch foo
❌ ERROR: couldn't parse `foo`: generations must be referenced by number
```

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
