### PR TITLE
fix(commands): Complete path arguments

### DIFF
--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -18,6 +18,7 @@ use macos_containerize_proxy::ContainerizeProxy;
 use tracing::{debug, info, instrument};
 
 use super::{EnvironmentSelect, environment_select};
+use crate::commands::SHELL_COMPLETION_FILE;
 use crate::environment_subcommand_metric;
 use crate::utils::message;
 use crate::utils::openers::first_in_path;
@@ -40,7 +41,7 @@ pub struct Containerize {
     /// File to write the container image to.
     /// '-` to write to stdout.
     /// Defaults to '{name}-container.tar' if '--runtime' isn't specified or detected.
-    #[bpaf(short, long, argument("file"))]
+    #[bpaf(short, long, argument("file"), complete_shell(SHELL_COMPLETION_FILE))]
     file: Option<FileOrStdout>,
 
     /// Tag to apply to the container, defaults to 'latest'

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -30,7 +30,7 @@ use super::{
     activated_environments,
     environment_select,
 };
-use crate::commands::{EnvironmentSelectError, ensure_floxhub_token};
+use crate::commands::{EnvironmentSelectError, SHELL_COMPLETION_FILE, ensure_floxhub_token};
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::errors::format_error;
 use crate::utils::message;
@@ -49,7 +49,7 @@ pub struct Edit {
 pub enum EditAction {
     EditManifest {
         /// Replace environment manifest with that in <file>
-        #[bpaf(long, short, argument("file"))]
+        #[bpaf(long, short, argument("file"), complete_shell(SHELL_COMPLETION_FILE))]
         file: Option<PathBuf>,
     },
 

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -22,7 +22,7 @@ use indoc::{formatdoc, indoc};
 use path_dedot::ParseDot;
 use tracing::{debug, info_span, instrument};
 
-use crate::commands::environment_description;
+use crate::commands::{SHELL_COMPLETION_DIR, environment_description};
 use crate::subcommand_metric;
 use crate::utils::dialog::Dialog;
 use crate::utils::message;
@@ -68,7 +68,7 @@ impl InitHook for InitHookType {
 #[derive(Bpaf, Clone)]
 pub struct Init {
     /// Directory to create the environment in (default: current directory)
-    #[bpaf(long, short, argument("path"))]
+    #[bpaf(long, short, argument("path"), complete_shell(SHELL_COMPLETION_DIR))]
     dir: Option<PathBuf>,
 
     /// Name of the environment

--- a/cli/flox/src/commands/lock_manifest.rs
+++ b/cli/flox/src/commands/lock_manifest.rs
@@ -8,6 +8,7 @@ use flox_rust_sdk::models::environment::fetcher::IncludeFetcher;
 use flox_rust_sdk::models::lockfile::Lockfile;
 use tracing::instrument;
 
+use crate::commands::SHELL_COMPLETION_FILE;
 use crate::subcommand_metric;
 
 /// Lock a manifest file read from the path specified or stdin if `-`.
@@ -18,11 +19,11 @@ use crate::subcommand_metric;
 #[derive(Bpaf, Clone)]
 pub struct LockManifest {
     /// The previous lockfile to use as a base.
-    #[bpaf(long, short, argument("path"))]
+    #[bpaf(long, short, argument("path"), complete_shell(SHELL_COMPLETION_FILE))]
     lockfile: Option<PathBuf>,
 
     /// The manifest file to lock. (default: stdin)
-    #[bpaf(positional("path to manifest"))]
+    #[bpaf(positional("path to manifest"), complete_shell(SHELL_COMPLETION_FILE))]
     manifest: PathBuf,
 }
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -34,7 +34,7 @@ use std::str::FromStr;
 use std::{env, fmt, fs, io, mem};
 
 use anyhow::{Context, Result, anyhow, bail};
-use bpaf::{Args, Bpaf, ParseFailure, Parser};
+use bpaf::{Args, Bpaf, ParseFailure, Parser, ShellComp};
 use flox_rust_sdk::data::FloxVersion;
 use flox_rust_sdk::flox::{
     DEFAULT_FLOXHUB_URL,
@@ -94,6 +94,9 @@ use crate::utils::init::{
 };
 use crate::utils::metrics::{AWSDatalakeConnection, Client, Hub, METRICS_UUID_FILE_NAME};
 use crate::utils::{TRAILING_NETWORK_CALL_TIMEOUT, message};
+
+const SHELL_COMPLETION_DIR: ShellComp = ShellComp::Dir { mask: None };
+const SHELL_COMPLETION_FILE: ShellComp = ShellComp::File { mask: None };
 
 // Relative to flox executable
 const DEFAULT_UPDATE_INSTRUCTIONS: &str =
@@ -1165,7 +1168,12 @@ impl Version {
 pub enum EnvironmentSelect {
     Dir(
         /// Path containing a .flox/ directory
-        #[bpaf(long("dir"), short('d'), argument("path"))]
+        #[bpaf(
+            long("dir"),
+            short('d'),
+            argument("path"),
+            complete_shell(SHELL_COMPLETION_DIR)
+        )]
         PathBuf,
     ),
     Remote(
@@ -1182,7 +1190,12 @@ pub enum EnvironmentSelect {
 pub enum DirEnvironmentSelect {
     Dir(
         /// Path containing a .flox/ directory
-        #[bpaf(long("dir"), short('d'), argument("path"))]
+        #[bpaf(
+            long("dir"),
+            short('d'),
+            argument("path"),
+            complete_shell(SHELL_COMPLETION_DIR)
+        )]
         PathBuf,
     ),
     #[default]

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -31,7 +31,7 @@ use crate::commands::build::{
     prefetch_flake_ref,
     system_override,
 };
-use crate::commands::ensure_floxhub_token;
+use crate::commands::{SHELL_COMPLETION_FILE, ensure_floxhub_token};
 use crate::config::Config;
 use crate::utils::errors::display_chain;
 use crate::utils::message;
@@ -79,7 +79,7 @@ struct CacheArgs {
     /// Flox.
     /// Takes precedence over the value of `publish.signing_private_key` from
     /// 'flox config'.
-    #[bpaf(long, argument("FILE"))]
+    #[bpaf(long, argument("FILE"), complete_shell(SHELL_COMPLETION_FILE))]
     signing_private_key: Option<PathBuf>,
 }
 

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -28,6 +28,7 @@ use tracing::{debug, info_span, instrument};
 
 use super::services::warn_manifest_changes_for_services;
 use super::{ConcreteEnvironment, open_path};
+use crate::commands::SHELL_COMPLETION_DIR;
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::{display_chain, format_core_error};
@@ -60,7 +61,7 @@ pub struct Pull {
     /// Directory in which to create a managed environment,
     /// or directory that already contains a managed environment
     /// (default: current directory)
-    #[bpaf(long, short, argument("path"))]
+    #[bpaf(long, short, argument("path"), complete_shell(SHELL_COMPLETION_DIR))]
     dir: Option<PathBuf>,
 
     /// Forcibly pull the environment

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -21,7 +21,7 @@ use flox_rust_sdk::models::environment::{
 use indoc::formatdoc;
 use tracing::{debug, instrument};
 
-use crate::commands::ensure_floxhub_token;
+use crate::commands::{SHELL_COMPLETION_DIR, ensure_floxhub_token};
 use crate::subcommand_metric;
 use crate::utils::errors::format_core_error;
 use crate::utils::message;
@@ -30,7 +30,7 @@ use crate::utils::message;
 #[derive(Bpaf, Clone)]
 pub struct Push {
     /// Directory to push the environment from (default: current directory)
-    #[bpaf(long, short, argument("path"))]
+    #[bpaf(long, short, argument("path"), complete_shell(SHELL_COMPLETION_DIR))]
     dir: Option<PathBuf>,
 
     /// FloxHub account to push environment to (default: current FloxHub user).

--- a/cli/flox/src/commands/upload.rs
+++ b/cli/flox/src/commands/upload.rs
@@ -8,7 +8,7 @@ use flox_rust_sdk::providers::publish::ClientSideCatalogStoreConfig;
 use tracing::instrument;
 use url::Url;
 
-use crate::commands::ensure_floxhub_token;
+use crate::commands::{SHELL_COMPLETION_FILE, ensure_floxhub_token};
 use crate::subcommand_metric;
 use crate::utils::message;
 
@@ -28,7 +28,7 @@ struct CacheArgs {
     store_url: Url,
 
     /// Path of the key file used to sign packages before copying.
-    #[bpaf(long, argument("FILE"))]
+    #[bpaf(long, argument("FILE"), complete_shell(SHELL_COMPLETION_FILE))]
     signing_key: PathBuf,
 }
 


### PR DESCRIPTION
## Proposed Changes

Fix shell completion for arguments that take files or directories as paths. Previously they would give incorrect suggestions of an empty string and the value given for `argument()`:

    % flox activate -d <TAB>
          path

Partial arguments wouldn't expand to anything:

    % flox activate -d ~/<TAB>

Assuming that you haven't enabled a fallback completer:

- https://zsh.sourceforge.io/FAQ/zshfaq04.html#l55

Now both work. Although there's an oddity when used with a combination of `zsh`, `zstyle ':completion:*' group-name ''`, and `ShellComp::Dir` which causes duplicates to be printed:

    % flox activate -d ~/demo/<TAB>
    -- file --
    bash/      composed/  default/   dep1/      dep2/      hello/     nef/       profile/   services/
    -- file --
    bash/      composed/  default/   dep1/      dep2/      hello/     nef/       profile/   services/

We could workaround that by only using `ShellComp::File`, which also includes dirs and doesn't appear to be affected by the same problem, but it seems to be relatively specific to my `zimfw` setup and doesn't actually break usage.

It's also possible to restrict the masks for arguments that take `.toml` or `.key` files but I don't think that filtering them provides a much better experience and might cause confusion if testing with non-standard file extensions.

I've mostly focused on `zsh` because that's what I use but I've also tested this in `bash` with `flox install bash bash-completion` and manually sourcing the completion stubs.

---

This has been subtly annoying me for ages and was one of those bugs that by the time I'd figured out whether it was a me-problem I was most of the way to solving it.

Upstream issues that describe the same duplicates issue:

- https://github.com/zimfw/zimfw/discussions/491
- https://github.com/ajeetdsouza/zoxide/issues/491

## Release Notes

Fixed shell completions for arguments that take file and directory paths.
