### PR TITLE
fix(executive): Use separate log verbosity flag

### DIFF
--- a/cli/flox-activations/src/logger.rs
+++ b/cli/flox-activations/src/logger.rs
@@ -75,14 +75,13 @@ pub fn init_stderr_logger(verbosity_arg: Option<u32>) -> Result<u32, anyhow::Err
     Ok(subsystem_verbosity)
 }
 
-/// Replace existing logging with a file. Used by long-living child processes.
+/// Initialize file logging for the executive process.
 pub fn init_file_logger(
-    verbosity_arg: Option<u32>,
+    verbosity: u32,
     log_file: impl AsRef<str>,
     log_dir: impl AsRef<Path>,
-) -> Result<u32, anyhow::Error> {
-    let (subsystem_verbosity, filter) = Verbosity::verbosity_from_env_and_arg(verbosity_arg);
-    let env_filter = EnvFilter::try_new(filter)?;
+) -> Result<(), anyhow::Error> {
+    let env_filter = EnvFilter::try_new(Verbosity::from(verbosity).env_filter())?;
 
     let file_appender = tracing_appender::rolling::daily(log_dir, log_file.as_ref());
 
@@ -97,5 +96,5 @@ pub fn init_file_logger(
         .with(env_filter)
         .init();
 
-    Ok(subsystem_verbosity)
+    Ok(())
 }

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -15,7 +15,7 @@ fn try_main() -> Result<(), Error> {
     let args = Cli::parse();
 
     if let cli::Command::Executive(executive_args) = args.command {
-        return executive_args.handle(args.verbosity);
+        return executive_args.handle();
     };
 
     let subsystem_verbosity =

--- a/cli/flox-core/src/activate/vars.rs
+++ b/cli/flox-core/src/activate/vars.rs
@@ -11,6 +11,7 @@ use std::sync::LazyLock;
 pub const FLOX_ACTIVE_ENVIRONMENTS_VAR: &str = "_FLOX_ACTIVE_ENVIRONMENTS";
 pub const FLOX_RUNTIME_DIR_VAR: &str = "FLOX_RUNTIME_DIR";
 pub const FLOX_ACTIVATIONS_VERBOSITY_VAR: &str = "_FLOX_ACTIVATIONS_VERBOSITY";
+pub const FLOX_EXECUTIVE_VERBOSITY_VAR: &str = "_FLOX_EXECUTIVE_VERBOSITY";
 
 pub static FLOX_ACTIVATIONS_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
     PathBuf::from(


### PR DESCRIPTION
## Proposed Changes

Use a numeric value from a new `_FLOX_EXECUTIVE_VERBOSITY` flag.

Previously we inferred this from the first `activate -v+` invocation that started the executive, but it's not clear to users which activation will start an executive and if initially started with very verbose logging then it might fill the disk.

## Release Notes

N/A, unreleased