### PR TITLE
docs(build): add man pages for `update-catalogs` and `nix-builds.toml`

### DIFF
--- a/cli/flox/doc/flox-build-update-catalogs.md
+++ b/cli/flox/doc/flox-build-update-catalogs.md
@@ -20,7 +20,7 @@ flox [<general-options>] build update-catalogs
 Read the catalog configuration from `.flox/nix-builds.toml` and generate
 (or regenerate) the lockfile at `.flox/nix-builds.lock`.
 
-Each catalog entry in `nix-builds.toml` is resolved and pinned:
+Each catalog entry in [`nix-builds.toml`](./nix-builds.toml.md) is resolved and pinned:
 Nix source-type catalogs are locked with `nix flake prefetch`,
 and FloxHub catalogs are locked against the FloxHub API.
 The resulting lockfile pins every catalog to a specific revision,

--- a/cli/flox/doc/flox-build-update-catalogs.md
+++ b/cli/flox/doc/flox-build-update-catalogs.md
@@ -1,0 +1,58 @@
+---
+title: FLOX-BUILD-UPDATE-CATALOGS
+section: 1
+header: "Flox User Manuals"
+...
+
+# NAME
+
+flox-build-update-catalogs - Update catalog lockfile for Nix expression builds
+
+# SYNOPSIS
+
+```
+flox [<general-options>] build update-catalogs
+     [-d=<path>]
+```
+
+# DESCRIPTION
+
+Read the catalog configuration from `.flox/nix-builds.toml` and generate
+(or regenerate) the lockfile at `.flox/nix-builds.lock`.
+
+Each catalog entry in `nix-builds.toml` is resolved and pinned:
+Nix source-type catalogs are locked with `nix flake prefetch`,
+and FloxHub catalogs are locked against the FloxHub API.
+The resulting lockfile pins every catalog to a specific revision,
+ensuring reproducible builds.
+
+Both `.flox/nix-builds.toml` and `.flox/nix-builds.lock` should be
+committed to version control so that all collaborators build against
+identical catalog inputs.
+
+This command only works with path (local) environments.
+It cannot be used with managed or remote environments.
+
+If no `.flox/nix-builds.toml` file exists, the command prints a warning
+with the expected file path and exits without error.
+
+# OPTIONS
+
+```{.include}
+./include/dir-environment-options.md
+./include/general-options.md
+```
+
+# EXAMPLES
+
+## Lock catalog inputs
+
+```
+$ flox build update-catalogs
+```
+
+# SEE ALSO
+
+[`nix-builds.toml(5)`](./nix-builds.toml.md)
+[`flox-build(1)`](./flox-build.md)
+[`manifest.toml(5)`](./manifest.toml.md)

--- a/cli/flox/doc/flox-build.md
+++ b/cli/flox/doc/flox-build.md
@@ -194,5 +194,8 @@ $ npx serve result-app
 # SEE ALSO
 
 [`flox-build-clean(1)`](./flox-build-clean.md)
+[`flox-build-import-nixpkgs(1)`](./flox-build-import-nixpkgs.md)
+[`flox-build-update-catalogs(1)`](./flox-build-update-catalogs.md)
 [`flox-activate(1)`](./flox-activate.md)
 [`manifest.toml(5)`](./manifest.toml.md)
+[`nix-builds.toml(5)`](./nix-builds.toml.md)

