### PR TITLE
docs: try to better differentiate the generations `list` and `history` subcommands

### DIFF
--- a/cli/flox/doc/flox-generations-history.md
+++ b/cli/flox/doc/flox-generations-history.md
@@ -6,7 +6,7 @@ header: "Flox User Manuals"
 
 # NAME
 
-flox-generations-history - print the history of the environment
+flox-generations-history - Show the change log for the current environment
 
 # SYNOPSIS
 
@@ -17,7 +17,7 @@ flox [<general-options>] generations history
 
 # DESCRIPTION
 
-Print the history of the environment.
+Show the change log for the current environment.
 
 For environments pushed to FloxHub, every modification to the environment
 creates a new generation of the environment.

--- a/cli/flox/doc/flox-generations-list.md
+++ b/cli/flox/doc/flox-generations-list.md
@@ -6,7 +6,7 @@ header: "Flox User Manuals"
 
 # NAME
 
-flox-generations-list - list generations of the environment
+flox-generations-list - show all environment generations that you can switch to
 
 # SYNOPSIS
 
@@ -17,7 +17,7 @@ flox [<general-options>] generations list
 
 # DESCRIPTION
 
-List generations of the environment.
+Show all environment generations that you can switch to.
 
 For environments pushed to FloxHub, every modification to the environment
 creates a new generation of the environment.
@@ -34,4 +34,3 @@ which generation is currently live.
 [`flox-generations-history(1)`](./flox-generations-history.md)
 [`flox-generations-rollback(1)`](./flox-generations-rollback.md)
 [`flox-generations-switch(1)`](./flox-generations-switch.md)
-

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -18,11 +18,11 @@ pub enum GenerationsCommands {
     #[bpaf(command, hide)]
     Help,
 
-    /// List generations of the environment
+    /// Show all environment generations that you can switch to
     #[bpaf(command)]
     List(#[bpaf(external(list::list))] list::List),
 
-    /// Print the history of the environment
+    /// Show the change log for the current environment
     #[bpaf(command)]
     History(#[bpaf(external(history::history))] history::History),
 


### PR DESCRIPTION
## Proposed Changes

The CLI help text for `generations list` and `generations history` isn't doing a good job of explaining how they differ.

This PR updates the text to try and emphasize that `generations list` is showing a list of things you can switch between, while `generations history` is showing the sequence of changes that led to the current environment definition.

This is complicated a bit by the fact that `generations` isn't a common word to describe the underlying concept of versions or snapshot, and our help text shouldn't redefine `generations` everywhere that it's used.

## Release Notes

* Update the help text of the `generations list` and `generations history` subcommands

