### PR TITLE
feat(init): always create lockfile

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -476,6 +476,13 @@ impl PathEnvironment {
             &manifest.as_writable(),
         )?;
 
+        // Lock but don't build
+        let mut env_view = CoreEnvironment::new(
+            environment.path.join(ENV_DIR_NAME),
+            environment.include_fetcher()?,
+        );
+        env_view.lock(flox)?;
+
         Ok(environment)
     }
 
@@ -517,13 +524,15 @@ impl PathEnvironment {
             &manifest.as_writable(),
         )?;
 
-        // Build environment if customization installs at least one package
+        // Always lock
+        let mut env_view = CoreEnvironment::new(
+            environment.path.join(ENV_DIR_NAME),
+            environment.include_fetcher()?,
+        );
+        env_view.lock(flox)?;
+
+        // Build+link only when packages are present
         if matches!(customization.packages.as_deref(), Some([_, ..])) {
-            let mut env_view = CoreEnvironment::new(
-                environment.path.join(ENV_DIR_NAME),
-                environment.include_fetcher()?,
-            );
-            env_view.lock(flox)?;
             let store_paths = env_view.build(flox)?;
             environment.link(&store_paths)?;
         }
@@ -829,6 +838,10 @@ pub mod tests {
             actual.manifest_path(&flox).unwrap().exists(),
             "manifest exists"
         );
+        assert!(
+            actual.lockfile_path(&flox).unwrap().exists(),
+            "lockfile exists"
+        );
         assert!(actual.path.is_absolute());
     }
 
@@ -853,7 +866,6 @@ pub mod tests {
         // build the environment -> out link is created -> no rebuild necessary
         let mut env_view =
             CoreEnvironment::new(env.path.join(ENV_DIR_NAME), env.include_fetcher().unwrap());
-        env_view.lock(&flox).unwrap();
         let store_paths = env_view.build(&flox).unwrap();
         env.link(&store_paths).unwrap();
 

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -105,6 +105,9 @@ EOF
   run ls -A
   assert_output ".flox"
 
+  # Lockfile is created
+  assert [ -e ".flox/env/manifest.lock" ]
+
   # .gitignore ignores run/
   run cat .flox/.gitignore
   assert_success
@@ -238,6 +241,7 @@ EOF
 
 @test "inits with bare manifest" {
   "$FLOX_BIN" init --bare
+  assert [ -e ".flox/env/manifest.lock" ]
   manifest="$("$FLOX_BIN" list -c)"
   expected="$(with_latest_schema "")"
   assert_equal "$manifest" "$expected"

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -493,6 +493,8 @@ EOF
 @test "installing package to bad manifest doesn't update lockfile" {
   unset RUST_BACKTRACE
   "$FLOX_BIN" init -b
+  # Save the lockfile created by init so we can verify install doesn't change it
+  cp "$PWD/.flox/env/manifest.lock" "$PWD/.flox/env/manifest.lock.before"
   cat >"$PWD/.flox/env/manifest.toml" <<- EOF
 version = 1
 
@@ -504,5 +506,5 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml" \
     run "$FLOX_BIN" install hello
   assert_failure
-  assert [ ! -f "$PWD/.flox/env/manifest.lock" ]
+  diff "$PWD/.flox/env/manifest.lock.before" "$PWD/.flox/env/manifest.lock"
 }


### PR DESCRIPTION
- **tests(init): consolidate init integration tests**
  Combine four tests that each run a plain `flox init` and make assertions
  about the result.
  

- **feat(init): always create lockfile**
  Always lock in `flox init` and `flox init --bare`.
  
  - There's no reason not to do this
  - If you immediately include an environment, it needs a lockfile
  - It's annoying if you commit just the manifest and then have to commit the lockfile later
  
  We still only build when init hooks add packages to the manifest. I
  could go either way on building consistently, but decided against it for
  now:
  - It keeps this change more minimal
  - It makes init slower and I don't see much reason we need to do it
  