### PR TITLE
docs: Add nix develop wrapping guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,16 @@ nix develop -c just test-all
 nix develop -c cargo clippy --all
 ```
 
-**This is required** — running `just`, `cargo`, or other build/test commands
-without the `nix develop` wrapper will fail with "command not found".
+**This includes git operations** — `git push` and `git commit` trigger
+pre-commit/pre-push hooks that depend on tools (clippy, rustfmt, treefmt)
+provided by the dev shell:
+
+```bash
+nix develop -c git push origin my-branch
+```
+
+**This is required** — running `just`, `cargo`, `git push`, or other commands
+without the `nix develop` wrapper will fail with "command not found" errors.
 
 ## Common Commands
 


### PR DESCRIPTION
## Summary

- Clarifies in AGENTS.md that `nix develop` is required for all commands, including `git push` and `git commit`
- Pre-push hooks depend on clippy, rustfmt, and treefmt from the dev shell
- Adds explicit `nix develop -c` examples for non-interactive/agent use
- Notes that all commands in the Common Commands section assume the dev shell

## Context

Claude Code agents running in forge were trying to `git push` without the dev shell, causing pre-push hook failures. The existing AGENTS.md only showed `nix develop` for entering an interactive shell without clarifying it's needed for git operations too.

## Test plan

- [x] Guidance is clear and actionable
- [x] Consistent with existing AGENTS.md style