### PR TITLE
fix: avoid roundtrip in as_original_schema

### DIFF
--- a/cli/flox-manifest/src/parsed/latest.rs
+++ b/cli/flox-manifest/src/parsed/latest.rs
@@ -1,4 +1,4 @@
-use crate::interfaces::{AsLatestSchema, AsTypedOnlyManifest, SchemaVersion};
+use crate::interfaces::{AsLatestSchema, AsTypedOnlyManifest};
 use crate::lockfile::Lockfile;
 use crate::parsed::common::KnownSchemaVersion;
 pub use crate::parsed::v1_10_0::{
@@ -13,31 +13,36 @@ use crate::{Manifest, ManifestError, TypedOnly};
 pub type ManifestLatest = crate::parsed::v1_10_0::ManifestV1_10_0;
 
 impl ManifestLatest {
-    /// Returns a copy of this manifest in its original schema if possible.
+    /// Try to return a manifest in it's original schema
+    ///
+    /// If original_schema is the same as the current schema, this just returns
+    /// self as a typed manifest
+    /// This will rewrite the schema-version or version field and see if the
+    /// manifest still parses
+    /// If it doesn't parse, returns None
     fn as_original_schema(
         &self,
         original_schema: KnownSchemaVersion,
     ) -> Result<Option<Manifest<TypedOnly>>, ManifestError> {
-        let mut untyped = serde_json::to_value(self).map_err(ManifestError::SerializeJson)?;
-        if self.get_schema_version() != original_schema {
-            match original_schema {
-                KnownSchemaVersion::V1 => {
-                    let map = untyped
-                        .as_object_mut()
-                        .expect("all valid manifests should serialize to JSON objects");
-                    map.remove("schema-version");
-                    map.insert("version".into(), 1.into());
-                },
-                KnownSchemaVersion::V1_10_0 => {},
-            }
-        }
+        let untyped = match original_schema {
+            KnownSchemaVersion::V1 => {
+                let mut untyped =
+                    serde_json::to_value(self).map_err(ManifestError::SerializeJson)?;
+                let map = untyped
+                    .as_object_mut()
+                    .expect("all valid manifests should serialize to JSON objects");
+                map.remove("schema-version");
+                map.insert("version".into(), 1.into());
+                untyped
+            },
+            KnownSchemaVersion::V1_10_0 => {
+                return Ok(Some(self.as_typed_only()));
+            },
+        };
 
         let maybe_typed = serde_json::from_value::<Manifest<TypedOnly>>(untyped);
-        if maybe_typed.is_err() {
-            return Ok(None);
-        }
         let Ok(typed_original_schema) = maybe_typed else {
-            unreachable!("already checked that deserialization succeeded");
+            return Ok(None);
         };
         Ok(Some(typed_original_schema))
     }
@@ -50,14 +55,12 @@ impl ManifestLatest {
         lockfile: Option<&Lockfile>,
     ) -> Result<Manifest<TypedOnly>, ManifestError> {
         let maybe_backwards_compatible = self.as_original_schema(original_schema)?;
-        if maybe_backwards_compatible.is_none() {
+        let Some(backwards_compatible) = maybe_backwards_compatible else {
             // If this was `None` it means we couldn't represent the current
             // manifest in the old schema at all (there could be new fields,
             // syntax, etc). In that case, we *must* migrate.
             return Ok(self.as_typed_only());
-        }
-        let backwards_compatible =
-            maybe_backwards_compatible.expect("just verified that option is some");
+        };
         let migrated_again = backwards_compatible.migrate_typed_only(lockfile)?;
         let migrated_again = migrated_again.as_latest_schema();
         if migrated_again == self {


### PR DESCRIPTION
Make a few code quality improvements to as_original_schema and as_maybe_backwards_compatible
This also avoids a serialize/deserialize round trip for latest manifests

## Release Notes

NA