### PR TITLE
fix: don't print upgrade notification right after pushing

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -1123,6 +1123,11 @@ impl History {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+
+    // Return the latest history entry
+    pub fn latest(&self) -> Option<&WithOtherFields<HistorySpec>> {
+        self.0.last()
+    }
 }
 
 mod compat {


### PR DESCRIPTION
Currently we print an upgrade notification right after pushing an environment if the upgrade-notification.json file is out of date