### PR TITLE
chore: fix review plugin installation in CI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,0 @@
-{
-  "enabledPlugins": {
-    "code-review@claude-plugins-official": true
-  }
-}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,4 +32,5 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: '--dangerously-skip-permissions'
-          prompt: '/code-review:code-review --comment'
+          plugins: 'code-review@claude-plugins-official'
+          prompt: '/code-review:code-review'


### PR DESCRIPTION
The plugin in .claude seems to be ignored in CI. Try using `plugins:` in
the action per
https://github.com/anthropics/claude-code-action/blob/ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae/action.yml#L145-L146

Remove --comment because I think I got that from the wrong README and I
don't see it at
https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review
