### PR TITLE
feat(upgrade): Improve output by grouping into version upgrades and source updates

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -671,9 +671,17 @@ fn notify_package_upgrades(
         debug!("Not notifying user of upgrade, no changes in lockfile");
         return Ok(());
     }
+    let diff_for_system = upgrade_result.diff_for_system(&flox.system);
+    if diff_for_system.is_empty() {
+        debug!("Not notifying user of upgrade, no changes for this system");
+        return Ok(());
+    }
     let description = environment_description(environment)?;
+    let (version_upgrades, source_updates) =
+        super::upgrade::count_upgrade_categories(&diff_for_system);
+    let summary = super::upgrade::format_upgrade_summary(version_upgrades, source_updates);
     let message = formatdoc! {"
-        Upgrades are available for packages in {description}.
+        {summary} available in {description}.
         Use 'flox upgrade --dry-run' for details.
     "};
     message::info(message);
@@ -1032,7 +1040,7 @@ mod upgrade_notification_tests {
         let printed = writer.to_string();
 
         assert_eq!(printed, formatdoc! {"
-            ℹ Upgrades are available for packages in 'name'.
+            ℹ 1 source update available in 'name'.
             Use 'flox upgrade --dry-run' for details.
 
         "});

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -213,11 +213,18 @@ impl List {
                 PackageToList::Flake(_, p) => &p.install_id,
                 PackageToList::StorePath(p) => &p.install_id,
             };
-            let upgrade_available = if upgrades
-                .as_ref()
-                .is_some_and(|diff| diff.contains_key(install_id))
-            {
-                " - upgrade available"
+            let upgrade_label = if let Some(diff) = upgrades.as_ref() {
+                if let Some((before, after)) = diff.get(install_id) {
+                    let old_ver = before.version().unwrap_or("unknown");
+                    let new_ver = after.version().unwrap_or("unknown");
+                    if old_ver != new_ver {
+                        " - version upgrade available"
+                    } else {
+                        " - source update available"
+                    }
+                } else {
+                    ""
+                }
             } else {
                 ""
             };
@@ -226,7 +233,7 @@ impl List {
                 PackageToList::Catalog(descriptor, p) => {
                     writeln!(
                         &mut out,
-                        "{id}: {path} ({version}{upgrade_available})",
+                        "{id}: {path} ({version}{upgrade_label})",
                         id = p.install_id,
                         path = descriptor.pkg_path,
                         version = p.version,
@@ -235,7 +242,7 @@ impl List {
                 PackageToList::Flake(descriptor, locked_package) => {
                     writeln!(
                         &mut out,
-                        "{id}: {flake}{upgrade_available}",
+                        "{id}: {flake}{upgrade_label}",
                         id = locked_package.install_id,
                         flake = descriptor.flake
                     )?;
@@ -275,11 +282,18 @@ impl List {
                 PackageToList::Flake(_, p) => &p.install_id,
                 PackageToList::StorePath(p) => &p.install_id,
             };
-            let upgrade_available = if upgrades
-                .as_ref()
-                .is_some_and(|diff| diff.contains_key(install_id))
-            {
-                " (upgrade available)"
+            let upgrade_label = if let Some(diff) = upgrades.as_ref() {
+                if let Some((before, after)) = diff.get(install_id) {
+                    let old_ver = before.version().unwrap_or("unknown");
+                    let new_ver = after.version().unwrap_or("unknown");
+                    if old_ver != new_ver {
+                        " (version upgrade available)"
+                    } else {
+                        " (source update available)"
+                    }
+                } else {
+                    ""
+                }
             } else {
                 ""
             };
@@ -289,7 +303,7 @@ impl List {
                     let outputs_lines = format_outputs_lines(package, show_outputs);
 
                     formatdoc! {"
-                        {name}:{upgrade_available}
+                        {name}:{upgrade_label}
                           Description:          {description}
                           Package Path:         {attr_path}
                           Package Name:         {pname}
@@ -339,7 +353,7 @@ impl List {
                     let outputs_lines = format_outputs_lines(package, show_outputs);
 
                     formatdoc! {"
-                    {install_id}:{upgrade_available}
+                    {install_id}:{upgrade_label}
                       Description:          {description}
                       Locked URL:           {locked_url}
                       Flake attribute:      {locked_flake_attr_path}
@@ -573,7 +587,7 @@ mod tests {
             pip_install_id: python3Packages.pip (N/A)
         "});
     }
-    /// If packages have upgrades available, the output should indicate that
+    /// If packages have version upgrades available, the output should indicate "version upgrade"
     #[test]
     fn test_print_extended_includes_upgrade_indicator() {
         let mut out = Vec::new();
@@ -596,7 +610,36 @@ mod tests {
         List::print_extended(&mut out, &packages, Some(upgrades)).unwrap();
         let out = String::from_utf8(out).unwrap();
         assert_eq!(out, indoc! {"
-            pip_install_id: python3Packages.pip (20.3.4 - upgrade available)
+            pip_install_id: python3Packages.pip (20.3.4 - version upgrade available)
+            python_install_id: python3Packages.python (3.9.5)
+        "});
+    }
+
+    /// If packages have source updates (same version), the output should indicate "source update"
+    #[test]
+    fn test_print_extended_includes_source_update_indicator() {
+        let mut out = Vec::new();
+
+        let mut packages = test_packages();
+        let PackageToList::Catalog(_, ref mut pip_lock) = packages[0] else {
+            unreachable!()
+        };
+        // Same version but source changed (e.g., different rev_count)
+        let mut pip_lock_source_updated = pip_lock.clone();
+        pip_lock_source_updated.rev_count = 999;
+
+        let upgrades = SingleSystemUpgradeDiff::from_iter(vec![(
+            "pip_install_id".to_string(),
+            (
+                LockedPackage::Catalog(pip_lock.clone()),
+                LockedPackage::Catalog(pip_lock_source_updated),
+            ),
+        )]);
+
+        List::print_extended(&mut out, &packages, Some(upgrades)).unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert_eq!(out, indoc! {"
+            pip_install_id: python3Packages.pip (20.3.4 - source update available)
             python_install_id: python3Packages.python (3.9.5)
         "});
     }
@@ -807,7 +850,7 @@ mod tests {
         "})
     }
 
-    /// If packages have upgrades available, the output should indicate that
+    /// If packages have version upgrades available, the output should indicate "version upgrade"
     #[test]
     fn test_print_detail_includes_upgrade_indicator() {
         let mut out = Vec::new();
@@ -830,7 +873,57 @@ mod tests {
         List::print_detail(&mut out, &packages, Some(upgrades), true).unwrap();
         let out = String::from_utf8(out).unwrap();
         assert_eq!(out, indoc! {"
-            pip_install_id: (upgrade available)
+            pip_install_id: (version upgrade available)
+              Description:          Python package installer
+              Package Path:         python3Packages.pip
+              Package Name:         pip
+              Priority:             100
+              Version:              20.3.4
+              License:              MIT
+              Unfree:               true
+              Broken:               false
+              Available Outputs:    [ ]
+              Installed Outputs:    [ ]
+
+            python_install_id:
+              Description:          Python interpreter
+              Package Path:         python3Packages.python
+              Package Name:         python
+              Priority:             200
+              Version:              3.9.5
+              License:              PSF
+              Unfree:               false
+              Broken:               false
+              Available Outputs:    [ ]
+              Installed Outputs:    [ ]
+        "});
+    }
+
+    /// If packages have source updates (same version), the output should indicate "source update"
+    #[test]
+    fn test_print_detail_includes_source_update_indicator() {
+        let mut out = Vec::new();
+
+        let mut packages = test_packages();
+        let PackageToList::Catalog(_, ref mut pip_lock) = packages[0] else {
+            unreachable!()
+        };
+        // Same version but source changed
+        let mut pip_lock_source_updated = pip_lock.clone();
+        pip_lock_source_updated.rev_count = 999;
+
+        let upgrades = SingleSystemUpgradeDiff::from_iter(vec![(
+            "pip_install_id".to_string(),
+            (
+                LockedPackage::Catalog(pip_lock.clone()),
+                LockedPackage::Catalog(pip_lock_source_updated),
+            ),
+        )]);
+
+        List::print_detail(&mut out, &packages, Some(upgrades), true).unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert_eq!(out, indoc! {"
+            pip_install_id: (source update available)
               Description:          Python package installer
               Package Path:         python3Packages.pip
               Package Name:         pip

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
 use bpaf::Bpaf;
+use chrono::Datelike;
 use crossterm::style::Stylize;
+use flox_manifest::lockfile::LockedPackage;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{Environment, SingleSystemUpgradeDiff};
 use indoc::formatdoc;
-use itertools::Itertools;
 use tracing::{info_span, instrument};
 
 use super::services::warn_manifest_changes_for_services;
@@ -99,7 +100,6 @@ impl Upgrade {
         let diff_for_system = result.diff_for_system(&flox.system);
 
         let rendered_diff = render_diff(&diff_for_system);
-        let num_changes_for_system = diff_for_system.len();
 
         if self.dry_run {
             if diff_for_system.is_empty() {
@@ -114,8 +114,10 @@ impl Upgrade {
                 }
                 return Ok(());
             }
+            let (ver_ups, src_ups) = count_upgrade_categories(&diff_for_system);
+            let summary = format_upgrade_summary(ver_ups, src_ups);
             message::plain(formatdoc! {"
-                Dry run: Upgrades available for {num_changes_for_system} package(s) in {description}:
+                Dry run: {summary} available for {description}:
                 {rendered_diff}
 
                 To apply these changes, run upgrade without the '--dry-run' flag.
@@ -135,8 +137,10 @@ impl Upgrade {
             Upgrades were not available for this system, but upgrades were applied for other
             systems supported by this environment."});
         } else {
+            let (ver_ups, src_ups) = count_upgrade_categories(&diff_for_system);
+            let summary = format_upgrade_summary(ver_ups, src_ups);
             message::plain(formatdoc! {"
-            {icon} Upgraded {num_changes_for_system} package(s) in {description}:
+            {icon} {summary} applied in {description}:
             {rendered_diff}
             "});
         }
@@ -147,25 +151,133 @@ impl Upgrade {
     }
 }
 
-/// Render a diff of locked packages before and after an upgrade
-fn render_diff(diff: &SingleSystemUpgradeDiff) -> String {
-    diff.iter()
-        .map(|(_, (before, after))| {
-            let install_id = before.install_id();
-            let old_version = before.version().unwrap_or("unknown");
-            let new_version = after.version().unwrap_or("unknown");
+/// Format a rev_date as "Mon DD" for current year, "Mon DD, YYYY" otherwise.
+fn format_rev_date(date: &chrono::DateTime<chrono::offset::Utc>) -> String {
+    let now = chrono::Utc::now();
+    if date.year() == now.year() {
+        date.format("%b %d").to_string()
+    } else {
+        date.format("%b %d, %Y").to_string()
+    }
+}
 
-            if new_version == old_version {
-                format!("- {install_id}: {old_version}")
-            } else {
-                format!("- {install_id}: {old_version} -> {new_version}")
+/// Format source update detail showing rev_count and date changes.
+/// Returns None for non-catalog packages.
+fn source_update_detail(before: &LockedPackage, after: &LockedPackage) -> Option<String> {
+    let old = before.as_catalog_package_ref()?;
+    let new = after.as_catalog_package_ref()?;
+
+    // Try rev_count + date first
+    if old.rev_count != 0 || new.rev_count != 0 {
+        let old_date = format_rev_date(&old.rev_date);
+        let new_date = format_rev_date(&new.rev_date);
+        return Some(format!(
+            "source: {} {} -> {} {}",
+            old.rev_count, old_date, new.rev_count, new_date
+        ));
+    }
+
+    // Fallback to 7-char rev SHA
+    let old_rev = &old.rev[..7.min(old.rev.len())];
+    let new_rev = &new.rev[..7.min(new.rev.len())];
+    if old_rev != new_rev {
+        return Some(format!("source: {} -> {}", old_rev, new_rev));
+    }
+
+    None
+}
+
+/// Count version upgrades vs source updates in a diff.
+pub(crate) fn count_upgrade_categories(diff: &SingleSystemUpgradeDiff) -> (usize, usize) {
+    let mut version_upgrades = 0;
+    let mut source_updates = 0;
+    for (_, (before, after)) in diff.iter() {
+        let old_version = before.version().unwrap_or("unknown");
+        let new_version = after.version().unwrap_or("unknown");
+        if new_version != old_version {
+            version_upgrades += 1;
+        } else {
+            source_updates += 1;
+        }
+    }
+    (version_upgrades, source_updates)
+}
+
+/// Determine whether a package upgrade involves a version change.
+fn is_version_upgrade(before: &LockedPackage, after: &LockedPackage) -> bool {
+    before.version().unwrap_or("unknown") != after.version().unwrap_or("unknown")
+}
+
+/// Format a human-readable summary of upgrade counts.
+pub(crate) fn format_upgrade_summary(version_upgrades: usize, source_updates: usize) -> String {
+    let version_part = match version_upgrades {
+        0 => None,
+        1 => Some("1 version upgrade".to_string()),
+        n => Some(format!("{n} version upgrades")),
+    };
+    let source_part = match source_updates {
+        0 => None,
+        1 => Some("1 source update".to_string()),
+        n => Some(format!("{n} source updates")),
+    };
+    match (version_part, source_part) {
+        (Some(v), Some(s)) => format!("{v} and {s}"),
+        (Some(v), None) => v,
+        (None, Some(s)) => s,
+        (None, None) => "Upgrades".to_string(),
+    }
+}
+
+/// Render a diff of locked packages before and after an upgrade, grouped by category.
+fn render_diff(diff: &SingleSystemUpgradeDiff) -> String {
+    let (version_upgrades, source_updates) = count_upgrade_categories(diff);
+    let mut lines = Vec::new();
+
+    // Version upgrades first
+    if version_upgrades > 0 {
+        let label = if version_upgrades == 1 {
+            "1 version upgrade:".to_string()
+        } else {
+            format!("{version_upgrades} version upgrades:")
+        };
+        lines.push(format!("  {label}"));
+        for (_, (before, after)) in diff.iter() {
+            if is_version_upgrade(before, after) {
+                let id = before.install_id();
+                let old_ver = before.version().unwrap_or("unknown");
+                let new_ver = after.version().unwrap_or("unknown");
+                lines.push(format!("  - {id}: {old_ver} -> {new_ver}"));
             }
-        })
-        .join("\n")
+        }
+    }
+
+    // Source updates
+    if source_updates > 0 {
+        let label = if source_updates == 1 {
+            "1 source update:".to_string()
+        } else {
+            format!("{source_updates} source updates:")
+        };
+        lines.push(format!("  {label}"));
+        for (_, (before, after)) in diff.iter() {
+            if !is_version_upgrade(before, after) {
+                let id = before.install_id();
+                let ver = after.version().unwrap_or("unknown");
+                match source_update_detail(before, after) {
+                    Some(detail) => lines.push(format!("  - {id}: {ver} ({detail})")),
+                    None => lines.push(format!("  - {id}: {ver} (source updated)")),
+                }
+            }
+        }
+    }
+
+    lines.join("\n")
 }
 
 #[cfg(test)]
 mod tests {
+    use flox_manifest::lockfile::LockedPackage;
+    use flox_manifest::lockfile::test_helpers::fake_catalog_package_lock;
     use flox_manifest::raw::PackageToInstall;
     use flox_rust_sdk::flox::test_helpers::flox_instance;
     use flox_rust_sdk::models::environment::Environment;
@@ -268,6 +380,147 @@ mod tests {
             Upgrades are not available for 'name' on this system, but upgrades are
             available for other systems supported by this environment.
             "}
+        );
+    }
+
+    /// Test format_upgrade_summary with various combinations
+    #[test]
+    fn test_format_upgrade_summary_version_only() {
+        assert_eq!(format_upgrade_summary(1, 0), "1 version upgrade");
+        assert_eq!(format_upgrade_summary(3, 0), "3 version upgrades");
+    }
+
+    #[test]
+    fn test_format_upgrade_summary_source_only() {
+        assert_eq!(format_upgrade_summary(0, 1), "1 source update");
+        assert_eq!(format_upgrade_summary(0, 2), "2 source updates");
+    }
+
+    #[test]
+    fn test_format_upgrade_summary_mixed() {
+        assert_eq!(
+            format_upgrade_summary(1, 1),
+            "1 version upgrade and 1 source update"
+        );
+        assert_eq!(
+            format_upgrade_summary(2, 3),
+            "2 version upgrades and 3 source updates"
+        );
+    }
+
+    #[test]
+    fn test_format_upgrade_summary_none() {
+        assert_eq!(format_upgrade_summary(0, 0), "Upgrades");
+    }
+
+    /// Test render_diff with version upgrades
+    #[test]
+    fn test_render_diff_version_upgrades() {
+        let (_iid, _desc, mut before) = fake_catalog_package_lock("curl", None);
+        before.version = "7.0.0".to_string();
+        let mut after = before.clone();
+        after.version = "8.0.0".to_string();
+
+        let diff = SingleSystemUpgradeDiff::from_iter(vec![(
+            "curl_install_id".to_string(),
+            (
+                LockedPackage::Catalog(before),
+                LockedPackage::Catalog(after),
+            ),
+        )]);
+
+        let rendered = render_diff(&diff);
+        assert!(rendered.contains("1 version upgrade:"), "Missing header");
+        assert!(
+            rendered.contains("- curl_install_id: 7.0.0 -> 8.0.0"),
+            "Missing entry"
+        );
+        assert!(
+            !rendered.contains("source update"),
+            "Should not show source update section"
+        );
+    }
+
+    /// Test render_diff with source updates (same version, different rev_count)
+    #[test]
+    fn test_render_diff_source_updates() {
+        let (_iid, _desc, mut before) = fake_catalog_package_lock("awscli2", None);
+        before.version = "2.33.2".to_string();
+        before.rev_count = 100;
+        before.rev_date = chrono::DateTime::parse_from_rfc3339("2020-01-15T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::offset::Utc);
+        let mut after = before.clone();
+        after.rev_count = 200;
+        after.rev_date = chrono::DateTime::parse_from_rfc3339("2020-02-20T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::offset::Utc);
+
+        let diff = SingleSystemUpgradeDiff::from_iter(vec![(
+            "awscli2_install_id".to_string(),
+            (
+                LockedPackage::Catalog(before),
+                LockedPackage::Catalog(after),
+            ),
+        )]);
+
+        let rendered = render_diff(&diff);
+        assert!(rendered.contains("1 source update:"), "Missing header");
+        assert!(rendered.contains("awscli2_install_id"), "Missing package");
+        assert!(rendered.contains("2.33.2"), "Missing version");
+        assert!(rendered.contains("source:"), "Missing source detail");
+        assert!(
+            !rendered.contains("version upgrade"),
+            "Should not show version upgrade section"
+        );
+    }
+
+    /// Test render_diff with mixed version upgrades and source updates
+    #[test]
+    fn test_render_diff_mixed() {
+        let (_c_iid, _c_desc, mut curl_before) = fake_catalog_package_lock("curl", None);
+        curl_before.version = "7.0.0".to_string();
+        let mut curl_after = curl_before.clone();
+        curl_after.version = "8.0.0".to_string();
+
+        let (_a_iid, _a_desc, mut aws_before) = fake_catalog_package_lock("awscli2", None);
+        aws_before.version = "2.33.2".to_string();
+        aws_before.rev_count = 100;
+        let mut aws_after = aws_before.clone();
+        aws_after.rev_count = 200;
+
+        let diff = SingleSystemUpgradeDiff::from_iter(vec![
+            (
+                "awscli2_install_id".to_string(),
+                (
+                    LockedPackage::Catalog(aws_before),
+                    LockedPackage::Catalog(aws_after),
+                ),
+            ),
+            (
+                "curl_install_id".to_string(),
+                (
+                    LockedPackage::Catalog(curl_before),
+                    LockedPackage::Catalog(curl_after),
+                ),
+            ),
+        ]);
+
+        let rendered = render_diff(&diff);
+        assert!(
+            rendered.contains("1 version upgrade:"),
+            "Missing version header"
+        );
+        assert!(
+            rendered.contains("1 source update:"),
+            "Missing source header"
+        );
+        // Version upgrades section should come before source updates
+        let ver_pos = rendered.find("version upgrade").unwrap();
+        let src_pos = rendered.find("source update").unwrap();
+        assert!(
+            ver_pos < src_pos,
+            "Version upgrades should come before source updates"
         );
     }
 }


### PR DESCRIPTION
## Summary

Improves `flox upgrade` CLI output to disambiguate between version upgrades and source-only updates. When the catalog updates a package's derivation path but the version number stays the same, users previously saw confusing output like `- awscli2: 2.33.2` with no explanation. This PR makes the distinction explicit.

<details>
<summary>Changes</summary>

- **upgrade.rs**: Add helper functions `format_upgrade_summary`, `count_upgrade_categories`, `is_version_upgrade`, `source_update_detail`, and `format_rev_date`. Rewrite `render_diff` to group output into "N version upgrades" and "N source updates" sections with contextual detail (rev_count + date for source updates). Update dry-run and success messages to use the category-aware summary.

- **activate.rs**: Update `notify_package_upgrades` to filter by current system (previously showing notifications for upgrades only on other systems) and use category-specific messaging (e.g. "1 source update available in 'name'").

- **list.rs**: Update upgrade indicators from generic "upgrade available" to type-specific "version upgrade available" or "source update available" in both extended and detail list modes.

</details>

## Example Output

**Before:**
```
✔ Upgraded 2 package(s) in 'myenv':
- awscli2: 2.33.2
- curl: 7.0.0 -> 8.0.0
```

**After:**
```
✔ 1 version upgrade and 1 source update applied in 'myenv':
  1 version upgrade:
  - curl: 7.0.0 -> 8.0.0
  1 source update:
  - awscli2: 2.33.2 (source: 100 Jan 15, 2020 -> 200 Feb 20, 2020)
```

## Test Plan

- [x] All existing list tests pass (24 tests)
- [x] All upgrade/activate upgrade tests pass that are not pre-existing failures (18 tests pass)
- [x] New tests added: `test_format_upgrade_summary_*`, `test_render_diff_*`, `test_print_extended_includes_source_update_indicator`, `test_print_detail_includes_source_update_indicator`
- [x] Existing tests updated: `test_print_extended_includes_upgrade_indicator` and `test_print_detail_includes_upgrade_indicator` now assert "version upgrade available"
- [x] `activate.rs` test `notification_printed_if_present` updated to expect "1 source update available" (correct because test data changes only derivation, not version)
- [x] Pre-existing failures: `upgrade_on_other_system` and `upgrade_dry_run_on_other_system` fail due to Nix environment build issue ("attribute 'version' missing") that also fails on main branch — not caused by these changes

**Note on pre-push hook:** The clippy pre-push hook fails in this dev environment because the hook's Cargo registry is missing the `dissimilar` crate (used by `pretty_assertions`, which was already a dependency before this PR). This is a pre-existing environment issue, not caused by these changes. Local `cargo clippy -p flox` passes clean.

## Ticket

Part of the effort to improve upgrade output clarity.

---
*Via Forge (implementation-worker) • 5a462cf*