### PR TITLE
fix(services): Prevent [re]start from hooks

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell_gen",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.17",
  "time",

--- a/cli/flox-core/Cargo.toml
+++ b/cli/flox-core/Cargo.toml
@@ -19,6 +19,7 @@ proptest-derive.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shell_gen = { path = "../shell_gen" }
+sysinfo.workspace = true
 tracing.workspace = true
 tempfile.workspace = true
 time.workspace = true

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -580,6 +580,14 @@ impl ActivationState {
         }
     }
 
+    /// Get the PID and store path of the activation that's currently starting, if any.
+    pub fn starting_pid_and_store_path(&self) -> Option<(Pid, &Path)> {
+        match &self.ready {
+            Ready::Starting(pid, start_id) => Some((*pid, &start_id.store_path)),
+            _ => None,
+        }
+    }
+
     /// Check if the current process-compose is current (up-to-date).
     ///
     /// If `expected_store_path` is provided, compares against that store path.


### PR DESCRIPTION
~~⚠️ Currently based on unmerged https://github.com/flox/flox/pull/3920~~

---

Return an error if `flox services start` or `flox services restart` are called from `hook.on-activate` in order to prevent deadlocks now that:

- hooks may not be run concurrently for different store paths of an environment
- activate will keep retrying with a warning, instead of timing out with an error

We use the store path and ancestry of the blocking PID to prevent false-positive warnings from other `flox services` processes which may still happen concurrently with an activation but will retry and warn with feedback.
