### PR TITLE
fix: better error when renaming FloxHub envs

### DIFF
--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -194,7 +194,11 @@ EOF
 
   run "$FLOX_BIN" edit --reference "owner/name" --name "renamed"
   assert_failure
-  assert_output --partial "Cannot rename environments on FloxHub"
+  assert_output --partial - <<EOF
+✘ ERROR: FloxHub environments must currently be renamed on FloxHub.
+Rename this environment at https://hub.flox.dev/owner/name/settings
+Then pull the renamed environment.
+EOF
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Give next steps instead of just failing

Before:
```
❌ ERROR: Cannot rename environments on FloxHub
```

After:
```
❌ ERROR: FloxHub environments must currently be renamed on FloxHub.
Rename this environment at https://hub.flox.dev/owner/name/settings
Then pull the renamed environment.
```

## Release Notes

Improved an error message (when failing to rename a FloxHub env, but not sure that's worth mentioning)