### PR TITLE
fix(build): No nix store delete for sandbox clean

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1149,7 +1149,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "serial_test",
  "shell-escape",
  "temp-env",
  "tempfile",
@@ -3543,7 +3542,6 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
 dependencies = [
- "fslock",
  "futures",
  "log",
  "once_cell",

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -41,7 +41,6 @@ url-escape.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
 xdg.workspace = true
-serial_test = { workspace = true, features = ["file_locks"] }
 tracing-subscriber = { workspace = true, optional = true }
 pretty_assertions = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
@@ -56,7 +55,6 @@ httpmock.workspace = true
 pretty_assertions.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
-serial_test.workspace = true
 tracing-subscriber.workspace = true
 flox-test-utils.workspace = true
 catalog-api-v1 = { workspace = true, features = ["tests"] }

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1159,10 +1159,6 @@ mod license_tests {
 ///
 /// Currently, this is _the_ testsuite for the `flox-build.mk` builder.
 #[cfg(test)]
-// TODO: https://github.com/flox/flox/issues/2185
-// Serialise all build tests to workaround potential Nix bug.
-// Use file-based locking to be compatible with `nextest`.
-#[serial_test::file_serial(build)]
 mod tests {
     use std::fs::{self, File};
     use std::os::unix::fs::PermissionsExt;
@@ -3487,7 +3483,6 @@ mod tests {
 }
 
 #[cfg(test)]
-#[serial_test::file_serial(build)]
 mod nef_tests {
     use std::fs;
 


### PR DESCRIPTION
## Proposed Changes

We stopped calling a background `nix store delete` for manifest builds (and later NEF builds) to workaround a Nix daemon GC bug:

- 29076c43e96b54df6954029a9771015a3f66b559

But we didn't apply this to manifest builds that use the sandbox, for reasons that are unclear to me. Doing so means that they won't be subject to the same bug and allows us to dramatically speed up the tests by removing serialisation.

Before:

    Summary [ 288.125s] 83 tests run: 83 passed (3 slow), 661 skipped

After:

    Summary [  69.784s] 83 tests run: 83 passed, 661 skipped

I verified that the tests still failed prior to this change and without serialisation. So we still have the underlying bug.

I've inlined and commented the differences between the two targets into one to make it clear that we're not using the other target. We can uncomment them if the upstream issue is fixed. I think it's worth keeping them commented, rather than deleted in history for this case, to make it clear that we're not GCing the underlying paths.

## Release Notes

N/A, probably not worth mentioning because we haven't had any recent reports.