### PR TITLE
refactor: always cleanup tempdirs

### DIFF
--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -108,6 +108,12 @@ pub struct FloxConfig {
 
     /// Release channel to use when checking for updates to Flox.
     pub installer_channel: Option<InstallerChannel>,
+
+    /// Flox creates a single tempdir for each process in
+    /// `$FLOX_CACHE_HOME/process`.
+    /// Flox will delete this empdir upon conclusion of the process
+    /// unless `keep_tempdir == true` AND verbose logs are enabled.
+    pub keep_tempdir: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Proposed Changes

Change tempdir cleanup behavior:

On startup, flox creates a main tempdir in `$FLOX_CACHE_HOME/process` for the lifetime of the process.
During normal usage, this directory is deleted after the process terminates.
Before this change, the deletion was skipped _iff_ flox was called with one or more `-v` flags.
However, in environments where flox is always being run with internal logs enabled,
no cleanup ever happens causing tempdirs to pile up.

This change adds a new config options `keep_tempdir`, which has to be set to true to enable the old behavior. without this flag, or the flag set to `false`, tempdirs are now always deleted.
Additionally this change consolidates the cleanup run after successful completion, and upon signals, to avoid unnecessary duplication.