### PR TITLE
refactor: drop pkgdb from internal env variables

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -5,7 +5,7 @@
 #   1. (-v) top-level activate script
 #   2. (-vv) language-specific profile scripts
 #   3. (-vvv) zsh `autoload -U compinit` (very verbose)
-export _flox_activate_tracelevel="${_FLOX_PKGDB_VERBOSITY:-0}"
+export _flox_activate_tracelevel="${_FLOX_SUBSYSTEM_VERBOSITY:-0}"
 [ "$_flox_activate_tracelevel" -eq 0 ] || set -x
 
 # Ensure that $_flox_activate_tracer is defined as an executable.

--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -5,7 +5,7 @@
 #   1. (-v) top-level activate script
 #   2. (-vv) language-specific profile scripts
 #   3. (-vvv) zsh `autoload -U compinit` (very verbose)
-export _flox_activate_tracelevel="${_FLOX_PKGDB_VERBOSITY:-0}"
+export _flox_activate_tracelevel="${_FLOX_SUBSYSTEM_VERBOSITY:-0}"
 [ "$_flox_activate_tracelevel" -eq 0 ] || set -x
 
 # Ensure that $_flox_activate_tracer is defined as an executable.

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -2683,7 +2683,7 @@ mod tests {
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, &manifest);
 
-        let output = temp_env::with_var("_FLOX_PKGDB_VERBOSITY", Some("1"), || {
+        let output = temp_env::with_var("_FLOX_SUBSYSTEM_VERBOSITY", Some("1"), || {
             assert_build_status(&flox, &mut env, &package_name, None, false)
         });
 
@@ -2723,7 +2723,7 @@ mod tests {
 
         let _git = GitCommandProvider::init(&env_path, false).unwrap();
 
-        let output = temp_env::with_var("_FLOX_PKGDB_VERBOSITY", Some("1"), || {
+        let output = temp_env::with_var("_FLOX_SUBSYSTEM_VERBOSITY", Some("1"), || {
             assert_build_status(&flox, &mut env, &package_name, None, succeed)
         });
 

--- a/cli/flox-rust-sdk/src/providers/flake_installable_locker.rs
+++ b/cli/flox-rust-sdk/src/providers/flake_installable_locker.rs
@@ -332,9 +332,7 @@ mod tests {
             id: "gonna_fail".to_string(),
             url: Url::parse(&format!("path:{}", flake_dir.display())).unwrap(),
         })];
-        let res = temp_env::with_var("_PKGDB_ALLOW_LOCAL_FLAKE", Some("1"), || {
-            env.install(&pkgs, &flox)
-        });
+        let res = env.install(&pkgs, &flox);
         if let Err(e) = res {
             eprintln!("Error: {:?}", e);
             let err_string = e.to_string();

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -100,11 +100,14 @@ fn main() -> ExitCode {
     let _sentry_guard = (!disable_metrics).then(init_sentry);
     let _metrics_guard = Hub::global().try_guard().ok();
 
-    // Pass down the verbosity level to all pkgdb calls
+    // Pass down the verbosity level to all sub-processes
     unsafe {
-        std::env::set_var("_FLOX_PKGDB_VERBOSITY", format!("{}", verbosity.to_i32()));
+        std::env::set_var(
+            "_FLOX_SUBSYSTEM_VERBOSITY",
+            format!("{}", verbosity.to_i32()),
+        );
     }
-    debug!("set _FLOX_PKGDB_VERBOSITY={}", verbosity.to_i32());
+    debug!("set _FLOX_SUBSYSTEM_VERBOSITY={}", verbosity.to_i32());
 
     // Run the argument parser
     //

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -88,17 +88,17 @@ endif
 # Path to Nix expession (NEF) library.
 _nef := $(_libexec_dir)/nef
 
-# Set makefile verbosity based on the value of _FLOX_PKGDB_VERBOSITY [sic]
+# Set makefile verbosity based on the value of _FLOX_SUBSYSTEM_VERBOSITY [sic]
 # as set in the environment by the flox CLI. First set it to 0 if not defined.
-ifeq (,$(_FLOX_PKGDB_VERBOSITY))
-  _FLOX_PKGDB_VERBOSITY = 0
+ifeq (,$(_FLOX_SUBSYSTEM_VERBOSITY))
+  _FLOX_SUBSYSTEM_VERBOSITY = 0
 endif
 
 # Invoke nix with the required experimental features enabled.
-_nix := $(_nix) --extra-experimental-features "flakes nix-command fetch-tree" $(intcmp 0,$(_FLOX_PKGDB_VERBOSITY),--trace-verbose)
+_nix := $(_nix) --extra-experimental-features "flakes nix-command fetch-tree" $(intcmp 0,$(_FLOX_SUBSYSTEM_VERBOSITY),--trace-verbose)
 
 # Ensure we use the Nix-provided SHELL.
-SHELL := $(_bash) $(intcmp 2,$(_FLOX_PKGDB_VERBOSITY),-x)
+SHELL := $(_bash) $(intcmp 2,$(_FLOX_SUBSYSTEM_VERBOSITY),-x)
 
 # Identify target O/S.
 OS := $(shell $(_uname) -s)
@@ -167,9 +167,9 @@ $(if $(MANIFEST_BUILDS),,\
     $(error no manifest or Nix expression builds found in $(FLOX_ENV))))
 
 # Then set them to empty string or "@" based on being greater than 0, 1, or 2.
-$(eval _V_ = $(intcmp 0,$(_FLOX_PKGDB_VERBOSITY),,@))
-$(eval _VV_ = $(intcmp 1,$(_FLOX_PKGDB_VERBOSITY),,@))
-$(eval _VVV_ = $(intcmp 2,$(_FLOX_PKGDB_VERBOSITY),,@))
+$(eval _V_ = $(intcmp 0,$(_FLOX_SUBSYSTEM_VERBOSITY),,@))
+$(eval _VV_ = $(intcmp 1,$(_FLOX_SUBSYSTEM_VERBOSITY),,@))
+$(eval _VVV_ = $(intcmp 2,$(_FLOX_SUBSYSTEM_VERBOSITY),,@))
 
 # Define a usage target to provide a helpful message when no target is specified.
 .PHONY: usage


### PR DESCRIPTION
* rename `_FLOX_{PKGDB -> SUBSYSTEM}_VERBOSITY`
* drop unused `_PKGDB_ALLOW_LOCAL_FLAKE`

![ghosts of the past](https://ichef.bbci.co.uk/images/ic/640x360/p07y97rs.jpg)