### PR TITLE
fix(push/pull): Include env in subcommand metric

### DIFF
--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -32,10 +32,10 @@ use tracing::{debug, info_span, instrument};
 use super::services::warn_manifest_changes_for_services;
 use super::{ConcreteEnvironment, open_path};
 use crate::commands::{EnvironmentSelect, environment_description, environment_select};
-use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::{display_chain, format_core_error};
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Debug, Clone, Bpaf)]
 enum PullSelect {
@@ -90,8 +90,6 @@ struct QueryFunctions {
 impl Pull {
     #[instrument(name = "pull", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        subcommand_metric!("pull");
-
         match self.pull_select {
             PullSelect::NewAbbreviated {
                 remote,
@@ -99,6 +97,10 @@ impl Pull {
                 copy,
                 generation,
             } => {
+                // This could be a `--copy` to `PathEnvironment`, rather than
+                // `ManagedEnvironment`, but we want to keep the remote name.
+                subcommand_metric!("pull", managed_environment = remote.to_string());
+
                 let (dir_message, dir) = match dir {
                     Some(dir) => (format!("{}", dir.display()), dir),
                     None => (
@@ -130,6 +132,7 @@ impl Pull {
             },
             PullSelect::RemoteUpdate { environment, copy } => {
                 let environment = environment.detect_concrete_environment(&flox, "Pull")?;
+                environment_subcommand_metric!("pull", environment);
 
                 if let ConcreteEnvironment::Path(environment) = environment {
                     bail!(

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -21,7 +21,7 @@ use indoc::formatdoc;
 use tracing::{debug, instrument};
 
 use crate::commands::{EnvironmentSelect, ensure_floxhub_token, environment_select};
-use crate::subcommand_metric;
+use crate::environment_subcommand_metric;
 use crate::utils::errors::format_core_error;
 use crate::utils::message;
 
@@ -51,8 +51,6 @@ pub struct Push {
 impl Push {
     #[instrument(name = "push", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
-        subcommand_metric!("push");
-
         // Ensure the user is logged in for the following remote operations
         ensure_floxhub_token(&mut flox).await?;
 
@@ -81,6 +79,8 @@ impl Push {
         let env = self
             .environment
             .detect_concrete_environment(&flox, "Push")?;
+
+        environment_subcommand_metric!("push", env);
 
         match (env, self.owner) {
             (ConcreteEnvironment::Managed(managed_environment), Some(owner)) => {


### PR DESCRIPTION
## Proposed Changes

So that we can identify patterns for remotes, like we can for activate, when users have opted into metrics.

For `PullSelect::RemoteUpdate` we use `environment_subcommand_metric` which will detect whether it's a managed or remote environment.

For `PullSelect::NewAbbreviated` the field is hardcoded to `managed_environment` because we know that we're pulling a remote even if it may end up as a path environment.

This should be a seamless addition to the existing metrics because all of the other fields are populated the same. We'll just need to bear in mind that older metrics won't have the older fields which may skew stats.

## Release Notes

N/A, internal
