### PR TITLE
docs: tweak wording for push/pull

### DIFF
--- a/cli/flox/doc/flox-pull.md
+++ b/cli/flox/doc/flox-pull.md
@@ -90,7 +90,7 @@ environments.
     Cannot be used with `--reference`.
 
 `<owner>/<name>`
-:   ID of the environment to pull into a directory.
+:   Reference of an environment to pull into a directory
 
     This is used when pulling a new environment for the first time.
 
@@ -110,10 +110,13 @@ environments.
     Must be used with `--copy`.
 
 `-r <owner>/<name>`, `--reference <owner>/<name>`
-:   Pull updates for a cached remote environment by reference.
+:   Pull updates for a local copy of a FloxHub environment
 
-    This updates a remote environment that has been activated or pulled
-    locally and is cached in `~/.cache/flox/remote/`.
+    The pulled environment can be used by passing '--reference' to other
+    subcommands.
+
+    This updates a FloxHub environment that has been activated or pulled
+    locally and is cached in `~/.cache`.
 
     Cannot be used with `--dir`, `--copy`, or `--generation`.
 

--- a/cli/flox/doc/flox-push.md
+++ b/cli/flox/doc/flox-push.md
@@ -64,9 +64,10 @@ FloxHub with local changes to the environment.
 ## Push Options
 
 `-d`, `--dir`
-:   Directory to push the environment from (default: current directory).
+:   Push an environment in a directory to FloxHub.
 
     Cannot be used with `--reference`.
+    Defaults to the current directory when `--reference` is not specified.
 
 `-o`, `--owner`, `--org`
 :   FloxHub owner to push environment to (default: current FloxHub user).
@@ -79,9 +80,9 @@ FloxHub with local changes to the environment.
 
 
 `-r`, `--reference`
-:   Update a remote environment by reference (e.g., `owner/name`).
+:   Push local copy of a FloxHub environment upstream.
 
-    This pushes the local changes made to a remote environment
+    This pushes the local changes made to a FloxHub environment
     using commands with the `--reference` flag.
     Referring to environments, that have never been accessed
     or explicitly pulled will cause an error.

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -39,12 +39,17 @@ use crate::utils::message;
 #[derive(Debug, Clone, Bpaf)]
 enum PullSelect {
     RemoteUpdate {
-        /// Pull updates for a cached remote environment
+        ///
+        ///
+        /// Pull updates for local copy of a FloxHub environment.
+        ///
+        /// The pulled environment can be used by passing '--reference' to other
+        /// subcommands.
         #[bpaf(long("reference"), long("ref"), short('r'), argument("owner>/<name"))]
         env_ref: RemoteEnvironmentRef,
     },
     NewAbbreviated {
-        /// ID of the environment to pull
+        /// Reference of an environment to pull into a directory
         #[bpaf(positional("owner>/<name"))]
         remote: RemoteEnvironmentRef,
     },
@@ -60,8 +65,8 @@ impl Default for PullSelect {
 // Pull environment from FloxHub
 #[derive(Bpaf, Clone)]
 pub struct Pull {
-    /// Directory in which to create a managed environment,
-    /// or directory that already contains a managed environment
+    /// Directory to pull an environment into, or directory that contains an
+    /// environment that has already been pulled
     /// (default: current directory)
     #[bpaf(long, short, argument("path"), complete_shell(SHELL_COMPLETION_DIR))]
     dir: Option<PathBuf>,

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -49,7 +49,7 @@ pub struct Push {
 #[derive(Bpaf, Clone)]
 enum PushMode {
     Directory {
-        /// Directory to push the environment from (default: current directory)
+        /// Push an environment in a directory to FloxHub
         #[bpaf(
             long,
             short('d'),
@@ -65,7 +65,12 @@ enum PushMode {
         owner: Option<EnvironmentOwner>,
     },
     Remote {
-        /// Push an environment to FloxHub
+        ///
+        ///
+        /// Push local copy of a FloxHub environment upstream.
+        ///
+        /// This pushes the local changes made to a FloxHub environment using
+        /// commands with the `--reference` flag.
         #[bpaf(long("reference"), short('r'), argument("owner>/<name"))]
         env_ref: RemoteEnvironmentRef,
     },


### PR DESCRIPTION
Try to clarify how push and pull are documented, using the vocabulary we've chosen for describing local vs upstream FloxHub environments

I also added a newline in the `--help` output for `--reference`. It's a bit hacky but it looks better
```
> flox pull --help
Pull an environment from FloxHub

Usage: flox pull [-d=<path>] [-f] [-c] [-g=ARG] [-r=<owner>/<name> |
<owner>/<name>]

Available positional items:
    <owner>/<name>        Reference of an environment to pull into a directory

Available options:
    -d, --dir=<path>      Directory to pull an environment into, or directory
                          that contains an environment that has already been
                          pulled (default: current directory)
    -f, --force           Forcibly pull the environment When pulling a new
                          environment, adds the system to the manifest if the
                          lockfile is incompatible and ignores eval and build
                          errors. When pulling an existing environment,
                          overrides local changes.
    -c, --copy            Create a copy of the upstream environment.
    -g, --generation=ARG  Pull the specified generation instead of the live
                          generation. Must be used with --copy
    -r, --reference=<owner>/<name>
                          Pull updates for local copy of a FloxHub environment.
                          The pulled environment can be used by passing
                          '--reference' to other subcommands.
    -h, --help            Prints help information

Run 'man flox-pull' for more details.
```

```
> flox push --help
Send an environment to FloxHub

Usage: flox push ([-d=<path>] [-o=<owner>] | -r=<owner>/<name>) [-f]

Determines the mode of push operation
    -d, --dir=<path>     Push an environment in a directory to FloxHub
    -o, --owner=<owner>  FloxHub account to push the environment to (default:
                         current FloxHub user). Can only be specified when
                         pushing an environment for the first time.
                         Organizations may use either '--owner=<orgname>' or
                         alias '--org=<orgname>'.
    -r, --reference=<owner>/<name>
                         Push local copy of a FloxHub environment upstream.
                         This pushes the local changes made to a FloxHub
                         environment using commands with the `--reference` flag.

Available options:
    -f, --force          Forcibly overwrite the remote copy of the environment
    -h, --help           Prints help information

Run 'man flox-push' for more details.
```

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
