### PR TITLE
fix(DirEnvironmentSelect): reject detected remote env at runtime

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -909,6 +909,8 @@ pub enum EnvironmentSelectError {
     EnvironmentError(#[from] EnvironmentError),
     #[error("Did not find an environment in the current directory.")]
     EnvNotFoundInCurrentDirectory,
+    #[error("Remote environments not supported for this operation")]
+    RemoteNotSupported,
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
 }
@@ -1068,6 +1070,9 @@ impl DirEnvironmentSelect {
             // already activated environment or an environment in the current
             // directory.
             DirEnvironmentSelect::Unspecified => match detect_environment(message)? {
+                Some(UninitializedEnvironment::Remote(_)) => {
+                    Err(EnvironmentSelectError::RemoteNotSupported)
+                },
                 Some(env) => {
                     let generation = activated_environments().is_active_with_generation(&env);
                     Ok(env.into_concrete_environment(flox, generation)?)

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -159,6 +159,7 @@ impl Publish {
                 bail!("Cannot publish from an environment on FloxHub.")
             },
             ConcreteEnvironment::Remote(_) => {
+                // guarded by DirEnvironmentSelect
                 unreachable!("Cannot publish from a remote environment")
             },
         };

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -704,6 +704,7 @@ pub fn format_environment_select_error(err: &EnvironmentSelectError) -> String {
         EnvironmentSelectError::EnvNotFoundInCurrentDirectory => formatdoc! {"
             Did not find an environment in the current directory.
         "},
+        EnvironmentSelectError::RemoteNotSupported => display_chain(err),
         EnvironmentSelectError::Anyhow(err) => err
             .chain()
             .skip(1)


### PR DESCRIPTION
## Proposed Changes

We recently added remote environmnt detection to `detect_environment`,
which means the `DirEnvironmentSelect::Unspecified` could resolve to a remote/Floxhub
environment, vialating downstream expectations.

This PR adds a runtime check to `DirEnvironmentSelect` resulting in an error at detection time
(rather than a panic later on).
