### PR TITLE
feat(generations): Page output from list+history

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "indoc",
  "inquire",
  "itertools",
+ "minus",
  "nix",
  "oauth2",
  "once_cell",
@@ -2157,6 +2158,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "minus"
+version = "5.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093bd0520d2a37943566a73750e6d44094dac75d66a978d1f0d97ffc78686832"
+dependencies = [
+ "crossbeam-channel",
+ "crossterm 0.27.0",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "textwrap",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2336,9 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "openapiv3"

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -57,6 +57,7 @@ uuid.workspace = true
 xdg.workspace = true
 flox-core.workspace = true
 sapling-renderdag = "0.1.0"
+minus = { version = "5.6.1", features = ["static_output", "search"] }
 
 [dev-dependencies]
 pretty_assertions.workspace = true


### PR DESCRIPTION
## Proposed Changes

The output from `generations list` and `generations history` can get
very long and spam the terminal for older environments that have lots of
generations.

The pager isn't invoked if the output would fit in the terminal, the
terminal isn't interactive, or the `--no-pager` argument is given.

Output has been reversed so that the most recent items appears at the
top of page. This behaviour doesn't change when not using a pager,
partly because we don't have control over when the pager decides to
page, but it's also consistent with how `git log` works.

This library seemed like a good choice and less fiddly than invoking an
external pager. There hasn't been a recent release but it looks pretty
feature complete. There are a few open issues but:

- I can't reproduce any problem with tracing
- text selection works for me when holding shift

The only thing that it's missing is the ability to persist the screen
when exiting the pager but that doesn't feel like a deal breaker when
you can disable the pager with an argument or by piping to `cat`.

I've verified the following features work fine for me:

- keyboard and mouse scrolling
- search, including incremental
- window resizing
- line wrapping
- metrics are sent when the pager is closed

There's not really much that we can write automated tests for, other
than getting output when non-interactive, but even that overlaps with
upstream tests and doesn't seem worth doing.

This doesn't appear to have affected the binary size by much:

    # Before
    % du -k cli/target/release/flox
    29148 cli/target/release/flox

    # After
    % du -k cli/target/release/flox
    29720 cli/target/release/flox
## Release Notes

`flox generations list` and `flox generations history` now use an interactive pager if the output is greater than the terminal size and the terminal is interactive. The behaviour can be disabled with `--no-pager`.
