### PR TITLE
fix(activate): Remove FLOX_ACTIVATION_PROFILE_ONLY

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -289,26 +289,17 @@ export _FLOX_ACTIVATION_STATE_DIR _FLOX_ACTIVATION_ID
 # If the current shell is re-activating the same environment then we should only
 # re-run profile scripts, without start or attach, because the shell will
 # already be attached to an activation.
-if [ "${_FLOX_ACTIVATION_PROFILE_ONLY:-}" == true ]; then
-  # Except for when the environment has been modified and generated a new store
-  # path since the last activation, in which case we need to mark that new
-  # activation as ready.
-  if [ "$_FLOX_ATTACH" == false ]; then
-    start "$_FLOX_ACTIVATION_STATE_DIR"
-  fi
-else # This is the standard path when the current shell is NOT re-activating.
-  if [ "$_FLOX_ATTACH" == true ]; then
-    # shellcheck source-path=SCRIPTDIR/activate.d
-    source "${_activate_d}/attach.bash"
-  else
-    start "$_FLOX_ACTIVATION_STATE_DIR"
-  fi
+if [ "$_FLOX_ATTACH" == true ]; then
+  # shellcheck source-path=SCRIPTDIR/activate.d
+  source "${_activate_d}/attach.bash"
+else
+  start "$_FLOX_ACTIVATION_STATE_DIR"
+fi
 
-  # Start services before the shell or command is invoked
-  if [ "${FLOX_ACTIVATE_START_SERVICES:-}" == "true" ]; then
-    # shellcheck source-path=SCRIPTDIR/activate.d
-    source "${_activate_d}/start-services.bash"
-  fi
+# Start services before the shell or command is invoked
+if [ "${FLOX_ACTIVATE_START_SERVICES:-}" == "true" ]; then
+  # shellcheck source-path=SCRIPTDIR/activate.d
+  source "${_activate_d}/start-services.bash"
 fi
 
 # From this point on the activation process depends on the mode:

--- a/assets/environment-interpreter/activate/activate.d/attach-command.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach-command.bash
@@ -15,7 +15,6 @@ case "$_flox_shell" in
         "$_flox_activate_tracelevel" \
         "$_FLOX_ACTIVATION_STATE_DIR" \
         "$_activate_d" \
-        "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
         "$FLOX_ENV" \
         "${_FLOX_ENV_CACHE:-}" \
         "${_FLOX_ENV_PROJECT:-}" \
@@ -42,7 +41,6 @@ case "$_flox_shell" in
         "$_flox_activate_tracelevel" \
         "$_FLOX_ACTIVATION_STATE_DIR" \
         "$_activate_d" \
-        "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
         "$FLOX_ENV" \
         "${_FLOX_ENV_CACHE:-}" \
         "${_FLOX_ENV_PROJECT:-}" \
@@ -67,7 +65,6 @@ case "$_flox_shell" in
         "$_flox_activate_tracelevel" \
         "$_FLOX_ACTIVATION_STATE_DIR" \
         "$_activate_d" \
-        "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
         "${FLOX_ENV}" \
         "${_FLOX_ENV_CACHE:-}" \
         "${_FLOX_ENV_PROJECT:-}" \

--- a/assets/environment-interpreter/activate/activate.d/attach-inplace.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach-inplace.bash
@@ -25,7 +25,6 @@ case "$_flox_shell" in
       "$_flox_activate_tracelevel" \
       "$_FLOX_ACTIVATION_STATE_DIR" \
       "$_activate_d" \
-      "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
       "$FLOX_ENV" \
       "${_FLOX_ENV_CACHE:-}" \
       "${_FLOX_ENV_PROJECT:-}" \
@@ -37,7 +36,6 @@ case "$_flox_shell" in
       "$_flox_activate_tracelevel" \
       "$_FLOX_ACTIVATION_STATE_DIR" \
       "$_activate_d" \
-      "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
       "$FLOX_ENV" \
       "${_FLOX_ENV_CACHE:-}" \
       "${_FLOX_ENV_PROJECT:-}" \
@@ -49,7 +47,6 @@ case "$_flox_shell" in
       "$_flox_activate_tracelevel" \
       "$_FLOX_ACTIVATION_STATE_DIR" \
       "$_activate_d" \
-      "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
       "$FLOX_ENV" \
       "${_FLOX_ENV_CACHE:-}" \
       "${_FLOX_ENV_PROJECT:-}" \

