### PR TITLE
fix: update bpaf to 0.9.24 (#4054)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,18 +609,18 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.9.22"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffe12d9bbc54238745f1749c5a18dc5759e03c235618dd05554a9be350390b1"
+checksum = "b2435ff2f08be8436bdcd06a3de2bd7696fd10e45eb630ecfc09af7fbfa3e69a"
 dependencies = [
  "bpaf_derive",
 ]
 
 [[package]]
 name = "bpaf_derive"
-version = "0.5.21"
+version = "0.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7d8cbf45f5994072fad3eb22761aacbe8752bbe733a247f7d35827556ea057"
+checksum = "549ca9c364fdc06f9f36d1356980193d930abc80db848193c2dd4d0e9a83de1b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 anyhow = "1"
 async-stream = "0.3.6"
 blake3 = "1.8.2"
-bpaf = { version = "0.9.22", features = ["derive", "autocomplete"] }
+bpaf = { version = "0.9.24", features = ["derive", "autocomplete"] }
 catalog-api-v1 = { path = "cli/catalog-api-v1" }
 flox-catalog = { path = "cli/flox-catalog" }
 chrono = { version = "0.4.43", features = ["serde"] }


### PR DESCRIPTION
## Proposed Changes
                                                                     
Update `bpaf` from 0.9.22 to 0.9.24 (and `bpaf_derive` from 0.5.21 to 0.5.23).               
Fixes #4054 

## Release Notes

"N/A"