### PR TITLE
feat(install): support adding outputs imperatively

### DIFF
--- a/cli/flox-manifest/src/lockfile/mod.rs
+++ b/cli/flox-manifest/src/lockfile/mod.rs
@@ -167,6 +167,12 @@ impl Lockfile {
     pub fn is_up_to_date_with_serialized_manifest(&self, manifest: &Manifest<TypedOnly>) -> bool {
         manifest == self.user_manifest()
     }
+
+    pub fn locked_package_with_id(&self, id: impl AsRef<str>) -> Option<&LockedPackage> {
+        self.packages
+            .iter()
+            .find(|pkg| pkg.install_id() == id.as_ref())
+    }
 }
 
 impl FromStr for Lockfile {
@@ -247,6 +253,24 @@ impl LockedPackage {
             LockedPackage::Catalog(pkg) => Some(&pkg.version),
             LockedPackage::Flake(pkg) => pkg.locked_installable.version.as_deref(),
             LockedPackage::StorePath(_) => None,
+        }
+    }
+
+    /// Returns None for store paths
+    pub fn outputs_to_install(&self) -> Option<Vec<String>> {
+        match self {
+            LockedPackage::Catalog(pkg) => pkg.outputs_to_install(),
+            LockedPackage::Flake(pkg) => pkg.outputs_to_install(),
+            LockedPackage::StorePath(_) => None,
+        }
+    }
+
+    /// Returns an empty vec for store paths since store paths don't have outputs
+    pub fn all_outputs(&self) -> Vec<String> {
+        match self {
+            LockedPackage::Catalog(pkg) => pkg.all_outputs(),
+            LockedPackage::Flake(pkg) => pkg.all_outputs(),
+            LockedPackage::StorePath(_) => Vec::new(),
         }
     }
 }

--- a/cli/flox-manifest/src/parsed/v1_10_0/package_descriptor.rs
+++ b/cli/flox-manifest/src/parsed/v1_10_0/package_descriptor.rs
@@ -239,6 +239,18 @@ impl SelectedOutputs {
     }
 }
 
+impl std::fmt::Display for SelectedOutputs {
+    // SelectedOutputs is the post-parse, manifest-side value, so its Display
+    // mirrors its serialized form ("all" for All, comma-joined names for
+    // Specific) rather than the CLI parser grammar used by RawSelectedOutputs.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All(_) => write!(f, "all"),
+            Self::Specific(names) => write!(f, "{}", names.join(",")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum AllSentinel {

--- a/cli/flox-manifest/src/raw/mod.rs
+++ b/cli/flox-manifest/src/raw/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::LazyLock;
@@ -13,6 +13,7 @@ use tracing::{debug, trace};
 
 use crate::interfaces::CommonFields;
 use crate::parsed::common::{self, KnownSchemaVersion, VersionKind};
+use crate::parsed::latest::ManifestPackageDescriptor;
 use crate::parsed::v1_10_0::SelectedOutputs;
 use crate::parsed::{Inner, v1, v1_10_0};
 use crate::util::is_custom_package;
@@ -191,13 +192,6 @@ pub enum TomlEditError {
     UnsupportedAttributeV1(String),
 }
 
-/// Records the result of trying to install a collection of packages to the
-#[derive(Debug)]
-pub struct PackageInsertion {
-    pub new_manifest: Option<Manifest<Migrated>>,
-    pub already_installed: HashMap<String, bool>,
-}
-
 /// Any kind of package that can be installed via `flox install`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PackageToInstall {
@@ -254,6 +248,16 @@ impl PackageToInstall {
             PackageToInstall::Catalog(pkg) => pkg.systems.clone(),
             PackageToInstall::Flake(_) => None,
             PackageToInstall::StorePath(pkg) => Some(vec![pkg.system.clone()]),
+        }
+    }
+
+    /// Return the requested outputs for this package, if any.
+    /// Store path packages do not support outputs and always return `None`.
+    pub fn outputs(&self) -> Option<&RawSelectedOutputs> {
+        match self {
+            PackageToInstall::Catalog(pkg) => pkg.outputs.as_ref(),
+            PackageToInstall::Flake(pkg) => pkg.outputs.as_ref(),
+            PackageToInstall::StorePath(_) => None,
         }
     }
 }
@@ -382,6 +386,15 @@ impl From<&RawSelectedOutputs> for SelectedOutputs {
         match value {
             RawSelectedOutputs::All => SelectedOutputs::all(),
             RawSelectedOutputs::Specific(items) => SelectedOutputs::Specific(items.clone()),
+        }
+    }
+}
+
+impl From<SelectedOutputs> for RawSelectedOutputs {
+    fn from(value: SelectedOutputs) -> Self {
+        match value {
+            SelectedOutputs::All(_) => RawSelectedOutputs::All,
+            SelectedOutputs::Specific(items) => RawSelectedOutputs::Specific(items),
         }
     }
 }
@@ -630,13 +643,14 @@ impl StorePath {
     }
 }
 
-/// The kind of modification to apply to a package during uninstall.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PackageModification {
     /// Remove the package entirely.
     Remove,
     /// Update the package's outputs to the given list.
-    UpdateOutputs(Vec<String>),
+    UpdateOutputs(SelectedOutputs),
+    /// Install a new package to the manifest.
+    Add(PackageToInstall),
 }
 
 /// A resolved package modification to apply.
@@ -737,94 +751,77 @@ impl From<&CatalogPackage> for InlineTable {
 }
 
 pub trait ModifyPackages {
-    /// Adds new packages to the manifest, returning a new manifest if one was created
-    /// along with a map of which of the newly added packages were already installed.
-    fn add_packages(&self, pkgs: &[PackageToInstall]) -> Result<PackageInsertion, ManifestError>;
-    /// Apply a set of modifications to existing packages (removals or output updates)
-    /// in the manifest.
+    /// Apply a list of packagemodifications (adds, removals, or output updates)
     fn modify_packages(
         &self,
         modifications: &[PackageToModify],
     ) -> Result<Manifest<Migrated>, ManifestError>;
 }
 
