### PR TITLE
docs(manifest): Add schema-version

### DIFF
--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -35,6 +35,23 @@ tables:
 - [`[options]`](#options)
 - [`containerize`] - see [`flox-containerize(1)`](./flox-containerize.md)
 
+## `schema-version`
+
+`schema-version` is a top-level field that specifies the minimum version of Flox
+that the manifest is compatible with.
+
+```toml
+schema-version = "1.10.0"
+```
+
+Valid string values are:
+
+- `1.10.0`: introduced package outputs
+
+Existing manifest schemas, including the older `version = 1` format, are
+automatically forward-migrated when using features that require a newer schema
+(e.g. `flox install` with package outputs).
+
 ## `[install]`
 
 The `[install]` table is the core of the environment,


### PR DESCRIPTION
## Proposed Changes

Document the new `schema-version` field and give a nod to the deprecated `version` field which some users may see in older environments.

We'll need to extend the list of valid schema versions as we add more in the future. At some point it may be worth automating that.

There wasn't a great place to put this since it doesn't fit into the existing structure of TOML tables so I've placed it above `[install]` but omitted it from the list of links.

## Release Notes

N/A, not yet released