### PR TITLE
feat: add CLI commands to generations history

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -80,6 +80,8 @@ pub struct Flox {
     pub system: String,
     pub system_user_name: String,
     pub system_hostname: String,
+    // The command used to run flox
+    pub argv: Vec<String>,
 
     pub floxhub: Floxhub,
 
@@ -367,6 +369,7 @@ pub mod test_helpers {
             system: env!("NIX_TARGET_SYSTEM").to_string(),
             system_user_name: "its-a-me-mario".to_string(),
             system_hostname: "mushroom-kingdom".to_string(),
+            argv: vec![],
             cache_dir,
             data_dir,
             state_dir,

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -253,6 +253,7 @@ impl Environment for ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
@@ -310,6 +311,7 @@ impl Environment for ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
@@ -345,6 +347,7 @@ impl Environment for ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
@@ -393,6 +396,7 @@ impl Environment for ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
@@ -435,6 +439,7 @@ impl Environment for ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
@@ -632,6 +637,7 @@ impl GenerationsExt for ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::Generations)?;
 
@@ -1008,6 +1014,7 @@ impl ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
@@ -1083,6 +1090,7 @@ impl ManagedEnvironment {
                 flox.temp_dir.clone(),
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
@@ -1250,6 +1258,7 @@ impl ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?
             .get_current_generation(self.include_fetcher.clone())
@@ -1468,6 +1477,7 @@ impl ManagedEnvironment {
                 &flox.temp_dir,
                 &flox.system_user_name,
                 &flox.system_hostname,
+                &flox.argv,
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
@@ -1986,7 +1996,10 @@ mod test {
         .unwrap();
 
         let mut writable = generations
-            .writable(&base_tempdir, "username", "hostname")
+            .writable(&base_tempdir, "username", "hostname", &[
+                "flox".to_string(),
+                "subcommand".to_string(),
+            ])
             .unwrap();
         writable.add_generation(env, HistoryKind::Import).unwrap();
 

--- a/cli/flox/src/commands/generations/history.rs
+++ b/cli/flox/src/commands/generations/history.rs
@@ -63,7 +63,16 @@ impl Display for DisplayChange<'_> {
             Author:     {author}
             Host:       {host}
             Generation: {generation}
-            Summary:    {summary}"})
+            "})?;
+
+        if let Some(command) = &self.change.command {
+            let command = command.join(" ");
+            write!(f, "{}", formatdoc! {"
+            Command:    {command}
+            "})?;
+        }
+        write!(f, "{}", formatdoc! {"
+        Summary:    {summary}"})
     }
 }
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -350,6 +350,7 @@ impl FloxArgs {
         let system_user_name =
             std::env::var("USER").context("could not determine username from $USER")?;
         let system_hostname = sys_info::hostname().context("could not determine hostname")?;
+        let argv = std::env::args().collect();
 
         let flox = Flox {
             cache_dir: config.flox.cache_dir.clone(),
@@ -361,6 +362,7 @@ impl FloxArgs {
             system: env!("NIX_TARGET_SYSTEM").to_string(),
             system_user_name,
             system_hostname,
+            argv,
             floxhub_token,
             floxhub,
             catalog_client,

--- a/cli/tests/generations.bats
+++ b/cli/tests/generations.bats
@@ -1,0 +1,73 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test rust impl of `flox generations`
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+# bats file_tags=generations
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.yaml"
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  setup_isolated_flox
+  project_setup
+  floxhub_setup "owner"
+}
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "commands are displayed for generations history" {
+  mkdir -p "machine_a"
+  mkdir -p "machine_b"
+
+  "$FLOX_BIN" init --name "test"
+  "$FLOX_BIN" push --owner owner
+
+  # Make a few modifications
+  # 1. an edit
+  MANIFEST_CONTENTS="$(cat << "EOF"
+    version = 1
+EOF
+  )"
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -f -
+
+  # 2. an install
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml" \
+    "$FLOX_BIN" install hello
+
+  # 3. switch generation, but set argv[0] to foo
+  (exec -a foo "$FLOX_BIN" generations switch 1)
+
+  run "$FLOX_BIN" generations history
+  assert_line "Command:    flox push --owner owner"
+  assert_line "Command:    flox edit -f -"
+  assert_line "Command:    flox install hello"
+  # Regardless of argv[0], we always print 'flox'
+  assert_line "Command:    flox generations switch 1"
+}

--- a/cli/tests/push.bats
+++ b/cli/tests/push.bats
@@ -40,24 +40,6 @@ teardown() {
   common_test_teardown
 }
 
-# simulate a dummy env update pushed to floxhub
-function update_dummy_env() {
-  OWNER="$1"
-  shift
-  ENV_NAME="$1"
-  shift
-
-  FLOXHUB_FLOXMETA_DIR="$BATS_TEST_TMPDIR/floxhub/$OWNER/floxmeta"
-
-  pushd "$FLOXHUB_FLOXMETA_DIR" >/dev/null || return
-
-  touch new_file
-  git add .
-  git commit -m "update"
-
-  popd >/dev/null || return
-}
-
 # ---------------------------------------------------------------------------- #
 # These don't need the catalog
 


### PR DESCRIPTION
### feat: add argv to Flox struct

This will be used by `generations history` to record what command was
used to modify an environment.

### test: drop dead helper

update_dummy_env is unused in push.bats

### feat: add CLI commands to generations history

Display the command used to modify an environment in `generations
history`.

This provides a more precise record of how the environment was modified.

Example output:
```
* Date:       2025-08-13 22:55:41 UTC
  Author:     author
  Host:       host
  Generation: 2
  Command:    flox install hello
  Summary:    installed package 'hello (hello)'
```

## Release Notes

NA