### PR TITLE
fix(buildenv): drain %postponed transitively in v1+ schema path

### DIFF
--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -780,16 +780,26 @@ if ($manifest) {
         # 1000, but we also assign values based on the priority of the
         # package that is propagating them, so that they can similarly have
         # precedence (or not) over collisions.
-        foreach my $pkgDir (keys %postponed) {
-            my $priority = $postponed{$pkgDir};
-            # Propagated dependencies can include other propagated dependencies
-            # so only bump the priority for pkgs with priority less than 1000.
-            $priority *= 1000 if $priority < 1000;
-            # Add the package using a priority based on that of the package that
-            # originally triggered the propagation, and add to that an ever-
-            # increasing counter to prevent collisions for propagated packages.
-            addPkg($pkgDir, 2, $ENV{"checkCollisionContents"} eq "1", $priority + $ignoreCollisionCounter++);
-            delete $postponed{$pkgDir};
+        # Drain %postponed transitively. addPkg() may push new entries
+        # into %postponed (the propagated deps of the package just
+        # processed), so we snapshot+clear before iterating and re-loop
+        # via the outer `while` until no propagated deps remain. This
+        # avoids the `each()`-on-mutated-hash warning while still
+        # processing dependencies-of-dependencies, which a single-pass
+        # `foreach (keys %postponed)` would silently drop.
+        while (scalar(keys %postponed) > 0) {
+            my %currentBatch = %postponed;
+            %postponed = ();
+            foreach my $pkgDir (sort byPackageName keys %currentBatch) {
+                my $priority = $currentBatch{$pkgDir};
+                # Propagated dependencies can include other propagated dependencies
+                # so only bump the priority for pkgs with priority less than 1000.
+                $priority *= 1000 if $priority < 1000;
+                # Add the package using a priority based on that of the package that
+                # originally triggered the propagation, and add to that an ever-
+                # increasing counter to prevent collisions for propagated packages.
+                addPkg($pkgDir, 2, $ENV{"checkCollisionContents"} eq "1", $priority + $ignoreCollisionCounter++);
+            }
         }
         # </flox>
 

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -337,6 +337,73 @@ EOF
 
 # ---------------------------------------------------------------------------- #
 
+# Regression test for #4217: propagated-build-inputs must drain transitively.
+# Three builds form a chain — 'top' propagates 'middle', 'middle' propagates
+# 'bottom'. When 'top' is installed in a consumer env, the merged closure
+# must contain executables from all three. A single-pass `foreach (keys
+# %postponed)` over the propagation worklist would link 'top' and 'middle'
+# (one hop) but silently drop 'bottom' (two hops, queued by addPkg() during
+# iteration).
+# bats test_tags=edit:priority-propagated-deps-transitive
+@test "'flox edit' propagated dependencies drain transitively" {
+  "$FLOX_BIN" init
+
+  MANIFEST=$(cat << "EOF"
+version = 1
+
+[install]
+hello.pkg-path = "hello"
+
+[build]
+bottom.command = """
+  mkdir -p $out/bin
+  printf '#!/bin/sh\necho BOTTOM\n' > $out/bin/bottom-bin
+  chmod +x $out/bin/bottom-bin
+"""
+
+middle.command = """
+  mkdir -p $out/bin $out/nix-support
+  printf '#!/bin/sh\necho MIDDLE\n' > $out/bin/middle-bin
+  chmod +x $out/bin/middle-bin
+  echo ${bottom} > $out/nix-support/propagated-build-inputs
+"""
+
+top.command = """
+  mkdir -p $out/bin $out/nix-support
+  printf '#!/bin/sh\necho TOP\n' > $out/bin/top-bin
+  chmod +x $out/bin/top-bin
+  echo ${middle} > $out/nix-support/propagated-build-inputs
+"""
+EOF
+  )
+
+  echo "$MANIFEST" | \
+    _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml" \
+    "$FLOX_BIN" edit -f -
+  "$FLOX_BIN" build top
+
+  consumer_dir="${BATS_TEST_TMPDIR}/consumer-multihop"
+  "$FLOX_BIN" init -d "$consumer_dir"
+  "$FLOX_BIN" install -d "$consumer_dir" "$(readlink result-top)"
+
+  # All three binaries must be reachable in the activated env. The
+  # bottom-bin assertion is the actual regression check — it is only
+  # present if propagation drained beyond the first hop.
+  run "$FLOX_BIN" activate -d "$consumer_dir" -- top-bin
+  assert_success
+  assert_output "TOP"
+
+  run "$FLOX_BIN" activate -d "$consumer_dir" -- middle-bin
+  assert_success
+  assert_output "MIDDLE"
+
+  run "$FLOX_BIN" activate -d "$consumer_dir" -- bottom-bin
+  assert_success
+  assert_output "BOTTOM"
+}
+
+# ---------------------------------------------------------------------------- #
+
 # bats test_tags=edit:install-store-path
 @test "'flox edit' install-store-path" {
   "$FLOX_BIN" init


### PR DESCRIPTION
## Proposed Changes

The `%postponed` drain loop in the v1+ schema path of `buildenv/builder.pl` is
single-pass:

```perl
foreach my $pkgDir (keys %postponed) {
    ...
    addPkg($pkgDir, ..., $priority + $ignoreCollisionCounter++);
    delete $postponed{$pkgDir};
}
```

`addPkg()` may push new entries into `%postponed` (the propagated deps of
the package just processed), but `foreach (keys %postponed)` evaluates the
key list once at loop entry, so those propagated-of-propagated entries are
silently dropped. The pre-#4149 code used a `while (keys %postponed)`
that drained the hash transitively; #4149 replaced it with `foreach` to
silence an `each()`-on-mutated-hash warning, which over-corrected.

This restores the transitive drain while keeping the priority logic from
#4149 intact, and avoids `each()` (so the warning doesn't recur):

```perl
while (scalar(keys %postponed) > 0) {
    my @pkgDirs = sort byPackageName keys %postponed;
    my %currentBatch = %postponed;
    %postponed = ();              # clear before addPkg can mutate
    foreach my $pkgDir (@pkgDirs) {
        my $priority = $currentBatch{$pkgDir};
        $priority *= 1000 if $priority < 1000;
        addPkg($pkgDir, 2, $ENV{"checkCollisionContents"} eq "1",
               $priority + $ignoreCollisionCounter++);
    }
}
```

## How this manifests

For Python envs, deeply propagated runtime deps are missing from the merged
`site-packages`. In flox/floxenvs's `langchain` env (which installs
`langchain-ollama`, `langchain-community`, `langgraph`, `ollama`):

- `pydantic` is linked — propagated by `langchain-core`, one hop.
- `pydantic-core` is **not** linked — propagated by `pydantic`, two hops.
- Same for `typing_extensions`, `annotated_types`, `attrs`, `idna`,
  `urllib3`, `charset_normalizer`, `frozenlist`, `multidict`, `aiosignal`,
  `anyio`, `httpx`, `httpcore`, `certifi`, `dotenv`, `click`, `orjson`,
  `langchain_text_splitters`, `cffi`, `pycparser`, `sniffio`, `h11`, …

| flox version          | top-level `site-packages` modules | works? |
| --------------------- | --------------------------------- | ------ |
| `v1.11.4`             | 68                                | yes    |
| `release-1.12.0` HEAD | ~24                               | no     |
| this PR               | 68                                | yes    |

Smoke test: `python3 -c "import langchain_ollama"` →
`No module named 'pydantic_core'` on `release-1.12.0`, fine with this PR.

## Verification

Tested locally on `aarch64-darwin` against
[flox/floxenvs](https://github.com/flox/floxenvs) with both the bare
`flox activate` path and the full `nix run .#run-test -- langchain` path
(which builds a fresh env in a tmpdir):

```
nix run --override-input flox 'path:/.../flox-fix' \
  .#run-test -- langchain
...
>>> All checks passed.

nix run --override-input flox 'path:/.../flox-fix' \
  .#run-test -- langchain-demo
...
>>> All checks passed.
```

Both fail without the patch (six-platform CI failure on
flox/floxenvs#1651).

## Related

- Closes flox#4217
- Unblocks flox/floxenvs#1651 (release v1.12.0 of floxenvs)
- A regression test exercising 2+ hop propagation (e.g. an env installing
  `python312Packages.langchain-ollama`) would be a good follow-up.

## Release Notes

* Fixes a regression introduced in 1.12.0-rc that caused
  propagated-of-propagated runtime dependencies to be silently dropped
  from rendered environments. Most visible on Python envs with
  pydantic v2 in the dep tree.
