### PR TITLE
fix(activate): ACTIVATION>START_STATE_DIR for zsh

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -114,8 +114,8 @@ if [ "$old_fpath" != "$new_fpath" ]; then
 fi
 
 # Restore environment variables set in the previous bash initialization.
-eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/del.env")"
-eval "$($_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_ACTIVATION_STATE_DIR/add.env")"
+eval "$($_sed -e 's/^/unset /' -e 's/$/;/' "$_FLOX_START_STATE_DIR/del.env")"
+eval "$($_sed -e 's/^/export /' -e 's/$/;/' "$_FLOX_START_STATE_DIR/add.env")"
 
 # Set the prompt if we're in an interactive shell.
 if [[ -o interactive ]]; then

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -24,7 +24,7 @@ pub fn generate_zsh_startup_commands(args: &ZshStartupArgs, writer: &mut impl Wr
         format!("{}", &args.flox_activate_tracelevel),
     ));
     stmts.push(set_unexported_unexpanded(
-        "_FLOX_ACTIVATION_STATE_DIR",
+        "_FLOX_START_STATE_DIR",
         args.activation_state_dir.display().to_string(),
     ));
     stmts.push(set_unexported_unexpanded(
@@ -96,7 +96,7 @@ mod tests {
         let output = String::from_utf8_lossy(&buf);
         expect![[r#"
             typeset -g _flox_activate_tracelevel='3';
-            typeset -g _FLOX_ACTIVATION_STATE_DIR='/activation_state_dir';
+            typeset -g _FLOX_START_STATE_DIR='/activation_state_dir';
             typeset -g _activate_d='/activate_d';
             typeset -g _FLOX_ENV='/flox_env';
             typeset -g _FLOX_ENV_CACHE='/flox_env_cache';


### PR DESCRIPTION
Rename some occurrences of the old environment variable name for zsh that we missed in 48bec7b56.