### PR TITLE
perf(nef): extend `lib` with `nef` overlay without instantiating nixpkgs

### DIFF
--- a/package-builder/nef/default.nix
+++ b/package-builder/nef/default.nix
@@ -13,7 +13,7 @@ let
     };
   };
   libOverlay = (import ./lib).overlay;
-  lib = nixpkgs.lib.extend libOverlay;
+  lib = nixpkgs-flake.lib.extend libOverlay;
 
   parsedRef =
     if builtins.isAttrs source-ref then


### PR DESCRIPTION
We saw that evaluating `reflect.attrPaths` and `reflect.targets` caused the unexplained evaluation of hundreds of derivations associated with the nixpkgs stdenv.
That was particularly unexpected as these reflect attributes will not evaluate any user authored derivations.


After inspection it turns out that using `nixpkgs.lib.extend`, where `nixpkgs = import nixpkgs-flake {...}`
caused a considerable overhead of instantiating nixpkgs, despite never accessing anything but `*.lib`,
especially noticeable when drv evaluation implies non trivial IO, e.g. due to talking to an external daemon. 
By using `nixpkgs-flake.lib`, we directly avoid
the instantiation of the nixpkgs package set
and related stdenv derivations.

