### PR TITLE
fix(activate): zsh profile script modify PATH

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/generate-bash-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-bash-startup-commands.bash
@@ -37,10 +37,10 @@ generate_bash_startup_commands() {
     # We use --rcfile to activate using bash which skips sourcing ~/.bashrc,
     # so source that here, but not if we're already in the process of sourcing
     # bashrc in a parent process.
-    if [ -f ~/.bashrc ] && [ -z "${_flox_already_sourcing_bashrc:=}" ]; then
-      echo "export _flox_already_sourcing_bashrc=1;"
+    if [ -f ~/.bashrc ] && [ -z "${_flox_sourcing_rc:=}" ]; then
+      echo "export _flox_sourcing_rc=1;"
       echo "source ~/.bashrc;"
-      echo "unset _flox_already_sourcing_bashrc;"
+      echo "unset _flox_sourcing_rc;"
     fi
 
     # Restore environment variables set in the previous bash initialization.

--- a/assets/environment-interpreter/activate/activate.d/zdotdir/.zlogin
+++ b/assets/environment-interpreter/activate/activate.d/zdotdir/.zlogin
@@ -23,6 +23,7 @@ _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
 _save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
+    unset _flox_sourcing_rc
     export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
     export FLOX_ENV="$_save_FLOX_ENV"
     export FLOX_ENV_CACHE="$_save_FLOX_ENV_CACHE"
@@ -43,6 +44,7 @@ restore_saved_vars() {
 
 if [ -f /etc/zlogin ]
 then
+    export _flox_sourcing_rc=1
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
     then
         ZDOTDIR="$FLOX_ORIG_ZDOTDIR" FLOX_ORIG_ZDOTDIR= source /etc/zlogin
@@ -55,6 +57,7 @@ fi
 zlogin="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zlogin"
 if [ -f "$zlogin" ]
 then
+    export _flox_sourcing_rc=1
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
     then
         ZDOTDIR="$FLOX_ORIG_ZDOTDIR" FLOX_ORIG_ZDOTDIR= source "$zlogin"

--- a/assets/environment-interpreter/activate/activate.d/zdotdir/.zprofile
+++ b/assets/environment-interpreter/activate/activate.d/zdotdir/.zprofile
@@ -22,6 +22,7 @@ _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
 _save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
+    unset _flox_sourcing_rc
     export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
     export FLOX_ENV="$_save_FLOX_ENV"
     export FLOX_ENV_CACHE="$_save_FLOX_ENV_CACHE"
@@ -42,6 +43,7 @@ restore_saved_vars() {
 
 if [ -f /etc/zprofile ]
 then
+    export _flox_sourcing_rc=1
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
     then
         ZDOTDIR="$FLOX_ORIG_ZDOTDIR" FLOX_ORIG_ZDOTDIR= source /etc/zprofile
@@ -54,6 +56,7 @@ fi
 zprofile="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zprofile"
 if [ -f "$zprofile" ]
 then
+    export _flox_sourcing_rc=1
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
     then
         ZDOTDIR="$FLOX_ORIG_ZDOTDIR" FLOX_ORIG_ZDOTDIR= source "$zprofile"

--- a/assets/environment-interpreter/activate/activate.d/zdotdir/.zshenv
+++ b/assets/environment-interpreter/activate/activate.d/zdotdir/.zshenv
@@ -23,6 +23,7 @@ _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
 _save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
+    unset _flox_sourcing_rc
     export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
     export FLOX_ENV="$_save_FLOX_ENV"
     export FLOX_ENV_CACHE="$_save_FLOX_ENV_CACHE"
@@ -43,6 +44,7 @@ restore_saved_vars() {
 
 if [ -f /etc/zshenv ]
 then
+    export _flox_sourcing_rc=1
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
     then
         ZDOTDIR="$FLOX_ORIG_ZDOTDIR" FLOX_ORIG_ZDOTDIR= source /etc/zshenv
@@ -55,6 +57,7 @@ fi
 zshenv="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zshenv"
 if [ -f "$zshenv" ]
 then
+    export _flox_sourcing_rc=1
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
     then
         ZDOTDIR="$FLOX_ORIG_ZDOTDIR" FLOX_ORIG_ZDOTDIR= source "$zshenv"

--- a/assets/environment-interpreter/activate/activate.d/zdotdir/.zshrc
+++ b/assets/environment-interpreter/activate/activate.d/zdotdir/.zshrc
@@ -23,6 +23,7 @@ _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
 _save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
+    unset _flox_sourcing_rc
     export _flox_activate_tracelevel="$_save_flox_activate_tracelevel"
     export FLOX_ENV="$_save_FLOX_ENV"
     export FLOX_ENV_CACHE="$_save_FLOX_ENV_CACHE"
@@ -44,6 +45,7 @@ restore_saved_vars() {
 
 if [ -f /etc/zshrc ]
 then
+    export _flox_sourcing_rc=1
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
     then
         ZDOTDIR="$FLOX_ORIG_ZDOTDIR" FLOX_ORIG_ZDOTDIR= source /etc/zshrc
@@ -56,6 +58,7 @@ fi
 zshrc="${FLOX_ORIG_ZDOTDIR:-$HOME}/.zshrc"
 if [ -f "$zshrc" ]
 then
+    export _flox_sourcing_rc=1
     if [ -n "${FLOX_ORIG_ZDOTDIR:-}" ]
     then
         ZDOTDIR="$FLOX_ORIG_ZDOTDIR" FLOX_ORIG_ZDOTDIR= source "$zshrc"

--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -109,7 +109,15 @@ source <("$_flox_activations" fix-paths --shell zsh --env-dirs "$FLOX_ENV_DIRS" 
 # and then _flox_env_helper may fix it up.
 # If this happens, we want to respect those modifications,
 # so we use FLOX_ENV_DIRS from the environment
-source <("$_flox_activations" profile-scripts --shell zsh --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}" --env-dirs "$FLOX_ENV_DIRS")
+if [ -n "${_flox_sourcing_rc:-}" ]; then
+  # Only source profile scripts for the current environment when activating from
+  # an RC file because other environments will source their profile scripts
+  # later in the nesting chain.
+  profile_script_dirs="$FLOX_ENV"
+else
+  profile_script_dirs="$FLOX_ENV_DIRS"
+fi
+source <("$_flox_activations" profile-scripts --shell zsh --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}" --env-dirs "$profile_script_dirs")
 
 # Disable command hashing to allow for newly installed flox packages
 # to be found immediately. We do this as the very last thing because

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1080,6 +1080,7 @@ dependencies = [
  "indoc",
  "log",
  "nix",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "temp-env",

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -30,3 +30,4 @@ indoc.workspace = true
 nix.workspace = true
 tempfile.workspace = true
 temp-env.workspace = true
+pretty_assertions.workspace = true

--- a/cli/flox-activations/src/cli/profile_scripts.rs
+++ b/cli/flox-activations/src/cli/profile_scripts.rs
@@ -228,4 +228,17 @@ mod test {
         let expected = vec!["_FLOX_SOURCED_PROFILE_SCRIPTS='newer:older';".to_string()];
         assert_eq!(expected, cmds);
     }
+
+    #[test]
+    fn prepend_already_sourced_when_no_overlap() {
+        let dirs = "standalone";
+        let already_sourced = "already:existing";
+        let cmds = source_profile_scripts_cmds(dirs, already_sourced, &Shell::Bash, |_| true);
+        let expected = vec![
+            "source 'standalone/activate.d/profile-common';".to_string(),
+            "source 'standalone/activate.d/profile-bash';".to_string(),
+            "_FLOX_SOURCED_PROFILE_SCRIPTS='standalone:already:existing';".to_string(),
+        ];
+        assert_eq!(expected, cmds);
+    }
 }

--- a/cli/flox-activations/src/cli/profile_scripts.rs
+++ b/cli/flox-activations/src/cli/profile_scripts.rs
@@ -87,6 +87,8 @@ fn source_profile_scripts_cmds(
 
 #[cfg(test)]
 mod test {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -5207,3 +5207,96 @@ EOF
   project_setup_common
   shell_vars_preserved_in_subshells zsh
 }
+
+profile_scripts_can_modify_path_with_default_environment() {
+  local shell="${1?}"
+
+  "$FLOX_BIN" init -d "$PROJECT_DIR/default"
+  case "$shell" in
+    bash)
+      # We use a non-interactive Bash invocation below, so use .bash_profile
+      rm "${HOME}/.bashrc"
+      cat > "${HOME}/.bash_profile" <<EOF
+eval "\$("$FLOX_BIN" activate -d "$PROJECT_DIR/default")"
+EOF
+      set_shell_path='export PATH="/me-first:${PATH}"'
+      ;;
+    fish)
+      cat > "${HOME}/.config/fish/config.fish" <<EOF
+"$FLOX_BIN" activate -d "$PROJECT_DIR/default" | source
+EOF
+      set_shell_path='set -gx PATH "/me-first:$PATH"'
+      ;;
+    tcsh)
+      cat > "${HOME}/.tcshrc" <<EOF
+eval "\`$FLOX_BIN activate -d $PROJECT_DIR/default\`"
+EOF
+      set_shell_path='setenv PATH "/me-first:${PATH}"'
+      ;;
+    zsh)
+      cat > "${HOME}/.zshenv" <<EOF
+eval "\$("$FLOX_BIN" activate -d "$PROJECT_DIR/default")"
+EOF
+      set_shell_path='export PATH="/me-first:${PATH}"'
+      # We don't want extra output
+      rm "${HOME}/.zshrc"
+      ;;
+    *)
+      echo "Unsupported shell: ${shell}"
+      exit 1
+      ;;
+  esac
+
+  "$FLOX_BIN" init -d project
+  MANIFEST_CONTENTS="$(cat << EOF
+    version = 1
+    [profile]
+    $shell = """
+      $set_shell_path
+    """
+EOF
+  )"
+  echo "$MANIFEST_CONTENTS" | "$FLOX_BIN" edit -d project -f -
+
+  if [[ "$shell" == "bash" ]]; then
+    # Use a login shell instead of an interactive one because of the /dev/tty
+    # issue
+    _FLOX_SHELL_FORCE="$shell" \
+      run "$FLOX_BIN" activate -d project -- "$shell" -lc 'echo "$PATH"'
+  elif [[ "$shell" == "tcsh" ]]; then
+    # tcsh does not parse the following:
+    #   % tcsh -m -c 'tcsh -ic "echo \"$shell_var\""'
+    #   Unmatched '"'.
+    # ... so we skip the quoting of $shell_var below.
+    _FLOX_SHELL_FORCE="$shell" \
+      run "$FLOX_BIN" activate -d project -- "$shell" -ic "echo \$PATH"
+  else
+    _FLOX_SHELL_FORCE="$shell" \
+      run "$FLOX_BIN" activate -d project -- "$shell" -ic 'echo "$PATH"'
+  fi
+  assert_success
+  assert_output --regexp '^/me-first:'
+}
+
+@test "bash: profile scripts can modify PATH with default environment" {
+  project_setup_common
+  profile_scripts_can_modify_path_with_default_environment bash
+}
+
+@test "fish: profile scripts can modify PATH with default environment" {
+  skip "broken on fish"
+  project_setup_common
+  profile_scripts_can_modify_path_with_default_environment fish
+}
+
+@test "tcsh: profile scripts can modify PATH with default environment" {
+  skip "broken on tcsh"
+  project_setup_common
+  profile_scripts_can_modify_path_with_default_environment tcsh
+}
+
+@test "zsh: profile scripts can modify PATH with default environment" {
+  skip "broken on zsh"
+  project_setup_common
+  profile_scripts_can_modify_path_with_default_environment zsh
+}

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -5296,7 +5296,6 @@ EOF
 }
 
 @test "zsh: profile scripts can modify PATH with default environment" {
-  skip "broken on zsh"
   project_setup_common
   profile_scripts_can_modify_path_with_default_environment zsh
 }