--- a/assets/environment-interpreter/activate/activate.d/attach-interactive.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach-interactive.bash
@@ -13,7 +13,6 @@ case "$_flox_shell" in
         "$_flox_activate_tracelevel" \
         "$_FLOX_ACTIVATION_STATE_DIR" \
         "$_activate_d" \
-        "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
         "$FLOX_ENV" \
         "${_FLOX_ENV_CACHE:-}" \
         "${_FLOX_ENV_PROJECT:-}" \
@@ -43,7 +42,6 @@ case "$_flox_shell" in
         "$_flox_activate_tracelevel" \
         "$_FLOX_ACTIVATION_STATE_DIR" \
         "$_activate_d" \
-        "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
         "$FLOX_ENV" \
         "${_FLOX_ENV_CACHE:-}" \
         "${_FLOX_ENV_PROJECT:-}" \
@@ -68,7 +66,6 @@ case "$_flox_shell" in
         "$_flox_activate_tracelevel" \
         "$_FLOX_ACTIVATION_STATE_DIR" \
         "$_activate_d" \
-        "${_FLOX_ACTIVATION_PROFILE_ONLY:-false}" \
         "$FLOX_ENV" \
         "${_FLOX_ENV_CACHE:-}" \
         "${_FLOX_ENV_PROJECT:-}" \

