### PR TITLE
fix: omit stub outputs

### DIFF
--- a/assets/environment-interpreter/common/etc/profile.d/0800_cuda.sh
+++ b/assets/environment-interpreter/common/etc/profile.d/0800_cuda.sh
@@ -44,7 +44,7 @@ activate_cuda() {
   if [ -z "$SYSTEM_LIBS" ]; then
     # shellcheck disable=SC2016
     SYSTEM_LIBS=$(
-      { "$_find" "${fhs_root_prefix}/run/opengl-driver" -type f -print 2> /dev/null || echo; } \
+      { "$_find" -L "${fhs_root_prefix}/run/opengl-driver" -type f -print 2> /dev/null || echo; } \
         | "$_nawk" -v lib_pattern="${lib_pattern}" \
           'BEGIN {files=""} $0 ~ lib_pattern {files = ( files == "" ? $NF : files ":" $NF)} END {print files}'
     )

--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -221,7 +221,10 @@ let
               # from the following conditional.
               filteredOutputs =
                 if (true || outputsToInstall == null) then
-                  (builtins.attrValues package.outputs)
+                  # Filter out outputs named `stubs` because they're needed at build time,
+                  # but break things at run time. This may be unnecessary once we do
+                  # "outputs to install".
+                  (builtins.attrValues (builtins.removeAttrs package.outputs [ "stubs" ]))
                 else
                   (builtins.map (x: builtins.getAttr x package.outputs) outputsToInstall);
             in


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**fix: follow symlinks in find command**

In the NixOS fallback command for CUDA detection, we crawl the user's
system with a `find` command. On NixOS, however, `/run/opengl-driver`
is a symlink that contains the drivers. Without the `-L` flag, the
drivers are never found on NixOS.

**fix: omit "stubs" output in buildenv.nix**

This is a temporary fix to omit the `stubs` output of packages that
install stub libraries to be used at build time, when other libraries
are needed at run time.

This is a mitigation for an issue caused by our recursive linking:
```
lib-stubs-pkg/
  lib/
    mylib.so <-- really a stub
    stubs/
      mylib.so <-- really a stub
lib-pkg/
  lib/
    otherlib.so
    stubs --> lib-stubs-pkg/lib/stubs
FLOX_ENV/
  lib/
    mylib.so <-- really a stub
    otherlib.so
    stubs/
      ...
```

When `lib-stubs-pkg` and `lib-pkg` are merged, the stub library
`lib-stubs-pkg/lib/mylib.so` is brought in at `FLOX_ENV/lib/mylib.so`,
putting it on the default search path for libraries. This is fine at
build time, but causes the binary to try to use the stub library
at runtime (in the same environment).

Since the `libs` output of the package contains a symlink to the
`stubs` output, it knows how to reach the stubs if necessary.

**fix: omit "stubs" outputs in Perl builder**

After omitting the `stubs` output in `buildenv.nix`, the stub libraries
were still found in the recursively linked environment. We tracked this
down to the Perl builder recursively including propagated build inputs.

This change omits *all* outputs whose store paths end in `-stubs`, which
is how a store path would be formatted for a `stubs` output of a larger
package. We could tailor this to be more specific.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
