### PR TITLE
refactor: prep to respect activation mode

### DIFF
--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -200,7 +200,7 @@ pub fn guard_service_commands_available(
 pub fn guard_is_within_activation(
     services_environment: &ServicesEnvironment,
     action: &str,
-) -> Result<Option<GenerationId>> {
+) -> Result<(ActivateMode, Option<GenerationId>)> {
     let activated_environments = activated_environments();
 
     let env =
@@ -213,7 +213,8 @@ pub fn guard_is_within_activation(
     }
     let generation = activated_environments.is_active_with_generation(&env);
 
-    Ok(generation)
+    // TODO: mode should come from the ActiveEnvironment
+    Ok((ActivateMode::Dev, generation))
 }
 
 /// Warn about manifest changes that may require services to be restarted, if
@@ -286,6 +287,7 @@ pub async fn start_services_with_new_process_compose(
     flox: Flox,
     environment_select: EnvironmentSelect,
     mut concrete_environment: ConcreteEnvironment,
+    activate_mode: ActivateMode,
     names: &[String],
     generation: Option<GenerationId>,
 ) -> Result<Vec<String>> {
@@ -318,8 +320,7 @@ pub async fn start_services_with_new_process_compose(
         print_script: false,
         start_services: true,
         use_fallback_interpreter: false,
-        // FIXME: This should match the current activation.
-        mode: Some(ActivateMode::Dev),
+        mode: Some(activate_mode),
         generation,
         run_args: vec!["true".to_string()],
     }

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -40,7 +40,7 @@ impl Restart {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         environment_subcommand_metric!("services::restart", env.environment);
-        let generation = guard_is_within_activation(&env, "restart")?;
+        let (current_mode, generation) = guard_is_within_activation(&env, "restart")?;
         guard_service_commands_available(&env, &flox.system)?;
 
         let socket = env.socket();
@@ -71,6 +71,7 @@ impl Restart {
                 flox,
                 self.environment,
                 env.into_inner(),
+                current_mode,
                 &self.names,
                 generation,
             )

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -39,7 +39,7 @@ impl Start {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
         environment_subcommand_metric!("services::start", env.environment);
-        let generation = guard_is_within_activation(&env, "start")?;
+        let (current_mode, generation) = guard_is_within_activation(&env, "start")?;
         guard_service_commands_available(&env, &flox.system)?;
 
         let start_new_process_compose = if !env.expect_services_running() {
@@ -56,6 +56,7 @@ impl Start {
                 flox,
                 self.environment,
                 env.into_inner(),
+                current_mode,
                 &self.names,
                 generation,
             )


### PR DESCRIPTION
This is a prep patch refactoring some code and adding a skipped test. I'll make the actual fix once I'm not concerned about merge conflicts with contents of _FLOX_ACTIVE_ENVIRONMENTS.

Currently running `activate -m run` followed by `services start` will run a dev mode activation to start services.

Additionally, we have a bug that activations will stop services started by an activation of a different mode.

This means that `flox services start` for a run mode default environment will start a dev mode activation that exits immediately and stops services.

To fix that case, detect the mode of the active environment when running `services start` and run our ephemeral services activation in that mode.

## Release Notes

NA