### PR TITLE
fix: ANSI escaping for `flox`

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -459,7 +459,10 @@ fn print_welcome_message(envs: EnvRegistry, active_environments: ActiveEnvironme
             2,
             DisplayEnvironments::new(active_environments.iter(), true).to_string(),
         );
-        message::plain(envs);
+        // We should use message::plain once bold formatting is fixed in
+        // tracing-subscriber
+        // https://github.com/tokio-rs/tracing/issues/3369
+        eprintln!("{envs}");
     }
 }
 


### PR DESCRIPTION
tracing-subscriber regressed ANSI formatting, so use eprintln instead for now

This is one more instance of 3770b24feb537c74fca46682f56d753c435a1d7b

## Release Notes

- Fixed garbling of escape codes in bare `flox` command output