### PR TITLE
refactor(activations): Move VarsFromEnvironment

### DIFF
--- a/cli/flox-activations/src/activate_script_builder.rs
+++ b/cli/flox-activations/src/activate_script_builder.rs
@@ -8,10 +8,10 @@ use flox_core::activations::StartIdentifier;
 use flox_core::util::default_nix_env_vars;
 use is_executable::IsExecutable;
 
-use crate::cli::activate::VarsFromEnvironment;
 use crate::cli::fix_paths::{fix_manpath_var, fix_path_var};
 use crate::cli::set_env_dirs::fix_env_dirs_var;
 use crate::env_diff::EnvDiff;
+use crate::vars_from_env::VarsFromEnvironment;
 pub const FLOX_ENV_LOG_DIR_VAR: &str = "_FLOX_ENV_LOG_DIR";
 pub const FLOX_PROMPT_ENVIRONMENTS_VAR: &str = "FLOX_PROMPT_ENVIRONMENTS";
 /// This variable is used to communicate what socket to use to the activate

--- a/cli/flox-activations/src/attach.rs
+++ b/cli/flox-activations/src/attach.rs
@@ -16,7 +16,7 @@ use shell_gen::{Shell, ShellWithPath};
 use tracing::debug;
 
 use crate::activate_script_builder::{activate_tracer, apply_activation_env, old_cli_envs};
-use crate::cli::activate::{NO_REMOVE_ACTIVATION_FILES, VarsFromEnvironment};
+use crate::cli::activate::NO_REMOVE_ACTIVATION_FILES;
 use crate::cli::attach::{AttachArgs, AttachExclusiveArgs};
 use crate::env_diff::EnvDiff;
 use crate::gen_rc::bash::{BashStartupArgs, generate_bash_startup_commands};
@@ -24,6 +24,7 @@ use crate::gen_rc::fish::{FishStartupArgs, generate_fish_startup_commands};
 use crate::gen_rc::tcsh::{TcshStartupArgs, generate_tcsh_startup_commands};
 use crate::gen_rc::zsh::{ZshStartupArgs, generate_zsh_startup_commands};
 use crate::gen_rc::{StartupArgs, StartupCtx};
+use crate::vars_from_env::VarsFromEnvironment;
 
 pub const STARTUP_SCRIPT_PATH_OVERRIDE_VAR: &str = "_FLOX_RC_FILE_PATH";
 

--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -21,12 +21,11 @@ use indoc::formatdoc;
 use nix::sys::signal::{Signal, kill};
 use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
 use nix::unistd::{Pid, getpid};
-use serde::{Deserialize, Serialize};
 use signal_hook::consts::{SIGCHLD, SIGUSR1};
 use signal_hook::iterator::Signals;
 use tracing::{debug, error};
 
-use crate::activate_script_builder::{FLOX_ENV_DIRS_VAR, assemble_activate_command};
+use crate::activate_script_builder::assemble_activate_command;
 use crate::attach::{attach, quote_run_args};
 use crate::cli::executive::ExecutiveCtx;
 use crate::process_compose::{
@@ -34,6 +33,7 @@ use crate::process_compose::{
     start_services_via_socket,
     wait_for_socket_ready,
 };
+use crate::vars_from_env::VarsFromEnvironment;
 
 pub const NO_REMOVE_ACTIVATION_FILES: &str = "_FLOX_NO_REMOVE_ACTIVATION_FILES";
 
@@ -484,32 +484,5 @@ impl ActivateArgs {
                 unreachable!("Received unexpected signal or empty iterator over signals");
             }
         }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct VarsFromEnvironment {
-    pub flox_env_dirs: Option<String>,
-    pub path: String,
-    pub manpath: Option<String>,
-}
-
-impl VarsFromEnvironment {
-    // TODO: move now that it's also used by executive
-    pub fn get() -> Result<Self> {
-        let flox_env_dirs = std::env::var(FLOX_ENV_DIRS_VAR).ok();
-        let path = match std::env::var("PATH") {
-            Ok(path) => path,
-            Err(e) => {
-                return Err(anyhow!("failed to get PATH from environment: {}", e));
-            },
-        };
-        let manpath = std::env::var("MANPATH").ok();
-
-        Ok(Self {
-            flox_env_dirs,
-            path,
-            manpath,
-        })
     }
 }

--- a/cli/flox-activations/src/lib.rs
+++ b/cli/flox-activations/src/lib.rs
@@ -5,5 +5,6 @@ pub mod env_diff;
 pub mod gen_rc;
 pub mod logger;
 mod process_compose;
+mod vars_from_env;
 
 pub type Error = anyhow::Error;

--- a/cli/flox-activations/src/process_compose.rs
+++ b/cli/flox-activations/src/process_compose.rs
@@ -12,8 +12,8 @@ use time::macros::format_description;
 use tracing::{debug, info};
 
 use crate::activate_script_builder::apply_activation_env;
-use crate::cli::activate::VarsFromEnvironment;
 use crate::env_diff::EnvDiff;
+use crate::vars_from_env::VarsFromEnvironment;
 
 /// Path to the process-compose binary
 /// TODO: we don't want the dependency here

--- a/cli/flox-activations/src/vars_from_env.rs
+++ b/cli/flox-activations/src/vars_from_env.rs
@@ -1,0 +1,30 @@
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+
+use crate::activate_script_builder::FLOX_ENV_DIRS_VAR;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct VarsFromEnvironment {
+    pub flox_env_dirs: Option<String>,
+    pub path: String,
+    pub manpath: Option<String>,
+}
+
+impl VarsFromEnvironment {
+    pub fn get() -> Result<Self> {
+        let flox_env_dirs = std::env::var(FLOX_ENV_DIRS_VAR).ok();
+        let path = match std::env::var("PATH") {
+            Ok(path) => path,
+            Err(e) => {
+                return Err(anyhow!("failed to get PATH from environment: {}", e));
+            },
+        };
+        let manpath = std::env::var("MANPATH").ok();
+
+        Ok(Self {
+            flox_env_dirs,
+            path,
+            manpath,
+        })
+    }
+}


### PR DESCRIPTION
Now that it's used by `cli::activate` and `cli::executive`.
