### PR TITLE
fix: avoid compose.composer schema version drift

### DIFF
--- a/cli/flox-manifest/src/interfaces/as_typed_only.rs
+++ b/cli/flox-manifest/src/interfaces/as_typed_only.rs
@@ -20,6 +20,7 @@ impl AsTypedOnlyManifest for Manifest<Validated> {
 }
 
 impl AsTypedOnlyManifest for Manifest<MigratedTypedOnly> {
+    /// This is always in the latest schema version
     fn as_typed_only(&self) -> Manifest<TypedOnly> {
         Manifest {
             inner: TypedOnly {

--- a/cli/flox-manifest/src/lib.rs
+++ b/cli/flox-manifest/src/lib.rs
@@ -614,6 +614,13 @@ impl Serialize for Manifest<TypedOnly> {
     }
 }
 
+impl Manifest<MigratedTypedOnly> {
+    /// Returns the pre-migration typed manifest.
+    pub fn pre_migration_manifest(&self) -> Manifest<TypedOnly> {
+        self.inner.original_parsed.as_typed_only()
+    }
+}
+
 impl Serialize for Manifest<MigratedTypedOnly> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1567,6 +1567,44 @@ mod migration_tests {
         assert_eq!(manifest.get_schema_version(), KnownSchemaVersion::latest());
     }
 
+    /// After locking a composed environment, compose.composer must match the
+    /// on-disk manifest so that lockfile_if_up_to_date() considers the
+    /// lockfile current. If compose.composer has a different schema version,
+    /// every flox activate will unnecessarily re-lock the environment.
+    #[test]
+    fn locking_composed_environment_preserves_old_schema() {
+        let (flox, tempdir) = flox_instance();
+
+        // Set up an included environment with only vars (backwards
+        // compatible).
+        let included_manifest = with_latest_schema(indoc! {r#"
+            [vars]
+            included_var = "value"
+        "#});
+        setup_locked_included_env(&flox, tempdir.path(), &included_manifest);
+
+        // Create and lock a v1 composer.
+        let mut composer = setup_v1_composer_with_include(&flox, tempdir.path());
+
+        let lockfile: Lockfile = composer.lockfile(&flox).unwrap().into();
+
+        // Both schemas of manifest in lockfile must be v1
+        assert_eq!(
+            lockfile.compose.unwrap().composer.get_schema_version(),
+            KnownSchemaVersion::V1
+        );
+        assert_eq!(
+            lockfile.manifest.get_schema_version(),
+            KnownSchemaVersion::V1
+        );
+        // On disk manifest schema must be v1
+        let on_disk_schema = composer
+            .manifest_without_migrating(&flox)
+            .unwrap()
+            .get_schema_version();
+        assert_eq!(on_disk_schema, KnownSchemaVersion::V1);
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn v1_manifest_doesnt_migrate_when_hello_is_installed() {
         let (mut flox, _tempdir) = flox_instance();

--- a/cli/flox-rust-sdk/src/providers/lock_manifest.rs
+++ b/cli/flox-rust-sdk/src/providers/lock_manifest.rs
@@ -374,25 +374,31 @@ impl LockManifest {
             packages: packages.clone(),
             compose: compose.clone(),
         };
-        // Decide which schema we can write the manifest as.
-        let merged = merged
+
+        let merged_maybe_backwards_compatible = merged
             .as_maybe_backwards_compatible(manifest.original_schema(), Some(&proposed_lockfile))?;
 
-        let merged_manfiest_is_latest_schema =
-            merged.get_schema_version() == KnownSchemaVersion::latest();
-        if let Some(compose) = compose.as_mut()
-            && merged_manfiest_is_latest_schema
+        // merge_manifest returns both a merged manifest and compose.composer as latest schema
+        // If the original manifest was latest or the merged manifest must be latest, we can leave compose.composer as latest
+        // If compose is None, we can't change it
+        // Otherwise, we know that merged is backwards compatible as
+        // original_schema(), and we want to set compose.composer to original schema version for consistency
+        if manifest.original_schema() != KnownSchemaVersion::latest()
+            && merged_maybe_backwards_compatible.get_schema_version()
+                != KnownSchemaVersion::latest()
+            && let Some(compose) = compose.as_mut()
         {
-            // Record the original schema of the user's manifest.
-            compose.composer = manifest.as_typed_only();
+            compose.composer = manifest.pre_migration_manifest();
         }
+
+        // Decide which schema we can write the manifest as.
         // The caller (CoreEnvironment::lock / include_upgrade) is responsible
         // for rewriting the user's on-disk manifest when the merged manifest
-        // ends up at a newer schema than the original.
+        // and compose.composer end up at a newer schema than the original.
 
         let lockfile = Lockfile {
             version: Version::<1>,
-            manifest: merged,
+            manifest: merged_maybe_backwards_compatible,
             packages,
             compose,
         };
@@ -1368,7 +1374,7 @@ mod tests {
         fake_flake_installable_lock,
         fake_store_path_lock,
     };
-    use flox_manifest::parsed::common::{DEFAULT_GROUP_NAME, Include, Vars};
+    use flox_manifest::parsed::common::{DEFAULT_GROUP_NAME, Include, KnownSchemaVersion, Vars};
     use flox_manifest::parsed::latest::PackageDescriptorFlake;
     use flox_manifest::raw::test_helpers::{
         empty_test_migrated_manifest,


### PR DESCRIPTION
- **test: locking composer should not migrate**
  Add a currently failing test showing that we migrate an environment with
  includes even when its backwards compatible
  

- **fix: avoid compose.composer schema version drift**
  Current code sets compose.composer = manifest.as_typed_only(), which is
  always in the latest schema version.
  
  When a manifest needs to be migrated, this is acceptable.
  
  When we do a backwards compatible write of lockfile.manifest, this
  leaves compose.composer out of sync with the on disk manifest, and
  ensure_manifest_schemas_match skips migrating the on disk manifest
  forwards, so we end up with drift between manifest schema version and
  lockfile.compose.composer schema version.
  
  This can surface via `flox include upgrade` with old schema manifests,
  or when locking an old schema manifest for the first time.
  
  Closes CLI-8
  