### PR TITLE
fix: use built system for publish

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -108,7 +108,7 @@ pub struct BuildResult {
     pub outputs: HashMap<String, BuiltStorePath>,
     pub meta: BuildResultMeta,
     pub version: String,
-    pub system: Option<String>,
+    pub system: String,
     pub log: BuiltStorePath,
     // TODO: factor out and use buildenv::BuiltStorePath (?)
     #[serde(rename = "resultLinks")]

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -753,7 +753,6 @@ fn get_client_side_catalog_store_config(
 
 fn check_build_metadata_from_build_result(
     build_result: &BuildResult,
-    system: PackageSystem,
 ) -> Result<CheckedBuildMetadata, PublishError> {
     let outputs = PackageOutputs(
         build_result
@@ -793,7 +792,9 @@ fn check_build_metadata_from_build_result(
 
         outputs,
         outputs_to_install,
-        system,
+        system: PackageSystem::from_str(build_result.system.as_str()).map_err(|_e| {
+            PublishError::UnsupportedEnvironmentState("Invalid system".to_string())
+        })?,
         version: Some(build_result.version.clone()),
 
         _private: (),
@@ -859,12 +860,7 @@ pub fn check_build_metadata(
     }
     let build_result = &build_results[0];
 
-    let metadata = check_build_metadata_from_build_result(
-        build_result,
-        PackageSystem::from_str(flox.system.as_str()).map_err(|_e| {
-            PublishError::UnsupportedEnvironmentState("Invalid system".to_string())
-        })?,
-    )?;
+    let metadata = check_build_metadata_from_build_result(build_result)?;
     Ok(metadata)
 }
 

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -485,10 +485,11 @@ define BUILD_local_template =
 	  --arg name "$(_name)" \
 	  --arg pname "$(_pname)" \
 	  --arg version "$(_version)" \
+	  --arg system "$(NIX_SYSTEM)" \
 	  --slurpfile manifest "$(MANIFEST_LOCK)" \
 	  --arg log "$(shell $(_readlink) $($(_pvarname)_result)-log)" \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
-	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, version:$$$$version, log:$$$$log, resultLinks: $$$$resultLinks, meta: $$$$meta }' $$< > $$@
+	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, system: $$$$system, version:$$$$version, log:$$$$log, resultLinks: $$$$resultLinks, meta: $$$$meta }' $$< > $$@
 	@echo "Completed build of $(_name) in local mode" && echo ""
 
 endef
@@ -571,9 +572,10 @@ define BUILD_nix_sandbox_template =
 	  --arg name "$(_name)" \
 	  --arg pname "$(_pname)" \
 	  --arg version "$(_version)" \
+	  --arg system "$(NIX_SYSTEM)" \
 	  --slurpfile manifest "$(MANIFEST_LOCK)" \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
-	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, version:$$$$version, log:.[0].outputs.log, resultLinks:$$$$resultLinks, meta: $$$$meta }' $$< > $$@
+	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, system: $$$$system, version:$$$$version, log:.[0].outputs.log, resultLinks:$$$$resultLinks, meta: $$$$meta }' $$< > $$@
 	@echo "Completed build of $(_name) in Nix sandbox mode" && echo ""
 	@# Check to see if a new buildCache has been created, and if so then go
 	@# ahead and run 'nix store delete' on the previous cache, keeping in
@@ -802,10 +804,11 @@ define NIX_EXPRESSION_BUILD_template =
   $($(_pvarname)_buildMetaJSON): $($(_pvarname)_evalJSON) $($(_pvarname)_buildJSON) $($(_pvarname)_result)-log
 	$(_V_) $(_jq) -n \
 	  --arg logfile $$(shell $(_readlink) $($(_pvarname)_result)-log) \
+	  --arg system $(NIX_SYSTEM) \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
 	  --slurpfile eval $($(_pvarname)_evalJSON) \
 	  --slurpfile build $($(_pvarname)_buildJSON) \
-	  '$$$$build[0][0] * $$$$eval[0] * { log: $$$$logfile, resultLinks: $$$$resultLinks }' > $$@
+	  '$$$$build[0][0] * $$$$eval[0] * { system: $$$$system, log: $$$$logfile, resultLinks: $$$$resultLinks }' > $$@
 	@echo -e "Completed build of $$(_name) in Nix expression mode\n"
 
   # Create targets for cleaning up the result and log symlinks.


### PR DESCRIPTION
We were inconsistent in the system used for publish.  This change passes the system actually used for the build back to the CLI in the build outputs, and uses that for publish, eliminating the multiple paths of interpreting the system override command line argument.

## Release Notes

Publish for the correct system when using `flox publish --system <override>`
