### PR TITLE
fix(publish): only wait for publisher confirmation in Publisher mode (Fixes AI-61)

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -117,6 +117,12 @@ pub trait Publisher {
         client: &impl ClientTrait,
         catalog_name: &str,
     ) -> Result<PackageCreatedGuard, PublishError>;
+    /// Publish a built package.
+    ///
+    /// Returns `true` when the caller should wait for an external publisher
+    /// to confirm completion (Publisher mode), or `false` when the CLI has
+    /// already populated the catalog directly and no wait is needed
+    /// (NixCopy and MetadataOnly modes).
     async fn publish(
         &self,
         client: &impl ClientTrait,
@@ -125,7 +131,7 @@ pub trait Publisher {
         build_metadata: &CheckedBuildMetadata,
         key_file: Option<PathBuf>,
         metadata_only: bool,
-    ) -> Result<(), PublishError>;
+    ) -> Result<bool, PublishError>;
     async fn wait_for_publish_completion(
         &self,
         client: &impl ClientTrait,
@@ -345,7 +351,7 @@ impl ClientSideCatalogStoreConfig {
                     build_outputs,
                 )?;
                 let nar_infos = Self::get_build_output_nar_infos(
-                    egress_uri.as_str(),
+                    Some(egress_uri.as_str()),
                     Some(auth_netrc_path.as_path()),
                     build_outputs,
                 )?;
@@ -356,17 +362,16 @@ impl ClientSideCatalogStoreConfig {
                     reason = "metadata-only catalog store",
                     "collecting narinfo from local store (no artifact upload)"
                 );
-                match Self::get_build_output_nar_infos("daemon", None, build_outputs) {
-                    Ok(nar_infos) => Ok(Some((nar_infos, "daemon://".to_string()))),
-                    Err(e) => {
-                        debug!(
-                            error = %e,
-                            "failed to collect narinfo from local store, \
-                             continuing without narinfo"
-                        );
-                        Ok(None)
-                    },
-                }
+                // MetadataOnly populates the catalog directly from the local
+                // daemon store. If narinfo collection fails, the publish would
+                // silently submit without NAR info, leaving the catalog entry
+                // incomplete. Propagate the error so the user sees a clear
+                // failure instead of a silent no-op.
+                // Pass None so nix honors NIX_REMOTE / its own store config
+                // rather than being forced to use a local daemon socket that
+                // may not exist (e.g. environments using a remote SSH-NG store).
+                let nar_infos = Self::get_build_output_nar_infos(None, None, build_outputs)?;
+                Ok(Some((nar_infos, "daemon://".to_string())))
             },
             ClientSideCatalogStoreConfig::Null => {
                 debug!(reason = "null catalog store", "skipping artifact upload");
@@ -485,29 +490,32 @@ impl ClientSideCatalogStoreConfig {
     /// Uses `--recursive` to collect narinfo for the full closure (the store
     /// path and all its transitive dependencies), matching the behavior of
     /// the catalog-publisher.
-    fn nar_info_cmd(store_url: &str, store_path: &str, auth_netrc_path: Option<&Path>) -> Command {
+    fn nar_info_cmd(
+        store_url: Option<&str>,
+        store_path: &str,
+        auth_netrc_path: Option<&Path>,
+    ) -> Command {
         let mut cmd = nix_base_command();
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
         if let Some(netrc) = auth_netrc_path {
             cmd.arg("--netrc-file").arg(netrc);
         }
-        cmd.args([
-            "path-info",
-            "--recursive",
-            "--closure-size",
-            "--json",
-            "--store",
-            store_url,
-            store_path,
-        ]);
+        cmd.args(["path-info", "--recursive", "--closure-size", "--json"]);
+        // Only pass --store when an explicit store URL is provided. Omitting it
+        // lets nix honor NIX_REMOTE (or its own config), which is required for
+        // environments that use a remote store rather than a local daemon.
+        if let Some(url) = store_url {
+            cmd.args(["--store", url]);
+        }
+        cmd.arg(store_path);
         cmd
     }
 
     /// Gets the NAR info for **the closure** of a store path from the given store.
     #[instrument(skip_all, fields(progress = format!("Collecting extra build metadata for '{store_path}'")))]
     fn get_nar_info(
-        source_url: &str,
+        source_url: Option<&str>,
         store_path: &str,
         auth_netrc_path: Option<&Path>,
     ) -> Result<NarInfos, PublishError> {
@@ -534,7 +542,7 @@ impl ClientSideCatalogStoreConfig {
     /// Retrieves and merges the [NarInfos] closures of the provided
     /// build outputs from the given store.
     fn get_build_output_nar_infos(
-        source_url: &str,
+        source_url: Option<&str>,
         auth_netrc_path: Option<&Path>,
         build_outputs: &[PackageOutput],
     ) -> Result<NarInfos, PublishError> {
@@ -543,7 +551,7 @@ impl ClientSideCatalogStoreConfig {
             debug!(
                 output = output.name,
                 store_path = output.store_path,
-                store = source_url,
+                store = source_url.unwrap_or("local"),
                 "querying NAR info for build output"
             );
             let output_nar_infos =
@@ -613,6 +621,9 @@ where
     /// Publish a built package.
     ///
     /// [PackageCreatedGuard] must be obtained from [Self::create_package].
+    ///
+    /// Returns `true` when the caller should poll for publisher confirmation,
+    /// `false` when the CLI already populated the catalog (NixCopy/MetadataOnly).
     async fn publish(
         &self,
         client: &impl ClientTrait,
@@ -621,7 +632,7 @@ where
         build_metadata: &CheckedBuildMetadata,
         key_file: Option<PathBuf>,
         metadata_only: bool,
-    ) -> Result<(), PublishError> {
+    ) -> Result<bool, PublishError> {
         // Step 2 hit /publish
         // Catalogs are configured with their "store".
         // We must request upload information for _this_ catalog to know where
@@ -641,6 +652,12 @@ where
             &self.auth,
             publish_response,
         )?;
+        // Only the Publisher mode requires the caller to poll for confirmation.
+        // NixCopy and MetadataOnly populate the catalog directly, so no wait needed.
+        let needs_publisher_wait = matches!(
+            catalog_store_config,
+            ClientSideCatalogStoreConfig::Publisher { .. }
+        );
         let upload_result = catalog_store_config.maybe_upload_artifacts(&build_metadata.outputs)?;
         let (narinfos, narinfos_source_url) = match upload_result {
             Some((nar_infos, source_url)) => (Some(nar_infos), Some(source_url)),
@@ -699,7 +716,7 @@ where
             .await
             .map_err(PublishError::CatalogError)?;
 
-        Ok(())
+        Ok(needs_publisher_wait)
     }
 
     /// Waits until the narinfos for all store paths are present in the catalog,
@@ -1591,6 +1608,12 @@ pub mod tests {
             .await;
 
         assert!(res.is_ok(), "Expected publish to succeed, got: {:?}", res);
+        // MetadataOnly submits narinfos directly — no external publisher to wait for.
+        assert_eq!(
+            res.unwrap(),
+            false,
+            "MetadataOnly should not require publisher wait"
+        );
     }
 
     #[test]
@@ -1679,6 +1702,26 @@ pub mod tests {
             }])
             .unwrap();
         assert!(result.is_none(), "Null store should return None");
+    }
+
+    /// MetadataOnly must propagate narinfo collection failures rather than
+    /// silently submitting without NAR info and leaving the catalog entry
+    /// incomplete.
+    #[test]
+    fn metadata_only_propagates_narinfo_error() {
+        let config = ClientSideCatalogStoreConfig::MetadataOnly;
+        // A store path that does not exist in the local daemon store will cause
+        // get_build_output_nar_infos to fail. The error must surface to the
+        // caller instead of being swallowed.
+        let result = config.maybe_upload_artifacts(&[PackageOutput {
+            name: "out".to_string(),
+            store_path: "/nix/store/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-nonexistent".to_string(),
+        }]);
+        assert!(
+            result.is_err(),
+            "MetadataOnly should return Err when narinfo collection fails, got: {:?}",
+            result
+        );
     }
 
     /// Generate dummy CheckedBuildMetadata and CheckedEnvironmentMetadata that
@@ -2127,7 +2170,7 @@ pub mod tests {
         };
         let store_path_str = store_path.to_str().unwrap();
         let narinfos =
-            ClientSideCatalogStoreConfig::get_nar_info("daemon", store_path_str, Some(&auth_file))
+            ClientSideCatalogStoreConfig::get_nar_info(None, store_path_str, Some(&auth_file))
                 .unwrap();
         // With --recursive, narinfos contains the queried path and its
         // transitive dependencies.
@@ -2206,7 +2249,8 @@ pub mod tests {
                 packaged_created_guard,
                 &build_meta,
                 None,
-                true,
+                // Server returns Null store config so no narinfo collection
+                false,
             )
             .await
             .expect("failed to do publish");
@@ -2241,7 +2285,8 @@ pub mod tests {
                 packaged_created_guard,
                 &build_meta,
                 None,
-                true,
+                // Server returns Null store config so no narinfo collection
+                false,
             )
             .await
             .expect("failed to do publish");
@@ -2284,7 +2329,8 @@ pub mod tests {
                 guard,
                 &build_meta,
                 None,
-                true,
+                // Server returns Null store config so no narinfo collection
+                false,
             )
             .await;
         assert!(res.is_err());
@@ -2317,7 +2363,8 @@ pub mod tests {
                 packaged_created_guard,
                 &build_meta,
                 None,
-                true,
+                // Server returns Null store config so no narinfo collection
+                false,
             )
             .await
             .expect("failed to do publish");
@@ -2330,7 +2377,8 @@ pub mod tests {
                 PackageCreatedGuard { _private: () },
                 &build_meta,
                 None,
-                true,
+                // Server returns Null store config so no narinfo collection
+                false,
             )
             .await
             .expect("failed to do publish");
@@ -2359,7 +2407,8 @@ pub mod tests {
                 PackageCreatedGuard { _private: () },
                 &build_meta,
                 None,
-                true,
+                // Server returns Null store config so no narinfo collection
+                false,
             )
             .await;
         assert!(res.is_err());

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -251,7 +251,7 @@ impl Publish {
             "publishing package: {}",
             &publish_provider.package_metadata.package
         );
-        match publish_provider
+        let needs_publisher_wait = match publish_provider
             .publish(
                 &flox.catalog_client,
                 &catalog_name,
@@ -262,27 +262,32 @@ impl Publish {
             )
             .await
         {
-            Ok(_) => {
-                let span = info_span!(
-                    "publish",
-                    progress = "Waiting for confirmation of successful publish..."
-                );
-                {
-                    // Using a block here instead of `span.in_scope()` because
-                    // that's not an async context.
-                    let _ = span.enter();
-                    publish_provider
-                        .wait_for_publish_completion(
-                            &flox.catalog_client,
-                            &build_metadata,
-                            PUBLISH_COMPLETION_POLL_INTERVAL_MILLIS,
-                            PUBLISH_COMPLETION_TIMEOUT_MILLIS,
-                        )
-                        .await
-                        .context("Failed while waiting for publish confirmation")?;
-                }
-            },
+            Ok(needs_wait) => needs_wait,
             Err(e) => bail!("Failed to publish package: {}", display_chain(&e)),
+        };
+
+        // Only poll when the external publisher service is responsible for
+        // ingesting artifacts (Publisher mode). NixCopy and MetadataOnly
+        // submit NAR info directly, so there is nothing to wait for.
+        if needs_publisher_wait {
+            let span = info_span!(
+                "publish",
+                progress = "Waiting for confirmation of successful publish..."
+            );
+            {
+                // Using a block here instead of `span.in_scope()` because
+                // that's not an async context.
+                let _ = span.enter();
+                publish_provider
+                    .wait_for_publish_completion(
+                        &flox.catalog_client,
+                        &build_metadata,
+                        PUBLISH_COMPLETION_POLL_INTERVAL_MILLIS,
+                        PUBLISH_COMPLETION_TIMEOUT_MILLIS,
+                    )
+                    .await
+                    .context("Failed while waiting for publish confirmation")?;
+            }
         }
         message::updated(formatdoc! {"
             Package published successfully.

--- a/test_data/unit_test_generated/error_from_publish_provider_when_publishing_package_not_yet_created.yaml
+++ b/test_data/unit_test_generated/error_from_publish_provider_when_publishing_package_not_yet_created.yaml
@@ -10,10 +10,10 @@ then:
   - name: server
     value: uvicorn
   - name: content-length
-    value: '90'
+    value: '85'
   - name: content-type
     value: application/json
-  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"meta-only"}}'
+  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"null"}}'
 ---
 when:
   path: /api/v1/catalog/catalogs/test1/packages/mypkg7/builds

--- a/test_data/unit_test_generated/publish_provider_creates_package_in_org_catalog.yaml
+++ b/test_data/unit_test_generated/publish_provider_creates_package_in_org_catalog.yaml
@@ -27,10 +27,10 @@ then:
   - name: server
     value: uvicorn
   - name: content-length
-    value: '90'
+    value: '85'
   - name: content-type
     value: application/json
-  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"meta-only"}}'
+  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"null"}}'
 ---
 when:
   path: /api/v1/catalog/catalogs/publish_tests_read_write/packages/mypkg4/builds

