### PR TITLE
fix: exec commands directly from activate script

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -24,7 +24,6 @@ else
 fi
 "$_flox_activate_tracer" "${BASH_SOURCE[0]}" "$@" START
 
-_bash="@bash@/bin/bash"
 _dirname="@coreutils@/bin/dirname"
 _getopt="@getopt@/bin/getopt"
 _readlink="@coreutils@/bin/readlink"
@@ -200,8 +199,9 @@ while true; do
   esac
 done
 
-# If provided, verify that $FLOX_CMD is the only argument, and set _flox_shell_mode
-# accordingly. Note that _flox_shell_mode is distinct from "_FLOX_ACTIVATION_MODE".
+# Convert the provided command string into an array of arguments in "$@".
+# Henceforth in the script it is assumed that these are the arguments to be
+# invoked either by this shell (when in build mode) or with the chosen userShell.
 if [ -n "$FLOX_CMD" ]; then
   # Throw an error if passed additional arguments along with the -c arg.
   if [ $# -gt 0 ]; then
@@ -209,9 +209,13 @@ if [ -n "$FLOX_CMD" ]; then
     echo "$USAGE" >&2
     exit 1
   fi
-  _flox_shell_mode="command"
-elif [ $# -gt 0 ]; then
-  # Used for container invocations and builds.
+
+  # Set $@ to reflect the command to be invoked.
+  set -- "$FLOX_CMD"
+fi
+
+# This is distinct from "_FLOX_ACTIVATION_MODE"
+if [ $# -gt 0 ]; then
   _flox_shell_mode="command"
 elif [ -t 1 ] || [ -n "${_FLOX_FORCE_INTERACTIVE:-}" ]; then
   _flox_shell_mode="interactive"
@@ -311,7 +315,8 @@ fi
 case "${_flox_shell_mode}" in
   command)
     if [ -n "${FLOX_CONTAINERD:-}" ]; then
-      exec $_bash --noprofile --norc -c "$FLOX_CMD"
+      # Temporary workaround while we await activate refactor.
+      FLOX_NOPROFILE="true"
     fi
     # shellcheck source-path=SCRIPTDIR/activate.d
     source "${_activate_d}/attach-command.bash"

--- a/assets/environment-interpreter/activate/activate.d/attach-command.bash
+++ b/assets/environment-interpreter/activate/activate.d/attach-command.bash
@@ -8,7 +8,7 @@
 case "$_flox_shell" in
   *bash)
     if [ -n "$FLOX_NOPROFILE" ]; then
-      exec "$_flox_shell" --noprofile --norc -c "$FLOX_CMD"
+      exec "$_flox_shell" --noprofile --norc -c "$*"
     else
       RCFILE="$(@coreutils@/bin/mktemp -p "$_FLOX_ACTIVATION_STATE_DIR")"
       generate_bash_startup_commands \
@@ -24,18 +24,18 @@ case "$_flox_shell" in
       # self destruct
       echo "@coreutils@/bin/rm '$RCFILE'" >> "$RCFILE"
       if [ -t 1 ]; then
-        exec "$_flox_shell" --noprofile --rcfile "$RCFILE" -c "$FLOX_CMD"
+        exec "$_flox_shell" --noprofile --rcfile "$RCFILE" -c "$*"
       else
         # The bash --rcfile option only works for interactive shells
         # so we need to cobble together our own means of sourcing our
         # startup script for non-interactive shells.
-        exec "$_flox_shell" --noprofile --norc -s <<< "source '$RCFILE' && $FLOX_CMD"
+        exec "$_flox_shell" --noprofile --norc -s <<< "source '$RCFILE' && $*"
       fi
     fi
     ;;
   *fish)
     if [ -n "$FLOX_NOPROFILE" ]; then
-      exec "$_flox_shell" -c "$FLOX_CMD"
+      exec "$_flox_shell" -c "$*"
     else
       RCFILE="$(@coreutils@/bin/mktemp -p "$_FLOX_ACTIVATION_STATE_DIR")"
       generate_fish_startup_commands \
@@ -49,12 +49,12 @@ case "$_flox_shell" in
         > "$RCFILE"
       # self destruct
       echo "@coreutils@/bin/rm '$RCFILE'" >> "$RCFILE"
-      exec "$_flox_shell" --init-command "source '$RCFILE'" -c "$FLOX_CMD"
+      exec "$_flox_shell" --init-command "source '$RCFILE'" -c "$*"
     fi
     ;;
   *tcsh)
     if [ -n "$FLOX_NOPROFILE" ]; then
-      exec "$_flox_shell" -c "$FLOX_CMD"
+      exec "$_flox_shell" -c "$*"
     else
       export FLOX_ORIG_HOME="$HOME"
       export HOME="$_tcsh_home"
@@ -75,12 +75,12 @@ case "$_flox_shell" in
       echo "@coreutils@/bin/rm '$FLOX_TCSH_INIT_SCRIPT'" >> "$FLOX_TCSH_INIT_SCRIPT"
       export FLOX_TCSH_INIT_SCRIPT
 
-      exec "$_flox_shell" -m -c "$FLOX_CMD"
+      exec "$_flox_shell" -m -c "$*"
     fi
     ;;
   *zsh)
     if [ -n "$FLOX_NOPROFILE" ]; then
-      exec "$_flox_shell" -o NO_GLOBAL_RCS -o NO_RCS -c "$FLOX_CMD"
+      exec "$_flox_shell" -o NO_GLOBAL_RCS -o NO_RCS -c "$*"
     else
       if [ -n "${ZDOTDIR:-}" ]; then
         export FLOX_ORIG_ZDOTDIR="$ZDOTDIR"
@@ -89,7 +89,7 @@ case "$_flox_shell" in
       export FLOX_ZSH_INIT_SCRIPT="$_activate_d/zsh"
       # The "NO_GLOBAL_RCS" option is necessary to prevent zsh from
       # automatically sourcing /etc/zshrc et al.
-      exec "$_flox_shell" -o NO_GLOBAL_RCS -c "$FLOX_CMD"
+      exec "$_flox_shell" -o NO_GLOBAL_RCS -c "$*"
     fi
     ;;
   *)


### PR DESCRIPTION
## Proposed Changes

Our method of introducing a shell invocation between the `activate` script and the commands to be invoked prevented signals from being communicated from the pid of the `flox activate` invocation to the resulting commands being invoked.

This patch adds conditional logic to replace that extra shell invocation with a direct `exec` when running under containerd, so that the invoked command can assume the PID of the `flox activate` invocation.

Closes https://github.com/flox/product/issues/984

## Release Notes

N/A