### PR TITLE
fix: restore FLOX_ENV_DIRS before fpath

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -28,6 +28,15 @@ fi
 # reload completions below.
 old_fpath="$FPATH"
 
+# We already customized the PATH and MANPATH, but the user and system
+# dotfiles may have changed them, so finish by doing this again.
+# We need to restore FLOX_ENV_DIRS before fixing fpath since fpath uses
+# FLOX_ENV_DIRS.
+# shellcheck disable=SC1090
+source <("$_flox_activations" set-env-dirs --shell zsh --flox-env "$FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
+# shellcheck disable=SC1090
+source <("$_flox_activations" fix-paths --shell zsh --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")
+
 # We use `FPATH` as input here so we can re-use machinery for rearranging
 # PATH-like variables, but we actually output code to set `fpath` instead.
 # 
@@ -100,15 +109,11 @@ if [[ -o interactive ]]; then
   source "$_activate_d/set-prompt.zsh"
 fi
 
-# We already customized the PATH and MANPATH, but the user and system
-# dotfiles may have changed them, so finish by doing this again.
-source <("$_flox_activations" set-env-dirs --shell zsh --flox-env "$FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
-source <("$_flox_activations" fix-paths --shell zsh --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")
-
 # Our ZDOTDIR startup files source user RC files that may modify FLOX_ENV_DIRS,
 # and then _flox_env_helper may fix it up.
 # If this happens, we want to respect those modifications,
 # so we use FLOX_ENV_DIRS from the environment
+# shellcheck disable=SC1090
 source <("$_flox_activations" profile-scripts --shell zsh --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}" --env-dirs "$FLOX_ENV_DIRS")
 
 # Disable command hashing to allow for newly installed flox packages


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This addresses a long standing bug described here: https://github.com/flox/flox/issues/1853#issuecomment-3120552520

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
