### PR TITLE
feat(auth): Set user-agent and redirect policy

### DIFF
--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -29,6 +29,7 @@ use oauth2::{
     TokenResponse,
     TokenUrl,
 };
+use reqwest::redirect;
 use serde::Serialize;
 use tracing::{debug, instrument};
 use url::Url;
@@ -100,6 +101,7 @@ pub async fn authorize(client: ConfiguredClient, floxhub_url: &Url) -> Result<Cr
     }
 
     let http_client = reqwest::ClientBuilder::new()
+        .redirect(redirect::Policy::none())
         .user_agent(format!("flox-cli/{}", &*FLOX_VERSION))
         .build()
         .expect("Failed to build OAuth HTTP client");


### PR DESCRIPTION
## Proposed Changes

**refactor(auth): Re-use HTTP client**

Rather than creating a new one for each request. There's a very small
benefit to being able to re-use connection pooling but more importantly
it will allow us to use the same connection settings in some subsequent
commits.

The previous `oauth2::reqwest::Client::new` was just a re-export of
`request::Client::new` which just wraps `ClientBuilder::new` with an
`.expect()`. Use the builder directly so that the error is more obvious
and we can apply some settings in subsequent commits.

**feat(auth): Set user-agent**

So that it's possible for the server to identify the client version.
There's marginal benefit for this when we don't own the auth provider
but it provides consistency with catalog and git requests.

**fix(auth): Set redirect policy none**

Per the warning about SSRF protection here:

- https://docs.rs/oauth2/latest/oauth2/#security-warning

## Release Notes

N/A