### PR TITLE
fix(activate): use Nix provided `rm`

### DIFF
--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 
 use flox_core::activate::context::ActivateCtx;
 
+/// Absolute path to coreutils `rm`, avoiding user alias expansion (e.g. `alias rm='rm -i'`).
+const RM: &str = concat!(env!("COREUTILS"), "/bin/rm");
+
 use crate::env_diff::EnvDiff;
 use crate::gen_rc::bash::BashStartupArgs;
 use crate::gen_rc::fish::FishStartupArgs;

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded, source_file};
 
 use crate::env_diff::EnvDiff;
+use crate::gen_rc::RM;
 
 /// Arguments for generating zsh startup commands
 #[derive(Debug, Clone)]
@@ -64,7 +65,7 @@ pub fn generate_zsh_startup_commands(
     if let Some(path) = args.clean_up.as_ref() {
         let path_str = path.to_string_lossy();
         let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
-        stmts.push(format!("rm {};", escaped_path).to_stmt());
+        stmts.push(format!("{RM} {};", escaped_path).to_stmt());
     }
 
     // N.B. the output of these scripts may be eval'd with backticks which have
@@ -110,6 +111,12 @@ mod tests {
         let mut buf = Vec::new();
         generate_zsh_startup_commands(&args, &env_diff, &mut buf).unwrap();
         let output = String::from_utf8_lossy(&buf);
+        let (main_output, last_line) = output
+            .strip_suffix('\n')
+            .unwrap()
+            .rsplit_once('\n')
+            .unwrap();
+        assert_eq!(last_line, format!("{RM} /path/to/rc/file;"));
         expect![[r#"
             typeset -g _flox_activate_tracelevel=3;
             typeset -g _activate_d=/activate_d;
@@ -120,9 +127,7 @@ mod tests {
             typeset -g _FLOX_ENV_CACHE=/flox_env_cache;
             typeset -g _FLOX_ENV_PROJECT=/flox_env_project;
             typeset -g _FLOX_ENV_DESCRIPTION=env_description;
-            source /activate_d/zsh;
-            rm /path/to/rc/file;
-        "#]]
-        .assert_eq(&output);
+            source /activate_d/zsh;"#]]
+        .assert_eq(main_output);
     }
 }

--- a/pkgs/flox-activations/default.nix
+++ b/pkgs/flox-activations/default.nix
@@ -21,6 +21,7 @@ let
     FLOX_ACTIVATIONS_BIN = "${placeholder "out"}/libexec/flox-activations";
     # Nix will ignore this if it starts with just BASH
     X_BASH_BIN = "${bash}/bin/bash";
+    COREUTILS = "${coreutils}";
   };
 
 in


### PR DESCRIPTION
- This avoids possibly prompting in the middle of activation. If a user has `alias rm='rm -i'` in their dotfiles, activation will prompt with something like: ``` rm: remove regular file '.../cz6fk83vmxjwjlh94z8n5h9ydqyci05r-environment-develop.1770828367462/flox_rc_zsh_MCvzTq'? ```
- We shouldn't be relying on host provided `rm` in the first place

## Release Notes

Fixed a bug where `flox activate` would prompt with `rm: remove regular file...?` when the user had the alias `alias rm='rm -i'`