### PR TITLE
feat: version the catalog config/manifest and lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ dependencies = [
  "anyhow",
  "clap",
  "flox-catalog",
+ "flox-core",
  "indexmap 2.13.0",
  "serde",
  "serde_json",

--- a/cli/nef-lock-catalog/Cargo.toml
+++ b/cli/nef-lock-catalog/Cargo.toml
@@ -14,4 +14,5 @@ indexmap.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 flox-catalog = { path = "../flox-catalog" }
+flox-core = {path = "../flox-core"}
 tokio.workspace = true

--- a/cli/nef-lock-catalog/src/nix_build_config.rs
+++ b/cli/nef-lock-catalog/src/nix_build_config.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use flox_catalog::ClientTrait;
+use flox_core::Version;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -67,6 +68,9 @@ struct NixSourceTypeSpec {
 /// and provided to builds using the NEF.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BuildConfig {
+    #[serde(rename = "version")]
+    _version: Version<1>,
+
     // Using an IndexMap to lock in user defined order.
     // This is no hard requirement, the lockfile will be sorted.
     catalogs: IndexMap<CatalogId, CatalogSpec>,
@@ -76,7 +80,23 @@ pub struct BuildConfig {
 pub fn read_config(path: impl AsRef<Path>) -> Result<BuildConfig> {
     let config = fs::read(&path)
         .with_context(|| format!("failed to read {path:?}", path = path.as_ref()))?;
-    let config = toml::from_slice(&config).context("failed to parse config")?;
+
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    #[serde(untagged)]
+    enum ConfigVersionCompat {
+        V1(BuildConfig),
+        VX { version: toml::Value },
+    }
+
+    let config: ConfigVersionCompat =
+        toml::from_slice(&config).context("failed to parse config")?;
+    let config = match config {
+        ConfigVersionCompat::V1(config) => config,
+        ConfigVersionCompat::VX { version } => {
+            anyhow::bail!("unsupported config version: {version}")
+        },
+    };
+
     Ok(config)
 }
 
@@ -109,6 +129,7 @@ pub async fn lock_config_with_options(
     options: &LockOptions,
 ) -> Result<BuildLock> {
     let BuildConfig {
+        _version: Version,
         catalogs: catalog_spec,
     } = config;
 
@@ -140,6 +161,7 @@ pub async fn lock_config_with_options(
     }
 
     Ok(BuildLock {
+        _version: Version,
         catalogs: locked_catalogs,
     })
 }

--- a/cli/nef-lock-catalog/src/nix_build_lock.rs
+++ b/cli/nef-lock-catalog/src/nix_build_lock.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use flox_core::Version;
 use serde::Serialize;
 use tracing::debug;
 
@@ -39,6 +40,8 @@ pub(crate) enum CatalogLock {
 /// sources of declared dependencies.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct BuildLock {
+    #[serde(rename = "version")]
+    pub(crate) _version: Version<1>,
     pub(crate) catalogs: BTreeMap<CatalogId, CatalogLock>,
 }
 

--- a/package-builder/nef/lib/instantiate.nix
+++ b/package-builder/nef/lib/instantiate.nix
@@ -215,7 +215,15 @@ in
 
       catalogs =
         if builtins.pathExists catalogsLock then
-          (lib.importJSON catalogsLock).catalogs
+          let
+            lockfile = (lib.importJSON catalogsLock);
+          in
+          # We have _internally_ published a few builds without a lockfile version.
+          # TODO: require a version before GA?
+          if !(lockfile ? version) || lockfile.version == 1 then
+            lockfile.catalogs
+          else
+            builtins.throw "unsupported catalog lockfile version"
         else
           builtins.throw ''
             `nix-builds.lock` not found, run `flox build update-catalogs` to generate it

--- a/package-builder/nef/tests/instantiateTests/testData/multi-level/mid/nix-builds.toml
+++ b/package-builder/nef/tests/instantiateTests/testData/multi-level/mid/nix-builds.toml
@@ -1,2 +1,4 @@
+version = 1
+
 [catalogs.leaf]
 url = "path:../leaf"

--- a/package-builder/nef/tests/instantiateTests/testData/multi-level/root/nix-builds.toml
+++ b/package-builder/nef/tests/instantiateTests/testData/multi-level/root/nix-builds.toml
@@ -1,2 +1,4 @@
+version = 1
+
 [catalogs.mid]
 url = "path:../mid"

--- a/package-builder/nef/tests/instantiateTests/testData/single-level/root/nix-builds.toml
+++ b/package-builder/nef/tests/instantiateTests/testData/single-level/root/nix-builds.toml
@@ -1,2 +1,3 @@
+version = 1
 [catalogs.child]
 url = "path:../child"


### PR DESCRIPTION
Only apply preliminary default versions (1) to both files, but allow the schemas to progress under new versions in the future. For config files, add a "forward compatibility" check against unsupported schemas.

Ref: ECO-38