### PR TITLE
fix(activate): Don't leak coreutils into dev envs

### DIFF
--- a/pkgs/flox-activations/default.nix
+++ b/pkgs/flox-activations/default.nix
@@ -46,14 +46,14 @@ craneLib.buildPackage (
     CARGO_PROFILE = "small";
 
     # runtime dependencies
-    buildInputs = rust-external-deps.buildInputs ++ [ ];
+    buildInputs = rust-external-deps.buildInputs ++ [
+      coreutils # for `sleep infinity`
+    ];
 
     # build dependencies
     nativeBuildInputs = rust-external-deps.nativeBuildInputs;
 
-    propagatedBuildInputs = rust-external-deps.propagatedBuildInputs ++ [
-      coreutils # for `sleep infinity`
-    ];
+    propagatedBuildInputs = rust-external-deps.propagatedBuildInputs ++ [ ];
 
     # https://github.com/ipetkov/crane/issues/385
     # doNotLinkInheritedArtifacts = true;


### PR DESCRIPTION
## Proposed Changes

Zach noticed this during the version policy bug bash:

    % flox --version
    1.9.0-g89b3fa4
    % flox init --bare --quiet
    % flox install hello
    ✔ 'hello' installed to environment 'tmp'
    % flox activate -c 'ls -al ${FLOX_ENV}/bin' | head
    total 0
    dr-xr-xr-x 110 root wheel 3520 Jan  1  1970 .
    dr-xr-xr-x  10 root wheel  320 Jan  1  1970 ..
    lrwxr-xr-x   1 root wheel   63 Jan  1  1970 [ -> /nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin/[
    lrwxr-xr-x   1 root wheel   67 Jan  1  1970 b2sum -> /nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin/b2sum
    lrwxr-xr-x   1 root wheel   68 Jan  1  1970 base32 -> /nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin/base32
    lrwxr-xr-x   1 root wheel   68 Jan  1  1970 base64 -> /nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin/base64
    lrwxr-xr-x   1 root wheel   70 Jan  1  1970 basename -> /nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin/basename
    lrwxr-xr-x   1 root wheel   68 Jan  1  1970 basenc -> /nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin/basenc
    lrwxr-xr-x   1 root wheel   65 Jan  1  1970 cat -> /nix/store/1swaqmkr1329q50ky497sps80p16fn95-coreutils-9.8/bin/cat

Fix it by moving `coreutils` from `propagatedBuildInputs` to `buildInputs` so that it doesn't propagate to the dev environment closure but it still a runtime dependency for the `executive` which starts `process-compose` with the config that references `sleep`:

    % ft init --bare --quiet
    % ft install hello
    ✔ 'hello' installed to environment 'tmp'
    % ft activate -c 'ls -al ${FLOX_ENV}/bin' | head
    lrwxr-xr-x 1 root wheel 60 Jan  1  1970 /Users/dcarley/tmp/.flox/run/aarch64-darwin.tmp.dev/bin -> /nix/store/c12lxpykv6sld7a0sakcnr3y0la70x8w-hello-2.12.2/bin

## Release Notes

Fixed a regression from v1.9.0 where binaries from `coreutils` were incorrectly added to the path for `flox activate -m dev`.
