### PR TITLE
fix(mcv): Use string values from v1.10.0

### DIFF
--- a/cli/flox-manifest/src/lib.rs
+++ b/cli/flox-manifest/src/lib.rs
@@ -40,7 +40,7 @@ use crate::interfaces::{
 use crate::lockfile::{Lockfile, LockfileError};
 use crate::migrate::{MigrationError, migrate_typed_only, migrate_with_formatting_data};
 use crate::parsed::common::KnownSchemaVersion;
-use crate::parsed::latest::{ManifestLatest, MinimumCliVersion};
+use crate::parsed::latest::ManifestLatest;
 use crate::parsed::v1::ManifestV1;
 use crate::parsed::v1_10_0::ManifestV1_10_0;
 use crate::parsed::v1_11_0::ManifestV1_11_0;
@@ -252,17 +252,6 @@ impl Parsed {
             Parsed::V1_11_0(_) => KnownSchemaVersion::V1_11_0,
         }
     }
-
-    /// Returns the minimum CLI version if present in the manifest.
-    pub(crate) fn minimum_cli_version(&self) -> Option<&MinimumCliVersion> {
-        match self {
-            Parsed::V1(_) => None,
-            // V1_10_0 has minimum_cli_version as Option<String> (not validated semver),
-            // but the feature is only formally supported from v1.11.0 onwards.
-            Parsed::V1_10_0(_) => None,
-            Parsed::V1_11_0(m) => m.minimum_cli_version.as_ref(),
-        }
-    }
 }
 
 /// Type states for the state machine that represents loading, parsing,
@@ -370,11 +359,6 @@ impl Manifest<TomlParsed> {
 }
 
 impl Manifest<Validated> {
-    /// Returns the minimum CLI version if present in the manifest.
-    pub fn minimum_cli_version(&self) -> Option<&MinimumCliVersion> {
-        self.inner.parsed.minimum_cli_version()
-    }
-
     /// Migrate a manifest with an optional lockfile.
     ///
     /// In some cases the lockfile simply isn't present and you stil must migrate.

--- a/cli/flox-manifest/src/parsed/v1_10_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_10_0/mod.rs
@@ -47,7 +47,6 @@ pub struct ManifestV1_10_0 {
     #[serde(rename = "schema-version")]
     pub schema_version: String,
     /// The minimum CLI version that can activate this environment.
-    // NOTE: this field will be used in a later release
     #[serde(rename = "minimum-cli-version")]
     pub minimum_cli_version: Option<String>,
     /// The packages to install in the form of a map from install_id

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -36,6 +36,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use bpaf::{Args, Bpaf, ParseFailure, Parser, ShellComp};
 use flox_core::data::environment_ref::{self, DEFAULT_NAME, RemoteEnvironmentRef};
 use flox_core::vars::FLOX_DISABLE_METRICS_VAR;
+use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::{Manifest, TypedOnly};
 use flox_rust_sdk::flox::{
     DEFAULT_FLOXHUB_URL,
@@ -913,7 +914,16 @@ fn warn_minimum_cli_version(env: &ConcreteEnvironment, flox: &Flox) {
             return;
         },
     };
-    let Some(mcv) = manifest.minimum_cli_version() else {
+    // Migrate without locking because we're in the hot path of other commands
+    // that don't expect locking, either prematurely or at all.
+    let manifest = match manifest.migrate(None) {
+        Ok(m) => m,
+        Err(e) => {
+            debug!("could not migrate manifest for minimum-cli-version check: {e}");
+            return;
+        },
+    };
+    let Some(mcv) = manifest.as_latest_schema().minimum_cli_version.as_ref() else {
         return;
     };
     let min_version = mcv.version();

--- a/cli/tests/minimum-cli-version.bats
+++ b/cli/tests/minimum-cli-version.bats
@@ -76,6 +76,21 @@ You can see the whole manifest with 'flox list --config'.
 EOF
 }
 
+@test "minimum-cli-version: warning for older schema-version" {
+  tomlq --in-place -t \
+    '."schema-version" = "1.10.0" | ."minimum-cli-version" = "99.99.99"' \
+    .flox/env/manifest.toml
+
+  run "$FLOX_BIN" list
+  assert_success
+  assert_output - << EOF
+! This environment requires Flox v99.99.99 or later, you have v${FLOX_CLI_SEMVER}.
+! No packages are installed for your current system ('${NIX_SYSTEM}').
+
+You can see the whole manifest with 'flox list --config'.
+EOF
+}
+
 @test "minimum-cli-version: invalid semver is rejected" {
   tomlq --in-place -t '."minimum-cli-version" = "not.a.version"' .flox/env/manifest.toml
 


### PR DESCRIPTION
## Proposed Changes

Fix a bug in v1.11.0 whereby if you added `minimum-cli-version` in its simple string format without changing `schema-version = "1.10.0"` the warning would be ignored.

This is a combined oddity of the field being added to the previous schema version before being used and other formats supported and wanting to use the value without locking the environment.

Fix it by migrating to the latest schema, which does convert older string values, but don't lock the environment which would cause a handful of other tests to fail as seen in:

- https://github.com/flox/flox/actions/runs/23143365878/job/67228712844
- https://github.com/flox/flox/actions/runs/23143365878/job/67225041042

This also roundabout addresses the concerns in #4094 about whether `Parsed` was the right place to put this getter and means that we don't have to extend the match for every new schema version.

Users still have to bump `schema-version` themselves if they add a field that isn't supported in the current schema, being discussed here:

- https://flox-dev.slack.com/archives/C05P6A5J6U8/p1774371643222979

## Release Notes

Fix a bug in v1.11.0 whereby if you added `minimum-cli-version` in its simple string format without changing `schema-version = "1.10.0"` the warning would be ignored.