### PR TITLE
test: allow 0 args for Justfile targets

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -232,12 +232,12 @@ gen-unit-data-for-publish floxhub_repo_path force="":
 
 # Run the CLI integration test suite using locally built binaries
 # This is equivalent to the "local" jobs in CI.
-@integ-tests +bats_args="": build
+@integ-tests *bats_args: build
     flox-cli-tests "$@"
 
 # Run the CLI integration test suite using Nix-built binaries
 # This is equivalent to the "remote" jobs in CI.
-@nix-integ-tests +bats_args="":
+@nix-integ-tests *bats_args:
     nix run \
         --accept-flake-config \
         --extra-experimental-features 'nix-command flakes' \


### PR DESCRIPTION
Fix running `just integ-tests` and `just nix-integ-tests` with 0
arguments.

The fix for quoting args to Just targets in
7d8b503ccbbb71b2896a7c88d7627e8ca2fe33d7
regressed passing 0 args.

just integ-tests and just nix-integ-tests currently fail with:
```
flox-cli-tests ERROR: Unrecognized arg(s) ''
Usage: /nix/store/irxm6iaxg10clmi6v58gbv6dkxlc5sv2-flox-cli-tests/bin/flox-cli-tests [--tests <TESTS_DIR>| -T <TESTS_DIR>]           [--watch | -W]           [--help | -h] -- [BATS ARGUMENTS]

Available options:
    -T, --tests          Path to folder of tests (Default: /Users/matthew/flox/cli/tests)
    -c, --ci-runner      Which runner this job is on, if any
    -W, --watch          Run tests in a continuous watch mode
    -h, --help           Prints help information
error: Recipe `integ-tests` failed on line 236 with exit code 1
```

After this fix, running with 0 args works:
just integ-tests
just nix-integ-tests

And the case fixed by that commit still works:
just integ-tests -- -f 'flox list --config'
just nix-integ-tests -- -f 'flox list --config'
