### PR TITLE
feat: add short service aliases

### DIFF
--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -58,7 +58,7 @@ pub enum ServicesCommands {
     #[bpaf(command, hide)]
     Help,
     /// Restart a service or services
-    #[bpaf(command)]
+    #[bpaf(command, short('r'))]
     Restart(#[bpaf(external(restart::restart))] restart::Restart),
 
     /// Ensure a service or services are running
@@ -74,7 +74,11 @@ pub enum ServicesCommands {
     Stop(#[bpaf(external(stop::stop))] stop::Stop),
 
     /// Print logs of services
-    #[bpaf(command, footer("Run 'man flox-services-logs' for more details."))]
+    #[bpaf(
+        command,
+        short('l'),
+        footer("Run 'man flox-services-logs' for more details.")
+    )]
     Logs(#[bpaf(external(logs::logs))] logs::Logs),
 }
 


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
Adds the ability to run the following commands:
```
# Same as 'flox services logs'
$ flox services l

# Same as 'flox services restart'
$ flox services r
```

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Adds the ability to run `flox services l` instead of `flox services logs`, and `flox services r` instead of `flox services restart`.

<!-- Many thanks! -->
