### PR TITLE
fix(push): deleted upstream bugs

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -26,3 +26,4 @@ yes,philiptaron,Philip Taron,<philip.taron@gmail.com>
 yes,RichardAlmanza,Richard Almanza,<al.vegari@gmail.com>
 yes,mahyarmirrashed,Mahyar Mirrashed,<mah.mirr@gmail.com>
 yes,mrswastik-robot,Swastik Patel,<swastikpatel29@gmail.com>
+yes,noor-latif,Noor Latif,<noor@latif.se>


### PR DESCRIPTION
## Summary
My rust knowledge is limited. So I tried to keep the code changes minimal and I tested the flox behaviour myself, it seems to be working now.

Fixes two bugs introduced in commit e6b1d34a during a refactoring that extracted [`fetch_remote_state()`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs#L259):
1. Misleading error message when `flox push` encounters a deleted FloxHub environment
2. Incorrect "already up to date" message after upstream deletion

Closes #3934

## Problem

**Symptom 1:** Users see a confusing error when pushing to a deleted environment:
```
ERROR: Environment not found in FloxHub.
You can run 'flox push' to push the environment back to FloxHub.
```
This message appears **while the user is already running `flox push`**, creating an error loop.

**Symptom 2:** After fixing proper error catching when upstream env is deleted, `flox push` now instead reports:
```
ℹ No changes to push for tmp.
The environment on FloxHub is already up to date.
```
When in fact the upstream doesn't exist and needs to be recreated.

## Root Cause

During the Dec 17, 2025 refactoring (commit 2f312b4d), `fetch_remote_state()` was copied from `ManagedEnvironment` to `FloxmetaBranch`, which introduced error wrapping through the abstraction boundary:

**Error Flow:**
1. `GitRemoteCommandError::RefNotFound` (upstream deleted)
2. > `FloxmetaBranchError::UpstreamNotFound` (converted in [`FloxmetaBranch::fetch_remote_state()`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs#L259))
3. > [`ManagedEnvironmentError::FloxmetaBranch(UpstreamNotFound)`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/managed_environment.rs#L78) (auto-wrapped via `#[from]` trait)

**The Bug:**
The catch site in `ManagedEnvironment::push()` still tried to match [`ManagedEnvironmentError::UpstreamNotFound`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/managed_environment.rs#L114) (direct variant) instead of the wrapped `ManagedEnvironmentError::FloxmetaBranch(FloxmetaBranchError::UpstreamNotFound)`.

This caused:
- The error to propagate uncaught -> showing misleading error message
- [`compare_remote()`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs#L287) to compare against stale local ref -> returning "already up to date"

## Solution

Added a new helper method [`FloxmetaBranch::fetch_and_compare_remote()`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs#L295) that:
1. Combines [`fetch_remote_state()`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs#L259) and [`compare_remote()`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs#L287) into a single operation
2. Handles `UpstreamNotFound` internally by returning [`BranchOrd::Ahead`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs#L689)
3. Keeps the error handling logic in the appropriate abstraction layer (`FloxmetaBranch`)

This approach simplifies the [call site in `push()`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/managed_environment.rs#L1418-L1422) while properly encapsulating the "deleted upstream = ahead" semantic.

**Before (in [`push()`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/managed_environment.rs#L1379)):**
```rust
let branch_ord = match self.floxmeta_branch.fetch_remote_state(flox, &self.pointer) {
	Err(FloxmetaBranchError::UpstreamNotFound { .. }) => {
		debug!("Upstream environment was deleted.");
		BranchOrd::Ahead
	},
	Err(e) => Err(ManagedEnvironmentError::FloxmetaBranch(e))?,
	Ok(_) => self
		.floxmeta_branch
		.compare_remote()
		.map_err(ManagedEnvironmentError::FloxmetaBranch)?,
};
```

**After:**
```rust
let branch_ord = self
	.floxmeta_branch
	.fetch_and_compare_remote(flox, &self.pointer)
	.map_err(ManagedEnvironmentError::FloxmetaBranch)?;
```

**New helper in [`FloxmetaBranch`](https://github.com/noor-latif/flox/blob/fix/push-deleted-upstream/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs#L295-L310):**
```rust
/// Fetch the remote state and compare it with the local branch.
///
/// This combines [`Self::fetch_remote_state`] and [`Self::compare_remote`].
/// If the upstream is not found, returns [`BranchOrd::Ahead`] since push will recreate it.
pub fn fetch_and_compare_remote(
	&self,
	flox: &Flox,
	pointer: &ManagedPointer,
) -> Result<BranchOrd, FloxmetaBranchError> {
	match self.fetch_remote_state(flox, pointer) {
		Err(FloxmetaBranchError::UpstreamNotFound { .. }) => {
			debug!("Upstream environment was deleted.");
			Ok(BranchOrd::Ahead)
		},
		Err(e) => Err(e),
		Ok(_) => self.compare_remote(),
	}
}
```

I don't know if we want to solve it this way. But I decided to give it a shot.
If the maintainers approve of the implementation. I'll try to make a unit test for it.