### PR TITLE
chore(ci): pin nix version in CI to 2.30.3

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -31,6 +31,8 @@ runs:
   steps:
     - name: "Install newer Nix"
       uses: "cachix/install-nix-action@v31"
+      with:
+        install_url: "https://releases.nixos.org/nix/nix-2.30.3/install"
 
     - name: "Configure Nix"
       uses: "flox/configure-nix-action@main"


### PR DESCRIPTION
IPv6 handling for Nix remote builders was changed in 2.31, but using the correct format `[2603:...]` causes other issues with how we use that address.

Temporarily pinning the Nix version used in CI to 2.30 until we can handle all the other address changes.

Reference: https://github.com/NixOS/nix/issues/13937