### PR TITLE
feat: show package outputs in 'flox list'

### DIFF
--- a/cli/flox-rust-sdk/src/models/lockfile.rs
+++ b/cli/flox-rust-sdk/src/models/lockfile.rs
@@ -234,6 +234,7 @@ pub struct LockedPackageCatalog {
     // endregion
 
     // region: converted fields
+    /// A map of output name to store path
     pub outputs: BTreeMap<String, String>,
     // endregion
 

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -234,6 +234,17 @@ impl List {
 
             let message = match package {
                 PackageToList::Catalog(_, locked) => {
+                    let mut sorted_outputs = locked
+                        .outputs
+                        .keys()
+                        .map(|s| format!("\"{s}\""))
+                        .collect::<Vec<_>>();
+                    sorted_outputs.sort();
+                    let outputs = if sorted_outputs.is_empty() {
+                        "[ ]".to_string()
+                    } else {
+                        format!("[ {} ]", sorted_outputs.join(", "))
+                    };
                     formatdoc! {"
                         {name}:{upgrade_available}
                           Description:  {description}
@@ -244,6 +255,7 @@ impl List {
                           License:      {license}
                           Unfree:       {unfree}
                           Broken:       {broken}
+                          Outputs:      {outputs}
                         ",
                         name = &locked.install_id,
                         pname = &locked.pname,
@@ -257,6 +269,19 @@ impl List {
                     }
                 },
                 PackageToList::Flake(_, package) => {
+                    let mut sorted_outputs = package
+                        .locked_installable
+                        .output_names
+                        .as_slice()
+                        .iter()
+                        .map(|s| format!("\"{s}\""))
+                        .collect::<Vec<_>>();
+                    sorted_outputs.sort();
+                    let outputs = if sorted_outputs.is_empty() {
+                        "[ ]".to_string()
+                    } else {
+                        format!("[ {} ]", sorted_outputs.join(", "))
+                    };
                     let LockedPackageFlake {
                         install_id,
                         locked_installable:
@@ -293,6 +318,7 @@ impl List {
                       {formatted_licenses}
                       Unfree:          {unfree}
                       Broken:          {broken}
+                      Outputs:         {outputs}
                     ",
                         formatted_pname = pname.as_deref().unwrap_or("N/A"),
                         description = description.as_deref().unwrap_or("N/A"),
@@ -514,6 +540,7 @@ mod tests {
               License:      MIT
               Unfree:       true
               Broken:       false
+              Outputs:      [ ]
 
             python_install_id:
               Description:  Python interpreter
@@ -524,6 +551,7 @@ mod tests {
               License:      PSF
               Unfree:       false
               Broken:       false
+              Outputs:      [ ]
         "})
     }
 
@@ -544,6 +572,7 @@ mod tests {
               License:         GPL-3.0
               Unfree:          false
               Broken:          false
+              Outputs:         [ \"out\" ]
         "});
     }
 
@@ -569,6 +598,7 @@ mod tests {
               License:         GPL-3.0
               Unfree:          false
               Broken:          false
+              Outputs:         [ \"out\" ]
         "});
     }
 
@@ -595,6 +625,7 @@ mod tests {
               Licenses:        GPL-3.0, license 2
               Unfree:          false
               Broken:          false
+              Outputs:         [ \"out\" ]
         "});
     }
 
@@ -619,6 +650,7 @@ mod tests {
               License:      PSF
               Unfree:       false
               Broken:       false
+              Outputs:      [ ]
 
             pip_install_id:
               Description:  Python package installer
@@ -629,6 +661,7 @@ mod tests {
               License:      MIT
               Unfree:       true
               Broken:       false
+              Outputs:      [ ]
         "})
     }
 
@@ -653,6 +686,7 @@ mod tests {
               License:      PSF
               Unfree:       false
               Broken:       false
+              Outputs:      [ ]
 
             pip_install_id:
               Description:  Python package installer
@@ -663,6 +697,7 @@ mod tests {
               License:      MIT
               Unfree:       true
               Broken:       false
+              Outputs:      [ ]
         "})
     }
 
@@ -682,6 +717,7 @@ mod tests {
               License:      N/A
               Unfree:       N/A
               Broken:       N/A
+              Outputs:      [ ]
         "})
     }
 
@@ -717,6 +753,7 @@ mod tests {
               License:      MIT
               Unfree:       true
               Broken:       false
+              Outputs:      [ ]
 
             python_install_id:
               Description:  Python interpreter
@@ -727,6 +764,7 @@ mod tests {
               License:      PSF
               Unfree:       false
               Broken:       false
+              Outputs:      [ ]
         "});
     }
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This surfaces the outputs of a package in the `flox list -a` view as shown below.

```
curl:
  Description:  Command line tool for transferring files with URL syntax
  Package Path: curl
  Package Name: curl
  Priority:     5
  Version:      8.14.1
  License:      curl
  Unfree:       false
  Broken:       false
  Outputs:      [ "bin", "dev", "devdoc", "man", "out" ]

ripgrep:
  Description:  Utility that combines the usability of The Silver Searcher with the raw speed of grep
  Package Path: ripgrep
  Package Name: ripgrep
  Priority:     5
  Version:      14.1.1
  License:      [ Unlicense, MIT ]
  Unfree:       false
  Broken:       false
  Outputs:      [ "out" ]

hello:
  Description:     Program that produces a familiar, friendly greeting
  Locked URL:      github:NixOS/nixpkgs/f962ff8e1bc00582f90509ab8dab04f0bacb6859?narHash=sha256-mFuT4MyJLWSKWobuGW24WTs1OjI9xjC%2BJyudOw2Dm%2BU%3D
  Flake attribute: legacyPackages.aarch64-darwin.hello
  Package Name:    hello
  Priority:        5
  Version:         2.12.2
  License:         GPL-3.0-or-later
  Unfree:          false
  Broken:          false
  Outputs:         [ "out" ]
```

Note that this doesn't list the outputs of packages installed via store path.

Closes #3511 

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users will now see the full list of available outputs for each package when using the `flox list --all` command.

<!-- Many thanks! -->
