### PR TITLE
docs: innacurate mention of tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 Flox provides native packages for each supported platform:
 
 - **macOS** — `pkg` installer or Homebrew
-- **Linux** — `.deb`, `.rpm`, or standalone tarball
+- **Linux** — `.deb` or `.rpm`
 
 See the [installation guide](https://flox.dev/docs/install-flox/install/) for step-by-step instructions.
 


### PR DESCRIPTION
We don't have a tarball installer