### PR TITLE
fix: Remote -> Upstream in error

### DIFF
--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -719,7 +719,7 @@ pub fn format_diverged_metadata(diversion: &DivergedMetadata) -> String {
 
          * {local_last_entry}
 
-        Remote:
+        Upstream:
 
          * {remote_last_entry}",
         local_last_entry = indent_by(3, local_last_entry),

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -245,7 +245,7 @@ Local:
    Generation:  2
    Timestamp: .*
 
-Remote:
+Upstream:
 
  \* $USER installed package 'vim \\(vim\\)' on .+
    Generation:  2


### PR DESCRIPTION
This is consistent with the language we've been using since dropping `--remote`