### PR TITLE
fix(manifest): Remove duplicate manifest errors

### DIFF
--- a/cli/flox-manifest/src/lib.rs
+++ b/cli/flox-manifest/src/lib.rs
@@ -66,27 +66,27 @@ pub enum ManifestError {
     // Parsing manifests
     // =========================================================================
     /// We failed to read a manifest from disk.
-    #[error("failed to read manifest file: {0}")]
+    #[error("failed to read manifest file")]
     IORead(#[source] std::io::Error),
 
     /// We failed to write a manifest to disk.
-    #[error("failed to write manifest file: {0}")]
+    #[error("failed to write manifest file")]
     IOWrite(#[source] std::io::Error),
 
     /// An atomic write of a manifest failed.
-    #[error("failed to write manifest file: {0}")]
+    #[error("failed to write manifest file")]
     AtomicWrite(#[source] WriteError),
 
     /// The provided string failed to parse as valid TOML of any kind.
-    #[error("manifest contents were not valid TOML: {0}")]
+    #[error("manifest contents were not valid TOML")]
     ParseToml(#[source] toml_edit::TomlError),
 
     /// The provided string failed to parse as valid JSON of any kind.
-    #[error("manifest contents were not valid JSON: {0}")]
+    #[error("manifest contents were not valid JSON")]
     ParseJson(#[source] serde_json::Error),
 
     /// Valid JSON did not deserialize into a manifest.
-    #[error("JSON was not a valid manifest: {0}")]
+    #[error("JSON was not a valid manifest")]
     DeserializeJson(#[source] serde_json::Error),
 
     #[error("manifest had invalid schema version '{0}'")]
@@ -95,13 +95,13 @@ pub enum ManifestError {
     #[error("manifest 'schema-version' field is missing")]
     MissingSchemaVersion,
 
-    #[error("invalid manifest: {0}")]
+    #[error("invalid manifest")]
     Invalid(#[source] toml_edit::de::Error),
 
-    #[error("failed to serialize manifest: {0}")]
+    #[error("failed to serialize manifest")]
     Serialize(#[source] toml_edit::ser::Error),
 
-    #[error("failed to serialize manifest to lockfile: {0}")]
+    #[error("failed to serialize manifest to lockfile")]
     SerializeJson(#[source] serde_json::Error),
 
     #[error("{0}")]

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -134,10 +134,18 @@ EOF
   ORIGINAL_MANIFEST_CONTENTS="$(cat "$MANIFEST_PATH")" # for check_manifest_unchanged
 
   cat "$EXTERNAL_MANIFEST_PATH" > ./manifest.toml
-  echo "foo = " > ./manifest.toml
+  echo "foo = ;" > ./manifest.toml
 
-  run "$FLOX_BIN" edit -f ./manifest.toml
+  RUST_BACKTRACE=0 run "$FLOX_BIN" edit -f ./manifest.toml
   assert_failure
+  assert_output - <<'EOF'
+✘ ERROR: manifest contents were not valid TOML: TOML parse error at line 1, column 7
+  |
+1 | foo = ;
+  |       ^
+string values must be quoted, expected literal string
+EOF
+
   run check_manifest_unchanged
   assert_success
 }
@@ -149,8 +157,16 @@ EOF
   "$FLOX_BIN" init
   ORIGINAL_MANIFEST_CONTENTS="$(cat "$MANIFEST_PATH")" # for check_manifest_unchanged
 
-  run sh -c "echo 'foo = ;' | ${FLOX_BIN} edit -f -"
+  RUST_BACKTRACE=0 run sh -c "echo 'foo = ;' | ${FLOX_BIN} edit -f -"
   assert_failure
+  assert_output - <<'EOF'
+✘ ERROR: manifest contents were not valid TOML: TOML parse error at line 1, column 7
+  |
+1 | foo = ;
+  |       ^
+string values must be quoted, expected literal string
+EOF
+
   run check_manifest_unchanged
   assert_success
 }


### PR DESCRIPTION
## Proposed Changes

Fix a regression for manifest errors in v1.10.0 that caused duplicates:

    % echo invalid | flox edit -f -
    ✘ ERROR: manifest contents were not valid TOML: TOML parse error at line 1, column 8
      |
    1 | invalid
      |        ^
    key with no value, expected `=`
    : TOML parse error at line 1, column 8
      |
    1 | invalid
      |        ^
    key with no value, expected `=`

This happened because ManifestError variants used both `{0}` in thiserror's `#[error(...)]` format string AND `#[source]` on the inner error. The `{0}` interpolation includes the inner error in Display, while `#[source]` exposes it via `.source()`. The `display_chain()` formatter calls `.to_string()` (getting the message with the inner error baked in) and then walks `.source()`, appending the same inner error a second time.

Alternatives considered:
- Changing `display_chain()` to detect and skip duplicates: fragile, since it would need substring matching, and the real issue is the double-reporting at the type level, not in the formatter.
- Removing `#[source]` instead of `{0}`: would break the error chain, losing .source() for programmatic error inspection and for any other code that walks the chain (e.g. logging, anyhow).
- Using `#[from]` without `#[source]`: `#[from]` implies `#[source]`, so the same duplication would occur.

The chosen approach follows the Rust convention: when using `#[source]`, the `Display` impl should provide context only, not repeat the source.

Added output to assertions to some existing integration tests which would have caught this. They don't cover all of the error variants, which could be covered by new unit tests, but they felt more brittle in terms of observing the actual impact.

I modified the input manifest for one of the tests to make it the same as the other partly to workaround an annoying issue with not being able to save the file with trailing whitespace in the assertion string.

## Release Notes

Fixed a bug with duplicate errors being reported for invalid manifests.
