### PR TITLE
fix(containerize): Set substitutors+keys for proxy

### DIFF
--- a/cli/flox-rust-sdk/src/providers/nix.rs
+++ b/cli/flox-rust-sdk/src/providers/nix.rs
@@ -1,6 +1,10 @@
+use std::fmt;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::LazyLock;
+
+use serde::Deserialize;
+use tracing::debug;
 
 static NIX_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
     std::env::var("NIX_BIN")
@@ -18,6 +22,97 @@ pub fn nix_base_command() -> Command {
         "nix-command flakes",
     ]);
     command
+}
+
+/// Raw shape of a single setting in `nix config show --json` output.
+/// Each setting is `{ "value": [...], ... }` — we only need the value(s).
+#[derive(Default, Deserialize)]
+struct NixConfigSetting {
+    #[serde(default)]
+    value: Vec<String>,
+}
+
+/// Subset of `nix config show --json` we currently care about.
+/// Unknown keys are discarded by serde's default behaviour.
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+struct NixConfigJson {
+    substituters: NixConfigSetting,
+    trusted_public_keys: NixConfigSetting,
+}
+
+impl NixConfigJson {
+    /// Read the host's effective nix config via `nix config show --json`.
+    fn from_nix_config() -> Result<Self, NixSubstituterConfigError> {
+        let mut command = nix_base_command();
+        command.args(["config", "show", "--json"]);
+
+        debug!(?command, "running nix config show");
+        let output = command.output().map_err(NixSubstituterConfigError::Exec)?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(NixSubstituterConfigError::Failed(stderr));
+        }
+
+        serde_json::from_slice(&output.stdout).map_err(NixSubstituterConfigError::Parse)
+    }
+}
+
+/// Substituter and signing key configuration read from the host's nix config.
+#[derive(Debug, Clone, Default)]
+pub struct NixSubstituterConfig {
+    pub substituters: Vec<String>,
+    pub trusted_public_keys: Vec<String>,
+}
+
+impl NixSubstituterConfig {
+    /// Read the host's effective substituter config.
+    pub fn from_nix_config() -> Result<Self, NixSubstituterConfigError> {
+        let result: Self = NixConfigJson::from_nix_config()?.into();
+        debug!(?result, "nix substituter config");
+        Ok(result)
+    }
+}
+
+/// Renders as a `NIX_CONFIG`-compatible string using `extra-*` variants
+/// so values are appended to (not replace) existing nix.conf settings.
+impl fmt::Display for NixSubstituterConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut lines = Vec::new();
+        if !self.substituters.is_empty() {
+            lines.push(format!(
+                "extra-substituters = {}",
+                self.substituters.join(" ")
+            ));
+        }
+        if !self.trusted_public_keys.is_empty() {
+            lines.push(format!(
+                "extra-trusted-public-keys = {}",
+                self.trusted_public_keys.join(" ")
+            ));
+        }
+        f.write_str(&lines.join("\n"))
+    }
+}
+
+impl From<NixConfigJson> for NixSubstituterConfig {
+    fn from(config: NixConfigJson) -> Self {
+        Self {
+            substituters: config.substituters.value,
+            trusted_public_keys: config.trusted_public_keys.value,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum NixSubstituterConfigError {
+    #[error("failed to execute nix config show")]
+    Exec(#[source] std::io::Error),
+    #[error("nix config show failed: {0}")]
+    Failed(String),
+    #[error("failed to parse nix config show output")]
+    Parse(#[source] serde_json::Error),
 }
 
 pub mod test_helpers {


### PR DESCRIPTION
## Proposed Changes



Make it possible to use `flox containerize` on macOS with environments
that have packages from custom FloxHub catalogs by including the public
keys that packages will be signed with.

We pass `--accept-flake-config` to the `nix run` invocation so that
`flox` can be run as a flake and substituted correctly from
`cache.flox.dev` but this doesn't propagate down to the `nix` calls that
`buildenv` makes and even so it's missing the `floxhub-1` key that the
publisher service signs custom packages with.

This never worked on macOS, even before we switched from `ghcr.io/flox`
to `nixos/nix` as the base image in 4cb3417, because that container
was also missing one of the required public keys due to a bug in how
`extra-` config options are applied:

- flox/flox-installers@88a6ded

I've verified that `NIX_CONFIG` isn't subject to the same bug:

    % podman run --rm nixos/nix:2.31.2 cat /etc/nix/nix.conf
    build-users-group = nixbld
    sandbox = false
    trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
    % podman run --rm \
     --env "NIX_CONFIG=$(cat <<EOF
    extra-substituters = https://test.example.com/
    extra-trusted-public-keys = test-1:one test-1:two
    EOF
     )" \
     nixos/nix:2.31.2 \
     nix --extra-experimental-features nix-command config show \
     | grep -E '(substituters|public-keys)'
    substituters = https://cache.nixos.org/ https://test.example.com/
    trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= test-1:one test-1:two
    trusted-substituters =

I originally implemented this by hardcoding the `flox-cache-public-1` and
`floxhub-1` keys as constants but realised that still wouldn't work for
customers that provide their own catalog store and keys. So instead I
switched to reading them from the host configuration. Values that appear
in both configs will be duplicated but functionally ignored.

There's no a nice way to integration test this because it would require
pinning a package from our real custom catalog and increasing the build
time of the containerize tests which are already slow. So I've opted for
manual testing for now:

    (2) ~/projects/flox/flox on dcarley/3971-containerize-trusted-keys [$><]
    % ft list -c
    version = 1

    [install]
    gcloud-with-auth.pkg-path = "flox/gcloud-with-auth"
    gcloud-with-auth.systems = ["aarch64-darwin", "x86_64-linux", "aarch64-linux"]
    gcloud-with-auth.pkg-group = "gcloud-with-auth"
    (2) ~/projects/flox/flox on dcarley/3971-containerize-trusted-keys [$><]
    % ft containerize
    ⚡︎ 'tmp:latest' written to Podman runtime

## Release Notes

Fixed a bug where `flox containerize` on macOS could not be used with custom packages.
