### PR TITLE
feat: allow pinning included remote environments to generation

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/fetcher.rs
+++ b/cli/flox-rust-sdk/src/models/environment/fetcher.rs
@@ -22,7 +22,7 @@ impl IncludeFetcher {
     ) -> Result<LockedInclude, EnvironmentError> {
         let (manifest, name) = match include_environment {
             IncludeDescriptor::Local { dir, name } => self.fetch_local(flox, dir, name),
-            IncludeDescriptor::Remote { remote, name } => self.fetch_remote(flox, remote, name),
+            IncludeDescriptor::Remote { remote, name, .. } => self.fetch_remote(flox, remote, name),
         }?;
 
         Ok(LockedInclude {
@@ -376,6 +376,7 @@ mod test {
         let include_descriptor = IncludeDescriptor::Remote {
             remote: "owner/name".parse().unwrap(),
             name: None,
+            generation: None,
         };
         let fetched = include_fetcher.fetch(&flox, &include_descriptor).unwrap();
         assert_eq!(

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -560,6 +560,11 @@ pub trait GenerationsExt {
         flox: &Flox,
         generation: GenerationId,
     ) -> Result<(), EnvironmentError>;
+
+    fn lockfile_contents_for_generation(
+        &self,
+        generation: usize,
+    ) -> Result<String, GenerationsError>;
 }
 
 /// Combined type for environments supporting generations,

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -138,7 +138,7 @@ impl<S> Generations<S> {
     }
 
     /// Read the lockfile of a given generation and return its contents as a string.
-    pub fn lockfile(&self, generation: usize) -> Result<String, GenerationsError> {
+    pub fn lockfile_contents(&self, generation: usize) -> Result<String, GenerationsError> {
         let metadata = self.metadata()?;
         if !metadata.generations().contains_key(&generation.into()) {
             return Err(GenerationsError::GenerationNotFound(generation));
@@ -171,7 +171,7 @@ impl<S> Generations<S> {
             .current_gen()
             .ok_or(GenerationsError::NoGenerations)?;
 
-        self.lockfile(*current_gen)
+        self.lockfile_contents(*current_gen)
     }
 
     pub(super) fn git(&self) -> &GitCommandProvider {

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -653,6 +653,13 @@ impl GenerationsExt for ManagedEnvironment {
 
         Ok(())
     }
+
+    fn lockfile_contents_for_generation(
+        &self,
+        generation: usize,
+    ) -> Result<String, GenerationsError> {
+        self.generations().lockfile_contents(generation)
+    }
 }
 
 /// Constructors and related functions

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -437,6 +437,13 @@ impl GenerationsExt for RemoteEnvironment {
             .and_then(|_| Self::update_out_link(flox, &self.rendered_env_links, &mut self.inner))?;
         Ok(())
     }
+
+    fn lockfile_contents_for_generation(
+        &self,
+        generation: usize,
+    ) -> Result<String, GenerationsError> {
+        self.inner.generations().lockfile_contents(generation)
+    }
 }
 
 #[cfg(any(test, feature = "tests"))]

--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -1043,16 +1043,20 @@ pub enum IncludeDescriptor {
         #[cfg_attr(test, proptest(strategy = "optional_string(5)"))]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         name: Option<String>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(test, proptest(strategy = "proptest::option::of(0..10usize)"))]
+        generation: Option<usize>,
     },
 }
 
 impl Display for IncludeDescriptor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IncludeDescriptor::Local { dir, name } => {
+            IncludeDescriptor::Local { dir, name, .. } => {
                 write!(f, "{}", name.as_deref().unwrap_or(&dir.to_string_lossy()))
             },
-            IncludeDescriptor::Remote { remote, name } => {
+            IncludeDescriptor::Remote { remote, name, .. } => {
                 write!(f, "{}", name.as_deref().unwrap_or(&remote.to_string()))
             },
         }
@@ -1331,6 +1335,7 @@ pub mod test {
             IncludeDescriptor::Remote {
                 remote: EnvironmentRef::new("owner", "repo").unwrap(),
                 name: Some("baz".to_string()),
+                generation: None,
             },
         ]);
     }


### PR DESCRIPTION
## Proposed Changes

Extend the include descriptor for remote environments, with an optional `generation` field:

```
IncludeDescriptor::Remote := {
  remote: string (serialization of EnvironmentRef)
  name?: string
  generation?: number
}
```

If the generation is provided, flox will attempt to retrieve a lockfile for this generation instead of the upstreams "live" generation.
Likewise on `flox include upgrade` the lock for such pinned environments
should remain unchanged.

To allow this, this PR adds a new `lockfile_contents_for_generation` method to the `GenerationsExt` trait (which is implemented for generation supporting environments).

> [!NOTE]
> #2840 mentioned to alternatively fold generation specifiers into `EnvironmentRef`.
> Format and use (e.g. in activate) has not been discussed since,
> so for this i opted for a more local change.
> Since this influences the commands implemented in the future,
> we should reach a decision before this is released.