### PR TITLE
feat: Add interactive authentication for -D/--default flag

### DIFF
--- a/cli/flox/doc/include/environment-options.md
+++ b/cli/flox/doc/include/environment-options.md
@@ -9,3 +9,10 @@ or the active environment that was last activated is used.
 
 `-r`, `--reference`
 :   A FloxHub environment, specified in the form `<owner>/<name>`.
+
+`-D`, `--default`
+:   Use your default environment (`<your-user>/default`).
+    When unauthenticated in an interactive context, you will be prompted to
+    log in.
+    In non-interactive contexts (e.g., scripts or CI), this flag will fail
+    with an error when authentication is missing.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -137,12 +137,12 @@ impl Activate {
         Ok(())
     }
 
-    pub async fn handle(self, mut config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut config: Config, mut flox: Flox) -> Result<()> {
         self.validate_service_flags()?;
 
         let mut concrete_environment = match self
             .environment
-            .to_concrete_environment(&flox, self.generation)
+            .to_concrete_environment(&mut flox, self.generation)
             .await
         {
             Ok(concrete_environment) => concrete_environment,

--- a/cli/flox/src/commands/activation_state.rs
+++ b/cli/flox/src/commands/activation_state.rs
@@ -12,10 +12,10 @@ pub struct ActivationState {
 }
 
 impl ActivationState {
-    pub async fn handle(&self, flox: Flox) -> Result<(), anyhow::Error> {
+    pub async fn handle(&self, mut flox: Flox) -> Result<(), anyhow::Error> {
         let concrete_env = self
             .environment
-            .detect_concrete_environment(&flox, "Environment path to get activation state")
+            .detect_concrete_environment(&mut flox, "Environment path to get activation state")
             .await?;
 
         let activation_state_dir =

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -130,12 +130,12 @@ enum SubcommandOrBuildTargets {
 }
 
 impl Build {
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         match self.subcommand_or_targets {
             SubcommandOrBuildTargets::Clean { targets } => {
                 let env = self
                     .environment
-                    .detect_concrete_environment(&flox, "Clean build files of")?;
+                    .detect_concrete_environment(&mut flox, "Clean build files of")?;
                 environment_subcommand_metric!("build::clean", env);
 
                 Self::clean(flox, env, targets).await
@@ -143,7 +143,7 @@ impl Build {
             SubcommandOrBuildTargets::ImportNixpkgs { installable, force } => {
                 let env = self
                     .environment
-                    .detect_concrete_environment(&flox, "Import package definition in")?;
+                    .detect_concrete_environment(&mut flox, "Import package definition in")?;
                 environment_subcommand_metric!("build::import-nixpkgs", env);
 
                 Self::import_nixpkgs(flox, env, installable, force).await
@@ -151,7 +151,7 @@ impl Build {
             SubcommandOrBuildTargets::UpdateCatalogs {} => {
                 let env = self
                     .environment
-                    .detect_concrete_environment(&flox, "Update catalogs in")?;
+                    .detect_concrete_environment(&mut flox, "Update catalogs in")?;
                 environment_subcommand_metric!("build::update-catalogs", env);
 
                 Self::update_catalogs(&flox, env).await
@@ -163,7 +163,7 @@ impl Build {
             } => {
                 let env = self
                     .environment
-                    .detect_concrete_environment(&flox, "Build packages of")?;
+                    .detect_concrete_environment(&mut flox, "Build packages of")?;
                 environment_subcommand_metric!("build", env);
 
                 Self::build(

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -56,10 +56,10 @@ pub struct Containerize {
 }
 impl Containerize {
     #[instrument(name = "containerize", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         let mut env = self
             .environment
-            .detect_concrete_environment(&flox, "Containerize")
+            .detect_concrete_environment(&mut flox, "Containerize")
             .await?;
         environment_subcommand_metric!("containerize", env);
 

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -25,10 +25,10 @@ pub struct Delete {
 
 impl Delete {
     #[instrument(name = "delete", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         let environment = self
             .environment
-            .detect_concrete_environment(&flox, "Delete")?;
+            .detect_concrete_environment(&mut flox, "Delete")?;
 
         environment_subcommand_metric!("delete", environment);
 

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -91,7 +91,7 @@ impl Edit {
 
         let mut detected_environment = match self
             .environment
-            .detect_concrete_environment(&flox, "Edit")
+            .detect_concrete_environment(&mut flox, "Edit")
             .await
         {
             Ok(concrete_env) => concrete_env,

--- a/cli/flox/src/commands/generations/history.rs
+++ b/cli/flox/src/commands/generations/history.rs
@@ -46,10 +46,10 @@ enum OutputMode {
 
 impl History {
     #[instrument(name = "history", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Show history for")
+            .detect_concrete_environment(&mut flox, "Show history for")
             .await?;
         environment_subcommand_metric!("generations::history", env);
 

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -51,10 +51,10 @@ enum OutputMode {
 
 impl List {
     #[instrument(name = "list", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "List using")
+            .detect_concrete_environment(&mut flox, "List using")
             .await?;
         environment_subcommand_metric!(
             "generations::list",

--- a/cli/flox/src/commands/generations/rollback.rs
+++ b/cli/flox/src/commands/generations/rollback.rs
@@ -24,14 +24,14 @@ pub struct Rollback {
 
 impl Rollback {
     #[instrument(name = "rollback", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         // TODO(zmitchell, 2025-20-12): `detect_concrete_environment` will prompt
         // which environment to use even when one of the choices is a path
         // environment (which fails when selected). We could be smarter about
         // this in the future.
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Rollback using")
+            .detect_concrete_environment(&mut flox, "Rollback using")
             .await?;
 
         environment_subcommand_metric!("generations::rollback", env);

--- a/cli/flox/src/commands/generations/switch.rs
+++ b/cli/flox/src/commands/generations/switch.rs
@@ -24,10 +24,10 @@ pub struct Switch {
 
 impl Switch {
     #[instrument(name = "switch", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Switch using")
+            .detect_concrete_environment(&mut flox, "Switch using")
             .await?;
 
         environment_subcommand_metric!("generations::switch", env);

--- a/cli/flox/src/commands/include.rs
+++ b/cli/flox/src/commands/include.rs
@@ -57,10 +57,13 @@ impl IncludeCommands {
 
 impl Upgrade {
     #[instrument(name = "upgrade", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         let mut environment = self
             .environment
-            .detect_concrete_environment(&flox, "Get latest changes to included environments in")
+            .detect_concrete_environment(
+                &mut flox,
+                "Get latest changes to included environments in",
+            )
             .await?;
 
         environment_subcommand_metric!("include::upgrade", environment);

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_catalog::{MsgAttrPathNotFoundNotFoundForAllSystems, MsgAttrPathNotFoundNotInCatalog};
-use flox_core::data::environment_ref::{DEFAULT_NAME, RemoteEnvironmentRef};
+use flox_core::data::environment_ref::DEFAULT_NAME;
 use flox_manifest::compose::{
     COMPOSER_MANIFEST_ID,
     new_package_overrides,
@@ -626,7 +626,7 @@ async fn try_create_default_environment_interactive(
     write_user_state_file(&user_state, &user_state_path, lock)
         .context("failed to save default environment choice")?;
 
-    prompt_to_modify_rc_file(&env.env_ref())?;
+    prompt_to_modify_rc_file()?;
 
     Ok(ConcreteEnvironment::Remote(env))
 }
@@ -641,18 +641,18 @@ fn package_list_for_prompt(packages: &[PackageToInstall]) -> Option<String> {
     }
 }
 
-fn prompt_to_modify_rc_file(env_ref: &RemoteEnvironmentRef) -> Result<bool, anyhow::Error> {
+fn prompt_to_modify_rc_file() -> Result<bool, anyhow::Error> {
     let shell = Activate::detect_shell_for_in_place()?;
     let shell_cmd = match shell {
-        // TODO: should we use source <(flox activate -r <env_ref>) for bash?
+        // TODO: should we use source <(flox activate --default) for bash?
         // There are unicode quoting issues with the current form
         // We can't use <() for zsh because it blocks input which can make it
         // impossible to Ctrl-C
         ShellWithPath::Bash(_) | ShellWithPath::Zsh(_) => {
-            format!(r#"eval "$(flox activate -r {env_ref} -m run)""#)
+            r#"eval "$(flox activate --default -m run)""#.to_string()
         },
-        ShellWithPath::Tcsh(_) => format!(r#"eval "`flox activate -r {env_ref} -m run`""#),
-        ShellWithPath::Fish(_) => format!("flox activate -r {env_ref} -m run | source"),
+        ShellWithPath::Tcsh(_) => r#"eval "`flox activate --default -m run`""#.to_string(),
+        ShellWithPath::Fish(_) => "flox activate --default -m run | source".to_string(),
     };
     let rc_file_names = match shell {
         ShellWithPath::Bash(_) => vec![".bashrc", ".profile"],

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -151,7 +151,7 @@ impl Install {
 
         let mut concrete_environment = match self
             .environment
-            .detect_concrete_environment(&flox, "Install to")
+            .detect_concrete_environment(&mut flox, "Install to")
             .await
         {
             Ok(concrete_environment) => concrete_environment,

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -58,12 +58,12 @@ pub enum ListMode {
 
 impl List {
     #[instrument(name = "list", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         sentry_set_tag("list_mode", format!("{:?}", &self.list_mode));
 
         let mut env = self
             .environment
-            .detect_concrete_environment(&flox, "List using")
+            .detect_concrete_environment(&mut flox, "List using")
             .await?;
         environment_subcommand_metric!("list", env);
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -957,7 +957,7 @@ impl EnvironmentSelect {
     /// it should default to an environment in the current directory.
     pub async fn to_concrete_environment(
         &self,
-        flox: &Flox,
+        flox: &mut Flox,
         generation: Option<GenerationId>,
     ) -> Result<ConcreteEnvironment, EnvironmentSelectError> {
         let env = match self {
@@ -994,9 +994,7 @@ impl EnvironmentSelect {
                 ConcreteEnvironment::Remote(env)
             },
             EnvironmentSelect::Default => {
-                let user_handle = flox.auth_context.handle().context(formatdoc! {"
-                    The '-D' and '--default' flags require authentication
-                "})?;
+                let user_handle = ensure_auth(flox).await?;
 
                 debug!(
                     user = %user_handle,
@@ -1029,7 +1027,7 @@ impl EnvironmentSelect {
     /// in the current directory.
     pub async fn detect_concrete_environment(
         &self,
-        flox: &Flox,
+        flox: &mut Flox,
         message: &str,
     ) -> Result<ConcreteEnvironment, EnvironmentSelectError> {
         let env = match self {
@@ -1059,9 +1057,7 @@ impl EnvironmentSelect {
             },
 
             EnvironmentSelect::Default => {
-                let user_handle = flox.auth_context.handle().context(formatdoc! {"
-                    The '-D' and '--default' flags require authentication
-                "})?;
+                let user_handle = ensure_auth(flox).await?;
 
                 debug!(
                     user = %user_handle,
@@ -1105,7 +1101,7 @@ impl EnvironmentSelect {
 impl DirEnvironmentSelect {
     pub fn detect_concrete_environment(
         &self,
-        flox: &Flox,
+        flox: &mut Flox,
         message: &str,
     ) -> Result<ConcreteEnvironment, EnvironmentSelectError> {
         match self {

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -103,10 +103,10 @@ struct PublishConfig {
 }
 
 impl Publish {
-    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, mut flox: Flox) -> Result<()> {
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Publish")?;
+            .detect_concrete_environment(&mut flox, "Publish")?;
         environment_subcommand_metric!("publish", env);
 
         let publish_config = PublishConfig {

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -90,7 +90,7 @@ struct QueryFunctions {
 
 impl Pull {
     #[instrument(name = "pull", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
         match self.pull_select {
             PullSelect::NewAbbreviated {
                 remote,
@@ -133,7 +133,7 @@ impl Pull {
             },
             PullSelect::RemoteUpdate { environment, copy } => {
                 let environment = environment
-                    .detect_concrete_environment(&flox, "Pull")
+                    .detect_concrete_environment(&mut flox, "Pull")
                     .await?;
                 environment_subcommand_metric!("pull", environment);
 

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -78,7 +78,7 @@ impl Push {
 
         let env = self
             .environment
-            .detect_concrete_environment(&flox, "Push")
+            .detect_concrete_environment(&mut flox, "Push")
             .await?;
 
         environment_subcommand_metric!("push", env);

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -35,8 +35,9 @@ pub struct Logs {
 
 impl Logs {
     #[instrument(name = "logs", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
+        let env =
+            ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::logs", env.environment);
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -169,7 +169,7 @@ impl ServicesEnvironment {
     ///
     /// Returns an error if the environment is remote or doesn't support services.
     pub async fn from_environment_selection(
-        flox: &Flox,
+        flox: &mut Flox,
         environment: &EnvironmentSelect,
     ) -> Result<Self> {
         let concrete_environment = environment

--- a/cli/flox/src/commands/services/persist.rs
+++ b/cli/flox/src/commands/services/persist.rs
@@ -31,8 +31,9 @@ pub struct Persist {
 
 impl Persist {
     #[instrument(name = "persist", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
+        let env =
+            ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::persist", env.environment);
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -39,9 +39,9 @@ pub struct Restart {
 
 impl Restart {
     #[instrument(name = "restart", skip_all)]
-    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, mut flox: Flox) -> Result<()> {
         let mut env =
-            ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
+            ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::restart", env.environment);
         let (current_mode, generation) = guard_is_within_activation(&env, "restart")?;
         guard_service_commands_available(&env, &flox.system)?;

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -35,9 +35,9 @@ pub struct Start {
 
 impl Start {
     #[instrument(name = "start", skip_all)]
-    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, mut flox: Flox) -> Result<()> {
         let mut env =
-            ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
+            ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::start", env.environment);
         let (current_mode, generation) = guard_is_within_activation(&env, "start")?;
         guard_service_commands_available(&env, &flox.system)?;

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -36,8 +36,9 @@ pub struct Status {
 
 impl Status {
     #[instrument(name = "status", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
+        let env =
+            ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::status", env.environment);
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -22,8 +22,9 @@ pub struct Stop {
 
 impl Stop {
     #[instrument(name = "stop", skip_all)]
-    pub async fn handle(self, flox: Flox) -> Result<()> {
-        let env = ServicesEnvironment::from_environment_selection(&flox, &self.environment).await?;
+    pub async fn handle(self, mut flox: Flox) -> Result<()> {
+        let env =
+            ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::stop", env.environment);
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services_socket.rs
+++ b/cli/flox/src/commands/services_socket.rs
@@ -11,10 +11,10 @@ pub struct ServicesSocket {
 }
 
 impl ServicesSocket {
-    pub async fn handle(&self, flox: Flox) -> Result<(), anyhow::Error> {
+    pub async fn handle(&self, mut flox: Flox) -> Result<(), anyhow::Error> {
         let concrete_env = self
             .environment
-            .detect_concrete_environment(&flox, "Environment path to get services socket")
+            .detect_concrete_environment(&mut flox, "Environment path to get services socket")
             .await?;
 
         let socket_path = concrete_env.services_socket_path(&flox)?;

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -48,7 +48,7 @@ impl Uninstall {
 
         let mut concrete_environment = match self
             .environment
-            .detect_concrete_environment(&flox, "Uninstall from")
+            .detect_concrete_environment(&mut flox, "Uninstall from")
             .await
         {
             Ok(concrete_environment) => concrete_environment,

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -45,7 +45,7 @@ impl Upgrade {
 
         let mut concrete_environment = self
             .environment
-            .detect_concrete_environment(&flox, "Upgrade")
+            .detect_concrete_environment(&mut flox, "Upgrade")
             .await?;
         environment_subcommand_metric!("upgrade", concrete_environment);
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -5342,13 +5342,13 @@ success"
 }
 
 # bats test_tags=activate,activate:default-flag
-@test "activate -D requires authentication" {
+@test "activate -D fails without auth in non-interactive context" {
   # Ensure we're not logged in by unsetting auth token
   unset FLOX_FLOXHUB_TOKEN
 
   run "$FLOX_BIN" activate -D
   assert_failure
-  assert_output --partial "The '-D' and '--default' flags require authentication"
+  assert_output --partial "You are not logged in to FloxHub."
 }
 
 # bats test_tags=activate,activate:default-flag


### PR DESCRIPTION
A follow up for the -D/--default flag introducing interactive login.

Depends on: https://github.com/flox/flox/pull/4201 

Implements [DEV-33](https://linear.app/floxdotdev/issue/DEV-33/)