### PR TITLE
fix(systemd): Enable deny_unknown_fields

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4297,6 +4297,7 @@ dependencies = [
  "indoc",
  "schemars 1.0.5",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror 2.0.17",
 ]

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -1016,6 +1016,7 @@
       "type": "object"
     },
     "Service": {
+      "additionalProperties": false,
       "description": "Service section configuration with resource limits",
       "properties": {
         "cpu_quota": {
@@ -1449,6 +1450,7 @@
       "type": "string"
     },
     "ServiceUnit": {
+      "additionalProperties": false,
       "description": "Represents a systemd service configuration",
       "properties": {
         "service": {
@@ -1482,6 +1484,7 @@
       "type": "object"
     },
     "Unit": {
+      "additionalProperties": false,
       "description": "Unit section configuration",
       "properties": {
         "after": {

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -609,6 +609,7 @@
       "type": "object"
     },
     "Service": {
+      "additionalProperties": false,
       "description": "Service section configuration with resource limits",
       "properties": {
         "cpu_quota": {
@@ -1042,6 +1043,7 @@
       "type": "string"
     },
     "ServiceUnit": {
+      "additionalProperties": false,
       "description": "Represents a systemd service configuration",
       "properties": {
         "service": {
@@ -1075,6 +1077,7 @@
       "type": "object"
     },
     "Unit": {
+      "additionalProperties": false,
       "description": "Unit section configuration",
       "properties": {
         "after": {

--- a/cli/systemd/Cargo.toml
+++ b/cli/systemd/Cargo.toml
@@ -11,3 +11,4 @@ thiserror.workspace = true
 
 [dev-dependencies]
 indoc.workspace = true
+serde_json.workspace = true


### PR DESCRIPTION
## Proposed Changes

So that users get feedback on incorrect fields rather than them being silently ignored. Everything here is an `Option<_>` so I don't expect any problems when we add new fields in the future.

Before:

    dcarley@lima-default:/Users/dcarley/demo/systemd$ flox edit -f - <<EOF
    > version = 1
    >
    > [services.test]
    > command = "test"
    > systemd.foo.bar = "baz"
    > EOF
    ✅ Environment successfully updated.

After:

    % flox edit -d ~/demo/systemd -f - <<EOF
    > version = 1
    >
    > [services.test]
    > command = "test"
    > systemd.foo.bar = "baz"
    > EOF
    ❌ ERROR: Failed to parse manifest:

    unknown field `foo`, expected `unit` or `service`

## Release Notes

N/A
