### PR TITLE
feat: Add -D/--default flag for default environment selection

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -880,6 +880,9 @@ pub enum EnvironmentSelect {
         #[bpaf(long("reference"), long("ref"), short('r'), argument("owner>/<name"))]
         environment_ref::RemoteEnvironmentRef,
     ),
+    /// Shorthand for "-r <current_user>/default"
+    #[bpaf(long("default"), short('D'))]
+    Default,
     #[default]
     #[bpaf(hide)]
     Unspecified,
@@ -998,6 +1001,29 @@ impl EnvironmentSelect {
                     .map_err(anyhow::Error::new)?;
                 ConcreteEnvironment::Remote(env)
             },
+            EnvironmentSelect::Default => {
+                let user_handle = flox.auth_strategy.get_handle().context(formatdoc! {"
+                    The '-D' and '--default' flags require authentication
+                "})?;
+
+                debug!(
+                    user = %user_handle,
+                    "getting default environment for logged-in user"
+                );
+
+                let env_ref = RemoteEnvironmentRef::new(&user_handle, DEFAULT_NAME)
+                    .context("Failed to construct default environment reference")?;
+
+                let pointer = ManagedPointer::new(
+                    env_ref.owner().clone(),
+                    env_ref.name().clone(),
+                    &flox.floxhub,
+                );
+
+                let env = RemoteEnvironment::new(flox, pointer, generation)
+                    .map_err(anyhow::Error::new)?;
+                ConcreteEnvironment::Remote(env)
+            },
         };
         warn_minimum_cli_version(&env, flox);
         Ok(env)
@@ -1039,6 +1065,34 @@ impl EnvironmentSelect {
 
                 ConcreteEnvironment::Remote(env)
             },
+
+            EnvironmentSelect::Default => {
+                let user_handle = flox.auth_strategy.get_handle().context(formatdoc! {"
+                    The '-D' and '--default' flags require authentication
+                "})?;
+
+                debug!(
+                    user = %user_handle,
+                    "getting default environment for logged-in user"
+                );
+
+                let env_ref = RemoteEnvironmentRef::new(&user_handle, DEFAULT_NAME)
+                    .context("Failed to construct default environment reference")?;
+
+                let pointer = ManagedPointer::new(
+                    env_ref.owner().clone(),
+                    env_ref.name().clone(),
+                    &flox.floxhub,
+                );
+
+                let generation = activated_environments()
+                    .is_active_with_generation(&UninitializedEnvironment::Remote(pointer.clone()));
+
+                let env = RemoteEnvironment::new(flox, pointer, generation)
+                    .map_err(anyhow::Error::new)?;
+
+                ConcreteEnvironment::Remote(env)
+            },
         };
         warn_minimum_cli_version(&env, flox);
         Ok(env)
@@ -1050,6 +1104,7 @@ impl EnvironmentSelect {
                 Some(vec!["-d".to_string(), path.display().to_string()])
             },
             EnvironmentSelect::Remote(env_ref) => Some(vec!["-r".to_string(), env_ref.to_string()]),
+            EnvironmentSelect::Default => Some(vec!["-D".to_string()]),
             EnvironmentSelect::Unspecified => None,
         }
     }

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -5340,3 +5340,34 @@ success"
 @test "zsh: activate succeeds with exported functions in hook" {
   activate_succeeds_with_exported_functions_in_hook zsh
 }
+
+# bats test_tags=activate,activate:default-flag
+@test "activate -D requires authentication" {
+  # Ensure we're not logged in by unsetting auth token
+  unset FLOX_FLOXHUB_TOKEN
+
+  run "$FLOX_BIN" activate -D
+  assert_failure
+  assert_output --partial "The '-D' and '--default' flags require authentication"
+}
+
+# bats test_tags=activate,activate:default-flag
+@test "activate -D activates default environment when logged in" {
+  project_setup
+  floxhub_setup "test"
+
+  # Create a directory for the default environment
+  DEFAULT_ENV_DIR="$PROJECT_DIR/default-env"
+  mkdir "$DEFAULT_ENV_DIR"
+
+  # Create and push test/default environment
+  run "$FLOX_BIN" init -d "$DEFAULT_ENV_DIR" --name default
+  assert_success
+  run "$FLOX_BIN" push -d "$DEFAULT_ENV_DIR" --owner test
+  assert_success
+
+  # Activate using -D should work
+  run "$FLOX_BIN" activate -D -- echo "activated"
+  assert_success
+  assert_output --partial "activated"
+}

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -508,3 +508,30 @@ EOF
   assert_failure
   diff "$PWD/.flox/env/manifest.lock.before" "$PWD/.flox/env/manifest.lock"
 }
+
+# bats test_tags=install,install:default-flag
+@test "install -D installs to default environment" {
+  project_setup
+  floxhub_setup "test"
+
+  # Create a directory for the default environment
+  DEFAULT_ENV_DIR="$PROJECT_DIR/default-env"
+  mkdir "$DEFAULT_ENV_DIR"
+
+  # Create and push test/default environment
+  run "$FLOX_BIN" init -d "$DEFAULT_ENV_DIR" --name default
+  assert_success
+  run "$FLOX_BIN" push -d "$DEFAULT_ENV_DIR" --owner test
+  assert_success
+
+  # Install using -D should work
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml"
+  run "$FLOX_BIN" install -D hello
+  assert_success
+  assert_output --partial "'hello' installed to environment"
+
+  # Verify package was installed by checking the remote environment
+  run "$FLOX_BIN" list -D
+  assert_success
+  assert_output --partial "hello"
+}


### PR DESCRIPTION
This adds `-D/--default` flag as a convenient shortcut for `-r {logged_in_user}/default`, allowing users to quickly reference their default FloxHub environment across all commands that support environment selection. 
When users aren't logged in, the flag shows a helpful error message with instructions to run `flox auth login`.

Closes [DEV-33](https://linear.app/floxdotdev/issue/DEV-33)
## Release Notes

> 
> **Added -D/--default flag** - Quick shortcut to reference your default FloxHub environment (user/default) across all commands instead of typing -r user/default.
