### PR TITLE
fix: wording tweaks: {current,active} -> live

### DIFF
--- a/cli/flox/doc/flox-generations-list.md
+++ b/cli/flox/doc/flox-generations-list.md
@@ -23,7 +23,7 @@ For environments pushed to FloxHub, every modification to the environment
 creates a new generation of the environment.
 
 `flox generations list` prints all generations of the environment, including
-which generation is currently active.
+which generation is currently live.
 
 ```{.include}
 ./include/environment-options.md

--- a/cli/flox/doc/flox-generations-rollback.md
+++ b/cli/flox/doc/flox-generations-rollback.md
@@ -6,7 +6,7 @@ header: "Flox User Manuals"
 
 # NAME
 
-flox-generations-rollback - switch to the previous generation
+flox-generations-rollback - switch to the previous live generation
 
 # SYNOPSIS
 
@@ -17,13 +17,13 @@ flox [<general-options>] generations rollback
 
 # DESCRIPTION
 
-Switch to the previously active generation of the environment.
+Switch to the previous live generation of the environment.
 
 Rolling back to the previous generation restores the environment's manifest and
 lockfile to the state of the previous generation, sets it as the current
-generation, and adds an entry the generation history.
+generation, and adds an entry to generation history.
 
-The previously active generation isn't always N-1. If you've previously rolled
+The previously live generation isn't always N-1. If you've previously rolled
 back from generation 3 -> 2 then rolling back again will take you from
 generation 2 -> 3. Similarly if you've switched from generation 3 -> 1 then
 rolling back will take you from generation 1 -> 3.

--- a/cli/flox/doc/flox-generations-rollback.md
+++ b/cli/flox/doc/flox-generations-rollback.md
@@ -20,7 +20,7 @@ flox [<general-options>] generations rollback
 Switch to the previous live generation of the environment.
 
 Rolling back to the previous generation restores the environment's manifest and
-lockfile to the state of the previous generation, sets it as the current
+lockfile to the state of the previous generation, sets it as the live
 generation, and adds an entry to generation history.
 
 The previously live generation isn't always N-1. If you've previously rolled

--- a/cli/flox/doc/flox-generations-switch.md
+++ b/cli/flox/doc/flox-generations-switch.md
@@ -26,7 +26,7 @@ Generation numbers can be found with
 
 Switching generation restores the environment's manifest and lockfile to the
 state of the specified generation, sets it as the current generation, and adds
-an entry the generation history.
+an entry to generation history.
 
 Generations don't always have a linear history. If you create generation 2 by
 installing a package, rollback to generation 1 and create generation 3 by

--- a/cli/flox/doc/flox-generations-switch.md
+++ b/cli/flox/doc/flox-generations-switch.md
@@ -25,7 +25,7 @@ Generation numbers can be found with
 [`flox-generations-list(1)`](./flox-generations-list.md).
 
 Switching generation restores the environment's manifest and lockfile to the
-state of the specified generation, sets it as the current generation, and adds
+state of the specified generation, sets it as the live generation, and adds
 an entry to generation history.
 
 Generations don't always have a linear history. If you create generation 2 by

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -49,8 +49,8 @@ impl Display for DisplayMetadata<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let description = &self.metadata.description;
         let created = self.metadata.created;
-        let last_active = if let Some(last_active) = self.metadata.last_active {
-            last_active.to_string()
+        let last_live = if let Some(last_live) = self.metadata.last_live {
+            last_live.to_string()
         } else {
             "Now".to_string()
         };
@@ -58,7 +58,7 @@ impl Display for DisplayMetadata<'_> {
         write!(f, "{}", formatdoc! {"
             Description: {description}
             Created:     {created}
-            Last Active: {last_active}"})
+            Last Live:   {last_live}"})
     }
 }
 
@@ -130,7 +130,7 @@ mod tests {
         let actual = DisplayMetadata {
             metadata: &SingleGenerationMetadata {
                 created: DateTime::default(),
-                last_active: Some(DateTime::default()),
+                last_live: Some(DateTime::default()),
                 description: "Generation description".to_string(),
             },
         }
@@ -139,7 +139,7 @@ mod tests {
         let expected = indoc! {"
             Description: Generation description
             Created:     1970-01-01 00:00:00 UTC
-            Last Active: 1970-01-01 00:00:00 UTC"
+            Last Live:   1970-01-01 00:00:00 UTC"
         };
 
         assert_eq!(actual, expected);
@@ -151,7 +151,7 @@ mod tests {
         let actual = DisplayMetadata {
             metadata: &SingleGenerationMetadata {
                 created: DateTime::default(),
-                last_active: None,
+                last_live: None,
                 description: "Generation description".to_string(),
             },
         }
@@ -160,7 +160,7 @@ mod tests {
         let expected = indoc! {"
             Description: Generation description
             Created:     1970-01-01 00:00:00 UTC
-            Last Active: Now"
+            Last Live:   Now"
         };
 
         assert_eq!(actual, expected);
@@ -194,17 +194,17 @@ mod tests {
             Generation:  1
             Description: mock
             Created:     1970-01-01 01:00:00 UTC
-            Last Active: 1970-01-01 02:00:00 UTC
+            Last Live:   1970-01-01 02:00:00 UTC
 
             Generation:  2 (current)
             Description: mock
             Created:     1970-01-01 02:00:00 UTC
-            Last Active: Now
+            Last Live:   Now
 
             Generation:  3
             Description: mock
             Created:     1970-01-01 03:00:00 UTC
-            Last Active: 1970-01-01 04:00:00 UTC"
+            Last Live:   1970-01-01 04:00:00 UTC"
         };
 
         assert_eq!(actual, expected);

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -67,7 +67,7 @@ impl Display for DisplayMetadata<'_> {
 ///
 /// Current version:
 /// ```text