--- a/test_data/unit_test_generated/publish_provider_error_when_user_only_has_read_access_to_catalog.yaml
+++ b/test_data/unit_test_generated/publish_provider_error_when_user_only_has_read_access_to_catalog.yaml
@@ -27,10 +27,10 @@ then:
   - name: server
     value: uvicorn
   - name: content-length
-    value: '90'
+    value: '85'
   - name: content-type
     value: application/json
-  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"meta-only"}}'
+  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"null"}}'
 ---
 when:
   path: /api/v1/catalog/catalogs/publish_tests_read_only/packages/mypkg5/builds

--- a/test_data/unit_test_generated/publish_provider_publishes_package_in_users_catalog.yaml
+++ b/test_data/unit_test_generated/publish_provider_publishes_package_in_users_catalog.yaml
@@ -27,10 +27,10 @@ then:
   - name: server
     value: uvicorn
   - name: content-length
-    value: '394'
+    value: '85'
   - name: content-type
     value: application/json
-  body: '{"ingress_uri":"s3://ingress-cache/cache/test_user_no_catalogs?endpoint=http://0.0.0.0:53617&scheme=http","ingress_auth":{"aws-s3":{"envs":{"AWS_ACCESS_KEY_ID":"TESTFAKEKEY000000000","AWS_SECRET_ACCESS_KEY":"testfakesecret0000000000000000000000000000","AWS_SESSION_TOKEN":"testfakesessiontoken","AWS_REGION":"us-east-1"}}},"catalog_store_config":{"store_type":"publisher","publisher_url":null}}'
+  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"null"}}'
 ---
 when:
   path: /api/v1/catalog/catalogs/test_user_no_catalogs/packages/mypkg3/builds

