### PR TITLE
fix: skip sourcing ~/.bashrc for in-place

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/attach-command.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach-command.bash
@@ -19,6 +19,7 @@ case "$_flox_shell" in
         "${_FLOX_ENV_CACHE:-}" \
         "${_FLOX_ENV_PROJECT:-}" \
         "${_FLOX_ENV_DESCRIPTION:-}" \
+        "false" \
         > "$RCFILE"
       # self destruct
       echo "@coreutils@/bin/rm '$RCFILE'" >> "$RCFILE"

--- a/assets/environment-interpreter/activate/activate.d/attach-inplace.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach-inplace.bash
@@ -28,7 +28,8 @@ case "$_flox_shell" in
       "$FLOX_ENV" \
       "${_FLOX_ENV_CACHE:-}" \
       "${_FLOX_ENV_PROJECT:-}" \
-      "${_FLOX_ENV_DESCRIPTION:-}"
+      "${_FLOX_ENV_DESCRIPTION:-}" \
+      "true" # is_in_place
     ;;
   *fish)
     echo "$_flox_activations attach --runtime-dir \"$FLOX_RUNTIME_DIR\" --pid \$fish_pid --flox-env \"$FLOX_ENV\" --id \"$_FLOX_ACTIVATION_ID\" --remove-pid \"$expiring_pid\";"

--- a/assets/environment-interpreter/activate/activate.d/attach-interactive.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach-interactive.bash
@@ -17,6 +17,7 @@ case "$_flox_shell" in
         "${_FLOX_ENV_CACHE:-}" \
         "${_FLOX_ENV_PROJECT:-}" \
         "${_FLOX_ENV_DESCRIPTION:-}" \
+        "false" \
         > "$RCFILE"
       # self destruct
       echo "@coreutils@/bin/rm '$RCFILE'" >> "$RCFILE"

--- a/assets/environment-interpreter/activate/activate.d/generate-bash-startup-commands.bash
+++ b/assets/environment-interpreter/activate/activate.d/generate-bash-startup-commands.bash
@@ -25,17 +25,25 @@ generate_bash_startup_commands() {
   shift
   _FLOX_ENV_DESCRIPTION="${1?}"
   shift
+  _is_in_place="${1?}"
+  shift
 
   if [ "$_flox_activate_tracelevel" -ge 2 ]; then
     echo "set -x;"
   fi
 
-  # TODO: should we skip this for in-place activations?
-  # We use --rcfile to activate using bash which skips sourcing ~/.bashrc,
-  # so source that here, but not if we're already in the process of sourcing
-  # bashrc in a parent process.
-  if [ -f ~/.bashrc ] && [ -z "${_flox_sourcing_rc:=}" ]; then
-    echo "export _flox_sourcing_rc=1;"
+  # We need to source the .bashrc file exactly once. We skip it for in-place
+  # activations under the assumption that it has already been sourced by one
+  # of the shells in the chain of ancestors UNLESS none of them were bash
+  # and therefore .bashrc hasn't been sourced yet.
+  # declare needs_sourcing
+  # if bashrc exists:
+  should_source="false"
+  if [ -f ~/.bashrc ] && [ "${_is_in_place:-}" != "true" ] && [ "${_flox_sourcing_rc:-}" != "true" ]; then
+    should_source="true"
+  fi
+  if [ "$should_source" = "true" ]; then
+    echo "export _flox_sourcing_rc=true;"
     echo "source ~/.bashrc;"
     echo "unset _flox_sourcing_rc;"
   fi


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

This change skips loading `~/.bashrc` for in-place activations with the assumption that it has already been sourced by the shell doing the in-place activation. This prevents the following sequence of events that sources `~/.bashrc` twice.
- Add an in-place activation of the default environment to `bashrc`
- Create a new bash shell
- Shell loads `bashrc` (1)
- `bashrc` initiates the in-place activation
- `_flox_sourcing_rc` is unset at this point, so source `bashrc` (2)
- Finish the activation
- Finish the original sourcing of `bashrc`

For reviewers, this required some changes to a couple of tests. Bash only loads `~/.bashrc` when interactive, but our activation code was loading `bashrc` regardless, so some tests that perform a `bash -c <cmd>` no longer load `bashrc` and therefore no longer emit the `Sourcing .bashrc` lines.

There's also the test that checks compatibility with the previous release, and since previous releases contain this bug, we can't assert that they contain the same `Sourcing .bashrc` lines. This test must be disabled until after a release contains this fix.

Closes #3539

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Bash users with default environments will no longer see that their `.bashrc` file is sourced twice.

<!-- Many thanks! -->
