### PR TITLE
feat: show diverged metadata on `flox push|pull` with diverged history

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -939,6 +939,12 @@ pub struct WithOtherFields<T> {
     other: BTreeMap<String, Value>,
 }
 
+impl<T> WithOtherFields<T> {
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
 impl<T> From<T> for WithOtherFields<T> {
     fn from(value: T) -> Self {
         WithOtherFields {

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -261,7 +261,7 @@ impl Pull {
 
         let mut env = {
             let result = ManagedEnvironment::open(flox, pointer, &dot_flox_path, None)
-                .map_err(Self::handle_error);
+                .map_err(Self::handle_open_error_during_pull_new);
             match result {
                 Err(err) => {
                     fs::remove_dir_all(&dot_flox_path)
@@ -516,7 +516,13 @@ impl Pull {
         Ok(choice == 1)
     }
 
-    fn handle_error(err: EnvironmentError) -> anyhow::Error {
+    // TODO: consider removing this function.
+    // 1. Its only used by [Self::pull_new_environment]
+    // 2. The access denied variant is not handled much different than its generic counter part
+    //    in errors.rs.
+    // 3. [UpstreamNotFound] is slightly different but could be folded into a generic message as well,
+    //    inlined into the caller.
+    fn handle_open_error_during_pull_new(err: EnvironmentError) -> anyhow::Error {
         if let EnvironmentError::ManagedEnvironment(err) = err {
             match err {
                 ManagedEnvironmentError::AccessDenied => {

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -523,10 +523,6 @@ impl Pull {
                     let message = "You do not have permission to pull this environment";
                     anyhow::Error::msg(message)
                 },
-                ManagedEnvironmentError::Diverged { .. } => {
-                    let message = "The environment has diverged from the remote version";
-                    anyhow::Error::msg(message)
-                },
                 ManagedEnvironmentError::UpstreamNotFound {
                     env_ref,
                     upstream: _,

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -523,7 +523,7 @@ impl Pull {
                     let message = "You do not have permission to pull this environment";
                     anyhow::Error::msg(message)
                 },
-                ManagedEnvironmentError::Diverged => {
+                ManagedEnvironmentError::Diverged { .. } => {
                     let message = "The environment has diverged from the remote version";
                     anyhow::Error::msg(message)
                 },

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -149,8 +149,8 @@ impl Push {
             EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::AccessDenied) => formatdoc! {"
                 You do not have permission to write to {owner}/{name}
             "}.into(),
-            EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::Diverged{..}) if create_remote => formatdoc! {"
-                An environment named {owner}/{name} already exists!
+            EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::UpstreamAlreadyExists { ref env_ref, .. }) if create_remote => formatdoc! {"
+                An environment named {env_ref} already exists!
 
                 To rename your environment: 'flox edit --name <new name>'
                 To pull and manually re-apply your changes: 'flox delete && flox pull -r {owner}/{name}'

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -149,7 +149,7 @@ impl Push {
             EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::AccessDenied) => formatdoc! {"
                 You do not have permission to write to {owner}/{name}
             "}.into(),
-            EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::Diverged) if create_remote => formatdoc! {"
+            EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::Diverged{..}) if create_remote => formatdoc! {"
                 An environment named {owner}/{name} already exists!
 
                 To rename your environment: 'flox edit --name <new name>'

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -476,6 +476,8 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
                 message.to_string()
             }
         },
+
+        ManagedEnvironmentError::UpstreamAlreadyExists { .. } => display_chain(err),
         // access denied is caught early as ManagedEnvironmentError::AccessDenied
         ManagedEnvironmentError::Push(_) => display_chain(err),
         ManagedEnvironmentError::PushWithLocalIncludes => display_chain(err),

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -425,7 +425,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
             * is not an IP address or 'localhost'
         "},
 
-        ManagedEnvironmentError::Diverged => formatdoc! {"
+        ManagedEnvironmentError::Diverged { .. } => formatdoc! {"
             The environment has diverged from the remote.
 
             This can happen if the environment is modified and pushed from another machine.
@@ -560,16 +560,17 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
             ", err = format_managed_error(err)},
         RemoteEnvironmentError::GetLatestVersion(err) => formatdoc! {"
             Failed to get latest version of remote environment: {err}
-
             ", err = display_chain(err)},
-        RemoteEnvironmentError::UpdateUpstream(ManagedEnvironmentError::Diverged) => formatdoc! {"
+        RemoteEnvironmentError::UpdateUpstream(ManagedEnvironmentError::Diverged { .. }) => {
+            formatdoc! {"
             The remote environment has diverged.
 
             This can happen if the environment is modified and pushed from another machine
             at the same time.
 
             Please try again after verifying the concurrent changes.
-        "},
+        "}
+        },
         RemoteEnvironmentError::UpdateUpstream(ManagedEnvironmentError::AccessDenied) => {
             formatdoc! {"
             Access denied to the remote environment.

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -214,8 +214,24 @@ EOF
   # assert that pulling fails
   run "$FLOX_BIN" pull
   assert_failure
-  # assert that the environment contains the installed package
-  assert_output --partial "diverged"
+  # assert that the error message includes infomration about the generations/history
+  assert_output --regexp "
+❌ ERROR: The environment has diverged from the remote:
+
+Local:
+
+ \* $USER installed package 'emacs \\(emacs\\)' on .+
+   Generation:  2
+   Timestamp: .*
+
+Remote:
+
+ \* $USER installed package 'vim \\(vim\\)' on .+
+   Generation:  2
+   Timestamp: .*
+"
+
+
 
   # assert that pulling with `--force` succeeds
   run "$FLOX_BIN" pull --force


### PR DESCRIPTION
* feat: include diverged metadata states in error message

Include generation, timestamp and summary of both the local and remote generation history
if they are detected to diverge during `flox push|pull`.

```
❌ ERROR: The environment has diverged from the remote:

Local:

 * yannik installed package 'iputils (iputils)' on Yanniks-NUC
   Generation:  4
   Timestamp: 2025-10-01 12:25:49 UTC

Remote:

 * yannik installed package 'gum (gum)' on Yanniks-MacBook-Pro.local
   Generation:  4
   Timestamp: 2025-10-01 12:25:15 UTC

This can happen if the environment is modified and pushed from another machine.

To resolve this issue, either
 * run 'flox pull --force'
   to discard local changes
   and reset the environment to the latest upstream version.
 * run 'flox push --force'
   to overwrite the remote environment with the local changes.
   Attention: this will discard any changes made on the remote machine
   and cause conflicts when the remote machine tries to pull or push!

```

* feat: return a more precise error variant when creating an env on floxhub

Pushing a _new_ environment to floxhub with a reference
that already exists previously returned the same `Diverged` error variant
as pushing or pulling _changes_.
Since the new error messaging would be confusing,
return a new `UpstreamalreadyExists` variant instead