### PR TITLE
feat: add flox feedback command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64",
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "bytes",
  "bytestring",
  "derive_more",
@@ -247,9 +247,6 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "arrayref"
@@ -528,7 +525,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -565,11 +562,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -678,10 +675,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -907,7 +905,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -923,7 +921,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1336,6 +1334,12 @@ dependencies = [
  "libc",
  "libredox",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "findshlibs"
@@ -2025,13 +2029,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http 1.4.0",
  "http-body",
@@ -2039,6 +2044,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2082,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2092,8 +2098,9 @@ dependencies = [
  "http 1.4.0",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2351,10 +2358,11 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae51d5da01ce7039024fbdec477767c102c454dbdb09d4e2a432ece705b1b25d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "crossterm 0.29.0",
  "dyn-clone",
  "fuzzy-matcher",
+ "tempfile",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2412,10 +2420,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2498,7 +2507,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834339e86b2561169d45d3b01741967fee3e5716c7d0b6e33cd4e3b34c9558cd"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "bytes",
  "lazy_static",
  "libgssapi-sys",
@@ -2536,7 +2545,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "libc",
  "redox_syscall",
 ]
@@ -2730,7 +2739,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2752,7 +2761,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -2881,7 +2890,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2929,7 +2938,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3228,7 +3237,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "chrono",
  "flate2",
  "procfs-core",
@@ -3241,7 +3250,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "chrono",
  "hex",
 ]
@@ -3320,7 +3329,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
@@ -3483,7 +3492,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3718,7 +3727,7 @@ version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -3731,7 +3740,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -3740,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -3762,7 +3771,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.0.1",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3776,18 +3785,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3833,7 +3843,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edffb89cab87bd0901c5749d576f5d37a1f34e05160e936f463f4e94cc447b61"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3950,7 +3960,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3959,11 +3969,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.0.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -3972,9 +3982,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3992,12 +4002,10 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a505499b38861edd82b5a688fa06ba4ba5875bb832adeeeba22b7b23fc4bc39a"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
  "httpdate",
- "log",
  "native-tls",
  "reqwest",
  "sentry-actix",
@@ -4014,9 +4022,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ad8bfdcfbc6e0d0dacaa5728555085ef459fa9226cfc2fe64eefa4b8038b7f"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -4027,9 +4034,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93cfb800654dc846ccbeb35254a2f6f194aaf7e187223fd90aeb7afafe722c"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -4038,9 +4044,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dace796060e4ad10e3d1405b122ae184a8b2e71dce05ae450e4f81b7686b0d9"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
  "backtrace",
  "regex",
@@ -4049,9 +4054,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bd9e6b51ffe2bc7188ebe36cb67557cb95749c08a3f81f33e8c9b135e0d1bc"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
  "hostname",
  "libc",
@@ -4063,22 +4067,20 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7426d4beec270cfdbb50f85f0bb2ce176ea57eed0b11741182a163055a558187"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
- "log",
  "rand 0.9.1",
  "sentry-types",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df15c066c04f34c4dfd496a8e76590106b93283f72ef1a47d8fb24d88493424"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -4086,9 +4088,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92beed69b776a162b6d269bef1eaa3e614090b6df45a88d9b239c4fdbffdfba"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4096,10 +4097,10 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c323492795de90824f3198562e33dd74ae3bc852fbb13c0cabec54a1cf73cd"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
