### PR TITLE
refactor: fold legacy activation env helpers into shared exports

### DIFF
--- a/cli/flox-activations/src/activate_script_builder.rs
+++ b/cli/flox-activations/src/activate_script_builder.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
@@ -6,6 +7,8 @@ use flox_core::activate::context::{ActivateCtx, AttachCtx, AttachProjectCtx};
 use flox_core::activate::vars::FLOX_ACTIVE_ENVIRONMENTS_VAR;
 use flox_core::util::default_nix_env_vars;
 use is_executable::IsExecutable;
+use itertools::Itertools;
+use shell_gen::ShellWithPath;
 
 use crate::cli::fix_paths::{fix_manpath_var, fix_path_var};
 use crate::cli::set_env_dirs::fix_env_dirs_var;
@@ -23,7 +26,7 @@ pub(super) fn assemble_activate_command(
     start_state_dir: &Path,
 ) -> Command {
     let mut command = Command::new(context.attach_ctx.interpreter_path.join("activate"));
-    command.envs(old_cli_envs(
+    command.envs(common_activation_envs(
         &context.attach_ctx,
         context.project_ctx.as_ref(),
     ));
@@ -47,7 +50,7 @@ pub fn apply_activation_env(
     vars_from_env: VarsFromEnvironment,
     env_diff: &EnvDiff,
 ) {
-    command.envs(old_cli_envs(context, project));
+    command.envs(common_activation_envs(context, project));
     add_old_activate_script_exports(
         command,
         context,
@@ -61,8 +64,8 @@ pub fn apply_activation_env(
     }
 }
 
-/// Build environment variables from activation context.
-pub fn old_cli_envs(
+/// Build environment variables exported before invoking activate script.
+fn common_activation_envs(
     context: &AttachCtx,
     project: Option<&AttachProjectCtx>,
 ) -> HashMap<&'static str, String> {
@@ -98,6 +101,24 @@ pub fn old_cli_envs(
     exports.extend(default_nix_env_vars());
 
     exports
+}
+
+/// Render shell exports for variables that are set before invoking attach.
+pub fn render_common_activation_envs(
+    shell: &ShellWithPath,
+    context: &AttachCtx,
+    project: Option<&AttachProjectCtx>,
+) -> String {
+    common_activation_envs(context, project)
+        .iter()
+        .map(|(key, value)| (key, shell_escape::escape(Cow::Borrowed(value))))
+        .map(|(key, value)| match shell {
+            ShellWithPath::Bash(_) => format!("export {key}={value};"),
+            ShellWithPath::Fish(_) => format!("set -gx {key} {value};"),
+            ShellWithPath::Tcsh(_) => format!("setenv {key} {value};"),
+            ShellWithPath::Zsh(_) => format!("export {key}={value};"),
+        })
+        .join("\n")
 }
 
 /// Options parsed by getopt in the activate script

--- a/cli/flox-activations/src/attach.rs
+++ b/cli/flox-activations/src/attach.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fs::OpenOptions;
 use std::io::{ErrorKind, IsTerminal};
 use std::os::unix::process::CommandExt;
@@ -10,12 +9,13 @@ use flox_core::activate::context::{ActivateCtx, InvocationType};
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
 use flox_core::activations::StartIdentifier;
 use indoc::formatdoc;
-use itertools::Itertools;
 use nix::unistd::{close, dup2_stdin, pipe, write};
 use shell_gen::{Shell, ShellWithPath};
 use tracing::debug;
 
-use crate::activate_script_builder::{activate_tracer, apply_activation_env, old_cli_envs};
+use crate::activate_script_builder::{
+    activate_tracer, apply_activation_env, render_common_activation_envs,
+};
 use crate::cli::activate::NO_REMOVE_ACTIVATION_FILES;
 use crate::cli::attach::{AttachArgs, AttachExclusiveArgs};
 use crate::env_diff::EnvDiff;
@@ -511,7 +511,11 @@ fn activate_in_place(startup_ctx: StartupCtx, start_id: StartIdentifier) -> Resu
     // Put a 5 second timeout on the activation
     attach_command.handle()?;
 
-    let legacy_exports = render_legacy_exports(&startup_ctx.act_ctx);
+    let legacy_exports = render_common_activation_envs(
+        &startup_ctx.act_ctx.shell,
+        &startup_ctx.act_ctx.attach_ctx,
+        startup_ctx.act_ctx.project_ctx.as_ref(),
+    );
 
     let exports_for_zsh = if matches!(startup_ctx.act_ctx.shell, ShellWithPath::Zsh(_)) {
         let zdotdir_path = startup_ctx
@@ -564,25 +568,6 @@ fn activate_in_place(startup_ctx: StartupCtx, start_id: StartIdentifier) -> Resu
     write_to_stdout(&startup_ctx)?;
 
     Ok(())
-}
-
-/// The CLI used to print export statements for in-place activations for
-/// every environment variable set prior to invoking the activate script
-fn render_legacy_exports(context: &ActivateCtx) -> String {
-    // Render the exports in the correct shell dialect.
-    old_cli_envs(&context.attach_ctx, context.project_ctx.as_ref())
-        .iter()
-        .map(|(key, value)| (key, shell_escape::escape(Cow::Borrowed(value))))
-        // TODO: we should use a method on Shell here, possibly using
-        // shell_escape in the Shell method?
-        // But not quoting here is intentional because we already use shell_escape
-        .map(|(key, value)| match context.shell {
-            ShellWithPath::Bash(_) => format!("export {key}={value};",),
-            ShellWithPath::Fish(_) => format!("set -gx {key} {value};",),
-            ShellWithPath::Tcsh(_) => format!("setenv {key} {value};",),
-            ShellWithPath::Zsh(_) => format!("export {key}={value};",),
-        })
-        .join("\n")
 }
 
 /// Quote run args so that words don't get split,


### PR DESCRIPTION
### Motivation
- Reduce duplication and ensure a single source of truth for the environment variables that are set before invoking the activate script so both command invocation paths and in-place activations use the same values.
- Make shell-specific export rendering reuse the same computed envs to avoid drift and bugs across interactive/exec/in-place activation code paths.

### Description
- Replace `old_cli_envs()` with a shared `common_activation_envs(context, project)` function that returns the `HashMap<&'static str, String>` of pre-activation variables.
- Replace uses of `old_cli_envs(...)` with `common_activation_envs(...)` in `assemble_activate_command` and `apply_activation_env` so command invocations source the same envs.
- Add `render_common_activation_envs(shell, context, project)` to `activate_script_builder.rs` to render shell-specific export statements and switch the in-place activation path to call this renderer instead of the removed `render_legacy_exports()`.
- Add necessary imports (`std::borrow::Cow`, `itertools::Itertools`, and `shell_gen::ShellWithPath`) and use `shell_escape` + `join` to produce correctly-quoted export lines.

### Testing
- Ran `cargo fmt` for the modified crates/files (`cargo fmt -p flox-activations -- flox-activations/src/activate_script_builder.rs flox-activations/src/attach.rs`) which completed successfully.
- Ran `cargo fmt --all` in the nix dev-shell wrapper which was attempted but could not complete in this environment due to Nix/network restrictions.
- Ran `cargo check -p flox-activations` which failed in this environment due to blocked network access when fetching Git dependencies (not related to the local code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d925f44d148329b5fc511852ec3836)