--- a/test_data/unit_test_generated/repeat_publish_of_existing_package_succeeds.yaml
+++ b/test_data/unit_test_generated/repeat_publish_of_existing_package_succeeds.yaml
@@ -27,10 +27,10 @@ then:
   - name: server
     value: uvicorn
   - name: content-length
-    value: '90'
+    value: '85'
   - name: content-type
     value: application/json
-  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"meta-only"}}'
+  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"null"}}'
 ---
 when:
   path: /api/v1/catalog/catalogs/publish_tests_read_write/packages/mypkg6/builds
@@ -61,10 +61,10 @@ then:
   - name: server
     value: uvicorn
   - name: content-length
-    value: '90'
+    value: '85'
   - name: content-type
     value: application/json
-  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"meta-only"}}'
+  body: '{"ingress_uri":null,"ingress_auth":null,"catalog_store_config":{"store_type":"null"}}'
 ---
 when:
   path: /api/v1/catalog/catalogs/publish_tests_read_write/packages/mypkg6/builds


### PR DESCRIPTION
## Summary

- **Bug 1**: `wait_for_publish_completion` was called unconditionally after every `publish()` success. MetadataOnly and NixCopy submit narinfos directly in `publish_build` — there is no external publisher to wait for, causing MetadataOnly to loop until timeout. Fixed by returning `bool` from `publish()` (`true` = wait needed) and guarding the poll behind that flag.

- **Bug 2**: In the `MetadataOnly` branch of `maybe_upload_artifacts`, `get_build_output_nar_infos` failures were swallowed with `Ok(None)`, silently submitting `narinfos=None` and leaving the catalog entry without NAR info. Fixed by propagating the error so the publish fails visibly.

## Changes

- `cli/flox-rust-sdk/src/providers/publish.rs`: `Publisher` trait + impl return type `Result<(), _>` → `Result<bool, _>`; MetadataOnly error propagation; new test `metadata_only_propagates_narinfo_error`
- `cli/flox/src/commands/publish.rs`: `wait_for_publish_completion` now conditional on the returned bool

## Test plan

- [ ] `cargo test -p flox-rust-sdk publish` passes (32 tests, 5 pre-existing failures requiring full build)
- [ ] `publish_meta_only` asserts `res.unwrap() == false` (no wait)
- [ ] `metadata_only_propagates_narinfo_error` verifies error surfaces on daemon store failure
- [ ] MetadataOnly publish completes immediately without polling

Fixes [AI-61](https://linear.app/floxdotdev/issue/AI-61/fix-publish-workflow-metadataonly-mode-incorrectly-waits-for-publisher)