### PR TITLE
fix: respect mode for services start

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -289,7 +289,11 @@ impl Activate {
             }
         } else {
             // Add to _FLOX_ACTIVE_ENVIRONMENTS so we can detect what environments are active.
-            flox_active_environments.set_last_active(now_active.clone(), self.generation);
+            flox_active_environments.set_last_active(
+                now_active.clone(),
+                self.generation,
+                mode.clone(),
+            );
         };
 
         // Determine values for `set_prompt` and `hide_default_prompt`, taking
@@ -831,7 +835,7 @@ mod tests {
     #[test]
     fn test_shell_prompt_default() {
         let mut active_environments = ActiveEnvironments::default();
-        active_environments.set_last_active(DEFAULT_ENV.clone(), None);
+        active_environments.set_last_active(DEFAULT_ENV.clone(), None, ActivateMode::Dev);
 
         // with `hide_default_prompt = false` we should see the default environment
         let prompt = Activate::make_prompt_environments(false, &active_environments);
@@ -845,8 +849,8 @@ mod tests {
     #[test]
     fn test_shell_prompt_mixed() {
         let mut active_environments = ActiveEnvironments::default();
-        active_environments.set_last_active(DEFAULT_ENV.clone(), None);
-        active_environments.set_last_active(NON_DEFAULT_ENV.clone(), None);
+        active_environments.set_last_active(DEFAULT_ENV.clone(), None, ActivateMode::Dev);
+        active_environments.set_last_active(NON_DEFAULT_ENV.clone(), None, ActivateMode::Dev);
 
         // with `hide_default_prompt = false` we should see the default environment
         let prompt = Activate::make_prompt_environments(false, &active_environments);
@@ -937,6 +941,7 @@ mod upgrade_notification_tests {
         active.set_last_active(
             UninitializedEnvironment::from_concrete_environment(&environment),
             None,
+            ActivateMode::Dev,
         );
 
         write_upgrade_available(&flox, &mut environment);

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -205,16 +205,15 @@ pub fn guard_is_within_activation(
 
     let env =
         UninitializedEnvironment::from_concrete_environment(&services_environment.environment);
-    if !activated_environments.is_active(&env) {
-        return Err(ServicesCommandsError::NotInActivation {
+
+    if let Some(active) = activated_environments.get_if_active(&env) {
+        Ok((active.mode.clone(), active.generation))
+    } else {
+        Err(ServicesCommandsError::NotInActivation {
             action: action.to_string(),
         }
-        .into());
+        .into())
     }
-    let generation = activated_environments.is_active_with_generation(&env);
-
-    // TODO: mode should come from the ActiveEnvironment
-    Ok((ActivateMode::Dev, generation))
 }
 
 /// Warn about manifest changes that may require services to be restarted, if

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1376,14 +1376,13 @@ EOF
 }
 
 @test "start: respects activation mode" {
-  skip "behavior not yet fixed"
   # Run a service that checks if CPATH is set
   # CPATH should be set in dev mode but not in run mode
   MANIFEST_CONTENTS="$(cat << 'EOF'
     version = 1
 
     [services]
-    one.command = "[[ -n '$CPATH' ]]"
+    one.command = "[[ -n \"$CPATH\" ]]"
 EOF
   )"
 


### PR DESCRIPTION
Store activation mode in _FLOX_ACTIVE_ENVIRONMENTS and use it to control activation mode for flox services start/restart, which were prepped for this change in
df4672d245a9c4973abaabdd441bf621aefe2bc1

## Release Notes

Fixed a bug where `flox services start` would fail for environments activated in run mode (`flox activate --mode run`)
