### PR TITLE
build: update tracing-subscriber to 0.23.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,11 +2682,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2866,12 +2866,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3073,12 +3072,6 @@ dependencies = [
  "serde",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3437,7 +3430,7 @@ dependencies = [
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3473,7 +3466,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.7",
+ "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3510,7 +3503,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3640,17 +3633,8 @@ checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.12",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3661,7 +3645,7 @@ checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3669,12 +3653,6 @@ name = "regex-lite"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5124,14 +5102,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -5553,7 +5531,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ toml_edit = { version = "0.23", features = ["serde"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-indicatif = "0.3"
-tracing-subscriber = { version = "=0.3.19", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = { version = "2.5", features = ["serde"] }
 url-escape = "0.1.1"
 uuid = { version = "1.16", features = ["serde", "v4"] }
@@ -141,4 +141,3 @@ opt-level = "z"
 strip = true
 lto = true
 codegen-units = 1
-

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -85,8 +85,10 @@ pub fn create_registry_and_filter_reload_handle() -> (
         .with_target(false);
     let message_layer = tracing_subscriber::fmt::layer()
         .with_writer(writer.clone())
-        // Colors are broken, see https://github.com/tokio-rs/tracing/issues/3369
         .with_ansi(use_colors)
+        // Without this, colored output is broken,
+        // see https://github.com/tokio-rs/tracing/issues/3369
+        .with_ansi_sanitization(false)
         .event_format(message_fmt)
         .with_filter(filter::filter_fn(|meta| {
             meta.target().starts_with("flox::utils::message")
@@ -108,8 +110,10 @@ pub fn create_registry_and_filter_reload_handle() -> (
     // here: a test for the field name "progress".
     let log_layer = tracing_subscriber::fmt::layer()
         .with_writer(writer.clone())
-        // Colors are broken, see https://github.com/tokio-rs/tracing/issues/3369
         .with_ansi(use_colors)
+        // Without this, colored output is broken,
+        // see https://github.com/tokio-rs/tracing/issues/3369
+        .with_ansi_sanitization(false)
         .map_fmt_fields(|format| {
             FilteredFormatFields::new(format, |field| field.name() != PROGRESS_TAG)
         })


### PR DESCRIPTION
tracing-subscriber >0.23.19,<0.23.3 was unconditionally sanitizing ANSI content. We rely on the tracing subscriber for (colored, stylized) messaging, following 0.23.19 our output was broken in several places. The same issue has been reported upstream too under at least <https://github.com/tokio-rs/tracing/issues/3369>. In response we have pinned tracing to v0.23.19 for hte time being, which also held back various common dependencies.

This commit finllay lifts the pin, and sets
`with_ansi_sanitization(false)`, which was added in the latest release via <https://github.com/tokio-rs/tracing/pull/3484>.
