### PR TITLE
feat(auth): display verification URL during login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio 1.0.2",
  "parking_lot",
  "rustix 1.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ chrono = { version = "0.4.43", features = ["serde"] }
 clap = { version = "4.5.56", features = ["derive"] }
 close_fds = "0.3"
 config = { version = "0.15", default-features = false, features = ["toml"] }
-crossterm = "0.29"
+crossterm = { version = "0.29", features = ["event-stream"] }
 derive_more = { version = "2.1.1", features= ["as_ref", "deref", "deref_mut", "display", "from", "from_str"]}
 dirs = "6.0.0"
 enum_dispatch = "0.3.13"

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -1,6 +1,3 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use chrono::offset::Utc;
@@ -36,7 +33,7 @@ use url::Url;
 
 use crate::commands::general::update_config;
 use crate::config::Config;
-use crate::utils::dialog::{Checkpoint, Dialog};
+use crate::utils::dialog::{Checkpoint, Dialog, WaitResult};
 use crate::utils::message;
 use crate::utils::openers::Browser;
 use crate::{Exit, subcommand_metric};
@@ -122,8 +119,6 @@ pub async fn authorize(client: ConfiguredClient, floxhub_url: &Url) -> Result<Cr
 
     let opener = Browser::detect();
 
-    let done = Arc::new(AtomicBool::default());
-
     let verification_uri = details
         .verification_uri_complete()
         .expect("Verification URI is always provided by the auth server")
@@ -131,12 +126,24 @@ pub async fn authorize(client: ConfiguredClient, floxhub_url: &Url) -> Result<Cr
         .as_str();
     let code = details.user_code().secret();
 
-    match opener {
+    // Start token polling — shared by both the browser and no-browser paths.
+    let token_future = client.exchange_device_access_token(&details).request_async(
+        &http_client,
+        tokio::time::sleep,
+        Some(details.expires_in()),
+    );
+    tokio::pin!(token_future);
+
+    let token_result = match opener {
         Ok(opener) => {
             let message = formatdoc! {"
+            Logging in to {url}
             Your one-time activation code is: {code}
 
-            Press enter to open {url} in your browser...
+            Open this URL in any browser:
+            {verification_uri}
+
+            Or press Enter to open your default browser...
             ",
                 url = floxhub_url.host_str().unwrap_or(floxhub_url.as_str()),
             };
@@ -146,20 +153,37 @@ pub async fn authorize(client: ConfiguredClient, floxhub_url: &Url) -> Result<Cr
                 details.expires_in().as_secs()
             );
 
-            Dialog {
+            let enter_future = Dialog {
                 message: &message,
                 help_message: None,
                 typed: Checkpoint,
             }
-            .checkpoint()?;
+            .checkpoint_async();
+            tokio::pin!(enter_future);
 
-            let mut command = opener.to_command();
-            command.arg(verification_uri);
+            // Race token polling against Enter-key listening.
+            //   - Enter pressed  → open the browser, then await the token
+            //   - Token received → drop enter_future (RawModeGuard cleans up)
+            //   - Ctrl-C         → bail with cancellation message
+            tokio::select! {
+                enter_result = &mut enter_future => {
+                    if enter_result == WaitResult::Interrupted {
+                        bail!("Authentication cancelled.");
+                    }
 
-            if command.spawn().is_err() {
-                message::warning(format!(
-                    "Could not open browser. Please open the following URL manually: {verification_uri}"
-                ));
+                    let mut command = opener.to_command();
+                    command.arg(verification_uri);
+                    if command.spawn().is_err() {
+                        message::warning(format!(
+                            "Could not open browser. \
+                             Please open the following URL manually: \
+                             {verification_uri}"
+                        ));
+                    }
+
+                    token_future.await
+                },
+                token_result = &mut token_future => token_result,
             }
         },
         Err(e) => {
@@ -171,26 +195,22 @@ pub async fn authorize(client: ConfiguredClient, floxhub_url: &Url) -> Result<Cr
             Your one-time activation code is: {code}
             "
             });
-        },
-    }
 
-    let token_result = client
-        .exchange_device_access_token(&details)
-        .request_async(&http_client, tokio::time::sleep, Some(details.expires_in()))
-        .await;
+            token_future.await
+        },
+    };
 
     let token = match token_result {
-        Err(RequestTokenError::ServerResponse(r))
+        Err(RequestTokenError::ServerResponse(ref r))
             if r.error() == &DeviceCodeErrorResponseType::ExpiredToken =>
         {
             bail!(
-                "failed to authenticate before the device code expired. Please retry to get a new code."
+                "failed to authenticate before the device code expired. \
+                 Please retry to get a new code."
             );
         },
         _ => token_result?,
     };
