### PR TITLE
docs: Update target path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         if: ${{ !cancelled() && steps.unit-tests.outcome != 'skipped' }}
         with:
           disable_search: true
-          files: "./cli/target/nextest/ci/junit.xml"
+          files: "./target/nextest/ci/junit.xml"
           flags: "dev-unittests, ${{ matrix.test-tags }}, ${{ matrix.os }}"
           verbose: true
           use_oidc: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,8 @@ just build-release             # Build optimized release version
 just build-cli                 # Build only CLI (faster for Rust-only changes)
 
 # Running
-./cli/target/debug/flox --help # Run built binary
-pushd cli; cargo run -- <args>; popd # Run via cargo
+./target/debug/flox --help     # Run built binary
+cargo run -p flox -- <args>    # Run via cargo
 
 # Testing
 just test-all                  # Full test suite (nix-plugins, unit, integration)
@@ -70,8 +70,8 @@ just integ-tests activate.bats -- --filter regex  # Run integration tests, filte
 
 # Formatting and Linting
 just format                    # Format all code
-pushd cli; cargo fmt; popd           # Format Rust
-pushd cli; cargo clippy --all; popd  # Lint Rust
+cargo fmt                      # Format Rust
+cargo clippy --all             # Lint Rust
 treefmt -f nix .               # Format Nix
 pre-commit run -a              # Run all linters
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ $ nix develop;
 # Build `flox' and its subsystems
 $ just build;
 # Run the build
-$ ./cli/target/debug/flox --help;
+$ ./target/debug/flox --help;
 # Run the test suite
 $ just test-all;
 ```
@@ -136,13 +136,12 @@ Flox must be buildable using `flox` or `nix`.
 
 - build and run flox
    ```console
-   $ pushd cli;
-   $ cargo run -- <args>;
+   $ cargo run -p flox -- <args>;
    ```
 - build a debug build of flox and all the necessary subsystems
    ```console
    $ just build;
-   # builds to ./cli/target/debug/flox
+   # builds to ./target/debug/flox
    ```
 - run flox unit tests
    ```console
@@ -157,7 +156,6 @@ Flox must be buildable using `flox` or `nix`.
 
 - format rust code:
   ```console
-  $ pushd cli;
   $ cargo fmt
   $ cargo fmt --check # just check
   ```
@@ -172,7 +170,6 @@ Flox must be buildable using `flox` or `nix`.
   A pre-commit hook is set up to check nix file formatting.
 - lint rust
   ```console
-  $ pushd cli;
   $ cargo clippy --all
   ```
 - lint all files (including for formatting):
@@ -320,7 +317,7 @@ $ just integ-tests
 #### Running tests against the Nix-built flox binary
 
 By default integration tests are run against the development build of `flox`
-that's at `./cli/target/debug/flox`.
+that's at `./target/debug/flox`.
 If you want to verify some behavior of the `flox` binary that's built with Nix,
 you can do that as well:
 


### PR DESCRIPTION
## Proposed Changes

This was moved in 84358e8ce but Claude was still trying to use the old path directly and only flagged it because the timestamp was old (Feb 16th).

Ideally we'd only use an unqualified `flox` from `PATH` but we haven't quite settled on whether agents should always run within the devShell so I'm just unbreaking it for now.

I've left the old `.gitignore` entry so that they don't get committed but it does require people to clean up their old checkouts.

## Release Notes

N/A
