### PR TITLE
fix: only show installed outputs in flox list -a

### DIFF
--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -5,6 +5,7 @@ use anyhow::{Result, bail};
 use bpaf::Bpaf;
 use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
 use flox_manifest::lockfile::{LockedInstallable, LockedPackageFlake, Lockfile, PackageToList};
+use flox_manifest::parsed::latest::SelectedOutputs;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::GenerationsExt;
 use flox_rust_sdk::models::environment::{
@@ -402,11 +403,31 @@ impl List {
 
 fn format_outputs_lines(package: &PackageToList, show_outputs_to_install: bool) -> String {
     let available_outputs = match package {
-        PackageToList::Catalog(_, locked) => {
-            format_as_sorted_list(&locked.outputs.keys().collect::<Vec<_>>())
+        PackageToList::Catalog(desc, locked) => match desc.outputs.as_ref() {
+            Some(SelectedOutputs::All(_)) => {
+                format_as_sorted_list(&locked.outputs.keys().collect::<Vec<_>>())
+            },
+            Some(SelectedOutputs::Specific(outputs)) => format_as_sorted_list(outputs),
+            None => {
+                if let Some(outputs) = locked.outputs_to_install.as_ref() {
+                    format_as_sorted_list(outputs)
+                } else {
+                    format_as_sorted_list(&locked.outputs.keys().collect::<Vec<_>>())
+                }
+            },
         },
-        PackageToList::Flake(_, locked) => {
-            format_as_sorted_list(&locked.locked_installable.output_names)
+        PackageToList::Flake(desc, locked) => match desc.outputs.as_ref() {
+            Some(SelectedOutputs::All(_)) => {
+                format_as_sorted_list(&locked.locked_installable.output_names)
+            },
+            Some(SelectedOutputs::Specific(outputs)) => format_as_sorted_list(outputs),
+            None => {
+                if let Some(outputs) = locked.locked_installable.outputs_to_install.as_ref() {
+                    format_as_sorted_list(outputs)
+                } else {
+                    format_as_sorted_list(&locked.locked_installable.output_names)
+                }
+            },
         },
         PackageToList::StorePath(_) => return String::new(),
     };


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
When only the default outputs are installed:
```
❯ flox list -a
bash:
  Description:          GNU Bourne-Again Shell, the de facto standard shell on Linux (for interactive use)
  Package Path:         bash
  Package Name:         bash
  Priority:             5
  Version:              5.3p9
  License:              GPL-3.0-or-later
  Unfree:               false
  Broken:               false
  Outputs:              [ "man", "out" ]

curl:
  Description:          Command line tool for transferring files with URL syntax
  Package Path:         curl
  Package Name:         curl
  Priority:             5
  Version:              8.18.0
  License:              curl
  Unfree:               false
  Broken:               false
  Outputs:              [ "bin", "man" ]
```

When `curl.outputs = "all"`:
```
❯ flox list -a
bash:
  Description:          GNU Bourne-Again Shell, the de facto standard shell on Linux (for interactive use)
  Package Path:         bash
  Package Name:         bash
  Priority:             5
  Version:              5.3p9
  License:              GPL-3.0-or-later
  Unfree:               false
  Broken:               false
  Outputs:              [ "man", "out" ]

curl:
  Description:          Command line tool for transferring files with URL syntax
  Package Path:         curl
  Package Name:         curl
  Priority:             5
  Version:              8.18.0
  License:              curl
  Unfree:               false
  Broken:               false
  Outputs:              [ "bin", "dev", "devdoc", "man", "out" ]
```

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
