### PR TITLE
feat: add `flox auth token` command

### DIFF
--- a/cli/flox/doc/flox-auth.md
+++ b/cli/flox/doc/flox-auth.md
@@ -13,7 +13,7 @@ flox-auth - FloxHub authentication commands
 
 ```
 flox [<general-options>] auth
-     (login | logout | status)
+     (login | logout | status | token)
 ```
 
 # DESCRIPTION

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -187,6 +187,10 @@ pub enum Auth {
     /// Print your current login status
     #[bpaf(command)]
     Status,
+
+    /// Print your token to stdout
+    #[bpaf(command)]
+    Token,
 }
 
 impl Auth {
@@ -231,6 +235,18 @@ impl Auth {
                     flox.floxhub.base_url()
                 ));
 
+                Ok(())
+            },
+            Auth::Token => {
+                let span = tracing::info_span!("token");
+                let _guard = span.enter();
+
+                let Some(token) = flox.floxhub_token else {
+                    message::warning("You are not currently logged in to FloxHub.");
+                    return Err(Exit(1.into()).into());
+                };
+
+                println!("{}", token.secret());
                 Ok(())
             },
         }


### PR DESCRIPTION
## Proposed Changes

If logged in, prints the user token, otherwise returns an error and exits unsuccessfully.

## Release Notes

A new command `flox auth token` to read out the current token e.g. for automations.
