### PR TITLE
fix: allow -f instead of --follow

### DIFF
--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -20,6 +20,7 @@ pub struct Logs {
     environment: EnvironmentSelect,
 
     /// Follow log output
+    #[bpaf(short('f'), long)]
     follow: bool,
 
     /// Number of lines to show from the end of the logs


### PR DESCRIPTION
Allos `flox services logs -f`. Because that's what every tool ever does

## Release Notes

We added the overlooked short option `-f` for `--follow`