### PR TITLE
fix(just): Allow quoted args

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,8 @@
 #
 # ---------------------------------------------------------------------------- #
 
+set positional-arguments
+
 nix_options := "--extra-experimental-features nix-command \
                 --extra-experimental-features flakes"
 INPUT_DATA := "${PWD}/test_data/input_data"
@@ -214,8 +216,7 @@ gen-unit-data-for-publish floxhub_repo_path force="":
 # Run the CLI integration test suite using locally built binaries
 # This is equivalent to the "local" jobs in CI.
 @integ-tests +bats_args="": build
-    flox-cli-tests \
-        {{bats_args}}
+    flox-cli-tests "$@"
 
 # Run the CLI integration test suite using Nix-built binaries
 # This is equivalent to the "remote" jobs in CI.
@@ -223,8 +224,7 @@ gen-unit-data-for-publish floxhub_repo_path force="":
     nix run \
         --accept-flake-config \
         --extra-experimental-features 'nix-command flakes' \
-        .#flox-cli-tests \
-        {{bats_args}}
+        .#flox-cli-tests -- "$@"
 
 @ut regex="" record="false":
     _FLOX_UNIT_TEST_RECORD={{record}} {{cargo_test_invocation}} {{regex}}


### PR DESCRIPTION
## Proposed Changes

Using the fix from:

- https://just.systems/man/en/avoiding-argument-splitting.html#positional-arguments

I've worked around this for a long time by replacing the spaces with dots to create a single argument regex but it's annoying and surprising for other users.

Before:

    % just integ-tests -- -f 'flox list --config'
    …
    ~/projects/flox/flox/cli ~/projects/flox/flox
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.29s
    flox-cli-tests: Running test suite with:
      PROJECT_TESTS_DIR:        /Users/dcarley/projects/flox/flox/cli/tests
      bats                      /nix/store/nv7hpfmc5vg99s39z6m0dxh7wvj7gw04-bats-with-libraries-1.12.0/bin/bats
      bats options              --print-output-on-failure --verbose-run --timing --jobs 4 --no-parallelize-across-files -f flox list --config
      bats tests                /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.yXueWu/flox-cli-tests-gjlP3k
    Error: Bad command line option '--config'
    Usage: bats [OPTIONS] <tests>
           bats [-h | -v]

After:

    % just integ-tests -- -f 'flox list --config'
    …
    ~/projects/flox/flox/cli ~/projects/flox/flox
        Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
    flox-cli-tests: Running test suite with:
      PROJECT_TESTS_DIR:        /Users/dcarley/projects/flox/flox/cli/tests
      bats                      /nix/store/nv7hpfmc5vg99s39z6m0dxh7wvj7gw04-bats-with-libraries-1.12.0/bin/bats
      bats options              --print-output-on-failure --verbose-run --timing --jobs 4 --no-parallelize-across-files -f flox list --config
      bats tests                /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.yXueWu/flox-cli-tests-xIVR7N
    …
    list.bats
     ✓ 'flox list --config' shows manifest content [1498]
     ✓ 'flox list --config' shows manifest content for composed environments [1332]
     ✓ 'flox list --config' shows notices about overrides [1666]

    3 tests, 0 failures in 8 seconds

## Release Notes

N/A, contributors only