### PR TITLE
chore(nix): Remove CARGO_LOG for cli+activations

### DIFF
--- a/pkgs/flox-activations/default.nix
+++ b/pkgs/flox-activations/default.nix
@@ -42,7 +42,6 @@ craneLib.buildPackage (
     # if we add shared (internal) packages.
     cargoExtraArgs = "--locked -p flox-activations";
 
-    CARGO_LOG = "cargo::core::compiler::fingerprint=info";
     CARGO_PROFILE = "small";
 
     # runtime dependencies

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -74,8 +74,6 @@ craneLib.buildPackage (
     cargoArtifacts = rust-internal-deps;
     cargoExtraArgs = "--locked -p flox";
 
-    CARGO_LOG = "cargo::core::compiler::fingerprint=info";
-
     # runtime dependencies
     buildInputs = rust-internal-deps.buildInputs ++ [ ];
 


### PR DESCRIPTION
## Proposed Changes

This results in logs that look like errors but aren't. It just means that `cargo` wasn't able to find a previous cache file.

Originally added to `flox-cli` when refactoring builds in 46de4158f and then copied to `flox-activations` when it was created in b22b97eb2.

Seen in:

- https://github.com/flox/flox/actions/runs/21950104668/job/63398203194?pr=3989#step:6:127

Example log:

    flox-activations> cargo 1.92.0 (344c4567c 2025-10-21)
    flox-activations> +++ command cargo build --profile small --message-format json-render-diagnostics --locked -p flox-activations
    flox-activations>    0.248964245s  INFO prepare_target{force=false package_id=flox-activations v0.0.0 (/build/flox-src/flox-activations) target="flox_activations"}: cargo::core::compiler::fingerprint: fingerprint error for flox-activations v0.0.0 (/build/flox-src/flox-activations)/Build/TargetInner { name_inferred: true, ..: lib_target("flox_activations", ["lib"], "/build/flox-src/flox-activations/src/lib.rs", Edition2024) }
    flox-activations>    0.249008005s  INFO prepare_target{force=false package_id=flox-activations v0.0.0 (/build/flox-src/flox-activations) target="flox_activations"}: cargo::core::compiler::fingerprint:     err: failed to read `/build/flox-src/target/small/.fingerprint/flox-activations-49b221cfb936283f/lib-flox_activations`
    flox-activations>
    flox-activations> Caused by:
    flox-activations>     No such file or directory (os error 2)
    flox-activations>    0.251609221s  INFO prepare_target{force=false package_id=flox-core v0.0.0 (/build/flox-src/flox-core) target="flox_core"}: cargo::core::compiler::fingerprint: fingerprint error for flox-core v0.0.0 (/build/flox-src/flox-core)/Build/TargetInner { name_inferred: true, ..: lib_target("flox_core", ["lib"], "/build/flox-src/flox-core/src/lib.rs", Edition2024) }
    flox-activations>    0.251642902s  INFO prepare_target{force=false package_id=flox-core v0.0.0 (/build/flox-src/flox-core) target="flox_core"}: cargo::core::compiler::fingerprint:     err: failed to read `/build/flox-src/target/small/.fingerprint/flox-core-5f41f7d0e343e35b/lib-flox_core`
    flox-activations>
    flox-activations> Caused by:
    flox-activations>     No such file or directory (os error 2)
    flox-activations>    0.264306221s  INFO prepare_target{force=false package_id=shell_gen v0.1.0 (/build/flox-src/shell_gen) target="shell_gen"}: cargo::core::compiler::fingerprint: fingerprint error for shell_gen v0.1.0 (/build/flox-src/shell_gen)/Build/TargetInner { name_inferred: true, ..: lib_target("shell_gen", ["lib"], "/build/flox-src/shell_gen/src/lib.rs", Edition2024) }
    flox-activations>    0.264337221s  INFO prepare_target{force=false package_id=shell_gen v0.1.0 (/build/flox-src/shell_gen) target="shell_gen"}: cargo::core::compiler::fingerprint:     err: failed to read `/build/flox-src/target/small/.fingerprint/shell_gen-9780cefff47b1243/lib-shell_gen`
    flox-activations>
    flox-activations> Caused by:
    flox-activations>     No such file or directory (os error 2)
    flox-activations>    0.266209713s  INFO prepare_target{force=false package_id=flox-activations v0.0.0 (/build/flox-src/flox-activations) target="flox-activations"}: cargo::core::compiler::fingerprint: fingerprint error for flox-activations v0.0.0 (/build/flox-src/flox-activations)/Build/TargetInner { name: "flox-activations", doc: true, ..: with_path("/build/flox-src/flox-activations/src/main.rs", Edition2024) }
    flox-activations>    0.266241033s  INFO prepare_target{force=false package_id=flox-activations v0.0.0 (/build/flox-src/flox-activations) target="flox-activations"}: cargo::core::compiler::fingerprint:     err: failed to read `/build/flox-src/target/small/.fingerprint/flox-activations-3988a2fd821400c4/bin-flox-activations`
    flox-activations>
    flox-activations> Caused by:
    flox-activations>     No such file or directory (os error 2)
    flox-activations>    Compiling shell_gen v0.1.0 (/build/flox-src/shell_gen)
    flox-activations>    Compiling flox-core v0.0.0 (/build/flox-src/flox-core)
    flox-activations>    Compiling flox-activations v0.0.0 (/build/flox-src/flox-activations)
    flox-activations>     Finished `small` profile [optimized] target(s) in 38.38s

## Release Notes

N/A, dev only.