### PR TITLE
feat: debug flox version

### DIFF
--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -83,6 +83,7 @@ fn main() -> ExitCode {
     };
 
     init_logger(Some(verbosity));
+    debug!("FLOX_VERSION={}", *FLOX_VERSION);
 
     if let Err(err) = set_user() {
         message::error(err.to_string());


### PR DESCRIPTION
fix: don't init logger twice

I'm guessing this is an artifact of when we initialized the logger with
a best guess verbosity and then re-initialized

feat: debug flox version

This will help when debugging verbose logs provided by users

## Release Notes

NA
