### PR TITLE
fix: no upgrade notification for command mode

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -140,11 +140,18 @@ impl Activate {
             .await?;
         }
 
-        let in_place = self.print_script || (!stdout().is_tty() && self.run_args.is_empty());
-        let interactive = !in_place && self.run_args.is_empty();
-        let command_mode = !in_place && !interactive;
+        let invocation_type =
+            if self.print_script || (!stdout().is_tty() && self.run_args.is_empty()) {
+                InvocationType::InPlace
+            } else if self.run_args.is_empty() {
+                InvocationType::Interactive
+            } else {
+                InvocationType::Command
+            };
 
-        if !command_mode && config.flox.upgrade_notifications.unwrap_or(true) {
+        if invocation_type != InvocationType::Command
+            && config.flox.upgrade_notifications.unwrap_or(true)
+        {
             // Read the results of a previous upgrade check
             // and print a message if an upgrade is available.
             notify_upgrade_if_available(&flox, &mut concrete_environment)?;
@@ -166,9 +173,8 @@ impl Activate {
             config,
             flox,
             concrete_environment,
+            invocation_type,
             false,
-            in_place,
-            interactive,
             &[],
         )
         .await
@@ -189,9 +195,8 @@ impl Activate {
         mut config: Config,
         flox: Flox,
         mut concrete_environment: ConcreteEnvironment,
+        invocation_type: InvocationType,
         is_ephemeral: bool,
-        in_place: bool,
-        interactive: bool,
         services_to_start: &[String],
     ) -> Result<()> {
         let now_active = UninitializedEnvironment::from_concrete_environment(&concrete_environment);
@@ -292,7 +297,7 @@ impl Activate {
                 "Environment is already active: environment={}. Not adding to active environments",
                 now_active.bare_description()
             );
-            if interactive {
+            if invocation_type == InvocationType::Interactive {
                 return Err(anyhow!(
                     "Environment {} is already active",
                     uninitialized_environment_description(&now_active)?
@@ -478,7 +483,7 @@ impl Activate {
         // e.g. in a .bashrc or .zshrc file:
         //
         //    eval "$(flox activate)"
-        if in_place {
+        if invocation_type == InvocationType::InPlace {
             let shell = Self::detect_shell_for_in_place()?;
             subcommand_metric!("activate", "shell" = shell.to_string());
             command.arg("--shell").arg(shell.exe_path());
@@ -491,7 +496,7 @@ impl Activate {
         subcommand_metric!("activate", "shell" = shell.to_string());
         command.arg("--shell").arg(shell.exe_path());
         // These functions will only return if exec fails
-        if interactive {
+        if invocation_type == InvocationType::Interactive {
             Self::activate_interactive(command)
         } else {
             Self::activate_command(command, self.run_args, is_ephemeral)
@@ -676,6 +681,13 @@ impl Activate {
 
         prompt_envs.join(" ")
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum InvocationType {
+    InPlace,
+    Interactive,
+    Command,
 }
 
 /// Notify the user of available upgrades

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -17,7 +17,7 @@ use super::{
     UninitializedEnvironment,
     activated_environments,
 };
-use crate::commands::activate::Activate;
+use crate::commands::activate::{Activate, InvocationType};
 use crate::commands::display_help;
 use crate::config::Config;
 use crate::utils::message;
@@ -331,9 +331,8 @@ pub async fn start_services_with_new_process_compose(
         config,
         flox,
         concrete_environment,
+        InvocationType::Command,
         true,
-        false,
-        false,
         &new_services_to_start(names),
     )
     .await?;


### PR DESCRIPTION
- **fix: no upgrade notification for command mode**
  Don't print an upgrade notification for `flox activate -- command`. This
  is annoying when using command mode for scripting
  

- **refactor: InvocationType enum**
  Add InvocationType enum instead of using multiple bools
  
  Besides being cleaner, this shuts up clippy::too-many-arguments for the
  activate function
 

## Release notes
- Environment upgrade notifications are no longer printed for `flox activate -- command`