### PR TITLE
feat: add update aliases

### DIFF
--- a/cli/flox/src/commands/include.rs
+++ b/cli/flox/src/commands/include.rs
@@ -17,7 +17,7 @@ pub enum IncludeCommands {
     #[bpaf(command, hide)]
     Help,
     /// Upgrade an environment with latest changes to its included environments
-    #[bpaf(command, header(indoc! {"
+    #[bpaf(command, long("update"), header(indoc! {"
         Get the latest contents of included environments and merge them with the
         composing environment.
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -638,7 +638,7 @@ enum ModifyCommands {
     ),
 
     /// Upgrade packages in an environment
-    #[bpaf(command, footer("Run 'man flox-upgrade' for more details."), header(indoc! {"
+    #[bpaf(command, long("update"), footer("Run 'man flox-upgrade' for more details."), header(indoc! {"
         When no arguments are specified,
         all packages in the environment are upgraded if possible.
         A package is upgraded if its version, build configuration,


### PR DESCRIPTION
Add `flox update` as an alias for `flox upgrade` and `flox include update` as an alias for `flox include upgrade`. It's unclear what the difference between an update and an upgrade is, so include update as an alias in case users type update

This is also consistent with how we provide remove as an alias for uninstall

## Release Notes

Added `flox update` as an alias for `flox upgrade` and `flox include update` as an alias for `flox include upgrade`