### PR TITLE
chore: compile hyper with optimizations

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -122,9 +122,3 @@ opt-level = "z"
 strip = true
 lto = true
 codegen-units = 1
-
-# Disable compiler optimizations until
-# https://github.com/rust-lang/rust/issues/140686
-# is fixed
-[profile.release.package."hyper"]
-opt-level = 0


### PR DESCRIPTION
Disabling hyper optimizations was a workaround for a bug in rustc. We're now on 1.89.0 which has the fix

## Release Notes

NA