### PR TITLE
fix(buildenv): Add reason to building from source

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -699,10 +699,16 @@ where
             format!("{}#{}", locked_url, attrpath)
         };
 
+        let reason = match (locked_pkg.unfree, locked_pkg.broken) {
+            (Some(true), _) => " (unfree license)",
+            (_, Some(true)) => " (upstream build marked as broken)",
+            _ => "",
+        };
+
         let _span = info_span!(
             parent: span,
             "build from catalog",
-            progress = format!("Building '{}' from source", locked_pkg.attr_path)
+            progress = format!("Building '{}' from source{reason}", locked_pkg.attr_path)
         )
         .entered();
 


### PR DESCRIPTION
## Proposed Changes

Provide some more feedback in the "building from source" spinner when we know the package is marked as `unfree` or `broken`. This should help a number of queries that we've had about why `claude-code` in particular is building from source rather than downloading.

I deliberated on the wording for a little bit:

- "unfree" matches the underlying definitions and feels more specific than something like "proprietary"
- "upstream build" indicates that it's not a local build that has failed without needing to go into too much detail about binary caches or whether the build is actually "broken"

If neither are set then we don't have any additional information to give in the reason.

## Release Notes

Provide more information about why a package is being built from source rather than downloaded from a binary cache.