### PR TITLE
test: Set git user/email for unit tests

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs
+++ b/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs
@@ -748,7 +748,7 @@ mod tests {
     use crate::flox::test_helpers::flox_instance;
     use crate::models::environment::{EnvironmentName, EnvironmentOwner};
     use crate::models::floxmeta::{FloxMeta, floxmeta_dir};
-    use crate::providers::git::tests::commit_file;
+    use crate::providers::git::tests::{commit_file, test_git_options};
     use crate::providers::git::{GitCommandProvider, GitProvider};
 
     /// Create a [ManagedPointer] for testing with mock owner and name data
@@ -774,7 +774,8 @@ mod tests {
             .join(test_pointer.owner.as_str())
             .join("floxmeta");
         fs::create_dir_all(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
+        let remote =
+            GitCommandProvider::init_with(test_git_options(), &remote_path, false).unwrap();
         (test_pointer, remote_path, remote)
     }
 
@@ -1538,7 +1539,8 @@ mod tests {
     fn create_equal_branches(flox: &Flox) -> (GitCommandProvider, &str, &str) {
         let branch_a = "branch_a";
         let branch_b = "branch_b";
-        let git = GitCommandProvider::init(flox.temp_dir.as_path(), false).unwrap();
+        let git = GitCommandProvider::init_with(test_git_options(), flox.temp_dir.as_path(), false)
+            .unwrap();
         git.checkout(branch_a, true).unwrap();
         commit_file(&git, "file_1");
         git.create_branch(branch_b, branch_a).unwrap();

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -1335,6 +1335,7 @@ mod tests {
     use crate::models::environment::Environment;
     use crate::models::environment::generations::test_helpers::{ARGV, AUTHOR, HOSTNAME};
     use crate::models::environment::path_environment::test_helpers::new_path_environment;
+    use crate::providers::git::tests::test_git_options;
 
     const GEN_ID_1: GenerationId = GenerationId(1);
     const GEN_ID_2: GenerationId = GenerationId(2);
@@ -2015,7 +2016,7 @@ mod tests {
         let floxmeta_temp_path = tempfile::tempdir_in(&tempdir).unwrap().keep();
 
         let mut generations = Generations::init(
-            GitCommandOptions::default(),
+            test_git_options(),
             floxmeta_checkedout_path,
             floxmeta_temp_path,
             "some-branch".to_string(),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1747,8 +1747,8 @@ mod test {
     use crate::models::manifest::typed::{Inner, Manifest, PackageDescriptorCatalog, Vars};
     use crate::providers::catalog::test_helpers::catalog_replay_client;
     use crate::providers::catalog::{GENERATED_DATA, MockClient};
-    use crate::providers::git::tests::commit_file;
-    use crate::providers::git::{GitCommandOptions, GitCommandProvider};
+    use crate::providers::git::GitCommandProvider;
+    use crate::providers::git::tests::{commit_file, test_git_options};
 
     /// Create a [ManagedPointer] for testing with mock owner and name data
     /// as well as an override for the floxhub git url to fetch from local
@@ -1773,7 +1773,8 @@ mod test {
             .join(test_pointer.owner.as_str())
             .join("floxmeta");
         fs::create_dir_all(&remote_path).unwrap();
-        let remote = GitCommandProvider::init(&remote_path, false).unwrap();
+        let remote =
+            GitCommandProvider::init_with(test_git_options(), &remote_path, false).unwrap();
         (test_pointer, remote_path, remote)
     }
 
@@ -1786,7 +1787,7 @@ mod test {
         let bare_tempdir = base_tempdir.as_ref().join(name);
 
         let mut generations = Generations::init(
-            GitCommandOptions::default(),
+            test_git_options(),
             &checked_out_tempdir,
             bare_tempdir,
             name.to_string(),

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -1292,10 +1292,17 @@ pub mod tests {
 
     use super::*;
 
+    pub fn test_git_options() -> GitCommandOptions {
+        let mut options = GitCommandOptions::default();
+        options.add_config_flag("user.name", "Test User");
+        options.add_config_flag("user.email", "test@example.com");
+        options
+    }
+
     pub fn init_temp_repo(bare: bool) -> (GitCommandProvider, tempfile::TempDir) {
         let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
-
-        let git_command_provider = GitCommandProvider::init(tempdir_handle.path(), bare).unwrap();
+        let git_command_provider =
+            GitCommandProvider::init_with(test_git_options(), tempdir_handle.path(), bare).unwrap();
         (git_command_provider, tempdir_handle)
     }
 
@@ -1305,8 +1312,8 @@ pub mod tests {
     ) -> (GitCommandProvider, tempfile::TempDir) {
         let tempdir_handle =
             tempfile::TempDir::with_prefix_in(format!("{name}-"), std::env::temp_dir()).unwrap();
-
-        let git_command_provider = GitCommandProvider::init(tempdir_handle.path(), bare).unwrap();
+        let git_command_provider =
+            GitCommandProvider::init_with(test_git_options(), tempdir_handle.path(), bare).unwrap();
         (git_command_provider, tempdir_handle)
     }
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1083,13 +1083,15 @@ pub mod tests {
         create_remotes,
         get_remote_url,
         init_temp_repo,
+        test_git_options,
     };
     use crate::providers::nix::test_helpers::known_store_path;
 
     fn example_git_remote_repo() -> (tempfile::TempDir, GitCommandProvider, String) {
         let tempdir_handle = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
 
-        let repo = GitCommandProvider::init(tempdir_handle.path(), true).unwrap();
+        let repo =
+            GitCommandProvider::init_with(test_git_options(), tempdir_handle.path(), true).unwrap();
 
         let remote_uri = format!("file://{}", tempdir_handle.path().display());
 
@@ -1147,7 +1149,7 @@ pub mod tests {
             None,
         );
 
-        let git = GitCommandProvider::init(repo_root, false).unwrap();
+        let git = GitCommandProvider::init_with(test_git_options(), repo_root, false).unwrap();
 
         git.checkout("main", true).expect("checkout main branch");
         git.add(&[&env.dot_flox_path()]).expect("adding flox files");


### PR DESCRIPTION
## Proposed Changes

To prevent the following error when running the unit tests when SSHed into a builder that doesn't have `~/.gitconfig`:

    be able to commit: BadExit(128, "", "Author identity unknown\n\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set your account's default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: empty ident name (for <dan@hetzner-aarch64-indigo-03.floxdev.com>) not allowed\n")

The following tests were affected:

    Summary [  46.857s] 828 tests run: 763 passed, 65 failed, 3 skipped
       FAIL [   0.062s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_compare_branches_diverged
       FAIL [   0.057s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_branch_noop
       FAIL [   0.055s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_branch_resets_wrong_commit
       FAIL [   0.068s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_compare_branches_ahead
       FAIL [   0.068s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_compare_branches_behind
       FAIL [   0.056s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_branch_resets_to_local_rev
       FAIL [   0.065s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_compare_branches_equal
       FAIL [   0.078s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_branch_creates_new
       FAIL [   0.054s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_generation_locked_rev_not_in_local_but_in_remote
       FAIL [   0.073s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_generation_locked_local_rev_missing
       FAIL [   0.073s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_new_complete_flow_clone_repo
       FAIL [   0.088s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_new_complete_flow_existing_repo
       FAIL [   0.092s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_generation_locked_with_rev_in_local
       FAIL [   0.092s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_new_upstream_not_found
       FAIL [   0.094s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_open_or_clone_clones_new
       FAIL [   0.093s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_generation_locked_with_local_rev
       FAIL [   0.099s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_open_or_clone_opens_existing
       FAIL [   0.102s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_generation_locked_no_local_branch_rev_not_in_remote
       FAIL [   0.104s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_generation_locked_no_lockfile
       FAIL [   0.104s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_generation_lock
       FAIL [   0.105s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_generation_locked_rev_not_found
       FAIL [   0.105s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_ensure_generation_locked_no_local_branch_rev_in_remote
       FAIL [   0.109s] flox-rust-sdk models::environment::floxmeta_branch::tests::test_new_with_existing_lock
       FAIL [   0.053s] flox-rust-sdk models::environment::managed_environment::test::test_validate_local_different_manifest
       FAIL [   0.066s] flox-rust-sdk models::environment::generations::tests::set_current_generation_already_current
       FAIL [   0.065s] flox-rust-sdk models::environment::managed_environment::test::deregisters_on_delete
       FAIL [   0.068s] flox-rust-sdk models::environment::generations::tests::set_current_generation_backwards_and_forwards
       FAIL [   0.061s] flox-rust-sdk models::environment::managed_environment::test::test_validate_local_different_binary_content
       FAIL [   0.074s] flox-rust-sdk models::environment::generations::tests::set_current_generation_not_found
       FAIL [   0.083s] flox-rust-sdk models::environment::managed_environment::test::test_validate_local_same_manifest
       FAIL [   0.084s] flox-rust-sdk models::environment::managed_environment::test::validate_different_lockfiles
       FAIL [   0.095s] flox-rust-sdk models::environment::managed_environment::test::gc_prunes_floxmeta_branches
       FAIL [   0.111s] flox-rust-sdk models::environment::managed_environment::test::registers_on_open
       FAIL [   0.027s] flox-rust-sdk providers::git::tests::identifies_local_commit_not_on_remote
       FAIL [   0.028s] flox-rust-sdk providers::git::tests::identifies_local_commit_on_remote
       FAIL [   0.028s] flox-rust-sdk providers::git::tests::test_branch_contains_commit
       FAIL [   0.027s] flox-rust-sdk providers::git::tests::test_branch_hash
       FAIL [   0.035s] flox-rust-sdk providers::git::tests::test_clone_branch
       FAIL [   0.029s] flox-rust-sdk providers::git::tests::test_commit_not_on_any_branch
       FAIL [   0.033s] flox-rust-sdk providers::git::tests::test_commit_not_on_branch
       FAIL [   0.026s] flox-rust-sdk providers::git::tests::test_fetch_bad_ref
       FAIL [   0.032s] flox-rust-sdk providers::git::tests::test_create_branch
       FAIL [   0.038s] flox-rust-sdk providers::git::tests::test_fetch_branch
       FAIL [   0.037s] flox-rust-sdk providers::git::tests::test_fetch_ref
       FAIL [   0.031s] flox-rust-sdk providers::git::tests::test_reset_branch_existing
       FAIL [   0.029s] flox-rust-sdk providers::git::tests::test_reset_branch_new
       FAIL [   0.033s] flox-rust-sdk providers::git::tests::test_status
       FAIL [   0.041s] flox-rust-sdk providers::git::tests::test_rev_count
       FAIL [   0.040s] flox-rust-sdk providers::git::tests::test_rev_date
       FAIL [   0.028s] flox-rust-sdk providers::publish::tests::error_when_not_pushed_to_any_remote
       FAIL [   0.026s] flox-rust-sdk providers::publish::tests::falls_back_to_any_pushed_remote
       FAIL [   0.028s] flox-rust-sdk providers::publish::tests::prefers_tracked_remote
       FAIL [   0.031s] flox-rust-sdk providers::publish::tests::prefers_origin_to_other_remote
       FAIL [   0.028s] flox-rust-sdk providers::publish::tests::prefers_upstream_to_origin
       FAIL [   0.046s] flox-rust-sdk providers::publish::tests::falls_back_to_untracked_remote
       FAIL [   0.027s] flox-rust-sdk providers::publish::tests::prefers_upstream_to_other_remote
       FAIL [   0.054s] flox-rust-sdk providers::publish::tests::publish_meta_only
       FAIL [   0.047s] flox-rust-sdk providers::publish::tests::test_check_build_meta_nominal
       FAIL [   0.045s] flox-rust-sdk providers::publish::tests::test_check_build_meta_null_fields
       FAIL [   0.048s] flox-rust-sdk providers::publish::tests::test_check_env_meta_dirty
       FAIL [   0.036s] flox-rust-sdk providers::publish::tests::test_check_env_meta_failure
       FAIL [   0.051s] flox-rust-sdk providers::publish::tests::test_check_package_meta_nominal
       FAIL [   0.058s] flox-rust-sdk providers::publish::tests::test_check_env_meta_nominal
       FAIL [   0.056s] flox-rust-sdk providers::publish::tests::test_check_env_meta_not_in_remote
       FAIL [   0.062s] flox-rust-sdk providers::publish::tests::upload_to_local_cache

## Release Notes

N/A
