### PR TITLE
refactor(env): Rename pre_migration_manifest

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -82,7 +82,7 @@ impl<State> CoreEnvironment<State> {
         &self.env_dir
     }
 
-    pub fn pre_migration_manifest(&self) -> Result<Manifest<Validated>, ManifestError> {
+    pub fn manifest_without_migrating(&self) -> Result<Manifest<Validated>, ManifestError> {
         Manifest::read_typed(self.manifest_path())
     }
 
@@ -136,7 +136,7 @@ impl<State> CoreEnvironment<State> {
 
         // Check if the manifest embedded in the lockfile and the manifest
         // itself have the same contents
-        let serialized_unmigrated_manifest = &self.pre_migration_manifest()?.as_typed_only();
+        let serialized_unmigrated_manifest = &self.manifest_without_migrating()?.as_typed_only();
         let already_locked =
             lockfile.is_up_to_date_with_serialized_manifest(serialized_unmigrated_manifest);
 
@@ -173,7 +173,7 @@ impl<State> CoreEnvironment<State> {
         let on_disk_manifest_needs_migration = schema_after_merging_and_locking != original_schema;
 
         if on_disk_manifest_needs_migration {
-            let migrated_manifest = self.pre_migration_manifest()?.migrate(Some(lockfile))?;
+            let migrated_manifest = self.manifest_without_migrating()?.migrate(Some(lockfile))?;
             migrated_manifest
                 .as_writable()
                 .write_to_file(self.manifest_path())?;
@@ -197,12 +197,12 @@ impl<State> CoreEnvironment<State> {
     /// It's included in the [ReadOnly] struct for ergonomic reasons
     /// and because it doesn't modify the manifest.
     pub fn lock(&mut self, flox: &Flox) -> Result<LockResult, EnvironmentError> {
-        let pre_migration_manifest = self.pre_migration_manifest()?.as_typed_only();
-        let original_schema = pre_migration_manifest.get_schema_version();
+        let manifest_without_migrating = self.manifest_without_migrating()?.as_typed_only();
+        let original_schema = manifest_without_migrating.get_schema_version();
 
         let existing_lockfile = self.existing_lockfile()?;
         let migrated_manifest_for_locking =
-            pre_migration_manifest.migrate_typed_only(existing_lockfile.as_ref())?;
+            manifest_without_migrating.migrate_typed_only(existing_lockfile.as_ref())?;
 
         // If a lockfile exists, it is used as a base.
         //
@@ -347,7 +347,7 @@ impl CoreEnvironment<ReadOnly> {
     }
 
     pub(crate) fn manifest(&mut self, flox: &Flox) -> Result<Manifest<Migrated>, EnvironmentError> {
-        let manifest = self.pre_migration_manifest()?;
+        let manifest = self.manifest_without_migrating()?;
         let lockfile = self.ensure_locked(flox)?.into();
         let migrated = manifest.migrate(Some(&lockfile))?;
         Ok(migrated)
@@ -461,7 +461,7 @@ impl CoreEnvironment<ReadOnly> {
         &self,
         contents: impl AsRef<str>,
     ) -> Result<bool, ManifestError> {
-        Ok(self.pre_migration_manifest()?.contents_match(contents))
+        Ok(self.manifest_without_migrating()?.contents_match(contents))
     }
 
     /// Atomically edit this environment, without checking that it still builds
@@ -706,8 +706,8 @@ impl CoreEnvironment<ReadOnly> {
             .map(Lockfile::from_str)
             .transpose()?;
 
-        let pre_migration_manifest = self.pre_migration_manifest()?;
-        let original_schema = pre_migration_manifest.get_schema_version();
+        let manifest_without_migrating = self.manifest_without_migrating()?;
+        let original_schema = manifest_without_migrating.get_schema_version();
 
         // This is `mut` because we may need to update the on-disk manifest to match the
         // schema of the merged manifest, and then we'll also have to update the
@@ -1367,7 +1367,7 @@ mod tests {
 
         assert_eq!(
             env_view
-                .pre_migration_manifest()
+                .manifest_without_migrating()
                 .unwrap()
                 .as_writable()
                 .to_string(),
@@ -1782,7 +1782,7 @@ mod tests {
             .update_manifest(&original_manifest.as_writable())
             .unwrap();
         writable_env.lock(&flox).unwrap();
-        let post_lock_manifest = writable_env.pre_migration_manifest().unwrap();
+        let post_lock_manifest = writable_env.manifest_without_migrating().unwrap();
         assert_eq!(
             original_manifest.as_writable().to_string(),
             post_lock_manifest.as_writable().to_string()

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -233,20 +233,23 @@ impl Environment for ManagedEnvironment {
             .map_err(EnvironmentError::Core)
     }
 
-    fn pre_migration_manifest(&self, flox: &Flox) -> Result<Manifest<Validated>, EnvironmentError> {
+    fn manifest_without_migrating(
+        &self,
+        flox: &Flox,
+    ) -> Result<Manifest<Validated>, EnvironmentError> {
         if let Some(generation) = self.generation {
-            let pre_migration_manifest_contents = self
+            let manifest_without_migrating_contents = self
                 .generations()
                 .manifest_contents(*generation)
                 .map_err(ManagedEnvironmentError::Generations)?;
-            let manifest = Manifest::parse_toml_typed(pre_migration_manifest_contents)?;
+            let manifest = Manifest::parse_toml_typed(manifest_without_migrating_contents)?;
             return Ok(manifest);
         }
 
         // Read straight from disk
         let env_view = self.local_env_or_copy_current_generation(flox)?;
         env_view
-            .pre_migration_manifest()
+            .manifest_without_migrating()
             .map_err(EnvironmentError::ManifestError)
     }
 
@@ -258,7 +261,7 @@ impl Environment for ManagedEnvironment {
                 .map_err(ManagedEnvironmentError::Generations)?;
             let lockfile = Lockfile::from_str(lockfile_contents.as_str())?;
             let manifest = self
-                .pre_migration_manifest(flox)?
+                .manifest_without_migrating(flox)?
                 .migrate(Some(&lockfile))?;
             return Ok(manifest);
         }
@@ -1128,7 +1131,7 @@ impl ManagedEnvironment {
             return Ok(false);
         }
 
-        let local_manifest = local.pre_migration_manifest()?;
+        let local_manifest = local.manifest_without_migrating()?;
         let remote_manifest = Manifest::parse_toml_typed(
             generations
                 .current_gen_manifest_contents()
@@ -1962,7 +1965,7 @@ mod test {
         let local_manifest = managed_env
             .local_env_or_copy_current_generation(&flox)
             .unwrap()
-            .pre_migration_manifest()
+            .manifest_without_migrating()
             .unwrap();
         assert_eq!(
             local_manifest.as_writable().to_string(),

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -156,7 +156,10 @@ pub trait Environment: Send {
     /// This is only intended to be used when comparing against manifests that are
     /// stored unmigrated e.g. manifests stored in the lockfile, manifests stored
     /// in generations, etc.
-    fn pre_migration_manifest(&self, flox: &Flox) -> Result<Manifest<Validated>, EnvironmentError>;
+    fn manifest_without_migrating(
+        &self,
+        flox: &Flox,
+    ) -> Result<Manifest<Validated>, EnvironmentError>;
 
     /// Reads the manifest from disk and returns the migrated manifest,
     /// potentially locking it if necessary.
@@ -1373,7 +1376,7 @@ mod migration_tests {
         env.lockfile(&flox).unwrap(); // ensure it's locked
 
         let manifest_contents = env
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();
@@ -1401,7 +1404,7 @@ mod migration_tests {
         composer.lockfile(&flox).unwrap();
 
         let composer_manifest_contents = composer
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();
@@ -1439,7 +1442,7 @@ mod migration_tests {
         composer.lockfile(&flox).unwrap();
 
         let composer_manifest_contents = composer
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();
@@ -1477,7 +1480,7 @@ mod migration_tests {
         composer.lockfile(&flox).unwrap();
 
         // The composer's manifest should be migrated to v1.10.0
-        let manifest = composer.pre_migration_manifest(&flox).unwrap();
+        let manifest = composer.manifest_without_migrating(&flox).unwrap();
         assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::latest());
     }
 
@@ -1502,7 +1505,7 @@ mod migration_tests {
         let mut composer = setup_v1_composer_with_include(&flox, tempdir.path());
         composer.lockfile(&flox).unwrap();
 
-        let manifest = composer.pre_migration_manifest(&flox).unwrap();
+        let manifest = composer.manifest_without_migrating(&flox).unwrap();
         assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::latest());
     }
 
@@ -1528,7 +1531,7 @@ mod migration_tests {
         let mut composer = setup_v1_composer_with_include(&flox, tempdir.path());
         composer.lockfile(&flox).unwrap();
 
-        let manifest = composer.pre_migration_manifest(&flox).unwrap();
+        let manifest = composer.manifest_without_migrating(&flox).unwrap();
         assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::V1);
 
         // Now update the included env to add a package with explicit outputs.
@@ -1549,7 +1552,7 @@ mod migration_tests {
         composer.include_upgrade(&flox, vec![]).unwrap();
 
         // The composer's manifest should now be migrated to v1.10.0.
-        let manifest = composer.pre_migration_manifest(&flox).unwrap();
+        let manifest = composer.manifest_without_migrating(&flox).unwrap();
         assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::latest());
     }
 
@@ -1561,7 +1564,7 @@ mod migration_tests {
         let mut env = new_path_environment(&flox, "version = 1");
         _ = env.lockfile(&flox).unwrap(); // make sure a lockfile exists
         assert_eq!(
-            env.pre_migration_manifest(&flox)
+            env.manifest_without_migrating(&flox)
                 .unwrap()
                 .get_schema_version(),
             KnownSchemaVersion::V1
@@ -1578,7 +1581,7 @@ mod migration_tests {
         )
         .unwrap();
         assert_eq!(
-            env.pre_migration_manifest(&flox)
+            env.manifest_without_migrating(&flox)
                 .unwrap()
                 .get_schema_version(),
             KnownSchemaVersion::V1
@@ -1595,7 +1598,7 @@ mod migration_tests {
         let mut env = new_path_environment(&flox, "version = 1");
         _ = env.lockfile(&flox).unwrap(); // make sure a lockfile exists
         assert_eq!(
-            env.pre_migration_manifest(&flox)
+            env.manifest_without_migrating(&flox)
                 .unwrap()
                 .get_schema_version(),
             KnownSchemaVersion::V1
@@ -1612,7 +1615,7 @@ mod migration_tests {
         )
         .unwrap();
         assert_eq!(
-            env.pre_migration_manifest(&flox)
+            env.manifest_without_migrating(&flox)
                 .unwrap()
                 .get_schema_version(),
             KnownSchemaVersion::latest()
@@ -1633,7 +1636,7 @@ mod migration_tests {
         env.lockfile(&flox).unwrap();
 
         assert_eq!(
-            env.pre_migration_manifest(&flox)
+            env.manifest_without_migrating(&flox)
                 .unwrap()
                 .get_schema_version(),
             KnownSchemaVersion::V1
@@ -1654,7 +1657,7 @@ mod migration_tests {
         env.lockfile(&flox).unwrap();
 
         assert_eq!(
-            env.pre_migration_manifest(&flox)
+            env.manifest_without_migrating(&flox)
                 .unwrap()
                 .get_schema_version(),
             KnownSchemaVersion::V1
@@ -1678,7 +1681,7 @@ mod migration_tests {
         composer.lockfile(&flox).unwrap();
 
         let composer_manifest_contents = composer
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();
@@ -1713,7 +1716,7 @@ mod migration_tests {
         composer.lockfile(&flox).unwrap();
 
         let composer_manifest_contents = composer
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -202,11 +202,11 @@ impl Environment for PathEnvironment {
             .map_err(EnvironmentError::Core)
     }
 
-    fn pre_migration_manifest(
+    fn manifest_without_migrating(
         &self,
         _flox: &Flox,
     ) -> Result<Manifest<Validated>, EnvironmentError> {
-        let manifest = self.as_core_environment()?.pre_migration_manifest()?;
+        let manifest = self.as_core_environment()?.manifest_without_migrating()?;
         Ok(manifest)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -367,8 +367,11 @@ impl Environment for RemoteEnvironment {
         self.inner.existing_lockfile(flox)
     }
 
-    fn pre_migration_manifest(&self, flox: &Flox) -> Result<Manifest<Validated>, EnvironmentError> {
-        self.inner.pre_migration_manifest(flox)
+    fn manifest_without_migrating(
+        &self,
+        flox: &Flox,
+    ) -> Result<Manifest<Validated>, EnvironmentError> {
+        self.inner.manifest_without_migrating(flox)
     }
 
     fn manifest(&mut self, flox: &Flox) -> Result<Manifest<Migrated>, EnvironmentError> {
@@ -708,7 +711,7 @@ mod tests {
 
         // TODO: should be changed to version 2 once released!
         assert_eq!(
-            env.pre_migration_manifest(&flox)
+            env.manifest_without_migrating(&flox)
                 .unwrap()
                 .as_writable()
                 .to_string(),

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -2121,7 +2121,7 @@ mod tests {
         let env_path = env.parent_path().unwrap();
 
         let base_manifest = env
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();
@@ -2204,7 +2204,7 @@ mod tests {
         let env_path = env.parent_path().unwrap();
 
         let base_manifest = env
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();
@@ -2292,7 +2292,7 @@ mod tests {
         let env_path = env.parent_path().unwrap();
 
         let base_manifest = env
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();
@@ -2923,7 +2923,7 @@ mod tests {
         let env_path = env.parent_path().unwrap();
 
         let base_manifest = env
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();
@@ -3048,7 +3048,7 @@ mod tests {
         let env_path = env.parent_path().unwrap();
 
         let base_manifest = env
-            .pre_migration_manifest(&flox)
+            .manifest_without_migrating(&flox)
             .unwrap()
             .as_writable()
             .to_string();

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1211,7 +1211,7 @@ pub mod tests {
             &manifest_path,
             format!(
                 "{}\n",
-                env.pre_migration_manifest(&flox)
+                env.manifest_without_migrating(&flox)
                     .unwrap()
                     .as_writable()
                     .to_string()

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -156,7 +156,9 @@ impl Activate {
                 &flox,
                 &env.env_ref(),
                 false,
-                &env.pre_migration_manifest(&flox)?.as_writable().to_string(),
+                &env.manifest_without_migrating(&flox)?
+                    .as_writable()
+                    .to_string(),
             )
             .await?;
         }

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -288,7 +288,7 @@ impl Edit {
         std::fs::write(
             &tmp_manifest,
             environment
-                .pre_migration_manifest(flox)?
+                .manifest_without_migrating(flox)?
                 .as_writable()
                 .to_string(),
         )?;

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -95,7 +95,9 @@ impl List {
                 (remote_manifest_contents, lockfile)
             },
             (env, false) => (
-                env.pre_migration_manifest(&flox)?.as_writable().to_string(),
+                env.manifest_without_migrating(&flox)?
+                    .as_writable()
+                    .to_string(),
                 env.lockfile(&flox)?.into(),
             ),
         };
@@ -927,7 +929,7 @@ mod tests {
             List::manifest_contents_to_print(
                 &lockfile,
                 composer
-                    .pre_migration_manifest(&flox)
+                    .manifest_without_migrating(&flox)
                     .unwrap()
                     .as_writable()
                     .to_string()

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -563,7 +563,7 @@ impl Pull {
     ) -> Result<Manifest<Migrated>, anyhow::Error> {
         let lockfile = env.existing_lockfile(flox)?;
         let mut manifest = env
-            .pre_migration_manifest(flox)?
+            .manifest_without_migrating(flox)?
             .migrate(lockfile.as_ref())?;
         let maybe_systems = manifest.options_mut().systems.as_mut();
         if let Some(systems) = maybe_systems {


### PR DESCRIPTION
## Proposed Changes

To more clearly indicate that the on-disk manifest may have already been migrated but this method simply read it as-is without performing a migration again.

I considered including "on disk" in the name but it felt too wordy.

`Environment` trait and all implementations have been changed. `Manifest<Migrated>::pre_migration_manifest` is left unchanged because it has different semantics and does return the original manifest from a migration result.

## Release Notes

N/A