### PR TITLE
fix(activate): Resilient to empty PATH

### DIFF
--- a/cli/flox-activations/src/activate_script_builder.rs
+++ b/cli/flox-activations/src/activate_script_builder.rs
@@ -221,7 +221,10 @@ fn fixed_vars_to_export(
             .flox_env_dirs
             .unwrap_or("".to_string()),
     );
-    let new_path = fix_path_var(&new_flox_env_dirs, &vars_from_environment.path);
+    let new_path = fix_path_var(
+        &new_flox_env_dirs,
+        &vars_from_environment.path.unwrap_or("".to_string()),
+    );
     let new_manpath = fix_manpath_var(
         &new_flox_env_dirs,
         &vars_from_environment.manpath.unwrap_or("".to_string()),

--- a/cli/flox-activations/src/vars_from_env.rs
+++ b/cli/flox-activations/src/vars_from_env.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::activate_script_builder::FLOX_ENV_DIRS_VAR;
@@ -6,19 +6,14 @@ use crate::activate_script_builder::FLOX_ENV_DIRS_VAR;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VarsFromEnvironment {
     pub flox_env_dirs: Option<String>,
-    pub path: String,
+    pub path: Option<String>,
     pub manpath: Option<String>,
 }
 
 impl VarsFromEnvironment {
     pub fn get() -> Result<Self> {
         let flox_env_dirs = std::env::var(FLOX_ENV_DIRS_VAR).ok();
-        let path = match std::env::var("PATH") {
-            Ok(path) => path,
-            Err(e) => {
-                return Err(anyhow!("failed to get PATH from environment: {}", e));
-            },
-        };
+        let path = std::env::var("PATH").ok();
         let manpath = std::env::var("MANPATH").ok();
 
         Ok(Self {

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -423,6 +423,18 @@ EOF
   assert_output --partial "Hello, world!"
 }
 
+# bats test_tags=activate:standalone
+@test "activation works with env -i (empty environment)" {
+  project_setup
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml" "$FLOX_BIN" install hello
+
+  # Current recommendation for isolating environments:
+  # https://github.com/flox/flox/issues/2447
+  run env -i FLOX_DISABLE_METRICS=true "$FLOX_BIN" activate -d "$PROJECT_DIR" -- hello
+  assert_success
+  assert_output "Hello, world!"
+}
+
 # bats test_tags=activate,activate:hook,activate:hook:fish
 @test "fish: interactive activate runs profile scripts" {
   project_setup


### PR DESCRIPTION
## Proposed Changes

The activate refactor in v1.9.0 broke the ability to run Flox without any previous environment variables set which we've previously recommended as a solution until we natively support isolating environments:

    env -i $(which flox) activate -- <command>

Fix it by treating it as optional like `MANPATH`.

Disable metrics is passed explicitly so that we don't skew our metrics
and the notice doesn't affect the assertion output. I don't *think* that
the lack of the other isolated environment variables that the test suite
sets up should poison anything else between builds for a simple
activation.

## Release Notes

Fix a regression that prevented Flox being run with `env -i`.
