### PR TITLE
feat: add auto-activate feature flag

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -130,6 +130,8 @@ pub struct Features {
     pub upload: bool,
     #[serde(default)]
     pub qa: bool,
+    #[serde(default)]
+    pub auto_activate: bool,
 }
 
 pub static DEFAULT_FLOXHUB_URL: LazyLock<Url> =


### PR DESCRIPTION
## Summary

- Adds `auto_activate` boolean to the `Features` struct, gating upcoming auto-activate behavior behind a feature flag
- Follows the existing pattern used by `upload` and `qa` feature flags
- No behavioral changes — downstream tickets (DEV-47, DEV-49, DEV-50) will add gate checks

## Demo

`auto_activate` flag is disabled by default:

```bash
% RUST_LOG=debug flox envs 2>&1 | grep "auto_activate"                                  
2026-04-28T22:26:46.627244Z DEBUG flox::commands: feature flags configured=Features { upload: false, qa: false, auto_activate: false }
```

`auto_activate` flag is enabled by passing `FLOX_FEATURES_AUTO_ACTIVATE=true`

```bash
% FLOX_FEATURES_AUTO_ACTIVATE=true RUST_LOG=debug flox envs 2>&1 | grep "auto_activate"
2026-04-28T22:26:30.060667Z DEBUG flox::commands: feature flags configured=Features { upload: false, qa: false, auto_activate: true }
```

Closes DEV-38

🤖 Generated with [Claude Code](https://claude.com/claude-code)