### PR TITLE
fix(activate): Omit message on activate -- command

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -214,6 +214,15 @@ if [ -n "$FLOX_CMD" ]; then
   set -- "$FLOX_CMD"
 fi
 
+# This is distinct from "_FLOX_ACTIVATION_MODE"
+if [ $# -gt 0 ]; then
+  _flox_shell_mode="command"
+elif [ -t 1 ] || [ -n "${_FLOX_FORCE_INTERACTIVE:-}" ]; then
+  _flox_shell_mode="interactive"
+else
+  _flox_shell_mode="inplace"
+fi
+
 # Propagate required variables that are documented as exposed.
 export FLOX_ENV="${_FLOX_ENV}"
 
@@ -290,11 +299,11 @@ export _FLOX_ACTIVATION_STATE_DIR _FLOX_ACTIVATION_ID
 if [ "$_FLOX_ATTACH" == true ]; then
   # shellcheck source-path=SCRIPTDIR/activate.d
   source "${_activate_d}/attach.bash"
-  attach "$_FLOX_ACTIVATION_STATE_DIR"
+  attach "$_FLOX_ACTIVATION_STATE_DIR" "$_flox_shell_mode"
 else
   # shellcheck source-path=SCRIPTDIR/activate.d
   source "${_activate_d}/start.bash"
-  start "$_FLOX_ACTIVATION_STATE_DIR"
+  start "$_FLOX_ACTIVATION_STATE_DIR" "$_flox_shell_mode"
 fi
 
 # Start services before the shell or command is invoked
@@ -303,16 +312,23 @@ if [ "${FLOX_ACTIVATE_START_SERVICES:-}" == "true" ]; then
   source "${_activate_d}/start-services.bash"
 fi
 
-# From this point on the activation process depends on the mode:
-if [ $# -gt 0 ]; then
-  # shellcheck source-path=SCRIPTDIR/activate.d
-  source "${_activate_d}/attach-command.bash"
-elif [ -t 1 ] || [ -n "${_FLOX_FORCE_INTERACTIVE:-}" ]; then
-  # shellcheck source-path=SCRIPTDIR/activate.d
-  source "${_activate_d}/attach-interactive.bash"
-else
-  # shellcheck source-path=SCRIPTDIR/activate.d
-  source "${_activate_d}/attach-inplace.bash"
-fi
+case "${_flox_shell_mode}" in
+  command)
+    # shellcheck source-path=SCRIPTDIR/activate.d
+    source "${_activate_d}/attach-command.bash"
+    ;;
+  interactive)
+    # shellcheck source-path=SCRIPTDIR/activate.d
+    source "${_activate_d}/attach-interactive.bash"
+    ;;
+  inplace)
+    # shellcheck source-path=SCRIPTDIR/activate.d
+    source "${_activate_d}/attach-inplace.bash"
+    ;;
+  *)
+    echo "Unsupported shell mode: ${_flox_shell_mode}" >&2
+    exit 1
+    ;;
+esac
 
 "$_flox_activate_tracer" "${BASH_SOURCE[0]}" "$@" END

--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -50,6 +50,8 @@ source "${_activate_d}/generate-tcsh-startup-commands.bash"
 source "${_activate_d}/helpers.bash"
 # shellcheck source-path=SCRIPTDIR/activate.d
 source "${_activate_d}/start.bash"
+# shellcheck source-path=SCRIPTDIR/activate.d
+source "${_activate_d}/attach.bash"
 
 # Top-level Flox environment activation script.
 
@@ -290,8 +292,7 @@ export _FLOX_ACTIVATION_STATE_DIR _FLOX_ACTIVATION_ID
 # re-run profile scripts, without start or attach, because the shell will
 # already be attached to an activation.
 if [ "$_FLOX_ATTACH" == true ]; then
-  # shellcheck source-path=SCRIPTDIR/activate.d
-  source "${_activate_d}/attach.bash"
+  attach "$_FLOX_ACTIVATION_STATE_DIR"
 else
   start "$_FLOX_ACTIVATION_STATE_DIR"
 fi

--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -48,10 +48,6 @@ source "${_activate_d}/generate-fish-startup-commands.bash"
 source "${_activate_d}/generate-tcsh-startup-commands.bash"
 # shellcheck source-path=SCRIPTDIR/activate.d
 source "${_activate_d}/helpers.bash"
-# shellcheck source-path=SCRIPTDIR/activate.d
-source "${_activate_d}/start.bash"
-# shellcheck source-path=SCRIPTDIR/activate.d
-source "${_activate_d}/attach.bash"
 
 # Top-level Flox environment activation script.
 
@@ -292,8 +288,12 @@ export _FLOX_ACTIVATION_STATE_DIR _FLOX_ACTIVATION_ID
 # re-run profile scripts, without start or attach, because the shell will
 # already be attached to an activation.
 if [ "$_FLOX_ATTACH" == true ]; then
+  # shellcheck source-path=SCRIPTDIR/activate.d
+  source "${_activate_d}/attach.bash"
   attach "$_FLOX_ACTIVATION_STATE_DIR"
 else
+  # shellcheck source-path=SCRIPTDIR/activate.d
+  source "${_activate_d}/start.bash"
   start "$_FLOX_ACTIVATION_STATE_DIR"
 fi
 

--- a/assets/environment-interpreter/activate/activate.d/attach.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach.bash
@@ -1,20 +1,25 @@
-"$_flox_activate_tracer" "$_activate_d/attach.bash" START
-
 _sed="@gnused@/bin/sed"
 
