### PR TITLE
feat(generations): alias as `flox generation`

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -962,7 +962,7 @@ enum ModifyCommands {
     Uninstall(#[bpaf(external(uninstall::uninstall))] uninstall::Uninstall),
 
     /// Version control for environments pushed to FloxHub
-    #[bpaf(command)]
+    #[bpaf(command, long("generations"), long("generation"))]
     Generations(
         #[bpaf(
             external(generations::generations_commands),


### PR DESCRIPTION
## Proposed Changes

Allow to run generation commands with both `flox generations` and `flox generation`
