### PR TITLE
fix(auth): suppress circular re-authentication advice in 'flox auth login'

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -296,9 +296,14 @@ impl FloxArgs {
                 None
             },
             Ok(Some(token)) if token.is_expired() => {
-                message::warning(
-                    "Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.",
-                );
+                if !matches!(
+                    self.command,
+                    Some(Commands::Admin(AdminCommands::Auth(auth::Auth::Login)))
+                ) {
+                    message::warning(
+                        "Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.",
+                    );
+                }
                 Some(token)
             },
             Ok(token) => token,


### PR DESCRIPTION
## Summary

- When a user's FloxHub token has expired and they run `flox auth login`, the warning message told them to run `'flox auth login' to re-authenticate` — the exact command they were already executing (closes #4211)
- Suppress the warning specifically when the subcommand being invoked is `auth login`; all other commands continue to show the advice as before

## Test plan

- [ ] New bats test in `cli/tests/auth.bats`: verifies that running `flox auth login` with an expired token does **not** show the circular re-authentication advice
- [ ] Existing `push.bats` test still passes: confirms that running `flox init` (a non-auth command) with an expired token still shows the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)