### PR TITLE
fix(activate): handle missing PATH in env -i activation

### DIFF
--- a/cli/flox-activations/src/vars_from_env.rs
+++ b/cli/flox-activations/src/vars_from_env.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::activate_script_builder::FLOX_ENV_DIRS_VAR;
@@ -13,12 +13,7 @@ pub struct VarsFromEnvironment {
 impl VarsFromEnvironment {
     pub fn get() -> Result<Self> {
         let flox_env_dirs = std::env::var(FLOX_ENV_DIRS_VAR).ok();
-        let path = match std::env::var("PATH") {
-            Ok(path) => path,
-            Err(e) => {
-                return Err(anyhow!("failed to get PATH from environment: {}", e));
-            },
-        };
+        let path = std::env::var("PATH").unwrap_or_default();
         let manpath = std::env::var("MANPATH").ok();
 
         Ok(Self {


### PR DESCRIPTION
## Summary

- Default `PATH` to empty string instead of hard-failing when `PATH` is
  not set in the environment
- This restores the `env -i` workaround for running flox in an isolated
  environment, which broke in v1.9.0

Ref #2447