### PR TITLE
fix: don't write formatting changes to lockfile

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -209,7 +209,7 @@ impl<State> CoreEnvironment<State> {
 
         let environment_lockfile_path = self.lockfile_path();
 
-        if Some(&lockfile_contents) == existing_lockfile_contents.as_ref() {
+        if Some(&lockfile) == existing_lockfile.as_ref() {
             debug!(
                 ?environment_lockfile_path,
                 "lockfile is up to date, skipping write"
@@ -1192,9 +1192,11 @@ mod tests {
     use super::*;
     use crate::flox::test_helpers::flox_instance;
     use crate::models::manifest::raw::CatalogPackage;
+    use crate::models::manifest::typed::ActivateMode;
     use crate::providers::catalog;
     use crate::providers::catalog::test_helpers::catalog_replay_client;
     use crate::providers::services::process_compose::SERVICE_CONFIG_FILENAME;
+    use crate::utils::serialize_json_with_newline;
 
     /// Create a CoreEnvironment with an empty manifest (with version = 1)
     fn empty_core_environment() -> (CoreEnvironment, Flox, TempDir) {
@@ -1505,17 +1507,15 @@ mod tests {
         assert_eq!(mtime_after, mtime_original);
     }
 
-    /// Locking an environment should write a lockfile
-    /// if the contents change compared to the existing lockfile,
-    /// even if the contents are semantically equivalent.
+    /// Locking an environment should not write a lockfile if the contents are
+    /// semantically equivalent to the existing lockfile.
     #[test]
-    fn lock_writes_if_contents_change() {
+    fn lock_skips_write_if_formatting_changes() {
         let (flox, _temp_dir_handle) = flox_instance();
         let mut environment =
             new_core_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
 
-        // add some whitespace to the file, that simulates different original content
-        // we subsequently expect the file to be modified
+        // add some whitespace to the file
         {
             let mut lockfile = OpenOptions::new()
                 .read(true)
@@ -1524,6 +1524,46 @@ mod tests {
                 .unwrap();
 
             writeln!(lockfile, "\n\n\n",).unwrap();
+
+            // fsync metadata to ensure the mtime is updated
+            lockfile.sync_all().unwrap();
+        }
+
+        let mtime_original = environment
+            .lockfile_path()
+            .metadata()
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let _ = environment.lock(&flox).unwrap();
+
+        let mtime_after = environment
+            .lockfile_path()
+            .metadata()
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        assert_eq!(mtime_after, mtime_original);
+    }
+
+    /// Locking an environment should write a lockfile if the contents change
+    /// semantically compared to the existing lockfile
+    #[test]
+    fn lock_writes_if_modified() {
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut environment =
+            new_core_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
+
+        // Make a non-formatting change to the lock
+        {
+            let mut lockfile = environment.existing_lockfile().unwrap().unwrap();
+            lockfile.manifest.options.activate.mode = Some(ActivateMode::Dev);
+            let lockfile_contents = serialize_json_with_newline(&lockfile).unwrap();
+            let lockfile_path = environment.lockfile_path();
+            let mut lockfile = OpenOptions::new().write(true).open(lockfile_path).unwrap();
+            lockfile.write_all(lockfile_contents.as_bytes()).unwrap();
 
             // fsync metadata to ensure the mtime is updated
             lockfile.sync_all().unwrap();

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -12,6 +12,7 @@ use std::time::SystemTime;
 use std::{env, fs, io};
 
 pub use flox_core::traceable_path;
+use serde::Serialize;
 use thiserror::Error;
 use tracing::{debug, trace};
 use walkdir;
@@ -251,6 +252,16 @@ pub fn maybe_traceable_path(maybe_path: &Option<PathBuf>) -> impl tracing::Value
     } else {
         String::from("null")
     }
+}
+
+/// Call serde_json::to_string_pretty and append a newline
+pub fn serialize_json_with_newline<T>(value: &T) -> Result<String, serde_json::Error>
+where
+    T: ?Sized + Serialize,
+{
+    let mut serialized = serde_json::to_string_pretty(value)?;
+    serialized.push('\n');
+    Ok(serialized)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Don't write changes to lockfiles when only formatting has changed
- Don't rebuild an environment if only formatting has changed

In 1.7.6 we started writing newlines to lockfiles, but this means that a lockfile generated prior to 1.7.6 will be re-written by a version post 1.7.6, which can lead to contention if you go back and forth between versions, even just running `flox activate`.

## Release Notes

Fixed bug where `flox activate` will modify lockfiles without newlines generated by flox versions prior to 1.7.6