### PR TITLE
docs: add error handling and type usage conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,31 @@ FLOX_ACTIVATE_TRACE=1 result/bin/flox activate [args]
   - Use `assert_eq!` on entire structs in tests so that it's easier to debug failures and catch new fields; don't `assert!` or `assert_eq!` on individual fields
   - Add `use` statements to modules; don't inline absolute paths and don't add to nearest function
   - Always update `use` statements when moving code between modules; don't re-export existing names
+- **Error handling architecture:**
+  - When improving error messages, first understand the existing error type
+    hierarchy before adding string-matching at call sites. Extend error
+    enums with new variants rather than parsing `.to_string()` output.
+  - The git provider layer has a classification pattern:
+    `GitCommandError` → `GitRemoteCommandError` (with typed variants like
+    `AccessDenied`, `Diverged`, `RefNotFound`). New failure modes should
+    be added as variants here, not detected by string matching downstream.
+  - Credential sanitization, access-denied detection, and similar
+    cross-cutting concerns belong in `Display` impls or `From` conversions
+    on the error types, not sprinkled at individual call sites.
+- **Don't constrain generics to a single concrete type:** If you find
+  yourself writing `impl Trait<AssocType = ConcreteError>` because you
+  need to match on concrete error variants, that's a sign the error
+  handling belongs at a lower layer. Either extend the trait's error
+  types to expose what you need, or take the concrete type directly.
+  Using generics with the trait is generally correct when the trait
+  is meaningful; pinning associated types to defeat the abstraction
+  is not.
+- **Understand semantics before rewriting messages:** Before changing an
+  error message, verify what condition actually triggers it. The message
+  must describe what is actually wrong, not an approximation inferred
+  from a surface reading of the code.
+- **Use `formatdoc!`** (from `indoc`) for multiline formatted strings
+  rather than `\n\` line continuations.
 - **Commits:** Conventional commits format (`feat:`, `fix:`, `chore:`, etc.). Use `cz commit` for interactive commits
 - **Rust 2024 edition** for main crates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,31 +153,48 @@ FLOX_ACTIVATE_TRACE=1 result/bin/flox activate [args]
   - Use `assert_eq!` on entire structs in tests so that it's easier to debug failures and catch new fields; don't `assert!` or `assert_eq!` on individual fields
   - Add `use` statements to modules; don't inline absolute paths and don't add to nearest function
   - Always update `use` statements when moving code between modules; don't re-export existing names
-- **Error handling architecture:**
-  - When improving error messages, first understand the existing error type
-    hierarchy before adding string-matching at call sites. Extend error
-    enums with new variants rather than parsing `.to_string()` output.
-  - The git provider layer has a classification pattern:
-    `GitCommandError` → `GitRemoteCommandError` (with typed variants like
-    `AccessDenied`, `Diverged`, `RefNotFound`). New failure modes should
-    be added as variants here, not detected by string matching downstream.
-  - Credential sanitization, access-denied detection, and similar
-    cross-cutting concerns belong in `Display` impls or `From` conversions
-    on the error types, not sprinkled at individual call sites.
-- **Don't constrain generics to a single concrete type:** If you find
-  yourself writing `impl Trait<AssocType = ConcreteError>` because you
-  need to match on concrete error variants, that's a sign the error
-  handling belongs at a lower layer. Either extend the trait's error
-  types to expose what you need, or take the concrete type directly.
-  Using generics with the trait is generally correct when the trait
-  is meaningful; pinning associated types to defeat the abstraction
-  is not.
-- **Understand semantics before rewriting messages:** Before changing an
-  error message, verify what condition actually triggers it. The message
-  must describe what is actually wrong, not an approximation inferred
-  from a surface reading of the code.
-- **Use `formatdoc!`** (from `indoc`) for multiline formatted strings
-  rather than `\n\` line continuations.
+  - **Error handling architecture:**
+    - When improving error messages, first understand the existing
+      error type hierarchy before adding string-matching at call
+      sites. Extend error enums with new variants rather than
+      parsing `.to_string()` output.
+    - The git provider layer has a classification pattern:
+      `GitCommandError` → `GitRemoteCommandError` (with typed
+      variants like `AccessDenied`, `Diverged`, `RefNotFound`).
+      New failure modes should be added as variants here, not
+      detected by string matching downstream.
+    - Credential sanitization, access-denied detection, and similar
+      cross-cutting concerns belong in `Display` impls or `From`
+      conversions on the error types, not sprinkled at individual
+      call sites.
+  - **Provider traits and associated types:**
+    - Before defining a provider trait, ask whether alternative
+      implementations (including mocks) are realistic. If not, a
+      concrete type is simpler and more honest.
+    - Avoid associated types on provider traits unless
+      alternative implementations are realistic. They make
+      bounds harder to write and in practice often constrain
+      consumers to exactly one implementation.
+    - If a provider trait already has associated types, don't
+      constrain them in consumers (e.g.,
+      `impl GitProvider<GetOriginError = …>`). If something only
+      works with one implementation, take the concrete type
+      directly rather than hiding that fact behind a pinned trait
+      constraint.
+    - For non-provider traits where associated types are
+      semantically meaningful (e.g.,
+      `impl IntoIterator<Item = X>`), constraining them is
+      correct and expected.
+  - **Understand semantics before rewriting messages:** Before
+    changing an error message, verify what condition actually
+    triggers it. The message must describe what is actually wrong,
+    not an approximation inferred from a surface reading of the
+    code.
+  - Use `formatdoc!` (from `indoc`) for multiline formatted
+    strings rather than `\n\` line continuations in function
+    bodies. Proc-macro attributes (`#[error(...)]`,
+    `#[bpaf(...)]`) require string literals and cannot use
+    macros.
 - **Commits:** Conventional commits format (`feat:`, `fix:`, `chore:`, etc.). Use `cz commit` for interactive commits
 - **Rust 2024 edition** for main crates
 


### PR DESCRIPTION
## Summary

Captures review feedback from PR #4165 as durable agent guidance in AGENTS.md conventions:

- Error types should be extended with new variants rather than string-matched at call sites
- Provider traits and associated types: question whether the trait is needed, avoid associated types on providers, don't pin them in consumers when only one impl exists, and do use them for non-provider traits where semantically meaningful
- Error messages must reflect the actual triggering condition, not a surface-level approximation
- `formatdoc!` preferred over `\n\` line continuations for multiline strings