### PR TITLE
style: Polish output for generations list and history

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -889,7 +889,7 @@ impl HistorySpec {
         match &self.info {
             HistoryKind::Import => "imported unmanaged path environment".to_string(),
             HistoryKind::MigrateV1 { description } => {
-                format!("migrated generation from v1 metadata: {description}")
+                format!("{description} [metadata migrated]")
             },
             HistoryKind::Install { targets } => format_targets("installed", "package", targets),
             HistoryKind::Edit => "manually edited the manifest".to_string(),


### PR DESCRIPTION
Closes #3500 

## Proposed Changes

* Reserve asterisks for marking the current generation in the `generations list` subcommand (remove from `generations history` entirely)
* Bold the first line of each entry to emphasize the sort order of `generations list` (generation) and `generations history` (date).
* Highlight `(current)` in yellow to visually emphasize what generation is current
* Left-align field values in the `generations list` subcommand (to match the formatting style of `generations history`.
* Ensure the current version has a `Last Active` field (set to `Now`) for consistency with other versions.
* Simplify the v1 migration message to `[metadata migrated]` and move it to the end of the description so it doesn't feel quite so redundant.

## Demo

https://github.com/user-attachments/assets/64a9ccbc-f510-49e0-acd2-95bdbb3e72e7

## Release Notes

N/A
