### PR TITLE
fix: allow anonymous access to public remote environments

### DIFF
--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -85,10 +85,13 @@ impl Edit {
         // in case we error before then
         subcommand_metric!("edit");
 
-        // Ensure the user is logged in for the following remote operations
-        if let EnvironmentSelect::Remote(_) = self.environment {
+        // Refresh an expired token if present, but allow anonymous access
+        // for public environments when no token is configured.
+        if let EnvironmentSelect::Remote(_) = self.environment
+            && flox.floxhub_token.as_ref().is_some_and(|t| t.is_expired())
+        {
             ensure_floxhub_token(&mut flox).await?;
-        };
+        }
 
         let mut detected_environment =
             match self.environment.detect_concrete_environment(&flox, "Edit") {

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -129,8 +129,11 @@ impl Install {
             self.environment
         );
 
-        // Ensure the user is logged in for the following remote operations
-        if let EnvironmentSelect::Remote(_) = self.environment {
+        // Refresh an expired token if present, but allow anonymous access
+        // for public environments when no token is configured.
+        if let EnvironmentSelect::Remote(_) = self.environment
+            && flox.floxhub_token.as_ref().is_some_and(|t| t.is_expired())
+        {
             ensure_floxhub_token(&mut flox).await?;
         }
 

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -38,10 +38,13 @@ impl Uninstall {
             self.environment
         );
 
-        // Ensure the user is logged in for the following remote operations
-        if let EnvironmentSelect::Remote(_) = self.environment {
+        // Refresh an expired token if present, but allow anonymous access
+        // for public environments when no token is configured.
+        if let EnvironmentSelect::Remote(_) = self.environment
+            && flox.floxhub_token.as_ref().is_some_and(|t| t.is_expired())
+        {
             ensure_floxhub_token(&mut flox).await?;
-        };
+        }
 
         let mut concrete_environment = match self
             .environment

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -38,10 +38,13 @@ impl Upgrade {
             "upgrading groups and install ids"
         );
 
-        // Ensure the user is logged in for the following remote operations
-        if let EnvironmentSelect::Remote(_) = self.environment {
+        // Refresh an expired token if present, but allow anonymous access
+        // for public environments when no token is configured.
+        if let EnvironmentSelect::Remote(_) = self.environment
+            && flox.floxhub_token.as_ref().is_some_and(|t| t.is_expired())
+        {
             ensure_floxhub_token(&mut flox).await?;
-        };
+        }
 
         let mut concrete_environment = self
             .environment


### PR DESCRIPTION
## Summary

The `install`, `edit`, `uninstall`, and `upgrade` commands
unconditionally require FloxHub authentication for all remote
environment operations. This prevents unauthenticated users from
operating on public environments, even though the git transport layer
(via FloxEM's gitolite server) already supports anonymous access.

`pull` works fine without login — these 4 commands should too.

## Changes

Change the token gate in all 4 commands from:

```rust
// Always requires login for remote envs
if let EnvironmentSelect::Remote(_) = self.environment {
    ensure_floxhub_token(&mut flox).await?;
}
```

To:

```rust
// Only re-auth if there's an expired token; allow anonymous access
if let EnvironmentSelect::Remote(_) = self.environment
    && flox.floxhub_token.as_ref().is_some_and(|t| t.is_expired())
{
    ensure_floxhub_token(&mut flox).await?;
}
```

**Behavior matrix:**

| Token State | Before | After |
|-------------|--------|-------|
| Valid token | Uses token | Uses token (no change) |
| Expired token | Prompts re-auth | Prompts re-auth (no change) |
| No token | **Blocks with login prompt** | **Proceeds anonymously** |

When no token is present, the git credential helper sends an empty
password. FloxEM's gitolite server creates an `AnonymousUser` context
that grants read-only access to public environments. If the target
environment is private, the git operation fails naturally — same as
`pull` today.

## Files Changed

- `cli/flox/src/commands/edit.rs`
- `cli/flox/src/commands/install.rs`
- `cli/flox/src/commands/uninstall.rs`
- `cli/flox/src/commands/upgrade.rs`

## Test plan

- [ ] `flox pull owner/public-env` works without login (unchanged)
- [ ] `flox install -e owner/public-env pkg` works without login
- [ ] `flox upgrade -e owner/public-env` works without login
- [ ] `flox edit -e owner/public-env` works without login
- [ ] `flox uninstall -e owner/public-env pkg` works without login
- [ ] Commands still prompt re-auth when token is expired
- [ ] Private environments still fail for unauthenticated users
- [ ] All existing tests pass

Ref: flox/floxhub#955

---
*Via Forge (interactive) • bfc97297a*