### PR TITLE
feat(activate): exclude sbin from PATH by default; add --add-sbin opt-in (ENT-17)

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -183,8 +183,17 @@ if [ "$_command_mode" = "true" ]; then
 
   # shellcheck disable=SC1090
   source <("$_flox_activations" set-env-dirs --shell bash --flox-env "$_FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
+
+  # Build fix-paths invocation, conditionally adding --add-sbin when the
+  # Rust-side caller set _FLOX_ADD_SBIN=true (from the `--add-sbin` CLI flag
+  # or the manifest's `options.activate.add-sbin` setting).
+  _flox_fix_paths_args=(fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")
+  if [ "${_FLOX_ADD_SBIN:-}" = "true" ]; then
+    _flox_fix_paths_args+=(--add-sbin)
+  fi
   # shellcheck disable=SC1090
-  source <("$_flox_activations" fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")
+  source <("$_flox_activations" "${_flox_fix_paths_args[@]}")
+  unset _flox_fix_paths_args
 fi
 
 if [ "$_command_mode" = "false" ]; then

--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -120,8 +120,7 @@ fi
 # prepend path
 # Honor the same _FLOX_ADD_SBIN signal that the main activate script uses
 # (set by the Rust caller from the CLI flag / manifest option). Defaults to
-# excluding sbin so that e.g. BusyBox's sbin binaries don't shadow other
-# packages' bin entries.
+# excluding sbin.
 if [ "${_FLOX_ADD_SBIN:-}" = "true" ]; then
   export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin:$PATH"
 else

--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -118,7 +118,15 @@ if [ -z "${FLOX_ENV-}" ]; then
 fi
 
 # prepend path
-export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin:$PATH"
+# Honor the same _FLOX_ADD_SBIN signal that the main activate script uses
+# (set by the Rust caller from the CLI flag / manifest option). Defaults to
+# excluding sbin so that e.g. BusyBox's sbin binaries don't shadow other
+# packages' bin entries.
+if [ "${_FLOX_ADD_SBIN:-}" = "true" ]; then
+  export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin:$PATH"
+else
+  export PATH="$FLOX_ENV/bin:$PATH"
+fi
 
 if [ "${SET_VARS-}" = "1" ]; then
  # Set static environment variables from the manifest.

--- a/cli/flox-activations/src/activate_script_builder.rs
+++ b/cli/flox-activations/src/activate_script_builder.rs
@@ -161,7 +161,13 @@ fn add_old_activate_script_exports(
         removals.push("FLOX_ENV_PROJECT");
     }
 
-    exports.extend(fixed_vars_to_export(&context.env, vars_from_environment));
+    exports.insert("_FLOX_ADD_SBIN", context.add_sbin.to_string());
+
+    exports.extend(fixed_vars_to_export(
+        &context.env,
+        vars_from_environment,
+        context.add_sbin,
+    ));
 
     command.envs(&exports);
     for var in &removals {
@@ -173,6 +179,7 @@ fn add_old_activate_script_exports(
 fn fixed_vars_to_export(
     flox_env: impl AsRef<str>,
     vars_from_environment: VarsFromEnvironment,
+    add_sbin: bool,
 ) -> HashMap<&'static str, String> {
     let new_flox_env_dirs = fix_env_dirs_var(
         flox_env.as_ref(),
@@ -183,6 +190,7 @@ fn fixed_vars_to_export(
     let new_path = fix_path_var(
         &new_flox_env_dirs,
         &vars_from_environment.path.unwrap_or("".to_string()),
+        add_sbin,
     );
     let new_manpath = fix_manpath_var(
         &new_flox_env_dirs,

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -487,6 +487,7 @@ mod test {
             flox_prompt_environments: "".to_string(),
             set_prompt: false,
             flox_env_cuda_detection: "".to_string(),
+            add_sbin: false,
             flox_active_environments: "".to_string(),
         };
         let project = AttachProjectCtx {

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -22,15 +22,18 @@ pub struct FixPathsArgs {
     #[arg(help = "The contents of MANPATH.")]
     #[arg(short, long, value_name = "STRING")]
     pub manpath: String,
+    #[arg(help = "Include $FLOX_ENV/sbin directories in PATH.")]
+    #[arg(long, default_value_t = false)]
+    pub add_sbin: bool,
 }
 
 impl FixPathsArgs {
     pub fn handle_inner(&self, output: &mut impl Write) -> Result<(), anyhow::Error> {
         debug!(
-            "Preparing to fix path vars, FLOX_ENV_DIRS={}",
-            self.env_dirs
+            "Preparing to fix path vars, FLOX_ENV_DIRS={}, add_sbin={}",
+            self.env_dirs, self.add_sbin
         );
-        let new_path = fix_path_var(&self.env_dirs, &self.path);
+        let new_path = fix_path_var(&self.env_dirs, &self.path, self.add_sbin);
         let new_manpath = fix_manpath_var(&self.env_dirs, &self.manpath);
         let sourceable_commands = match self.shell.as_ref() {
             "bash" => {
@@ -121,11 +124,16 @@ pub fn prepend_dirs_to_pathlike_var(
 }
 
 /// Calculate the new PATH variable from FLOX_ENV_DIRS and the existing PATH.
-pub fn fix_path_var(flox_env_dirs_var: &str, path_var: &str) -> String {
+///
+/// When `add_sbin` is `true`, both `bin` and `sbin` subdirectories of each
+/// FLOX_ENV_DIRS entry are prepended. When `false`, only `bin` is prepended
+/// so that `sbin` binaries don't shadow binaries from other packages (e.g.
+/// BusyBox's `sbin/ifconfig` shadowing a dedicated networking package).
+pub fn fix_path_var(flox_env_dirs_var: &str, path_var: &str, add_sbin: bool) -> String {
     let path_dirs = separate_dir_list(path_var);
     let flox_env_dirs = separate_dir_list(flox_env_dirs_var);
-    let suffixes = ["bin", "sbin"];
-    let fixed_path_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs);
+    let suffixes: &[&str] = if add_sbin { &["bin", "sbin"] } else { &["bin"] };
+    let fixed_path_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, suffixes, &path_dirs);
     join_dir_list(fixed_path_dirs)
 }
 
@@ -269,6 +277,7 @@ mod test {
                 env_dirs: env_dirs.to_string(),
                 path: path.to_string(),
                 manpath: manpath.to_string(),
+                add_sbin: false,
             }
             .handle_inner(&mut buf)
             .unwrap();
@@ -295,6 +304,25 @@ mod test {
     }
 
     #[test]
+    fn sbin_excluded_by_default() {
+        let env_dirs = "/flox_env1:/flox_env2";
+        let path = "/path1:/path2";
+        let fixed = fix_path_var(env_dirs, path, false);
+        assert_eq!(fixed, "/flox_env1/bin:/flox_env2/bin:/path1:/path2");
+    }
+
+    #[test]
+    fn sbin_included_when_add_sbin_true() {
+        let env_dirs = "/flox_env1:/flox_env2";
+        let path = "/path1:/path2";
+        let fixed = fix_path_var(env_dirs, path, true);
+        assert_eq!(
+            fixed,
+            "/flox_env1/bin:/flox_env1/sbin:/flox_env2/bin:/flox_env2/sbin:/path1:/path2"
+        );
+    }
+
+    #[test]
     fn handles_blank_manpath() {
         let env_dirs = "/env1:/env2";
         let manpath = "";
@@ -315,9 +343,9 @@ mod test {
         let env_dirs = "/env1:/env2";
         let path = "/foo:/bar";
         let manpath = "/baz:/qux";
-        let fixed_path = fix_path_var(env_dirs, path);
+        let fixed_path = fix_path_var(env_dirs, path, true);
         let fixed_manpath = fix_manpath_var(env_dirs, manpath);
-        let fixed_path_again = fix_path_var(env_dirs, &fixed_path);
+        let fixed_path_again = fix_path_var(env_dirs, &fixed_path, true);
         let fixed_manpath_again = fix_manpath_var(env_dirs, &fixed_manpath);
         assert_eq!(fixed_path, fixed_path_again);
         assert_eq!(fixed_manpath, fixed_manpath_again);

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -127,8 +127,7 @@ pub fn prepend_dirs_to_pathlike_var(
 ///
 /// When `add_sbin` is `true`, both `bin` and `sbin` subdirectories of each
 /// FLOX_ENV_DIRS entry are prepended. When `false`, only `bin` is prepended
-/// so that `sbin` binaries don't shadow binaries from other packages (e.g.
-/// BusyBox's `sbin/ifconfig` shadowing a dedicated networking package).
+/// so that `sbin` binaries don't shadow binaries from other packages.
 pub fn fix_path_var(flox_env_dirs_var: &str, path_var: &str, add_sbin: bool) -> String {
     let path_dirs = separate_dir_list(path_var);
     let flox_env_dirs = separate_dir_list(flox_env_dirs_var);

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -38,6 +38,12 @@ pub struct AttachCtx {
     /// CUDA detection enabled
     pub flox_env_cuda_detection: String,
 
+    /// Whether to include `$FLOX_ENV/sbin` directories in PATH when activating.
+    /// Defaults to `false` so that `sbin` binaries don't shadow binaries from
+    /// other packages (e.g. BusyBox's `sbin/ifconfig`).
+    #[serde(default)]
+    pub add_sbin: bool,
+
     /// Path to the interpreter (activate scripts)
     pub interpreter_path: PathBuf,
 }

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -40,7 +40,7 @@ pub struct AttachCtx {
 
     /// Whether to include `$FLOX_ENV/sbin` directories in PATH when activating.
     /// Defaults to `false` so that `sbin` binaries don't shadow binaries from
-    /// other packages (e.g. BusyBox's `sbin/ifconfig`).
+    /// other packages.
     #[serde(default)]
     pub add_sbin: bool,
 

--- a/cli/flox-manifest/src/compose/shallow.rs
+++ b/cli/flox-manifest/src/compose/shallow.rs
@@ -316,7 +316,7 @@ impl ManifestMergeTrait for ShallowMerger {
 
         trace!(section = "options", "merging manifest section");
         let (options, options_warnings) =
-            Self::merge_options(low_priority.options(), high_priority.options())?;
+            Self::merge_options(&low_priority.options, &high_priority.options)?;
 
         trace!(section = "services", "merging manifest section");
         let (services, services_warnings) =

--- a/cli/flox-manifest/src/compose/shallow.rs
+++ b/cli/flox-manifest/src/compose/shallow.rs
@@ -13,19 +13,17 @@ use super::{
 use crate::interfaces::CommonFields;
 use crate::parsed::Inner;
 use crate::parsed::common::{
-    ActivateOptions,
     Allows,
     Build,
     Containerize,
     Hook,
     Include,
-    Options,
     Profile,
     SemverOptions,
     Vars,
 };
 use crate::parsed::latest::{Install, ManifestLatest, MinimumCliVersion};
-use crate::parsed::v1_12_0::Services;
+use crate::parsed::v1_12_0::{ActivateOptions, Options, Services};
 
 /// Merges two manifests by applying `manifest2` on top of `manifest1` and
 /// overwriting any conflicts for keys within the top-level of each `ManifestV1`
@@ -195,6 +193,12 @@ impl ShallowMerger {
             high_priority.activate.mode.clone(),
         );
 
+        let (merged_activate_add_sbin, activate_add_sbin_warning) = shallow_merge_options(
+            root_key.extend(["activate", "add-sbin"]),
+            low_priority.activate.add_sbin,
+            high_priority.activate.add_sbin,
+        );
+
         let merged = Options {
             systems: merged_systems,
             allow: Allows {
@@ -208,12 +212,14 @@ impl ShallowMerger {
             cuda_detection: merged_cuda_detection,
             activate: ActivateOptions {
                 mode: merged_activate_mode,
+                add_sbin: merged_activate_add_sbin,
             },
         };
 
         warnings.extend(
             [
                 activate_mode_warning,
+                activate_add_sbin_warning,
                 allow_unfree_warning,
                 allow_broken_warning,
                 allow_licenses_warning,
@@ -518,6 +524,7 @@ mod tests {
             let cuda_detection = options2.cuda_detection.or(options1.cuda_detection);
             let activate = ActivateOptions {
                 mode: options2.activate.mode.or(options1.activate.mode),
+                add_sbin: options2.activate.add_sbin.or(options1.activate.add_sbin),
             };
             let expected = Options { systems, allow, semver, cuda_detection, activate };
             prop_assert_eq!(merged, expected);

--- a/cli/flox-manifest/src/interfaces/common_fields.rs
+++ b/cli/flox-manifest/src/interfaces/common_fields.rs
@@ -1,5 +1,18 @@
+use flox_core::activate::mode::ActivateMode;
+use flox_core::data::System;
+
 use crate::{Manifest, Migrated, MigratedTypedOnly, Parsed, TypedOnly, Validated, parsed};
 
+/// Accessors for fields that are shared across all schema versions.
+///
+/// The trait historically exposed `options()` / `options_mut()` returning
+/// `&parsed::common::Options`, but that could not accommodate schema versions
+/// that need to store version-local types nested inside `options` (e.g.
+/// `options.activate.add-sbin` in V1_12_0). Instead the trait exposes
+/// per-field accessors for each option that is actually read or written by
+/// callers. New option fields added in later schema versions should be
+/// surfaced as new trait methods with default impls returning `None`/`false`
+/// so that pre-existing schema versions remain unchanged.
 pub trait CommonFields {
     fn vars(&self) -> &parsed::common::Vars;
     fn hook(&self) -> Option<&parsed::common::Hook>;
@@ -8,7 +21,14 @@ pub trait CommonFields {
     fn include(&self) -> &parsed::common::Include;
     fn build(&self) -> &parsed::common::Build;
     fn containerize(&self) -> Option<&parsed::common::Containerize>;
-    fn options(&self) -> &parsed::common::Options;
+
+    // `options.*` accessors.
+    fn systems(&self) -> Option<&Vec<System>>;
+    fn allows(&self) -> &parsed::common::Allows;
+    fn semver_options(&self) -> &parsed::common::SemverOptions;
+    fn cuda_detection(&self) -> Option<bool>;
+    fn activate_mode(&self) -> Option<&ActivateMode>;
+
     /// Returns whether services should auto-start on activation.
     ///
     /// Returns `false` for all schema versions before V1_12_0.
@@ -25,7 +45,10 @@ pub trait CommonFields {
     fn include_mut(&mut self) -> &mut parsed::common::Include;
     fn build_mut(&mut self) -> &mut parsed::common::Build;
     fn containerize_mut(&mut self) -> Option<&mut parsed::common::Containerize>;
-    fn options_mut(&mut self) -> &mut parsed::common::Options;
+
+    // `options.*` mutable accessors.
+    fn systems_mut(&mut self) -> &mut Option<Vec<System>>;
+    fn activate_mode_mut(&mut self) -> &mut Option<ActivateMode>;
 }
 
 impl CommonFields for Parsed {
@@ -92,12 +115,48 @@ impl CommonFields for Parsed {
         }
     }
 
-    fn options(&self) -> &parsed::common::Options {
+    fn systems(&self) -> Option<&Vec<System>> {
         match self {
-            Parsed::V1(inner) => inner.options(),
-            Parsed::V1_10_0(inner) => inner.options(),
-            Parsed::V1_11_0(inner) => inner.options(),
-            Parsed::V1_12_0(inner) => inner.options(),
+            Parsed::V1(inner) => inner.systems(),
+            Parsed::V1_10_0(inner) => inner.systems(),
+            Parsed::V1_11_0(inner) => inner.systems(),
+            Parsed::V1_12_0(inner) => inner.systems(),
+        }
+    }
+
+    fn allows(&self) -> &parsed::common::Allows {
+        match self {
+            Parsed::V1(inner) => inner.allows(),
+            Parsed::V1_10_0(inner) => inner.allows(),
+            Parsed::V1_11_0(inner) => inner.allows(),
+            Parsed::V1_12_0(inner) => inner.allows(),
+        }
+    }
+
+    fn semver_options(&self) -> &parsed::common::SemverOptions {
+        match self {
+            Parsed::V1(inner) => inner.semver_options(),
+            Parsed::V1_10_0(inner) => inner.semver_options(),
+            Parsed::V1_11_0(inner) => inner.semver_options(),
+            Parsed::V1_12_0(inner) => inner.semver_options(),
+        }
+    }
+
+    fn cuda_detection(&self) -> Option<bool> {
+        match self {
+            Parsed::V1(inner) => inner.cuda_detection(),
+            Parsed::V1_10_0(inner) => inner.cuda_detection(),
+            Parsed::V1_11_0(inner) => inner.cuda_detection(),
+            Parsed::V1_12_0(inner) => inner.cuda_detection(),
+        }
+    }
+
+    fn activate_mode(&self) -> Option<&ActivateMode> {
+        match self {
+            Parsed::V1(inner) => inner.activate_mode(),
+            Parsed::V1_10_0(inner) => inner.activate_mode(),
+            Parsed::V1_11_0(inner) => inner.activate_mode(),
+            Parsed::V1_12_0(inner) => inner.activate_mode(),
         }
     }
 
@@ -173,276 +232,122 @@ impl CommonFields for Parsed {
         }
     }
 
-    fn options_mut(&mut self) -> &mut parsed::common::Options {
+    fn systems_mut(&mut self) -> &mut Option<Vec<System>> {
         match self {
-            Parsed::V1(inner) => inner.options_mut(),
-            Parsed::V1_10_0(inner) => inner.options_mut(),
-            Parsed::V1_11_0(inner) => inner.options_mut(),
-            Parsed::V1_12_0(inner) => inner.options_mut(),
+            Parsed::V1(inner) => inner.systems_mut(),
+            Parsed::V1_10_0(inner) => inner.systems_mut(),
+            Parsed::V1_11_0(inner) => inner.systems_mut(),
+            Parsed::V1_12_0(inner) => inner.systems_mut(),
+        }
+    }
+
+    fn activate_mode_mut(&mut self) -> &mut Option<ActivateMode> {
+        match self {
+            Parsed::V1(inner) => inner.activate_mode_mut(),
+            Parsed::V1_10_0(inner) => inner.activate_mode_mut(),
+            Parsed::V1_11_0(inner) => inner.activate_mode_mut(),
+            Parsed::V1_12_0(inner) => inner.activate_mode_mut(),
         }
     }
 }
 
-impl CommonFields for Manifest<Validated> {
-    fn vars(&self) -> &parsed::common::Vars {
-        self.inner.parsed.vars()
-    }
+/// Forwarding impls for the `Manifest<S>` type-state wrappers. Each delegates
+/// to the underlying `parsed` / `migrated_parsed` which is itself a `Parsed`.
+macro_rules! impl_common_fields_for_manifest {
+    ($state:ty, $field:ident) => {
+        impl CommonFields for Manifest<$state> {
+            fn vars(&self) -> &parsed::common::Vars {
+                self.inner.$field.vars()
+            }
 
-    fn hook(&self) -> Option<&parsed::common::Hook> {
-        self.inner.parsed.hook()
-    }
+            fn hook(&self) -> Option<&parsed::common::Hook> {
+                self.inner.$field.hook()
+            }
 
-    fn profile(&self) -> Option<&parsed::common::Profile> {
-        self.inner.parsed.profile()
-    }
+            fn profile(&self) -> Option<&parsed::common::Profile> {
+                self.inner.$field.profile()
+            }
 
-    fn services(&self) -> &parsed::common::Services {
-        self.inner.parsed.services()
-    }
+            fn services(&self) -> &parsed::common::Services {
+                self.inner.$field.services()
+            }
 
-    fn include(&self) -> &parsed::common::Include {
-        self.inner.parsed.include()
-    }
+            fn include(&self) -> &parsed::common::Include {
+                self.inner.$field.include()
+            }
 
-    fn build(&self) -> &parsed::common::Build {
-        self.inner.parsed.build()
-    }
+            fn build(&self) -> &parsed::common::Build {
+                self.inner.$field.build()
+            }
 
-    fn containerize(&self) -> Option<&parsed::common::Containerize> {
-        self.inner.parsed.containerize()
-    }
+            fn containerize(&self) -> Option<&parsed::common::Containerize> {
+                self.inner.$field.containerize()
+            }
 
-    fn options(&self) -> &parsed::common::Options {
-        self.inner.parsed.options()
-    }
+            fn systems(&self) -> Option<&Vec<System>> {
+                self.inner.$field.systems()
+            }
 
-    fn vars_mut(&mut self) -> &mut parsed::common::Vars {
-        self.inner.parsed.vars_mut()
-    }
+            fn allows(&self) -> &parsed::common::Allows {
+                self.inner.$field.allows()
+            }
 
-    fn hook_mut(&mut self) -> Option<&mut parsed::common::Hook> {
-        self.inner.parsed.hook_mut()
-    }
+            fn semver_options(&self) -> &parsed::common::SemverOptions {
+                self.inner.$field.semver_options()
+            }
 
-    fn profile_mut(&mut self) -> Option<&mut parsed::common::Profile> {
-        self.inner.parsed.profile_mut()
-    }
+            fn cuda_detection(&self) -> Option<bool> {
+                self.inner.$field.cuda_detection()
+            }
 
-    fn services_mut(&mut self) -> &mut parsed::common::Services {
-        self.inner.parsed.services_mut()
-    }
+            fn activate_mode(&self) -> Option<&ActivateMode> {
+                self.inner.$field.activate_mode()
+            }
 
-    fn include_mut(&mut self) -> &mut parsed::common::Include {
-        self.inner.parsed.include_mut()
-    }
+            fn services_auto_start(&self) -> bool {
+                self.inner.$field.services_auto_start()
+            }
 
-    fn build_mut(&mut self) -> &mut parsed::common::Build {
-        self.inner.parsed.build_mut()
-    }
+            fn vars_mut(&mut self) -> &mut parsed::common::Vars {
+                self.inner.$field.vars_mut()
+            }
 
-    fn containerize_mut(&mut self) -> Option<&mut parsed::common::Containerize> {
-        self.inner.parsed.containerize_mut()
-    }
+            fn hook_mut(&mut self) -> Option<&mut parsed::common::Hook> {
+                self.inner.$field.hook_mut()
+            }
 
-    fn options_mut(&mut self) -> &mut parsed::common::Options {
-        self.inner.parsed.options_mut()
-    }
+            fn profile_mut(&mut self) -> Option<&mut parsed::common::Profile> {
+                self.inner.$field.profile_mut()
+            }
+
+            fn services_mut(&mut self) -> &mut parsed::common::Services {
+                self.inner.$field.services_mut()
+            }
+
+            fn include_mut(&mut self) -> &mut parsed::common::Include {
+                self.inner.$field.include_mut()
+            }
+
+            fn build_mut(&mut self) -> &mut parsed::common::Build {
+                self.inner.$field.build_mut()
+            }
+
+            fn containerize_mut(&mut self) -> Option<&mut parsed::common::Containerize> {
+                self.inner.$field.containerize_mut()
+            }
+
+            fn systems_mut(&mut self) -> &mut Option<Vec<System>> {
+                self.inner.$field.systems_mut()
+            }
+
+            fn activate_mode_mut(&mut self) -> &mut Option<ActivateMode> {
+                self.inner.$field.activate_mode_mut()
+            }
+        }
+    };
 }
 
-impl CommonFields for Manifest<TypedOnly> {
-    fn vars(&self) -> &parsed::common::Vars {
-        self.inner.parsed.vars()
-    }
-
-    fn hook(&self) -> Option<&parsed::common::Hook> {
-        self.inner.parsed.hook()
-    }
-
-    fn profile(&self) -> Option<&parsed::common::Profile> {
-        self.inner.parsed.profile()
-    }
-
-    fn services(&self) -> &parsed::common::Services {
-        self.inner.parsed.services()
-    }
-
-    fn include(&self) -> &parsed::common::Include {
-        self.inner.parsed.include()
-    }
-
-    fn build(&self) -> &parsed::common::Build {
-        self.inner.parsed.build()
-    }
-
-    fn containerize(&self) -> Option<&parsed::common::Containerize> {
-        self.inner.parsed.containerize()
-    }
-
-    fn options(&self) -> &parsed::common::Options {
-        self.inner.parsed.options()
-    }
-
-    fn vars_mut(&mut self) -> &mut parsed::common::Vars {
-        self.inner.parsed.vars_mut()
-    }
-
-    fn hook_mut(&mut self) -> Option<&mut parsed::common::Hook> {
-        self.inner.parsed.hook_mut()
-    }
-
-    fn profile_mut(&mut self) -> Option<&mut parsed::common::Profile> {
-        self.inner.parsed.profile_mut()
-    }
-
-    fn services_mut(&mut self) -> &mut parsed::common::Services {
-        self.inner.parsed.services_mut()
-    }
-
-    fn include_mut(&mut self) -> &mut parsed::common::Include {
-        self.inner.parsed.include_mut()
-    }
-
-    fn build_mut(&mut self) -> &mut parsed::common::Build {
-        self.inner.parsed.build_mut()
-    }
-
-    fn containerize_mut(&mut self) -> Option<&mut parsed::common::Containerize> {
-        self.inner.parsed.containerize_mut()
-    }
-
-    fn options_mut(&mut self) -> &mut parsed::common::Options {
-        self.inner.parsed.options_mut()
-    }
-}
-
-impl CommonFields for Manifest<MigratedTypedOnly> {
-    fn vars(&self) -> &parsed::common::Vars {
-        self.inner.migrated_parsed.vars()
-    }
-
-    fn hook(&self) -> Option<&parsed::common::Hook> {
-        self.inner.migrated_parsed.hook()
-    }
-
-    fn profile(&self) -> Option<&parsed::common::Profile> {
-        self.inner.migrated_parsed.profile()
-    }
-
-    fn services(&self) -> &parsed::common::Services {
-        self.inner.migrated_parsed.services()
-    }
-
-    fn include(&self) -> &parsed::common::Include {
-        self.inner.migrated_parsed.include()
-    }
-
-    fn build(&self) -> &parsed::common::Build {
-        self.inner.migrated_parsed.build()
-    }
-
-    fn containerize(&self) -> Option<&parsed::common::Containerize> {
-        self.inner.migrated_parsed.containerize()
-    }
-
-    fn options(&self) -> &parsed::common::Options {
-        self.inner.migrated_parsed.options()
-    }
-
-    fn vars_mut(&mut self) -> &mut parsed::common::Vars {
-        self.inner.migrated_parsed.vars_mut()
-    }
-
-    fn hook_mut(&mut self) -> Option<&mut parsed::common::Hook> {
-        self.inner.migrated_parsed.hook_mut()
-    }
-
-    fn profile_mut(&mut self) -> Option<&mut parsed::common::Profile> {
-        self.inner.migrated_parsed.profile_mut()
-    }
-
-    fn services_mut(&mut self) -> &mut parsed::common::Services {
-        self.inner.migrated_parsed.services_mut()
-    }
-
-    fn include_mut(&mut self) -> &mut parsed::common::Include {
-        self.inner.migrated_parsed.include_mut()
-    }
-
-    fn build_mut(&mut self) -> &mut parsed::common::Build {
-        self.inner.migrated_parsed.build_mut()
-    }
-
-    fn containerize_mut(&mut self) -> Option<&mut parsed::common::Containerize> {
-        self.inner.migrated_parsed.containerize_mut()
-    }
-
-    fn options_mut(&mut self) -> &mut parsed::common::Options {
-        self.inner.migrated_parsed.options_mut()
-    }
-}
-
-impl CommonFields for Manifest<Migrated> {
-    fn vars(&self) -> &parsed::common::Vars {
-        self.inner.migrated_parsed.vars()
-    }
-
-    fn hook(&self) -> Option<&parsed::common::Hook> {
-        self.inner.migrated_parsed.hook()
-    }
-
-    fn profile(&self) -> Option<&parsed::common::Profile> {
-        self.inner.migrated_parsed.profile()
-    }
-
-    fn services(&self) -> &parsed::common::Services {
-        self.inner.migrated_parsed.services()
-    }
-
-    fn include(&self) -> &parsed::common::Include {
-        self.inner.migrated_parsed.include()
-    }
-
-    fn build(&self) -> &parsed::common::Build {
-        self.inner.migrated_parsed.build()
-    }
-
-    fn containerize(&self) -> Option<&parsed::common::Containerize> {
-        self.inner.migrated_parsed.containerize()
-    }
-
-    fn options(&self) -> &parsed::common::Options {
-        self.inner.migrated_parsed.options()
-    }
-
-    fn vars_mut(&mut self) -> &mut parsed::common::Vars {
-        self.inner.migrated_parsed.vars_mut()
-    }
-
-    fn hook_mut(&mut self) -> Option<&mut parsed::common::Hook> {
-        self.inner.migrated_parsed.hook_mut()
-    }
-
-    fn profile_mut(&mut self) -> Option<&mut parsed::common::Profile> {
-        self.inner.migrated_parsed.profile_mut()
-    }
-
-    fn services_mut(&mut self) -> &mut parsed::common::Services {
-        self.inner.migrated_parsed.services_mut()
-    }
-
-    fn include_mut(&mut self) -> &mut parsed::common::Include {
-        self.inner.migrated_parsed.include_mut()
-    }
-
-    fn build_mut(&mut self) -> &mut parsed::common::Build {
-        self.inner.migrated_parsed.build_mut()
-    }
-
-    fn containerize_mut(&mut self) -> Option<&mut parsed::common::Containerize> {
-        self.inner.migrated_parsed.containerize_mut()
-    }
-
-    fn options_mut(&mut self) -> &mut parsed::common::Options {
-        self.inner.migrated_parsed.options_mut()
-    }
-}
+impl_common_fields_for_manifest!(Validated, parsed);
+impl_common_fields_for_manifest!(TypedOnly, parsed);
+impl_common_fields_for_manifest!(MigratedTypedOnly, migrated_parsed);
+impl_common_fields_for_manifest!(Migrated, migrated_parsed);

--- a/cli/flox-manifest/src/interfaces/common_fields.rs
+++ b/cli/flox-manifest/src/interfaces/common_fields.rs
@@ -29,6 +29,14 @@ pub trait CommonFields {
     fn cuda_detection(&self) -> Option<bool>;
     fn activate_mode(&self) -> Option<&ActivateMode>;
 
+    /// Returns whether `$FLOX_ENV/sbin` directories should be prepended to
+    /// PATH when activating. Returns `None` for all schema versions before
+    /// V1_12_0 (callers should treat `None` as `false`). V1_12_0 reads this
+    /// from the manifest's `options.activate.add-sbin` field.
+    fn activate_add_sbin(&self) -> Option<bool> {
+        None
+    }
+
     /// Returns whether services should auto-start on activation.
     ///
     /// Returns `false` for all schema versions before V1_12_0.
@@ -157,6 +165,15 @@ impl CommonFields for Parsed {
             Parsed::V1_10_0(inner) => inner.activate_mode(),
             Parsed::V1_11_0(inner) => inner.activate_mode(),
             Parsed::V1_12_0(inner) => inner.activate_mode(),
+        }
+    }
+
+    fn activate_add_sbin(&self) -> Option<bool> {
+        match self {
+            Parsed::V1(inner) => inner.activate_add_sbin(),
+            Parsed::V1_10_0(inner) => inner.activate_add_sbin(),
+            Parsed::V1_11_0(inner) => inner.activate_add_sbin(),
+            Parsed::V1_12_0(inner) => inner.activate_add_sbin(),
         }
     }
 
@@ -302,6 +319,10 @@ macro_rules! impl_common_fields_for_manifest {
 
             fn activate_mode(&self) -> Option<&ActivateMode> {
                 self.inner.$field.activate_mode()
+            }
+
+            fn activate_add_sbin(&self) -> Option<bool> {
+                self.inner.$field.activate_add_sbin()
             }
 
             fn services_auto_start(&self) -> bool {

--- a/cli/flox-manifest/src/migrate/v1_11_0_to_v1_12_0.rs
+++ b/cli/flox-manifest/src/migrate/v1_11_0_to_v1_12_0.rs
@@ -1,15 +1,29 @@
 use crate::migrate::MigrationError;
 use crate::parsed::v1_11_0::ManifestV1_11_0;
-use crate::parsed::v1_12_0::{ManifestV1_12_0, Services};
+use crate::parsed::v1_12_0::{ActivateOptions, ManifestV1_12_0, Options, Services};
 
 /// Migrate a v1.11.0 manifest to a v1.12.0 manifest.
 ///
-/// This is a lossless migration: V1_12_0 adds an optional `auto-start` field
-/// to the `[services]` section. All V1_11_0 manifests are valid V1_12_0
-/// manifests with `auto_start: None`.
+/// This is a lossless migration. V1_12_0 adds:
+/// - an optional `auto-start` field to the `[services]` section
+/// - an optional `add-sbin` field to `[options.activate]`
+///
+/// All V1_11_0 manifests are valid V1_12_0 manifests with those new fields
+/// defaulting to `None`.
 pub(crate) fn migrate_manifest_v1_11_0_to_v1_12_0(
     manifest: &ManifestV1_11_0,
 ) -> Result<ManifestV1_12_0, MigrationError> {
+    let old_options = &manifest.options;
+    let options = Options {
+        systems: old_options.systems.clone(),
+        allow: old_options.allow.clone(),
+        semver: old_options.semver.clone(),
+        cuda_detection: old_options.cuda_detection,
+        activate: ActivateOptions {
+            mode: old_options.activate.mode.clone(),
+            add_sbin: None,
+        },
+    };
     Ok(ManifestV1_12_0 {
         schema_version: "1.12.0".to_string(),
         minimum_cli_version: manifest.minimum_cli_version.clone(),
@@ -17,7 +31,7 @@ pub(crate) fn migrate_manifest_v1_11_0_to_v1_12_0(
         vars: manifest.vars.clone(),
         hook: manifest.hook.clone(),
         profile: manifest.profile.clone(),
-        options: manifest.options.clone(),
+        options,
         services: Services {
             auto_start: None,
             service_map: manifest.services.clone(),

--- a/cli/flox-manifest/src/parsed/v1/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1/mod.rs
@@ -122,8 +122,24 @@ impl CommonFields for ManifestV1 {
         self.containerize.as_ref()
     }
 
-    fn options(&self) -> &super::common::Options {
-        &self.options
+    fn systems(&self) -> Option<&Vec<flox_core::data::System>> {
+        self.options.systems.as_ref()
+    }
+
+    fn allows(&self) -> &super::common::Allows {
+        &self.options.allow
+    }
+
+    fn semver_options(&self) -> &super::common::SemverOptions {
+        &self.options.semver
+    }
+
+    fn cuda_detection(&self) -> Option<bool> {
+        self.options.cuda_detection
+    }
+
+    fn activate_mode(&self) -> Option<&flox_core::activate::mode::ActivateMode> {
+        self.options.activate.mode.as_ref()
     }
 
     fn vars_mut(&mut self) -> &mut super::common::Vars {
@@ -154,8 +170,12 @@ impl CommonFields for ManifestV1 {
         self.containerize.as_mut()
     }
 
-    fn options_mut(&mut self) -> &mut super::common::Options {
-        &mut self.options
+    fn systems_mut(&mut self) -> &mut Option<Vec<flox_core::data::System>> {
+        &mut self.options.systems
+    }
+
+    fn activate_mode_mut(&mut self) -> &mut Option<flox_core::activate::mode::ActivateMode> {
+        &mut self.options.activate.mode
     }
 }
 

--- a/cli/flox-manifest/src/parsed/v1_10_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_10_0/mod.rs
@@ -149,8 +149,24 @@ impl CommonFields for ManifestV1_10_0 {
         self.containerize.as_ref()
     }
 
-    fn options(&self) -> &super::common::Options {
-        &self.options
+    fn systems(&self) -> Option<&Vec<flox_core::data::System>> {
+        self.options.systems.as_ref()
+    }
+
+    fn allows(&self) -> &super::common::Allows {
+        &self.options.allow
+    }
+
+    fn semver_options(&self) -> &super::common::SemverOptions {
+        &self.options.semver
+    }
+
+    fn cuda_detection(&self) -> Option<bool> {
+        self.options.cuda_detection
+    }
+
+    fn activate_mode(&self) -> Option<&flox_core::activate::mode::ActivateMode> {
+        self.options.activate.mode.as_ref()
     }
 
     fn vars_mut(&mut self) -> &mut super::common::Vars {
@@ -181,8 +197,12 @@ impl CommonFields for ManifestV1_10_0 {
         self.containerize.as_mut()
     }
 
-    fn options_mut(&mut self) -> &mut super::common::Options {
-        &mut self.options
+    fn systems_mut(&mut self) -> &mut Option<Vec<flox_core::data::System>> {
+        &mut self.options.systems
+    }
+
+    fn activate_mode_mut(&mut self) -> &mut Option<flox_core::activate::mode::ActivateMode> {
+        &mut self.options.activate.mode
     }
 }
 

--- a/cli/flox-manifest/src/parsed/v1_11_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_11_0/mod.rs
@@ -148,8 +148,24 @@ impl CommonFields for ManifestV1_11_0 {
         self.containerize.as_ref()
     }
 
-    fn options(&self) -> &super::common::Options {
-        &self.options
+    fn systems(&self) -> Option<&Vec<flox_core::data::System>> {
+        self.options.systems.as_ref()
+    }
+
+    fn allows(&self) -> &super::common::Allows {
+        &self.options.allow
+    }
+
+    fn semver_options(&self) -> &super::common::SemverOptions {
+        &self.options.semver
+    }
+
+    fn cuda_detection(&self) -> Option<bool> {
+        self.options.cuda_detection
+    }
+
+    fn activate_mode(&self) -> Option<&flox_core::activate::mode::ActivateMode> {
+        self.options.activate.mode.as_ref()
     }
 
     fn vars_mut(&mut self) -> &mut super::common::Vars {
@@ -180,8 +196,12 @@ impl CommonFields for ManifestV1_11_0 {
         self.containerize.as_mut()
     }
 
-    fn options_mut(&mut self) -> &mut super::common::Options {
-        &mut self.options
+    fn systems_mut(&mut self) -> &mut Option<Vec<flox_core::data::System>> {
+        &mut self.options.systems
+    }
+
+    fn activate_mode_mut(&mut self) -> &mut Option<flox_core::activate::mode::ActivateMode> {
+        &mut self.options.activate.mode
     }
 }
 

--- a/cli/flox-manifest/src/parsed/v1_12_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_12_0/mod.rs
@@ -16,7 +16,6 @@ use crate::parsed::common::{
     Hook,
     Include,
     KnownSchemaVersion,
-    Options,
     Profile,
     SemverOptions,
     ServiceDescriptor,
@@ -170,6 +169,10 @@ impl CommonFields for ManifestV1_12_0 {
         self.options.activate.mode.as_ref()
     }
 
+    fn activate_add_sbin(&self) -> Option<bool> {
+        self.options.activate.add_sbin
+    }
+
     fn vars_mut(&mut self) -> &mut super::common::Vars {
         &mut self.vars
     }
@@ -209,6 +212,68 @@ impl CommonFields for ManifestV1_12_0 {
     fn services_auto_start(&self) -> bool {
         self.services.auto_start == Some(true)
     }
+}
+
+/// V1_12_0-local `ActivateOptions`: adds `add-sbin` alongside `mode`.
+///
+/// This is duplicated from `parsed::common::ActivateOptions` (rather than
+/// flattened) because `common::ActivateOptions` carries
+/// `#[serde(deny_unknown_fields)]`, which conflicts with `#[serde(flatten)]`.
+/// The `mode` field continues to reference the shared `common::ActivateMode`
+/// enum.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub struct ActivateOptions {
+    pub mode: Option<ActivateMode>,
+    /// Whether to include `$FLOX_ENV/sbin` in PATH when activating.
+    /// Defaults to `None` (treated as `false`) so that `sbin` binaries don't
+    /// shadow binaries from other packages.
+    pub add_sbin: Option<bool>,
+}
+
+impl SkipSerializing for ActivateOptions {
+    fn skip_serializing(&self) -> bool {
+        // Destructuring here prevents us from missing new fields if they're
+        // added in the future.
+        let ActivateOptions { mode, add_sbin } = self;
+        mode.is_none() && add_sbin.is_none()
+    }
+}
+
+/// V1_12_0-local `Options`: duplicates `parsed::common::Options` but uses the
+/// V1_12_0-local `ActivateOptions` (which adds `add-sbin`). All other leaf
+/// types (`Allows`, `SemverOptions`) continue to be imported from
+/// `parsed::common`.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    /// A list of systems that each package is resolved for.
+    #[cfg_attr(
+        any(test, feature = "tests"),
+        proptest(strategy = "flox_test_utils::proptest::optional_vec_of_strings(3, 4)")
+    )]
+    pub systems: Option<Vec<System>>,
+    /// Options that control what types of packages are allowed.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Allows::skip_serializing")]
+    pub allow: Allows,
+    /// Options that control how semver versions are resolved.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "SemverOptions::skip_serializing")]
+    pub semver: SemverOptions,
+    /// Whether to detect CUDA devices and libs during activation.
+    // TODO: Migrate to `ActivateOptions`.
+    pub cuda_detection: Option<bool>,
+    /// Options that control the behavior of activations.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "ActivateOptions::skip_serializing")]
+    pub activate: ActivateOptions,
 }
 
 /// Service configuration for V1_12_0: adds optional auto-start behavior
@@ -281,5 +346,57 @@ impl Inner for Services {
 
     fn into_inner(self) -> Self::Inner {
         self.service_map.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::test_helpers::with_latest_schema;
+
+    /// `options.activate.add-sbin = true` round-trips through v1.12.0.
+    #[test]
+    fn parses_add_sbin_true() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [options.activate]
+            add-sbin = true
+        "#});
+        let parsed: ManifestV1_12_0 = toml_edit::de::from_str(&manifest).unwrap();
+        assert_eq!(parsed.options.activate, ActivateOptions {
+            mode: None,
+            add_sbin: Some(true),
+        });
+    }
+
+    /// Omitting `add-sbin` leaves the field as `None`.
+    #[test]
+    fn add_sbin_defaults_to_none() {
+        let manifest = with_latest_schema("");
+        let parsed: ManifestV1_12_0 = toml_edit::de::from_str(&manifest).unwrap();
+        assert_eq!(parsed.options.activate, ActivateOptions::default());
+        assert_eq!(parsed.options.activate.add_sbin, None);
+    }
+
+    /// A manifest whose `ActivateOptions` defaults to `None`/`None` must not
+    /// emit any keys into the serialized output.
+    #[test]
+    fn add_sbin_none_skipped_in_serialization() {
+        let opts = ActivateOptions::default();
+        assert!(opts.skip_serializing());
+    }
+
+    /// A manifest with `add-sbin = Some(false)` still needs to be serialized
+    /// so that downstream tooling can distinguish "unset" from "explicitly
+    /// off".
+    #[test]
+    fn add_sbin_explicit_false_is_serialized() {
+        let opts = ActivateOptions {
+            mode: None,
+            add_sbin: Some(false),
+        };
+        assert!(!opts.skip_serializing());
     }
 }

--- a/cli/flox-manifest/src/parsed/v1_12_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_12_0/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use flox_core::activate::mode::ActivateMode;
 use flox_core::data::System;
 #[cfg(any(test, feature = "tests"))]
 use proptest::prelude::*;
@@ -9,6 +10,7 @@ use serde_with::skip_serializing_none;
 
 use crate::interfaces::{AsTypedOnlyManifest, CommonFields, SchemaVersion, impl_pkg_lookup};
 use crate::parsed::common::{
+    Allows,
     Build,
     Containerize,
     Hook,
@@ -16,6 +18,7 @@ use crate::parsed::common::{
     KnownSchemaVersion,
     Options,
     Profile,
+    SemverOptions,
     ServiceDescriptor,
     Vars,
 };
@@ -147,8 +150,24 @@ impl CommonFields for ManifestV1_12_0 {
         self.containerize.as_ref()
     }
 
-    fn options(&self) -> &super::common::Options {
-        &self.options
+    fn systems(&self) -> Option<&Vec<System>> {
+        self.options.systems.as_ref()
+    }
+
+    fn allows(&self) -> &Allows {
+        &self.options.allow
+    }
+
+    fn semver_options(&self) -> &SemverOptions {
+        &self.options.semver
+    }
+
+    fn cuda_detection(&self) -> Option<bool> {
+        self.options.cuda_detection
+    }
+
+    fn activate_mode(&self) -> Option<&ActivateMode> {
+        self.options.activate.mode.as_ref()
     }
 
     fn vars_mut(&mut self) -> &mut super::common::Vars {
@@ -179,8 +198,12 @@ impl CommonFields for ManifestV1_12_0 {
         self.containerize.as_mut()
     }
 
-    fn options_mut(&mut self) -> &mut super::common::Options {
-        &mut self.options
+    fn systems_mut(&mut self) -> &mut Option<Vec<System>> {
+        &mut self.options.systems
+    }
+
+    fn activate_mode_mut(&mut self) -> &mut Option<ActivateMode> {
+        &mut self.options.activate.mode
     }
 
     fn services_auto_start(&self) -> bool {

--- a/cli/flox-manifest/src/raw/mod.rs
+++ b/cli/flox-manifest/src/raw/mod.rs
@@ -893,11 +893,8 @@ impl SyncTypedToRaw for Manifest<Validated> {
     }
 
     fn update_systems(&mut self) -> Result<(), ManifestError> {
-        update_systems(
-            &mut self.inner.raw,
-            self.inner.parsed.options().systems.as_ref(),
-        )
-        .map_err(ManifestError::TomlEdit)
+        update_systems(&mut self.inner.raw, self.inner.parsed.systems())
+            .map_err(ManifestError::TomlEdit)
     }
 
     fn update_raw_packages_from_typed_manifest(&mut self) -> Result<(), ManifestError> {
@@ -913,7 +910,7 @@ impl SyncTypedToRaw for Manifest<Migrated> {
     fn update_systems(&mut self) -> Result<(), ManifestError> {
         update_systems(
             &mut self.inner.migrated_raw,
-            self.inner.migrated_parsed.options().systems.as_ref(),
+            self.inner.migrated_parsed.systems(),
         )
         .map_err(ManifestError::TomlEdit)
     }
@@ -2104,7 +2101,7 @@ curl.outputs = [\"bin\", \"man\"]
         "#});
         let mut manifest = Manifest::parse_toml_typed(&toml_str).unwrap();
         let systems = vec!["x86_64-linux".to_string()];
-        manifest.options_mut().systems = Some(systems.clone());
+        *manifest.systems_mut() = Some(systems.clone());
         manifest.update_systems().unwrap();
         let updated_systems = manifest.inner.raw["options"]["systems"]
             .as_array()
@@ -2123,7 +2120,7 @@ curl.outputs = [\"bin\", \"man\"]
             allow.unfree = true
         "#});
         let mut manifest = Manifest::parse_toml_typed(&toml_str).unwrap();
-        manifest.options_mut().systems = None;
+        *manifest.systems_mut() = None;
         manifest.update_systems().unwrap();
         let opts = manifest.inner.raw["options"].clone();
         assert!(opts["allow"]["unfree"].as_bool().unwrap());
@@ -2444,7 +2441,7 @@ curl.outputs = [\"bin\", \"man\"]
             ]
         "#});
         let mut manifest = Manifest::parse_toml_typed(&toml_str).unwrap();
-        manifest.options_mut().systems = Some(vec![
+        *manifest.systems_mut() = Some(vec![
             "aarch64-darwin".to_string(),
             "x86_64-linux".to_string(),
         ]);

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1308,6 +1308,7 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     use flox_core::activate::mode::ActivateMode;
+    use flox_manifest::interfaces::CommonFields;
     use flox_manifest::parsed::Inner;
     use flox_manifest::raw::CatalogPackage;
     use flox_manifest::test_helpers::{with_latest_schema, with_schema};
@@ -1710,7 +1711,7 @@ mod tests {
         // Make a non-formatting change to the lock
         {
             let mut lockfile = environment.existing_lockfile().unwrap().unwrap();
-            lockfile.manifest.options_mut().activate.mode = Some(ActivateMode::Dev);
+            *lockfile.manifest.activate_mode_mut() = Some(ActivateMode::Dev);
             let lockfile_contents = serialize_json_with_newline(&lockfile).unwrap();
             let lockfile_path = environment.lockfile_path();
             let mut lockfile = OpenOptions::new().write(true).open(lockfile_path).unwrap();

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -873,7 +873,7 @@ pub mod tests {
 
         // modify the lockfile  -> rebuild necessary
         let mut lockfile = env.existing_lockfile(&flox).unwrap().unwrap();
-        lockfile.manifest.options_mut().activate.mode = Some(ActivateMode::Dev);
+        *lockfile.manifest.activate_mode_mut() = Some(ActivateMode::Dev);
         let lockfile_contents = serialize_json_with_newline(&lockfile).unwrap();
         fs::write(env.lockfile_path(&flox).unwrap(), lockfile_contents).unwrap();
         assert!(env.needs_rebuild().unwrap());

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1068,7 +1068,7 @@ where
         // Without this check the lockfile would succeed to build on any system,
         // but (in the general case) contain no packages,
         // because the lockfile won't contain locks of packages for the current system.
-        if let Some(ref systems) = lockfile.manifest.options().systems
+        if let Some(systems) = lockfile.manifest.systems()
             && !systems.contains(&env!("NIX_TARGET_SYSTEM").to_string())
         {
             return Err(BuildEnvError::LockfileIncompatible {

--- a/cli/flox-rust-sdk/src/providers/lock_manifest.rs
+++ b/cli/flox-rust-sdk/src/providers/lock_manifest.rs
@@ -658,7 +658,7 @@ impl LockManifest {
             already_locked_packages
                 .iter()
                 .filter_map(LockedPackage::as_catalog_package_ref),
-            &manifest.options().allow,
+            manifest.allows(),
         )?;
 
         // Update the priority of already locked packages to match the manifest.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -305,7 +305,7 @@ impl Activate {
         let mode = self
             .mode
             .clone()
-            .unwrap_or(manifest.options().activate.mode.clone().unwrap_or_default());
+            .unwrap_or(manifest.activate_mode().cloned().unwrap_or_default());
         let mode_link_path = rendered_env_path.clone().for_mode(&mode);
         let store_path = fs::read_link(&mode_link_path).with_context(|| {
             format!(
@@ -383,7 +383,7 @@ impl Activate {
 
         let socket_path = concrete_environment.services_socket_path(&flox)?;
 
-        let flox_env_cuda_detection = match manifest.options().cuda_detection {
+        let flox_env_cuda_detection = match manifest.cuda_detection() {
             Some(false) => "0", // manifest opts-out
             _ => "1",           // default to enabling CUDA
         };

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -119,6 +119,13 @@ pub struct Activate {
     #[bpaf(short, long)]
     pub mode: Option<ActivateMode>,
 
+    /// Include `$FLOX_ENV/sbin` directories in PATH when activating.
+    /// Overrides the `options.activate.add-sbin` setting in the manifest.
+    /// Defaults to excluding `sbin` so that e.g. BusyBox's `sbin/ifconfig`
+    /// does not shadow a dedicated networking package's `bin/ifconfig`.
+    #[bpaf(long("add-sbin"))]
+    pub add_sbin: bool,
+
     /// Activate a FloxHub environment at a specific generation.
     #[bpaf(long, short)]
     pub generation: Option<GenerationId>,
@@ -306,6 +313,11 @@ impl Activate {
             .mode
             .clone()
             .unwrap_or(manifest.activate_mode().cloned().unwrap_or_default());
+
+        // Precedence: CLI flag wins when set (`--add-sbin`), otherwise
+        // fall back to the manifest's `options.activate.add-sbin`, otherwise
+        // default to `false` (exclude sbin).
+        let add_sbin = self.add_sbin || manifest.activate_add_sbin().unwrap_or(false);
         let mode_link_path = rendered_env_path.clone().for_mode(&mode);
         let store_path = fs::read_link(&mode_link_path).with_context(|| {
             format!(
@@ -423,6 +435,7 @@ impl Activate {
             flox_prompt_environments,
             set_prompt,
             flox_env_cuda_detection: flox_env_cuda_detection.to_string(),
+            add_sbin,
             interpreter_path,
         };
 
@@ -925,6 +938,7 @@ mod tests {
             start_services,
             no_start_services,
             mode: None,
+            add_sbin: false,
             generation: None,
             command: None,
         }

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -121,8 +121,7 @@ pub struct Activate {
 
     /// Include `$FLOX_ENV/sbin` directories in PATH when activating.
     /// Overrides the `options.activate.add-sbin` setting in the manifest.
-    /// Defaults to excluding `sbin` so that e.g. BusyBox's `sbin/ifconfig`
-    /// does not shadow a dedicated networking package's `bin/ifconfig`.
+    /// Defaults to excluding `sbin`.
     #[bpaf(long("add-sbin"))]
     pub add_sbin: bool,
 

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -90,7 +90,7 @@ impl Containerize {
         let env_name = env.name();
         let lockfile: Lockfile = env.lockfile(&flox)?.into();
         let manifest = lockfile.manifest;
-        let mode = manifest.options().clone().activate.mode.unwrap_or_default();
+        let mode = manifest.activate_mode().cloned().unwrap_or_default();
         let source = if std::env::consts::OS == "linux" {
             let container_config = manifest
                 .containerize()

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -565,7 +565,7 @@ impl Pull {
         let mut manifest = env
             .manifest_without_migrating(flox)?
             .migrate(lockfile.as_ref())?;
-        let maybe_systems = manifest.options_mut().systems.as_mut();
+        let maybe_systems = manifest.systems_mut().as_mut();
         if let Some(systems) = maybe_systems {
             if systems.contains(&flox.system) {
                 return Ok(manifest);

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -408,6 +408,8 @@ pub async fn start_services_with_new_process_compose(
         start_services: true,
         no_start_services: false,
         mode: Some(activate_mode),
+        // Preserve the manifest's add-sbin setting by not forcing it on.
+        add_sbin: false,
         generation,
         // this isn't actually used because we pass invocation type below
         command: Some(CommandSelect::ExecCommand {

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -420,6 +420,30 @@
           },
           "type": "object"
         },
+        "ActivateOptions2": {
+          "additionalProperties": false,
+          "description": "V1_12_0-local `ActivateOptions`: adds `add-sbin` alongside `mode`.\n\nThis is duplicated from `parsed::common::ActivateOptions` (rather than\nflattened) because `common::ActivateOptions` carries\n`#[serde(deny_unknown_fields)]`, which conflicts with `#[serde(flatten)]`.\nThe `mode` field continues to reference the shared `common::ActivateMode`\nenum.",
+          "properties": {
+            "add-sbin": {
+              "description": "Whether to include `$FLOX_ENV/sbin` in PATH when activating.\nDefaults to `None` (treated as `false`) so that `sbin` binaries don't\nshadow binaries from other packages.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "mode": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivateMode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
         "AllSentinel": {
           "enum": [
             "all"
@@ -1047,7 +1071,7 @@
               "description": "The minimum CLI version that can activate this environment."
             },
             "options": {
-              "$ref": "#/$defs/Options",
+              "$ref": "#/$defs/Options2",
               "default": {},
               "description": "Options that control the behavior of the manifest."
             },
@@ -1114,6 +1138,42 @@
           "properties": {
             "activate": {
               "$ref": "#/$defs/ActivateOptions",
+              "description": "Options that control the behavior of activations."
+            },
+            "allow": {
+              "$ref": "#/$defs/Allows",
+              "description": "Options that control what types of packages are allowed."
+            },
+            "cuda-detection": {
+              "description": "Whether to detect CUDA devices and libs during activation.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "semver": {
+              "$ref": "#/$defs/SemverOptions",
+              "description": "Options that control how semver versions are resolved."
+            },
+            "systems": {
+              "description": "A list of systems that each package is resolved for.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "Options2": {
+          "additionalProperties": false,
+          "description": "V1_12_0-local `Options`: duplicates `parsed::common::Options` but uses the\nV1_12_0-local `ActivateOptions` (which adds `add-sbin`). All other leaf\ntypes (`Allows`, `SemverOptions`) continue to be imported from\n`parsed::common`.",
+          "properties": {
+            "activate": {
+              "$ref": "#/$defs/ActivateOptions2",
               "description": "Options that control the behavior of activations."
             },
             "allow": {

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -23,6 +23,30 @@
       },
       "type": "object"
     },
+    "ActivateOptions2": {
+      "additionalProperties": false,
+      "description": "V1_12_0-local `ActivateOptions`: adds `add-sbin` alongside `mode`.\n\nThis is duplicated from `parsed::common::ActivateOptions` (rather than\nflattened) because `common::ActivateOptions` carries\n`#[serde(deny_unknown_fields)]`, which conflicts with `#[serde(flatten)]`.\nThe `mode` field continues to reference the shared `common::ActivateMode`\nenum.",
+      "properties": {
+        "add-sbin": {
+          "description": "Whether to include `$FLOX_ENV/sbin` in PATH when activating.\nDefaults to `None` (treated as `false`) so that `sbin` binaries don't\nshadow binaries from other packages.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivateMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "AllSentinel": {
       "enum": [
         "all"
@@ -650,7 +674,7 @@
           "description": "The minimum CLI version that can activate this environment."
         },
         "options": {
-          "$ref": "#/$defs/Options",
+          "$ref": "#/$defs/Options2",
           "default": {},
           "description": "Options that control the behavior of the manifest."
         },
@@ -717,6 +741,42 @@
       "properties": {
         "activate": {
           "$ref": "#/$defs/ActivateOptions",
+          "description": "Options that control the behavior of activations."
+        },
+        "allow": {
+          "$ref": "#/$defs/Allows",
+          "description": "Options that control what types of packages are allowed."
+        },
+        "cuda-detection": {
+          "description": "Whether to detect CUDA devices and libs during activation.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "semver": {
+          "$ref": "#/$defs/SemverOptions",
+          "description": "Options that control how semver versions are resolved."
+        },
+        "systems": {
+          "description": "A list of systems that each package is resolved for.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "Options2": {
+      "additionalProperties": false,
+      "description": "V1_12_0-local `Options`: duplicates `parsed::common::Options` but uses the\nV1_12_0-local `ActivateOptions` (which adds `add-sbin`). All other leaf\ntypes (`Allows`, `SemverOptions`) continue to be imported from\n`parsed::common`.",
+      "properties": {
+        "activate": {
+          "$ref": "#/$defs/ActivateOptions2",
           "description": "Options that control the behavior of activations."
         },
         "allow": {

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4835,10 +4835,14 @@ nested_activation_get_output() {
 # process, namely that PATH and MANPATH have been repaired properly.
 #
 # In this context, "repaired" means that both the outer and default environments
-# are present in PATH, and the outer environment appears first.
+# are present in PATH, and the outer environment appears first. `sbin` is
+# excluded by default (see ENT-17): only `bin` subdirectories are prepended.
 nested_activation_assertions() {
   # Check that PATH is repaired
-  assert_output --partial "$outer_stub/bin:$outer_stub/sbin:$default_stub/bin:$default_stub/sbin:before_path"
+  assert_output --partial "$outer_stub/bin:$default_stub/bin:before_path"
+  # Ensure `sbin` is NOT silently prepended
+  refute_output --partial "$outer_stub/sbin"
+  refute_output --partial "$default_stub/sbin"
   # Check that MANPATH is repaired
   assert_output --partial "$outer_stub/share/man:$default_stub/share/man"
 }
@@ -4897,6 +4901,49 @@ check_nested_activation_repairs_path_and_manpath() {
 # bats test_tags=activate:fish,activate:nested
 @test "fish: in-place: nested activation repairs (MAN)PATH" {
   check_nested_activation_repairs_path_and_manpath fish eval
+}
+
+# ---------------------------------------------------------------------------- #
+# `options.activate.add-sbin` / `flox activate --add-sbin`
+#
+# ENT-17: sbin is excluded from PATH by default so that e.g. BusyBox's
+# sbin/ifconfig doesn't shadow a dedicated networking package's bin/ifconfig.
+# The CLI flag `--add-sbin` and the manifest setting
+# `options.activate.add-sbin = true` opt back in.
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=activate:sbin
+@test "activate: excludes sbin from PATH by default" {
+  project_setup
+  run "$FLOX_BIN" activate -- sh -c 'echo "$PATH"'
+  assert_success
+  # The `bin` entry for this env must be present.
+  assert_output --partial "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin"
+  # The `sbin` entry for this env must NOT be present.
+  refute_output --partial "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/sbin"
+}
+
+# bats test_tags=activate:sbin
+@test "activate: --add-sbin prepends sbin to PATH" {
+  project_setup
+  run "$FLOX_BIN" activate --add-sbin -- sh -c 'echo "$PATH"'
+  assert_success
+  assert_output --partial "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin"
+  assert_output --partial "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/sbin"
+}
+
+# bats test_tags=activate:sbin
+@test "activate: options.activate.add-sbin = true prepends sbin to PATH" {
+  project_setup
+  with_latest_schema "$(cat <<'EOF'
+[options.activate]
+add-sbin = true
+EOF
+  )" | "$FLOX_BIN" edit -f -
+  run "$FLOX_BIN" activate -- sh -c 'echo "$PATH"'
+  assert_success
+  assert_output --partial "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin"
+  assert_output --partial "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/sbin"
 }
 
 # With an in-place activation in dotfiles, an interactive activation should only

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4836,7 +4836,7 @@ nested_activation_get_output() {
 #
 # In this context, "repaired" means that both the outer and default environments
 # are present in PATH, and the outer environment appears first. `sbin` is
-# excluded by default (see ENT-17): only `bin` subdirectories are prepended.
+# excluded by default: only `bin` subdirectories are prepended.
 nested_activation_assertions() {
   # Check that PATH is repaired
   assert_output --partial "$outer_stub/bin:$default_stub/bin:before_path"
@@ -4906,8 +4906,7 @@ check_nested_activation_repairs_path_and_manpath() {
 # ---------------------------------------------------------------------------- #
 # `options.activate.add-sbin` / `flox activate --add-sbin`
 #
-# ENT-17: sbin is excluded from PATH by default so that e.g. BusyBox's
-# sbin/ifconfig doesn't shadow a dedicated networking package's bin/ifconfig.
+# sbin is excluded from PATH by default
 # The CLI flag `--add-sbin` and the manifest setting
 # `options.activate.add-sbin = true` opt back in.
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/activate/verify_PATH.bash
+++ b/cli/tests/activate/verify_PATH.bash
@@ -14,7 +14,7 @@ IFS=: read -ra path_array <<< "$PATH"
   echo "ERROR: first PATH element not $FLOX_ENV/bin" >&2;
   exit 1;
 }
-# 2) does NOT contain "$FLOX_ENV/sbin" at all (ENT-17: sbin is excluded by
+# 2) does NOT contain "$FLOX_ENV/sbin" at all, sbin is excluded by
 #    default; a separate test exercises the --add-sbin opt-in).
 for p in "${path_array[@]}"; do
     if [ "$p" = "$FLOX_ENV/sbin" ]; then

--- a/cli/tests/activate/verify_PATH.bash
+++ b/cli/tests/activate/verify_PATH.bash
@@ -14,27 +14,22 @@ IFS=: read -ra path_array <<< "$PATH"
   echo "ERROR: first PATH element not $FLOX_ENV/bin" >&2;
   exit 1;
 }
-# 2) contains "$FLOX_ENV/sbin" as its second element
-[ "${path_array[1]}" = "$FLOX_ENV/sbin" ] || {
-  echo "ERROR: second PATH element not $FLOX_ENV/sbin" >&2;
-  exit 1;
-}
-# 3) contains neither of the above more than once
+# 2) does NOT contain "$FLOX_ENV/sbin" at all (ENT-17: sbin is excluded by
+#    default; a separate test exercises the --add-sbin opt-in).
+for p in "${path_array[@]}"; do
+    if [ "$p" = "$FLOX_ENV/sbin" ]; then
+        echo "ERROR: PATH unexpectedly contains $FLOX_ENV/sbin" >&2;
+        exit 1;
+    fi
+done
+# 3) does not contain "$FLOX_ENV/bin" more than once
 declare seen_bin=""
-declare seen_sbin=""
 for p in "${path_array[@]}"; do
     if [ "$p" = "$FLOX_ENV/bin" ]; then
         if [ -n "$seen_bin" ]; then
             exit 1
         else
             seen_bin=1
-        fi
-    fi
-    if [ "$p" = "$FLOX_ENV/sbin" ]; then
-        if [ -n "$seen_sbin" ]; then
-            exit 1
-        else
-            seen_sbin=1
         fi
     fi
 done


### PR DESCRIPTION
## Summary

`flox activate` no longer prepends `$FLOX_ENV/sbin` to `PATH` by default. Users opt back in via the new `--add-sbin` CLI flag, or by setting `[options.activate] add-sbin = true` in their manifest. Precedence: CLI flag > manifest > default (false). The wrapper script (`flox build` shims) honors the same setting via `_FLOX_ADD_SBIN`.

Closes [ENT-17](https://linear.app/floxdotdev/issue/ENT-17). Replaces flox/product#1232.

## Why

For environments containing BusyBox-style multi-call binaries, `$FLOX_ENV/sbin/ifconfig` shadows a dedicated networking package's `bin/ifconfig`. DESCO hit this with their on-prem POC. The Slack discussion concluded this lands with Dev Workflows since it concerns both the packager and the activator.

## Stacking

> [!IMPORTANT]
> This PR is **stacked on #4152** (auto-start services). Both branches independently bump schema to v1.12.0; rebasing here on top of #4152 avoids a merge conflict in `parsed/v1_12_0/`. **Merge #4152 first.** When #4152 lands I'll rebase this onto `main`.

## Approach

Two commits:

1. **`refactor(manifest): replace CommonFields::options() with per-field accessors`** — `CommonFields::options()` / `options_mut()` returned `&common::Options`, which prevented any schema version from owning a version-local `Options` type. Replaced with per-field accessors (`systems`, `allows`, `cuda_detection`, `activate_mode`, `activate_mode_mut`, `systems_mut`, `semver_options`). Updated 11 call sites across flox, flox-rust-sdk, and flox-manifest. Collapsed five hand-written `Manifest` impls into a single macro.

2. **`feat(activate): exclude sbin from PATH by default; add --add-sbin opt-in`** — adds the v1_12_0-local `ActivateOptions { mode, add_sbin }`, the `--add-sbin` CLI flag, the `_FLOX_ADD_SBIN` env-var plumbing through `AttachCtx`, the conditional in `flox-activations fix-paths`, the conditional in the wrapper script, and tests.

### Why duplicate `Options` / `ActivateOptions` in v1_12_0?

Both `common::Options` and `common::ActivateOptions` carry `#[serde(deny_unknown_fields)]`, which is incompatible with `#[serde(flatten)]`. The `Services` flatten trick stephenyeargin used in #4152 works because `common::Services` is a tuple struct with no `deny_unknown_fields`. So for nested-options additions, version-local duplication is the only path that preserves strict schema gating.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo test -p flox-manifest` — 120/120 (incl. 4 new v1_12_0 add-sbin unit tests + migration suite)
- [x] `cargo test -p flox-activations fix_paths` — 14/14 (incl. 2 new sbin unit tests)
- [x] `cargo test -p flox --bins` — 234/234
- [x] `cargo test -p flox-rust-sdk` — 460/462 (the 2 failures in `models::floxmeta::header_tests` are **pre-existing flakes** unrelated to this PR — they pass in isolation; verified on the base branch with my changes stashed)
- [x] `just build` — succeeds (rebuilds activation + wrapper scripts)
- [x] `just integ-tests activate.bats -- --filter sbin` — 3/3
- [x] `just integ-tests activate.bats -- --filter 'nested activation'` — 25/25 (existing nested-activation assertion updated to expect sbin **excluded**)
- [x] Manual smoke test on `/tmp/sbin-smoke`: default excludes `sbin-smoke.dev/sbin`; `--add-sbin` includes it
- [ ] CI green
- [ ] Reviewer to verify the wrapper-script branch end-to-end via a `flox build`-produced binary (not exercised by my smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)