--- a/assets/environment-interpreter/activate/activate.d/generate-fish-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-fish-startup-commands.bash
@@ -16,8 +16,6 @@ generate_fish_startup_commands() {
   shift
   _activate_d="${1?}"
   shift
-  _FLOX_ACTIVATION_PROFILE_ONLY="${1?}"
-  shift
   _FLOX_ENV="${1?}"
   shift
   _FLOX_ENV_CACHE="${1?}"
@@ -31,29 +29,27 @@ generate_fish_startup_commands() {
     echo "set -gx fish_trace 1;"
   fi
 
-  if [ "${_FLOX_ACTIVATION_PROFILE_ONLY:-}" != true ]; then
-    # The fish --init-command option allows us to source our startup
-    # file after the normal configuration has been processed, so there
-    # is no requirement to go back and source the user's own config
-    # as we do in bash.
+  # The fish --init-command option allows us to source our startup
+  # file after the normal configuration has been processed, so there
+  # is no requirement to go back and source the user's own config
+  # as we do in bash.
 
-    # Restore environment variables set in the previous bash initialization.
-    $_sed -e 's/^/set -e /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"
-    $_sed -e 's/^/set -gx /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"
+  # Restore environment variables set in the previous bash initialization.
+  $_sed -e 's/^/set -e /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"
+  $_sed -e 's/^/set -gx /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"
 
-    # Propagate required variables that are documented as exposed.
-    echo "set -gx FLOX_ENV '$_FLOX_ENV';"
+  # Propagate required variables that are documented as exposed.
+  echo "set -gx FLOX_ENV '$_FLOX_ENV';"
 
-    # Propagate optional variables that are documented as exposed.
-    for var_key in FLOX_ENV_CACHE FLOX_ENV_PROJECT FLOX_ENV_DESCRIPTION; do
-      eval "var_val=\${_$var_key-}"
-      if [ -n "$var_val" ]; then
-        echo "set -gx $var_key '$var_val';"
-      else
-        echo "set -e $var_key;"
-      fi
-    done
-  fi
+  # Propagate optional variables that are documented as exposed.
+  for var_key in FLOX_ENV_CACHE FLOX_ENV_PROJECT FLOX_ENV_DESCRIPTION; do
+    eval "var_val=\${_$var_key-}"
+    if [ -n "$var_val" ]; then
+      echo "set -gx $var_key '$var_val';"
+    else
+      echo "set -e $var_key;"
+    fi
+  done
 
   # Propagate $_activate_d to the environment.
   echo "set -gx _activate_d '$_activate_d';"

--- a/assets/environment-interpreter/activate/activate.d/generate-tcsh-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-tcsh-startup-commands.bash
@@ -17,8 +17,6 @@ generate_tcsh_startup_commands() {
   shift
   _activate_d="${1?}"
   shift
-  _FLOX_ACTIVATION_PROFILE_ONLY="${1?}"
-  shift
   _FLOX_ENV="${1?}"
   shift
   _FLOX_ENV_CACHE="${1?}"
@@ -32,30 +30,28 @@ generate_tcsh_startup_commands() {
     echo "set verbose;"
   fi
 
-  if [ "${_FLOX_ACTIVATION_PROFILE_ONLY:-}" != true ]; then
-    # The tcsh implementation will source our custom .tcshrc
-    # which will then source the result of this script as $FLOX_TCSH_INIT_SCRIPT
-    # after the normal configuration has been processed,
-    # so there is no requirement to go back and source the user's own config
-    # as we do in bash.
+  # The tcsh implementation will source our custom .tcshrc
+  # which will then source the result of this script as $FLOX_TCSH_INIT_SCRIPT
+  # after the normal configuration has been processed,
+  # so there is no requirement to go back and source the user's own config
+  # as we do in bash.
 
-    # Restore environment variables set in the previous bash initialization.
-    $_sed -e 's/^/unsetenv /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"
-    $_sed -e 's/^/setenv /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"
+  # Restore environment variables set in the previous bash initialization.
+  $_sed -e 's/^/unsetenv /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env"
+  $_sed -e 's/^/setenv /' -e 's/=/ /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env"
 
-    # Propagate required variables that are documented as exposed.
-    echo "setenv FLOX_ENV '$_FLOX_ENV';"
+  # Propagate required variables that are documented as exposed.
+  echo "setenv FLOX_ENV '$_FLOX_ENV';"
 
-    # Propagate optional variables that are documented as exposed.
-    for var_key in FLOX_ENV_CACHE FLOX_ENV_PROJECT FLOX_ENV_DESCRIPTION; do
-      eval "var_val=\${_$var_key-}"
-      if [ -n "$var_val" ]; then
-        echo "setenv $var_key '$var_val';"
-      else
-        echo "unsetenv $var_key;"
-      fi
-    done
-  fi
+  # Propagate optional variables that are documented as exposed.
+  for var_key in FLOX_ENV_CACHE FLOX_ENV_PROJECT FLOX_ENV_DESCRIPTION; do
+    eval "var_val=\${_$var_key-}"
+    if [ -n "$var_val" ]; then
+      echo "setenv $var_key '$var_val';"
+    else
+      echo "unsetenv $var_key;"
+    fi
+  done
 
   # Propagate $_activate_d to the environment.
   echo "setenv _activate_d '$_activate_d';"

--- a/assets/environment-interpreter/activate/activate.d/zdotdir/.zlogin
+++ b/assets/environment-interpreter/activate/activate.d/zdotdir/.zlogin
@@ -20,7 +20,6 @@ _save_ZDOTDIR="$ZDOTDIR"
 _save_activate_d="$_activate_d"
 _save_flox_activate_tracer="$_flox_activate_tracer"
 _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
-_save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
     unset _flox_sourcing_rc
@@ -35,7 +34,6 @@ restore_saved_vars() {
     export _flox_activate_tracer="$_save_flox_activate_tracer"
     export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
     export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
-    export _FLOX_ACTIVATION_PROFILE_ONLY="$_save_FLOX_ACTIVATION_PROFILE_ONLY"
     # shellcheck disable=SC1090
     source <("$_flox_activations" set-env-dirs --shell zsh --flox-env "$FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
     # shellcheck disable=SC1090

--- a/assets/environment-interpreter/activate/activate.d/zdotdir/.zprofile
+++ b/assets/environment-interpreter/activate/activate.d/zdotdir/.zprofile
@@ -19,7 +19,6 @@ _save_ZDOTDIR="$ZDOTDIR"
 _save_activate_d="$_activate_d"
 _save_flox_activate_tracer="$_flox_activate_tracer"
 _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
-_save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
     unset _flox_sourcing_rc
@@ -34,7 +33,6 @@ restore_saved_vars() {
     export _flox_activate_tracer="$_save_flox_activate_tracer"
     export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
     export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
-    export _FLOX_ACTIVATION_PROFILE_ONLY="$_save_FLOX_ACTIVATION_PROFILE_ONLY"
     # shellcheck disable=SC1090
     source <("$_flox_activations" set-env-dirs --shell zsh --flox-env "$FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
     # shellcheck disable=SC1090

--- a/assets/environment-interpreter/activate/activate.d/zdotdir/.zshenv
+++ b/assets/environment-interpreter/activate/activate.d/zdotdir/.zshenv
@@ -20,7 +20,6 @@ _save_ZDOTDIR="$ZDOTDIR"
 _save_activate_d="$_activate_d"
 _save_flox_activate_tracer="$_flox_activate_tracer"
 _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
-_save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
     unset _flox_sourcing_rc
@@ -35,7 +34,6 @@ restore_saved_vars() {
     export _flox_activate_tracer="$_save_flox_activate_tracer"
     export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
     export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
-    export _FLOX_ACTIVATION_PROFILE_ONLY="$_save_FLOX_ACTIVATION_PROFILE_ONLY"
     # shellcheck disable=SC1090
     source <("$_flox_activations" set-env-dirs --shell zsh --flox-env "$FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
     # shellcheck disable=SC1090

--- a/assets/environment-interpreter/activate/activate.d/zdotdir/.zshrc
+++ b/assets/environment-interpreter/activate/activate.d/zdotdir/.zshrc
@@ -20,7 +20,6 @@ _save_ZDOTDIR="$ZDOTDIR"
 _save_activate_d="$_activate_d"
 _save_flox_activate_tracer="$_flox_activate_tracer"
 _save_FLOX_ZSH_INIT_SCRIPT="$FLOX_ZSH_INIT_SCRIPT"
-_save_FLOX_ACTIVATION_PROFILE_ONLY="$_FLOX_ACTIVATION_PROFILE_ONLY"
 
 restore_saved_vars() {
     unset _flox_sourcing_rc
@@ -35,7 +34,6 @@ restore_saved_vars() {
     export _flox_activate_tracer="$_save_flox_activate_tracer"
     export FLOX_ZSH_INIT_SCRIPT="$_save_FLOX_ZSH_INIT_SCRIPT"
     export _FLOX_ACTIVATION_STATE_DIR="$_save_FLOX_ACTIVATION_STATE_DIR"
-    export _FLOX_ACTIVATION_PROFILE_ONLY="$_save_FLOX_ACTIVATION_PROFILE_ONLY"
     # shellcheck disable=SC1090
     source <("$_flox_activations" set-env-dirs --shell zsh --flox-env "$FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
     # shellcheck disable=SC1090

--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -89,11 +89,9 @@ if [ "$old_fpath" != "$new_fpath" ]; then
   fi
 fi
 
-if [ "${_FLOX_ACTIVATION_PROFILE_ONLY:-}" != true ]; then
-  # Restore environment variables set in the previous bash initialization.
-  eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
-  eval "$($_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
-fi
+# Restore environment variables set in the previous bash initialization.
+eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
+eval "$($_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
 
 # Set the prompt if we're in an interactive shell.
 if [[ -o interactive ]]; then

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -270,9 +270,7 @@ impl Activate {
         let mut flox_active_environments = activated_environments();
 
         // Detect if the current environment is already active
-        // For in-place and command (but not ephemeral) activations, if the
-        // environment is already active, we only want to re-run profile scripts
-        let profile_only = if flox_active_environments.is_active(&now_active) {
+        if flox_active_environments.is_active(&now_active) {
             debug!(
                 "Environment is already active: environment={}. Not adding to active environments",
                 now_active.bare_description()
@@ -283,11 +281,9 @@ impl Activate {
                     uninitialized_environment_description(&now_active)?
                 ));
             }
-            !is_ephemeral
         } else {
             // Add to _FLOX_ACTIVE_ENVIRONMENTS so we can detect what environments are active.
             flox_active_environments.set_last_active(now_active.clone());
-            false
         };
 
         // Determine values for `set_prompt` and `hide_default_prompt`, taking
@@ -351,7 +347,6 @@ impl Activate {
                 FLOX_RUNTIME_DIR_VAR,
                 flox.runtime_dir.to_string_lossy().to_string(),
             ),
-            ("_FLOX_ACTIVATION_PROFILE_ONLY", profile_only.to_string()),
         ]);
 
         if is_ephemeral && !services_to_start.is_empty() {

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1761,7 +1761,7 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate:scripts:on-activate,activate:scripts:on-activate:bash
-@test "'hook.on-activate' modifies environment variables for first nested activation (bash)" {
+@test "'hook.on-activate' resets environment variables for first nested activation (bash)" {
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/on-activate.toml"
 
@@ -1773,15 +1773,15 @@ EOF
     fi
     unset foo
     eval "$("$FLOX_BIN" activate)"
-    if [[ ! -z "${foo:-}" ]]; then
-      echo "foo=$foo when it should be unset"
+    if [[ "$foo" != "baz" ]]; then
+      echo "foo=$foo when it should be foo=baz"
       exit 1
     fi
 EOF
 }
 
 # bats test_tags=activate:scripts:on-activate,activate:scripts:on-activate:fish
-@test "'hook.on-activate' modifies environment variables for first nested activation (fish)" {
+@test "'hook.on-activate' resets environment variables for first nested activation (fish)" {
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/on-activate.toml"
 
@@ -1790,15 +1790,12 @@ EOF
     echo "$foo" | string match "baz"
     set -e foo
     eval "$("$FLOX_BIN" activate)"
-    if set -q foo
-      echo "foo=$foo when it should be unset"
-      exit 1
-    end
+    echo "$foo" | string match "baz"
 EOF
 }
 
 # bats test_tags=activate:scripts:on-activate,activate:scripts:on-activate:tcsh
-@test "'hook.on-activate' modifies environment variables for first nested activation (tcsh)" {
+@test "'hook.on-activate' resets environment variables for first nested activation (tcsh)" {
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/on-activate.toml"
 
@@ -1810,15 +1807,15 @@ EOF
     endif
     unsetenv foo
     eval "`$FLOX_BIN activate`"
-    if ( $?foo ) then
-      echo "foo=$foo when it should be unset"
+    if ( "$foo" != "baz" ) then
+      echo "foo=$foo when it should be foo=baz"
       exit 1
     endif
 EOF
 }
 
 # bats test_tags=activate:scripts:on-activate,activate:scripts:on-activate:zsh
-@test "'hook.on-activate' modifies environment variables for first nested activation (zsh)" {
+@test "'hook.on-activate' resets environment variables for first nested activation (zsh)" {
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/on-activate.toml"
 
@@ -1830,8 +1827,8 @@ EOF
     fi
     unset foo
     eval "$("$FLOX_BIN" activate)"
-    if [[ ! -z "${foo:-}" ]]; then
-      echo "foo=$foo when it should be unset"
+    if [[ "$foo" != "baz" ]]; then
+      echo "foo=$foo when it should be foo=baz"
       exit 1
     fi
 EOF
@@ -1863,8 +1860,8 @@ EOF
     fi
     export foo=baz
     eval "$(FLOX_SHELL="bash" "$FLOX_BIN" activate)"
-    if [[ "$foo" != "baz" ]]; then
-      echo "foo=$foo when it should be foo=baz"
+    if [[ ! -z "${foo:-}" ]]; then
+      echo "foo=$foo when it should be unset"
       exit 1
     fi
 EOF
@@ -1894,7 +1891,10 @@ EOF
     end
     set -gx foo baz
     eval "$("$FLOX_BIN" activate)"
-    echo "$foo" | string match "baz"
+    if set -q foo
+      echo "foo=$foo when it should be unset"
+      exit 1
+    end
 EOF
 }
 
@@ -1922,8 +1922,8 @@ EOF
     endif
     setenv foo baz
     eval "`$FLOX_BIN activate`"
-    if ( "$foo" != "baz" ) then
-      echo "foo=$foo when it should be foo=baz"
+    if ( $?foo ) then
+      echo "foo=$foo when it should be unset"
       exit 1
     endif
 EOF
@@ -1953,8 +1953,8 @@ EOF
     fi
     export foo=baz
     eval "$("$FLOX_BIN" activate)"
-    if [[ "$foo" != "baz" ]]; then
-      echo "foo=$foo when it should be foo=baz"
+    if [[ ! -z "${foo:-}" ]]; then
+      echo "foo=$foo when it should be unset"
       exit 1
     fi
 EOF


### PR DESCRIPTION
## Proposed Changes

This was originally introduced for bash in fa66016 (plus other shells in other commits) as a solution to `PATH` and `FPATH` being incorrectly ordered when replaying activations for nested environments.

We've since fixed the ordering of `PATH`, `FPATH`, and several other vars by re-constructing them correctly from `FLOX_ENV_DIRS` in `flox-activations`.

So we should be able to remove this logic, which is hard to read and threaded all the way through the interpreter.

This changes the behaviour of 8 related tests (2 groups of 4 shells) because we now replay environments for the first in-place activation when running a second in-place activation. This seems like the correct behaviour to me and I'm not clear whether the existing tests were intentional or documenting a side-effect.

## Release Notes

Nested in-place activations will now restore environment variables that were modified in `hook.on-activate`.