### PR TITLE
feat(publish): enable S3 multipart uploads for packages > 5 GB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "reqwest",
  "rsevents-extra",
  "schemars 1.2.1",
+ "semver",
  "serde",
  "serde_json",
  "serde_with",

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -26,6 +26,7 @@ pollster.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 rsevents-extra.workspace = true
+semver.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 serde_with.workspace = true

--- a/cli/flox-rust-sdk/src/providers/nix.rs
+++ b/cli/flox-rust-sdk/src/providers/nix.rs
@@ -6,6 +6,9 @@ use std::sync::LazyLock;
 use serde::Deserialize;
 use tracing::debug;
 
+/// Minimum Nix version that supports S3 multipart upload query parameters.
+pub const NIX_MULTIPART_MIN_VERSION: semver::Version = semver::Version::new(2, 33, 0);
+
 static NIX_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
     std::env::var("NIX_BIN")
         .unwrap_or_else(|_| env!("NIX_BIN").to_string())
@@ -115,6 +118,55 @@ pub enum NixSubstituterConfigError {
     Parse(#[source] serde_json::Error),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum NixVersionError {
+    #[error("failed to execute nix --version")]
+    Exec(#[source] std::io::Error),
+    #[error("nix --version failed: {0}")]
+    Failed(String),
+    #[error("failed to parse nix version from output: {0}")]
+    Parse(String),
+}
+
+/// Parse the version from `nix --version` output.
+///
+/// Expected format: `"nix (Nix) 2.31.2+1\n"`.
+/// Development builds use: `"nix (Nix) 2.33.0pre20251224_e23983d"`.
+///
+/// The `+N` build metadata suffix is stripped because build metadata does
+/// not affect semver precedence and simplifies parsing. The `preYYYYMMDD_hash`
+/// dev suffix is not valid semver, so we strip it to extract the base version.
+fn parse_nix_version_output(output: &str) -> Result<semver::Version, NixVersionError> {
+    let version_str = output
+        .trim()
+        .strip_prefix("nix (Nix) ")
+        .ok_or_else(|| NixVersionError::Parse(output.trim().to_string()))?;
+    // Strip +N build suffix (e.g., "2.31.2+1" → "2.31.2")
+    let clean = version_str.split('+').next().unwrap_or(version_str);
+    // Strip preYYYYMMDD_hash dev suffix (e.g., "2.33.0pre20251224_e23983d" → "2.33.0")
+    let clean = clean.split("pre").next().unwrap_or(clean);
+    semver::Version::parse(clean).map_err(|_| NixVersionError::Parse(version_str.to_string()))
+}
+
+/// Detect the runtime Nix version by running `nix --version`.
+///
+/// This respects the `NIX_BIN` environment variable override, so it returns
+/// the version of whichever Nix binary will actually be used for operations.
+pub fn nix_runtime_version() -> Result<semver::Version, NixVersionError> {
+    let output = Command::new(&*NIX_BIN)
+        .arg("--version")
+        .output()
+        .map_err(NixVersionError::Exec)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(NixVersionError::Failed(stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_nix_version_output(&stdout)
+}
+
 pub mod test_helpers {
     use std::path::PathBuf;
 
@@ -123,5 +175,63 @@ pub mod test_helpers {
     /// Returns a Nix store path that's known to exist.
     pub fn known_store_path() -> PathBuf {
         NIX_BIN.to_path_buf().canonicalize().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_clean_version() {
+        let version = parse_nix_version_output("nix (Nix) 2.33.0").unwrap();
+        assert_eq!(version, semver::Version::new(2, 33, 0));
+    }
+
+    #[test]
+    fn parse_version_with_build_suffix() {
+        let version = parse_nix_version_output("nix (Nix) 2.31.2+1").unwrap();
+        assert_eq!(version, semver::Version::new(2, 31, 2));
+    }
+
+    #[test]
+    fn parse_version_with_trailing_newline() {
+        let version = parse_nix_version_output("nix (Nix) 2.33.1\n").unwrap();
+        assert_eq!(version, semver::Version::new(2, 33, 1));
+        assert!(version >= NIX_MULTIPART_MIN_VERSION);
+    }
+
+    #[test]
+    fn parse_old_version_below_multipart_minimum() {
+        let version = parse_nix_version_output("nix (Nix) 2.31.4").unwrap();
+        assert!(version < NIX_MULTIPART_MIN_VERSION);
+    }
+
+    #[test]
+    fn parse_prerelease_dev_build() {
+        let version = parse_nix_version_output("nix (Nix) 2.33.0pre20251224_e23983d").unwrap();
+        assert_eq!(version, semver::Version::new(2, 33, 0));
+        assert!(version >= NIX_MULTIPART_MIN_VERSION);
+    }
+
+    #[test]
+    fn parse_prerelease_with_build_metadata() {
+        let version = parse_nix_version_output("nix (Nix) 2.33.0-rc.1+1").unwrap();
+        assert_eq!(version, semver::Version::parse("2.33.0-rc.1").unwrap());
+        // Pre-release versions compare below the release, so multipart
+        // is not enabled for release candidates. This is intentional.
+        assert!(version < NIX_MULTIPART_MIN_VERSION);
+    }
+
+    #[test]
+    fn parse_garbage_input() {
+        let result = parse_nix_version_output("garbage");
+        assert!(matches!(result, Err(NixVersionError::Parse(_))));
+    }
+
+    #[test]
+    fn parse_empty_version_string() {
+        let result = parse_nix_version_output("nix (Nix) ");
+        assert!(matches!(result, Err(NixVersionError::Parse(_))));
     }
 }

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -49,7 +49,7 @@ use crate::flox::Flox;
 use crate::models::environment::{Environment, EnvironmentError, copy_dir_recursive, open_path};
 use crate::providers::auth::catalog_auth_to_envs;
 use crate::providers::git::GitProvider;
-use crate::providers::nix::nix_base_command;
+use crate::providers::nix::{NIX_MULTIPART_MIN_VERSION, nix_base_command, nix_runtime_version};
 use crate::utils::CommandExt;
 
 #[derive(Debug, Error)]
@@ -84,6 +84,11 @@ pub enum PublishError {
 
     #[error("Failed to upload to cache: {0}")]
     CacheUploadError(String),
+
+    #[error(
+        "Package exceeds the S3 single-upload limit (5 GB). Your Nix version ({nix_version}) does not support multipart uploads. Upgrade to Nix 2.33 or later to publish packages larger than 5 GB."
+    )]
+    MultipartUnsupported { nix_version: String },
 
     #[error("Failed to get additional artifact metadata: {0}")]
     GetNarInfo(String),
@@ -440,6 +445,24 @@ impl ClientSideCatalogStoreConfig {
         if destination_url.scheme() == "s3" {
             // https://nix.dev/manual/nix/2.24/command-ref/new-cli/nix3-help-stores#store-s3-binary-cache-store-ls-compression
             query.append_pair("ls-compression", "zstd");
+
+            // Enable S3 multipart upload support (Nix 2.33+).
+            // Without this, uploads are limited to the S3 single-PUT maximum of 5 GB.
+            match nix_runtime_version() {
+                Ok(version) if version >= NIX_MULTIPART_MIN_VERSION => {
+                    debug!(%version, "Nix supports multipart uploads, enabling");
+                    query.append_pair("multipart-upload", "true");
+                },
+                Ok(version) => {
+                    debug!(%version, "Nix < 2.33, multipart uploads not available");
+                },
+                Err(err) => {
+                    debug!(
+                        ?err,
+                        "Could not detect Nix version, skipping multipart param"
+                    );
+                },
+            }
         }
         drop(query);
 
@@ -471,11 +494,29 @@ impl ClientSideCatalogStoreConfig {
             .output()
             .map_err(|e| PublishError::CacheUploadError(e.to_string()))?;
         if output.status.success() {
-            Ok(())
-        } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(PublishError::CacheUploadError(stderr.to_string()))
+            return Ok(());
         }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        Err(Self::classify_upload_error(
+            &stderr,
+            nix_runtime_version().ok(),
+        ))
+    }
+
+    /// Classify a `nix copy` upload failure, providing an actionable error
+    /// when the S3 size limit is hit on old Nix.
+    fn classify_upload_error(stderr: &str, nix_version: Option<semver::Version>) -> PublishError {
+        if stderr.contains("EntityTooLarge")
+            && let Some(version) = nix_version
+            && version < NIX_MULTIPART_MIN_VERSION
+        {
+            return PublishError::MultipartUnsupported {
+                nix_version: version.to_string(),
+            };
+        }
+        PublishError::CacheUploadError(stderr.to_string())
     }
 
     /// Constructs a `nix path-info` command that will get the NAR info for a
@@ -2450,6 +2491,49 @@ pub mod tests {
         assert!(
             msg.contains("dirty"),
             "Expected 'dirty' in message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn classify_entity_too_large_old_nix() {
+        let stderr = "error: AWS error uploading 'nar/abc.nar.zst': Unable to parse ExceptionName: EntityTooLarge Message: Your proposed upload exceeds the maximum allowed size";
+        let version = Some(semver::Version::new(2, 31, 4));
+        let err = ClientSideCatalogStoreConfig::classify_upload_error(stderr, version);
+        assert!(
+            matches!(err, PublishError::MultipartUnsupported { ref nix_version } if nix_version == "2.31.4"),
+            "Expected MultipartUnsupported, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_entity_too_large_new_nix() {
+        let stderr = "error: EntityTooLarge";
+        let version = Some(semver::Version::new(2, 33, 0));
+        let err = ClientSideCatalogStoreConfig::classify_upload_error(stderr, version);
+        assert!(
+            matches!(err, PublishError::CacheUploadError(_)),
+            "Expected CacheUploadError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_entity_too_large_unknown_nix() {
+        let stderr = "error: EntityTooLarge";
+        let err = ClientSideCatalogStoreConfig::classify_upload_error(stderr, None);
+        assert!(
+            matches!(err, PublishError::CacheUploadError(_)),
+            "Expected CacheUploadError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_generic_upload_error() {
+        let stderr = "error: some other nix copy failure";
+        let version = Some(semver::Version::new(2, 31, 4));
+        let err = ClientSideCatalogStoreConfig::classify_upload_error(stderr, version);
+        assert!(
+            matches!(err, PublishError::CacheUploadError(ref msg) if msg.contains("some other nix copy failure")),
+            "Expected CacheUploadError with original message, got: {err:?}"
         );
     }
 }


### PR DESCRIPTION
Publishing large packages (e.g., ML model checkpoint weights) fails with `EntityTooLarge` because `nix copy` uses a single S3 PUT, which is limited to 5 GB. Nix 2.33+ supports multipart uploads via the `multipart-upload=true` query parameter on S3 store URLs.

This change adds runtime Nix version detection and conditionally enables multipart uploads when the Nix binary supports it.

## What changed

### Runtime Nix version detection (`nix.rs`)

- Added `nix_runtime_version()`: shells out to `nix --version` and parses the output into a `semver::Version`. Respects the `NIX_BIN` env var override, so it detects the version of whichever Nix binary will actually be used for the upload — not just the compile-time bundled version.

- Added `parse_nix_version_output()`: handles the three version formats Nix produces:
  - Release builds: `nix (Nix) 2.33.0`
  - Dev builds: `nix (Nix) 2.33.0pre20251224_e23983d`
  - Build metadata: `nix (Nix) 2.31.2+1`

- Added `NIX_MULTIPART_MIN_VERSION` constant (2.33.0) and `NixVersionError` enum following the existing `NixSubstituterConfigError` pattern.

### Conditional multipart upload (`publish.rs`)

- In `upload_store_path()`, when the destination is an S3 URL, the runtime Nix version is checked. If >= 2.33, `multipart-upload=true` is appended to the S3 store URL query parameters. If the version is old or undetectable, the parameter is silently skipped and uploads proceed as before (single PUT).

- Extracted `classify_upload_error()` to classify `nix copy` failures. When stderr contains `EntityTooLarge` and the Nix version is < 2.33, returns a `MultipartUnsupported` error with an actionable message telling the user to upgrade Nix. Otherwise returns the raw error.

### Error handling

- Added `PublishError::MultipartUnsupported` variant with a clear user-facing message: "Package exceeds the S3 single-upload limit (5 GB). Your Nix version (X.Y.Z) does not support multipart uploads. Upgrade to Nix 2.33 or later to publish packages larger than 5 GB."

## Design decisions

- **Always-on when supported**: No configuration knob. Nix's defaults (100 MiB multipart threshold, 5 MiB chunk size) are sensible.

- **Graceful degradation**: Old Nix or undetectable version → param skipped silently (debug-level log). Uploads < 5 GB work as before.

- **Runtime detection over compile-time constant**: The existing `NIX_VERSION` compile-time constant reflects the bundled Nix, but users who install flox via Nix can override the binary via `NIX_BIN` at runtime. Runtime detection handles both cases.

- **No signature changes**: `upload_store_path()` signature is unchanged. Both callers (`upload_build_outputs` and `flox upload`) are unaffected.

## Server-side prerequisite

The S3 ingress bucket IAM policy must permit multipart operations (s3:AbortMultipartUpload, s3:ListBucketMultipartUploads, s3:ListMultipartUploadParts) in addition to s3:PutObject. This is a separate two-line server-side change on the publisher. @devusb has already developed something for this. Note: this fix isn't currently implemented.

## Test coverage

- 8 unit tests for version parsing: clean version, build suffix, trailing newline, old version, dev build (pre suffix), rc + build metadata, garbage input, empty string.

- 4 unit tests for error classification: EntityTooLarge + old Nix → MultipartUnsupported, EntityTooLarge + new Nix → CacheUploadError, EntityTooLarge + unknown Nix → CacheUploadError, generic error → CacheUploadError.

## Proposed Changes

Publishing large packages (e.g., ML model checkpoint weights) fails with `EntityTooLarge` because `nix copy` uses a single S3 PUT, which is limited to 5 GB. Nix 2.33+ supports multipart uploads via the `multipart-upload=true` query parameter on S3 store URLs.

This change adds runtime Nix version detection and conditionally enables multipart uploads when the Nix binary supports it:

- **`nix.rs`**: Added `nix_runtime_version()` which shells out to `nix --version` and parses the result into a `semver::Version`. Respects the `NIX_BIN` env var override so it detects the actual runtime Nix, not the compile-time bundled version. Handles release (`2.33.0`), dev build (`2.33.0pre20251224_hash`), and build metadata (`2.31.2+1`) formats.

- **`publish.rs`**: In `upload_store_path()`, when the destination is S3 and Nix >= 2.33, appends `multipart-upload=true` to the store URL. When Nix is old or undetectable, silently skips the param (uploads < 5 GB work as before). Extracted `classify_upload_error()` so that `EntityTooLarge` failures on old Nix return an actionable `MultipartUnsupported` error telling the user to upgrade.

**Server-side prerequisite**: The S3 ingress bucket IAM policy must permit multipart operations (`s3:AbortMultipartUpload`, `s3:ListBucketMultipartUploads`, `s3:ListMultipartUploadParts`). Morgan has identified this as a two-line publisher-side change.

## Release Notes

When publishing packages larger than 5 GB (such as ML model weights), `flox publish` now automatically enables S3 multipart uploads if the system's Nix version supports it (Nix 2.33+). Users on older Nix versions who hit the 5 GB upload limit will see a clear error message advising them to upgrade.

<!-- Many thanks! -->
beaucoups of thanks to @garbas @devusb @billlevine 