### PR TITLE
chore: list -a shows available/installed outputs

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -1058,6 +1058,9 @@ pub enum ManifestError {
     MultiplePackagesMatch(String, Vec<String>),
     #[error("not a valid activation mode")]
     ActivateModeInvalid,
+
+    #[error("outputs '{0:?}' don't exists for package {1}")]
+    InvalidOutputs(Vec<String>, String),
 }
 
 /// The section where users can declare dependencies on other environments.


### PR DESCRIPTION
## Proposed Changes

Enhanced the `flox list -a` command to distinguish between available and installed package outputs. Previously, the output only showed available outputs. Now it displays both "Available outputs" (all outputs the package provides) and "Installed outputs" (outputs that will actually be installed). The change includes refactoring to extract common formatting logic into a reusable `format_as_sorted_list` helper function.


Before: 
```
          nix-eval-jobs:
              Description:     Hydra's builtin hydra-eval-jobs as a standalone
              Locked URL:      github:nix-community/nix-eval-jobs/c132534bc68eb48479a59a3116ee7ce0f16ce12b
              Flake attribute: packages.aarch64-darwin.default
              Package Name:    N/A
              Priority:        5
              Version:         2.23.0
              License:         GPL-3.0
              Unfree:          false
              Broken:          false
              Outputs:         [ \"out\" ]
```

After:
```
            nix-eval-jobs:
              Description:          Hydra's builtin hydra-eval-jobs as a standalone
              Locked URL:           github:nix-community/nix-eval-jobs/c132534bc68eb48479a59a3116ee7ce0f16ce12b
              Flake attribute:      packages.aarch64-darwin.default
              Package Name:         nix-eval-jobs
              Priority:             5
              Version:              2.23.0
              License:              GPL-3.0
              Unfree:               false
              Broken:               false
              Available Outputs:    [ \"out\" ]
              Installed Outputs:    [ \"out\" ]
```
## Release Notes

`flox list -a` now shows both available and installed outputs for each package, making it clearer which outputs are actually being installed.