### PR TITLE
fix(build): Qualify more paths

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -75,6 +75,7 @@ _sed := $(call __package_bin,$(__gnused),sed)
 _sha256sum := $(call __package_bin,$(__coreutils),sha256sum)
 _sort := $(call __package_bin,$(__coreutils),sort)
 _tar := $(call __package_bin,$(__gnutar),tar)
+_touch := $(call __package_bin,$(__coreutils),touch)
 _t3 := $(call __package_bin,$(__t3),t3) --relative $(if $(NO_COLOR),,--forcecolor)
 _tr := $(call __package_bin,$(__coreutils),tr)
 _uname := $(call __package_bin,$(__coreutils),uname)
@@ -193,8 +194,8 @@ $(PROJECT_TMPDIR)/check-build-prerequisites:
 	@# Check that the BUILDTIME_NIXPKGS_URL and EXPRESSION_BUILD_NIXPKGS_URL are defined.
 	$(if $(BUILDTIME_NIXPKGS_URL),,$(error BUILDTIME_NIXPKGS_URL not defined))
 	$(if $(EXPRESSION_BUILD_NIXPKGS_URL),,$(error EXPRESSION_BUILD_NIXPKGS_URL not defined))
-	@mkdir -p $(@D)
-	@touch $@
+	@$(_mkdir) -p $(@D)
+	@$(_touch) $@
 
 # The `nix build` command will attempt a rebuild in every instance,
 # and we will presumably want `flox build` to do the same. However,

--- a/package-builder/validate-build.bash
+++ b/package-builder/validate-build.bash
@@ -8,6 +8,7 @@ set -euo pipefail
 
 _basename="@coreutils@/bin/basename"
 _env="@coreutils@/bin/env"
+_grep="@gnugrep@/bin/grep"
 _jq="@jq@/bin/jq"
 _nix="@nix@/bin/nix"
 _nix_store="@nix@/bin/nix-store"
@@ -386,7 +387,7 @@ function report_missing_files {
         fi
     # Note: we assume filenames and ref_paths contain no colons.
     done < <(
-        grep --binary-files=text -RHo -e "${build_env}[^:\"'[:cntrl:][:space:]]*" -- "$output_dir"
+        $_grep --binary-files=text -RHo -e "${build_env}[^:\"'[:cntrl:][:space:]]*" -- "$output_dir"
     )
 
     return $rc


### PR DESCRIPTION
## Proposed Changes

I found these while debugging #3713 with a slightly convoluted way to hide my `git` binary:

    PATH=/bin $(which flox) build

## Release Notes

N/A, not important enough to flag.
