### PR TITLE
fix(ci): CodeCov on merge queue, for realz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,13 +188,14 @@ jobs:
       - name: "CLI Unit Tests"
         # Only run unit tests if when not running specialized integration tests
         if: ${{ matrix.test-tags == '!activate,!containerize,!catalog' }}
+        id: unit-tests
         env:
           RUST_BACKTRACE: 1
         run: nix develop -L --no-update-lock-file --command just impure-tests
 
       - name: "Upload CLI Unit Test Results"
         uses: "codecov/test-results-action@v1"
-        if: ${{ !cancelled() && matrix.test-tags == '!activate,!containerize,!catalog' }}
+        if: ${{ !cancelled() && steps.unit-tests.outcome != 'skipped' }}
         with:
           disable_search: true
           files: "./cli/target/nextest/ci/junit.xml"


### PR DESCRIPTION
## Proposed Changes

**fix(ci): CodeCov on all branches**

So that we get flakey test reports from the merge queue.

I previously thought in 9f7756c and 0abdc44 that filtering on the
`main` branch was enough to do this, based on the branch field in the
debug output of the CodeCov step, but the step was skipped when that PR
was in the merge queue:

- https://github.com/flox/flox/actions/runs/17619311246/job/50060919500

It's actually CodeCov that now converts the branch name from the
`gh-readonly-queue` prefixed name to the target branch name:

- getsentry/prevent-cli@9f34ed8

Sending the reports on all branches also means that we get the nice test
summary comments on PRs so that you can see which tests failed without
scrolling through the GitHub Actions output. We should have unlimited
uploads because we're both a) using a public repo, and b) are on the Pro
plan:

- https://about.codecov.io/pricing/
- https://app.codecov.io/plan/github/flox

**refactor(ci): Depend on step rather than tags**

Make it clearer why we only upload CodeCov results for unit tests in
some matrix runs by depending on the step outcome rather than the matrix
tags.

I went searching through history to understand why we had this
restriction as far back as using BuildKite before finding the comment a
few lines above.

## Release Notes

N/A
