### PR TITLE
feat: add Claude Code formatting hook for edited files

### DIFF
--- a/.claude/hooks/format.sh
+++ b/.claude/hooks/format.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook: format a file after Edit/Write
+# Usage: bash format.sh <formatter> [args...]
+# Requires jq and the formatter to be on PATH (e.g. via nix develop).
+# Exits 0 if dependencies are missing so we don't block development outside nix
+# develop.
+
+set -euo pipefail
+
+FORMATTER=("$@")
+
+if ! command -v jq &>/dev/null; then
+  echo "jq not found, skipping - likely not inside nix develop" >&2
+  exit 1
+fi
+
+if ! command -v "${FORMATTER[0]}" &>/dev/null; then
+  echo "${FORMATTER[0]} not found, skipping - likely not inside nix develop" >&2
+  exit 1
+fi
+
+# Extract file path from stdin JSON
+FILE=$(jq -r '.tool_input.file_path')
+
+"${FORMATTER[@]}" "$FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,137 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Edit(*.rs)",
+            "command": ".claude/hooks/format.sh rustfmt --edition 2024",
+            "timeout": 30,
+            "statusMessage": "Formatting Rust..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.rs)",
+            "command": ".claude/hooks/format.sh rustfmt --edition 2024",
+            "timeout": 30,
+            "statusMessage": "Formatting Rust..."
+          },
+          {
+            "type": "command",
+            "if": "Edit(*.nix)",
+            "command": ".claude/hooks/format.sh treefmt",
+            "timeout": 30,
+            "statusMessage": "Formatting Nix..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.nix)",
+            "command": ".claude/hooks/format.sh treefmt",
+            "timeout": 30,
+            "statusMessage": "Formatting Nix..."
+          },
+          {
+            "type": "command",
+            "if": "Edit(*.yml)",
+            "command": ".claude/hooks/format.sh treefmt",
+            "timeout": 30,
+            "statusMessage": "Formatting YAML..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.yml)",
+            "command": ".claude/hooks/format.sh treefmt",
+            "timeout": 30,
+            "statusMessage": "Formatting YAML..."
+          },
+          {
+            "type": "command",
+            "if": "Edit(*.yaml)",
+            "command": ".claude/hooks/format.sh treefmt",
+            "timeout": 30,
+            "statusMessage": "Formatting YAML..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.yaml)",
+            "command": ".claude/hooks/format.sh treefmt",
+            "timeout": 30,
+            "statusMessage": "Formatting YAML..."
+          },
+          {
+            "type": "command",
+            "if": "Edit(*.c)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.c)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Edit(*.h)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.h)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Edit(*.cpp)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.cpp)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Edit(*.c++)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.c++)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Edit(*.hpp)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          },
+          {
+            "type": "command",
+            "if": "Write(*.hpp)",
+            "command": ".claude/hooks/format.sh clang-format -i",
+            "timeout": 30,
+            "statusMessage": "Formatting C/C++..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -7,6 +7,7 @@
   flox-cli,
   flox-nix-plugins,
   hivemind,
+  jq,
   just,
   krb5,
   lib,
@@ -38,6 +39,7 @@ let
       daemonize
       flox-cli-tests
       hivemind
+      jq
       just
       nix-unit
       nixfmt-rfc-style


### PR DESCRIPTION
Automatically runs the appropriate formatter (rustfmt, treefmt, clang-format)
on files after Claude edits them via a PostToolUse hook.

Skip if jq or the formatter is not available, so we don't block working
outside of a devShell.

I considered moving Rust formatting to treefmt but it was slower, which
matters more for a hook run repeatedly.
Probably not a big deal, but it was enough to convince me not to make
the change right now.

With:
```
[formatter.rust]
command = "rustfmt"
options = [ "--edition", "2024" ]
includes = [ "*.rs" ]
```

```
> hyperfine --prepare "cp cli/flox/src/commands/activate.rs.badfmt cli/flox/src/commands/activate.rs" "rustfmt --edition 2024 cli/flox/src/commands/activate.rs"
Benchmark 1: rustfmt --edition 2024 cli/flox/src/commands/activate.rs
  Time (mean ± σ):      28.4 ms ±  36.2 ms    [User: 12.6 ms, System: 6.8 ms]
  Range (min … max):    17.3 ms … 163.3 ms    16 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (163.3 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--prepare' option which can be used to clear caches. If you did not use a cache-clearing command with '--prepare', you can either try that or consider using the '--warmup' option to fill those caches before the actual benchmark.

> hyperfine --prepare "cp cli/flox/src/commands/activate.rs.badfmt cli/flox/src/commands/activate.rs" "treefmt cli/flox/src/commands/activate.rs"
Benchmark 1: treefmt cli/flox/src/commands/activate.rs
  Time (mean ± σ):      76.4 ms ±  68.1 ms    [User: 21.7 ms, System: 16.5 ms]
  Range (min … max):    48.0 ms … 267.6 ms    10 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (267.6 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--prepare' option which can be used to clear caches. If you did not use a cache-clearing command with '--prepare', you can either try that or consider using the '--warmup' option to fill those caches before the actual benchmark.
```
