### PR TITLE
feat: output processed markdown manpages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,7 @@
           flox-activations = callPackage ./pkgs/flox-activations { };
           flox-cli = callPackage ./pkgs/flox-cli { };
           flox-manpages = callPackage ./pkgs/flox-manpages { }; # Flox Command Line Interface Manpages
+          flox-manpages-md = callPackage ./pkgs/flox-manpages { outputFormat = "markdown"; }; # Flox Command Line Interface Manpages (as markdown)
           flox = callPackage ./pkgs/flox { }; # Flox Command Line Interface ( production build ).
 
           # Wrapper scripts for running test suites.
@@ -192,6 +193,7 @@
           flox-cli
           flox-cli-tests
           flox-manpages
+          flox-manpages-md
           flox
           ld-floxlib
           pre-commit-check


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Creates a Nix output, `flox-manpages-md` that contains the processed markdown files. These markdown files have all of the `include`s resolved, which is necessary for consumption by some static site generators.

The output directory looks like this (mostly because it didn't require any work):
```
$out/
  share/
    man/
      manmd/
        *.md
```

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
