### PR TITLE
fix: metrics infinite growth

### DIFF
--- a/cli/flox/src/utils/metrics.rs
+++ b/cli/flox/src/utils/metrics.rs
@@ -269,40 +269,41 @@ impl MetricsBuffer {
     fn push(&mut self, entry: MetricEntry) -> Result<()> {
         debug!("pushing entry to metrics buffer: {entry:?}");
 
-        // Enforce maximum buffer size by removing oldest entry if at capacity
-        let needs_rewrite = if self.buffer.len() >= MAX_BUFFER_SIZE {
-            debug!("Buffer at max size ({MAX_BUFFER_SIZE}), removing oldest entry");
-            self.buffer.pop_front();
-            true
-        } else {
-            false
-        };
-
         // update the buffer in memory
         self.buffer.push_back(entry);
 
-        if needs_rewrite {
-            // Rewrite the entire file when we've hit the limit
+        // Enforce maximum buffer size by removing oldest entry if at capacity, and overwrite file
+        if self.buffer.len() >= MAX_BUFFER_SIZE {
+            debug!("Buffer at max size ({MAX_BUFFER_SIZE}), removing oldest entry");
+            self.pop_front_to_max_size();
             self.overwrite_file()?;
         } else {
-            // Just append the new entry
-            // [MetricsBuffer::read] ensures that the file is opened with write permissions
-            // and append mode.
-            let mut buffer_json = String::new();
-            buffer_json.push_str(&serde_json::to_string(self.buffer.back().unwrap())?);
-            buffer_json.push('\n');
-            self.storage
-                .write_all(buffer_json.as_bytes())
-                .context("could not write new metrics entry to buffer file")?;
-            self.storage.flush()?;
-        }
+            self.append_new_metrics()?;
+        };
 
+        Ok(())
+    }
+
+    fn append_new_metrics(&mut self) -> Result<(), anyhow::Error> {
+        let mut buffer_json = String::new();
+        buffer_json.push_str(&serde_json::to_string(self.buffer.back().unwrap())?);
+        buffer_json.push('\n');
+        self.storage
+            .write_all(buffer_json.as_bytes())
+            .context("could not write new metrics entry to buffer file")?;
+        self.storage.flush()?;
         Ok(())
     }
 
     /// Returns an iterator over the entries in the buffer
     fn iter(&self) -> impl Iterator<Item = &MetricEntry> {
         self.buffer.iter()
+    }
+
+    fn pop_front_to_max_size(&mut self) {
+        while self.buffer.len() >= MAX_BUFFER_SIZE {
+            self.buffer.pop_front();
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

  This PR fixes an issue where the metrics buffer file could grow indefinitely, potentially consuming excessive disk space over time.

  The changes implement two key improvements to the metrics collection system:

  1. Maximum buffer size limit: Enforces a maximum of 1000 entries in the metrics buffer (MAX_BUFFER_SIZE). When the buffer reaches capacity, the oldest entry is
  removed before adding a new one, preventing unbounded growth.
  2. Batched metrics transmission: Sends metrics to the telemetry backend in batches of 100 entries (BATCH_SIZE) instead of all at once. After each successful
  batch transmission, the buffer file is updated to remove the sent entries, ensuring the file is incrementally cleared rather than attempting to send potentially
  large amounts of data in a single request.

  The implementation adds a new overwrite_file() method that rewrites the entire buffer file with current in-memory contents, used both when enforcing the size
  limit and when clearing sent entries after successful transmission.

## Release Notes

  N/A - Internal improvement to metrics collection system. No user-facing changes.