### PR TITLE
fix(just): clean contents of build/nix-plugins

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -52,7 +52,8 @@ version:
 
 # Clean the nix-plugins build cache
 @clean-nix-plugins:
-   meson compile -C nix-plugins/builddir --clean
+   meson compile -C nix-plugins/builddir --clean; \
+   rm -rf build/nix-plugins
 
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

Delete the contents of `build/nix-plugins` when running `just clean`.

A few weeks ago I shared my checkout dir to a Linux VM and thought that I'd succesfully switched back to Darwin built artifacts after running `just clean && just build` but I only just noticed that some integration tests which use flakes were failing:

    % flox install -d ~/tmp github:nixos/nixpkgs#hello
    ❌ ERROR: resolution failed:
    Failed to lock flake installable: error: could not dynamically open plugin file '"/Users/dcarley/projects/flox/flox/build/nix-plugins/lib/nix-plugins/libwrapped-nixpkgs-input.so"': dlopen(/Users/dcarley/projects/flox/flox/build/nix-plugins/lib/nix-plugins/libwrapped-nixpkgs-input.so, 0x0005): tried: '/Users/dcarley/projects/flox/flox/build/nix-plugins/lib/nix-plugins/libwrapped-nixpkgs-input.so' (slice is not valid mach-o file), '/System/Volumes/Preboot/Cryptexes/OS/Users/dcarley/projects/flox/flox/build/nix-plugins/lib/nix-plugins/libwrapped-nixpkgs-input.so' (no such file), '/Users/dcarley/projects/flox/flox/build/nix-plugins/lib/nix-plugins/libwrapped-nixpkgs-input.so' (slice is not valid mach-o file)

Because these files hadn't been cleaned:

    % l build/nix-plugins/lib/nix-plugins
    total 13M
    -rwxr-xr-x 1 dcarley staff 432K Dec  2 10:07 liblock-flake-installable.dylib
    -rwxr-xr-x 1 dcarley staff 7.3M Nov 18 17:39 liblock-flake-installable.so
    -rwxr-xr-x 1 dcarley staff 324K Dec  2 10:07 libwrapped-nixpkgs-input.dylib
    -rwxr-xr-x 1 dcarley staff 4.8M Nov 18 17:39 libwrapped-nixpkgs-input.so

## Release Notes

N/A
