### PR TITLE
docs: Add nix develop wrapping guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,28 @@ Flox is a virtual environment and package manager built on Nix. It creates porta
 
 ## Development Setup
 
+All tools (`just`, `cargo`, `rustc`, `bats`, etc.) are provided by the Nix dev
+shell. They are not available on bare PATH.
+
 ```bash
-nix develop                    # Enter dev shell with all dependencies
+nix develop                    # Enter interactive dev shell
 ```
 
+**For agents and non-interactive use**, wrap every command with `nix develop -c`:
+
+```bash
+nix develop -c just build
+nix develop -c just test-all
+nix develop -c cargo clippy --all
+```
+
+**This is required** — running `just`, `cargo`, or other build/test commands
+without the `nix develop` wrapper will fail with "command not found".
+
 ## Common Commands
+
+All commands below assume you are inside `nix develop` or prefixed with
+`nix develop -c`.
 
 ```bash
 # Building


### PR DESCRIPTION
## Summary

AGENTS.md (symlinked from CLAUDE.md) listed commands like `just build` and `just test-all` without stating they must run inside the Nix dev shell. Human developers enter `nix develop` interactively, but AI agents run individual Bash commands and need to wrap each with `nix develop -c <command>`.

Without this guidance, an agent spawned by Forge's Implementation Worker would try to run `just test-all` directly, get "command not found", and either fail or waste time debugging.

## Changes

Added to the Development Setup section:
- Explicit note that all tools are provided by the Nix dev shell
- `nix develop -c` wrapper pattern for agents and non-interactive use
- Note that Common Commands section assumes the wrapper or an active shell
- Clear statement that running without the wrapper fails

## Related

- Forge PR flox/forge#429 — updates Implementation Worker to read project CLAUDE.md first for environment detection

---
*Via Forge (interactive) • c3f7f3b*