-# If interactive and a command has not been passed, this is an interactive
-# activate,
-# and we print a message to the user
-# If inside a container, FLOX_ENV_DESCRIPTION won't be set, and we don't need to
-# print a message (although attach isn't reachable anyways)
-if [ -t 1 ] && [ $# -eq 0 ] && [ -n "${FLOX_ENV_DESCRIPTION:-}" ]; then
-  echo "✅ Attached to existing activation of environment '$FLOX_ENV_DESCRIPTION'" >&2
-  echo "To stop using this environment, type 'exit'" >&2
-  echo >&2
-fi
+attach() {
+  _flox_activation_state_dir="${1?}"
+  shift
 
-# Replay the environment for the benefit of this shell.
-eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
-eval "$($_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
+  "$_flox_activate_tracer" "$_activate_d/attach.bash" START
 
-"$_flox_activate_tracer" "$_activate_d/attach.bash" END
+  # If interactive and a command has not been passed, this is an interactive
+  # activate,
+  # and we print a message to the user
+  # If inside a container, FLOX_ENV_DESCRIPTION won't be set, and we don't need to
+  # print a message (although attach isn't reachable anyways)
+  if [ -t 1 ] && [ $# -eq 0 ] && [ -n "${FLOX_ENV_DESCRIPTION:-}" ]; then
+    echo "✅ Attached to existing activation of environment '$FLOX_ENV_DESCRIPTION'" >&2
+    echo "To stop using this environment, type 'exit'" >&2
+    echo >&2
+  fi
+
+  # Replay the environment for the benefit of this shell.
+  eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "${_flox_activation_state_dir}/del.env")"
+  eval "$($_sed -e 's/^/export /' -e 's/$/;/' "${_flox_activation_state_dir}/add.env")"
+
+  "$_flox_activate_tracer" "$_activate_d/attach.bash" END
+}

--- a/assets/environment-interpreter/activate/activate.d/attach.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach.bash
@@ -3,15 +3,15 @@ _sed="@gnused@/bin/sed"
 attach() {
   _flox_activation_state_dir="${1?}"
   shift
+  _flox_shell_mode="${1?}"
+  shift
 
   "$_flox_activate_tracer" "$_activate_d/attach.bash" START
 
-  # If interactive and a command has not been passed, this is an interactive
-  # activate,
-  # and we print a message to the user
+  # Don't clobber STDERR or recommend 'exit' for non-interactive shells.
   # If inside a container, FLOX_ENV_DESCRIPTION won't be set, and we don't need to
   # print a message (although attach isn't reachable anyways)
-  if [ -t 1 ] && [ $# -eq 0 ] && [ -n "${FLOX_ENV_DESCRIPTION:-}" ]; then
+  if [ "${_flox_shell_mode}" = "interactive" ] && [ -n "${FLOX_ENV_DESCRIPTION:-}" ]; then
     echo "✅ Attached to existing activation of environment '$FLOX_ENV_DESCRIPTION'" >&2
     echo "To stop using this environment, type 'exit'" >&2
     echo >&2

--- a/assets/environment-interpreter/activate/activate.d/start.bash
+++ b/assets/environment-interpreter/activate/activate.d/start.bash
@@ -12,6 +12,8 @@ _sort="@coreutils@/bin/sort"
 start() {
   _flox_activation_state_dir="${1?}"
   shift
+  _flox_shell_mode="${1?}"
+  shift
 
   if [ -z "$_flox_activation_state_dir" ]; then
     echo "Error: _flox_activation_state_dir cannot be empty" >&2
@@ -20,12 +22,10 @@ start() {
 
   "$_flox_activate_tracer" "$_activate_d/start.bash" START
 
-  # If interactive and a command has not been passed, this is an interactive
-  # activate,
-  # and we print a message to the user
+  # Don't clobber STDERR or recommend 'exit' for non-interactive shells.
   # If inside a container, FLOX_ENV_DESCRIPTION won't be set, and we don't need to
   # print a message
-  if [ -t 1 ] && [ $# -eq 0 ] && [ -n "${FLOX_ENV_DESCRIPTION:-}" ]; then
+  if [ "${_flox_shell_mode}" = "interactive" ] && [ -n "${FLOX_ENV_DESCRIPTION:-}" ]; then
     echo "✅ You are now using the environment '$FLOX_ENV_DESCRIPTION'." >&2
     echo "To stop using this environment, type 'exit'" >&2
     echo >&2


### PR DESCRIPTION
## Proposed Changes

We shouldn't print a message on `activate -- command` because it:

1. tells you to use `exit` to leave an activation which you don't have
   an interactive shell for
2. also tells you to use `exit` when using `flox/flox-direnv` which
   causes you to exit the entire shell rather than just the activation
3. clobbers STDERR from the command that's being executed

This was working correctly for "attach":

    flox [default term]
    (2) ~/demo/hello
    % flox activate
    ✅ You are now using the environment 'hello'.
    To stop using this environment, type 'exit'

    flox [hello default term]
    (3) ~/demo/hello
    % flox activate -- hello
    Hello, world!

But not for "start":

    (2) ~/demo/hello
    % flox activate -- hello
    ✅ You are now using the environment 'hello'.
    To stop using this environment, type 'exit'

    Hello, world!

Which we regressed when refactoring `start` into a function where `$#`
is always non-zero. Fix this by detecting the mode earlier on and
explicitly storing it in a local variable.

I haven't add any new tests because it's pretty fiddly to capture the
complete matrix of interactive x non-interactive x start x attach,
whilst also asserting on the complete output when we have a lot of noise
from the RC files and expect.

## Release Notes

Fixed a bug where `flox activate -- command` incorrectly printed a message to STDERR.
