### PR TITLE
feat: add `flox generation list --tree`

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -396,6 +396,9 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "blake3"
@@ -1037,6 +1040,7 @@ dependencies = [
  "proptest-derive",
  "regex",
  "reqwest 0.12.12",
+ "sapling-renderdag",
  "semver",
  "sentry",
  "serde",
@@ -3088,6 +3092,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sapling-renderdag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edffb89cab87bd0901c5749d576f5d37a1f34e05160e936f463f4e94cc447b61"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -796,6 +796,7 @@ impl AllGenerationsMetadata {
                     }
 
                     map.insert(spec.current_generation, SingleGenerationMetadata {
+                        parent: spec.previous_generation,
                         created: spec.timestamp,
                         last_live: None,
                         description: spec.summary(),
@@ -811,6 +812,8 @@ impl AllGenerationsMetadata {
 /// Metadata for a single generation of an environment
 #[derive(Clone, Debug, PartialEq)]
 pub struct SingleGenerationMetadata {
+    pub parent: Option<GenerationId>,
+
     /// unix timestamp of the creation time of this generation
     pub created: DateTime<Utc>,
 
@@ -826,6 +829,7 @@ impl SingleGenerationMetadata {
     /// Create a new generation metadata instance
     pub fn new(description: String) -> Self {
         Self {
+            parent: None,
             created: Utc::now(),
             last_live: None,
             description,
@@ -841,6 +845,7 @@ impl SingleGenerationMetadata {
     Eq,
     PartialOrd,
     Ord,
+    Hash,
     Default,
     derive_more::Deref,
     derive_more::DerefMut,

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -56,6 +56,7 @@ url.workspace = true
 uuid.workspace = true
 xdg.workspace = true
 flox-core.workspace = true
+sapling-renderdag = "0.1.0"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/cli/flox/doc/flox-generations-list.md
+++ b/cli/flox/doc/flox-generations-list.md
@@ -13,6 +13,7 @@ flox-generations-list - show all environment generations that you can switch to
 ```
 flox [<general-options>] generations list
      [-d=<path> | -r=<owner/name>]
+     [-t]
 ```
 
 # DESCRIPTION
@@ -24,6 +25,12 @@ creates a new generation of the environment.
 
 `flox generations list` prints all generations of the environment, including
 which generation is currently live.
+
+# OPTIONS
+
+`--tree`, `-t`
+:   Render generations as a tree
+
 
 ```{.include}
 ./include/environment-options.md

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -6,11 +6,13 @@ use crossterm::style::Stylize;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::{
     AllGenerationsMetadata,
+    GenerationId,
     GenerationsEnvironment,
     GenerationsExt,
     SingleGenerationMetadata,
 };
 use indoc::formatdoc;
+use renderdag::{Ancestor, GraphRowRenderer, Renderer as _};
 use tracing::instrument;
 
 use crate::commands::{EnvironmentSelect, environment_select};
@@ -22,6 +24,10 @@ use crate::utils::dialog::Dialog;
 pub struct List {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     environment: EnvironmentSelect,
+
+    /// Render generations as a tree
+    #[bpaf(long, short)]
+    tree: bool,
 }
 
 impl List {
@@ -34,6 +40,11 @@ impl List {
 
         let env: GenerationsEnvironment = env.try_into()?;
         let metadata = env.generations_metadata()?;
+
+        if self.tree {
+            println!("{}", render_tree(&metadata));
+            return Ok(());
+        }
 
         println!("{}", DisplayAllMetadata(&metadata));
         Ok(())
@@ -107,6 +118,73 @@ impl Display for DisplayAllMetadata<'_> {
     }
 }
 
+/// Render generations as a tree, clearly showing the parent generation,
+/// and construction of the current state.
+///
+/// ## Example
+///
+/// ```text
+/// 7  (live) installed package 'gum (gum)' (created: 2025-09-19 15:27:44 UTC, last live: Now)
+/// │
+/// │ 6  installed package 'jq (jq)' (created: 2025-09-19 15:22:33 UTC, last live: 2025-09-19 15:27:18 UTC)
+/// │ │
+/// │ │ 5  installed packages 'jq (jq)', 'htop (htop)' (created: 2025-09-19 15:21:57 UTC, last live: 2025-09-19 15:22:22 UTC)
+/// │ │ │
+/// 4 │ │  installed package 'lolcat (lolcat)' (created: 2025-09-19 15:19:10 UTC, last live: 2025-09-19 15:27:44 UTC)
+/// │ │ │
+/// │ 3 │  installed package 'htop (htop)' (created: 2025-09-18 15:53:59 UTC, last live: 2025-09-19 15:22:33 UTC)
+/// ├─╯ │
+/// 2   │  installed package 'hello (hello)' (created: 2025-09-18 15:53:49 UTC, last live: 2025-09-19 15:19:10 UTC)
+/// ├───╯
+/// 1  manually edited the manifest [metadata migrated] (created: 2025-08-07 16:02:02 UTC, last live: 2025-09-19 15:21:57 UTC)
+/// │
+/// ~
+/// ```
+fn render_tree(metadata: &AllGenerationsMetadata) -> String {
+    let mut graph_nodes: Vec<(GenerationId, SingleGenerationMetadata)> = Vec::new();
+
+    for (id, generation) in metadata.generations() {
+        graph_nodes.push((id, generation))
+    }
+
+    let current_gen = metadata.current_gen();
+
+    let mut renderer = GraphRowRenderer::new()
+        .output()
+        .with_min_row_height(2)
+        .build_box_drawing();
+
+    graph_nodes
+        .into_iter()
+        .rev()
+        .map(|(id, generation)| {
+            let glyph = id.to_string();
+
+            let live_prefix = if Some(id) == current_gen {
+                "(live) "
+            } else {
+                ""
+            };
+
+            let description = format!("{live_prefix}{}", generation.description.bold());
+            let created = generation.created;
+            let last_live = if let Some(last_live) = generation.last_live {
+                last_live.to_string()
+            } else {
+                "Now".to_string()
+            };
+
+            let message = format!("{description} (created: {created}, last live: {last_live})");
+            let parents = match generation.parent {
+                None => vec![Ancestor::Anonymous],
+                Some(parent) => vec![Ancestor::Parent(parent)],
+            };
+
+            renderer.next_row(id, parents, glyph, message)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -129,6 +207,7 @@ mod tests {
     fn test_fmt_single_generation() {
         let actual = DisplayMetadata {
             metadata: &SingleGenerationMetadata {
+                parent: None,
                 created: DateTime::default(),
                 last_live: Some(DateTime::default()),
                 description: "Generation description".to_string(),
@@ -150,6 +229,7 @@ mod tests {
     fn test_fmt_single_generation_never_active() {
         let actual = DisplayMetadata {
             metadata: &SingleGenerationMetadata {
+                parent: None,
                 created: DateTime::default(),
                 last_live: None,
                 description: "Generation description".to_string(),


### PR DESCRIPTION
## Proposed Changes

Render generations as a tree, clearly showing the parent generation,
and construction of the current state.

## Example

```text
7  (live) installed package 'gum (gum)' (created: 2025-09-19 15:27:44 UTC, last live: Now)
│
│ 6  installed package 'jq (jq)' (created: 2025-09-19 15:22:33 UTC, last live: 2025-09-19 15:27:18 UTC)
│ │
│ │ 5  installed packages 'jq (jq)', 'htop (htop)' (created: 2025-09-19 15:21:57 UTC, last live: 2025-09-19 15:22:22 UTC)
│ │ │
4 │ │  installed package 'lolcat (lolcat)' (created: 2025-09-19 15:19:10 UTC, last live: 2025-09-19 15:27:44 UTC)
│ │ │
│ 3 │  installed package 'htop (htop)' (created: 2025-09-18 15:53:59 UTC, last live: 2025-09-19 15:22:33 UTC)
├─╯ │
2   │  installed package 'hello (hello)' (created: 2025-09-18 15:53:49 UTC, last live: 2025-09-19 15:19:10 UTC)
├───╯
1  manually edited the manifest [metadata migrated] (created: 2025-08-07 16:02:02 UTC, last live: 2025-09-19 15:21:57 UTC)
│
~
```

## Release Notes

Adds a `--tree` flag to `flox generations list` to render generations as a tree
