### PR TITLE
fix: increase TLS buffer tunable

### DIFF
--- a/assets/environment-interpreter/common/etc/profile.d/0101_common-dev-mode-additional-paths.sh
+++ b/assets/environment-interpreter/common/etc/profile.d/0101_common-dev-mode-additional-paths.sh
@@ -47,7 +47,7 @@ if [ -n "${FLOX_ENV_DIRS:-}" ]; then
         # biome: 1553
         # fd: 1561
         # See https://sourceware.org/bugzilla/show_bug.cgi?id=31991
-        export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=2500
+        export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=25000
       fi
       ;;
     Darwin*)


### PR DESCRIPTION
A number of upstream nixpkgs changes landed related to changes to PIE handling around glibc/gcc:

- 411faf46e2c8 gcc: build with --enable-default-pie configure option (#439314)
- 33816365dec9 {cc-wrapper,bintools-wrapper}: drop pie hardening flag (#442510)
- eda556d94b12 treewide: remove usages of obsolete pie hardening flag (#449771)

These resulted in our current override being insufficient.

Seems the PIE changes blew out the "optional static TLS" buffer which broke rustfmt:

- We previously encountered this issue and worked around it by setting the buffer size to 2500 in https://github.com/flox/flox/pull/2976
- empirically we have tested and confirmed that for rustfmt on aarch64-linux we need to raise this to some number between 8500 and 9000
- given that this is only required in a Flox dev mode activation, my recommendation is to blow it out by 10x; this command works and would be a 1-character patch to Flox to change 2500 to 25000: `GLIBC_TUNABLES=glibc.rtld.optional_static_tls=25000 rustfmt`

## Release Notes

Improved robustness of dev-mode activations under new nixpkgs PIE defaults. `rustfmt` known to be affected.