--- a/cli/flox/doc/nix-builds.toml.md
+++ b/cli/flox/doc/nix-builds.toml.md
@@ -1,0 +1,149 @@
+---
+title: NIX-BUILDS.TOML
+section: 5
+header: "Flox User Manuals"
+...
+
+# NAME
+
+nix-builds.toml - catalog configuration for Nix expression builds
+
+# SYNOPSIS
+
+The `nix-builds.toml` file declares external catalogs that are made
+available to Nix expression builds within a Flox environment.
+It lives at `.flox/nix-builds.toml` alongside the environment manifest.
+
+# DESCRIPTION
+
+When a Flox environment uses Nix expression builds (packages defined
+as `.nix` files under `.flox/pkgs/`), those expressions can depend on
+packages provided by external catalogs.
+The `nix-builds.toml` file declares which catalogs are available and
+where they come from.
+
+Running `flox build update-catalogs` resolves every catalog entry and
+writes the pinned result to `.flox/nix-builds.lock`.
+Both files should be committed to version control.
+
+## `version`
+
+Required.
+The configuration format version.
+Currently the only supported value is `1`.
+
+```toml
+version = 1
+```
+
+## `[catalogs.<name>]`
+
+Each section under `catalogs` declares a single catalog.
+The `<name>` becomes the key used to reference the catalog in Nix
+expressions: a package `foo` in catalog `mycatalog` is accessed as
+`catalogs.mycatalog.foo`.
+
+A catalog can be specified in one of three forms.
+
+### URL string
+
+Provide a single `url` field containing a Nix flake reference:
+
+```toml
+[catalogs.mycatalog]
+url = "git+https://github.com/org/repo"
+```
+
+The URL follows Nix flake reference syntax and may include query
+parameters such as `?ref=<branch>` or `?rev=<commit>`.
+
+### Structured Nix source type
+
+Provide a `type` field naming a Nix source type together with
+additional fields appropriate to that type:
+
+```toml
+[catalogs.mycatalog]
+type = "git"
+url = "https://github.com/org/repo"
+ref = "main"
+```
+
+The supported types and their fields are documented in the
+[Nix manual under *Source types*](https://nix.dev/manual/nix/latest/language/builtins.html#source-types).
+
+### FloxHub catalog
+
+Set `type` to `"floxhub"` to pull packages from a catalog published
+on FloxHub:
+
+```toml
+[catalogs.mycatalog]
+type = "floxhub"
+```
+
+The catalog name must match a catalog identifier registered on FloxHub.
+
+## Lockfile
+
+Running `flox build update-catalogs` produces `.flox/nix-builds.lock`,
+a JSON file that pins every catalog to a specific resolved state.
+The lockfile is consumed at build time; it must be present and up to
+date before running `flox build` on packages that reference catalogs.
+
+## Using catalogs in Nix expressions
+
+Nix expressions under `.flox/pkgs/` receive a `catalogs` argument.
+Each catalog declared in `nix-builds.toml` appears as an attribute set
+keyed by `<name>`:
+
+```nix
+# .flox/pkgs/hello.nix
+{ catalogs }:
+catalogs.mycatalog.some-package
+```
+
+# EXAMPLES
+
+## Declare a Git catalog
+
+```toml
+version = 1
+
+[catalogs.mylib]
+url = "git+https://github.com/org/mylib"
+```
+
+## Declare a catalog with a pinned branch
+
+```toml
+version = 1
+
+[catalogs.mylib]
+type = "git"
+url = "https://github.com/org/mylib"
+ref = "release-2.0"
+```
+
+## Declare a FloxHub catalog
+
+```toml
+version = 1
+
+[catalogs.published]
+type = "floxhub"
+```
+
+## Use a catalog in a package expression
+
+```nix
+# .flox/pkgs/app.nix
+{ catalogs }:
+catalogs.mylib.build-tool
+```
+
+# SEE ALSO
+
+[`flox-build-update-catalogs(1)`](./flox-build-update-catalogs.md)
+[`flox-build(1)`](./flox-build.md)
+[`manifest.toml(5)`](./manifest.toml.md)

--- a/cli/flox/doc/nix-builds.toml.md
+++ b/cli/flox/doc/nix-builds.toml.md
@@ -45,18 +45,6 @@ expressions: a package `foo` in catalog `mycatalog` is accessed as
 
 A catalog can be specified in one of three forms.
 
-### URL string
-
-Provide a single `url` field containing a Nix flake reference:
-
-```toml
-[catalogs.mycatalog]
-url = "git+https://github.com/org/repo"
-```
-
-The URL follows Nix flake reference syntax and may include query
-parameters such as `?ref=<branch>` or `?rev=<commit>`.
-
 ### Structured Nix source type
 
 Provide a `type` field naming a Nix source type together with
@@ -71,6 +59,19 @@ ref = "main"
 
 The supported types and their fields are documented in the
 [Nix manual under *Source types*](https://nix.dev/manual/nix/latest/language/builtins.html#source-types).
+
+### URL string
+
+As a shorthand for the structured form, provide a single `url`
+field containing a Nix source reference:
+
+```toml
+[catalogs.mycatalog]
+url = "git+https://github.com/org/repo"
+```
+
+The URL follows Nix source reference syntax and may include query
+parameters such as `?ref=<branch>` or `?rev=<commit>`.
 
 ### FloxHub catalog
 
@@ -130,7 +131,7 @@ ref = "release-2.0"
 ```toml
 version = 1
 
-[catalogs.published]
+[catalogs.myorg]
 type = "floxhub"
 ```
 
@@ -139,7 +140,7 @@ type = "floxhub"
 ```nix
 # .flox/pkgs/app.nix
 { catalogs }:
-catalogs.mylib.build-tool
+catalogs.myorg.build-tool
 ```
 
 # SEE ALSO

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -106,10 +106,12 @@ enum SubcommandOrBuildTargets {
         #[bpaf(positional("installable"))]
         installable: String,
     },
+    /// Update catalog lockfile
+    ///
+    /// Resolves catalog inputs and writes the lockfile.
     #[bpaf(
         command,
-        footer("Run 'man flox-build-update-catalogs' for more details."),
-        hide, // todo: add man-pages when alongside un-hiding this
+        footer("Run 'man flox-build-update-catalogs' for more details.")
     )]
     UpdateCatalogs {},
     BuildTargets {

--- a/pkgs/flox-manpages/default.nix
+++ b/pkgs/flox-manpages/default.nix
@@ -55,6 +55,7 @@ runCommand "flox-manpages"
 
     find . -name "*.md" -exec ${compileManPageBin} {} $buildDir 1 \;
     mv $buildDir/manifest.toml.1 $buildDir/manifest.toml.5
+    mv $buildDir/nix-builds.toml.1 $buildDir/nix-builds.toml.5
 
     ls $buildDir
 


### PR DESCRIPTION
## Summary

- Add section 1 man page for `flox build update-catalogs`
- Add section 5 man page for `nix-builds.toml` file format
- Unhide the `update-catalogs` subcommand (it was hidden pending documentation)
- Update manpage build to handle the new section 5 page
- Add cross-references in `flox-build.md` SEE ALSO

### Verification

- `cargo check -p flox` passes
- `nix build .#flox-manpages` produces both `flox-build-update-catalogs.1` and `nix-builds.toml.5`
- All pre-commit hooks pass (clippy, rustfmt, treefmt)

### Test plan

- [x] CI passes (`cargo check`, `nix build`)
- [x] `man flox-build-update-catalogs` renders correctly
- [x] `man nix-builds.toml` renders correctly
- [x] `flox build --help` shows `update-catalogs` subcommand

### Ticket

Fixes ECO-45