### PR TITLE
docs: remove double --dir

### DIFF
--- a/cli/flox/doc/flox-services-logs.md
+++ b/cli/flox/doc/flox-services-logs.md
@@ -36,9 +36,6 @@ An error will be returned if a specified service does not exist.
 
 # OPTIONS
 
-`-d`, `--dir`
-:   Path containing a .flox/ directory.
-
 `--follow`
 :   Follow log output for the specified services. Required when no service
     names are supplied.

--- a/cli/flox/doc/flox-services-restart.md
+++ b/cli/flox/doc/flox-services-restart.md
@@ -39,9 +39,6 @@ An error is displayed if the specified service does not exist.
 
 # OPTIONS
 
-`-d`, `--dir`
-:   Path containing a .flox/ directory.
-
 `<name>`
 :   The name(s) of the services to restart.
 

--- a/cli/flox/doc/flox-services-start.md
+++ b/cli/flox/doc/flox-services-start.md
@@ -37,9 +37,6 @@ of how many times the environment is activated concurrently.
 
 # OPTIONS
 
-`-d`, `--dir`
-:   Path containing a .flox/ directory.
-
 `<name>`
 :   The name(s) of the services to start.
 

--- a/cli/flox/doc/flox-services-start.md
+++ b/cli/flox/doc/flox-services-start.md
@@ -62,13 +62,13 @@ $ flox services start
 Attempt to start a service that doesn't exist:
 ```
 $ flox services start myservice doesnt_exist
-❌ ERROR: Service 'doesnt_exist' not found.  
+❌ ERROR: Service 'doesnt_exist' not found.
 ```
 
 Attempt to start a service that is already running:
 ```
 $ flox services start running not_running
-✅ Service 'not_running' started  
+✅ Service 'not_running' started
 ⚠️  Service 'running' is already running
 ```
 

--- a/cli/flox/doc/flox-services-status.md
+++ b/cli/flox/doc/flox-services-status.md
@@ -28,9 +28,6 @@ does not exist.
 
 # OPTIONS
 
-`-d`, `--dir`
-:   Path containing a .flox/ directory.
-
 `--json`
 :   Print statuses formatted as JSON. Each service is printed as a single JSON
     object on its own line.

--- a/cli/flox/doc/flox-services-stop.md
+++ b/cli/flox/doc/flox-services-stop.md
@@ -58,14 +58,14 @@ $ flox services stop
 Attempt to stop a service that doesn't exist:
 ```
 $ flox services stop myservice doesnt_exist
-❌ ERROR: Service 'doesnt_exist' not found.  
+❌ ERROR: Service 'doesnt_exist' not found.
 ```
 
 Attempt to stop a service that isn't running:
 ```
 $ flox services stop running not_running
 ⚠️  Service 'not_running' is not running
-✅ Service 'running' stopped  
+✅ Service 'running' stopped
 ```
 
 # SEE ALSO

--- a/cli/flox/doc/flox-services-stop.md
+++ b/cli/flox/doc/flox-services-stop.md
@@ -33,9 +33,6 @@ non-zero exit code will be returned.
 
 # OPTIONS
 
-`-d`, `--dir`
-:   Path containing a .flox/ directory.
-
 `<name>`
 :   The name(s) of the services to stop.
 


### PR DESCRIPTION
docs: remove double --dir

All our services man pages have `--dir` in them twice, once inline and
once via an include

docs: fix trailing whitespace

## Release Notes

NA