### PR TITLE
fix(manifest): skip_serializing_none for systemd

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4297,6 +4297,7 @@ dependencies = [
  "indoc",
  "schemars 1.0.5",
  "serde",
+ "serde_with",
  "thiserror 2.0.17",
 ]
 

--- a/cli/systemd/Cargo.toml
+++ b/cli/systemd/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 schemars.workspace = true
 serde.workspace = true
+serde_with.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/cli/systemd/src/unit.rs
+++ b/cli/systemd/src/unit.rs
@@ -14,6 +14,7 @@ use std::io;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -24,6 +25,7 @@ pub enum Error {
 }
 
 /// Represents a systemd service configuration
+#[skip_serializing_none]
 #[derive(Debug, Clone, Default, JsonSchema, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ServiceUnit {
     pub unit: Option<Unit>,
@@ -31,6 +33,7 @@ pub struct ServiceUnit {
 }
 
 /// Unit section configuration
+#[skip_serializing_none]
 #[derive(Debug, Clone, Default, JsonSchema, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Unit {
     pub description: Option<String>,
@@ -42,6 +45,7 @@ pub struct Unit {
 }
 
 /// Service section configuration with resource limits
+#[skip_serializing_none]
 #[derive(Debug, Clone, Default, JsonSchema, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Service {
     // Basic service configuration


### PR DESCRIPTION
## Proposed Changes

Prevent unset fields in `services.*.systemd` from being serialized as `null` values in the lockfile.

It wouldn't have caused extra backwards-compat issues in this case because you have to opt-in to setting some systemd fields and they won't work with older Flox versions, but it does add unncessary bloat to the lockfile.

The existing test didn't catch this because we bypassed proptest for the child fields due to generating too many test cases. I've fixed this by generating just enough to trip the test, which failed as follows prior to adding the type attributes.

    thread 'models::manifest::typed::test::manifest_does_not_serialize_null_fields' panicked at flox-rust-sdk/src/models/manifest/typed.rs:1198:5:
    Test failed: json: {
      "version": 1,
      "options": {},
      "services": {
        "0": {
          "command": "0",
          "systemd": {
            "unit": {
              "description": null,
              "documentation": null,
              "wants": null,
              "requires": null,
              "before": null,
              "after": null
            },
            "service": {
              "type_": null,
              "exec_start": null,
              "exec_start_pre": null,
              "exec_start_post": null,
              "exec_stop": null,
              "restart": null,
              "restart_sec": null,
              "timeout_start_sec": null,
              "timeout_stop_sec": null,
              "cpu_quota": null,
              "cpu_shares": null,
              "cpu_weight": null,
              "memory_max": null,
              "memory_high": null,
              "memory_low": null,
              "tasks_max": null,
              "io_weight": null,
              "limit_cpu": null,
              "limit_fsize": null,
              "limit_data": null,
              "limit_stack": null,
              "limit_core": null,
              "limit_rss": null,
              "limit_nofile": null,
              "limit_as": null,
              "limit_nproc": null,
              "limit_memlock": null,
              "limit_locks": null,
              "limit_sigpending": null,
              "limit_msgqueue": null,
              "limit_nice": null,
              "limit_rtprio": null,
              "limit_rttime": null,
              "private_tmp": null,
              "protect_system": null,
              "protect_home": null,
              "no_new_privileges": null,
              "environment": null,
              "environment_file": null
            }
          }
        }
      }
    } at flox-rust-sdk/src/models/manifest/typed.rs:1202.

## Release Notes

N/A
