### PR TITLE
feat(outputs): Include outputs in flake package history strings

### DIFF
--- a/cli/flox-manifest/src/raw/mod.rs
+++ b/cli/flox-manifest/src/raw/mod.rs
@@ -359,6 +359,15 @@ impl RawSelectedOutputs {
     }
 }
 
+impl std::fmt::Display for RawSelectedOutputs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All => write!(f, ".."),
+            Self::Specific(names) => write!(f, "{}", names.join(",")),
+        }
+    }
+}
+
 impl From<RawSelectedOutputs> for SelectedOutputs {
     fn from(value: RawSelectedOutputs) -> Self {
         match value {
@@ -525,6 +534,15 @@ pub struct FlakePackage {
     pub id: String,
     pub url: Url,
     pub outputs: Option<RawSelectedOutputs>,
+}
+
+impl std::fmt::Display for FlakePackage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.outputs {
+            Some(outputs) => write!(f, "{}^{}", self.url, outputs),
+            None => write!(f, "{}", self.url),
+        }
+    }
 }
 
 impl TryFrom<Url> for FlakePackage {

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -306,7 +306,7 @@ impl Environment for ManagedEnvironment {
                 PackageToInstall::Catalog(CatalogPackage { id, pkg_path, .. }) => {
                     format!("{id} ({pkg_path})")
                 },
-                PackageToInstall::Flake(FlakePackage { id, url, .. }) => format!("{id} ({url})"),
+                PackageToInstall::Flake(pkg @ FlakePackage { id, .. }) => format!("{id} ({pkg})"),
                 PackageToInstall::StorePath(StorePath { id, store_path, .. }) => {
                     format!("{id} ({})", store_path.display())
                 },


### PR DESCRIPTION
Add Display impls for RawSelectedOutputs and FlakePackage so that history entries for flake installs show output information (e.g. "curl (github:nixos/nixpkgs#curl^bin)").

## Release Notes

NA