### PR TITLE
fix(ci): CodeCov on merge queue and unset defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,4 +473,3 @@ jobs:
           flags: "nix-integration-tests, ${{ matrix.test-tags }}, ${{ matrix.system }}"
           verbose: true
           use_oidc: true
-          override_build_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,4 +474,3 @@ jobs:
           verbose: true
           use_oidc: true
           override_build_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          override_branch: "main-or-merge-queue"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: "Upload CLI Unit Test Results"
         uses: "codecov/test-results-action@v1"
-        if: ${{ !cancelled() && matrix.test-tags == '!activate,!containerize,!catalog' }}
+        if: ${{ !cancelled() && github.ref_name == 'main' && matrix.test-tags == '!activate,!containerize,!catalog' }}
         with:
           disable_search: true
           files: "./cli/target/nextest/ci/junit.xml"
@@ -223,7 +223,7 @@ jobs:
 
       - name: "Upload CLI Integration Test Results"
         uses: "codecov/test-results-action@v1"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.ref_name == 'main' }}
         with:
           disable_search: true
           files: "./test-results/report.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
 
       - name: "Upload Bats Tests results"
         uses: "codecov/test-results-action@v1"
-        if: ${{ !cancelled() && (github.ref_name == 'main' || github.event_name != 'merge_group') }}
+        if: ${{ !cancelled() && github.ref_name == 'main' }}
         with:
           disable_search: true
           files: "./report.xml"


### PR DESCRIPTION
## Proposed Changes

**fix(ci): CodeCov from merge queue**

Send test reports to CodeCov when running from the merge queue. It seems
this conditional may have been a mistake because we set it at the same
time as forcing both runs to have the same `branch_name`, so that the
results are collated together, but excluded the merge queue from runs.

Before that change:

- commit: 87b38f1
- merge: https://github.com/flox/flox/actions/runs/16978182037/job/48132841669
- push: https://github.com/flox/flox/actions/runs/16978656531/job/48133848083

After that change, job skipped:

- commit: bdc2728
- merge: https://github.com/flox/flox/actions/runs/16978824316/job/48134381261
- push: https://github.com/flox/flox/actions/runs/16979135480/job/48135251182

**refactor(ci): Unset override_branch**

This defaults to `main` on both push and merge_group events now that we
filter the `ref_name` so there's no need to override it.

**refactor(ci): Unset override_build_url**

This matches the default so we don't need to set it.

- before, merge: https://github.com/flox/flox/actions/runs/16978182037/job/48132841669#step:6:72
- before, push: https://github.com/flox/flox/actions/runs/16978656531/job/48133848083#step:6:72
- after, push: https://github.com/flox/flox/actions/runs/16979135480/job/48135251182#step:6:74

I've raised a support query (162100) so see if it's possible to list the
individual runs and their build URLs from the Test Analytics UI. The
fact that it's not included in the API doesn't give me a lot of hope
though:

- https://docs.codecov.com/reference/repos_test_results_list

## Release Notes

N/A
