### PR TITLE
feat: detect flox containerd runtime

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -34,7 +34,7 @@ use super::publish::CheckedEnvironmentMetadata;
 use crate::data::System;
 use crate::flox::{FLOX_VERSION, Flox};
 use crate::models::search::{PackageDetails, ResultCount, SearchLimit, SearchResults};
-use crate::utils::IN_CI;
+use crate::utils::{IN_CI, IN_CONTAINERD};
 
 pub const FLOX_CATALOG_MOCK_DATA_VAR: &str = "_FLOX_USE_CATALOG_MOCK";
 pub const FLOX_CATALOG_DUMP_DATA_VAR: &str = "_FLOX_CATALOG_DUMP_RESPONSE_FILE";
@@ -376,6 +376,13 @@ impl CatalogClient {
         if *IN_CI {
             header_map.insert(
                 header::HeaderName::from_static("flox-ci"),
+                header::HeaderValue::from_static("true"),
+            );
+        };
+
+        if *IN_CONTAINERD {
+            header_map.insert(
+                header::HeaderName::from_static("flox-containerd"),
                 header::HeaderValue::from_static("true"),
             );
         };

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -23,6 +23,9 @@ use self::errors::IoError;
 /// but for now just use the `CI` environment variable
 pub static IN_CI: LazyLock<bool> = LazyLock::new(|| env::var("CI").is_ok());
 
+/// Whether the CLI is being run in a flox containerd context
+pub static IN_CONTAINERD: LazyLock<bool> = LazyLock::new(|| env::var("FLOX_CONTAINERD").is_ok());
+
 #[derive(Error, Debug)]
 pub enum FindAndReplaceError {
     #[error("walkdir error: {0}")]

--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -9,7 +9,7 @@ use std::time::Duration as TimeoutDuration;
 
 use anyhow::{Context, Result, bail};
 use flox_rust_sdk::flox::FLOX_VERSION;
-use flox_rust_sdk::utils::IN_CI;
+use flox_rust_sdk::utils::{IN_CI, IN_CONTAINERD};
 use fslock::LockFile;
 use indoc::indoc;
 use serde::{Deserialize, Serialize};
@@ -448,6 +448,7 @@ impl Connection for AWSDatalakeConnection {
                         "kernel_version": entry.os_family_release,
 
                         "ci": *IN_CI,
+                        "containerd": *IN_CONTAINERD,
 
                         "$set_once": {
                             "initial_flox_version": entry.flox_version,


### PR DESCRIPTION
* Detect if `FLOX_CONTAINERD` _is set_ (irrespective of its value, which is consistent with how we handle the `CI` variable).
* Add a `containerd` field to the `subcommand_metric` payload, which is set to true IFF a containerd environment was detected.
* Add a `flox-containerd` header to catalog requests which is set to true IFF a containerd environment was detected.

Note: Sentry metrics don't seem to take note of `CI` either and are thus unaffected by this change.
