### PR TITLE
chore: fix claude plugin name

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,5 +32,5 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: '--dangerously-skip-permissions'
-          plugins: 'code-review@claude-plugins-official'
+          plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review'


### PR DESCRIPTION
Use plugin mentioned at
https://github.com/anthropics/claude-code-action/blob/ba026a3e56b9f646ae3b1be02dd9c0812aa2f8ae/action.yml#L145
