### PR TITLE
fix(floxmeta): Treat expired token as anon

### DIFF
--- a/cli/flox-rust-sdk/src/models/floxmeta.rs
+++ b/cli/flox-rust-sdk/src/models/floxmeta.rs
@@ -219,16 +219,20 @@ pub fn floxmeta_git_options(
         format!("{floxhub_git_url}/{floxhub_owner}/floxmeta"),
     );
 
-    let token = if let Some(token) = floxhub_token {
-        if token.is_expired() {
-            debug!("FloxHub token is expired, sending for identification");
-        } else {
+    let token = match floxhub_token {
+        Some(token) if !token.is_expired() => {
             debug!("using valid FloxHub token");
-        }
-        token.secret()
-    } else {
-        debug!("no FloxHub token configured");
-        ""
+            token.secret()
+        },
+        Some(_) => {
+            // FloxEM will reject an expired token rather than treating it as anon.
+            debug!("FloxHub token is expired, falling back to unauthenticated access");
+            ""
+        },
+        None => {
+            debug!("no FloxHub token configured");
+            ""
+        },
     };
 
     // Set authentication with the FloxHub token using an inline credential helper.


### PR DESCRIPTION
## Proposed Changes

Fix the ability fetch public environments when your token has expired, whilst still not discarding the token so that we can use the original owner information for implicit trust decisions.

This was regressed in v1.8.0:

- https://github.com/flox/flox/pull/3921#discussion_r2716389931
- 2797715d8d669aceaa2225a3c2edd050d7b40a50

Observed by Michael:

- https://flox-dev.slack.com/archives/C05P6A5J6U8/p1771164247960669

This is pretty awkward to test because you can't generate an expired (or soon to be) token without duplicating a lot of setup in Auth0 or waiting a ~month for an existing token to expire.

Based on how FloxEM handles tokens:

- https://github.com/flox/floxhub/blob/78366aea6d515ad9a7e3b8b4b3fc3c82447c7c4b/src/floxem/floxEM/auth.py#L70-L75

The closest I can use to reproduce is a token with a past expiry and an invalid token, which seemingly hits the same code paths:

    export FLOX_FLOXHUB_TOKEN=$(python3 -c "
    import json, base64, time, urllib.request
    kid = json.loads(urllib.request.urlopen('https://auth.flox.dev/.well-known/jwks.json').read())['keys'][0]['kid']
    b64 = lambda d: base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b'=').decode()
    print(b64({'typ':'JWT','alg':'RS256','kid':kid}) + '.' +
    b64({'https://flox.dev/handle':'dcarley','exp':int(time.time())-3600,'iat':int(time.time())-7200,'aud':'https://hub.flox.dev/api','iss':'https://auth.flox.dev/'}) + '.fakesig')
    ")

The CLI considers it as expired because it doesn't validate sigs:

    % flox auth status
    ! Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.
    You are logged in as dcarley on https://hub.flox.dev/

Then any `floxmeta` operation that requires a `clone` or `fetch` will fail with the original error that Michael saw:

    % flox activate -r flox/echoip
    ! Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.
    ✘ ERROR: Environment not found in FloxHub.

Specifically, in this case, where I already have a clone:

    2026-02-16T14:26:56.126567Z DEBUG open{pointer=ManagedPointer { owner: EnvironmentOwner("flox"), name: EnvironmentName("echoip"), floxhub_base_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } }}: flox_rust_sdk::providers::git: running git command: env FLOX_FLOXHUB_TOKEN=eyJ0eXAiOiAiSldUIiwgImFsZyI6ICJSUzI1NiIsICJraWQiOiAiUDFOanV6OHdyN2dvZVEwbmwzT1ZJIn0.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6ICJkY2FybGV5IiwgImV4cCI6IDE3NzEyNDgwMzIsICJpYXQiOiAxNzcxMjQ0NDMyLCAiYXVkIjogImh0dHBzOi8vaHViLmZsb3guZGV2L2FwaSIsICJpc3MiOiAiaHR0cHM6Ly9hdXRoLmZsb3guZGV2LyJ9.fakesig GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null /nix/store/45l0inx8p4lfm1fbvv6k38986zx1ma2d-git-minimal-2.51.2/bin/git -c 'credential.https://api.flox.dev/git.helper='\!'f(){ echo "username=oauth"; echo "password=$FLOX_FLOXHUB_TOKEN"; }; f' -c 'remote.dynamicorigin.url=https://api.flox.dev/git/flox/floxmeta' -c 'user.email=floxuser@example.invalid' -c 'user.name=Flox User' -C /Users/dcarley/.local/share/flox/meta/flox fetch dynamicorigin 'refs/heads/echoip:refs/heads/echoip'
    2026-02-16T14:26:56.795634Z DEBUG open{pointer=ManagedPointer { owner: EnvironmentOwner("flox"), name: EnvironmentName("echoip"), floxhub_base_url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("hub.flox.dev")), port: None, path: "/", query: None, fragment: None }, floxhub_git_url_override: None, version: Version { value: 1 } }}: flox_rust_sdk::providers::git: Access denied: Git failed with: [exit code 128]
      stdout:
      stderr: fatal: Authentication failed for 'https://api.flox.dev/git/flox/floxmeta/'

Fix this by reverting back to using an empty token, only for floxmeta calls, when the token is expired:

    % flox activate -r flox/echoip
    ! Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.
    ✔ You are now using the environment 'flox/echoip (local)'
    To stop using this environment, type 'exit'

An alternative solution would be to change FloxEM to "downgrade" expired tokens to anon access rather than rejecting them but this makes feedback harder when used outside of the CLI which already does it's own expiry checks and might complicate the permissions model.

## Release Notes

Fixed a bug with the use of public FloxHub environments when your token had expired.