### PR TITLE
refactor: make EnvironmentSelect methods async

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -143,6 +143,7 @@ impl Activate {
         let mut concrete_environment = match self
             .environment
             .to_concrete_environment(&flox, self.generation)
+            .await
         {
             Ok(concrete_environment) => concrete_environment,
             Err(e @ EnvironmentSelectError::EnvNotFoundInCurrentDirectory) => {

--- a/cli/flox/src/commands/activation_state.rs
+++ b/cli/flox/src/commands/activation_state.rs
@@ -12,10 +12,11 @@ pub struct ActivationState {
 }
 
 impl ActivationState {
-    pub fn handle(&self, flox: Flox) -> Result<(), anyhow::Error> {
+    pub async fn handle(&self, flox: Flox) -> Result<(), anyhow::Error> {
         let concrete_env = self
             .environment
-            .detect_concrete_environment(&flox, "Environment path to get activation state")?;
+            .detect_concrete_environment(&flox, "Environment path to get activation state")
+            .await?;
 
         let activation_state_dir =
             activation_state_dir_path(&flox.runtime_dir, concrete_env.dot_flox_path());

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -59,7 +59,8 @@ impl Containerize {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         let mut env = self
             .environment
-            .detect_concrete_environment(&flox, "Containerize")?;
+            .detect_concrete_environment(&flox, "Containerize")
+            .await?;
         environment_subcommand_metric!("containerize", env);
 
         // Check that a specified runtime exists.

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -89,12 +89,15 @@ impl Edit {
             ensure_auth(&mut flox).await?;
         };
 
-        let mut detected_environment =
-            match self.environment.detect_concrete_environment(&flox, "Edit") {
-                Ok(concrete_env) => concrete_env,
-                Err(EnvironmentSelectError::Anyhow(e)) => Err(e)?,
-                Err(e) => Err(e)?,
-            };
+        let mut detected_environment = match self
+            .environment
+            .detect_concrete_environment(&flox, "Edit")
+            .await
+        {
+            Ok(concrete_env) => concrete_env,
+            Err(EnvironmentSelectError::Anyhow(e)) => Err(e)?,
+            Err(e) => Err(e)?,
+        };
         environment_subcommand_metric!("edit", detected_environment);
 
         match self.action {

--- a/cli/flox/src/commands/generations/history.rs
+++ b/cli/flox/src/commands/generations/history.rs
@@ -46,10 +46,11 @@ enum OutputMode {
 
 impl History {
     #[instrument(name = "history", skip_all)]
-    pub fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Show history for")?;
+            .detect_concrete_environment(&flox, "Show history for")
+            .await?;
         environment_subcommand_metric!("generations::history", env);
 
         let env: GenerationsEnvironment = env.try_into()?;

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -51,10 +51,11 @@ enum OutputMode {
 
 impl List {
     #[instrument(name = "list", skip_all)]
-    pub fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "List using")?;
+            .detect_concrete_environment(&flox, "List using")
+            .await?;
         environment_subcommand_metric!(
             "generations::list",
             env,

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -37,15 +37,15 @@ pub enum GenerationsCommands {
 
 impl GenerationsCommands {
     #[instrument(name = "generations", skip_all)]
-    pub fn handle(self, _config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, _config: Config, flox: Flox) -> Result<()> {
         match self {
             GenerationsCommands::Help => {
                 display_help(Some("generations".to_string()));
             },
-            GenerationsCommands::List(args) => args.handle(flox)?,
-            GenerationsCommands::History(args) => args.handle(flox)?,
-            GenerationsCommands::Rollback(args) => args.handle(flox)?,
-            GenerationsCommands::Switch(args) => args.handle(flox)?,
+            GenerationsCommands::List(args) => args.handle(flox).await?,
+            GenerationsCommands::History(args) => args.handle(flox).await?,
+            GenerationsCommands::Rollback(args) => args.handle(flox).await?,
+            GenerationsCommands::Switch(args) => args.handle(flox).await?,
         }
 
         Ok(())

--- a/cli/flox/src/commands/generations/rollback.rs
+++ b/cli/flox/src/commands/generations/rollback.rs
@@ -24,14 +24,15 @@ pub struct Rollback {
 
 impl Rollback {
     #[instrument(name = "rollback", skip_all)]
-    pub fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
         // TODO(zmitchell, 2025-20-12): `detect_concrete_environment` will prompt
         // which environment to use even when one of the choices is a path
         // environment (which fails when selected). We could be smarter about
         // this in the future.
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Rollback using")?;
+            .detect_concrete_environment(&flox, "Rollback using")
+            .await?;
 
         environment_subcommand_metric!("generations::rollback", env);
         let mut env: GenerationsEnvironment = env.try_into()?;

--- a/cli/flox/src/commands/generations/switch.rs
+++ b/cli/flox/src/commands/generations/switch.rs
@@ -24,10 +24,11 @@ pub struct Switch {
 
 impl Switch {
     #[instrument(name = "switch", skip_all)]
-    pub fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Switch using")?;
+            .detect_concrete_environment(&flox, "Switch using")
+            .await?;
 
         environment_subcommand_metric!("generations::switch", env);
         let mut env: GenerationsEnvironment = env.try_into()?;

--- a/cli/flox/src/commands/include.rs
+++ b/cli/flox/src/commands/include.rs
@@ -60,7 +60,8 @@ impl Upgrade {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         let mut environment = self
             .environment
-            .detect_concrete_environment(&flox, "Get latest changes to included environments in")?;
+            .detect_concrete_environment(&flox, "Get latest changes to included environments in")
+            .await?;
 
         environment_subcommand_metric!("include::upgrade", environment);
 

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -152,6 +152,7 @@ impl Install {
         let mut concrete_environment = match self
             .environment
             .detect_concrete_environment(&flox, "Install to")
+            .await
         {
             Ok(concrete_environment) => concrete_environment,
             Err(EnvironmentSelectError::EnvironmentError(

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -63,7 +63,8 @@ impl List {
 
         let mut env = self
             .environment
-            .detect_concrete_environment(&flox, "List using")?;
+            .detect_concrete_environment(&flox, "List using")
+            .await?;
         environment_subcommand_metric!("list", env);
 
         let (manifest_contents, lockfile) = match (&mut env, self.upstream) {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -675,7 +675,7 @@ impl ModifyCommands {
             ModifyCommands::Include(args) => args.handle(flox).await?,
             ModifyCommands::Upgrade(args) => args.handle(flox).await?,
             ModifyCommands::Uninstall(args) => args.handle(flox).await?,
-            ModifyCommands::Generations(args) => args.handle(config, flox)?,
+            ModifyCommands::Generations(args) => args.handle(config, flox).await?,
         }
         Ok(())
     }
@@ -812,8 +812,8 @@ impl InternalCommands {
             InternalCommands::LockManifest(args) => args.handle(flox).await?,
             InternalCommands::CheckForUpgrades(args) => args.handle(flox).await?,
             InternalCommands::Exit(args) => args.handle(flox)?,
-            InternalCommands::ActivationState(args) => args.handle(flox)?,
-            InternalCommands::ServicesSocket(args) => args.handle(flox)?,
+            InternalCommands::ActivationState(args) => args.handle(flox).await?,
+            InternalCommands::ServicesSocket(args) => args.handle(flox).await?,
         }
         Ok(())
     }
@@ -960,7 +960,7 @@ impl EnvironmentSelect {
     /// behavior based on whether an environment is already active. For example,
     /// `flox activate` should never re-activate the last activated environment;
     /// it should default to an environment in the current directory.
-    pub fn to_concrete_environment(
+    pub async fn to_concrete_environment(
         &self,
         flox: &Flox,
         generation: Option<GenerationId>,
@@ -1009,7 +1009,7 @@ impl EnvironmentSelect {
     /// currently activated environment. For example, `flox install` should
     /// install to the last activated environment if there isn't an environment
     /// in the current directory.
-    pub fn detect_concrete_environment(
+    pub async fn detect_concrete_environment(
         &self,
         flox: &Flox,
         message: &str,

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -131,7 +131,9 @@ impl Pull {
                 Self::pull_new_environment(&flox, dir, remote, copy, self.force, generation)?;
             },
             PullSelect::RemoteUpdate { environment, copy } => {
-                let environment = environment.detect_concrete_environment(&flox, "Pull")?;
+                let environment = environment
+                    .detect_concrete_environment(&flox, "Pull")
+                    .await?;
                 environment_subcommand_metric!("pull", environment);
 
                 if let ConcreteEnvironment::Path(environment) = environment {

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -78,7 +78,8 @@ impl Push {
 
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Push")?;
+            .detect_concrete_environment(&flox, "Push")
+            .await?;
 
         environment_subcommand_metric!("push", env);
 

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -36,7 +36,7 @@ pub struct Logs {
 impl Logs {
     #[instrument(name = "logs", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
         environment_subcommand_metric!("services::logs", env.environment);
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -168,11 +168,13 @@ impl ServicesEnvironment {
     /// Create a [ServicesEnvironment] from an [EnvironmentSelect],
     ///
     /// Returns an error if the environment is remote or doesn't support services.
-    pub fn from_environment_selection(
+    pub async fn from_environment_selection(
         flox: &Flox,
         environment: &EnvironmentSelect,
     ) -> Result<Self> {
-        let concrete_environment = environment.detect_concrete_environment(flox, "Services in")?;
+        let concrete_environment = environment
+            .detect_concrete_environment(flox, "Services in")
+            .await?;
         Self::from_concrete_environment(flox, concrete_environment)
     }
 

--- a/cli/flox/src/commands/services/persist.rs
+++ b/cli/flox/src/commands/services/persist.rs
@@ -32,7 +32,7 @@ pub struct Persist {
 impl Persist {
     #[instrument(name = "persist", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
         environment_subcommand_metric!("services::persist", env.environment);
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -40,7 +40,8 @@ pub struct Restart {
 impl Restart {
     #[instrument(name = "restart", skip_all)]
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
-        let mut env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+        let mut env =
+            ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
         environment_subcommand_metric!("services::restart", env.environment);
         let (current_mode, generation) = guard_is_within_activation(&env, "restart")?;
         guard_service_commands_available(&env, &flox.system)?;

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -36,7 +36,8 @@ pub struct Start {
 impl Start {
     #[instrument(name = "start", skip_all)]
     pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
-        let mut env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+        let mut env =
+            ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
         environment_subcommand_metric!("services::start", env.environment);
         let (current_mode, generation) = guard_is_within_activation(&env, "start")?;
         guard_service_commands_available(&env, &flox.system)?;

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -37,7 +37,7 @@ pub struct Status {
 impl Status {
     #[instrument(name = "status", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
         environment_subcommand_metric!("services::status", env.environment);
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -23,7 +23,7 @@ pub struct Stop {
 impl Stop {
     #[instrument(name = "stop", skip_all)]
     pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment)?;
+        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
         environment_subcommand_metric!("services::stop", env.environment);
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services_socket.rs
+++ b/cli/flox/src/commands/services_socket.rs
@@ -11,10 +11,11 @@ pub struct ServicesSocket {
 }
 
 impl ServicesSocket {
-    pub fn handle(&self, flox: Flox) -> Result<(), anyhow::Error> {
+    pub async fn handle(&self, flox: Flox) -> Result<(), anyhow::Error> {
         let concrete_env = self
             .environment
-            .detect_concrete_environment(&flox, "Environment path to get services socket")?;
+            .detect_concrete_environment(&flox, "Environment path to get services socket")
+            .await?;
 
         let socket_path = concrete_env.services_socket_path(&flox)?;
         println!("{}", socket_path.display());

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -49,6 +49,7 @@ impl Uninstall {
         let mut concrete_environment = match self
             .environment
             .detect_concrete_environment(&flox, "Uninstall from")
+            .await
         {
             Ok(concrete_environment) => concrete_environment,
             Err(EnvironmentSelectError::EnvironmentError(

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -45,7 +45,8 @@ impl Upgrade {
 
         let mut concrete_environment = self
             .environment
-            .detect_concrete_environment(&flox, "Upgrade")?;
+            .detect_concrete_environment(&flox, "Upgrade")
+            .await?;
         environment_subcommand_metric!("upgrade", concrete_environment);
 
         let description = environment_description(&concrete_environment)?;


### PR DESCRIPTION
Make EnvironmentSelect::to_concrete_environment and EnvironmentSelect::detect_concrete_environment async. This is in preparation for using async auth methods for `-D/--default`
