### PR TITLE
fix: search suggestions, color cleanups

### DIFF
--- a/cli/flox/src/commands/generations/history.rs
+++ b/cli/flox/src/commands/generations/history.rs
@@ -15,8 +15,7 @@ use tracing::instrument;
 
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
-use crate::utils::dialog::Dialog;
-use crate::utils::message::page_output;
+use crate::utils::message::{page_output, stdout_supports_color};
 
 /// Arguments for the `flox generations history` command
 #[derive(Bpaf, Debug, Clone)]
@@ -56,7 +55,7 @@ impl History {
         let output = match self.output_mode {
             OutputMode::Pretty => DisplayHistory {
                 history: metadata.history(),
-                pretty: Dialog::can_prompt(),
+                pretty: stdout_supports_color(),
             }
             .to_string(),
             OutputMode::Json => {

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -17,8 +17,7 @@ use tracing::instrument;
 
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
-use crate::utils::dialog::Dialog;
-use crate::utils::message::page_output;
+use crate::utils::message::{page_output, stdout_supports_color};
 
 /// Arguments for the `flox generations list` command
 #[derive(Bpaf, Debug, Clone)]
@@ -65,7 +64,7 @@ impl List {
         let output = match self.output_mode {
             OutputMode::Pretty => DisplayAllMetadata {
                 metadata: &metadata,
-                pretty: Dialog::can_prompt(),
+                pretty: stdout_supports_color(),
             }
             .to_string(),
             OutputMode::Tree => render_tree(&metadata),

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -56,7 +56,7 @@ use crate::commands::{
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::didyoumean::{DidYouMean, InstallSuggestion};
 use crate::utils::errors::format_error;
-use crate::utils::message;
+use crate::utils::message::{self};
 use crate::utils::openers::Shell;
 use crate::utils::tracing::sentry_set_tag;
 use crate::{Exit, environment_subcommand_metric, subcommand_metric};

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -12,7 +12,7 @@ use tracing::{debug, instrument};
 use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::didyoumean::{DidYouMean, SearchSuggestion};
-use crate::utils::message;
+use crate::utils::message::{self, stderr_supports_color, stdout_supports_color};
 use crate::utils::search::DisplaySearchResults;
 use crate::utils::tracing::sentry_set_tag;
 
@@ -88,8 +88,12 @@ impl Search {
         } else {
             debug!("printing search results as user facing");
 
-            let suggestion =
-                DidYouMean::<SearchSuggestion>::new(search_term, &flox.catalog_client, flox.system);
+            let suggestion = DidYouMean::<SearchSuggestion>::new(
+                search_term,
+                &flox.catalog_client,
+                flox.system,
+                stderr_supports_color(),
+            );
 
             if results.results.is_empty() {
                 let mut message =
@@ -106,7 +110,11 @@ impl Search {
                 bail!(message);
             }
 
-            let results = DisplaySearchResults::from_search_results(search_term, results)?;
+            let results = DisplaySearchResults::from_search_results(
+                search_term,
+                results,
+                stdout_supports_color(),
+            )?;
             println!("{results}");
 
             let mut hints = String::new();

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -9,6 +9,7 @@ use tracing_subscriber::{EnvFilter, Registry, filter};
 
 use crate::commands::Verbosity;
 use crate::utils::init::logger::indicatif::PROGRESS_TAG;
+use crate::utils::message::stderr_supports_color;
 use crate::utils::metrics::MetricsLayer;
 
 static LOGGER_HANDLE: OnceLock<Handle<EnvFilter, Registry>> = OnceLock::new();
@@ -72,7 +73,7 @@ pub fn create_registry_and_filter_reload_handle() -> (
     let filter = tracing_subscriber::filter::EnvFilter::try_new("trace").unwrap();
 
     let (filter, filter_reload_handle) = tracing_subscriber::reload::Layer::new(filter);
-    let use_colors = supports_color::on(supports_color::Stream::Stderr).is_some();
+    let use_colors = stderr_supports_color();
 
     // Tracing layer that handles user facing messages.
     // That is messages that are produced by the `crate::utils::message` module,

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -58,7 +58,7 @@ pub(crate) fn package_installed(pkg: &PackageToInstall, environment_description:
     ));
 }
 
-/// Page large output to the terminal.
+/// Page large output to terminal stdout.
 /// The output will be printed without a pager if it's not larger than the
 /// terminal window or the terminal is not interactive.
 pub(crate) fn page_output(s: impl Into<String>) -> anyhow::Result<()> {
@@ -73,6 +73,14 @@ pub(crate) fn page_output(s: impl Into<String>) -> anyhow::Result<()> {
     page_all(pager)?;
 
     Ok(())
+}
+
+pub fn stdout_supports_color() -> bool {
+    supports_color::on(supports_color::Stream::Stdout).is_some()
+}
+
+pub fn stderr_supports_color() -> bool {
+    supports_color::on(supports_color::Stream::Stderr).is_some()
 }
 
 /// Display a message for packages that were successfully installed for all

--- a/cli/flox/src/utils/search.rs
+++ b/cli/flox/src/utils/search.rs
@@ -1,9 +1,7 @@
 use std::fmt::Display;
-use std::io::stdout;
 
 use anyhow::Result;
 use crossterm::style::Stylize;
-use crossterm::tty::IsTty;
 use flox_rust_sdk::models::search::{SearchResult, SearchResults};
 
 pub const DEFAULT_DESCRIPTION: &'_ str = "<no description provided>";
@@ -82,12 +80,11 @@ impl DisplaySearchResults {
     pub(crate) fn from_search_results(
         search_term: &str,
         search_results: SearchResults,
+        use_bold: bool,
     ) -> Result<DisplaySearchResults> {
         let n_results = search_results.results.len();
 
         let display_items: DisplayItems = search_results.results.into();
-
-        let use_bold = stdout().is_tty();
 
         Ok(DisplaySearchResults {
             search_term: search_term.to_string(),


### PR DESCRIPTION
- **fix: don't garble search suggestions**
  For security reasons, tracing-subscriber started escaping ANSI codes in
  0.3.20, which we recently updated to in
  8d4c7e521893bc5cc99bc419d98c90082c1e062d
  See https://github.com/tokio-rs/tracing/issues/3369
  
  This regressed our formatting for search suggestions
  
  Use eprintln until tracing subscriber supports bold formatting
  
  We could instead pin to 0.3.19 but I think this is the only place we
  need ANSI codes and using eprintln is a straightforward workaround.
  

- **fix: cleanup when we output bold and colors**
  - Respect NO_COLOR
  - Handle different combinations of whether stdout, stderr, and stdin are
    ttys
  
  We currently use 3 different things to decide when to output colors:
  - Dialog::can_prompt()
  - stdout().is_tty()
  - supports_color::on(supports_color::Stream::Stderr).is_some();
  
  Instead add two methods that use supports_color, one for stdout and one
  for stderr.
  
  Behavior changes:
  - We respect NO_COLOR throughout
  - flox search java > /dev/null will now bold suggestions printed to
    stderr (previously it was checking if stdout was a tty)
  - flox generations list 2>/dev/null will now colorize output (previously
    it was using can_prompt() which checks stderr to determine whether to
    colorize)
  - flox generations history 2>/dev/null will now bold output
  

## Release Notes

- Fixed ANSI code escaping for flox search
- Add respect for NO_COLOR