### PR TITLE
fix(push): Error when changing owner

### DIFF
--- a/cli/flox/doc/flox-push.md
+++ b/cli/flox/doc/flox-push.md
@@ -52,6 +52,10 @@ FloxHub with local changes to the environment.
 `-o`, `--owner`, `--org`
 :   FloxHub owner to push environment to (default: current FloxHub user).
 
+    Can only be specified when pushing an environment for the first time.
+    Use 'flox pull --copy' to copy an existing environment and push it to a new
+    owner.
+
 `-f`, `--force`
 :   Forcibly overwrite the remote copy of the environment.
 

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -119,6 +119,27 @@ EOF
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=managed,pull,managed:pull
+@test "managed environment can't be pushed to another owner" {
+  make_empty_managed_env
+
+  NEW_OWNER="another-owner"
+  RUST_BACKTRACE=0 run "$FLOX_BIN" push --owner "$NEW_OWNER"
+  assert_failure
+  assert_output - << EOF
+⚠️  Using file://${FLOX_FLOXHUB_PATH} as FloxHub host
+'\$_FLOX_FLOXHUB_GIT_URL' is used for testing purposes only,
+alternative FloxHub hosts are not yet supported!
+
+❌ ERROR: Cannot change the owner of an environment already pushed to FloxHub.
+
+To push this environment to another owner or org:
+* Push any outstanding changes with 'flox push'
+* Create copy of the environment with 'flox pull --copy -d <directory> ${OWNER}/${PROJECT_NAME}'
+* Push the copy to the new owner with 'flox push --owner ${NEW_OWNER}'
+EOF
+}
+
+# bats test_tags=managed,pull,managed:pull
 @test "m4: pushed environment can be pulled" {
   mkdir a a_data
   mkdir b b_data


### PR DESCRIPTION
## Proposed Changes

This flag was previously ignored when operating on an existing managed
environment. We would just push to the existing owner and print a
message referencing the existing remote ref.

Now raise an error and instruct them to use `flox pull --copy` to make a
copy of the environment before pushing again. This puts some burden on
the user if they want to keep a single environment in sync between two
users or orgs, but it saves us from dealing with a handful of unexpected
behaviours with tracking multiple remotes whilst we don't currently know
if it's a common use case.

Make this an error and instruct the user to do the push again, rather
than push with a warning, because we don't know for sure that the user
wanted to update the existing remote.

## Release Notes

Return an error when `flox push --owner` is used on an existing managed environment. This argument was previously ignored.
