### PR TITLE
fix: consolidate manifest test helpers to be cross-platform

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1186,24 +1186,12 @@ pub mod test_helpers {
         systems = ["aarch64-darwin"]
         "#};
 
-    #[cfg(target_os = "macos")]
     pub fn manifest_with_incompatible_system() -> Manifest<Validated> {
         Manifest::parse_toml_typed(MANIFEST_INCOMPATIBLE_SYSTEM_STR).unwrap()
     }
 
-    #[cfg(target_os = "linux")]
-    pub fn manifest_with_incompatible_system() -> Manifest<Validated> {
-        Manifest::parse_typed(MANIFEST_INCOMPATIBLE_SYSTEM_STR).unwrap()
-    }
-
-    #[cfg(target_os = "macos")]
     pub fn manifest_with_incompatible_system_v1() -> Manifest<Validated> {
         Manifest::parse_toml_typed(MANIFEST_INCOMPATIBLE_SYSTEM_V1_STR).unwrap()
-    }
-
-    #[cfg(target_os = "linux")]
-    pub fn manifest_with_incompatible_system_v1() -> Manifest<Validated> {
-        Manifest::parse_typed(MANIFEST_INCOMPATIBLE_SYSTEM_V1_STR).unwrap()
     }
 
     pub fn new_core_environment(flox: &Flox, contents: &str) -> CoreEnvironment {


### PR DESCRIPTION
## Summary

- Remove platform-specific `#[cfg(target_os = ...)]` attributes from `manifest_with_incompatible_system` and `manifest_with_incompatible_system_v1` test helpers
- Consolidate to a single cross-platform implementation using `parse_toml_typed` on all platforms

## Test plan

- [ ] Verify tests pass on both Linux and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)