### PR TITLE
chore(agents): Add rules for flox-manifest crate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,48 @@ FLOX_ACTIVATE_TRACE=1 result/bin/flox activate [args]
 - **Commits:** Conventional commits format (`feat:`, `fix:`, `chore:`, etc.). Use `cz commit` for interactive commits
 - **Rust 2024 edition** for main crates
 
+## Manifest usage (`flox-manifest` crate)
+
+The `flox-manifest` crate uses a type-state pattern (`Manifest<S>`) to enforce
+correct manifest lifecycle at compile time. Follow these rules strictly.
+
+- **New schema version for shape changes** - any change to the manifest schema
+  (adding, removing, or renaming fields/sections/tables) requires creating a
+  new schema version. Never modify an existing schema version's structure.
+
+- **Adding new schemas** - copy the latest `flox-manifest/src/parsed/v*.rs` to
+  a new version file and duplicate modified leaf types. Unmodified types
+  continue to live in `parsed::common` or their respective version.
+
+- **Always use `Manifest` constructors** - don't pass manifest content as
+  `String` or deserialize into inner types directly (e.g.
+  `toml_edit::de::from_str::<ManifestLatest>()`). Any manifest read from disk
+  or received as text must be migrated. Use the typed constructors:
+  - `Manifest::read_typed(path)` / `Manifest::parse_toml_typed(s)` →
+    `Manifest<Validated>`
+  - `Manifest::read_and_migrate(path, lockfile)` /
+    `Manifest::parse_and_migrate(s, lockfile)` → `Manifest<Migrated>`
+  - `Manifest::parse_json(s)` for lockfile-embedded manifests →
+    `Manifest<TypedOnly>`
+
+- **Never serialize manifests by hand** - don't use
+  `toml_edit::ser::to_string()` on inner types. Use
+  `manifest.as_writable().to_string()` or
+  `manifest.as_writable().write_to_file(path)`, which handle schema version
+  selection and format preservation.
+
+- **Use trait methods, not inner type access** - prefer trait methods
+  (`CommonFields`, `PackageLookup`, `SchemaVersion`, `AsLatestSchema`) over
+  extracting and mutating inner types directly. Only use
+  `as_latest_schema()` / `as_latest_schema_mut()` when you genuinely need
+  latest-schema-specific fields.
+
+- **Tests: use test helpers** (behind `feature = "tests"`):
+  - `flox_manifest::raw::test_helpers`: `mk_test_manifest_from_contents()`,
+    `empty_test_migrated_manifest()`
+  - `flox_manifest::test_helpers`: `with_latest_schema("body")` to prepend
+    the correct schema version to TOML content strings
+
 ## IDE Setup
 
 For rust-analyzer, add to `.vscode/settings.json`:


### PR DESCRIPTION
## Proposed Changes

Claude is really eager to undo some of the intentions of the manifest refactor work. Specifically:

- in the Claude rebase of "uninstall outputs" it changed a CLI struct from `Manifest<Migrated>` to `String`
- in a Claude plan for "minimum-cli-version" it preferred to use `Manifest<Migrated>::pre_migration_manifest` and `inner_manifest` types

I've attempted to glean some rules to prevent those kinds of regressions based on this doc:

- https://www.notion.so/floxdev/Manifest-rework-2f5744c8e316806295e3c5acbbdd3993

I was in two minds about whether we should instead, or also, write this into crate or `CONTRIBUTING.md` docs, since it will affect other contributors too and the original changes were mostly socialised amongst the small group of people that worked on the refactor. This seems like a good place to start though even if it's only picked up by agentic code reviews.


## Release Notes

N/A