### PR TITLE
refactor(EnvDiff): add `#[cfg(test)]` gate to private test constructor

### DIFF
--- a/cli/flox-activations/src/env_diff.rs
+++ b/cli/flox-activations/src/env_diff.rs
@@ -39,7 +39,7 @@ impl EnvDiff {
         Ok(from_parsed_files(&start_env, &end_env))
     }
 
-    // Primarily for testing
+    #[cfg(test)]
     pub fn from_parts(additions: HashMap<String, String>, deletions: Vec<String>) -> Self {
         Self {
             additions,


### PR DESCRIPTION
Use `#[cfg(test)]` instead of commenting that a method is for tests
