### PR TITLE
test: fail if manifest.toml man page is missing schema versions

### DIFF
--- a/cli/flox-manifest/src/parsed/common.rs
+++ b/cli/flox-manifest/src/parsed/common.rs
@@ -656,6 +656,38 @@ impl Display for IncludeDescriptor {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ensure the manifest.toml man page documents all schema versions that use
+    /// the `schema-version` key (i.e. all versions after the legacy `version = 1`).
+    ///
+    /// If this test fails, update the "Valid string values" list in
+    /// `cli/flox/doc/manifest.toml.md` to include the new schema version.
+    #[test]
+    fn man_page_lists_all_schema_versions() {
+        let doc_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../flox/doc/manifest.toml.md");
+        let contents = std::fs::read_to_string(&doc_path).expect("failed to read manifest.toml.md");
+
+        for version in KnownSchemaVersion::iter() {
+            // V1 uses the legacy "version = 1" format, not "schema-version",
+            // so it's not expected in the valid values list.
+            if version == KnownSchemaVersion::V1 {
+                continue;
+            }
+            let needle = format!("- `{version}`:");
+            assert!(
+                contents.contains(&needle),
+                "manifest.toml.md is missing schema version {version}.\n\
+                 Expected to find a line like: {needle}\n\
+                 Update the 'Valid string values' list in cli/flox/doc/manifest.toml.md."
+            );
+        }
+    }
+}
+
 #[cfg(any(test, feature = "tests"))]
 pub mod test_helpers {
     use super::*;


### PR DESCRIPTION
## Disclaimer

Hi, i just wanted to improve a couple of things(along with 'bpaf' fix for #3411), will gladly improve/iterate on this PR. This wasn't hand-written, but resulting code and tests looks good to me.

## Summary

- Adds a test that checks `manifest.toml.md` documents all `KnownSchemaVersion` variants using the `schema-version` key
- If a new schema version is added but not documented, the test fails with a clear message pointing to the file to update

Closes #4073

## Test plan

- [x] Test passes with current schema versions
- [x] Verified test would fail if a version entry is removed from the man page