### PR TITLE
feat(executive): Pass --env for process listings

### DIFF
--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -147,6 +147,8 @@ impl ActivateArgs {
             let mut executive = Command::new((*FLOX_ACTIVATIONS_BIN).clone());
             executive.args([
                 "executive",
+                "--env",
+                &context.env,
                 "--executive-ctx",
                 &executive_ctx_path.to_string_lossy(),
             ]);

--- a/cli/flox-activations/src/cli/executive.rs
+++ b/cli/flox-activations/src/cli/executive.rs
@@ -34,6 +34,12 @@ pub struct ExecutiveCtx {
 
 #[derive(Debug, Args)]
 pub struct ExecutiveArgs {
+    /// Environment path
+    // This isn't consumed and serves only to identify in process listings which
+    // environment the executive is responsible for.
+    #[arg(long)]
+    pub env: String,
+
     /// Path to JSON file containing executive context
     #[arg(long)]
     pub executive_ctx: PathBuf,


### PR DESCRIPTION
## Proposed Changes

Previously we were able to identify `flox-watchdog` processes by their `--flox-env` and `--activation-id` arguments.

It wasn't currently possible to identify `flox-activations executive` processes once their parent `flox activate` process had exited and other attachments were keeping them running because because the only argument we were passing was `--executive-ctx` and the contents of that file  is removed by default.

The original executive design called for modifying the process title to reflect the original `flox activate` arguments however..

Doing this on Darwin requires using undocumented SDKs:

- https://github.com/dvarrazzo/py-setproctitle/commit/f5013d13396c8812a7ecf456fdf9aa487bf36fa9

Doing this on Linux requires rewriting `argv` memory pointers:

- https://github.com/flox/flox/pull/3742/files#diff-c1656abd1c1a946dbf4c3375a8abc2c5dee22ec0e37d89eb2f655a98aecbe76f
- https://source.chromium.org/chromium/chromium/src/+/main:base/process/set_process_title_linux.cc
- https://github.com/nginx/nginx/blob/367113670ecda664074926e1ceb66fcef03972d1/src/os/unix/ngx_setproctitle.c

Using `prctl(PR_SET_NAME, …)` on Linux only changes `comm` which is limited to 16 bytes and potentially only used by top.

Additionally the original `flox activate` arguments would make it hard to correlate which environment or attachment the executive was in relation to once the original invocation had exited, which is when it matters most because it's re-parented to PID 1.

For now we'll pass an "unused" argument of `--env` so that we can identify the environment. This might later change to the `.flox` directory if one executive is responsbile for all activations modes of an environment.

Process tree now looks like this:

    flox [dcarley/tmp default] bash-5.3$ pstree $$
    -+= 90178 dcarley bash --noprofile --rcfile /Users/dcarley/.cache/flox/run/39df059f/c919872d/flox_rc_bash_YVNLwQ
     |--= 90224 dcarley /Users/dcarley/projects/flox/flox/cli/target/debug/flox-activations executive --env /Users/dcarley/tmp/.flox/run/aarch64-darwin.tmp.dev --executive-ctx /Users/dcarley/.cache/flox/run/39df059
     \-+= 90307 dcarley pstree 90178
       \--- 90308 dcarley ps -axwwo user,pid,ppid,pgid,command

We can add more arguments in the future if necessary. Another option we discussed is to pass `ExecutiveCtx` as an environment variable and then we can pass whatever we like, but we'd lose some safety from the parser.

## Release Notes

N/A