### PR TITLE
fix: correct typo in path for build time set `NIX_PLUGINS`

### DIFF
--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -72,7 +72,7 @@ let
       FLOX_EXPRESSION_BUILD_NIX = "${flox-package-builder}/libexec/nef/default.nix";
     }
     // lib.optionalAttrs (flox-nix-plugins != null) {
-      NIX_PLUGINS = "${flox-nix-plugins}/bin/flox-nix-plugins";
+      NIX_PLUGINS = "${flox-nix-plugins}/lib/nix-plugins";
     }
     // lib.optionalAttrs (flox-mk-container != null) {
       FLOX_MK_CONTAINER_NIX = "${flox-mk-container}/mkContainer.nix";


### PR DESCRIPTION
The buildtime `NIX_PLUGINS` was set to
`${flox-nix-plugins}/bin/flox-nix-plugins`, while `flox-nix-plugins` only exposes a lib dir with the follwign contents:

```
/lib/nix-plugins/liblock-flake-installable.so
/lib/nix-plugins/libwrapped-nixpkgs-input.so
```

