### PR TITLE
feat(containerize): Add --mode flag to select dev or run environment

### DIFF
--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -16,6 +16,7 @@ flox [<general-options>] containerize
      [-f=<file>] [--runtime=<runtime>]
      [--tag=<tag>]
      [--label=<key=value>]
+     [-m=(dev|run)]
 ```
 
 # DESCRIPTION
@@ -59,6 +60,12 @@ similar to `flox activate --`.
     Specify as `key=value` pairs.
     Can be specified multiple times.
     Works alongside labels defined in the manifest's `[containerize.config]` section.
+
+`-m (dev|run)`, `--mode (dev|run)`
+:   Containerize the environment in either "dev" or "run" mode.
+    Overrides the `options.activate.mode` setting in the manifest.
+    See [`manifest.toml(5)`](./manifest.toml.md) for more details on activation
+    modes.
 
 ```{.include}
 ./include/environment-options.md

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::LazyLock;
 
+use flox_core::activate::context::ActivateMode;
 use flox_core::vars::FLOX_DISABLE_METRICS_VAR;
 use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
 use flox_rust_sdk::providers::container_builder::{ContainerBuilder, ContainerSource};
@@ -41,6 +42,7 @@ pub(crate) struct ContainerizeProxy {
     environment_path: PathBuf,
     container_runtime: Runtime,
     labels: Vec<String>,
+    mode: Option<ActivateMode>,
 }
 
 impl ContainerizeProxy {
@@ -48,11 +50,13 @@ impl ContainerizeProxy {
         environment_path: PathBuf,
         container_runtime: Runtime,
         labels: Vec<String>,
+        mode: Option<ActivateMode>,
     ) -> Self {
         Self {
             environment_path,
             container_runtime,
             labels,
+            mode,
         }
     }
 
@@ -242,6 +246,9 @@ impl ContainerizeProxy {
         command.args(["--tag", tag.as_ref()]);
         command.args(["--file", "-"]);
         command.args(self.labels.iter().flat_map(|l| ["--label", l]));
+        if let Some(mode) = &self.mode {
+            command.args(["--mode", &mode.to_string()]);
+        }
     }
 }
 

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -98,10 +98,10 @@ impl Containerize {
         let lockfile: Lockfile = env.lockfile(&flox)?.into();
         let manifest = lockfile.migrated_manifest()?;
         let manifest = manifest.as_latest_schema();
-        let mode = self
-            .mode
-            .unwrap_or(manifest.options.activate.mode.clone().unwrap_or_default());
         let source = if std::env::consts::OS == "linux" {
+            let mode = self
+                .mode
+                .unwrap_or(manifest.options.activate.mode.clone().unwrap_or_default());
             let container_config = manifest
                 .containerize
                 .as_ref()
@@ -126,7 +126,7 @@ impl Containerize {
                     Exporting a container on macOS requires Docker or Podman to be installed.
                 "#});
             };
-            let builder = ContainerizeProxy::new(env_path, proxy_runtime, self.labels, Some(mode));
+            let builder = ContainerizeProxy::new(env_path, proxy_runtime, self.labels, self.mode);
             builder.create_container_source(&flox, env_name.as_ref(), output_tag)?
         };
 

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -8,6 +8,7 @@ use std::{fs, io};
 
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
+use flox_core::activate::context::ActivateMode;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::lockfile::Lockfile;
 use flox_manifest::parsed::common::ContainerizeConfig;
@@ -53,6 +54,11 @@ pub struct Containerize {
     /// Set metadata for an image
     #[bpaf(long("label"), argument("key=value"))]
     labels: Vec<String>,
+
+    /// Containerize the environment in either "dev" or "run" mode.
+    /// Overrides the "options.activate.mode" setting in the manifest.
+    #[bpaf(short, long)]
+    mode: Option<ActivateMode>,
 }
 impl Containerize {
     #[instrument(name = "containerize", skip_all)]
@@ -92,7 +98,9 @@ impl Containerize {
         let lockfile: Lockfile = env.lockfile(&flox)?.into();
         let manifest = lockfile.migrated_manifest()?;
         let manifest = manifest.as_latest_schema();
-        let mode = manifest.options.activate.mode.clone().unwrap_or_default();
+        let mode = self
+            .mode
+            .unwrap_or(manifest.options.activate.mode.clone().unwrap_or_default());
         let source = if std::env::consts::OS == "linux" {
             let container_config = manifest
                 .containerize
@@ -118,7 +126,7 @@ impl Containerize {
                     Exporting a container on macOS requires Docker or Podman to be installed.
                 "#});
             };
-            let builder = ContainerizeProxy::new(env_path, proxy_runtime, self.labels);
+            let builder = ContainerizeProxy::new(env_path, proxy_runtime, self.labels, Some(mode));
             builder.create_container_source(&flox, env_name.as_ref(), output_tag)?
         };
 


### PR DESCRIPTION
Came up in a discussion with @smorin:
> It would be great if a single manifest could separate dev and production assets, making it easy to build optimized Docker containers from that.

## Summary

- Adds `--mode`/`-m` flag to `flox containerize`, matching the existing pattern from `flox activate`
- CLI flag takes priority over `options.activate.mode` in the manifest, which falls back to `dev` (the default)
- Forwards the resolved mode through the macOS proxy path so the inner `flox containerize` invocation uses the correct mode

## Context

`flox containerize` builds a container image of the environment but previously always used whichever mode was set in the manifest (defaulting to dev). This made it impossible to containerize a run-mode environment without editing the manifest. The `--mode` flag provides a CLI override, consistent with how `flox activate --mode` already works.

## Test plan

- [ ] `flox containerize` without `--mode` continues to default to dev mode (no behavior change)
- [ ] `flox containerize --mode run` produces a container with the runtime environment (no propagated build inputs)
- [ ] `flox containerize --mode dev` explicitly produces a container with the dev environment
- [ ] `flox containerize -m run` short flag works
- [ ] Manifest `options.activate.mode = "run"` is respected when no CLI flag is given
- [ ] CLI `--mode` overrides manifest setting
- [ ] macOS proxy path forwards mode correctly (if testable on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)