### PR TITLE
fix(buildenv): Improve untrusted package error

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -111,7 +111,10 @@ pub enum BuildEnvError {
 
     /// A custom package has been uploaded, but the current user hasn't configured
     /// a trusted public key that matches a signature of this package.
-    #[error("Package '{0}' is not signed by a trusted key")]
+    #[error(
+        "Package '{0}' is not signed by a trusted key.\n\
+        See https://flox.dev/docs/customer/signing-keys/ for more information."
+    )]
     UntrustedPackage(String),
 
     #[error("authentication error")]


### PR DESCRIPTION
## Proposed Changes

Add a hint to the documentation which describes what the Flox installer does and what you need to do if using a custom catalog store.

This is still a bit light on information for people that have installed from flake or are using one of the older `ghcr.io/flox` containers but it's enough, without getting into the weeds, until we do more work on this slice:

- https://github.com/flox/forge/blob/main/efforts/2026/02-floxdocs-audit/slices.md#sl-017-document-official-flox-signing-keys

## Release Notes

Improved the error message when a package can't be installed due to a signature mismatch.
