### PR TITLE
chore: improve show output

### DIFF
--- a/cli/flox/src/commands/show.rs
+++ b/cli/flox/src/commands/show.rs
@@ -79,6 +79,54 @@ fn render_show_catalog(
         .unwrap_or(DEFAULT_DESCRIPTION.into());
     writeln!(writer, "{pkg_path} - {description}")?;
 
+    let first_pkg = &search_results[0];
+
+    if let Some(catalog) = &first_pkg.catalog {
+        writeln!(writer, "Catalog: {catalog}")?;
+    }
+
+    // Print Latest version (first version in results is the latest)
+    writeln!(writer, "Latest:  {pkg_path}@{}", first_pkg.version)?;
+
+    // Print License
+    if let Some(license) = &first_pkg.license {
+        writeln!(writer, "License: {license}")?;
+    }
+
+    // Print Outputs
+    if !first_pkg.outputs.0.is_empty() {
+        let output_names: Vec<String> = first_pkg
+            .outputs
+            .0
+            .iter()
+            .map(|output| {
+                // Mark the outputs_to_install with asterisk
+                if let Some(ref to_install) = first_pkg.outputs_to_install
+                    && to_install.contains(&output.name)
+                {
+                    return format!("{}*", output.name);
+                }
+                output.name.clone()
+            })
+            .collect();
+        writeln!(
+            writer,
+            "Outputs: {} (* installed by default)",
+            output_names.join(", ")
+        )?;
+    }
+
+    // Print Systems (all systems where the latest version is available)
+    let latest_version_systems: Vec<String> = search_results
+        .iter()
+        .filter(|pkg| pkg.version == first_pkg.version)
+        .map(|pkg| pkg.system.to_string())
+        .collect();
+    writeln!(writer, "Systems: {}", latest_version_systems.join(", "))?;
+
+    writeln!(writer)?; // Empty line before versions list
+    writeln!(writer, "Other versions:")?;
+
     // Organize the versions to be queried and printed
     let version_to_systems = {
         let mut map = BTreeMap::new();
@@ -146,7 +194,7 @@ fn render_show_catalog(
 
 #[cfg(test)]
 mod test {
-    use catalog_api_v1::types::{PackageOutputs, PackageSystem};
+    use catalog_api_v1::types::{PackageOutput, PackageOutputs, PackageSystem};
     use flox_rust_sdk::flox::test_helpers::flox_instance;
     use flox_rust_sdk::providers::catalog::test_helpers::auto_recording_catalog_client;
     use indoc::indoc;
@@ -174,6 +222,12 @@ mod test {
 
     #[test]
     fn test_column_alignment_for_system_restrictions() {
+        use chrono::TimeZone;
+
+        let rev_date = chrono::Utc
+            .with_ymd_and_hms(2025, 5, 31, 12, 5, 15)
+            .unwrap();
+
         let mock_pkg = |version: &str, system: &str| PackageBuild {
             pkg_path: "pkg".to_string(),
             version: version.to_string(),
@@ -182,19 +236,28 @@ mod test {
             attr_path: String::new(),
             broken: None,
             cache_uri: None,
-            catalog: None,
+            catalog: Some("nixpkgs".to_string()),
             derivation: String::new(),
             insecure: None,
-            license: None,
-            locked_url: String::new(),
+            license: Some("MIT".to_string()),
+            locked_url: "https://github.com/flox/nixpkgs?rev=abc123".to_string(),
             missing_builds: None,
             name: String::new(),
-            outputs: PackageOutputs(vec![]),
-            outputs_to_install: None,
+            outputs: PackageOutputs(vec![
+                PackageOutput {
+                    name: "sub-pkg".to_string(),
+                    store_path: "somestorepath".to_string(),
+                },
+                PackageOutput {
+                    name: "sub-pkg-other".to_string(),
+                    store_path: "somestorepath".to_string(),
+                },
+            ]),
+            outputs_to_install: Some(vec!["sub-pkg".to_string()]),
             pname: String::new(),
             rev: String::new(),
             rev_count: 0,
-            rev_date: chrono::Utc::now(),
+            rev_date,
             scrape_date: None,
             stabilities: None,
             unfree: None,
@@ -222,6 +285,13 @@ mod test {
         // Verify that system restrictions are aligned despite different version lengths
         assert_eq!(output, indoc! {"
                 pkg - test
+                Catalog: nixpkgs
+                Latest:  pkg@1.0
+                License: MIT
+                Outputs: sub-pkg*, sub-pkg-other (* installed by default)
+                Systems: aarch64-darwin
+
+                Other versions:
                     pkg@1.0    (aarch64-darwin only)
                     pkg@10.0.0 (aarch64-darwin only)
             "});

--- a/cli/tests/show.bats
+++ b/cli/tests/show.bats
@@ -76,10 +76,16 @@ setup_file() {
   run "$FLOX_BIN" show hello
   assert_success
   assert_equal "${lines[0]}" "hello - Program that produces a familiar, friendly greeting"
-  assert_equal "${lines[1]}" "    hello@2.12.2"
-  assert_equal "${lines[2]}" "    hello@2.12.1"
-  assert_equal "${lines[3]}" "    hello@2.12"
-  assert_equal "${lines[4]}" "    hello@2.10"
+  assert_equal "${lines[1]}" "Catalog: nixpkgs"
+  assert_equal "${lines[2]}" "Latest:  hello@2.12.2"
+  assert_equal "${lines[3]}" "License: GPL-3.0-or-later"
+  assert_equal "${lines[4]}" "Outputs: out* (* installed by default)"
+  assert_equal "${lines[5]}" "Systems: x86_64-darwin, aarch64-linux, x86_64-linux, aarch64-darwin"
+  assert_equal "${lines[6]}" "Other versions:"
+  assert_equal "${lines[7]}" "    hello@2.12.2"
+  assert_equal "${lines[8]}" "    hello@2.12.1"
+  assert_equal "${lines[9]}" "    hello@2.12"
+  assert_equal "${lines[10]}" "    hello@2.10"
 }
 
 # bats test_tags=python


### PR DESCRIPTION
 ## Proposed Changes

  This PR improves the output of the flox show command by adding more detailed package information to the display.

 ## Release Notes

  The flox show command now displays additional package metadata including catalog, license, outputs (with default install markers), supported systems,
  source URL, and publication date. This provides users with more comprehensive information when viewing package details.