-/// Generation: <generation id> (current)
+/// Generation: <generation id> (live)
 /// <generation metadata>          # implemented by [DisplayMetadata] above
 /// ```
 ///
@@ -83,7 +83,7 @@ impl Display for DisplayAllMetadata<'_> {
         while let (Some((id, metadata)), peek) = (iter.next(), iter.peek()) {
             let generation = format!("Generation:  {id}");
             let current = if Some(id) == self.0.current_gen() {
-                " (current)"
+                " (live)"
             } else {
                 ""
             };
@@ -196,7 +196,7 @@ mod tests {
             Created:     1970-01-01 01:00:00 UTC
             Last Live:   1970-01-01 02:00:00 UTC
 
-            Generation:  2 (current)
+            Generation:  2 (live)
             Description: mock
             Created:     1970-01-01 02:00:00 UTC
             Last Live:   Now

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -26,7 +26,7 @@ pub enum GenerationsCommands {
     #[bpaf(command)]
     History(#[bpaf(external(history::history))] history::History),
 
-    /// Switch to the previously active generation
+    /// Switch to the previous live generation
     #[bpaf(command)]
     Rollback(#[bpaf(external(rollback::rollback))] rollback::Rollback),
 

--- a/cli/flox/src/commands/generations/rollback.rs
+++ b/cli/flox/src/commands/generations/rollback.rs
@@ -57,7 +57,7 @@ impl Rollback {
     }
 }
 
-/// "previous generation" currently means "previously active"
+/// "previous generation" currently means "previously live"
 /// (as opposed to e.g. originating generation or generation N-1).
 /// That implies that switching to the "previous generation",
 /// i.e. rollback, returns at the original generation.
@@ -69,7 +69,7 @@ fn determine_previous_generation(
     metadata
         .generations()
         .into_iter()
-        .sorted_by_key(|(_id, meta)| meta.last_active)
+        .sorted_by_key(|(_id, meta)| meta.last_live)
         .next_back()
 }
 
@@ -101,11 +101,11 @@ mod tests {
 
     /// Use mock generations that were rolled back once from generation 3 -> genration 2.
     /// By our current definition of "previous generation" we expect another rollback
-    /// to "roll forward" to generation 3, as thats the one previously active.
+    /// to "roll forward" to generation 3, as thats the one previously live.
     #[test]
-    fn rollback_rolls_back_to_newer_generation_if_previously_active() {
+    fn rollback_rolls_back_to_newer_generation_if_previously_live() {
         // e.g. rolled back once 3->2
-        // last created active
+        // last created live
         let mut metadata = AllGenerationsMetadata::default();
         metadata.add_generation(default_add_generation_options());
         metadata.add_generation(default_add_generation_options());


### PR DESCRIPTION
### fix: wording tweak: active -> live

Use "live" instead of "active" when describing the currently live generation.

Also print "Last Live" in `flox generations list`

Active is overloaded since we have `flox activate`, and "last active"
mean either "last time `flox activate` was run with this generation" or
"last time this generation was the current version of the environment"

### fix: wording tweak: current -> live

Use "live" instead of "current" when referring to generations.

Also print "(live)" instead of "(current)" in `flox generations list`

The word "current" means "most recent" which has an implication about
time.

Because you can switch to an older generation that is not "most recent,"
"current" has some incorrect implications. We avoid the word "latest"
for the same reasons (although with "latest," it's a bit more overt)

Because of it's implications about time, "current" is also hard to use
in documentation or messaging about the past. "Previously current" or
"last current" are oxymorons.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
