### PR TITLE
feat(run): binary-first UX — flox run <binary> [-- args]

### DIFF
--- a/cli/flox-catalog/src/client.rs
+++ b/cli/flox-catalog/src/client.rs
@@ -226,6 +226,19 @@ pub trait ClientTrait {
             "binary lookup endpoint not yet implemented".to_string(),
         ))
     }
+
+    /// Make an authenticated GET request to the catalog API.
+    ///
+    /// This is a low-level helper for endpoints that don't have generated
+    /// client methods yet (e.g., `/packages/by-binary`).
+    async fn authenticated_get(
+        &self,
+        _url: &str,
+    ) -> Result<reqwest::Response, CatalogClientError> {
+        Err(CatalogClientError::Other(
+            "authenticated_get not available on this client".to_string(),
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -476,6 +489,74 @@ impl ClientTrait for CatalogClient {
             .map_api_error()
             .await
             .map(|res| res.into_inner().into())
+    }
+
+    async fn authenticated_get(
+        &self,
+        url: &str,
+    ) -> Result<reqwest::Response, CatalogClientError> {
+        let http_client = build_http_client(&self.config)?;
+        let mut request = http_client
+            .get(url)
+            .build()
+            .map_err(|e| CatalogClientError::Other(e.to_string()))?;
+        self.config
+            .auth_strategy
+            .add_auth_headers(request.headers_mut());
+        http_client
+            .execute(request)
+            .await
+            .map_err(|e| CatalogClientError::Other(e.to_string()))
+    }
+
+    async fn packages_by_binary(
+        &self,
+        binary_name: impl AsRef<str> + Send + Sync,
+        system: api_types::PackageSystem,
+    ) -> Result<Vec<PackageByBinary>, CatalogClientError> {
+        let binary = binary_name.as_ref();
+        let url = format!(
+            "{}/api/v1/catalog/packages/by-binary/{}?system={}&page=0&pageSize=20",
+            self.config.catalog_url, binary, system,
+        );
+        debug!(binary, %url, "querying by-binary endpoint");
+
+        let response = self.authenticated_get(&url).await?;
+
+        if !response.status().is_success() {
+            return Err(CatalogClientError::Other(format!(
+                "by-binary endpoint returned status {}",
+                response.status(),
+            )));
+        }
+
+        // The endpoint returns { "items": [...], "total_count": N, ... }
+        // where each item has the same shape as a package search result.
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| CatalogClientError::Other(e.to_string()))?;
+
+        let items = body["items"]
+            .as_array()
+            .ok_or_else(|| {
+                CatalogClientError::Other("unexpected by-binary response shape".to_string())
+            })?;
+
+        let candidates = items
+            .iter()
+            .map(|item| PackageByBinary {
+                attr_path: item["attr_path"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                pname: item["pname"].as_str().unwrap_or_default().to_string(),
+                description: item["description"].as_str().map(|s| s.to_string()),
+                version: item["version"].as_str().map(|s| s.to_string()),
+            })
+            .collect();
+
+        Ok(candidates)
     }
 }
 

--- a/cli/flox-catalog/src/client.rs
+++ b/cli/flox-catalog/src/client.rs
@@ -209,6 +209,23 @@ pub trait ClientTrait {
 
     /// Get information about the base catalog and available stabilities.
     async fn get_base_catalog_info(&self) -> Result<BaseCatalogInfo, CatalogClientError>;
+
+    /// Look up packages that provide a given binary name.
+    ///
+    /// Calls `GET /api/v1/catalog/packages/by-binary/{binary_name}?system=...`.
+    ///
+    /// Returns a list of candidate packages. The default implementation
+    /// returns an error indicating the endpoint is not available, allowing
+    /// callers to fall back gracefully until the backend is deployed.
+    async fn packages_by_binary(
+        &self,
+        _binary_name: impl AsRef<str> + Send + Sync,
+        _system: api_types::PackageSystem,
+    ) -> Result<Vec<PackageByBinary>, CatalogClientError> {
+        Err(CatalogClientError::Other(
+            "binary lookup endpoint not yet implemented".to_string(),
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/flox-catalog/src/types.rs
+++ b/cli/flox-catalog/src/types.rs
@@ -88,6 +88,31 @@ pub use api_types::{
     StorepathStatusResponse,
 };
 
+// ---------------------------------------------------------------------------
+// Binary lookup types
+// ---------------------------------------------------------------------------
+
+/// A package that provides a given binary, as returned by the by-binary endpoint.
+///
+/// The `GET /api/v1/catalog/packages/by-binary/{binary_name}` endpoint returns
+/// these records. Fields mirror [`SearchResult`] / [`PackageInfoSearch`] for
+/// consistency.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageByBinary {
+    /// Full attribute path (e.g. "binutils").
+    pub attr_path: String,
+    /// Package name (e.g. "binutils").
+    pub pname: String,
+    /// Human-readable description.
+    pub description: Option<String>,
+    /// Package version.
+    pub version: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Resolution message types
+// ---------------------------------------------------------------------------
+
 /// The content of a generic message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MsgGeneral {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -84,6 +84,7 @@ pub enum Response {
     CreatePackage,
     PublishBuild,
     GetBaseCatalog(BaseCatalogInfo),
+    ByBinary(Vec<flox_catalog::PackageByBinary>),
 }
 
 #[derive(Debug, Error)]
@@ -250,6 +251,17 @@ impl ClientTrait for Client {
             Client::Mock(c) => c.get_base_catalog_info().await,
         }
     }
+
+    async fn packages_by_binary(
+        &self,
+        binary_name: impl AsRef<str> + Send + Sync,
+        system: PackageSystem,
+    ) -> Result<Vec<flox_catalog::PackageByBinary>, CatalogClientError> {
+        match self {
+            Client::Catalog(c) => c.packages_by_binary(binary_name, system).await,
+            Client::Mock(c) => c.packages_by_binary(binary_name, system).await,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, derive_more::Display, PartialEq)]
@@ -311,6 +323,14 @@ impl MockClient {
             .lock()
             .expect("couldn't acquire mock lock")
             .push_back(Response::GetStoreInfo(resp));
+    }
+
+    /// Push a by-binary response into the list of mock responses.
+    pub fn push_by_binary_response(&mut self, resp: Vec<flox_catalog::PackageByBinary>) {
+        self.mock_responses
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .push_back(Response::ByBinary(resp));
     }
 
     /// See [test_helpers::reset_mocks].
@@ -513,6 +533,28 @@ impl ClientTrait for MockClient {
         };
 
         Ok(resp)
+    }
+
+    async fn packages_by_binary(
+        &self,
+        _binary_name: impl AsRef<str> + Send + Sync,
+        _system: PackageSystem,
+    ) -> Result<Vec<flox_catalog::PackageByBinary>, CatalogClientError> {
+        let mock_resp = self
+            .mock_responses
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .pop_front();
+        match mock_resp {
+            Some(Response::ByBinary(resp)) => Ok(resp),
+            Some(Response::Error(err)) => Err(CatalogClientError::APIError(
+                flox_catalog::ApiError::ErrorResponse(
+                    err.try_into()
+                        .expect("couldn't convert mock error response"),
+                ),
+            )),
+            _ => panic!("expected ByBinary response, found {:?}", &mock_resp),
+        }
     }
 }
 

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -15,7 +15,7 @@ flox [<general-options>] run
      [-p=<package>]
      [--reselect]
      <binary>
-     [<arguments>...]
+     [-- <arguments>...]
 ```
 
 # DESCRIPTION
@@ -59,13 +59,9 @@ the available packages and suggesting `--package`.
 
 ## Passing Arguments
 
-Everything after the binary name is passed directly to the binary.
-Flox options such as `--package` and `--reselect` must appear
-*before* the binary name.
-
-A `--` separator is accepted but not required.
-It can be useful for readability or when you want to be explicit
-about where `flox run` options end and binary arguments begin.
+Use `--` to separate `flox run` options from arguments intended
+for the invoked binary.
+Everything after `--` is passed directly to the binary.
 
 # OPTIONS
 
@@ -89,10 +85,9 @@ about where `flox run` options end and binary arguments begin.
     In non-interactive contexts this will fail with an error
     listing the available packages.
 
-`<arguments>`
-:   All arguments after the binary name are passed directly to the
-    invoked binary.
-    A `--` separator is accepted but not required.
+`-- <arguments>`
+:   Pass all remaining arguments to the invoked binary.
+    Options after `--` are not interpreted by `flox run`.
 
 ```{.include}
 ./include/general-options.md
@@ -103,14 +98,14 @@ about where `flox run` options end and binary arguments begin.
 Run a command from a package:
 
 ```
-$ flox run cowsay "Hello, world!"
+$ flox run cowsay -- "Hello, world!"
 ```
 
 Run a binary whose name differs from its package
 (`readelf` is provided by `binutils`):
 
 ```
-$ flox run readelf --version
+$ flox run readelf -- --version
 ```
 
 Specify the package explicitly:
@@ -122,19 +117,13 @@ $ flox run --package vim vi
 Pipe input to a command:
 
 ```
-$ echo '{"name":"Flox"}' | flox run jq '.name'
+$ echo '{"name":"Flox"}' | flox run jq -- '.name'
 ```
 
 Clear a cached choice and re-select:
 
 ```
 $ flox run --reselect vi
-```
-
-The `--` separator is optional but still accepted:
-
-```
-$ flox run curl -- -sL http://example.com
 ```
 
 # SEE ALSO

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -15,15 +15,18 @@ flox [<general-options>] run
      [-p=<package>]
      [--reselect]
      <binary>
-     [-- <arguments>...]
+     [--] [<arguments>...]
 ```
 
 # DESCRIPTION
 
-Run a binary from a Nix package without installing it to an environment.
+Run a binary from a Nix package without installing it to an
+environment.
 
 `flox run` is designed for one-off invocations.
-Instead of requiring the overhead of an environment, it fetches the required package and executes the binary, all in one command.
+Instead of requiring the overhead of an environment,
+it fetches the required package and executes the binary,
+all in one command.
 
 ## Binary Lookup
 
@@ -43,28 +46,32 @@ recommend using `--package` to specify the package directly.
 If multiple packages provide the same binary
 (for example, `vi` is provided by `vim`, `nvi`, and others),
 Flox will prompt you to choose which package to use.
-Your choice is cached so that subsequent invocations of the same
-binary run silently without re-prompting.
+Your choice is saved as a preference so that subsequent
+invocations of the same binary run silently without
+re-prompting.
 
 In non-interactive contexts
 (when stdin is not a terminal, such as in pipelines or CI),
-Flox will use a previously cached choice if one exists.
-If no cached choice is available,
-the command will fail with a helpful error listing
-the available packages and suggesting `--package`.
+Flox will use a saved preference if one exists.
+If no preference is saved,
+the command will fail with an error listing the packages
+that provide the binary and suggesting `--package`.
 
 ## Passing Arguments
 
-Use `--` to separate `flox run` options from arguments intended
-for the invoked binary.
-Everything after `--` is passed directly to the binary.
+Arguments after the binary name are passed to the invoked
+binary.
+Use `--` when passing option-style arguments (e.g. `-s`, `--verbose`)
+to the binary so they are not interpreted by `flox run`.
+Bare arguments such as URLs, filenames, and strings do not
+require `--`.
 
 # OPTIONS
 
 ## Run Options
 
 `<binary>`
-:   The name of the binary to run.
+:   Required. The name of the binary to run.
     Flox looks up which package provides this binary via FloxHub.
 
 `-p <package>`, `--package <package>`
@@ -72,18 +79,21 @@ Everything after `--` is passed directly to the binary.
     bypassing the binary-to-package lookup.
     This is useful when you know the package name
     or when the automatic lookup does not find the right package.
-    The choice is saved to the cache
+    The choice is saved as a preference
     so that future invocations of the same binary use this package.
 
 `--reselect`
-:   Clear the cached package choice for this binary and
+:   Clear the saved preference for this binary and
     re-prompt for disambiguation.
     In non-interactive contexts this will fail with an error
     listing the available packages.
 
-`-- <arguments>`
-:   Pass all remaining arguments to the invoked binary.
-    Options after `--` are not interpreted by `flox run`.
+`[--] <arguments>`
+:   Arguments passed to the invoked binary.
+    The `--` separator is optional for bare arguments but
+    required when passing option-style arguments (e.g. `-f`,
+    `--verbose`) to prevent them from being interpreted by
+    `flox run`.
 
 ```{.include}
 ./include/general-options.md
@@ -91,17 +101,23 @@ Everything after `--` is passed directly to the binary.
 
 # EXAMPLES
 
-Run a command from a package:
+Run a command with a bare argument (no `--` needed):
 
 ```
-$ flox run cowsay -- "Hello, world!"
+$ flox run cowsay "Hello, world\!"
 ```
 
 Run a binary whose name differs from its package
-(`readelf` is provided by `binutils`):
+(`grep` is provided by `gnugrep`):
 
 ```
-$ flox run readelf -- --version
+$ flox run --package gnugrep grep -- --color=auto -r "pattern" .
+```
+
+Use `--` to pass option-style arguments to the binary:
+
+```
+$ flox run curl -- -sL http://example.com
 ```
 
 Specify the package explicitly:
@@ -116,10 +132,16 @@ Pipe input to a command:
 $ echo '{"name":"Flox"}' | flox run jq -- '.name'
 ```
 
-Clear a cached choice and re-select:
+Clear a saved preference and re-select:
 
 ```
 $ flox run --reselect vi
+```
+
+Search for packages that provide a binary:
+
+```
+$ flox search --binary rg
 ```
 
 # SEE ALSO

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -22,12 +22,8 @@ flox [<general-options>] run
 
 Run a binary from a Nix package without installing it to an environment.
 
-`flox run` is designed for one-off invocations where creating an
-environment would be unnecessary overhead.
-It creates a temporary environment behind the scenes,
-installs the required package,
-executes the binary,
-and cleans up when the command exits.
+`flox run` is designed for one-off invocations.
+Instead of requiring the overhead of an environment, it fetches the required package and executes the binary, all in one command.
 
 ## Binary Lookup
 
@@ -35,8 +31,8 @@ When you run `flox run <binary>`,
 Flox queries FloxHub to find which packages provide that binary.
 You do not need to know the package name.
 For example,
-`flox run readelf` will find and run the `readelf` binary from
-the `binutils` package without you needing to specify `binutils`.
+`flox run grep` will find and run the `grep` binary from
+the `gnugrep` package without you needing to specify `gnugrep`.
 
 If the binary cannot be found,
 Flox will print an error with suggestions and

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -15,7 +15,7 @@ flox [<general-options>] run
      [-p=<package>]
      [--reselect]
      <binary>
-     [-- <arguments>...]
+     [<arguments>...]
 ```
 
 # DESCRIPTION
@@ -59,9 +59,13 @@ the available packages and suggesting `--package`.
 
 ## Passing Arguments
 
-Use `--` to separate `flox run` options from arguments intended
-for the invoked binary.
-Everything after `--` is passed directly to the binary.
+Everything after the binary name is passed directly to the binary.
+Flox options such as `--package` and `--reselect` must appear
+*before* the binary name.
+
+A `--` separator is accepted but not required.
+It can be useful for readability or when you want to be explicit
+about where `flox run` options end and binary arguments begin.
 
 # OPTIONS
 
@@ -85,9 +89,10 @@ Everything after `--` is passed directly to the binary.
     In non-interactive contexts this will fail with an error
     listing the available packages.
 
-`-- <arguments>`
-:   Pass all remaining arguments to the invoked binary.
-    Options after `--` are not interpreted by `flox run`.
+`<arguments>`
+:   All arguments after the binary name are passed directly to the
+    invoked binary.
+    A `--` separator is accepted but not required.
 
 ```{.include}
 ./include/general-options.md
@@ -98,14 +103,14 @@ Everything after `--` is passed directly to the binary.
 Run a command from a package:
 
 ```
-$ flox run cowsay -- "Hello, world!"
+$ flox run cowsay "Hello, world!"
 ```
 
 Run a binary whose name differs from its package
 (`readelf` is provided by `binutils`):
 
 ```
-$ flox run readelf -- --version
+$ flox run readelf --version
 ```
 
 Specify the package explicitly:
@@ -117,13 +122,19 @@ $ flox run --package vim vi
 Pipe input to a command:
 
 ```
-$ echo '{"name":"Flox"}' | flox run jq -- '.name'
+$ echo '{"name":"Flox"}' | flox run jq '.name'
 ```
 
 Clear a cached choice and re-select:
 
 ```
 $ flox run --reselect vi
+```
+
+The `--` separator is optional but still accepted:
+
+```
+$ flox run curl -- -sL http://example.com
 ```
 
 # SEE ALSO

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -1,0 +1,132 @@
+---
+title: FLOX-RUN
+section: 1
+header: "Flox User Manuals"
+...
+
+# NAME
+
+flox-run - run a command without installing it
+
+# SYNOPSIS
+
+```
+flox [<general-options>] run
+     [-p=<package>]
+     [--reselect]
+     <binary>
+     [-- <arguments>...]
+```
+
+# DESCRIPTION
+
+Run a binary from a Nix package without installing it to an environment.
+
+`flox run` is designed for one-off invocations where creating an
+environment would be unnecessary overhead.
+It creates a temporary environment behind the scenes,
+installs the required package,
+executes the binary,
+and cleans up when the command exits.
+
+## Binary Lookup
+
+When you run `flox run <binary>`,
+Flox queries FloxHub to find which packages provide that binary.
+You do not need to know the package name.
+For example,
+`flox run readelf` will find and run the `readelf` binary from
+the `binutils` package without you needing to specify `binutils`.
+
+If the binary cannot be found,
+Flox will print an error with suggestions and
+recommend using `--package` to specify the package directly.
+
+## Disambiguation
+
+If multiple packages provide the same binary
+(for example, `vi` is provided by `vim`, `nvi`, and others),
+Flox will prompt you to choose which package to use.
+Your choice is cached so that subsequent invocations of the same
+binary run silently without re-prompting.
+
+In non-interactive contexts
+(when stdin is not a terminal, such as in pipelines or CI),
+Flox will use a previously cached choice if one exists.
+If no cached choice is available,
+the command will fail with a helpful error listing
+the available packages and suggesting `--package`.
+
+## Passing Arguments
+
+Use `--` to separate `flox run` options from arguments intended
+for the invoked binary.
+Everything after `--` is passed directly to the binary.
+
+# OPTIONS
+
+## Run Options
+
+`<binary>`
+:   The name of the binary to run.
+    Flox looks up which package provides this binary via FloxHub.
+
+`-p <package>`, `--package <package>`
+:   Specify the package directly,
+    bypassing the binary-to-package lookup.
+    This is useful when you know the package name
+    or when the automatic lookup does not find the right package.
+    The choice is saved to the cache
+    so that future invocations of the same binary use this package.
+
+`--reselect`
+:   Clear the cached package choice for this binary and
+    re-prompt for disambiguation.
+    In non-interactive contexts this will fail with an error
+    listing the available packages.
+
+`-- <arguments>`
+:   Pass all remaining arguments to the invoked binary.
+    Options after `--` are not interpreted by `flox run`.
+
+```{.include}
+./include/general-options.md
+```
+
+# EXAMPLES
+
+Run a command from a package:
+
+```
+$ flox run cowsay -- "Hello, world!"
+```
+
+Run a binary whose name differs from its package
+(`readelf` is provided by `binutils`):
+
+```
+$ flox run readelf -- --version
+```
+
+Specify the package explicitly:
+
+```
+$ flox run --package vim vi
+```
+
+Pipe input to a command:
+
+```
+$ echo '{"name":"Flox"}' | flox run jq -- '.name'
+```
+
+Clear a cached choice and re-select:
+
+```
+$ flox run --reselect vi
+```
+
+# SEE ALSO
+[`flox-activate(1)`](./flox-activate.md),
+[`flox-install(1)`](./flox-install.md),
+[`flox-search(1)`](./flox-search.md)

--- a/cli/flox/doc/flox-search.md
+++ b/cli/flox/doc/flox-search.md
@@ -15,6 +15,7 @@ flox-search - search for packages
 flox [<general options>] search
      [--json]
      [-a]
+     [--binary]
      <search-term>
 ```
 
@@ -51,9 +52,31 @@ portion of the pkg-path or description.
 `-a`, `--all`
 :   Display all search results (default: at most 10).
 
+`--binary`
+:   Search for packages that provide a specific binary.
+    Instead of matching package names and descriptions,
+    this searches for packages whose `bin/` directory contains
+    the specified binary name.
+    For example, `flox search --binary rg` finds `ripgrep`.
+
 ```{.include}
 ./include/general-options.md
 ```
 
+# EXAMPLES
+
+Search for a package by name:
+
+```
+$ flox search curl
+```
+
+Search for packages that provide a binary:
+
+```
+$ flox search --binary rg
+```
+
 # SEE ALSO
-[`flox-show(1)`](./flox-show.md)
+[`flox-show(1)`](./flox-show.md),
+[`flox-run(1)`](./flox-run.md)

--- a/cli/flox/doc/flox.md
+++ b/cli/flox/doc/flox.md
@@ -53,6 +53,9 @@ sharing environments, and administration.
 `activate`
 :   Enter the environment, type `exit` to leave.
 
+`run`
+:   Run a command from a package without installing it.
+
 `search`
 :   Search for system or library packages to install.
 
@@ -124,6 +127,7 @@ sharing environments, and administration.
 
 [`flox-init`(1)](./flox-init.md),
 [`flox-activate`(1)](./flox-activate.md),
+[`flox-run(1)`](./flox-run.md),
 [`flox-install`(1)](./flox-install.md),
 [`flox-uninstall(1)`](./flox-uninstall.md),
 [`flox-upgrade`(1)](./flox-upgrade.md),

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -35,7 +35,7 @@ pub struct Run {
     #[bpaf(long("package"), short('p'), argument("PKG"))]
     pub package: Option<String>,
 
-    /// Clear the cached package choice and re-prompt
+    /// Clear the saved preference and re-prompt
     #[bpaf(long("reselect"))]
     pub reselect: bool,
 
@@ -271,15 +271,14 @@ pub async fn choose_package_interactive<'a>(
 
 /// Build a helpful error message for ambiguous binary in non-interactive mode.
 fn non_interactive_ambiguity_error(binary: &str, candidates: &[PackageCandidate]) -> String {
-    let list = candidates
+    let pkg_list = candidates
         .iter()
-        .map(|c| format!("  - {}", c.attr_path))
+        .map(|c| c.attr_path.as_str())
         .collect::<Vec<_>>()
-        .join("\n");
+        .join(", ");
     format!(
-        "Multiple packages provide '{binary}' and no cached choice exists.\n\
-         Cannot prompt in non-interactive mode.\n\n\
-         Packages that provide '{binary}':\n{list}\n\n\
+        "Multiple packages provide '{binary}' and no preference is saved.\n\
+         Packages with this binary: {pkg_list}\n\
          Use 'flox run --package <pkg> {binary}' to specify a package.",
     )
 }

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -245,11 +245,7 @@ fn non_interactive_ambiguity_error(binary: &str, candidates: &[PackageCandidate]
 
 /// Build a helpful error message for binary not found.
 fn not_found_error(binary: &str) -> String {
-    format!(
-        "No packages found that provide the binary '{binary}'.\n\
-         Try 'flox search {binary}' to find related packages, then use\n\
-         'flox run --package <pkg> {binary}' to run it explicitly.",
-    )
+    format!("No packages found that provide the binary '{binary}'.")
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -20,19 +20,6 @@ use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::message;
 
-/// Filter for [`bpaf::any`]: consume every token except `--help` / `-h`
-/// so that those still trigger the built-in help. Silently drops a bare
-/// `--` separator (accepted but not required).
-fn not_help(s: String) -> Option<String> {
-    if s == "--help" || s == "-h" {
-        return None; // let bpaf handle it
-    }
-    if s == "--" {
-        return None; // drop the separator quietly
-    }
-    Some(s)
-}
-
 /// Run a binary from a package without installing it into an environment.
 ///
 /// Looks up the binary name in the Flox catalog to find which package provides
@@ -56,10 +43,8 @@ pub struct Run {
     #[bpaf(positional("binary"))]
     pub binary: String,
 
-    /// Arguments passed to the binary.
-    /// Everything after the binary name is forwarded directly.
-    /// A `--` separator is accepted but not required.
-    #[bpaf(any("ARGS", not_help), many)]
+    /// Arguments passed to the binary (after --)
+    #[bpaf(positional("args"), strict, many)]
     pub args: Vec<String>,
 }
 

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -20,6 +20,19 @@ use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::message;
 
+/// Filter for [`bpaf::any`]: consume every token except `--help` / `-h`
+/// so that those still trigger the built-in help. Silently drops a bare
+/// `--` separator (accepted but not required).
+fn not_help(s: String) -> Option<String> {
+    if s == "--help" || s == "-h" {
+        return None; // let bpaf handle it
+    }
+    if s == "--" {
+        return None; // drop the separator quietly
+    }
+    Some(s)
+}
+
 /// Run a binary from a package without installing it into an environment.
 ///
 /// Looks up the binary name in the Flox catalog to find which package provides
@@ -43,8 +56,10 @@ pub struct Run {
     #[bpaf(positional("binary"))]
     pub binary: String,
 
-    /// Arguments passed to the binary (after --)
-    #[bpaf(positional("args"), strict, many)]
+    /// Arguments passed to the binary.
+    /// Everything after the binary name is forwarded directly.
+    /// A `--` separator is accepted but not required.
+    #[bpaf(any("ARGS", not_help), many)]
     pub args: Vec<String>,
 }
 

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -1,47 +1,395 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
+use flox_catalog::{ClientTrait, SearchResults};
 use flox_core::data::environment_ref::EnvironmentName;
 use flox_manifest::raw::PackageToInstall;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::PathEnvironment;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, PathPointer};
+use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use super::EnvironmentSelect;
 use super::activate::{Activate, CommandSelect};
 use crate::config::Config;
 use crate::subcommand_metric;
+use crate::utils::dialog::{Dialog, Select};
+use crate::utils::message;
 
-/// Run a command from a package without installing it into an environment.
+/// Run a binary from a package without installing it into an environment.
 ///
-/// Creates a temporary environment, installs the specified package,
-/// and executes a command from it. The environment is cleaned up after
-/// the command exits.
-#[derive(Bpaf, Clone)]
+/// Looks up the binary name in the Flox catalog to find which package provides
+/// it, creates a temporary environment with that package, and executes the
+/// binary. The environment is cleaned up after the command exits.
+///
+/// When multiple packages provide the same binary, Flox prompts you to choose.
+/// Your choice is remembered for future invocations. Use --reselect to pick
+/// again, or --package to force a specific package.
+#[derive(Bpaf, Clone, Debug)]
 pub struct Run {
-    /// Name of the binary to execute (defaults to package name)
-    #[bpaf(long("bin"), short('b'), argument("BINARY"))]
-    pub bin: Option<String>,
+    /// Use a specific package instead of looking up the binary
+    #[bpaf(long("package"), short('p'), argument("PKG"))]
+    pub package: Option<String>,
 
-    /// The package to run (e.g. "cowsay", "python@3.11")
-    #[bpaf(positional("package"))]
-    pub package: String,
+    /// Clear the cached package choice and re-prompt
+    #[bpaf(long("reselect"))]
+    pub reselect: bool,
+
+    /// The binary to run (e.g. "readelf", "jq", "vi")
+    #[bpaf(positional("binary"))]
+    pub binary: String,
 
     /// Arguments passed to the binary (after --)
     #[bpaf(positional("args"), strict, many)]
     pub args: Vec<String>,
 }
 
+// ---------------------------------------------------------------------------
+// Cache types
+// ---------------------------------------------------------------------------
+
+/// User-scoped cache for binary → package choices.
+///
+/// Persisted as TOML at `state_dir/binary_preferences.toml`.
+/// Mirrors the `trusted_environments` pattern in `flox.toml`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct BinaryPreferences {
+    /// Map from binary name to chosen package attr_path.
+    #[serde(default)]
+    pub choices: HashMap<String, String>,
+}
+
+impl BinaryPreferences {
+    /// Load from disk, returning a default empty cache if file does not exist.
+    pub fn load(state_dir: &Path) -> Result<Self> {
+        let path = preferences_path(state_dir);
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let contents = std::fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read binary preferences from {path:?}"))?;
+        let prefs = toml::from_str(&contents)
+            .with_context(|| format!("Failed to parse binary preferences from {path:?}"))?;
+        Ok(prefs)
+    }
+
+    /// Persist to disk atomically.
+    pub fn save(&self, state_dir: &Path) -> Result<()> {
+        let path = preferences_path(state_dir);
+        std::fs::create_dir_all(state_dir)
+            .with_context(|| format!("Failed to create state directory {state_dir:?}"))?;
+        let contents =
+            toml::to_string(self).context("Failed to serialize binary preferences")?;
+        // Write to a temp file and rename for atomicity.
+        let tmp = path.with_extension("tmp");
+        std::fs::write(&tmp, &contents)
+            .with_context(|| format!("Failed to write binary preferences to {tmp:?}"))?;
+        std::fs::rename(&tmp, &path)
+            .with_context(|| format!("Failed to rename {tmp:?} to {path:?}"))?;
+        Ok(())
+    }
+
+    /// Get the cached choice for a binary, if any.
+    pub fn get(&self, binary: &str) -> Option<&str> {
+        self.choices.get(binary).map(|s| s.as_str())
+    }
+
+    /// Set a choice and persist it.
+    pub fn set_and_save(&mut self, binary: &str, pkg: &str, state_dir: &Path) -> Result<()> {
+        self.choices.insert(binary.to_string(), pkg.to_string());
+        self.save(state_dir)
+    }
+
+    /// Clear the choice for a binary and persist.
+    pub fn clear_and_save(&mut self, binary: &str, state_dir: &Path) -> Result<()> {
+        self.choices.remove(binary);
+        self.save(state_dir)
+    }
+}
+
+fn preferences_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("binary_preferences.toml")
+}
+
+// ---------------------------------------------------------------------------
+// Package candidate type
+// ---------------------------------------------------------------------------
+
+/// A candidate package that provides the requested binary.
+#[derive(Debug, Clone)]
+pub struct PackageCandidate {
+    pub attr_path: String,
+    pub pname: String,
+    pub description: Option<String>,
+    pub version: Option<String>,
+}
+
+impl std::fmt::Display for PackageCandidate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Show attr_path; fall back to pname only if they differ (e.g., nested attrs).
+        write!(f, "{}", self.attr_path)?;
+        if self.pname != self.attr_path {
+            write!(f, " ({})", self.pname)?;
+        } else if let Some(ref ver) = self.version {
+            write!(f, " ({})", ver)?;
+        }
+        if let Some(ref desc) = self.description {
+            // Truncate long descriptions for the menu.
+            let truncated = if desc.len() > 60 {
+                format!("{:.57}...", desc)
+            } else {
+                desc.clone()
+            };
+            write!(f, " — {}", truncated)?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Binary lookup
+// ---------------------------------------------------------------------------
+
+/// Look up packages that provide the given binary via the catalog.
+///
+/// Because the `by-binary` endpoint may not exist yet, we fall back to
+/// a search-based heuristic: search for the binary name and filter
+/// results where `pname` or the last segment of `attr_path` matches.
+///
+/// When the real endpoint is added to the catalog API and codegen, replace
+/// the body of this function with a direct API call.
+pub async fn lookup_binary_candidates(
+    binary: &str,
+    flox: &Flox,
+) -> Result<Vec<PackageCandidate>> {
+    // Try the dedicated by-binary endpoint first.
+    // The method returns Err if the endpoint doesn't exist or returns an
+    // error, in which case we fall back to search.
+    match flox
+        .catalog_client
+        .packages_by_binary(binary, flox.system.clone().try_into()?)
+        .await
+    {
+        Ok(by_binary) if !by_binary.is_empty() => {
+            debug!(
+                binary,
+                count = by_binary.len(),
+                "found candidates via by-binary endpoint"
+            );
+            let candidates = by_binary
+                .into_iter()
+                .map(|p| PackageCandidate {
+                    attr_path: p.attr_path,
+                    pname: p.pname,
+                    description: p.description,
+                    version: p.version,
+                })
+                .collect();
+            return Ok(candidates);
+        },
+        Ok(_) => {
+            debug!(
+                binary,
+                "by-binary endpoint returned empty results, falling back to search"
+            );
+        },
+        Err(e) => {
+            debug!(
+                binary,
+                error = %e,
+                "by-binary endpoint unavailable, falling back to search"
+            );
+        },
+    }
+
+    // Fallback: search for the binary name and heuristically filter.
+    let limit = std::num::NonZeroU8::new(20);
+    let results: SearchResults = flox
+        .catalog_client
+        .search(binary, flox.system.clone().try_into()?, limit)
+        .await
+        .with_context(|| format!("Failed to search catalog for binary '{binary}'"))?;
+
+    let candidates: Vec<PackageCandidate> = results
+        .results
+        .into_iter()
+        .filter(|pkg| {
+            // Keep results where the last attr_path segment or pname match the binary.
+            let last_segment = pkg.attr_path.rsplit('.').next().unwrap_or(&pkg.attr_path);
+            last_segment == binary || pkg.pname == binary
+        })
+        .map(|pkg| PackageCandidate {
+            attr_path: pkg.attr_path,
+            pname: pkg.pname,
+            description: pkg.description,
+            version: pkg.version,
+        })
+        .collect();
+
+    Ok(candidates)
+}
+
+// ---------------------------------------------------------------------------
+// Disambiguation
+// ---------------------------------------------------------------------------
+
+/// Choose a package from a list of candidates.
+///
+/// - If stdin+stderr are TTYs: show an interactive prompt.
+/// - Otherwise: return None (caller should error with helpful message).
+pub async fn choose_package_interactive<'a>(
+    binary: &'a str,
+    candidates: &'a [PackageCandidate],
+) -> Result<Option<&'a PackageCandidate>> {
+    if !Dialog::<()>::can_prompt() {
+        return Ok(None);
+    }
+
+    let options = candidates.to_vec();
+    let message = format!(
+        "Multiple packages provide '{}'. Which would you like to use?",
+        binary
+    );
+
+    let choice = Dialog {
+        message: &message,
+        help_message: Some("Use arrow keys to select, Enter to confirm"),
+        typed: Select { options },
+    }
+    .prompt()
+    .await
+    .context("Prompt interrupted")?;
+
+    // Find the chosen candidate by attr_path
+    let chosen = candidates
+        .iter()
+        .find(|c| c.attr_path == choice.attr_path)
+        .expect("chosen candidate must be in the list");
+
+    Ok(Some(chosen))
+}
+
+/// Build a helpful error message for ambiguous binary in non-interactive mode.
+fn non_interactive_ambiguity_error(binary: &str, candidates: &[PackageCandidate]) -> String {
+    let list = candidates
+        .iter()
+        .map(|c| format!("  - {}", c.attr_path))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Multiple packages provide '{binary}' and no cached choice exists.\n\
+         Cannot prompt in non-interactive mode.\n\n\
+         Packages that provide '{binary}':\n{list}\n\n\
+         Use 'flox run --package <pkg> {binary}' to specify a package.",
+    )
+}
+
+/// Build a helpful error message for binary not found.
+fn not_found_error(binary: &str) -> String {
+    format!(
+        "No packages found that provide the binary '{binary}'.\n\
+         Try 'flox search {binary}' to find related packages, then use\n\
+         'flox run --package <pkg> {binary}' to run it explicitly.",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
 impl Run {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("run");
 
-        let package = PackageToInstall::parse(&flox.system, &self.package)
+        let state_dir = &config.flox.state_dir;
+        let binary = &self.binary;
+
+        // Determine which package attr_path to use.
+        let pkg_attr_path = if let Some(ref pkg) = self.package {
+            // Explicit --package: use it, update cache.
+            debug!(binary, pkg, "using explicit --package override");
+            let mut prefs = BinaryPreferences::load(state_dir)?;
+            prefs.set_and_save(binary, pkg, state_dir)?;
+            pkg.clone()
+        } else {
+            // Binary-first: look up the binary in the catalog.
+            let mut prefs = BinaryPreferences::load(state_dir)?;
+
+            // --reselect: clear cached choice before proceeding.
+            if self.reselect {
+                debug!(binary, "clearing cached choice due to --reselect");
+                if Dialog::<()>::can_prompt() {
+                    prefs.clear_and_save(binary, state_dir)?;
+                } else {
+                    bail!(
+                        "--reselect requires an interactive terminal.\n\
+                         Use 'flox run --package <pkg> {binary}' to specify a package.",
+                    );
+                }
+            }
+
+            // Check cache first (unless --reselect cleared it).
+            if let Some(cached) = prefs.get(binary) {
+                debug!(binary, pkg = cached, "using cached package choice");
+                cached.to_string()
+            } else {
+                // Look up candidates.
+                let candidates = lookup_binary_candidates(binary, &flox).await?;
+
+                match candidates.len() {
+                    0 => {
+                        bail!("{}", not_found_error(binary));
+                    },
+                    1 => {
+                        // Single candidate: use it and cache silently.
+                        let pkg = &candidates[0].attr_path;
+                        debug!(binary, pkg, "single candidate found, using it");
+                        prefs.set_and_save(binary, pkg, state_dir)?;
+                        pkg.clone()
+                    },
+                    _ => {
+                        // Multiple candidates: disambiguate.
+                        message::plain(format!(
+                            "Multiple packages provide '{binary}'."
+                        ));
+
+                        let chosen =
+                            choose_package_interactive(binary, &candidates).await?;
+
+                        match chosen {
+                            Some(candidate) => {
+                                let pkg = &candidate.attr_path;
+                                prefs.set_and_save(binary, pkg, state_dir)?;
+                                pkg.clone()
+                            },
+                            None => {
+                                bail!(
+                                    "{}",
+                                    non_interactive_ambiguity_error(binary, &candidates)
+                                );
+                            },
+                        }
+                    },
+                }
+            }
+        };
+
+        debug!(
+            binary,
+            pkg = %pkg_attr_path,
+            "creating temporary environment for flox run"
+        );
+
+        // Parse the package to install.
+        let package_spec = pkg_attr_path.clone();
+        let package = PackageToInstall::parse(&flox.system, &package_spec)
             .context("Failed to parse package specification")?;
 
-        // Only support catalog packages for now
+        // Only support catalog packages for now.
         if !matches!(package, PackageToInstall::Catalog(_)) {
             bail!(
                 "flox run currently only supports catalog packages.\n\
@@ -49,20 +397,7 @@ impl Run {
             );
         }
 
-        let binary_name = self
-            .bin
-            .clone()
-            .unwrap_or_else(|| derive_binary_name(&self.package));
-
-        debug!(
-            package = %self.package,
-            binary = %binary_name,
-            "Creating temporary environment for flox run"
-        );
-
         // Create a temp directory for the ephemeral environment.
-        // This lives under flox.temp_dir which is a per-process TempDir
-        // managed by FloxArgs::handle.
         let run_temp_dir = flox.temp_dir.join("flox-run");
         std::fs::create_dir_all(&run_temp_dir)
             .context("Failed to create temporary directory for flox run")?;
@@ -76,46 +411,37 @@ impl Run {
 
         debug!(
             "Installing package '{}' into temporary environment",
-            self.package
+            package_spec
         );
 
         path_env
             .install(&[package], &flox)
-            .with_context(|| format!("Failed to install package '{}'", self.package))?;
+            .with_context(|| {
+                format!("Failed to install package '{}'", package_spec)
+            })?;
 
         let mut concrete_environment = ConcreteEnvironment::Path(path_env);
 
-        // Resolve the binary to run. If --bin was explicitly provided, use it as-is.
-        // Otherwise, try to find the best binary in the built environment.
+        // Resolve the binary in the built environment.
         let rendered = concrete_environment
             .rendered_env_links(&flox)
             .context("Failed to get environment paths")?;
         let bin_dir = rendered.runtime.join("bin");
-        let binary_name = if self.bin.is_some() {
-            // User explicitly chose a binary — validate it exists
-            if bin_dir.is_dir() && !bin_dir.join(&binary_name).exists() {
-                let available = list_binaries(&bin_dir);
-                let list = if available.is_empty() {
-                    String::new()
-                } else {
-                    format!("\n\nAvailable binaries: {}", available.join(", "))
-                };
-                bail!(
-                    "Binary '{binary_name}' not found in package '{package}'.{list}",
-                    package = self.package,
-                );
-            }
-            binary_name
+
+        // The binary name is the user-provided name; try to find it in the
+        // installed package, falling back to the resolution heuristics.
+        let resolved_binary = if bin_dir.is_dir() && bin_dir.join(binary).exists() {
+            // Exact match.
+            binary.clone()
         } else {
-            resolve_binary(&binary_name, &bin_dir, &self.package)?
+            resolve_binary(binary, &bin_dir, &pkg_attr_path)?
         };
 
         // Build the exec command: [binary_name, args...]
-        let mut exec_args = vec![binary_name.clone()];
+        let mut exec_args = vec![resolved_binary.clone()];
         exec_args.extend(self.args.clone());
 
-        // Reuse the Activate flow — same pattern as services start
-        // (cli/flox/src/commands/services/mod.rs:402-424)
+        // Reuse the Activate flow — same pattern as services start.
         Activate {
             environment: EnvironmentSelect::Dir(run_temp_dir),
             trust: false,
@@ -123,9 +449,8 @@ impl Run {
             start_services: false,
             mode: None,
             generation: None,
-            // this isn't actually used because we pass invocation_type below
             command: Some(CommandSelect::ExecCommand {
-                command: binary_name,
+                command: resolved_binary,
                 args: self.args,
             }),
         }
@@ -140,29 +465,12 @@ impl Run {
     }
 }
 
-/// Derive a binary name from a package specification string.
-///
-/// Examples:
-/// - "cowsay" -> "cowsay"
-/// - "python@3.11" -> "python"
-/// - "python3Packages.numpy" -> "numpy"
-/// - "curl^bin,man" -> "curl"
-fn derive_binary_name(package_spec: &str) -> String {
-    package_spec
-        .split('@')
-        .next()
-        .unwrap() // strip version
-        .split('^')
-        .next()
-        .unwrap() // strip outputs
-        .rsplit('.')
-        .next()
-        .unwrap() // last segment of attr path
-        .to_string()
-}
+// ---------------------------------------------------------------------------
+// Binary resolution helpers (kept from prototype)
+// ---------------------------------------------------------------------------
 
 /// List binary names available in a bin directory.
-fn list_binaries(bin_dir: &std::path::Path) -> Vec<String> {
+fn list_binaries(bin_dir: &Path) -> Vec<String> {
     let mut bins: Vec<String> = std::fs::read_dir(bin_dir)
         .into_iter()
         .flatten()
@@ -181,14 +489,16 @@ fn list_binaries(bin_dir: &std::path::Path) -> Vec<String> {
 /// Resolve the best binary to run from a package's bin directory.
 ///
 /// Strategy:
-/// 1. If the derived name exists in bin/, use it (e.g. "cowsay" → "cowsay")
+/// 1. If the name exists in bin/, use it (e.g. "cowsay" → "cowsay")
 /// 2. If only one binary exists, use it
-/// 3. If the derived name is a prefix of exactly one binary, use it (e.g. "python3" → "python3.11")
-/// 4. If a binary is a prefix of the derived name, use it (e.g. "nodejs" → "node")
+/// 3. If the name is a prefix of exactly one binary, use it
+///    (e.g. "python3" → "python3.11")
+/// 4. If a binary is a prefix of the name, use it
+///    (e.g. "nodejs" → "node")
 /// 5. Otherwise, error with the list of available binaries
-fn resolve_binary(
+pub fn resolve_binary(
     derived_name: &str,
-    bin_dir: &std::path::Path,
+    bin_dir: &Path,
     package_spec: &str,
 ) -> Result<String> {
     // Exact match
@@ -246,15 +556,39 @@ fn resolve_binary(
 
     bail!(
         "Binary '{derived_name}' not found in package '{package_spec}'.\n\
-         Try: flox run --bin <BINARY> {package_spec} -- ...\n\n\
+         Try: flox run --package <PKG> {derived_name} -- ...\n\n\
          Available binaries: {}",
         available.join(", ")
     );
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ----- derive_binary_name -----
+
+    /// Derive a binary name from a package specification string.
+    ///
+    /// This utility is preserved for testing purposes; in production,
+    /// the binary name is always provided directly by the user.
+    fn derive_binary_name(package_spec: &str) -> String {
+        package_spec
+            .split('@')
+            .next()
+            .unwrap()
+            .split('^')
+            .next()
+            .unwrap()
+            .rsplit('.')
+            .next()
+            .unwrap()
+            .to_string()
+    }
 
     #[test]
     fn test_derive_binary_name_simple() {
@@ -280,6 +614,8 @@ mod tests {
     fn test_derive_binary_name_version_and_path() {
         assert_eq!(derive_binary_name("python3Packages.numpy@1.24"), "numpy");
     }
+
+    // ----- resolve_binary -----
 
     #[test]
     fn test_resolve_binary_exact_match() {
@@ -329,5 +665,92 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Available binaries: bar, foo"));
+    }
+
+    // ----- BinaryPreferences -----
+
+    #[test]
+    fn test_binary_prefs_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path();
+
+        let mut prefs = BinaryPreferences::default();
+        prefs.set_and_save("vi", "vim", state_dir).unwrap();
+
+        let loaded = BinaryPreferences::load(state_dir).unwrap();
+        assert_eq!(loaded.get("vi"), Some("vim"));
+    }
+
+    #[test]
+    fn test_binary_prefs_empty_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path();
+
+        let prefs = BinaryPreferences::load(state_dir).unwrap();
+        assert_eq!(prefs.get("vi"), None);
+    }
+
+    #[test]
+    fn test_binary_prefs_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path();
+
+        let mut prefs = BinaryPreferences::default();
+        prefs.set_and_save("vi", "vim", state_dir).unwrap();
+        prefs.set_and_save("vi", "neovim", state_dir).unwrap();
+
+        let loaded = BinaryPreferences::load(state_dir).unwrap();
+        assert_eq!(loaded.get("vi"), Some("neovim"));
+    }
+
+    #[test]
+    fn test_binary_prefs_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path();
+
+        let mut prefs = BinaryPreferences::default();
+        prefs.set_and_save("vi", "vim", state_dir).unwrap();
+        prefs.clear_and_save("vi", state_dir).unwrap();
+
+        let loaded = BinaryPreferences::load(state_dir).unwrap();
+        assert_eq!(loaded.get("vi"), None);
+    }
+
+    #[test]
+    fn test_binary_prefs_multiple_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path();
+
+        let mut prefs = BinaryPreferences::default();
+        prefs.set_and_save("vi", "vim", state_dir).unwrap();
+        prefs.set_and_save("jq", "jq", state_dir).unwrap();
+
+        let loaded = BinaryPreferences::load(state_dir).unwrap();
+        assert_eq!(loaded.get("vi"), Some("vim"));
+        assert_eq!(loaded.get("jq"), Some("jq"));
+    }
+
+    // ----- non_interactive_ambiguity_error -----
+
+    #[test]
+    fn test_non_interactive_error_lists_candidates() {
+        let candidates = vec![
+            PackageCandidate {
+                attr_path: "vim".to_string(),
+                pname: "vim".to_string(),
+                description: None,
+                version: None,
+            },
+            PackageCandidate {
+                attr_path: "vimer".to_string(),
+                pname: "vimer".to_string(),
+                description: None,
+                version: None,
+            },
+        ];
+        let err = non_interactive_ambiguity_error("vi", &candidates);
+        assert!(err.contains("vim"));
+        assert!(err.contains("vimer"));
+        assert!(err.contains("--package"));
     }
 }

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::{Context, Result, bail};
@@ -10,11 +9,12 @@ use flox_manifest::raw::PackageToInstall;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::PathEnvironment;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, PathPointer};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tracing::debug;
 
 use super::EnvironmentSelect;
 use super::activate::{Activate, CommandSelect};
+use super::general::update_config;
 use crate::config::Config;
 use crate::subcommand_metric;
 use crate::utils::dialog::{Dialog, Select};
@@ -49,69 +49,27 @@ pub struct Run {
 }
 
 // ---------------------------------------------------------------------------
-// Cache types
+// Preference helpers
 // ---------------------------------------------------------------------------
 
-/// User-scoped cache for binary → package choices.
-///
-/// Persisted as TOML at `state_dir/binary_preferences.toml`.
-/// Mirrors the `trusted_environments` pattern in `flox.toml`.
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct BinaryPreferences {
-    /// Map from binary name to chosen package attr_path.
-    #[serde(default)]
-    pub choices: HashMap<String, String>,
+/// Save a binary → package preference to the config framework.
+fn save_preference(config_dir: &Path, binary: &str, pkg: &str) -> Result<()> {
+    update_config(
+        config_dir,
+        format!("binary_preferences.{binary}"),
+        Some(pkg),
+    )
+    .with_context(|| format!("Failed to save preference for '{binary}'"))
 }
 
-impl BinaryPreferences {
-    /// Load from disk, returning a default empty cache if file does not exist.
-    pub fn load(state_dir: &Path) -> Result<Self> {
-        let path = preferences_path(state_dir);
-        if !path.exists() {
-            return Ok(Self::default());
-        }
-        let contents = std::fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read binary preferences from {path:?}"))?;
-        let prefs = toml::from_str(&contents)
-            .with_context(|| format!("Failed to parse binary preferences from {path:?}"))?;
-        Ok(prefs)
-    }
-
-    /// Persist to disk atomically.
-    pub fn save(&self, state_dir: &Path) -> Result<()> {
-        let path = preferences_path(state_dir);
-        std::fs::create_dir_all(state_dir)
-            .with_context(|| format!("Failed to create state directory {state_dir:?}"))?;
-        let contents = toml::to_string(self).context("Failed to serialize binary preferences")?;
-        // Write to a temp file and rename for atomicity.
-        let tmp = path.with_extension("tmp");
-        std::fs::write(&tmp, &contents)
-            .with_context(|| format!("Failed to write binary preferences to {tmp:?}"))?;
-        std::fs::rename(&tmp, &path)
-            .with_context(|| format!("Failed to rename {tmp:?} to {path:?}"))?;
-        Ok(())
-    }
-
-    /// Get the cached choice for a binary, if any.
-    pub fn get(&self, binary: &str) -> Option<&str> {
-        self.choices.get(binary).map(|s| s.as_str())
-    }
-
-    /// Set a choice and persist it.
-    pub fn set_and_save(&mut self, binary: &str, pkg: &str, state_dir: &Path) -> Result<()> {
-        self.choices.insert(binary.to_string(), pkg.to_string());
-        self.save(state_dir)
-    }
-
-    /// Clear the choice for a binary and persist.
-    pub fn clear_and_save(&mut self, binary: &str, state_dir: &Path) -> Result<()> {
-        self.choices.remove(binary);
-        self.save(state_dir)
-    }
-}
-
-fn preferences_path(state_dir: &Path) -> PathBuf {
-    state_dir.join("binary_preferences.toml")
+/// Clear a binary → package preference from the config framework.
+fn clear_preference(config_dir: &Path, binary: &str) -> Result<()> {
+    update_config(
+        config_dir,
+        format!("binary_preferences.{binary}"),
+        None::<String>,
+    )
+    .with_context(|| format!("Failed to clear preference for '{binary}'"))
 }
 
 // ---------------------------------------------------------------------------
@@ -300,25 +258,21 @@ impl Run {
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("run");
 
-        let state_dir = &config.flox.state_dir;
+        let config_dir = &config.flox.config_dir;
         let binary = &self.binary;
 
         // Determine which package attr_path to use.
         let pkg_attr_path = if let Some(ref pkg) = self.package {
-            // Explicit --package: use it, update cache.
+            // Explicit --package: use it, save as preference.
             debug!(binary, pkg, "using explicit --package override");
-            let mut prefs = BinaryPreferences::load(state_dir)?;
-            prefs.set_and_save(binary, pkg, state_dir)?;
+            save_preference(config_dir, binary, pkg)?;
             pkg.clone()
         } else {
-            // Binary-first: look up the binary in the catalog.
-            let mut prefs = BinaryPreferences::load(state_dir)?;
-
-            // --reselect: clear cached choice before proceeding.
+            // --reselect: clear saved preference before proceeding.
             if self.reselect {
-                debug!(binary, "clearing cached choice due to --reselect");
+                debug!(binary, "clearing saved preference due to --reselect");
                 if Dialog::<()>::can_prompt() {
-                    prefs.clear_and_save(binary, state_dir)?;
+                    clear_preference(config_dir, binary)?;
                 } else {
                     bail!(
                         "--reselect requires an interactive terminal.\n\
@@ -327,10 +281,10 @@ impl Run {
                 }
             }
 
-            // Check cache first (unless --reselect cleared it).
-            if let Some(cached) = prefs.get(binary) {
-                debug!(binary, pkg = cached, "using cached package choice");
-                cached.to_string()
+            // Check saved preference first (unless --reselect cleared it).
+            if let Some(saved) = config.flox.binary_preferences.get(binary.as_str()) {
+                debug!(binary, pkg = saved.as_str(), "using saved preference");
+                saved.clone()
             } else {
                 // Look up candidates.
                 let candidates = lookup_binary_candidates(binary, &flox).await?;
@@ -340,10 +294,10 @@ impl Run {
                         bail!("{}", not_found_error(binary));
                     },
                     1 => {
-                        // Single candidate: use it and cache silently.
+                        // Single candidate: use it and save preference.
                         let pkg = &candidates[0].attr_path;
                         debug!(binary, pkg, "single candidate found, using it");
-                        prefs.set_and_save(binary, pkg, state_dir)?;
+                        save_preference(config_dir, binary, pkg)?;
                         pkg.clone()
                     },
                     _ => {
@@ -355,7 +309,7 @@ impl Run {
                         match chosen {
                             Some(candidate) => {
                                 let pkg = &candidate.attr_path;
-                                prefs.set_and_save(binary, pkg, state_dir)?;
+                                save_preference(config_dir, binary, pkg)?;
                                 pkg.clone()
                             },
                             None => {
@@ -650,67 +604,52 @@ mod tests {
         assert!(err.contains("Available binaries: bar, foo"));
     }
 
-    // ----- BinaryPreferences -----
+    // ----- Preference helpers (config framework) -----
 
     #[test]
-    fn test_binary_prefs_round_trip() {
+    fn test_save_and_read_preference() {
         let dir = tempfile::tempdir().unwrap();
-        let state_dir = dir.path();
+        let config_dir = dir.path();
+        save_preference(config_dir, "vi", "vim").unwrap();
 
-        let mut prefs = BinaryPreferences::default();
-        prefs.set_and_save("vi", "vim", state_dir).unwrap();
-
-        let loaded = BinaryPreferences::load(state_dir).unwrap();
-        assert_eq!(loaded.get("vi"), Some("vim"));
+        let contents = std::fs::read_to_string(config_dir.join("flox.toml")).unwrap();
+        assert!(contents.contains("[binary_preferences]"));
+        assert!(contents.contains("vi = \"vim\""));
     }
 
     #[test]
-    fn test_binary_prefs_empty_default() {
+    fn test_save_preference_overwrite() {
         let dir = tempfile::tempdir().unwrap();
-        let state_dir = dir.path();
+        let config_dir = dir.path();
+        save_preference(config_dir, "vi", "vim").unwrap();
+        save_preference(config_dir, "vi", "neovim").unwrap();
 
-        let prefs = BinaryPreferences::load(state_dir).unwrap();
-        assert_eq!(prefs.get("vi"), None);
+        let contents = std::fs::read_to_string(config_dir.join("flox.toml")).unwrap();
+        assert!(contents.contains("vi = \"neovim\""));
+        assert!(!contents.contains("vi = \"vim\""));
     }
 
     #[test]
-    fn test_binary_prefs_overwrite() {
+    fn test_clear_preference() {
         let dir = tempfile::tempdir().unwrap();
-        let state_dir = dir.path();
+        let config_dir = dir.path();
+        save_preference(config_dir, "vi", "vim").unwrap();
+        clear_preference(config_dir, "vi").unwrap();
 
-        let mut prefs = BinaryPreferences::default();
-        prefs.set_and_save("vi", "vim", state_dir).unwrap();
-        prefs.set_and_save("vi", "neovim", state_dir).unwrap();
-
-        let loaded = BinaryPreferences::load(state_dir).unwrap();
-        assert_eq!(loaded.get("vi"), Some("neovim"));
+        let contents = std::fs::read_to_string(config_dir.join("flox.toml")).unwrap();
+        assert!(!contents.contains("vi"));
     }
 
     #[test]
-    fn test_binary_prefs_clear() {
+    fn test_save_multiple_preferences() {
         let dir = tempfile::tempdir().unwrap();
-        let state_dir = dir.path();
+        let config_dir = dir.path();
+        save_preference(config_dir, "vi", "vim").unwrap();
+        save_preference(config_dir, "jq", "jq").unwrap();
 
-        let mut prefs = BinaryPreferences::default();
-        prefs.set_and_save("vi", "vim", state_dir).unwrap();
-        prefs.clear_and_save("vi", state_dir).unwrap();
-
-        let loaded = BinaryPreferences::load(state_dir).unwrap();
-        assert_eq!(loaded.get("vi"), None);
-    }
-
-    #[test]
-    fn test_binary_prefs_multiple_entries() {
-        let dir = tempfile::tempdir().unwrap();
-        let state_dir = dir.path();
-
-        let mut prefs = BinaryPreferences::default();
-        prefs.set_and_save("vi", "vim", state_dir).unwrap();
-        prefs.set_and_save("jq", "jq", state_dir).unwrap();
-
-        let loaded = BinaryPreferences::load(state_dir).unwrap();
-        assert_eq!(loaded.get("vi"), Some("vim"));
-        assert_eq!(loaded.get("jq"), Some("jq"));
+        let contents = std::fs::read_to_string(config_dir.join("flox.toml")).unwrap();
+        assert!(contents.contains("vi = \"vim\""));
+        assert!(contents.contains("jq = \"jq\""));
     }
 
     // ----- non_interactive_ambiguity_error -----

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -119,7 +119,7 @@ fn preferences_path(state_dir: &Path) -> PathBuf {
 // ---------------------------------------------------------------------------
 
 /// A candidate package that provides the requested binary.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PackageCandidate {
     pub attr_path: String,
     pub pname: String,

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -82,8 +82,7 @@ impl BinaryPreferences {
         let path = preferences_path(state_dir);
         std::fs::create_dir_all(state_dir)
             .with_context(|| format!("Failed to create state directory {state_dir:?}"))?;
-        let contents =
-            toml::to_string(self).context("Failed to serialize binary preferences")?;
+        let contents = toml::to_string(self).context("Failed to serialize binary preferences")?;
         // Write to a temp file and rename for atomicity.
         let tmp = path.with_extension("tmp");
         std::fs::write(&tmp, &contents)
@@ -162,10 +161,7 @@ impl std::fmt::Display for PackageCandidate {
 ///
 /// When the real endpoint is added to the catalog API and codegen, replace
 /// the body of this function with a direct API call.
-pub async fn lookup_binary_candidates(
-    binary: &str,
-    flox: &Flox,
-) -> Result<Vec<PackageCandidate>> {
+pub async fn lookup_binary_candidates(binary: &str, flox: &Flox) -> Result<Vec<PackageCandidate>> {
     // Try the dedicated by-binary endpoint first.
     // The method returns Err if the endpoint doesn't exist or returns an
     // error, in which case we fall back to search.
@@ -353,12 +349,9 @@ impl Run {
                     },
                     _ => {
                         // Multiple candidates: disambiguate.
-                        message::plain(format!(
-                            "Multiple packages provide '{binary}'."
-                        ));
+                        message::plain(format!("Multiple packages provide '{binary}'."));
 
-                        let chosen =
-                            choose_package_interactive(binary, &candidates).await?;
+                        let chosen = choose_package_interactive(binary, &candidates).await?;
 
                         match chosen {
                             Some(candidate) => {
@@ -367,10 +360,7 @@ impl Run {
                                 pkg.clone()
                             },
                             None => {
-                                bail!(
-                                    "{}",
-                                    non_interactive_ambiguity_error(binary, &candidates)
-                                );
+                                bail!("{}", non_interactive_ambiguity_error(binary, &candidates));
                             },
                         }
                     },
@@ -416,9 +406,7 @@ impl Run {
 
         path_env
             .install(&[package], &flox)
-            .with_context(|| {
-                format!("Failed to install package '{}'", package_spec)
-            })?;
+            .with_context(|| format!("Failed to install package '{}'", package_spec))?;
 
         let mut concrete_environment = ConcreteEnvironment::Path(path_env);
 
@@ -496,11 +484,7 @@ fn list_binaries(bin_dir: &Path) -> Vec<String> {
 /// 4. If a binary is a prefix of the name, use it
 ///    (e.g. "nodejs" → "node")
 /// 5. Otherwise, error with the list of available binaries
-pub fn resolve_binary(
-    derived_name: &str,
-    bin_dir: &Path,
-    package_spec: &str,
-) -> Result<String> {
+pub fn resolve_binary(derived_name: &str, bin_dir: &Path, package_spec: &str) -> Result<String> {
     // Exact match
     if bin_dir.join(derived_name).exists() {
         return Ok(derived_name.to_string());

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -283,8 +283,15 @@ impl Run {
                 }
             }
 
-            // Check saved preference first (unless --reselect cleared it).
-            if let Some(saved) = config.flox.binary_preferences.get(binary.as_str()) {
+            // Check saved preference. Skip when --reselect is set because
+            // the in-memory config is stale after clear_preference wrote
+            // to disk — we need to fall through to the lookup/prompt.
+            let saved = if self.reselect {
+                None
+            } else {
+                config.flox.binary_preferences.get(binary.as_str())
+            };
+            if let Some(saved) = saved {
                 debug!(binary, pkg = saved.as_str(), "using saved preference");
                 saved.clone()
             } else {

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -43,8 +43,10 @@ pub struct Run {
     #[bpaf(positional("binary"))]
     pub binary: String,
 
-    /// Arguments passed to the binary (after --)
-    #[bpaf(positional("args"), strict, many)]
+    /// Arguments passed to the binary.
+    /// Bare arguments are passed through automatically.
+    /// Use `--` to pass option-style arguments (e.g. `-f`, `--verbose`).
+    #[bpaf(positional("args"), many)]
     pub args: Vec<String>,
 }
 

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -1,13 +1,15 @@
 use std::fmt::Write;
 use std::num::NonZeroU8;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_catalog::{ClientTrait, SearchResults};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::catalog::SearchTerm;
 use indoc::{formatdoc, indoc};
 use tracing::{debug, instrument};
+
+use super::run::lookup_binary_candidates;
 
 use crate::config::Config;
 use crate::subcommand_metric;
@@ -37,6 +39,10 @@ pub struct Search {
     #[bpaf(short, long)]
     pub all: bool,
 
+    /// Search for packages that provide a specific binary
+    #[bpaf(long)]
+    pub binary: bool,
+
     /// The package to search for in the format '<pkg-path>'.
     ///
     /// ex. python310Packages.pip
@@ -55,6 +61,14 @@ impl Search {
         subcommand_metric!("search", search_term = search_term);
 
         debug!("performing search for term: {}", search_term);
+
+        // Binary search mode: use the by-binary endpoint instead of
+        // normal package name/description search.
+        if self.binary {
+            return self
+                .handle_binary_search(search_term, &flox)
+                .await;
+        }
 
         let limit = if self.all {
             None
@@ -136,6 +150,38 @@ impl Search {
             // https://github.com/tokio-rs/tracing/issues/3369
             eprintln!("{hints}");
         }
+        Ok(())
+    }
+
+    /// Handle `flox search --binary <name>`: search for packages that
+    /// provide a specific binary via the FloxHub binary-to-package index.
+    async fn handle_binary_search(&self, binary_name: &str, flox: &Flox) -> Result<()> {
+        debug!("performing binary search for: {}", binary_name);
+
+        let candidates = lookup_binary_candidates(binary_name, flox)
+            .await
+            .context("Failed to look up packages by binary name")?;
+
+        if candidates.is_empty() {
+            bail!(
+                "No packages found that provide the binary '{}'.",
+                binary_name,
+            );
+        }
+
+        if self.json {
+            let json = serde_json::to_string(&candidates)?;
+            println!("{json}");
+        } else {
+            for candidate in &candidates {
+                let desc = candidate
+                    .description
+                    .as_deref()
+                    .unwrap_or("<no description provided>");
+                println!("{:<30} {}", candidate.attr_path, desc);
+            }
+        }
+
         Ok(())
     }
 }

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -75,6 +75,12 @@ pub struct FloxConfig {
     #[serde(default)]
     pub trusted_environments: HashMap<RemoteEnvironmentRef, EnvironmentTrust>,
 
+    /// Saved binary → package preferences for `flox run`.
+    /// When a user resolves an ambiguous binary to a specific package,
+    /// the choice is saved here as a preference.
+    #[serde(default)]
+    pub binary_preferences: HashMap<String, String>,
+
     /// The URL of the FloxHub instance to use
     pub floxhub_url: Option<Url>,
 

--- a/cli/tests/run.bats
+++ b/cli/tests/run.bats
@@ -1,0 +1,131 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Integration tests for `flox run` — binary-first UX.
+#
+# These tests cover:
+#   - Argument parsing and --help output
+#   - Binary not found (empty search result → helpful error)
+#   - Ambiguous binary in non-interactive mode (multiple packages → helpful error)
+#   - Cache: read, write, clear via --reselect
+#   - Explicit --package flag
+#
+# Tests that require actual package builds (happy path, piped input) are
+# marked @skip-without-build and run only in environments with full Nix.
+#
+# bats file_tags=run
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  setup_isolated_flox
+}
+
+teardown() {
+  common_test_teardown
+}
+
+setup_file() {
+  common_file_setup
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run --help' shows binary-first usage" {
+  run "$FLOX_BIN" run --help
+  assert_success
+  assert_output --partial "<binary>"
+  assert_output --partial "--package"
+  assert_output --partial "--reselect"
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run' requires a binary argument" {
+  export RUST_BACKTRACE=0
+  run "$FLOX_BIN" run
+  assert_failure
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run' errors helpfully when binary is not found in catalog" {
+  export RUST_BACKTRACE=0
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/run/not_found.yaml"
+  run "$FLOX_BIN" run nonexistent-binary-xyz
+  assert_failure
+  assert_output --partial "nonexistent-binary-xyz"
+  assert_output --partial "flox search"
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run' fails with helpful error for ambiguous binary in non-interactive mode" {
+  export RUST_BACKTRACE=0
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/run/vi_ambiguous.yaml"
+  # Pipe something to stdin to make it non-interactive.
+  run bash -c "echo '' | '$FLOX_BIN' run vi"
+  assert_failure
+  # Should list candidates and suggest --package.
+  assert_output --partial "vim"
+  assert_output --partial "--package"
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run' caches binary choice and uses it on subsequent invocations" {
+  # Populate the binary preferences cache directly.
+  local state_dir="$FLOX_STATE_DIR"
+  mkdir -p "$state_dir"
+  cat > "$state_dir/binary_preferences.toml" <<EOF
+[choices]
+testbinary = "testpkg"
+EOF
+
+  # Now run with a mock that would fail if searched (we expect cache hit).
+  # The search endpoint mock returns empty — if we hit search, we'd fail.
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/run/not_found.yaml"
+  export RUST_BACKTRACE=0
+
+  # We expect to fail at the install stage (package doesn't exist in store),
+  # not at the search stage. The error should NOT say "No packages found".
+  run "$FLOX_BIN" run testbinary
+  # Should NOT fail with "No packages found" (which is the search error).
+  refute_output --partial "No packages found that provide"
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run --reselect' fails in non-interactive mode" {
+  export RUST_BACKTRACE=0
+  run bash -c "echo '' | '$FLOX_BIN' run --reselect vi"
+  assert_failure
+  assert_output --partial "--reselect"
+  assert_output --partial "interactive"
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run --package' with explicit package is accepted" {
+  export RUST_BACKTRACE=0
+  # With a mock that returns empty search (we should bypass search with --package).
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/run/not_found.yaml"
+  # The command will fail at the install stage (no real nix store), but should
+  # not fail with "No packages found" (search is bypassed when --package is given).
+  run "$FLOX_BIN" run --package hello hello
+  refute_output --partial "No packages found that provide"
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run' help text mentions 'man flox-run'" {
+  run "$FLOX_BIN" run --help
+  assert_success
+  assert_output --partial "man flox-run"
+}

--- a/test_data/generated/run/not_found.yaml
+++ b/test_data/generated/run/not_found.yaml
@@ -1,0 +1,9 @@
+when:
+  path: /api/v1/catalog/search
+  method: GET
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"items":[],"total_count":0}'

--- a/test_data/generated/run/vi_ambiguous.yaml
+++ b/test_data/generated/run/vi_ambiguous.yaml
@@ -1,0 +1,9 @@
+when:
+  path: /api/v1/catalog/search
+  method: GET
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"items":[{"attr_path":"vim","catalog":null,"pkg_path":"vim","name":"vim-9.1.1100","pname":"vi","version":"9.1.1100","description":"Vi IMproved, a text editor","stabilities":[],"system":"aarch64-darwin"},{"attr_path":"neovim","catalog":null,"pkg_path":"neovim","name":"neovim-0.10.4","pname":"vi","version":"0.10.4","description":"Vim text editor fork focused on extensibility and agility","stabilities":[],"system":"aarch64-darwin"},{"attr_path":"vimer","catalog":null,"pkg_path":"vimer","name":"vimer-0.0.4","pname":"vi","version":"0.0.4","description":"Vim-er is a minimal Vim distribution","stabilities":[],"system":"aarch64-darwin"}],"total_count":3}'


### PR DESCRIPTION
## Summary

Refactors `flox run` from package-first to binary-first invocation, addressing Michael's UX feedback that users shouldn't need to know which package provides a binary.

- New CLI form: `flox run [--package <pkg>] [--reselect] <binary> [-- args...]`
- Binary name is the primary argument; Flox looks up the package from the catalog (with fallback to search-based heuristic while the by-binary endpoint is built)
- Interactive disambiguation prompt (inquire Select) when multiple packages provide the binary; graceful degradation in non-interactive mode (CI, piped input)
- Binary preference cache persisted at `state_dir/binary_preferences.toml` (TOML, serde)
- `--package <pkg>`: bypass lookup and cache, also updates cache
- `--reselect`: clear cached choice and re-prompt
- `--` passthrough: args after `--` forwarded cleanly to the binary
- New `PackageByBinary` type and `packages_by_binary` method on `ClientTrait` with default error implementation (backend endpoint pending) and `MockClient` support
- 14 new unit tests for cache round-trips, resolution helpers, error messages
- `cli/tests/run.bats` with 7 integration tests covering help, error cases, cache behavior

## Effort Reference

See the Flox Run effort document at https://github.com/flox/forge/blob/main/efforts/2026/04-flox-run/effort.md for full context, stories (ST-001 through ST-005), and requirements (REQ-001 through REQ-004).

---
*Via Forge (implementation-worker) • 8c8050af*