### PR TITLE
docs: cleanup a few more instances of activate --

### DIFF
--- a/cli/flox-rust-sdk/src/models/manifest/typed.rs
+++ b/cli/flox-rust-sdk/src/models/manifest/typed.rs
@@ -995,7 +995,7 @@ pub struct ContainerizeConfig {
     /// These values act as defaults and may be replaced by any specified when creating a container.
     /// Flox sets an entrypoint to activate the containerized environment,
     /// and `cmd` is then run inside the activation, similar to
-    /// `flox activate -- cmd`.
+    /// `flox activate -c cmd`.
     #[cfg_attr(test, proptest(strategy = "optional_vec_of_strings(3, 4)"))]
     pub cmd: Option<Vec<String>>,
     /// A set of directories describing where the process is

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -30,7 +30,7 @@ Configures a shell with everything defined by the environment:
 * Runs hooks.
 * Starts services (if `--start-services` is specified).
 
-`flox activate` may run in one of three modes:
+`flox activate` may run in one of four modes:
 
 * interactive: `flox activate` when invoked from an interactive shell\
   Launches an interactive sub-shell.

--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -105,7 +105,7 @@ ContainerizeConfig ::= {
     These values act as defaults and may be replaced by any specified when creating a container.
     Flox sets an entrypoint to activate the containerized environment,
     and `cmd` is then run inside the activation, similar to
-    `flox activate -- cmd`.
+    `flox activate -c cmd`.
 
 `volumes`
 :   A set of directories describing where the process is

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -380,10 +380,8 @@ fish = """
 """
 ```
 
-Profile scripts are re-run for nested activations.
-A nested activation can occur when an environment is already active and either
-`eval "$(flox activate)"` or `flox activate -- CMD` is run.
-In this scenario, profile scripts are run a second time.
+Profile scripts are re-run when an environment is already active and
+`eval "$(flox activate)"` or `flox activate -c CMD` is run.
 Re-running profile scripts allows aliases to be set in subshells that inherit
 from a parent shell with an already active environment.
 

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -216,7 +216,7 @@
       "description": "Container config derived from\nhttps://github.com/opencontainers/image-spec/blob/main/config.md\n\nEnv and Entrypoint are left out since they interfere with our activation implementation\nDeprecated and reserved keys are also left out",
       "properties": {
         "cmd": {
-          "description": "Default arguments to the entrypoint of the container.\nThese values act as defaults and may be replaced by any specified when creating a container.\nFlox sets an entrypoint to activate the containerized environment,\nand `cmd` is then run inside the activation, similar to\n`flox activate -- cmd`.",
+          "description": "Default arguments to the entrypoint of the container.\nThese values act as defaults and may be replaced by any specified when creating a container.\nFlox sets an entrypoint to activate the containerized environment,\nand `cmd` is then run inside the activation, similar to\n`flox activate -c cmd`.",
           "items": {
             "type": "string"
           },

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -188,7 +188,7 @@
       "description": "Container config derived from\nhttps://github.com/opencontainers/image-spec/blob/main/config.md\n\nEnv and Entrypoint are left out since they interfere with our activation implementation\nDeprecated and reserved keys are also left out",
       "properties": {
         "cmd": {
-          "description": "Default arguments to the entrypoint of the container.\nThese values act as defaults and may be replaced by any specified when creating a container.\nFlox sets an entrypoint to activate the containerized environment,\nand `cmd` is then run inside the activation, similar to\n`flox activate -- cmd`.",
+          "description": "Default arguments to the entrypoint of the container.\nThese values act as defaults and may be replaced by any specified when creating a container.\nFlox sets an entrypoint to activate the containerized environment,\nand `cmd` is then run inside the activation, similar to\n`flox activate -c cmd`.",
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
These were missed in ab9356fa0011d15ecff48768b03de2e78240bb76