### PR TITLE
feat: add hidden path-hash command

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod init;
 mod install;
 mod list;
 mod lock_manifest;
+mod path_hash;
 mod publish;
 mod pull;
 mod push;
@@ -1095,6 +1096,11 @@ enum InternalCommands {
     /// Print information how to exit environment
     #[bpaf(command, long("exit"), long("deactivate"), hide)]
     Exit(#[bpaf(external(exit::exit))] exit::Exit),
+
+    /// Print the hash of a filesystem path. Useful for determining which
+    /// activation state directory to look at while debugging.
+    #[bpaf(command, long("path-hash"), hide)]
+    PathHash(#[bpaf(external(path_hash::path_hash))] path_hash::PathHash),
 }
 
 impl InternalCommands {
@@ -1105,6 +1111,7 @@ impl InternalCommands {
             InternalCommands::LockManifest(args) => args.handle(flox).await?,
             InternalCommands::CheckForUpgrades(args) => args.handle(flox).await?,
             InternalCommands::Exit(args) => args.handle(flox)?,
+            InternalCommands::PathHash(args) => args.handle()?,
         }
         Ok(())
     }

--- a/cli/flox/src/commands/path_hash.rs
+++ b/cli/flox/src/commands/path_hash.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+use bpaf::Bpaf;
+
+#[derive(Debug, Clone, Bpaf)]
+pub struct PathHash {
+    /// The path to compute the hash of. If not specified, we fall back
+    /// to the hash of `$FLOX_ENV`.
+    #[bpaf(positional("path"))]
+    pub path: Option<PathBuf>,
+}
+
+impl PathHash {
+    pub fn handle(&self) -> Result<(), anyhow::Error> {
+        let path = if let Some(path) = self.path.as_ref() {
+            path.clone()
+        } else {
+            let flox_env = std::env::var("FLOX_ENV").context("FLOX_ENV not set")?;
+            PathBuf::from(flox_env)
+        };
+        let hash = flox_core::path_hash(&path);
+        println!("{hash}");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This is an internal command solely for debugging. It prints out a hash of the specified path, or of `$FLOX_ENV` if it's defined. This will be used to figure out which directory in `~/.cache/flox/run` belongs to a specific activation.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
