### PR TITLE
fix(tests): Revert ssh-agent to socket in $TMPDIR

### DIFF
--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -206,7 +206,7 @@ ssh_key_setup() {
   # start a new one.
   unset SSH_AUTH_SOCK SSH_AGENT_PID
   # You can't find work in this town without a good agent. Lets get one.
-  eval "$(ssh-agent -s)"
+  eval "$(ssh-agent -sT)"
   ssh-add "$FLOX_TEST_SSH_KEY"
   unset SSH_ASKPASS
   export __FT_RAN_SSH_KEY_SETUP=:


### PR DESCRIPTION
## Proposed Changes

Integration tests were failing for me locally:

    (from function `ssh_key_setup' in file setup_suite.bash, line 210,
        from function `common_suite_setup' in file setup_suite.bash, line 411,
        from function `setup_suite' in test file setup_suite.bash, line 441)
         `setup_suite() { common_suite_setup; }' failed with status 2
       unix_listener_tmp: path "/var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.LsBGhd/bats-run-kXniSq/suite/home/.ssh/agent/s.VOdJC1OkXl.agent.7nCglkEu8s" too long for Unix domain socket
       main: Couldn't prepare agent socket
       Could not open a connection to your authentication agent.

We previously worked around the same symptom in 6bfb1a75 but this time it was caused by the nixpkgs bump in c63a8e81 which upgraded OpenSSH and changed the behaviour of `ssh-agent`. Revert to the old behaviour by adding the new `-T` flag:

> * ssh-agent(1), sshd(8): move agent listener sockets from /tmp to
>   under ~/.ssh/agent for both ssh-agent(1) and forwarded sockets
>   in sshd(8).
>
>   This ensures processes that have restricted filesystem access
>   that includes /tmp do not ambiently have the ability to use keys
>   in an agent.
>
>   …
>
>   ssh-agent(1) gains some new flags: -U suppresses the automatic
>   cleanup of stale sockets when it starts. -u forces a cleanup
>   without keeping a running agent, -uu forces a cleanup that ignores
>   the hostname. -T makes ssh-agent put the socket back in /tmp.

This is a case that the local dev tests in CI would have caught before merging prior to 47880bce.

## Release Notes

N/a