### PR TITLE
fix(services): Disable .env support

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/start-services.bash
+++ b/assets/environment-interpreter/activate/activate.d/start-services.bash
@@ -59,9 +59,9 @@ start_services_blocking() {
   # services
   if [ -n "${_FLOX_SERVICES_TO_START:-}" ]; then
     readarray -t services_to_start < <(echo "$_FLOX_SERVICES_TO_START" | "$_jq" -r '.[]')
-    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up "${services_to_start[@]}" -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
+    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up "${services_to_start[@]}" -f "$config_file" -u "$socket_file" -L "$log_file" --disable-dotenv --tui=false > /dev/null 2>&1 &
   else
-    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --tui=false > /dev/null 2>&1 &
+    COMPOSE_SHELL="$_bash" "$_setsid" "$_setsid" "$_process_compose" up -f "$config_file" -u "$socket_file" -L "$log_file" --disable-dotenv --tui=false > /dev/null 2>&1 &
   fi
   # Make these functions available in subshells so that `timeout` can call them
   export -f wait_for_services_socket poll_services_status


### PR DESCRIPTION
## Proposed Changes

Prevent `process-compose` from loading `.env` files because it causes environment variables to shadow `[vars]` and `[services.*.vars]` in the manifest:

- https://f1bonacc1.github.io/process-compose/configuration/#env-file

This functionality was added upstream in:

- https://github.com/F1bonacc1/process-compose/releases/tag/v1.24.0

Users that want `.env` support should source the file from `hook.on-activate` instead so that it's layered correctly.

Prior to the code change the new test fails with:

    -- output does not contain substring --
    substring (1 lines):
      right_value
    output (2 lines):
      ✅ Service 'one' started.
      hello wrong_value
    --

The duplicate `process-compose up` lines could benefit from being refactored into conditional args in an array but I believe they're going to change in the ongoing activate refactor.

## Release Notes

Fixed a regression where `.env` files shadowed environment variables set in `[vars]` and `[services.*.vars]`. Users that want `.env` support should instead source the file from `hook.on-activate` so that it's layered correctly.

Thanks to @ryansch for the report and diagnosis.