### PR TITLE
fix: buildenv empty outputs_to_install bug

### DIFF
--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -434,7 +434,7 @@ if ($manifest) {
                     $package->{"outputs_to_install"} = $package->{"outputs-to-install"};
                 }
                 unless ( defined $package->{"outputs_to_install"} ) {
-                    $package->{"outputs_to_install"} = keys %{$package->{"outputs"}};
+                    @{$package->{"outputs_to_install"}} = grep { $_ ne "log" } keys %{$package->{"outputs"}};
                 }
                 foreach my $output (keys %{$package->{"outputs"}}) {
                     # Unfortunately, due to pkgdb limitations in the 1.0 release we

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -179,7 +179,7 @@ pub struct BuildResultMeta {
     pub unfree: Option<bool>,
 
     #[serde(rename = "outputsToInstall")]
-    pub outputs_to_install: Option<Vec<String>>,
+    pub outputs_to_install: Vec<String>,
 }
 
 /// A manifest builder that uses the [FLOX_BUILD_MK] makefile to build packages.
@@ -974,7 +974,7 @@ mod license_tests {
         assert_eq!(meta.license, Some(NixyLicense::String("MIT".to_string())));
         assert_eq!(meta.broken, Some(false));
         assert_eq!(meta.insecure, None);
-        assert_eq!(meta.outputs_to_install, Some(vec!["out".to_string()]));
+        assert_eq!(meta.outputs_to_install, vec!["out".to_string()]);
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -770,6 +770,11 @@ fn check_build_metadata_from_build_result(
     // Get outputs to install from the build result, or default to all outputs.
     let outputs_to_install = build_result.meta.outputs_to_install.clone();
 
+    // Wrapping `outputs_to_install` in an option to satisfy the API.
+    // In practice outputs_to_install are required / must be always `Some`
+    // so a future change will update the API to reflect that.
+    let outputs_to_install = Some(outputs_to_install);
+
     let license = match &build_result.meta.license {
         Some(lic) => Some(lic.to_catalog_license()?),
         None => None,
@@ -1284,7 +1289,7 @@ pub mod tests {
         let _license_in_manifest = "[\"my very private license\"]";
 
         assert_eq!(meta.outputs.len(), 1);
-        assert!(meta.outputs_to_install.is_none());
+        assert_eq!(meta.outputs_to_install, Some(vec!["out".to_string()]));
         assert_eq!(meta.outputs[0].store_path.starts_with("/nix/store/"), true);
         assert_eq!(meta.drv_path.starts_with("/nix/store/"), true);
         assert_eq!(meta.version, Some(version_in_manifest.to_string()));
@@ -1326,7 +1331,7 @@ pub mod tests {
         .unwrap();
 
         assert_eq!(meta.outputs.len(), 1);
-        assert!(meta.outputs_to_install.is_none());
+        assert_eq!(meta.outputs_to_install, Some(vec!["out".to_string()]));
         assert_eq!(meta.outputs[0].store_path.starts_with("/nix/store/"), true);
         assert_eq!(meta.drv_path.starts_with("/nix/store/"), true);
         assert_eq!(meta.pname, EXAMPLE_PACKAGE_NAME_MISSING_FIELDS.to_string());

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -488,7 +488,7 @@ define BUILD_local_template =
 	  --slurpfile manifest "$(MANIFEST_LOCK)" \
 	  --arg log "$(shell $(_readlink) $($(_pvarname)_result)-log)" \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
-	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, version:$$$$version, log:$$$$log, resultLinks: $$$$resultLinks, meta: $$$$meta }' $$< > $$@
+	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, version:$$$$version, log:$$$$log, resultLinks: $$$$resultLinks, meta: $$$$meta }' $$< > $$@
 	@echo "Completed build of $(_name) in local mode" && echo ""
 
 endef
@@ -573,7 +573,7 @@ define BUILD_nix_sandbox_template =
 	  --arg version "$(_version)" \
 	  --slurpfile manifest "$(MANIFEST_LOCK)" \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
-	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, version:$$$$version, log:.[0].outputs.log, resultLinks:$$$$resultLinks, meta: $$$$meta }' $$< > $$@
+	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, version:$$$$version, log:.[0].outputs.log, resultLinks:$$$$resultLinks, meta: $$$$meta }' $$< > $$@
 	@echo "Completed build of $(_name) in Nix sandbox mode" && echo ""
 	@# Check to see if a new buildCache has been created, and if so then go
 	@# ahead and run 'nix store delete' on the previous cache, keeping in


### PR DESCRIPTION
Set outputs to install with list context rather than scalar context.

Manifest builds are now published with empty outputs_to_install. This reaches previously unreached code that sets outputs_to_install to all outputs. Currently this leads to an error:
```
❌ ERROR: Can't use string ("1") as an ARRAY ref while "strict refs" in use
```

This is because the current line
```
$package->{"outputs_to_install"} = keys %{$package->{"outputs"}};
```

is making an assignment in scalar context, which sets $package->{"outputs_to_install"} to the number of keys in outputs instead of the actual keys.


## Release Notes

NA