### PR TITLE
fix(agents): Remove regex arg from unit-tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ just test-cli                  # CLI tests only (impure + integration)
 just unit-tests                # Unit tests
 just impure-tests              # Unit tests with extra-tests feature
 just integ-tests               # Integration tests (bats)
-just unit-tests regex="test_name"     # Run specific unit test
+just unit-tests "test_name"           # Run specific unit test
 just integ-tests usage.bats                       # Run specific integration test file
 just integ-tests -- --filter-tags tag             # Run integration tests by tag
 just integ-tests -- --filter regex                # Run integration tests by name


### PR DESCRIPTION
## Proposed Changes

This syntax was misinterpreted when an agent first generated `AGENTS.md` and I keep seeing `claude-code` trip over and correct itself when using it.

Just recipe parameters default to being positional when called from the CLI. It's possible to assign them short and long arg names but I don't think there's any value here:

- https://just.systems/man/en/recipe-parameters.html#recipe-flags-and-options

Incorrect, `regex=…` is passed as a literal to `nextest` and doesn't match any tests:

    % just unit-tests regex=test_column_alignment_for_system_restrictions
    …
    ────────────
     Nextest run ID c5693bd3-32f7-4b0a-b2a8-6bca53b42127 with nextest profile: ci
        Starting 0 tests across 14 binaries (881 tests skipped)
    ────────────
         Summary [   0.002s] 0 tests run: 0 passed, 881 skipped
    error: no tests to run
    (hint: use `--no-tests` to customize)
    error: Recipe `ut` failed on line 247 with exit code 4

Correct, matches one test:

    % just unit-tests test_column_alignment_for_system_restrictions
    …
    ────────────
     Nextest run ID 76374404-187d-4608-a6d3-089b7f6f1761 with nextest profile: ci
        Starting 1 test across 14 binaries (880 tests skipped)
            PASS [   0.031s] flox::bin/flox commands::show::test::test_column_alignment_for_system_restrictions
    ────────────
         Summary [   0.034s] 1 test run: 1 passed, 880 skipped

## Release Notes

N/A, development
