### PR TITLE
fix: reimplement jwt expiry validation

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use jsonwebtoken::{DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use serde_with::DeserializeFromStr;
 use thiserror::Error;
@@ -159,27 +158,40 @@ impl FromStr for FloxhubToken {
     type Err = FloxhubTokenError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut validation = Validation::default();
         // Client side we don't need to verify the signature,
         // as all priviledged access is guarded server side.
         // It's still convenient to verify common claims e.g. expiration dates.
 
-        // Deprecated in <https://github.com/Keats/jsonwebtoken/pull/441> in favor of
-        // `jsonwebtoken::dangerous::insecure_decode` which doesn't do _any_ validation.
-        #[allow(deprecated)]
-        validation.insecure_disable_signature_validation();
-        validation.validate_aud = false;
+        #[derive(Clone, Debug, Deserialize)]
+        struct ClaimsWithValidation<T> {
+            exp: Option<usize>,
+            #[serde(flatten)]
+            claims: T,
+        }
 
         let token =
-            jsonwebtoken::decode::<FloxTokenClaims>(s, &DecodingKey::from_secret(&[]), &validation)
-                .map_err(|e| match e.kind() {
-                    jsonwebtoken::errors::ErrorKind::ExpiredSignature => FloxhubTokenError::Expired,
-                    _ => FloxhubTokenError::InvalidToken(e),
-                })?;
+            jsonwebtoken::dangerous::insecure_decode::<ClaimsWithValidation<FloxTokenClaims>>(s)
+                .map_err(FloxhubTokenError::InvalidToken)?;
+
+        let now = {
+            let start = std::time::SystemTime::now();
+            start
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs() as usize
+        };
+
+        match token.claims.exp {
+            None => Err(FloxhubTokenError::InvalidToken(
+                jsonwebtoken::errors::ErrorKind::InvalidToken.into(),
+            ))?,
+            Some(exp) if exp < now => Err(FloxhubTokenError::Expired)?,
+            Some(_) => {},
+        };
 
         Ok(FloxhubToken {
             token: s.to_string(),
-            token_data: token.claims,
+            token_data: token.claims.claims,
         })
     }
 }


### PR DESCRIPTION
`jsonwebtoken` depricated (and completely removed the implementation of) validating tokens without validating the signature in <https://github.com/Keats/jsonwebtoken/pull/441>.

4f6dd581f41286b1a93502bd109a3f4db534c181 falsely assumed that while deprecated,
`Validation::insecure_disable_signature_validation` would still be effective.

However, `flox auth login` would now error with `InvalidKeyFormat`, on account of attempting to verify the signature against the dummy value we used to pass into the decoder
(which was originally ignored).

This change replaces `jsonwebtoken::decode` with
`jsonwebtoken::dangerous::insecure_decode`, which skips _all_ validation, and manually reimplements expiry validation
on top of the raw unvalidated claims.

This is considered "safe" as the decoding only informs us of
1. the expriry date (for eager cli side management of the token)
2. the user handle for messaging and argument defaults

Auth and validation are only performed server side!
