### PR TITLE
fix: tweak imported environment wording

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -1013,7 +1013,7 @@ impl HistorySpec {
         }
 
         match &self.kind {
-            HistoryKind::Import => "imported unmanaged path environment".to_string(),
+            HistoryKind::Import => "imported environment".to_string(),
             HistoryKind::MigrateV1 { description } => {
                 format!("{description} [metadata migrated]")
             },


### PR DESCRIPTION
I think "unmanaged path" doesn't mean much to a user, so drop it from the summary line "imported unmanaged path environment"

## Release Notes

NA