### PR TITLE
ci: skip containerize and activate tests for x86_64-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,9 +398,17 @@ jobs:
           - "containerize"
           - "!containerize"
         exclude:
-          # Skip containerize tests on this runner because it's actually Rosetta on aarch64-darwin
+          # Skip containerize tests on x86_64-darwin (except the ones enabled in the include section below)
           - system: "x86_64-darwin"
-            test-tags: "containerize"
+        include:
+          # Disable containerize and activation tests on x86_64-darwin
+          # Containerize tests are run through rosetta, and thius are slow and dont necessarily represent real usage.
+          # Activation tests are taking the largest part of test runtime (up to ~10 minutes)
+          # we disable these in an effort to speed up CI.
+          # We assume that activation is sufficiently testsd on macos through aarch64-darwin
+          # and on x86_64-darwin through the remaining integration tests.
+          - system: "x86_64-darwin"
+            test-tags: "!containerize,!activate"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Shave off ~ 10 minutes of CI time by disabling x86_64-darwin activation tests.

We assume that activation is sufficiently tested on macos through aarch64-darwin
and on x86_64-darwin through the remaining integration tests.