### PR TITLE
chore: pin GitHub Actions to SHA

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: Add team label automatically to new issues and PRs
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           labels: "team-cli"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,11 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
           limit-access-to-users: ${{ inputs.allowedUptermUsers }}
@@ -98,11 +98,11 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
           limit-access-to-users: ${{ inputs.allowedUptermUsers }}
@@ -141,11 +141,11 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
           limit-access-to-users: ${{ inputs.allowedUptermUsers }}
@@ -162,7 +162,7 @@ jobs:
           SSH_KEY: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
 
       - name: "Cache Cargo"
-        uses: "actions/cache@v5"
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -184,7 +184,7 @@ jobs:
         run: nix develop -L --no-update-lock-file --command just impure-tests
 
       - name: "Upload CLI Unit Test Results"
-        uses: "codecov/test-results-action@v1"
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         if: ${{ !cancelled() && steps.unit-tests.outcome != 'skipped' }}
         with:
           disable_search: true
@@ -228,14 +228,14 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         # needed for git describe to work
         with:
           fetch-depth: 0
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
           limit-access-to-users: ${{ inputs.allowedUptermUsers }}
@@ -257,7 +257,7 @@ jobs:
           SETUP_NIX: "false"
 
       - name: "Configure AWS Credentials"
-        uses: "aws-actions/configure-aws-credentials@v6"
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: "arn:aws:iam::759020684799:role/github-oidc-role-flox-cache-public"
           role-session-name: "${{ github.run_id }}"
@@ -306,13 +306,13 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
           limit-access-to-users: ${{ inputs.allowedUptermUsers }}
@@ -334,7 +334,7 @@ jobs:
           SETUP_NIX: "false"
 
       - name: "Configure AWS Credentials"
-        uses: "aws-actions/configure-aws-credentials@v6"
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: "arn:aws:iam::759020684799:role/github-oidc-role-flox-cache-public"
           role-session-name: "${{ github.run_id }}"
@@ -369,7 +369,7 @@ jobs:
     steps:
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
           limit-access-to-users: ${{ inputs.allowedUptermUsers }}
@@ -377,7 +377,7 @@ jobs:
 
       - name: "Trigger flox-installers workflow"
         id: "trigger-workflow"
-        uses: "convictional/trigger-workflow-and-wait@v1.6.5"
+        uses: convictional/trigger-workflow-and-wait@f69fa9eedd3c62a599220f4d5745230e237904be # v1.6.5
         with:
           owner: "flox"
           repo: "flox-installers"
@@ -405,7 +405,7 @@ jobs:
           cat shipit.json | jq
 
       - name: "Upload artifact"
-        uses: "actions/upload-artifact@v7"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: ${{ success() || failure() }}
         with:
           name: "shipit"
@@ -428,14 +428,14 @@ jobs:
     steps:
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
           limit-access-to-users: ${{ inputs.allowedUptermUsers }}
           wait-timeout-minutes: 15
 
       - name: "Slack Notification"
-        uses: "rtCamp/action-slack-notify@v2"
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_TITLE: "Something broke CI for flox/flox on ${{ github.ref_name }}"
           SLACK_FOOTER: "Thank you for caring"
@@ -482,11 +482,11 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
         with:
           limit-access-to-actor: true
           limit-access-to-users: ${{ inputs.allowedUptermUsers }}
@@ -514,7 +514,7 @@ jobs:
         run: ./.github/scripts/remote-execute-integration-tests.sh
 
       - name: "Upload Bats Tests results"
-        uses: "codecov/test-results-action@v1"
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         if: ${{ !cancelled() }}
         with:
           disable_search: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,16 +28,16 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@bee87b3258c251f9279e5371b0cc3660f37f3f77 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -66,16 +66,16 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@bee87b3258c251f9279e5371b0cc3660f37f3f77 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # This is an optional setting that allows Claude to read CI results on PRs

--- a/.github/workflows/nix-managed-lints.yml
+++ b/.github/workflows/nix-managed-lints.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup Nix"
         uses: "./.github/actions/common-setup"


### PR DESCRIPTION
## Summary

- Pin all external action references to immutable commit SHAs
- Dependabot `github-actions` ecosystem already configured

## Why

Actions referenced by tag or branch are mutable and vulnerable to
supply chain attacks. Pinning to SHA ensures CI runs exactly the code
reviewed, not whatever a tag points to at runtime.

## What changed

All workflow files updated. Every external `uses:` now references a
SHA with version comment. No logic changes.

## Test plan

- [ ] CI passes on this PR

Tracking: https://github.com/flox/product/issues/1302