### PR TITLE
chore(devShell): Remove mitmproxy

### DIFF
--- a/cli/catalog-api-v1/README.md
+++ b/cli/catalog-api-v1/README.md
@@ -33,19 +33,26 @@ Mid-term updating the client library and proposing it as a PR will be done by au
 
 [mitmproxy](https://mitmproxy.org/) can be used to debug requests and responses from the Catalog API.
 
-1. Start the interface and leave it running in a separate terminal:
-    ```
-    nix run github:flox/nixpkgs/stable.20240203#mitmproxy
-    ```
-    Note that `mitmproxy` has been broken on Darwin for some time now,
-    hence the need to run it from an old nixpkgs revision.
-    Of course once we implement catalog binary cache verification
-    then using this will be as simple as `flox install mitmproxy`,
-    but in the meantime we just run it from the most recent stable
-    nixpkgs revision on which it is known to build.
-1. Install the Certificate Authority per [these instructions](https://docs.mitmproxy.org/stable/concepts-certificates/).
-1. Run a `flox` command, using the catalog and the proxy:
+1. Start the interface in one terminal:
 
-        HTTPS_PROXY=http://localhost:8080 SSL_CERT_FILE=~/.mitmproxy/mitmproxy-ca-cert.pem flox show bash
+        flox activate -r dcarley/mitmproxy -- mitmproxy
 
-1. Explore the recorded flows in the `mitmproxy` interface.
+1. Proxy a `flox` command in another terminal:
+
+        % flox activate -r dcarley/mitmproxy
+        ✔ Attached to existing activation of environment 'dcarley/mitmproxy (local)'
+        To stop using this environment, type 'exit'
+
+        Start the proxy in one terminal:
+          mitmproxy    (TUI)
+          mitmweb      (web interface)
+          mitmdump     (non-interactive)
+
+        Then route commands through it with:
+          proxy <command>
+          proxy curl https://example.com
+
+        % proxy flox show bash
+        …
+
+1. Inspect the recorded flows in the first terminal.

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -11,7 +11,6 @@
   krb5,
   lib,
   rustPlatform,
-  mitmproxy,
   mkShell,
   nix-unit,
   nixfmt-rfc-style,
@@ -20,7 +19,6 @@
   procps,
   pstree,
   shfmt,
-  stdenv,
   treefmt,
   writeShellScript,
   yamlfmt,
@@ -50,13 +48,6 @@ let
       treefmt
       yamlfmt
       yq
-    ]
-    ++ lib.optionals stdenv.isLinux [
-      # The python3Packages.mitmproxy-macos package is broken on mac:
-      #   nix-repl> legacyPackages.aarch64-darwin.python3Packages.mitmproxy-macos.meta.broken
-      #   true
-      # ... so only install it on Linux. It's only an optional dev dependency.
-      mitmproxy
     ];
 
   envWrapper = writeShellScript "wrapper" ''


### PR DESCRIPTION
## Proposed Changes

Use from a Flox environment instead of `devShell` because:

- it's not used very frequently
- the instructions were already complicated for macOS
- it blocks an upcoming nixpkgs bump

Referencing my own FloxHub environment for now. It can be forked later if necessary.

## Release Notes

N/A
