### PR TITLE
fix(build): Prevent additional errors from find

### DIFF
--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -237,8 +237,10 @@ define COMMON_BUILD_VARS_template =
   # Create a target for cleaning up the temporary directory.
   .PHONY: clean/$(_pname)
   clean/$(_pname):
-	-$(_V_) $(_find) $($(_pvarname)_tmpBasename) -type d -exec $(_chmod) +w {} \;
-	-$(_V_) $(_rm) -rf $($(_pvarname)_tmpBasename)
+	-$(_V_) if [ -d "$($(_pvarname)_tmpBasename)" ]; then \
+	  $(_find) $($(_pvarname)_tmpBasename) -type d -exec $(_chmod) +w {} \; && \
+	  $(_rm) -rf $($(_pvarname)_tmpBasename); \
+	fi
 
   clean_targets += clean/$(_pname)
 
@@ -422,8 +424,10 @@ define BUILD_local_template =
 	@# Actually perform the build using the temporary build wrapper.
 	@#
 	@echo "Building $(_name) in local mode"
-	-$(_VV_) $(_find) $($(_pvarname)_out) -type d -exec $(_chmod) +w {} \;
-	-$(_VV_) $(_rm) -rf $($(_pvarname)_out)
+	-$(_VV_) if [ -e "$($(_pvarname)_out)" ]; then \
+	  $(_find) $($(_pvarname)_out) -type d -exec $(_chmod) +w {} \; && \
+	  $(_rm) -rf $($(_pvarname)_out); \
+	fi
 	$(_V_) $(_env) $$(QUOTED_ENV_DISALLOW_ARGS) out=$($(_pvarname)_out) \
 	  $(if $(_virtualSandbox),$(PRELOAD_VARS) FLOX_SRC_DIR=$(PWD) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
 	  $(FLOX_INTERPRETER)/activate --env $$($(_pvarname)_develop_copy_env) \


### PR DESCRIPTION
## Proposed Changes

Guard two of the `find` calls added in 8ffc82eb9 to prevent unrelated error messages when a build fails to produce a `$out`.

The second hunk uses `-e` instead of `-d` because `$out` may either be a file or a directory. Whereas the first hunk is always a directory.

The other two unmodified instances are already guarded.

Before:

    % ft build
    Rendering foo build script to /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T//f16fea2e/foo/build.bash
    Building foo-0.0.0 in local mode
    find: ‘/tmp/store_051b9299247304ed9cab0219416485d7-foo-0.0.0’: No such file or directory
    make: [/nix/store/4vqx7w35m4kndq0jnbb8v4s865v9g0vb-package-builder-1.0.0/libexec/flox-build.mk:740: /tmp/store_051b9299247304ed9cab0219416485d7-foo-0.0.0] Error 1 (ignored)
    00:00:00.004741 + false
    make: *** [/nix/store/4vqx7w35m4kndq0jnbb8v4s865v9g0vb-package-builder-1.0.0/libexec/flox-build.mk:742: /tmp/store_051b9299247304ed9cab0219416485d7-foo-0.0.0] Error 1
    ✘ ERROR: Build failed

After:

    % ft build
    Rendering foo build script to /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.cYCSob/f16fea2e/foo/build.bash
    Building foo-0.0.0 in local mode
    00:00:00.004716 + false
    make: *** [/Users/dcarley/projects/flox/flox/build/flox-package-builder/libexec/flox-build.mk:745: /tmp/store_051b9299247304ed9cab0219416485d7-foo-0.0.0] Error 1
    ✘ ERROR: Build failed


## Release Notes

N/A, not worth mentioning