### PR TITLE
feat(publish): differentiate error messages for common failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,16 @@ FLOX_ACTIVATE_TRACE=1 result/bin/flox activate [args]
     bodies. Proc-macro attributes (`#[error(...)]`,
     `#[bpaf(...)]`) require string literals and cannot use
     macros.
+  - **User-facing string literals:** Prefer stretching past the
+    line-width limit rather than breaking messages with `\`
+    continuations. The output the user sees matters more than
+    source line length. Quote suggested commands with single
+    quotes (e.g., `'git push'`).
+  - **Test naming:** Do not prefix test functions with `test_`.
+    The `#[cfg(test)]` module and `#[test]` attribute already
+    identify them as tests. Name tests descriptively for what
+    they verify (e.g.,
+    `gather_repo_meta_no_upstream_suggests_set_upstream`).
 - **Commits:** Conventional commits format (`feat:`, `fix:`, `chore:`, etc.). Use `cz commit` for interactive commits
 - **Rust 2024 edition** for main crates
 

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -1983,7 +1983,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_is_access_denied() {
+    fn is_access_denied() {
         let denied = GitCommandError::BadExit(
             128,
             String::new(),

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -151,6 +151,19 @@ pub enum GitCommandError {
     InvalidUrl(#[source] url::ParseError),
 }
 
+impl GitCommandError {
+    /// Whether this error indicates an authentication or permissions failure.
+    pub fn is_access_denied(&self) -> bool {
+        matches!(
+            self,
+            GitCommandError::BadExit(_, _, stderr)
+                if stderr.contains("DENIED")
+                    || stderr.contains("Authentication failed")
+                    || stderr.contains("Permission denied")
+        )
+    }
+}
+
 /// Representation of the git push status.
 /// See: https://git-scm.com/docs/git-push#Documentation/git-push.txt-flag
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -704,9 +717,22 @@ pub enum GitCommandOpenError {
 #[derive(Error, Debug)]
 pub enum GitCommandGetOriginError {
     #[error(transparent)]
-    Command(#[from] GitCommandError),
+    Command(GitCommandError),
     #[error("Couldn't determine upstream remote name for the current HEAD")]
     NoUpstream,
+    #[error("access denied: {0}")]
+    AccessDenied(GitCommandError),
+}
+
+impl From<GitCommandError> for GitCommandGetOriginError {
+    fn from(err: GitCommandError) -> Self {
+        if err.is_access_denied() {
+            debug!("Access denied: {err}");
+            GitCommandGetOriginError::AccessDenied(err)
+        } else {
+            GitCommandGetOriginError::Command(err)
+        }
+    }
 }
 
 #[derive(Error, Debug)]
@@ -750,9 +776,7 @@ const REMOTE_BRANCH_NOT_FOUND_IN_UPSTREAM_ERR_PREFIX: &str = "fatal: Remote bran
 impl From<GitCommandError> for GitRemoteCommandError {
     fn from(err: GitCommandError) -> Self {
         match err {
-            GitCommandError::BadExit(_, _, ref stderr)
-                if stderr.contains("DENIED") || stderr.contains("Authentication failed") =>
-            {
+            ref e if e.is_access_denied() => {
                 debug!("Access denied: {err}");
                 GitRemoteCommandError::AccessDenied
             },
@@ -1956,5 +1980,33 @@ pub mod tests {
                 .rev_exists_on_remote(&status.rev, "some_remote")
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn test_is_access_denied() {
+        let denied = GitCommandError::BadExit(
+            128,
+            String::new(),
+            "ERROR: Repository not found. DENIED".to_string(),
+        );
+        assert!(denied.is_access_denied());
+
+        let auth_failed = GitCommandError::BadExit(
+            128,
+            String::new(),
+            "Authentication failed for 'https://github.com/foo/bar'".to_string(),
+        );
+        assert!(auth_failed.is_access_denied());
+
+        let permission = GitCommandError::BadExit(
+            128,
+            String::new(),
+            "Permission denied (publickey)".to_string(),
+        );
+        assert!(permission.is_access_denied());
+
+        let other =
+            GitCommandError::BadExit(1, String::new(), "fatal: not a git repository".to_string());
+        assert!(!other.is_access_denied());
     }
 }

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -43,7 +43,7 @@ use super::build::{
     PackageTargetKind,
     find_toplevel_group_nixpkgs,
 };
-use super::git::{GitCommandError, GitCommandProvider, StatusInfo};
+use super::git::{GitCommandError, GitCommandGetOriginError, GitCommandProvider, StatusInfo};
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
 use crate::models::environment::{Environment, EnvironmentError, copy_dir_recursive, open_path};
@@ -936,22 +936,9 @@ pub fn check_build_metadata(
     Ok(metadata)
 }
 
-/// Creates the error message for a build repo that's in an invalid state
-/// by filling out a template with a provided specific error message.
-fn build_repo_err_msg(msg: &str) -> String {
-    formatdoc! {"
-        \n{msg}
-
-        The build repository must satisfy a few requirements in order to use the 'flox publish' command:
-        - It must be a git repository.
-        - All of the tracked files must be in a clean state.
-        - A remote must be configured.
-        - The current revision must be pushed to a remote.
-    "}
-}
-
+/// Creates an error for a build repo that's in an invalid state.
 pub fn build_repo_err(msg: &str) -> PublishError {
-    PublishError::UnsupportedEnvironmentState(build_repo_err_msg(msg))
+    PublishError::UnsupportedEnvironmentState(msg.to_string())
 }
 
 /// Verify that the critical environment files are tracked by git.
@@ -987,9 +974,11 @@ fn check_env_files_tracked(
 /// This entails checking that:
 /// - The repo has a remote configured.
 /// - The tracked source files are clean.
-/// - The current revision is the latest one on the remote.
+/// - The current revision exists on the tracked remote branch.
 #[instrument(skip_all, fields(progress = "Checking repository state"))]
-fn gather_build_repo_meta(git: &impl GitProvider) -> Result<RemoteBuildRepoMetadata, PublishError> {
+fn gather_build_repo_meta(
+    git: &GitCommandProvider,
+) -> Result<RemoteBuildRepoMetadata, PublishError> {
     let status = git
         .status()
         .map_err(|_e| build_repo_err("Unable to get repository status."))?;
@@ -1000,14 +989,74 @@ fn gather_build_repo_meta(git: &impl GitProvider) -> Result<RemoteBuildRepoMetad
         ));
     }
 
-    let remote_info = git
-        .get_current_branch_remote_info()
-        .map_err(|e| build_repo_err(&e.to_string()))?;
+    let remote_info = git.get_current_branch_remote_info().map_err(|e| match e {
+        GitCommandGetOriginError::NoUpstream => {
+            let remote_hint = git
+                .remotes()
+                .ok()
+                .and_then(|r| match r.as_slice() {
+                    [single] if !single.is_empty() => Some(single.clone()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| "<remote>".to_string());
 
-    if remote_info.revision.as_ref() != Some(&status.rev) {
-        return Err(build_repo_err(
-            "Revisions of local branch and tracked remote branch differ.",
-        ));
+            if let Some(branch) = status
+                .ref_
+                .as_deref()
+                .and_then(|r| r.strip_prefix("refs/heads/"))
+            {
+                build_repo_err(&formatdoc! {"
+                    Current branch '{branch}' has no upstream \
+                    remote configured.
+                    Set one with: git branch \
+                    --set-upstream-to={remote_hint}/{branch}"
+                })
+            } else {
+                build_repo_err(&formatdoc! {"
+                    Repository is in detached HEAD state and has \
+                    no upstream remote configured.
+                    Check out a branch before publishing: \
+                    git checkout -b <branch-name>"
+                })
+            }
+        },
+        GitCommandGetOriginError::AccessDenied(ref cmd_err) => build_repo_err(&formatdoc! {"
+            Could not access the remote repository: {cmd_err}
+            Check your SSH agent (`ssh-add -l`) or \
+            credential configuration."
+        }),
+        GitCommandGetOriginError::Command(ref cmd_err) => build_repo_err(&cmd_err.to_string()),
+    })?;
+
+    let rev_on_remote = match git.rev_exists_on_remote(&status.rev, &remote_info.name) {
+        Ok(exists) => exists,
+        Err(ref cmd_err) if cmd_err.is_access_denied() => {
+            return Err(build_repo_err(&formatdoc! {"
+                Could not access remote '{remote_name}' while \
+                verifying the local revision: {cmd_err}
+                Check your SSH agent (`ssh-add -l`) or \
+                credential configuration.",
+                remote_name = remote_info.name,
+            }));
+        },
+        Err(cmd_err) => {
+            return Err(build_repo_err(&formatdoc! {"
+                Failed to check whether local revision exists \
+                on remote '{remote_name}/{remote_branch}': \
+                {cmd_err}",
+                remote_name = remote_info.name,
+                remote_branch = remote_info.reference,
+            }));
+        },
+    };
+    if !rev_on_remote {
+        return Err(build_repo_err(&formatdoc! {"
+            Local revision is not present on remote \
+            '{remote_name}/{remote_branch}'.
+            Push your commits with: git push",
+            remote_name = remote_info.name,
+            remote_branch = remote_info.reference,
+        }));
     }
 
     let url =

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -2372,7 +2372,7 @@ pub mod tests {
     // ---- gather_build_repo_meta error differentiation tests ----
 
     #[test]
-    fn test_gather_repo_meta_no_upstream_suggests_set_upstream() {
+    fn gather_repo_meta_no_upstream_suggests_set_upstream() {
         // A repo with a commit and a remote but no upstream tracking
         // branch should produce an error using the actual remote name.
         let (_remote_tempdir, _remote_repo, remote_uri) = example_git_remote_repo();
@@ -2390,7 +2390,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_gather_repo_meta_no_upstream_no_remote_uses_placeholder() {
+    fn gather_repo_meta_no_upstream_no_remote_uses_placeholder() {
         // A repo with no remotes at all should use a placeholder in
         // the set-upstream-to suggestion.
         let (git, _tempdir) = init_temp_repo(false);
@@ -2406,7 +2406,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_gather_repo_meta_revision_not_on_remote_suggests_push() {
+    fn gather_repo_meta_revision_not_on_remote_suggests_push() {
         // When the local revision is not present on the remote, the
         // error should mention the remote/branch and suggest `git push`.
         let (_remote_tempdir, _remote_repo, remote_uri) = example_git_remote_repo();
@@ -2432,7 +2432,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_gather_repo_meta_dirty_repo_mentions_dirty_files() {
+    fn gather_repo_meta_dirty_repo_mentions_dirty_files() {
         // A repo with uncommitted changes should produce an error
         // about dirty tracked files.
         let (_remote_tempdir, _remote_repo, remote_uri) = example_git_remote_repo();

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1006,24 +1006,20 @@ fn gather_build_repo_meta(
                 .and_then(|r| r.strip_prefix("refs/heads/"))
             {
                 build_repo_err(&formatdoc! {"
-                    Current branch '{branch}' has no upstream \
-                    remote configured.
-                    Set one with: git branch \
-                    --set-upstream-to={remote_hint}/{branch}"
+                    Current branch '{branch}' has no upstream remote configured.
+                    Set one with 'git branch --set-upstream-to={remote_hint}/{branch}'"
                 })
             } else {
                 build_repo_err(&formatdoc! {"
-                    Repository is in detached HEAD state and has \
-                    no upstream remote configured.
+                    Repository is in detached HEAD state and has no upstream remote configured.
                     Check out a branch before publishing: \
-                    git checkout -b <branch-name>"
+                        git checkout -b <branch-name>"
                 })
             }
         },
         GitCommandGetOriginError::AccessDenied(ref cmd_err) => build_repo_err(&formatdoc! {"
             Could not access the remote repository: {cmd_err}
-            Check your SSH agent (`ssh-add -l`) or \
-            credential configuration."
+            Check your SSH agent (`ssh-add -l`) or credential configuration."
         }),
         GitCommandGetOriginError::Command(ref cmd_err) => build_repo_err(&cmd_err.to_string()),
     })?;
@@ -1032,18 +1028,14 @@ fn gather_build_repo_meta(
         Ok(exists) => exists,
         Err(ref cmd_err) if cmd_err.is_access_denied() => {
             return Err(build_repo_err(&formatdoc! {"
-                Could not access remote '{remote_name}' while \
-                verifying the local revision: {cmd_err}
-                Check your SSH agent (`ssh-add -l`) or \
-                credential configuration.",
+                Could not access remote '{remote_name}' while verifying the local revision: {cmd_err}
+                Check your SSH agent (`ssh-add -l`) or credential configuration.",
                 remote_name = remote_info.name,
             }));
         },
         Err(cmd_err) => {
             return Err(build_repo_err(&formatdoc! {"
-                Failed to check whether local revision exists \
-                on remote '{remote_name}/{remote_branch}': \
-                {cmd_err}",
+                Failed to check whether local revision exists on remote '{remote_name}/{remote_branch}': {cmd_err}",
                 remote_name = remote_info.name,
                 remote_branch = remote_info.reference,
             }));
@@ -1051,9 +1043,8 @@ fn gather_build_repo_meta(
     };
     if !rev_on_remote {
         return Err(build_repo_err(&formatdoc! {"
-            Local revision is not present on remote \
-            '{remote_name}/{remote_branch}'.
-            Push your commits with: git push",
+            Local revision is not present on remote '{remote_name}/{remote_branch}'.
+            Push your commits with 'git push'",
             remote_name = remote_info.name,
             remote_branch = remote_info.reference,
         }));

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1435,9 +1435,10 @@ pub mod tests {
             Err(PublishError::UnsupportedEnvironmentState(msg)) => {
                 assert_eq!(
                     msg,
-                    build_repo_err_msg(indoc! {"
+                    indoc! {"
                     The following environment files are not tracked by git:
-                    - subdir_for_flox_stuff/.flox/env.json"})
+                    - subdir_for_flox_stuff/.flox/env.json"}
+                    .to_string()
                 );
             },
             _ => panic!("Expected UnsupportedEnvironmentState error"),
@@ -2375,5 +2376,89 @@ pub mod tests {
             )
             .await;
         assert!(res.is_err());
+    }
+
+    // ---- gather_build_repo_meta error differentiation tests ----
+
+    #[test]
+    fn test_gather_repo_meta_no_upstream_suggests_set_upstream() {
+        // A repo with a commit and a remote but no upstream tracking
+        // branch should produce an error using the actual remote name.
+        let (_remote_tempdir, _remote_repo, remote_uri) = example_git_remote_repo();
+        let (git, _tempdir) = init_temp_repo(false);
+        git.checkout("main", true).unwrap();
+        commit_file(&git, "init.txt");
+        git.add_remote("upstream", &remote_uri).unwrap();
+
+        let err = gather_build_repo_meta(&git).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--set-upstream-to=upstream/main"),
+            "Expected suggestion with actual remote name, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_gather_repo_meta_no_upstream_no_remote_uses_placeholder() {
+        // A repo with no remotes at all should use a placeholder in
+        // the set-upstream-to suggestion.
+        let (git, _tempdir) = init_temp_repo(false);
+        git.checkout("main", true).unwrap();
+        commit_file(&git, "init.txt");
+
+        let err = gather_build_repo_meta(&git).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--set-upstream-to=<remote>/main"),
+            "Expected placeholder <remote> in suggestion, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_gather_repo_meta_revision_not_on_remote_suggests_push() {
+        // When the local revision is not present on the remote, the
+        // error should mention the remote/branch and suggest `git push`.
+        let (_remote_tempdir, _remote_repo, remote_uri) = example_git_remote_repo();
+        let (git, _tempdir) = init_temp_repo(false);
+        git.checkout("main", true).unwrap();
+        commit_file(&git, "first.txt");
+        git.add_remote("origin", &remote_uri).unwrap();
+        git.push("origin", true).unwrap();
+
+        // Create a local commit that hasn't been pushed
+        commit_file(&git, "local_only.txt");
+
+        let err = gather_build_repo_meta(&git).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("origin/main"),
+            "Expected 'origin/main' in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("git push"),
+            "Expected 'git push' suggestion, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_gather_repo_meta_dirty_repo_mentions_dirty_files() {
+        // A repo with uncommitted changes should produce an error
+        // about dirty tracked files.
+        let (_remote_tempdir, _remote_repo, remote_uri) = example_git_remote_repo();
+        let (git, _tempdir) = init_temp_repo(false);
+        git.checkout("main", true).unwrap();
+        commit_file(&git, "init.txt");
+        git.add_remote("origin", &remote_uri).unwrap();
+        git.push("origin", true).unwrap();
+
+        // Dirty the repo by modifying a tracked file without committing
+        std::fs::write(git.path().join("init.txt"), "modified").unwrap();
+
+        let err = gather_build_repo_meta(&git).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("dirty"),
+            "Expected 'dirty' in message, got: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replaces the generic 4-bullet requirements list in `flox publish` error output with failure-specific messages that tell users exactly what went wrong and how to fix it.

Previously, every validation failure in `gather_build_repo_meta` produced the same block of text starting with "The build repository must satisfy a few requirements...". Now each failure mode gets a targeted message:

- **No upstream tracking branch**: names the branch, detects the remote name from `git.remotes()` (or uses `<remote>` as placeholder), suggests `'git branch --set-upstream-to'`
- **Detached HEAD**: separate message advising `'git checkout -b'`
- **SSH/auth failure**: classified via `GitCommandGetOriginError::AccessDenied` variant, passes through the original git error with a credential-check hint
- **Revision not on remote**: uses `rev_exists_on_remote()` to check reachability rather than tip equality, names the remote/branch in the message
- **Dirty working tree**: unchanged (already specific)

Access-denied detection is shared between `GitCommandGetOriginError` and `GitRemoteCommandError` via `GitCommandError::is_access_denied()`. Credentials in remote URLs are sanitized before inclusion in error output. `gather_build_repo_meta` takes `&GitCommandProvider` directly rather than a trait-constrained generic. Errors from `rev_exists_on_remote` are handled explicitly rather than swallowed.

Also documents two conventions in AGENTS.md from review feedback: drop `test_` prefix on test functions, and prefer full-line user-facing string literals over `\` continuations.

### Test plan

- [x] `gather_repo_meta_no_upstream_suggests_set_upstream` (with named remote)
- [x] `gather_repo_meta_no_upstream_no_remote_uses_placeholder`
- [x] `gather_repo_meta_revision_not_on_remote_suggests_push`
- [x] `gather_repo_meta_dirty_repo_mentions_dirty_files`
- [x] `is_access_denied` (unit tests for SSH, auth, permission-denied, and negative case)
- [x] clippy clean, rustfmt clean

### Ticket

Fixes ECO-26