### PR TITLE
[Exploration] Add rename support for FloxHub environments

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1562,7 +1562,7 @@ impl ManagedEnvironment {
 
         // Create HTTP client and call rename API
         let client =
-            crate::providers::floxhub_client::FloxhubClient::new(&api_base_url, token.secret());
+            crate::providers::floxhub_client::FloxhubClient::new(&api_base_url, token.clone());
         let response = client
             .rename_environment(
                 self.pointer.owner.as_ref(),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -179,6 +179,9 @@ pub enum ManagedEnvironmentError {
 
     #[error(transparent)]
     Core(#[from] CoreEnvironmentError),
+
+    #[error("failed to rename environment")]
+    Rename(#[source] crate::providers::floxhub_client::FloxhubClientError),
 }
 
 #[derive(Debug)]
@@ -1517,6 +1520,67 @@ impl ManagedEnvironment {
         self.link(&store_paths)?;
 
         Ok(PullResult::Updated)
+    }
+
+    /// Rename this managed environment on FloxHub
+    #[instrument(skip(self, flox), fields(progress = "Renaming environment on FloxHub"))]
+    pub async fn rename(
+        &mut self,
+        flox: &Flox,
+        new_name: EnvironmentName,
+    ) -> Result<(), EnvironmentError> {
+        // Check if already has that name - if so, no-op
+        if self.name() == new_name {
+            return Ok(());
+        }
+
+        // Ensure user is authenticated
+        let token = flox.floxhub_token.as_ref().ok_or_else(|| {
+            EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::AccessDenied)
+        })?;
+
+        // Derive API base URL from the pointer's configuration
+        // If there's a git URL override, derive the API URL from it
+        // e.g., https://api.local.flox.dev:8000/floxem-gitolite -> https://api.local.flox.dev:8000/floxem/
+        let api_base_url = match &self.pointer.floxhub_git_url_override {
+            Some(git_url) => {
+                let mut api_url = git_url.clone();
+                api_url.set_path("floxem/");
+                api_url
+            },
+            None => self.pointer.floxhub_base_url.clone(),
+        };
+
+        // Create HTTP client and call rename API
+        let client =
+            crate::providers::floxhub_client::FloxhubClient::new(&api_base_url, token.secret());
+        let _response = client
+            .rename_environment(
+                self.pointer.owner.as_ref(),
+                self.pointer.name.as_ref(),
+                new_name.as_ref(),
+            )
+            .await
+            .map_err(|e| match e {
+                crate::providers::floxhub_client::FloxhubClientError::AccessDenied => {
+                    EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::AccessDenied)
+                },
+                _ => EnvironmentError::ManagedEnvironment(ManagedEnvironmentError::Rename(e)),
+            })?;
+
+        // Update local pointer file
+        self.pointer.name = new_name;
+        let mut pointer_content = serde_json::to_string_pretty(&self.pointer)
+            .map_err(ManagedEnvironmentError::SerializePointer)?;
+        pointer_content.push('\n');
+
+        fs::write(
+            self.path.join(ENVIRONMENT_POINTER_FILENAME),
+            pointer_content,
+        )
+        .map_err(ManagedEnvironmentError::WritePointer)?;
+
+        Ok(())
     }
 
     /// Detach the environment from the remote repository.

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -147,6 +147,12 @@ pub enum ManagedEnvironmentError {
     SerializePointer(#[source] serde_json::Error),
     #[error("couldn't write environment pointer")]
     WritePointer(#[source] std::io::Error),
+    #[error("failed to update local pointer after remote rename to '{new_name}'")]
+    WritePointerAfterRemoteRename {
+        new_name: String,
+        #[source]
+        err: std::io::Error,
+    },
 
     // todo: improve description
     #[error("could not create floxmeta directory")]
@@ -1591,7 +1597,10 @@ impl ManagedEnvironment {
             self.path.join(ENVIRONMENT_POINTER_FILENAME),
             pointer_content,
         )
-        .map_err(ManagedEnvironmentError::WritePointer)?;
+        .map_err(|e| ManagedEnvironmentError::WritePointerAfterRemoteRename {
+            new_name: self.pointer.name.to_string(),
+            err: e,
+        })?;
 
         Ok(())
     }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -79,12 +79,6 @@ pub enum RemoteEnvironmentError {
 
     #[error("generations error")]
     Generations(#[source] GenerationsError),
-
-    #[error("could not remove existing cache directory")]
-    RemoveExistingCache(#[source] std::io::Error),
-
-    #[error("could not rename cache directory")]
-    RenameCacheDir(#[source] std::io::Error),
 }
 
 #[derive(Debug)]

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -310,6 +310,15 @@ impl RemoteEnvironment {
         self.inner.fetch_remote_state(flox)?;
         Ok(())
     }
+
+    /// Rename this remote environment on FloxHub
+    pub async fn rename(
+        &mut self,
+        flox: &Flox,
+        new_name: EnvironmentName,
+    ) -> Result<(), EnvironmentError> {
+        self.inner.rename(flox, new_name).await
+    }
 }
 
 impl Environment for RemoteEnvironment {

--- a/cli/flox-rust-sdk/src/providers/floxhub_client.rs
+++ b/cli/flox-rust-sdk/src/providers/floxhub_client.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
+use crate::flox::FloxhubToken;
+
 #[derive(Serialize)]
 struct RenameRequest {
     name: String,
@@ -17,15 +19,15 @@ pub struct RenameResponse {
 pub struct FloxhubClient {
     client: Client,
     base_url: Url,
-    token: String,
+    token: FloxhubToken,
 }
 
 impl FloxhubClient {
-    pub fn new(base_url: &Url, token: &str) -> Self {
+    pub fn new(base_url: &Url, token: FloxhubToken) -> Self {
         Self {
             client: Client::new(),
             base_url: base_url.clone(),
-            token: token.to_string(),
+            token,
         }
     }
 
@@ -43,7 +45,7 @@ impl FloxhubClient {
         let response = self
             .client
             .post(url)
-            .header("X-Flox-Github-Token", &self.token)
+            .header("X-Flox-Github-Token", self.token.secret())
             .json(&RenameRequest {
                 name: new_name.to_string(),
             })

--- a/cli/flox-rust-sdk/src/providers/floxhub_client.rs
+++ b/cli/flox-rust-sdk/src/providers/floxhub_client.rs
@@ -1,0 +1,83 @@
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+
+#[derive(Serialize)]
+struct RenameRequest {
+    name: String,
+}
+
+#[derive(Deserialize)]
+pub struct RenameResponse {
+    pub owner: String,
+    pub name: String,
+}
+
+pub struct FloxhubClient {
+    client: Client,
+    base_url: Url,
+    token: String,
+}
+
+impl FloxhubClient {
+    pub fn new(base_url: &Url, token: &str) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.clone(),
+            token: token.to_string(),
+        }
+    }
+
+    pub async fn rename_environment(
+        &self,
+        owner: &str,
+        current_name: &str,
+        new_name: &str,
+    ) -> Result<RenameResponse, FloxhubClientError> {
+        let url = self
+            .base_url
+            .join(&format!("environment/{}/{}/rename", owner, current_name))
+            .map_err(FloxhubClientError::InvalidUrl)?;
+
+        let response = self
+            .client
+            .post(url)
+            .header("X-Flox-Github-Token", &self.token)
+            .json(&RenameRequest {
+                name: new_name.to_string(),
+            })
+            .send()
+            .await
+            .map_err(FloxhubClientError::Request)?;
+
+        match response.status() {
+            status if status.is_success() => Ok(response
+                .json()
+                .await
+                .map_err(FloxhubClientError::Response)?),
+            status if status == 403 => Err(FloxhubClientError::AccessDenied),
+            status if status == 409 => Err(FloxhubClientError::Conflict),
+            status if status == 400 => Err(FloxhubClientError::InvalidName),
+            _ => Err(FloxhubClientError::Other(response.status())),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum FloxhubClientError {
+    #[error("Access denied: not permitted to rename environment")]
+    AccessDenied,
+    #[error("An environment with that name already exists")]
+    Conflict,
+    #[error("Invalid environment name")]
+    InvalidName,
+    #[error("Invalid URL")]
+    InvalidUrl(#[source] url::ParseError),
+    #[error("Request failed")]
+    Request(#[source] reqwest::Error),
+    #[error("Failed to parse response")]
+    Response(#[source] reqwest::Error),
+    #[error("HTTP {0}")]
+    Other(reqwest::StatusCode),
+}

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -4,6 +4,7 @@ pub mod buildenv;
 pub mod catalog;
 pub mod container_builder;
 pub mod flake_installable_locker;
+pub mod floxhub_client;
 pub mod git;
 pub mod nix;
 pub mod publish;

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -120,8 +120,10 @@ impl Edit {
                     ConcreteEnvironment::Path(ref mut environment) => {
                         environment.rename(name.clone())?;
                     },
-                    ConcreteEnvironment::Managed(ref mut environment) => {
-                        environment.rename(&flox, name.clone()).await?;
+                    ConcreteEnvironment::Managed(_) => {
+                        bail!(
+                            "Use 'flox edit -r <owner>/<name> -n <new_name>' to rename environments on FloxHub"
+                        );
                     },
                     ConcreteEnvironment::Remote(ref mut environment) => {
                         environment.rename(&flox, name.clone()).await?;

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -126,7 +126,20 @@ impl Edit {
                         );
                     },
                     ConcreteEnvironment::Remote(ref mut environment) => {
+                        // Check if environment is active before renaming
+                        let uninit_env =
+                            UninitializedEnvironment::Remote(environment.pointer().clone());
+                        let was_active = activated_environments().is_active(&uninit_env);
+
                         environment.rename(&flox, name.clone()).await?;
+
+                        if was_active {
+                            message::warning(format!(
+                                "Environment is active. Exit and re-activate with: flox activate -r {}/{}",
+                                environment.pointer().owner,
+                                name
+                            ));
+                        }
                     },
                 }
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -447,6 +447,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
         },
 
         ManagedEnvironmentError::UpstreamAlreadyExists { .. } => display_chain(err),
+        ManagedEnvironmentError::Rename(_) => display_chain(err),
         // access denied is caught early as ManagedEnvironmentError::AccessDenied
         ManagedEnvironmentError::Push(_) => display_chain(err),
         ManagedEnvironmentError::PushWithLocalIncludes => display_chain(err),

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -694,6 +694,8 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
         RemoteEnvironmentError::WriteNewOutlink(_) => display_chain(err),
         RemoteEnvironmentError::CreateGcRootDir(_) => display_chain(err),
         RemoteEnvironmentError::Generations(_) => display_chain(err),
+        RemoteEnvironmentError::RemoveExistingCache(_) => display_chain(err),
+        RemoteEnvironmentError::RenameCacheDir(_) => display_chain(err),
     }
 }
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -470,6 +470,13 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
 
             Please ensure that you have write permissions to '.flox/{ENVIRONMENT_POINTER_FILENAME}'.
         "},
+        ManagedEnvironmentError::WritePointerAfterRemoteRename { new_name, .. } => formatdoc! {"
+            The environment was renamed to '{new_name}' on FloxHub, but the local
+            pointer file could not be updated.
+
+            To complete the rename locally, update the 'name' field in
+            '.flox/{ENVIRONMENT_POINTER_FILENAME}' to '{new_name}'.
+        "},
         ManagedEnvironmentError::CreateFloxmetaDir(_) => display_chain(err),
         ManagedEnvironmentError::CreateGenerationFiles(_) => display_chain(err),
         ManagedEnvironmentError::CommitGeneration(

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -694,8 +694,6 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
         RemoteEnvironmentError::WriteNewOutlink(_) => display_chain(err),
         RemoteEnvironmentError::CreateGcRootDir(_) => display_chain(err),
         RemoteEnvironmentError::Generations(_) => display_chain(err),
-        RemoteEnvironmentError::RemoveExistingCache(_) => display_chain(err),
-        RemoteEnvironmentError::RenameCacheDir(_) => display_chain(err),
     }
 }
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -448,6 +448,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
 
         ManagedEnvironmentError::UpstreamAlreadyExists { .. } => display_chain(err),
         ManagedEnvironmentError::Rename(_) => display_chain(err),
+        ManagedEnvironmentError::RenameResponseMismatch { .. } => display_chain(err),
         // access denied is caught early as ManagedEnvironmentError::AccessDenied
         ManagedEnvironmentError::Push(_) => display_chain(err),
         ManagedEnvironmentError::PushWithLocalIncludes => display_chain(err),

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -202,19 +202,15 @@ EOF
 }
 
 # bats test_tags=edit:rename-managed
-@test "'flox edit --name' renames a managed environment" {
+@test "'flox edit --name' fails with a managed environment" {
   floxhub_setup "owner"
 
   "$FLOX_BIN" init --name name
   "$FLOX_BIN" push --owner "owner"
 
   run "$FLOX_BIN" edit --name "renamed"
-  assert_success
-  assert_output --partial "renamed environment 'name' to 'renamed'"
-
-  # Verify local pointer was updated
-  run cat .flox/env.json
-  assert_output --partial '"name": "renamed"'
+  assert_failure
+  assert_output --partial "Use 'flox edit -r <owner>/<name> -n <new_name>' to rename environments on FloxHub"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -186,15 +186,35 @@ EOF
 }
 
 # bats test_tags=edit:rename-remote
-@test "'flox edit --name' fails with a remote environment" {
+@test "'flox edit --name' renames a remote environment" {
   floxhub_setup "owner"
 
   "$FLOX_BIN" init --name name
   "$FLOX_BIN" push --owner "owner"
 
   run "$FLOX_BIN" edit --reference "owner/name" --name "renamed"
-  assert_failure
-  assert_output --partial "Cannot rename environments on FloxHub"
+  assert_success
+  assert_output --partial "renamed environment 'name' to 'renamed'"
+
+  # Verify the rename worked
+  run "$FLOX_BIN" list --reference "owner/renamed"
+  assert_success
+}
+
+# bats test_tags=edit:rename-managed
+@test "'flox edit --name' renames a managed environment" {
+  floxhub_setup "owner"
+
+  "$FLOX_BIN" init --name name
+  "$FLOX_BIN" push --owner "owner"
+
+  run "$FLOX_BIN" edit --name "renamed"
+  assert_success
+  assert_output --partial "renamed environment 'name' to 'renamed'"
+
+  # Verify local pointer was updated
+  run cat .flox/env.json
+  assert_output --partial '"name": "renamed"'
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -192,11 +192,22 @@ EOF
   "$FLOX_BIN" init --name name
   "$FLOX_BIN" push --owner "owner"
 
+  # Access the remote environment to create the cache
+  run "$FLOX_BIN" list --reference "owner/name"
+  assert_success
+
+  # Verify old cache exists before rename
+  assert [ -d "$FLOX_CACHE_DIR/remote/owner/name" ]
+
   run "$FLOX_BIN" edit --reference "owner/name" --name "renamed"
   assert_success
   assert_output --partial "renamed environment 'name' to 'renamed'"
 
-  # Verify the rename worked
+  # Verify the cache directory was renamed
+  assert [ ! -d "$FLOX_CACHE_DIR/remote/owner/name" ]
+  assert [ -d "$FLOX_CACHE_DIR/remote/owner/renamed" ]
+
+  # Verify the rename worked on FloxHub
   run "$FLOX_BIN" list --reference "owner/renamed"
   assert_success
 }


### PR DESCRIPTION
## Proposed Changes

I should be able to edit an environment hosted on FloxHub using `flox edit -r <owner>/<name>`.

## Release Notes

`flox edit -r <owner>/<name>` will succeed instead of showing an error message and forcing users to login to the FloxHub UI and edit the name there.
