### PR TITLE
fix(publish): Check for untracked .flox/*

### DIFF
--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -91,6 +91,8 @@ pub trait GitProvider: Sized + std::fmt::Debug {
     fn status(&self) -> Result<StatusInfo, Self::StatusError>;
     fn checkout(&self, name: &str, orphan: bool) -> Result<(), Self::CheckoutError>;
     fn list_branches(&self) -> Result<Vec<BranchInfo>, Self::ListBranchesError>;
+    /// List untracked and non-ignored files under the given path.
+    fn list_files_untracked(&self, path: &Path) -> Result<Vec<String>, GitCommandError>;
     fn rename_branch(&self, new_name: &str) -> Result<(), Self::RenameError>;
     fn remote_branches_containing_revision(
         &self,
@@ -1154,6 +1156,20 @@ impl GitProvider for GitCommandProvider {
         Ok(info)
     }
 
+    fn list_files_untracked(&self, path: &Path) -> Result<Vec<String>, GitCommandError> {
+        let mut command = self.new_command();
+        command.args(["ls-files", "--others", "--exclude-standard", "-z", "--"]);
+        command.arg(path);
+        let output = GitCommandProvider::run_command(&mut command)?;
+        let stdout = output.to_string_lossy();
+        let files = stdout
+            .split('\0')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        Ok(files)
+    }
+
     fn fetch(&self) -> Result<(), Self::FetchError> {
         GitCommandProvider::run_command(self.new_command().arg("fetch").arg("--all"))?;
         Ok(())
@@ -1866,6 +1882,42 @@ pub mod tests {
         .unwrap_err();
 
         assert!(matches!(dbg!(err), GitRemoteCommandError::AccessDenied));
+    }
+
+    #[test]
+    fn list_files_untracked_returns_untracked_and_excludes_gitignored() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+
+        let subdir = repo.path.join("subdir");
+        fs::create_dir(&subdir).unwrap();
+        commit_file(&repo, "subdir/tracked");
+        fs::write(subdir.join("untracked"), "u").unwrap();
+        fs::write(subdir.join("ignored"), "i").unwrap();
+        fs::write(subdir.join(".gitignore"), "ignored\n").unwrap();
+
+        let mut result = repo.list_files_untracked(&subdir).unwrap();
+        result.sort();
+        assert_eq!(result, vec![
+            "subdir/.gitignore".to_string(),
+            "subdir/untracked".to_string(),
+        ]);
+    }
+
+    #[test]
+    fn list_files_untracked_empty_when_all_tracked() {
+        let (repo, _tempdir_handle) = init_temp_repo(false);
+        repo.checkout("branch_1", true).unwrap();
+
+        let subdir = repo.path.join("subdir");
+        fs::create_dir(&subdir).unwrap();
+        let tracked = subdir.join("tracked");
+        fs::write(&tracked, "t").unwrap();
+        repo.add(&[&tracked]).unwrap();
+        repo.commit("add tracked").unwrap();
+
+        let result = repo.list_files_untracked(&subdir).unwrap();
+        assert_eq!(result, Vec::<String>::new());
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -24,6 +24,7 @@ use flox_manifest::lockfile::Lockfile;
 use git_url_parse::GitUrl;
 use indexmap::IndexSet;
 use indoc::{formatdoc, indoc};
+use itertools::Itertools;
 use nef_lock_catalog::LockOptions;
 use nef_lock_catalog::lock::{NixFlakeref, lock_url_with_options};
 use serde_json::json;
@@ -953,6 +954,33 @@ pub fn build_repo_err(msg: &str) -> PublishError {
     PublishError::UnsupportedEnvironmentState(build_repo_err_msg(msg))
 }
 
+/// Verify that the critical environment files are tracked by git.
+/// Publishing creates a clean checkout, so untracked files won't be available.
+fn check_env_files_tracked(
+    git: &impl GitProvider,
+    dot_flox_path: &impl AsRef<Path>,
+) -> Result<(), PublishError> {
+    // Find files in `.flox/` that are untracked and not ignored according to
+    // the rules generated in `.flox/.gitignore`.
+    let untracked_files = git
+        .list_files_untracked(dot_flox_path.as_ref())
+        .map_err(|e| {
+            PublishError::UnsupportedEnvironmentState(format!("Failed to check git tracking: {e}"))
+        })?;
+
+    if !untracked_files.is_empty() {
+        let listing = untracked_files
+            .iter()
+            .map(|path| format!("- {path}"))
+            .join("\n");
+        return Err(build_repo_err(&formatdoc! {"
+            The following environment files are not tracked by git:
+            {listing}",
+        }));
+    }
+    Ok(())
+}
+
 /// Check the local repo that the build source is in to make sure that it's in
 /// a state amenable to publishing an artifact built from it.
 ///
@@ -1079,8 +1107,9 @@ pub fn check_environment_metadata(
         PublishError::UnsupportedEnvironmentState(format!(".flox/ dir not in git repo: {e}"))
     })?;
 
-    let build_repo_meta = gather_build_repo_meta(&git)?;
+    check_env_files_tracked(&git, &dot_flox_path)?;
 
+    let build_repo_meta = gather_build_repo_meta(&git)?;
     let toplevel_catalog_ref = find_toplevel_group_nixpkgs(&lockfile);
 
     Ok(CheckedEnvironmentMetadata {
@@ -1155,6 +1184,7 @@ pub mod tests {
         flox_instance,
         set_test_auth,
     };
+    use crate::models::environment::ENVIRONMENT_POINTER_FILENAME;
     use crate::models::environment::path_environment::PathEnvironment;
     use crate::models::environment::path_environment::test_helpers::new_path_environment_from_env_files_in;
     use crate::providers::auth::{Auth, write_floxhub_netrc};
@@ -1329,6 +1359,40 @@ pub mod tests {
                 .is_ok()
         );
         assert_eq!(build_repo_meta.rev_count, 1);
+    }
+
+    #[test]
+    fn test_check_env_files_tracked_success() {
+        let (flox, _temp_dir_handle) = flox_instance();
+        let (_tempdir_handle, _remote_repo, remote_uri) = example_git_remote_repo();
+        let (env, git) = example_path_environment(&flox, Some(&remote_uri));
+
+        check_env_files_tracked(&git, &env.dot_flox_path())
+            .expect("all env files should be tracked");
+    }
+
+    #[test]
+    fn test_check_env_files_tracked_untracked_file() {
+        let (flox, _temp_dir_handle) = flox_instance();
+        let (_tempdir_handle, _remote_repo, remote_uri) = example_git_remote_repo();
+        let (env, git) = example_path_environment(&flox, Some(&remote_uri));
+
+        let env_json_path = env.dot_flox_path().join(ENVIRONMENT_POINTER_FILENAME);
+        git.rm(&[env_json_path.as_path()], false, false, true)
+            .expect("cached remove of env.json");
+
+        let result = check_env_files_tracked(&git, &env.dot_flox_path());
+        match result {
+            Err(PublishError::UnsupportedEnvironmentState(msg)) => {
+                assert_eq!(
+                    msg,
+                    build_repo_err_msg(indoc! {"
+                    The following environment files are not tracked by git:
+                    - subdir_for_flox_stuff/.flox/env.json"})
+                );
+            },
+            _ => panic!("Expected UnsupportedEnvironmentState error"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Proposed Changes

Prevent the following unclear error message that Jacquie saw when `.flox/env.json` wasn't committed and available in the clean checkout that's used by build via publish:

    ❯ flox publish luckyflox
    ✘ ERROR: The environment is in an unsupported state for publishing: could not find environment pointer file

Check that we have the pointer, manifest, and lockfile, which are all needed to open an environment. The error now looks like this:

    % flox publish -d ~/demo/build
    ✘ ERROR: The environment is in an unsupported state for publishing:
    The following environment files are not tracked by git:
    - .flox/env.json

    The build repository must satisfy a few requirements in order to use the 'flox publish' command:
    - It must be a git repository.
    - All of the tracked files must be in a clean state.
    - A remote must be configured.
    - The current revision must be pushed to a remote.

## Release Notes

Improved error message when `flox publish` is run without tracking `.flox` files.