### PR DESCRIPTION
## Proposed Changes

Fix the (newly added) failing test for zsh with the suggestion:

> An alternative would be exporting a variable similar to what we already do with _flox_already_sourcing_bashrc and use that to so that activations in RC files only source profile scripts for FLOX_ENV. Using env variables to communicate between two activations seems error prone, but it’s been working okay for bash

I explored this other suggestion for a while, which would be preferable,
but the recursion and identifying the number of places it *might* break
which we might not have test coverage for broke my head:

> Although for the first half of the proposal, the suggestion is not adding to FLOX_ENV_DIRS until after starting userShell. I don’t think we can do that without a decent amount of re-work, because etc-profiles, which runs before userShell, depends on FLOX_ENV_DIRS containing FLOX_ENV. Refactoring how we use FLOX_ENV_DIRS might end up being a code quality improvement but I’m unsure how difficult that would be to do.

These were known caveats of:

- https://github.com/flox/flox/commit/35a5eec5219b93943e905e60c9c17feda4426998
- https://flox-dev.slack.com/archives/C05P6A5J6U8/p1757427682740799

This approach doesn't currently work for fish or tcsh because they
automatically load RC files first, which sources profile scripts for all
environments and then re-orders the modified path after all
environments.

I briefly experimented with applying `--no-config` and the following to
fish but it seemed to still be double loading the config file in some of
our tests. Plus it breaks our support for fish 3.2 from https://github.com/flox/flox/commit/281f0941afe92dbb71f573483682ea982ffeb92e:

    if [ -f ~/.config/fish/config.fish ] && [ -z "${_flox_sourcing_rc:=}" ]; then
      echo "set -gx _flox_sourcing_rc 1;"
      echo "source ~/.config/fish/config.fish;"
      echo "set -e _flox_sourcing_rc;"
    fi

This seems OK for now given:

- zsh and bash are our most popular shells
- zsh is already structured differently to the other shells
- current uncertainty about refactoring activation

## Release Notes

zsh can now modify `PATH` from profile scripts, as used by Python auto setup hooks, when used with default environments. There is still an outstanding bug for fish and tcsh.