-
-    done.store(true, Ordering::Relaxed);
 
     Ok(Credential {
         token: token.access_token().secret().to_string(),

--- a/cli/flox/src/utils/dialog.rs
+++ b/cli/flox/src/utils/dialog.rs
@@ -1,9 +1,77 @@
 use std::fmt::Display;
 use std::io::IsTerminal;
 
+use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::terminal;
+use futures::StreamExt;
 use inquire::ui::{Attributes, RenderConfig, StyleSheet, Styled};
 
-use super::{TERMINAL_STDERR, colors};
+use super::{TERMINAL_STDERR, colors, message};
+
+/// Outcome of waiting for the user to press Enter.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WaitResult {
+    /// The user pressed Enter.
+    Enter,
+    /// The user pressed Ctrl-C.
+    Interrupted,
+}
+
+/// RAII guard that disables terminal raw mode on drop.
+///
+/// Ensures `disable_raw_mode()` is called even if the caller panics,
+/// preventing the terminal from being left in a corrupted state.
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn enable() -> std::io::Result<Self> {
+        terminal::enable_raw_mode()?;
+        Ok(RawModeGuard)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        // Best-effort: ignore errors on cleanup
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+/// Wait for the user to press Enter or Ctrl-C.
+///
+/// Returns [`WaitResult::Enter`] when Enter is pressed,
+/// or [`WaitResult::Interrupted`] when Ctrl-C is pressed or the
+/// event stream ends unexpectedly.
+async fn wait_for_enter() -> WaitResult {
+    // Enable raw mode so we receive individual keystrokes.
+    // The guard ensures raw mode is disabled on any exit path.
+    let _guard = match RawModeGuard::enable() {
+        Ok(g) => g,
+        Err(_) => return WaitResult::Interrupted,
+    };
+
+    let mut reader = EventStream::new();
+
+    while let Some(event) = reader.next().await {
+        match event {
+            Ok(Event::Key(KeyEvent {
+                code: KeyCode::Enter,
+                ..
+            })) => return WaitResult::Enter,
+            Ok(Event::Key(KeyEvent {
+                code: KeyCode::Char('c'),
+                modifiers,
+                ..
+            })) if modifiers.contains(KeyModifiers::CONTROL) => {
+                return WaitResult::Interrupted;
+            },
+            _ => {},
+        }
+    }
+
+    // Stream ended without a recognized key — treat as interruption.
+    WaitResult::Interrupted
+}
 
 #[allow(unused)]
 #[derive(Debug, Clone)]
@@ -15,6 +83,7 @@ pub struct Select<T> {
     pub options: Vec<T>,
 }
 
+/// Marker type for a dialog that waits for the user to press Enter.
 #[derive(Debug, Clone)]
 pub struct Checkpoint;
 
@@ -23,6 +92,17 @@ pub struct Dialog<'a, Type> {
     pub message: &'a str,
     pub help_message: Option<&'a str>,
     pub typed: Type,
+}
+
+impl Dialog<'_, Checkpoint> {
+    /// Print the dialog message and wait for the user to press Enter.
+    ///
+    /// Returns [`WaitResult::Enter`] when Enter is pressed,
+    /// or [`WaitResult::Interrupted`] when Ctrl-C is pressed.
+    pub async fn checkpoint_async(self) -> WaitResult {
+        message::plain(self.message);
+        wait_for_enter().await
+    }
 }
 
 impl Dialog<'_, Confirm> {
@@ -49,32 +129,6 @@ impl Dialog<'_, Confirm> {
         })
         .await
         .expect("Failed to join blocking dialog")
-    }
-}
-
-impl Dialog<'_, Checkpoint> {
-    /// Print the message and wait for the user to press enter
-    pub fn checkpoint(self) -> inquire::error::InquireResult<()> {
-        let message = self.message;
-        let help_message = self.help_message;
-
-        let _stderr_lock = TERMINAL_STDERR.lock();
-
-        let dialog = inquire::CustomType {
-            message,
-            default: None,
-            placeholder: None,
-            help_message,
-            starting_input: None,
-            formatter: &|()| "".to_string(),
-            default_value_formatter: &|()| "".to_string(),
-            parser: &|_| Ok(()),
-            validators: vec![],
-            error_message: "".to_string(),
-            render_config: flox_theme(),
-        };
-
-        dialog.prompt()
     }
 }
 


### PR DESCRIPTION
## Summary
- Show the verification URL in the `flox auth login` prompt so users can copy it to any browser
- Helps users with multiple GitHub accounts authenticate with the right one (e.g., copy URL to incognito or a different browser profile)
- Default behavior unchanged — pressing Enter still opens the system browser
