### PR TITLE
fix: composer manifest not updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "enum_dispatch",
+ "expect-test",
  "flox-core",
  "flox-manifest",
  "flox-test-utils",

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -56,6 +56,7 @@ base64 = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow.workspace = true
+expect-test.workspace = true
 httpmock.workspace = true
 pretty_assertions.workspace = true
 proptest.workspace = true

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -163,6 +163,27 @@ impl<State> CoreEnvironment<State> {
         }
     }
 
+    fn ensure_manifest_schemas_match(
+        &mut self,
+        original_schema: KnownSchemaVersion,
+        lockfile: &mut Lockfile,
+    ) -> Result<(), EnvironmentError> {
+        let schema_after_merging_and_locking = lockfile.manifest.get_schema_version();
+        let on_disk_manifest_needs_migration = schema_after_merging_and_locking != original_schema;
+
+        if on_disk_manifest_needs_migration {
+            let migrated_manifest = self.pre_migration_manifest()?.migrate(Some(lockfile))?;
+            migrated_manifest
+                .as_writable()
+                .write_to_file(self.manifest_path())?;
+            if let Some(compose) = lockfile.compose.as_mut() {
+                compose.composer = migrated_manifest.as_typed_only().clone();
+            }
+        }
+
+        Ok(())
+    }
+
     /// Lock the environment.
     ///
     /// Use a catalog client to lock the environment,
