### PR TITLE
chore: update claude /release-notes

### DIFF
--- a/.claude/commands/release-notes.md
+++ b/.claude/commands/release-notes.md
@@ -21,3 +21,36 @@ followed by changes, and lastly fixes.
 Check with the user on what items to include, allowing them to ask for details
 for any item, before compiling a final list that is a user facing summary of the
 issues the user would like to include.
+
+
+Phrase the items using the following guidelines:
+- Group into "features" and "fixes".  Add a third group for "changes" only when
+  an item is very clearly a change in behavior the user needs to be aware of.
+- Frame all items in present tense as a single complete sentence, only adding a
+  second sentence when needed for clarity or additional explanation.
+- Use backticks "`" for command examples, environment variables or arguments.
+- Note any commits that were made by community members (not flox.dev).
+
+Use the following markdown template for formatting (updating the version in the
+link accordingly.:
+```
+## Features
+- Running command x will now do something cool
+
+## Fixes
+- Some command now properly does that.
+- Using xyz will always do this.
+
+## Download Links
+
+* [DEB (x86_64-linux)](https://downloads.flox.dev/by-env/stable/deb/flox-1.0.0.x86_64-linux.deb)
+* [DEB (aarch64-linux)](https://downloads.flox.dev/by-env/stable/deb/flox-1.0.0.aarch64-linux.deb)
+* [RPM (x86_64-linux)](https://downloads.flox.dev/by-env/stable/rpm/flox-1.0.0.x86_64-linux.rpm)
+* [RPM (aarch64-linux)](https://downloads.flox.dev/by-env/stable/rpm/flox-1.0.0.aarch64-linux.rpm)
+* [OSX (x86_64-darwin)](https://downloads.flox.dev/by-env/stable/osx/flox-1.0.0.x86_64-darwin.pkg)
+* [OSX (aarch64-darwin)](https://downloads.flox.dev/by-env/stable/osx/flox-1.0.0.aarch64-darwin.pkg
+```
+
+Upon completion and acceptence, offer to write the contents to a file so the
+user can copy from that, explaining that copying from the terminal will likely
+show leading spaces that will affect the markdown.


### PR DESCRIPTION
Update the /release-notes command to have a format and tone closer to be copy-pastable.  Raw output for 1.8.1 now looks like:

## Features
- Running `flox pull` or `flox push` without arguments in an activation detects the active environment and prompts if multiple candidates are available.
- `flox show` now displays additional package metadata including catalog, license, outputs (with default install markers), supported systems, source URL, and publication date.
- Java installations now have `JAVA_HOME` set automatically on activation.

## Fixes
- `flox activate --trust` now propagates trust to the includes of remote environments.
- Pure sandbox builds that create outputs containing directories with mode 555 no longer fail.

## Download Links

* [DEB (x86_64-linux)](https://downloads.flox.dev/by-env/stable/deb/flox-1.8.1.x86_64-linux.deb)
* [DEB (aarch64-linux)](https://downloads.flox.dev/by-env/stable/deb/flox-1.8.1.aarch64-linux.deb)
* [RPM (x86_64-linux)](https://downloads.flox.dev/by-env/stable/rpm/flox-1.8.1.x86_64-linux.rpm)
* [RPM (aarch64-linux)](https://downloads.flox.dev/by-env/stable/rpm/flox-1.8.1.aarch64-linux.rpm)
* [OSX (x86_64-darwin)](https://downloads.flox.dev/by-env/stable/osx/flox-1.8.1.x86_64-darwin.pkg)
* [OSX (aarch64-darwin)](https://downloads.flox.dev/by-env/stable/osx/flox-1.8.1.aarch64-darwin.pkg)
