### PR TITLE
feat(containerize): chown working-dir

### DIFF
--- a/cli/flox/doc/flox-containerize.md
+++ b/cli/flox/doc/flox-containerize.md
@@ -73,7 +73,9 @@ Configuration for the container image produced by `flox containerize` may be spe
 > `containerize.config` is **experimental**,
 > and its behaviour is subject to change
 
-The following options from the OCI spec are supported, specified in `kebab-case` rather than `PascalCase`:
+The following options from the OCI spec are supported, specified in `kebab-case` rather than `PascalCase`.
+Some options are passed through directly as container image config, while others are also used at container build time.
+See details below.
 ```
 ContainerizeConfig ::= {
   user                      = null | <STRING>
@@ -93,6 +95,7 @@ ContainerizeConfig ::= {
     If `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` and `/etc/group` from the container are applied.
     If `group`/`gid` is specified, supplementary groups from the container are ignored.
     This will add an entry to /etc/passwd and /etc/groups inside the container, so no manual useradd is required.
+    If both `user` and `working-dir` are specified, `working-dir` will be created with `user` as owner.
 
 `exposed-ports`
 :   A set of ports to expose from a container running this image.
@@ -114,6 +117,7 @@ ContainerizeConfig ::= {
 `working-dir`
 :   Sets the current working directory of the entrypoint process in the container.
     This value acts as a default and may be replaced by a working directory specified when creating a container.
+    If both `user` and `working-dir` are specified, `working-dir` will be created with `user` as owner.
 
 `labels`
 :   This field contains arbitrary metadata for the container.

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -411,6 +411,11 @@ EOF
 }
 "SIGKILL"
 EOF
+
+  # Verify working-dir exists and is owned by the specified user
+  run podman run --rm "test:$TAG" stat -c '%U %a' /working/dir
+  assert_success
+  assert_output --partial "user 755"
 }
 
 @test "cmd can run binary from activated environment" {

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -30,6 +30,7 @@ let
   inherit (pkgs.lib)
     optionalAttrs
     optionals
+    optionalString
     toIntBase10
     assertMsg
     isValidPosixName
@@ -42,6 +43,8 @@ let
   containerConfig = fromJSON containerConfigJSON;
 
   nixStoreOwner = (containerConfig.User or "0:0");
+
+  workingDir = (containerConfig.WorkingDir or null);
 
   isNixStoreUserOwnedRegex = "^(root|0):\?(root|0)\?$";
 
@@ -139,6 +142,10 @@ let
       # single user installation inside the container
       fakeRootCommands = ''
         chown -R ${toString nixStoreUserGroup.uid}:${toString nixStoreUserGroup.gid} /run
+      ''
+      + optionalString (workingDir != null) ''
+        mkdir -p -m 0755 "${workingDir}"
+        chown ${toString nixStoreUserGroup.uid}:${toString nixStoreUserGroup.gid} "${workingDir}"
       '';
       enableFakechroot = true;
     }


### PR DESCRIPTION
When both a non-root `user` and `working-dir` are set in `[containerize.config]`, create the working directory with 0755 permissions and chown it to the specified user

When a Dockerfile contains
```
USER app
WORKDIR /app
```

`/app` is created owned by `app`.

Prior to this change, with:
```
[containerize.config]
user = "app"
working-dir = "/app"
```

`flox containerize` leaves `working-dir` owned by root.

Interestingly, Docker leaves `/app` owned by root with inverted order:
```
WORKDIR /app
USER app
```

Although we originally treated config more as passthrough to the OCI container config, we already have some special handling for user and ownership of the Nix store. And I think it's much more likely in practice to need working-dir to be owned by user rather than root.

## Release Notes
When both a non-root `user` and `working-dir` are set in `[containerize.config]`, `working-dir` is created and chown'ed to `user`