### PR TITLE
feat(activate): Error exit/exec in on-activate

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -245,19 +245,10 @@ if [ "$_skip_hook_on_activate" = "false" ]; then
     # as configuration statements by the "in-place" activation
     # mode. So, we'll redirect stdout to stderr.
     set +euo pipefail
-    if [ "$_command_mode" = "false" ]; then
-      # Capture env if hook calls `exit` early.
-      # shellcheck disable=SC2329 # called indirectly
-      exit() {
-        $_jq -nS env > "$_end_env_json"
-        builtin exit "$@"
-      }
-    fi
     "$_flox_activate_tracer" "$FLOX_ENV/activate.d/hook-on-activate" START
     # shellcheck disable=SC1091 # from rendered environment
     source "$FLOX_ENV/activate.d/hook-on-activate" 1>&2
     "$_flox_activate_tracer" "$FLOX_ENV/activate.d/hook-on-activate" END
-    unset -f exit 2> /dev/null || true
     set -euo pipefail
   else
     "$_flox_activate_tracer" "$FLOX_ENV/activate.d/hook-on-activate" NOT FOUND
@@ -273,7 +264,7 @@ if [ "$_command_mode" = "true" ]; then
 fi
 
 if [ "$_command_mode" = "false" ]; then
-  # Capture ending environment for normal completion (no early `exit` from hook)
+  # Capture ending environment.
   $_jq -nS env > "$_end_env_json"
 fi
 

--- a/cli/flox-activations/src/env_diff.rs
+++ b/cli/flox-activations/src/env_diff.rs
@@ -9,6 +9,9 @@ use shell_gen::{GenerateShell, SetVar, Statement, UnsetVar};
 /// in hooks and result in keys containing `%%` that are invalid in other userShells.
 const BASH_EXPORTED_FUNC_PREFIX: &str = "BASH_FUNC_";
 
+pub const ENV_DIFF_START_JSON: &str = "start.env.json";
+pub const ENV_DIFF_END_JSON: &str = "end.env.json";
+
 #[derive(Debug, Clone)]
 pub struct EnvDiff {
     pub additions: HashMap<String, String>,
@@ -25,8 +28,8 @@ impl EnvDiff {
 
     /// Load an EnvDiff from start.env.json and end.env.json files in activation_state_dir
     pub fn from_files(activation_state_dir: impl AsRef<Path>) -> Result<EnvDiff> {
-        let start_json = activation_state_dir.as_ref().join("start.env.json");
-        let end_json = activation_state_dir.as_ref().join("end.env.json");
+        let start_json = activation_state_dir.as_ref().join(ENV_DIFF_START_JSON);
+        let end_json = activation_state_dir.as_ref().join(ENV_DIFF_END_JSON);
 
         let start_env = parse_env_json(&start_json)
             .with_context(|| format!("Failed to read {}", start_json.display()))?;


### PR DESCRIPTION
⚠️ Branched from https://github.com/flox/flox/pull/3974

## Proposed Changes

Prevent the use of `exit` or `exec` in `hook.on-activate` by removing the workaround from 67adf3485 and returning an error if `end.env.json` doesn't exist after running the interpreter.

This is slightly more robust than the previous approach and we realised that the previous behaviour only "worked" but short-circuiting the activation, which was being abused by `containerd-shim-flox-installer` but shouldn't be useful to any other users:

    % flox list -c -d ~/tmp
    version = 1

    [hook]
    on-activate = """
      echo "from hook before exit"
      exit
    """

    % nix run github:flox/flox/v1.8.3 -- activate -d ~/tmp -- echo "should see this" && echo success || echo failure
    from hook before exit
    success

This will however break the current version of the shim installer which uses `exit 0` in two places. If merging this, we'll have to publish new versions of the shim installer, and hope that no one uses the old version with a newer version of Flox.

This also doesn't help the behaviour of `flox build` will may still exit early from hooks but doesn't perform any environment snapshotting (or use `flox-activations`) in command mode.

## Release Notes

`exit` and `exec` can no longer be used in `hook.on-activate`.