### PR TITLE
chore(ci): unpin nix version

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -31,8 +31,6 @@ runs:
   steps:
     - name: "Install newer Nix"
       uses: "cachix/install-nix-action@v31"
-      with:
-        install_url: "https://releases.nixos.org/nix/nix-2.30.3/install"
 
     - name: "Configure Nix"
       uses: "flox/configure-nix-action@main"


### PR DESCRIPTION
the around IPv6 address handling requiring pinning Nix version in https://github.com/flox/flox/pull/3585 has been resolved upstream