### PR TITLE
fix(activate): Apply --trust to remote includes

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -70,8 +70,8 @@ pub struct Activate {
     #[bpaf(external(environment_select), fallback(Default::default()))]
     pub environment: EnvironmentSelect,
 
-    /// Trust a remote environment temporarily for this activation.
-    /// This is not applied to includes of remote environments.
+    /// Trust a remote environment temporarily for this activation, including
+    /// the includes of any remote environments.
     #[bpaf(long, short)]
     pub trust: bool,
 
@@ -210,7 +210,9 @@ impl Activate {
         };
         let manifest = &lockfile.manifest;
 
-        if let Some(compose) = &lockfile.compose {
+        if !self.trust
+            && let Some(compose) = &lockfile.compose
+        {
             for include in &compose.include {
                 if let IncludeDescriptor::Remote { ref remote, .. } = include.descriptor {
                     ensure_environment_trust(

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -195,12 +195,11 @@ EOF
   assert_success
 }
 
-@test "m10.1: 'activate --trust' isn't supported for included remote environment" {
+@test "m10.1: 'activate --trust' succeeds for included remote environment" {
   make_composer_with_remote_include
 
   run "$FLOX_BIN" activate --trust -- true
-  assert_failure
-  assert_output --partial "The included environment $OWNER/test is not trusted."
+  assert_success
 }
 
 # We can use the `config to trust a specific remote environment.
@@ -246,13 +245,16 @@ EOF
   assert_success
 }
 
-@test "m10.0: 'activate' fails if included remote environment is denied by config" {
+@test "m10.0: 'activate' fails if included remote environment is denied by config, --trust overrides" {
   make_composer_with_remote_include
 
   run "$FLOX_BIN" config --set "trusted_environments.$OWNER/test" "deny"
-  run "$FLOX_BIN" activate --trust -- true
+  run "$FLOX_BIN" activate -- true
   assert_failure
   assert_output --partial "The included environment $OWNER/test is not trusted."
+
+  run "$FLOX_BIN" activate --trust -- true
+  assert_success
 }
 
 # bats test_tags=remote,activate,trust,remote:activate:trust-current-user


### PR DESCRIPTION
## Proposed Changes

Steve noted that it's not currently possible to use the Kubernetes shim with remote environments that include other remote environments because although we pass `--trust` it still prompts for the includes:

- https://flox-dev.slack.com/archives/C09D3Q4811D/p1764443732056389

I'm still not 100% convinced by our model for trusting remote includes and I don't recall why I explicitly chose (and documented) not to propagate the `--trust` flag but it seems reasonable to relax the check when the user has already specificed `--trust`:

- https://github.com/flox/flox/commit/7e552b9e998fde7a922eadbb083f112382c3008f

## Release Notes

`flox activate --trust` now propagate trust to the includes of remote environments.