### PR TITLE
refactor: hooks and services in flox-activations

### DIFF
--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -1,17 +1,16 @@
 use std::fs::{self};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use anyhow::{Result, anyhow, bail};
 use clap::Args;
 use flox_core::activate::context::{ActivateCtx, InvocationType};
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
-use flox_core::activations::{self, activations_json_path};
 use indoc::formatdoc;
 use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
 use nix::unistd::{Pid, getpid};
 use serde::{Deserialize, Serialize};
-use signal_hook::consts::{SIGCHLD, SIGUSR1, SIGUSR2};
+use signal_hook::consts::{SIGCHLD, SIGUSR1};
 use signal_hook::iterator::Signals;
 use tracing::debug;
 
@@ -129,10 +128,7 @@ impl ActivateArgs {
             // Serialize ExecutiveCtx before forking
             let executive_ctx = ExecutiveCtx {
                 context: context.clone(),
-                subsystem_verbosity,
-                vars_from_env: vars_from_env.clone(),
                 start_or_attach: start_or_attach.clone(),
-                invocation_type: invocation_type.clone(),
                 parent_pid: parent_pid.as_raw(),
             };
 


### PR DESCRIPTION
- **refactor: hooks and services in flox-activations**
  Run start.bash and start services from `flox-activations activate`
  
  - Updated architecture has `hook.on-activate` running from
    `flox-activations activate`
  - Updated architecture has flox-activations activate signalling the
    executive when to start services, so although we'll need to change to
    signalling the executive instead of actually starting services, the
    decision to signal will still need to be made in
    `flox-activations activate` so this is closer to the desired end state
  

- **refactor: drop unused fields from ExecutiveCtx**
  