+ "bitflags 2.11.0",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -4108,9 +4109,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b6c9287202294685cb1f749b944dbbce8160b81a1061ecddc073025fed129f"
+version = "0.42.0"
+source = "git+https://github.com/zmitchell/sentry-rust?branch=add-feedback-0.42.0#459d075b15b203eadd18830805cd6104779fffd5"
 dependencies = [
  "debugid",
  "hex",
@@ -4592,7 +4592,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5144,15 +5144,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64",
+ "der",
  "log",
  "native-tls",
- "once_cell",
- "url",
+ "percent-encoding",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf-8",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -5176,6 +5192,12 @@ checksum = "44e0ce4d1246d075ca5abec4b41d33e87a6054d08e2366b63205665e950db218"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -5305,47 +5327,36 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5353,22 +5364,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -5385,9 +5399,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5401,6 +5415,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5856,7 +5879,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ httpmock = { git = "https://github.com/flox/httpmock.git", default-features = fa
 indent = "0.1.1"
 indexmap = { version = "2.13.0", features = ["serde"] }
 indoc = "2.0.7"
-inquire = "0.9.2"
+inquire = { version = "0.9.2", features = ["editor"] }
 indicatif = "0.18"
 is_executable = "1.0.5"
 itertools = "0.14.0"
@@ -70,11 +70,10 @@ reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
 rsevents-extra = "0.2.2"
 schemars = "1"
 semver = "1.0.27"
-sentry = { version = "0.38.1", features = [
+sentry = { git = "https://github.com/zmitchell/sentry-rust", branch = "add-feedback-0.42.0", features = [
     "test",
     "anyhow",
     "tracing",
-    "debug-logs",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/cli/flox/src/commands/feedback.rs
+++ b/cli/flox/src/commands/feedback.rs
@@ -1,0 +1,94 @@
+use anyhow::bail;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use indoc::indoc;
+use inquire::validator::{ErrorMessage, StringValidator, Validation};
+use inquire::{Editor, Text};
+use sentry::protocol::Feedback as UserFeedback;
+use sentry::{Envelope, Hub};
+
+use crate::config::Config;
+
+#[derive(Debug, Clone, Bpaf)]
+pub struct Feedback {
+    // Print the Sentry envelope instead of sending the feedback
+    // Only used for debugging
+    #[bpaf(short, long, hide)]
+    pub print: bool,
+}
+
+impl Feedback {
+    pub async fn handle(&self, config: Config, _flox: Flox) -> Result<(), anyhow::Error> {
+        let error_msg = indoc! {"Can't send feedback in this configuration, sorry!
+
+        Since this is an experimental command, there are some limitations:
+        - Telemetry must be enabled (can be temporarily enabled via FLOX_DISABLE_METRICS=false flox feedback)
+        - Flox must be installed from an official installer, not via Nix
+        "};
+        if config.flox.disable_metrics {
+            bail!(error_msg);
+        }
+
+        // Check whether the Sentry DSN is set _before_ a user
+        // goes through the trouble of entering any information
+        let hub = Hub::current();
+        let maybe_sentry_client = hub.client();
+        if maybe_sentry_client.is_none() {
+            bail!(error_msg);
+        }
+        let sentry_client = maybe_sentry_client.unwrap();
+
+        let name = Text::new("Name:")
+            .with_help_message("This is optional (Esc to skip)")
+            .prompt_skippable()?;
+        let email = Text::new("Email:")
+            .with_help_message("This is optional in case you'd like us to follow up (Esc to skip)")
+            .prompt_skippable()?;
+        let message = Editor::new("Open an editor to write your message:")
+            .with_help_message(
+                "You'll brought back here after closing your editor (Enter to submit)",
+            )
+            .with_validator(EmptySubmissionValidator)
+            .prompt()?;
+
+        let feedback = UserFeedback {
+            contact_email: email,
+            name,
+            message,
+        };
+        let envelope: Envelope = feedback.into();
+        if self.print {
+            // This branch is only for debugging
+            print_envelope(&envelope);
+        } else {
+            sentry_client.send_envelope(envelope);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EmptySubmissionValidator;
+
+impl StringValidator for EmptySubmissionValidator {
+    fn validate(
+        &self,
+        input: &str,
+    ) -> Result<inquire::validator::Validation, inquire::CustomUserError> {
+        if input.is_empty() {
+            Ok(Validation::Invalid(ErrorMessage::Custom(
+                "Feedback was empty".to_string(),
+            )))
+        } else {
+            Ok(Validation::Valid)
+        }
+    }
+}
+
+fn print_envelope(envelope: &Envelope) {
+    let mut buf = Vec::new();
+    envelope.to_writer(&mut buf).unwrap();
+    let output = String::from_utf8_lossy(buf.as_slice());
+    eprintln!("ENVELOPE: {output}");
+}

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod delete;
 mod edit;
 mod envs;
 mod exit;
+mod feedback;
 mod gc;
 mod general;
 mod generations;
@@ -736,6 +737,21 @@ enum AdminCommands {
         footer("Run 'man flox-gc' for more details.")
     )]
     Gc(#[bpaf(external(gc::gc))] gc::Gc),
+
+    /// Send Flox feedback
+    ///
+    /// This will prompt you to enter some optional contact information in case
+    /// you'd like us to follow up with you, and then opens an editor for you
+    /// to enter your message.
+    #[bpaf(
+        command,
+        header(indoc!{"This is an experimental command for sending bug reports, suggestions, etc
+                       to Flox. This currently requires that telemetry is enabled, but you can
+                       temporarily enable telemetry for a single invocation via the command below:
+
+                       FLOX_DISABLE_METRICS=false flox feedback"}),
+    )]
+    Feedback(#[bpaf(external(feedback::feedback))] feedback::Feedback),
 }
 
 impl AdminCommands {
@@ -744,6 +760,7 @@ impl AdminCommands {
             AdminCommands::Auth(args) => args.handle(config, flox).await?,
             AdminCommands::Config(args) => args.handle(config, flox).await?,
             AdminCommands::Gc(args) => args.handle(flox)?,
+            AdminCommands::Feedback(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -110,6 +110,7 @@ Administration
     auth           FloxHub authentication commands
     config         View and set configuration options
     gc             Garbage collects any data for deleted environments.
+    feedback       Send Flox feedback
 
 Available options:
     -v, --verbose  Increase logging verbosity


### PR DESCRIPTION
## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->
This command opens an interactive prompt to get some information from a user. It asks for a name (optional), email (optional, so we can follow up if the user wants), and then a message. The message is written by opening an editor for the user.

This command currently requires two things:
- Telemetry to be enabled
- A Sentry DSN to be present

From a user's perspective this means:
- Telemetry is enabled in their config or they run the command with FLOX_DISABLE_METRICS=false
- They installed Flox from an official installer, not through Nix

We check for these conditions to be met before we allow a user to enter any information, since it would be frustrating to go through this process and _then_ find out that (1) your message is lost, and (2) they did all of that for nothing.

This second point is an arbitrary limitation due to the fact that we don't embed the Sentry DSN in CLI builds that aren't installers. See https://github.com/flox/flox/issues/1986.

For developers you can simply run the command as below:
```
$ FLOX_SENTRY_DSN="<sentry dsn>" \
FLOX_DISABLE_METRICS=false \
flox feedback
```

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
Adds a `flox feedback` command that users can run to send Flox bug reports, provide suggestions, or just tell us how awesome we are.

<!-- Many thanks! -->
