### PR TITLE
fix: don't log tokens

### DIFF
--- a/cli/flox-rust-sdk/src/models/floxmeta.rs
+++ b/cli/flox-rust-sdk/src/models/floxmeta.rs
@@ -22,6 +22,7 @@ use crate::utils::{HEADER_DEVICE_UUID, HEADER_INVOCATION_SOURCE, INVOCATION_SOUR
 
 pub const FLOXMETA_DIR_NAME: &str = "meta";
 pub const BRANCH_NAME_PATH_SEPARATOR: &str = ".";
+pub const FLOXHUB_TOKEN_ENV_VAR: &str = "FLOX_FLOXHUB_TOKEN";
 
 #[derive(Debug, Clone)]
 pub struct FloxMeta {
@@ -254,10 +255,10 @@ pub fn floxmeta_git_options(
     //
     // If no token is provided, we still set the credential helper and pass an empty string as password
     // to enforce authentication failures and avoid fallback to pinentry
-    options.add_env_var("FLOX_FLOXHUB_TOKEN", token);
+    options.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token);
     options.add_config_flag(
         &format!("credential.{floxhub_git_url}.helper"),
-        r#"!f(){ echo "username=oauth"; echo "password=$FLOX_FLOXHUB_TOKEN"; }; f"#,
+        format!(r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#),
     );
 
     if let Some(uuid) = metrics_device_uuid {

--- a/cli/flox-rust-sdk/src/providers/auth.rs
+++ b/cli/flox-rust-sdk/src/providers/auth.rs
@@ -67,6 +67,7 @@ pub fn catalog_auth_to_envs(auth: &CatalogAuth) -> Result<HashMap<String, String
         ));
     };
 
+    // If we pass through additional secrets, we should add them to SENSITIVE_ENV_VARS
     let envs = serde_json::from_value(envs_value.clone())
         .map_err(|e| AuthError::CatchAll(format!("Expected 'envs' to be a map: {e}")))?;
 

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -29,6 +29,14 @@ use walkdir;
 use self::errors::IoError;
 use crate::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
 
+/// Environment variable names whose values should be redacted in logs.
+const SENSITIVE_ENV_VARS: &[&str] = &[
+    FLOXHUB_TOKEN_ENV_VAR,
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+];
+
 pub static FLOX_INTERPRETER: LazyLock<PathBuf> = LazyLock::new(|| {
     PathBuf::from(env::var("FLOX_INTERPRETER").unwrap_or(env!("FLOX_INTERPRETER").to_string()))
 });
@@ -132,7 +140,7 @@ impl Display for DisplayCommand<'_> {
                 let v = v.to_string_lossy();
                 let redacted_value = k
                     .to_str()
-                    .and_then(|s| (s == FLOXHUB_TOKEN_ENV_VAR).then_some("***"))
+                    .and_then(|s| SENSITIVE_ENV_VARS.contains(&s).then_some("***"))
                     .unwrap_or(&v);
 
                 format!(

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -27,6 +27,7 @@ use tracing::{debug, trace};
 use walkdir;
 
 use self::errors::IoError;
+use crate::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
 
 pub static FLOX_INTERPRETER: LazyLock<PathBuf> = LazyLock::new(|| {
     PathBuf::from(env::var("FLOX_INTERPRETER").unwrap_or(env!("FLOX_INTERPRETER").to_string()))
@@ -128,10 +129,16 @@ impl Display for DisplayCommand<'_> {
                     return format!("-u {}", k.to_string_lossy());
                 };
 
+                let v = v.to_string_lossy();
+                let redacted_value = k
+                    .to_str()
+                    .and_then(|s| (s == FLOXHUB_TOKEN_ENV_VAR).then_some("***"))
+                    .unwrap_or(&v);
+
                 format!(
                     "{k}={v}",
                     k = k.to_string_lossy(),
-                    v = shell_escape::escape(v.to_string_lossy())
+                    v = shell_escape::escape(redacted_value.into())
                 )
             })
             .peekable();


### PR DESCRIPTION
Redact FLOX_FLOXHUB_TOKEN when logging to log files or verbose output

This now shows up as
```
running git command: env FLOX_FLOXHUB_TOKEN='***' ...
```

## Release Notes
FLOX_FLOXHUB_TOKEN is redacted when logging to log files or verbose output