### PR TITLE
chore(ci): Remove codecov action

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -29,3 +29,4 @@ yes,mrswastik-robot,Swastik Patel,<swastikpatel29@gmail.com>
 yes,noor-latif,Noor Latif,<noor@latif.se>
 yes,martijnarts,Martijn Arts,<martijn@martijnarts.com>
 yes,electricalen,David Sawyer,<electricalen@gmail.com>
+yes,jsoref,Josh Soref,<jsoref@gmail.com>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,15 +183,6 @@ jobs:
           RUST_BACKTRACE: 1
         run: nix develop -L --no-update-lock-file --command just impure-tests
 
-      - name: "Upload CLI Unit Test Results"
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
-        if: ${{ !cancelled() && steps.unit-tests.outcome != 'skipped' }}
-        with:
-          disable_search: true
-          files: "./target/nextest/ci/junit.xml"
-          flags: "dev-unittests, ${{ matrix.test-tags }}, ${{ matrix.os }}"
-          verbose: true
-          use_oidc: true
       - name: "Check schemas are up to date"
         run: |
           nix develop -L --no-update-lock-file --command just gen-schemas
@@ -512,13 +503,3 @@ jobs:
           MATRIX_SYSTEM: ${{ matrix.system }}
           MATRIX_TEST_TAGS: ${{ matrix.test-tags }}
         run: ./.github/scripts/remote-execute-integration-tests.sh
-
-      - name: "Upload Bats Tests results"
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
-        if: ${{ !cancelled() }}
-        with:
-          disable_search: true
-          files: "./report.xml"
-          flags: "nix-integration-tests, ${{ matrix.test-tags }}, ${{ matrix.system }}"
-          verbose: true
-          use_oidc: true


### PR DESCRIPTION
## Proposed Changes

Per https://floxcommunitygroup.slack.com/archives/C08M9CHMH88/p1778559669979509?thread_ts=1777642447.487989&cid=C08M9CHMH88, removes codecov

https://github.com/flox/flox/actions/runs/25214716271
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3, flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true`. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Release Notes

N/A