@@ -176,12 +197,18 @@ impl<State> CoreEnvironment<State> {
     /// and because it doesn't modify the manifest.
     pub fn lock(&mut self, flox: &Flox) -> Result<LockResult, EnvironmentError> {
         let pre_migration_manifest = self.pre_migration_manifest()?.as_typed_only();
+        let original_schema = pre_migration_manifest.get_schema_version();
+
         let existing_lockfile = self.existing_lockfile()?;
         let migrated_manifest_for_locking =
             pre_migration_manifest.migrate_typed_only(existing_lockfile.as_ref())?;
 
         // If a lockfile exists, it is used as a base.
-        let lockfile = LockManifest::lock_manifest(
+        //
+        // This is `mut` because we may need to update the on-disk manifest to match the
+        // schema of the merged manifest, and then we'll also have to update the
+        // `compose.composer` to match.
+        let mut lockfile = LockManifest::lock_manifest(
             flox,
             &migrated_manifest_for_locking,
             existing_lockfile.as_ref(),
@@ -189,25 +216,9 @@ impl<State> CoreEnvironment<State> {
         )
         .block_on()?;
 
-        // Now that we have an up to date lockfile, we can migrate the manifest
-        // if necessary.
-        //
-        // The lockfile always contains the manifest in the latest schema, but
-        // the on-disk manifest may be in an older schema. We only need to
-        // rewrite the manifest if it's not backwards compatible with the
-        // original schema.
-        let original_schema = pre_migration_manifest.get_schema_version();
-        let lockfile_schema_version = lockfile.manifest.get_schema_version();
-        let lockfile_has_latest_schema_version =
-            lockfile_schema_version == KnownSchemaVersion::latest();
-        if lockfile_has_latest_schema_version && (lockfile_schema_version != original_schema) {
-            let migrated_manifest = self.pre_migration_manifest()?.migrate(Some(&lockfile))?;
-            if !migrated_manifest.is_backwards_compatible()? {
-                migrated_manifest
-                    .as_writable()
-                    .write_to_file(self.manifest_path())?;
-            }
-        }
+        // Now that we have an up to date lockfile, we check the schema version of its manifest
+        // and ensure that the manifest on disk and the manifest in the lockfile are all in sync.
+        self.ensure_manifest_schemas_match(original_schema, &mut lockfile)?;
 
         let mut lockfile_contents =
             serde_json::to_string_pretty(&lockfile).expect("lockfile structure is valid json");
@@ -672,7 +683,13 @@ impl CoreEnvironment<ReadOnly> {
             .map(Lockfile::from_str)
             .transpose()?;
 
-        let new_lockfile = LockManifest::lock_manifest_with_include_upgrades(
+        let pre_migration_manifest = self.pre_migration_manifest()?;
+        let original_schema = pre_migration_manifest.get_schema_version();
+
+        // This is `mut` because we may need to update the on-disk manifest to match the
+        // schema of the merged manifest, and then we'll also have to update the
+        // `compose.composer` to match.
+        let mut new_lockfile = LockManifest::lock_manifest_with_include_upgrades(
             flox,
             &manifest.as_migrated_typed_only(),
             existing_lockfile.as_ref(),
@@ -680,6 +697,11 @@ impl CoreEnvironment<ReadOnly> {
             Some(to_upgrade),
         )
         .block_on()?;
+
+        // If the merged manifest required a newer schema than the composer's
+        // on-disk manifest (due to composition introducing features like
+        // explicit outputs), migrate the composer's manifest to match.
+        self.ensure_manifest_schemas_match(original_schema, &mut new_lockfile)?;
 
         let mut result = UpgradeResult {
             old_lockfile: existing_lockfile,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1327,3 +1327,228 @@ mod test {
         ));
     }
 }
+
+#[cfg(test)]
+mod migration_composition_tests {
+    use expect_test::expect;
+    use flox_manifest::interfaces::{AsWritableManifest, SchemaVersion, WriteManifest};
+    use flox_manifest::parsed::common::KnownSchemaVersion;
+    use flox_manifest::test_helpers::{with_latest_schema, with_schema};
+    use flox_test_utils::GENERATED_DATA;
+    use indoc::indoc;
+
+    use super::*;
+    use crate::flox::test_helpers::flox_instance;
+    use crate::models::environment::path_environment::test_helpers::new_path_environment_in;
+    use crate::providers::catalog::test_helpers::catalog_replay_client;
+
+    /// Set up an included PathEnvironment with the given manifest contents,
+    /// lock it, and return the path to its parent directory.
+    fn setup_locked_included_env(flox: &Flox, parent_dir: &Path, manifest_contents: &str) {
+        let included_path = parent_dir.join("included");
+        let mut env = new_path_environment_in(flox, manifest_contents, &included_path);
+        env.lockfile(flox).unwrap();
+    }
+
+    /// Create a v1 composer PathEnvironment that includes the "included" env.
+    fn setup_v1_composer_with_include(flox: &Flox, parent_dir: &Path) -> PathEnvironment {
+        let manifest_contents = with_schema(KnownSchemaVersion::V1, indoc! {r#"
+            [include]
+            environments = [
+              { dir = "../included" },
+            ]
+        "#});
+
+        let composer_path = parent_dir.join("composer");
+        new_path_environment_in(flox, &manifest_contents, &composer_path)
+    }
+
+    /// A v1.10.0 manifest created by init should not be downgraded to v1.
+    #[test]
+    fn latest_schema_is_not_downgraded() {
+        let (flox, tempdir) = flox_instance();
+        let manifest = with_latest_schema("");
+        let mut env = new_path_environment_in(&flox, &manifest, tempdir.path());
+        env.lockfile(&flox).unwrap(); // ensure it's locked
+
+        let manifest_contents = env
+            .pre_migration_manifest(&flox)
+            .unwrap()
+            .as_writable()
+            .to_string();
+
+        expect![[r#"
+            schema-version = "1.10.0"
+        "#]]
+        .assert_eq(&manifest_contents);
+    }
+
+    /// A v1 composer including a v1.10.0 environment with only vars (no
+    /// packages) should not be migrated because the merged manifest is
+    /// backwards compatible with v1.
+    #[test]
+    fn v1_including_latest_with_only_vars_is_not_migrated() {
+        let (flox, tempdir) = flox_instance();
+
+        let included_manifest = with_latest_schema(indoc! {r#"
+            [vars]
+            included_var = "value"
+        "#});
+        setup_locked_included_env(&flox, tempdir.path(), &included_manifest);
+
+        let mut composer = setup_v1_composer_with_include(&flox, tempdir.path());
+        composer.lockfile(&flox).unwrap();
+
+        let composer_manifest_contents = composer
+            .pre_migration_manifest(&flox)
+            .unwrap()
+            .as_writable()
+            .to_string();
+
+        expect![[r#"
+            version = 1
+
+            [include]
+            environments = [
+              { dir = "../included" },
+            ]
+
+        "#]]
+        .assert_eq(&composer_manifest_contents);
+    }
+
+    /// A v1 composer including a v1.10.0 environment with hello (whose
+    /// outputs match outputs_to_install) should not be migrated because
+    /// hello doesn't require explicit outputs.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn v1_including_latest_with_hello_is_not_migrated() {
+        let (mut flox, tempdir) = flox_instance();
+
+        let included_manifest = with_latest_schema(indoc! {r#"
+            [install]
+            hello.pkg-path = "hello"
+        "#});
+
+        flox.catalog_client =
+            catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
+
+        setup_locked_included_env(&flox, tempdir.path(), &included_manifest);
+
+        let mut composer = setup_v1_composer_with_include(&flox, tempdir.path());
+        composer.lockfile(&flox).unwrap();
+
+        let composer_manifest_contents = composer
+            .pre_migration_manifest(&flox)
+            .unwrap()
+            .as_writable()
+            .to_string();
+
+        expect![[r#"
+            version = 1
+
+            [include]
+            environments = [
+              { dir = "../included" },
+            ]
+
+        "#]]
+        .assert_eq(&composer_manifest_contents);
+    }
+
+    /// A v1 composer including a v1.10.0 environment with `outputs = "all"`
+    /// on bash should be migrated. The explicit outputs field can't be
+    /// represented in v1 (v1 PackageDescriptorCatalog has no outputs field
+    /// and uses deny_unknown_fields), so the merged manifest requires
+    /// v1.10.0 and the composer's on-disk manifest should be rewritten.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn v1_including_latest_with_outputs_all_is_migrated() {
+        let (mut flox, tempdir) = flox_instance();
+        flox.catalog_client = catalog_replay_client(GENERATED_DATA.join("envs/bash.yaml")).await;
+
+        let included_manifest = with_latest_schema(indoc! {r#"
+            [install]
+            bash.pkg-path = "bashNonInteractive"
+            bash.outputs = "all"
+        "#});
+        setup_locked_included_env(&flox, tempdir.path(), &included_manifest);
+
+        let mut composer = setup_v1_composer_with_include(&flox, tempdir.path());
+        composer.lockfile(&flox).unwrap();
+
+        // The composer's manifest should be migrated to v1.10.0
+        let manifest = composer.pre_migration_manifest(&flox).unwrap();
+        assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::latest());
+    }
+
+    /// A v1 composer including a v1.10.0 environment with
+    /// `outputs = ["out"]` on bash should be migrated. Even though "out"
+    /// is a common output, the explicit outputs field means the merged
+    /// manifest can't be deserialized as v1.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn v1_including_latest_with_specific_outputs_is_migrated() {
+        let (mut flox, tempdir) = flox_instance();
+
+        let included_manifest = with_latest_schema(indoc! {r#"
+            [install]
+            bash.pkg-path = "bashNonInteractive"
+            bash.outputs = ["out"]
+        "#});
+
+        flox.catalog_client = catalog_replay_client(GENERATED_DATA.join("envs/bash.yaml")).await;
+
+        setup_locked_included_env(&flox, tempdir.path(), &included_manifest);
+
+        let mut composer = setup_v1_composer_with_include(&flox, tempdir.path());
+        composer.lockfile(&flox).unwrap();
+
+        let manifest = composer.pre_migration_manifest(&flox).unwrap();
+        assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::latest());
+    }
+
+    /// A v1 composer that initially includes a backwards-compatible v1.10.0
+    /// environment (only vars) should be migrated when the included
+    /// environment is updated to contain a package with explicit outputs
+    /// and `include_upgrade` is called.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn include_upgrade_triggers_migration_when_included_adds_outputs() {
+        let (mut flox, tempdir) = flox_instance();
+
+        // Start with an included env that only has vars (backwards compatible).
+        let included_manifest = with_latest_schema(indoc! {r#"
+            [vars]
+            included_var = "value"
+        "#});
+        let included_path = tempdir.path().join("included");
+        let mut included_env = new_path_environment_in(&flox, &included_manifest, &included_path);
+        included_env.lockfile(&flox).unwrap();
+
+        // Lock the composer; it should stay v1 since the include is
+        // backwards compatible.
+        let mut composer = setup_v1_composer_with_include(&flox, tempdir.path());
+        composer.lockfile(&flox).unwrap();
+
+        let manifest = composer.pre_migration_manifest(&flox).unwrap();
+        assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::V1);
+
+        // Now update the included env to add a package with explicit outputs.
+        let updated_included_manifest = with_latest_schema(indoc! {r#"
+            [vars]
+            included_var = "value"
+
+            [install]
+            bash.pkg-path = "bashNonInteractive"
+            bash.outputs = "all"
+        "#});
+
+        flox.catalog_client = catalog_replay_client(GENERATED_DATA.join("envs/bash.yaml")).await;
+
+        included_env.edit(&flox, updated_included_manifest).unwrap();
+
+        // Upgrade all includes on the composer.
+        composer.include_upgrade(&flox, vec![]).unwrap();
+
+        // The composer's manifest should now be migrated to v1.10.0.
+        let manifest = composer.pre_migration_manifest(&flox).unwrap();
+        assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::latest());
+    }
+}

--- a/cli/flox-rust-sdk/src/providers/lock_manifest.rs
+++ b/cli/flox-rust-sdk/src/providers/lock_manifest.rs
@@ -383,8 +383,9 @@ impl LockManifest {
             // Record the original schema of the user's manifest.
             compose.composer = manifest.as_typed_only();
         }
-        // FIXME: if we write out the merged manifest in the migrated schema, we also need
-        //        to write out the user's manifest in that schema to match
+        // The caller (CoreEnvironment::lock / include_upgrade) is responsible
+        // for rewriting the user's on-disk manifest when the merged manifest
+        // ends up at a newer schema than the original.
 
         let lockfile = Lockfile {
             version: Version::<1>,


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
When a manifest with an older schema includes a manifest with a newer schema in a way that's not backwards compatible, we store the newer schema in the lockfile. In some cases, the on-disk composing manifest wouldn't get updated to reflect the schema change. This change fixes that bug and adds some tests to protect against regressions.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