-impl ModifyPackages for Manifest<Migrated> {
-    fn add_packages(&self, pkgs: &[PackageToInstall]) -> Result<PackageInsertion, ManifestError> {
-        let mut manifest = self.clone();
-        let pkg_map = manifest.inner.migrated_parsed.install.inner_mut();
-        let mut already_installed: HashMap<String, bool> = HashMap::new();
-        for pkg in pkgs.iter() {
-            if pkg_map.contains_key(pkg.id()) {
-                already_installed.insert(pkg.id().to_string(), true);
-                debug!("package already installed: id={}", pkg.id());
-                continue;
-            }
-            already_installed.insert(pkg.id().to_string(), false);
-            match pkg {
-                PackageToInstall::Catalog(pkg_raw) => {
-                    let pkg_group = if pkg_raw.is_custom_catalog() {
-                        Some(pkg.id().to_string())
-                    } else {
-                        None
-                    };
-                    let catalog_descriptor = v1_10_0::PackageDescriptorCatalog {
-                        pkg_path: pkg_raw.pkg_path.clone(),
-                        pkg_group,
-                        priority: None,
-                        version: pkg_raw.version.clone(),
-                        systems: pkg_raw.systems.clone(),
-                        outputs: pkg_raw.outputs.clone().map(|outputs| outputs.into()),
-                    };
-                    let descriptor =
-                        v1_10_0::ManifestPackageDescriptor::Catalog(catalog_descriptor);
-                    pkg_map.insert(pkg.id().to_string(), descriptor);
-                    debug!(
-                        "package newly installed: id={}, pkg-path={}",
-                        pkg_raw.id, pkg_raw.pkg_path
-                    );
-                },
-                PackageToInstall::Flake(flake_raw) => {
-                    let flake_descriptor = v1_10_0::PackageDescriptorFlake {
-                        flake: flake_raw.url.to_string(),
-                        priority: None,
-                        systems: pkg.systems(),
-                        outputs: flake_raw.outputs.as_ref().map(|o| o.into()),
-                    };
-                    let descriptor = v1_10_0::ManifestPackageDescriptor::FlakeRef(flake_descriptor);
-                    pkg_map.insert(pkg.id().to_string(), descriptor);
-                    debug!(
-                        "package newly installed: id={}, flakeref={}",
-                        flake_raw.id,
-                        flake_raw.url.to_string()
-                    );
-                },
-                PackageToInstall::StorePath(store_path_raw) => {
-                    let store_path_descriptor = common::PackageDescriptorStorePath {
-                        store_path: store_path_raw.store_path.to_string_lossy().to_string(),
-                        systems: None,
-                        priority: None,
-                    };
-                    let descriptor =
-                        v1_10_0::ManifestPackageDescriptor::StorePath(store_path_descriptor);
-                    pkg_map.insert(pkg.id().to_string(), descriptor);
-                    debug!(id=pkg.id(), store_path=%store_path_raw.store_path.display(),
-                        "store path newly installed"
-                    );
-                },
-            }
+impl Manifest<Migrated> {
+    /// Add a package to the typed manifest
+    /// The caller is responsible for calling
+    /// `update_raw_packages_from_typed_manifest()` afterwards
+    /// It's assumed that `pkg` does not yet exist in the manifest
+    fn add_package(
+        pkg: &PackageToInstall,
+        pkg_map: &mut BTreeMap<String, ManifestPackageDescriptor>,
+    ) {
+        match pkg {
+            PackageToInstall::Catalog(pkg_raw) => {
+                let pkg_group = if pkg_raw.is_custom_catalog() {
+                    Some(pkg.id().to_string())
+                } else {
+                    None
+                };
+                let catalog_descriptor = v1_10_0::PackageDescriptorCatalog {
+                    pkg_path: pkg_raw.pkg_path.clone(),
+                    pkg_group,
+                    priority: None,
+                    version: pkg_raw.version.clone(),
+                    systems: pkg_raw.systems.clone(),
+                    outputs: pkg_raw.outputs.clone().map(|outputs| outputs.into()),
+                };
+                let descriptor = v1_10_0::ManifestPackageDescriptor::Catalog(catalog_descriptor);
+                pkg_map.insert(pkg.id().to_string(), descriptor);
+                debug!(
+                    "package newly installed: id={}, pkg-path={}",
+                    pkg_raw.id, pkg_raw.pkg_path
+                );
+            },
+            PackageToInstall::Flake(flake_raw) => {
+                let flake_descriptor = v1_10_0::PackageDescriptorFlake {
+                    flake: flake_raw.url.to_string(),
+                    priority: None,
+                    systems: pkg.systems(),
+                    outputs: flake_raw.outputs.as_ref().map(|o| o.into()),
+                };
+                let descriptor = v1_10_0::ManifestPackageDescriptor::FlakeRef(flake_descriptor);
+                pkg_map.insert(pkg.id().to_string(), descriptor);
+                debug!(
+                    "package newly installed: id={}, flakeref={}",
+                    flake_raw.id,
+                    flake_raw.url.to_string()
+                );
+            },
+            PackageToInstall::StorePath(store_path_raw) => {
+                let store_path_descriptor = common::PackageDescriptorStorePath {
+                    store_path: store_path_raw.store_path.to_string_lossy().to_string(),
+                    systems: None,
+                    priority: None,
+                };
+                let descriptor =
+                    v1_10_0::ManifestPackageDescriptor::StorePath(store_path_descriptor);
+                pkg_map.insert(pkg.id().to_string(), descriptor);
+                debug!(id=pkg.id(), store_path=%store_path_raw.store_path.display(),
+                    "store path newly installed"
+                );
+            },
         }
-        let new_manifest = if already_installed.values().all(|p| *p) {
-            None
-        } else {
-            manifest.update_raw_packages_from_typed_manifest()?;
-            Some(manifest)
-        };
-        Ok(PackageInsertion {
-            new_manifest,
-            already_installed,
-        })
     }
+}
 
+impl ModifyPackages for Manifest<Migrated> {
     fn modify_packages(
         &self,
         modifications: &[PackageToModify],
@@ -834,6 +831,7 @@ impl ModifyPackages for Manifest<Migrated> {
         let pkg_map = manifest.inner.migrated_parsed.install.inner_mut();
         for modification in modifications {
             match &modification.modification {
+                PackageModification::Add(pkg) => Self::add_package(pkg, pkg_map),
                 PackageModification::Remove => {
                     if !pkg_map.contains_key(&modification.install_id) {
                         return Err(ManifestError::PackageNotFound(
@@ -843,13 +841,12 @@ impl ModifyPackages for Manifest<Migrated> {
                     pkg_map.remove(&modification.install_id);
                     debug!(id = modification.install_id, "package removed");
                 },
-                // As this is currently only used for uninstalls, we don't worry about ever setting to all
                 PackageModification::UpdateOutputs(outputs) => {
                     let descriptor =
                         pkg_map.get_mut(&modification.install_id).ok_or_else(|| {
                             ManifestError::PackageNotFound(modification.install_id.clone())
                         })?;
-                    descriptor.set_outputs(Some(SelectedOutputs::Specific(outputs.clone())));
+                    descriptor.set_outputs(Some(outputs.clone()));
                     debug!(
                         id = modification.install_id,
                         ?outputs,
@@ -1543,54 +1540,41 @@ mod test {
 
     #[test]
     fn insert_adds_new_package() {
-        let test_packages = vec![PackageToInstall::Catalog(
-            CatalogPackage::from_str("python").unwrap(),
-        )];
+        let test_packages = vec![PackageToModify {
+            install_id: "python".to_owned(),
+            modification: PackageModification::Add(PackageToInstall::Catalog(
+                CatalogPackage::from_str("python").unwrap(),
+            )),
+        }];
         let pre_addition_manifest = dummy_manifest();
         let pre_addition_toml = pre_addition_manifest.inner.migrated_raw.clone();
-        assert!(!contains_package(&pre_addition_toml, test_packages[0].id()));
-        let insertion = pre_addition_manifest.add_packages(&test_packages).unwrap();
-        assert!(
-            insertion.new_manifest.is_some(),
-            "manifest was changed by install"
-        );
-        let new_toml = insertion.new_manifest.unwrap().inner.migrated_raw;
-        assert!(contains_package(&new_toml, test_packages[0].id()));
-    }
-
-    #[test]
-    fn no_change_adding_existing_package() {
-        let test_packages = vec![PackageToInstall::Catalog(
-            CatalogPackage::from_str("hello").unwrap(),
-        )];
-        let pre_addition_manifest = dummy_manifest();
-        let pre_addition_toml = pre_addition_manifest.inner.migrated_raw.clone();
-        // dummy manifest already contains `hello`
-        assert!(contains_package(&pre_addition_toml, test_packages[0].id()));
-        let insertion = pre_addition_manifest.add_packages(&test_packages).unwrap();
-        assert!(
-            insertion.new_manifest.is_none(),
-            "manifest shouldn't be changed installing existing package"
-        );
-        assert!(
-            insertion.already_installed.values().all(|p| *p),
-            "all of the packages should be listed as already installed"
-        );
+        assert!(!contains_package(
+            &pre_addition_toml,
+            &test_packages[0].install_id
+        ));
+        let new_manifest = pre_addition_manifest
+            .modify_packages(&test_packages)
+            .unwrap();
+        assert!(contains_package(
+            &new_manifest.inner.migrated_raw,
+            &test_packages[0].install_id
+        ));
     }
 
     #[test]
     fn insert_adds_install_table_when_missing() {
-        let test_packages = vec![PackageToInstall::Catalog(
-            CatalogPackage::from_str("foo").unwrap(),
-        )];
+        let test_packages = vec![PackageToModify {
+            install_id: "foo".to_owned(),
+            modification: PackageModification::Add(PackageToInstall::Catalog(
+                CatalogPackage::from_str("foo").unwrap(),
+            )),
+        }];
         let manifest = dummy_manifest();
-        let insertion = manifest.add_packages(&test_packages).unwrap();
-        let toml = insertion.new_manifest.unwrap().inner.migrated_raw;
-        assert!(contains_package(&toml, test_packages[0].id()));
-        assert!(
-            !insertion.already_installed.values().all(|p| *p),
-            "none of the packages should be listed as already installed"
-        );
+        let new_manifest = manifest.modify_packages(&test_packages).unwrap();
+        assert!(contains_package(
+            &new_manifest.inner.migrated_raw,
+            &test_packages[0].install_id
+        ));
     }
 
     #[test]
@@ -1636,23 +1620,22 @@ mod test {
     #[test]
     fn inserts_package_needing_quotes() {
         let attrs = r#"foo."bar.baz".qux"#;
-        let test_packages = vec![PackageToInstall::Catalog(
-            CatalogPackage::from_str(attrs).unwrap(),
-        )];
+        let test_packages = vec![PackageToModify {
+            install_id: "qux".to_owned(),
+            modification: PackageModification::Add(PackageToInstall::Catalog(
+                CatalogPackage::from_str(attrs).unwrap(),
+            )),
+        }];
         let pre_addition = dummy_manifest();
         assert!(!contains_package(
             &pre_addition.inner.migrated_raw,
-            test_packages[0].id()
+            &test_packages[0].install_id
         ));
-        let insertion = pre_addition
-            .add_packages(&test_packages)
+        let new_manifest = pre_addition
+            .modify_packages(&test_packages)
             .expect("couldn't add package");
-        assert!(
-            insertion.new_manifest.is_some(),
-            "manifest was changed by install"
-        );
-        let new_toml = insertion.new_manifest.unwrap().inner.migrated_raw;
-        assert!(contains_package(&new_toml, test_packages[0].id()));
+        let new_toml = new_manifest.inner.migrated_raw;
+        assert!(contains_package(&new_toml, &test_packages[0].install_id));
         let inserted_path = new_toml["install"]["qux"]["pkg-path"].as_str().unwrap();
         assert_eq!(inserted_path, r#"foo."bar.baz".qux"#);
     }
@@ -1820,16 +1803,14 @@ mod test {
 schema-version = \"1.10.0\"
         ";
         let manifest = mk_test_manifest_from_contents(contents);
-        let insertion = manifest
-            .add_packages(&[package])
+        let new_manifest = manifest
+            .modify_packages(&[PackageToModify {
+                install_id: package.id().to_string(),
+                modification: PackageModification::Add(package),
+            }])
             .expect("couldn't add package");
         assert_eq!(
-            insertion
-                .new_manifest
-                .unwrap()
-                .inner
-                .migrated_raw
-                .to_string(),
+            new_manifest.inner.migrated_raw.to_string(),
             "
 schema-version = \"1.10.0\"
 

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -37,6 +37,7 @@ use super::{
 };
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
+use crate::models::environment::install::compute_install_modifications;
 use crate::providers::buildenv::{
     self,
     BuildEnv,
@@ -354,27 +355,30 @@ impl CoreEnvironment<ReadOnly> {
 
     /// Install packages to the environment atomically
     ///
-    /// Returns the new manifest content if the environment was modified. Also
-    /// returns a map of the packages that were already installed. The installation
-    /// will proceed if at least one of the requested packages were added to the
-    /// manifest.
+    /// Skips rebuilding if all packages are already installed
     pub fn install(
         &mut self,
         packages: &[PackageToInstall],
         flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError> {
         let manifest = self.manifest(flox)?;
-        let insertion = manifest.add_packages(packages)?;
-        let built_environments = insertion
-            .new_manifest
-            .as_ref()
-            .map(|m| self.transact_with_manifest(m, flox))
-            .transpose()?
-            .map(|(store_path, _)| store_path);
+        // TODO: this could lead to double resolution and surprising errors
+        // (e.g. if you try to install a package and we fail to resolve a different package)
+        // We need a lockfile for logic about output merging
+        let lockfile: Lockfile = self.lock(flox)?.into();
+
+        let modifications = compute_install_modifications(packages, &manifest, &lockfile)?;
+
+        let built_environments = if modifications.is_empty() {
+            None
+        } else {
+            let new_manifest = manifest.modify_packages(&modifications)?;
+            let (built_environments, _) = self.transact_with_manifest(&new_manifest, flox)?;
+            Some(built_environments)
+        };
 
         Ok(InstallationAttempt {
-            manifest_modified: built_environments.is_some(),
-            already_installed: insertion.already_installed,
+            modifications,
             built_environments,
         })
     }
@@ -389,6 +393,9 @@ impl CoreEnvironment<ReadOnly> {
         uninstall_specs: Vec<UninstallSpec>,
         flox: &Flox,
     ) -> Result<UninstallationAttempt, EnvironmentError> {
+        // TODO: this could lead to double resolution and surprising errors
+        // (e.g. if you try to uninstall a package and we fail to resolve that package)
+        // We need a lockfile for logic about output mergine
         let lockfile: Lockfile = self.lock(flox)?.into();
 
         let manifest = self.manifest(flox)?;

--- a/cli/flox-rust-sdk/src/models/environment/install.rs
+++ b/cli/flox-rust-sdk/src/models/environment/install.rs
@@ -1,0 +1,247 @@
+use flox_manifest::interfaces::PackageLookup;
+use flox_manifest::lockfile::Lockfile;
+use flox_manifest::parsed::latest::{AllSentinel, SelectedOutputs};
+use flox_manifest::raw::{
+    PackageModification,
+    PackageToInstall,
+    PackageToModify,
+    RawSelectedOutputs,
+};
+use flox_manifest::{Manifest, Migrated};
+use tracing::debug;
+
+use crate::models::environment::InstallOrUninstallError;
+
+/// Compute all modifications needed to install the given packages.
+///
+/// Errors for invalid requests and filters out no-ops,
+/// so the returned Vec<PackageToModify> is a validated list of changes to make
+pub(super) fn compute_install_modifications(
+    packages: &[PackageToInstall],
+    manifest: &Manifest<Migrated>,
+    lockfile: &Lockfile,
+) -> Result<Vec<PackageToModify>, InstallOrUninstallError> {
+    let modifications = packages
+        .iter()
+        .filter_map(|pkg| compute_install_modification(pkg, manifest, lockfile).transpose())
+        .collect::<Result<Vec<_>, _>>()?;
+
+    debug!(?modifications, "computed install modifications");
+    Ok(modifications)
+}
+
+/// Compute the modification (if any) needed to install a single package.
+///
+/// Returns `Ok(None)` when the package is already installed
+pub(super) fn compute_install_modification(
+    pkg: &PackageToInstall,
+    manifest: &Manifest<Migrated>,
+    lockfile: &Lockfile,
+) -> Result<Option<PackageToModify>, InstallOrUninstallError> {
+    let install_id = pkg.id();
+
+    // We don't check whether the package is already installed via an include.
+    // We just install the package as an override and later warn in the CLI
+
+    let Some(manifest_descriptor) = manifest.pkg_descriptor_with_id(install_id) else {
+        // Package is not yet in the manifest — add it.
+        return Ok(Some(PackageToModify {
+            install_id: install_id.to_string(),
+            modification: PackageModification::Add(pkg.clone()),
+        }));
+    };
+
+    // Package is already installed. Check whether outputs need merging.
+
+    // TODO: outputs of a package could change if a package gets re-resolved to a different version,
+    // but we'll ignore that as an edge case for now
+    let requested_outputs = pkg.outputs();
+    let current_outputs = manifest_descriptor.get_outputs();
+
+    match (current_outputs, requested_outputs) {
+        // When no outputs are requested for an already installed package, do nothing
+        (_, None) => Ok(None),
+        // If all outputs are already installed, do nothing
+        (Some(SelectedOutputs::All(_)), _) => Ok(None),
+        // If all outputs are requested, set outputs to all
+        (_, Some(RawSelectedOutputs::All)) => Ok(Some(PackageToModify {
+            install_id: install_id.to_string(),
+            modification: PackageModification::UpdateOutputs(SelectedOutputs::All(
+                AllSentinel::All,
+            )),
+        })),
+        // In all other cases, merge current and requested outputs
+        (current_outputs, Some(RawSelectedOutputs::Specific(requested))) => {
+            // Determine effective current outputs from manifest or
+            // lockfile defaults (what the resolver originally chose).
+            let locked_pkg = lockfile.locked_package_with_id(install_id).ok_or_else(|| {
+                InstallOrUninstallError::PackageInManifestNotInLockfile(install_id.to_string())
+            })?;
+
+            let effective_current: Vec<String> = match current_outputs {
+                // This will lead to weird behavior if e.g:
+                // outputs_to_install = None
+                // requested = ["lib"]
+                // and buildenv is currently defaulting to ["out"]
+                // We'll go from having ["out"] installed to ["lib"]
+                // That's pretty unlikely because nixpkgs `stdenv`
+                // auto-populates `meta.outputsToInstall` for any package built
+                // via `stdenv.mkDerivation`.
+                // From `pkgs/stdenv/generic/check-meta.nix`:
+                //
+                // ```nix
+                // outputsToInstall = [
+                //   (if hasOutput "bin" then "bin"
+                //    else if hasOutput "out" then "out"
+                //    else findFirst hasOutput null outputs)
+                // ] ++ optional (hasOutput "man") "man";
+                // ```
+                //
+                // So every stdenv-built package gets at minimum `["out"]` (or
+                // `["bin"]`, plus `"man"` when present). To produce `null` you
+                // need one of:
+                //
+                // - A non-stdenv derivation that bypasses `commonMeta`
+                // - A package that explicitly sets `meta.outputsToInstall = null;`
+                // - A catalog ingestion bug
+                None => locked_pkg.outputs_to_install().unwrap_or_default(),
+                Some(SelectedOutputs::Specific(list)) => list.clone(),
+                Some(SelectedOutputs::All(_)) => unreachable!(),
+            };
+
+            // Union: current + requested, preserving order and
+            // uniqueness.
+            let mut merged = effective_current.clone();
+            let mut added_output = false;
+            let all_outputs = locked_pkg.all_outputs();
+            for output in requested {
+                if !merged.contains(output) {
+                    if !all_outputs.contains(output) {
+                        return Err(InstallOrUninstallError::InvalidOutputForPackage(
+                            output.to_string(),
+                            install_id.to_string(),
+                        ));
+                    }
+                    merged.push(output.clone());
+                    added_output = true;
+                }
+            }
+
+            if added_output {
+                Ok(Some(PackageToModify {
+                    install_id: install_id.to_string(),
+                    modification: PackageModification::UpdateOutputs(SelectedOutputs::Specific(
+                        merged,
+                    )),
+                }))
+            } else {
+                Ok(None)
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use flox_core::canonical_path::CanonicalPath;
+    use flox_manifest::raw::CatalogPackage;
+    use flox_manifest::raw::test_helpers::empty_test_migrated_manifest;
+    use flox_test_utils::GENERATED_DATA;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Load a `Manifest<Migrated>` and `Lockfile` from a generated env directory.
+    fn load_manifest_and_lockfile(env_subdir: &str) -> (Manifest<Migrated>, Lockfile) {
+        let env_dir = GENERATED_DATA.join(Path::new("envs").join(env_subdir));
+        let manifest_path = env_dir.join("manifest.toml");
+        let lockfile_path = env_dir.join("manifest.lock");
+        let manifest = Manifest::read_and_migrate(&manifest_path, &lockfile_path).unwrap();
+        let lockfile =
+            Lockfile::read_from_file(&CanonicalPath::new(&lockfile_path).unwrap()).unwrap();
+        (manifest, lockfile)
+    }
+
+    fn package_to_install(
+        id: &str,
+        pkg_path: &str,
+        outputs: Option<RawSelectedOutputs>,
+    ) -> PackageToInstall {
+        PackageToInstall::Catalog(CatalogPackage {
+            id: id.to_string(),
+            pkg_path: pkg_path.to_string(),
+            version: None,
+            systems: None,
+            outputs,
+        })
+    }
+
+    // For an empty manifest
+    // `install bashNonInteractive -i bash`
+    // installs bashNonInteractive
+    #[test]
+    fn add_new_packages() {
+        let manifest = empty_test_migrated_manifest();
+        let lockfile = Lockfile::default();
+        let pkg = package_to_install("bash", "bashNonInteractive", None);
+
+        let result =
+            compute_install_modifications(std::slice::from_ref(&pkg), &manifest, &lockfile)
+                .unwrap();
+
+        assert_eq!(result, vec![PackageToModify {
+            install_id: "bash".to_string(),
+            modification: PackageModification::Add(pkg),
+        }]);
+    }
+
+    // If manifest has `bash.outputs = ["out"]`
+    // `install bashNonInteractive -i bash`
+    // is a no-op
+    #[test]
+    fn pkg_already_installed_no_outputs_requested_is_noop() {
+        let (manifest, lockfile) = load_manifest_and_lockfile("bash_v1_10_0_out");
+        let pkg = package_to_install("bash", "bashNonInteractive", None);
+
+        let result = compute_install_modifications(&[pkg], &manifest, &lockfile).unwrap();
+
+        assert_eq!(result, Vec::new());
+    }
+
+    // If manifest has `bash.outputs = ["out"]`
+    // `install bashNonInteractive^.. -i bash`
+    // updates outputs to "all"
+    #[test]
+    fn install_all_outputs_updates_manifest() {
+        let (manifest, lockfile) = load_manifest_and_lockfile("bash_v1_10_0_out");
+        let pkg = package_to_install("bash", "bashNonInteractive", Some(RawSelectedOutputs::All));
+
+        let result = compute_install_modifications(&[pkg], &manifest, &lockfile).unwrap();
+
+        assert_eq!(result, vec![PackageToModify {
+            install_id: "bash".to_string(),
+            modification: PackageModification::UpdateOutputs(SelectedOutputs::All(
+                AllSentinel::All
+            )),
+        }]);
+    }
+
+    // If manifest has `bash.outputs = ["out"]`
+    // `install bashNonInteractive^out -i bash`
+    // is a no-op
+    #[test]
+    fn request_outputs_already_installed_is_noop() {
+        let (manifest, lockfile) = load_manifest_and_lockfile("bash_v1_10_0_out");
+        let pkg = package_to_install(
+            "bash",
+            "bashNonInteractive",
+            Some(RawSelectedOutputs::Specific(vec!["out".to_string()])),
+        );
+
+        let result = compute_install_modifications(&[pkg], &manifest, &lockfile).unwrap();
+
+        assert_eq!(result, Vec::new());
+    }
+}

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -318,7 +318,7 @@ impl Environment for ManagedEnvironment {
             .collect();
 
         let result = local_checkout.install(packages, flox)?;
-        if result.manifest_modified {
+        if !result.modifications.is_empty() {
             let change = HistoryKind::Install { targets };
             generations
                 .add_generation(&mut local_checkout, change)

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -59,6 +59,7 @@ pub use core_environment::{
 pub mod fetcher;
 pub mod floxmeta_branch;
 pub mod generations;
+mod install;
 pub mod managed_environment;
 pub mod path_environment;
 pub mod remote_environment;
@@ -83,12 +84,10 @@ pub const FLOX_SERVICES_SOCKET_OVERRIDE_VAR: &str = "_FLOX_SERVICES_SOCKET_OVERR
 
 pub use flox_core::N_HASH_CHARS;
 
-/// The result of an installation attempt that contains whether the manifest
-/// was modified along with whether each package was already installed
 #[derive(Debug)]
 pub struct InstallationAttempt {
-    pub manifest_modified: bool,
-    pub already_installed: HashMap<String, bool>,
+    /// The modifications that were actually made
+    pub modifications: Vec<PackageToModify>,
     /// The store paths of environment that was built to validate the install.
     /// This is used as an optimization to skip builds that we've already done.
     pub built_environments: Option<BuildEnvOutputs>,
@@ -842,7 +841,7 @@ pub enum InstallOrUninstallError {
     PackageOnlyIncluded(String, String),
 
     #[error("'{0}' was not found in Lockfile")]
-    PackageNotInLockfile(String),
+    PackageInManifestNotInLockfile(String),
 
     #[error("'{1}' does not have an output '{0}'")]
     InvalidOutputForPackage(String, String),

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -697,7 +697,7 @@ pub enum EnvironmentError {
     #[error(transparent)]
     ManifestError(#[from] ManifestError),
     #[error(transparent)]
-    Uninstall(#[from] UninstallError),
+    InstallOrUninstall(#[from] InstallOrUninstallError),
     #[error(transparent)]
     Lockfile(#[from] LockfileError),
     #[error(transparent)]
@@ -832,7 +832,7 @@ pub enum UpgradeError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum UninstallError {
+pub enum InstallOrUninstallError {
     #[error(transparent)]
     ManifestError(#[from] ManifestError),
     #[error(

--- a/cli/flox-rust-sdk/src/models/environment/uninstall.rs
+++ b/cli/flox-rust-sdk/src/models/environment/uninstall.rs
@@ -15,7 +15,7 @@ use flox_manifest::{Manifest, ManifestError, Migrated};
 use reqwest::Url;
 use tracing::debug;
 
-use super::UninstallError;
+use super::InstallOrUninstallError;
 
 /// A specification for what to uninstall.
 ///
@@ -79,7 +79,7 @@ pub fn resolve_specs_to_modifications(
     specs: &[UninstallSpec],
     manifest: &Manifest<Migrated>,
     lockfile: &Lockfile,
-) -> Result<Vec<PackageToModify>, UninstallError> {
+) -> Result<Vec<PackageToModify>, InstallOrUninstallError> {
     let mut removals = HashMap::new();
 
     for spec in specs {
@@ -95,7 +95,7 @@ pub fn resolve_specs_to_modifications(
                     .transpose()?
                     .flatten()
                 {
-                    return Err(UninstallError::PackageOnlyIncluded(
+                    return Err(InstallOrUninstallError::PackageOnlyIncluded(
                         pkg.clone(),
                         include.name,
                     ));
@@ -148,7 +148,7 @@ fn compute_uninstall_modifications(
     removals: impl IntoIterator<Item = (String, RawSelectedOutputs)>,
     manifest: &Manifest<Migrated>,
     lockfile: &Lockfile,
-) -> Result<Vec<PackageToModify>, UninstallError> {
+) -> Result<Vec<PackageToModify>, InstallOrUninstallError> {
     let mut modifications = Vec::new();
 
     for (install_id, outputs_to_uninstall) in removals {
@@ -159,7 +159,7 @@ fn compute_uninstall_modifications(
         // Get all available outputs and outputs_to_install from lockfile
         let locked_pkg = lockfile
             .locked_package_with_id(&install_id)
-            .ok_or_else(|| UninstallError::PackageNotInLockfile(install_id.clone()))?;
+            .ok_or_else(|| InstallOrUninstallError::PackageNotInLockfile(install_id.clone()))?;
 
         let locked_outputs_to_install = locked_pkg.outputs_to_install();
         let all_outputs = locked_pkg.all_outputs();
@@ -168,7 +168,7 @@ fn compute_uninstall_modifications(
         if let RawSelectedOutputs::Specific(outputs) = &outputs_to_uninstall {
             for output in outputs {
                 if !all_outputs.contains(output) {
-                    return Err(UninstallError::InvalidOutputForPackage(
+                    return Err(InstallOrUninstallError::InvalidOutputForPackage(
                         output.clone(),
                         install_id.clone(),
                     ));
@@ -559,7 +559,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                UninstallError::ManifestError(ManifestError::PackageNotFound(ref p))
+                InstallOrUninstallError::ManifestError(ManifestError::PackageNotFound(ref p))
                     if p == "nonexistent"
             ),
             "expected PackageNotFound, got: {err:?}"
@@ -581,7 +581,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                UninstallError::InvalidOutputForPackage(ref output, ref id)
+                InstallOrUninstallError::InvalidOutputForPackage(ref output, ref id)
                     if output == "nonexistent" && id == "hello"
             ),
             "expected InvalidOutputForPackage, got: {err:?}"
@@ -605,7 +605,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                UninstallError::PackageNotInLockfile(ref id) if id == "hello"
+                InstallOrUninstallError::PackageNotInLockfile(ref id) if id == "hello"
             ),
             "expected PackageNotInLockfile, got: {err:?}"
         );

--- a/cli/flox-rust-sdk/src/models/environment/uninstall.rs
+++ b/cli/flox-rust-sdk/src/models/environment/uninstall.rs
@@ -157,9 +157,13 @@ fn compute_uninstall_modifications(
         let current_outputs = manifest_descriptor.as_ref().and_then(|d| d.get_outputs());
 
         // Get all available outputs and outputs_to_install from lockfile
+        // We resolved an install_id in the caller, so we know the install_id is
+        // already in the manifest
         let locked_pkg = lockfile
             .locked_package_with_id(&install_id)
-            .ok_or_else(|| InstallOrUninstallError::PackageNotInLockfile(install_id.clone()))?;
+            .ok_or_else(|| {
+                InstallOrUninstallError::PackageInManifestNotInLockfile(install_id.clone())
+            })?;
 
         let locked_outputs_to_install = locked_pkg.outputs_to_install();
         let all_outputs = locked_pkg.all_outputs();
@@ -232,7 +236,7 @@ fn modification_for_outputs(
         return PackageModification::Remove;
     }
 
-    PackageModification::UpdateOutputs(remaining_outputs)
+    PackageModification::UpdateOutputs(SelectedOutputs::Specific(remaining_outputs))
 }
 
 #[cfg(test)]
@@ -261,7 +265,10 @@ mod tests {
         );
         assert_eq!(
             result,
-            PackageModification::UpdateOutputs(vec!["out".to_string(), "dev".to_string()])
+            PackageModification::UpdateOutputs(SelectedOutputs::Specific(vec![
+                "out".to_string(),
+                "dev".to_string()
+            ]))
         );
     }
 
@@ -275,7 +282,10 @@ mod tests {
         );
         assert_eq!(
             result,
-            PackageModification::UpdateOutputs(vec!["out".to_string(), "dev".to_string()])
+            PackageModification::UpdateOutputs(SelectedOutputs::Specific(vec![
+                "out".to_string(),
+                "dev".to_string()
+            ]))
         );
     }
 
@@ -290,7 +300,7 @@ mod tests {
         );
         assert_eq!(
             result,
-            PackageModification::UpdateOutputs(vec!["out".to_string()])
+            PackageModification::UpdateOutputs(SelectedOutputs::Specific(vec!["out".to_string()]))
         );
     }
 
@@ -408,7 +418,10 @@ mod tests {
 
         assert_eq!(result, vec![PackageToModify {
             install_id: "hello".into(),
-            modification: PackageModification::UpdateOutputs(vec!["dev".into(), "out".into()]),
+            modification: PackageModification::UpdateOutputs(SelectedOutputs::Specific(vec![
+                "dev".into(),
+                "out".into()
+            ])),
         }]);
     }
 
@@ -515,7 +528,10 @@ mod tests {
 
         assert_eq!(result, vec![PackageToModify {
             install_id: "hello".into(),
-            modification: PackageModification::UpdateOutputs(vec!["dev".into(), "out".into()]),
+            modification: PackageModification::UpdateOutputs(SelectedOutputs::Specific(vec![
+                "dev".into(),
+                "out".into()
+            ])),
         }]);
     }
 
@@ -605,7 +621,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                InstallOrUninstallError::PackageNotInLockfile(ref id) if id == "hello"
+                InstallOrUninstallError::PackageInManifestNotInLockfile(ref id) if id == "hello"
             ),
             "expected PackageNotInLockfile, got: {err:?}"
         );

--- a/cli/flox-rust-sdk/src/models/environment/uninstall.rs
+++ b/cli/flox-rust-sdk/src/models/environment/uninstall.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
 use flox_manifest::interfaces::PackageLookup;
-use flox_manifest::lockfile::{LockedPackage, Lockfile, PackageOutputs};
+use flox_manifest::lockfile::Lockfile;
 use flox_manifest::parsed::v1_10_0::SelectedOutputs;
 use flox_manifest::raw::{
     CatalogPackage,
@@ -158,17 +158,11 @@ fn compute_uninstall_modifications(
 
         // Get all available outputs and outputs_to_install from lockfile
         let locked_pkg = lockfile
-            .packages
-            .iter()
-            .find(|pkg| pkg.install_id() == install_id)
+            .locked_package_with_id(&install_id)
             .ok_or_else(|| UninstallError::PackageNotInLockfile(install_id.clone()))?;
 
-        let (locked_outputs_to_install, all_outputs) = match locked_pkg {
-            LockedPackage::Catalog(p) => (p.outputs_to_install(), p.all_outputs()),
-            LockedPackage::Flake(p) => (p.outputs_to_install(), p.all_outputs()),
-            // We assume store paths have no multiple outputs
-            LockedPackage::StorePath(_) => (None, Vec::new()),
-        };
+        let locked_outputs_to_install = locked_pkg.outputs_to_install();
+        let all_outputs = locked_pkg.all_outputs();
 
         // Validate that requested outputs exist for this package
         if let RawSelectedOutputs::Specific(outputs) = &outputs_to_uninstall {

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -12,7 +12,13 @@ use flox_manifest::compose::{
     package_overrides_for_manifest_id,
 };
 use flox_manifest::lockfile::LockedPackage;
-use flox_manifest::raw::{CatalogPackage, PackageToInstall, catalog_packages_to_install};
+use flox_manifest::parsed::latest::SelectedOutputs;
+use flox_manifest::raw::{
+    CatalogPackage,
+    PackageModification,
+    PackageToInstall,
+    catalog_packages_to_install,
+};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironmentError;
 use flox_rust_sdk::models::environment::remote_environment::{
@@ -110,6 +116,7 @@ struct PartitionedPackages {
     successes: Vec<PackageToInstall>,
     system_subsets: Vec<PackageToInstall>,
     already_installed: Vec<PackageToInstall>,
+    outputs_updated: Vec<(PackageToInstall, SelectedOutputs)>,
 }
 
 impl Install {
@@ -260,8 +267,7 @@ impl Install {
                 })
                 .collect::<Vec<_>>()
         };
-        let partitioned =
-            Self::partition_installed_packages(&installed, &installation.already_installed);
+        let partitioned = Self::partition_installed_packages(&installed, &installation);
 
         // Print status messages for the installation attempt
         let install_ids = partitioned
@@ -273,9 +279,10 @@ impl Install {
         message::packages_with_additional_outputs(&install_ids, &lockfile, &flox.system);
         message::packages_installed_with_system_subsets(&partitioned.system_subsets);
         message::packages_already_installed(&partitioned.already_installed, &description);
+        message::packages_outputs_updated(&partitioned.outputs_updated, &description);
         message::packages_newly_overridden_by_composer(&new_package_overrides);
 
-        if installation.manifest_modified {
+        if !installation.modifications.is_empty() {
             for warning in Self::generate_unfree_and_broken_warnings(
                 &lockfile.packages,
                 &catalog_packages_to_install(&packages_to_install),
@@ -301,7 +308,7 @@ impl Install {
 
     fn partition_installed_packages(
         pkgs: &[PackageToInstallRetry],
-        already_installed_map: &HashMap<String, bool>,
+        installation: &InstallationAttempt,
     ) -> PartitionedPackages {
         let (partials, maybe_successes): (Vec<_>, Vec<_>) =
             pkgs.iter().partition(|p| p.system_subset);
@@ -315,13 +322,35 @@ impl Install {
             .cloned()
             .map(|p| p.pkg)
             .collect::<Vec<_>>();
-        let (successes, already_installed): (Vec<_>, Vec<_>) = maybe_successes
-            .into_iter()
-            .partition(|p| already_installed_map.get(p.id()).is_some_and(|v| !*v));
+
+        let mut successes = Vec::new();
+        let mut already_installed = Vec::new();
+        let mut outputs_updated = Vec::new();
+
+        for pkg in maybe_successes {
+            let id = pkg.id();
+            if let Some(m) = installation
+                .modifications
+                .iter()
+                .find(|m| m.install_id == id)
+            {
+                match &m.modification {
+                    PackageModification::Add(_) => successes.push(pkg),
+                    PackageModification::UpdateOutputs(outputs) => {
+                        outputs_updated.push((pkg, outputs.clone()))
+                    },
+                    PackageModification::Remove => unreachable!(),
+                }
+            } else {
+                already_installed.push(pkg);
+            }
+        }
+
         PartitionedPackages {
             successes,
             system_subsets: partials,
             already_installed,
+            outputs_updated,
         }
     }
 

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
+use flox_manifest::parsed::latest::SelectedOutputs;
 use flox_manifest::raw::PackageModification;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::uninstall::UninstallSpec;
@@ -107,12 +108,17 @@ impl Uninstall {
                         ));
                     }
                 },
-                PackageModification::UpdateOutputs(ref outputs) => {
+                PackageModification::UpdateOutputs(SelectedOutputs::Specific(ref outputs)) => {
                     message::deleted(format!(
                         "Updated outputs of {install_id} to [{}] from environment {description}",
                         outputs.join(", ")
                     ));
                 },
+                PackageModification::UpdateOutputs(SelectedOutputs::All(_)) => {
+                    unreachable!("if we removed something we shouldn't be left with all outputs")
+                },
+                // Add is only used for installs, never uninstalls.
+                PackageModification::Add(_) => unreachable!(),
             }
         }
 

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -8,6 +8,7 @@ use flox_core::util::message::{format_error, format_updated};
 pub use flox_core::util::message::{stderr_supports_color, stdout_supports_color};
 use flox_manifest::compose::{COMPOSER_MANIFEST_ID, Warning};
 use flox_manifest::lockfile::{LockedPackage, Lockfile, PackageOutputs};
+use flox_manifest::parsed::latest::SelectedOutputs;
 use flox_manifest::raw::PackageToInstall;
 use indoc::formatdoc;
 use minus::{ExitStrategy, Pager, page_all};
@@ -133,6 +134,19 @@ pub(crate) fn packages_installed_with_system_subsets(pkgs: &[PackageToInstall]) 
             // path anyway.
             pkg.systems().unwrap_or_default().join(", ")
         ))
+    }
+}
+
+/// Display a message for packages whose outputs were updated.
+pub(crate) fn packages_outputs_updated(
+    pkgs: &[(PackageToInstall, SelectedOutputs)],
+    environment_description: &str,
+) {
+    for (pkg, outputs) in pkgs {
+        updated(format!(
+            "'{}' outputs updated to '{outputs}' in environment {environment_description}",
+            pkg.id(),
+        ));
     }
 }
 

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -194,6 +194,55 @@ EOF
   assert_regex "$manifest" 'hello\.pkg-path = "hello"'
 }
 
+# This covers a few of the main cases when installing a package with outputs
+# - How it interacts with includes
+# - Merging outputs
+# More specific cases are unit tested
+@test "'flox install' with outputs selected" {
+  # Included environment with bash already installed for the first output.
+  "$FLOX_BIN" init -d included
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/envs/bash_v1_10_0_out.yaml" \
+    "$FLOX_BIN" install -d included -i bash "bashNonInteractive^out"
+
+  # Composing environment that pulls bash in via the include.
+  "$FLOX_BIN" init -n "composer"
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/envs/bash_v1_10_0_out.yaml" \
+    "$FLOX_BIN" edit -f - <<< "$(with_latest_schema '[include]
+environments = [
+  { dir = "included" }
+]')"
+
+  # Install a second output in the composer; should override the include.
+  run "$FLOX_BIN" install -i bash "bashNonInteractive^man"
+  assert_success
+  assert_output <<EOF
+✔ 'bash' installed to environment 'composer'
+ℹ 'bash' has additional outputs, use 'flox list -a' to see more
+ℹ This environment now overrides package with id 'bash'
+EOF
+
+  outputs="$(tomlq -r -c '.install.bash.outputs' < "$MANIFEST_PATH")"
+  assert_equal "$outputs" '["man"]'
+
+  # The composer's dev environment should expose bash's `man` output (from
+  # the override) but not its `out` output (which the include provides).
+  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer.dev/share/man/man1/bash.1.gz" ]
+  [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer.dev/bin/bash" ]
+
+  # Adding `out` on top should merge with the existing `man` override.
+  run "$FLOX_BIN" install -i bash "bashNonInteractive^out"
+  assert_success
+  assert_output <<EOF
+✔ 'bash' outputs updated to 'man,out' in environment 'composer'
+EOF
+
+  outputs="$(tomlq -r -c '.install.bash.outputs' < "$MANIFEST_PATH")"
+  assert_equal "$outputs" '["man","out"]'
+
+  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer.dev/share/man/man1/bash.1.gz" ]
+  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer.dev/bin/bash" ]
+}
+
 # This is also checking we can build an unfree package
 @test "'flox install' warns about unfree packages" {
   "$FLOX_BIN" init


### PR DESCRIPTION
- **refactor: factor out (un)install helpers**
  Factor out code used by uninstall that we can re-use in install
  

- **refactor: rename UninstallError -> InstallOrUninstallError**
  

- **feat(install): support adding outputs imperatively**
  When a package is already installed, support `flox install
  foo^someoutput` to append `someoutput` to the outputs installed for that
  package.
  
  We already support specifying an output, but only when the package is
  not already installed.
  
  If the specified output is already installed, do nothing.
  