### PR TITLE
feat: minimal options for flox init

### DIFF
--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -86,6 +86,10 @@ pub struct Init {
     /// make suggestions.
     #[bpaf(long)]
     no_auto_setup: bool,
+
+    /// Set up the environment with the emptiest possible manifest.
+    #[bpaf(short, long)]
+    bare: bool,
 }
 
 impl Init {
@@ -119,7 +123,8 @@ impl Init {
 
         // Don't run language hooks for "default" environment
         let should_customize = !default_environment || self.auto_setup;
-        let customization = if self.no_auto_setup {
+        let skip_customize = self.bare || self.no_auto_setup;
+        let customization = if skip_customize {
             debug!("user asked to skip auto-setup");
             InitCustomization::default()
         } else if should_customize {
@@ -138,16 +143,19 @@ impl Init {
             }
         };
 
+        let path_pointer = PathPointer::new(env_name);
         let env = if customization.packages.is_some() {
             info_span!(
                 "init_with_suggested_packages",
                 progress = "Installing Flox suggested packages"
             )
-            .in_scope(|| {
-                PathEnvironment::init(PathPointer::new(env_name), &dir, &customization, &flox)
-            })?
+            .in_scope(|| PathEnvironment::init(path_pointer, &dir, &customization, &flox))?
+        } else if self.bare {
+            debug!("creating environment with bare manifest");
+            PathEnvironment::init_bare(path_pointer, &dir, &flox)?
         } else {
-            PathEnvironment::init(PathPointer::new(env_name), &dir, &customization, &flox)?
+            debug!("creating environment");
+            PathEnvironment::init(path_pointer, &dir, &customization, &flox)?
         };
 
         let env_in_git_repo = GitCommandProvider::discover(&dir).is_ok();

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -245,6 +245,14 @@ EOF
   FLOX_SHELL=zsh "$FLOX_BIN" activate --trust -r "$OWNER/$NAME" -- python -c "import requests"
 }
 
+@test "inits with bare manifest" {
+  "$FLOX_BIN" init --bare
+  # -z: treats the whole input as a single line
+  # 's/\n*$//': replace any trailing newlines with an empty string
+  # In short, remove any trailing newlines from the manifest.
+  manifest="$("$FLOX_BIN" list -c | sed -z 's/\n*$//')"
+  assert_equal "$manifest" "version = 1"
+}
 # ---------------------------------------------------------------------------- #
 #
 #


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
**feat: add --no-auto-setup flag**

In some cases you want to initialize an environment in a repository that
has an existing project in it, but you don't want Flox to prompt you
about suggested packages. This flag prevents the CLI from prompting you
when you know you don't want the suggested packages.

Reasons why you might want that:
- You want to install packages from a particular catalog rather than the
  base catalog.
- You disagree with the existing auto-setup-provided hooks.
- You just prefer to write things yourself.

**feat: add --bare flag for minimal init**

A common workflow for those of us that like small manifests is to
manually delete all of the manifest contents after running `flox init`.
This is just extra work when all you want is an empty manifest. This
flag initializes the environment with the following manifest:

```
version = 1
```

This is the smallest legal manifest.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Users can now save a small amount of time when creating environments if they don't want to apply suggestions from the CLI or any of the default manifest template.

<!-- Many thanks! -->
