### PR TITLE
refactor(publish): CLI-9 centralize SystemOverride resolution

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -62,7 +62,7 @@ pub trait ManifestBuilder {
         flox_interpreter: &Path,
         package: &[PackageTargetName],
         build_cache: Option<bool>,
-        system_override: Option<String>,
+        system: Option<&str>,
     ) -> Result<BuildResults, ManifestBuilderError>;
 
     fn clean(self, package: &[PackageTargetName]) -> Result<(), ManifestBuilderError>;
@@ -301,7 +301,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         flox_interpreter: &Path,
         packages: &[PackageTargetName],
         build_cache: Option<bool>,
-        system_override: Option<String>,
+        system: Option<&str>,
     ) -> Result<BuildResults, ManifestBuilderError> {
         let mut command = self.base_command(self.base_dir);
         command.arg("build");
@@ -310,8 +310,8 @@ impl ManifestBuilder for FloxBuildMk<'_> {
             "EXPRESSION_BUILD_NIXPKGS_URL={expression_build_nixpkgs_url}"
         ));
 
-        if let Some(system_override) = system_override {
-            command.arg(format!("NIX_SYSTEM={system_override}"));
+        if let Some(system) = system {
+            command.arg(format!("NIX_SYSTEM={system}"));
         }
 
         command.arg(format!(

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -62,7 +62,7 @@ pub trait ManifestBuilder {
         flox_interpreter: &Path,
         package: &[PackageTargetName],
         build_cache: Option<bool>,
-        system: Option<&str>,
+        system_override: Option<&str>,
     ) -> Result<BuildResults, ManifestBuilderError>;
 
     fn clean(self, package: &[PackageTargetName]) -> Result<(), ManifestBuilderError>;
@@ -301,7 +301,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         flox_interpreter: &Path,
         packages: &[PackageTargetName],
         build_cache: Option<bool>,
-        system: Option<&str>,
+        system_override: Option<&str>,
     ) -> Result<BuildResults, ManifestBuilderError> {
         let mut command = self.base_command(self.base_dir);
         command.arg("build");
@@ -310,7 +310,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
             "EXPRESSION_BUILD_NIXPKGS_URL={expression_build_nixpkgs_url}"
         ));
 
-        if let Some(system) = system {
+        if let Some(system) = system_override {
             command.arg(format!("NIX_SYSTEM={system}"));
         }
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -889,7 +889,7 @@ fn convert_build_result_to_build_metadata(
 pub fn check_build_metadata(
     flox: &Flox,
     base_nixpkgs_url: &BaseCatalogUrl,
-    system_override: Option<String>,
+    system: Option<&str>,
     env_metadata: &CheckedEnvironmentMetadata,
     pkg: &PackageTarget,
 ) -> Result<CheckedBuildMetadata, PublishError> {
@@ -937,7 +937,7 @@ pub fn check_build_metadata(
         &built_environments.develop,
         &[pkg.name()],
         Some(false),
-        system_override.clone(),
+        system,
     )?;
 
     if build_results.len() != 1 {

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -75,7 +75,7 @@ impl SystemOverride {
     /// without cloning the underlying `String`.
     /// When `None`, the build backend falls back to `nix config show system`
     /// at runtime (see `flox-build.mk`).
-    pub fn resolved(&self) -> Option<&str> {
+    pub fn as_str(&self) -> Option<&str> {
         self.system.as_deref()
     }
 }
@@ -183,7 +183,7 @@ impl Build {
                     env,
                     targets,
                     base_catalog_url_select,
-                    system_override.resolved(),
+                    system_override.as_str(),
                 )
                 .await
             },
@@ -1172,23 +1172,18 @@ mod test {
             );
         }
     }
-}
-
-#[cfg(test)]
-mod system_override_tests {
-    use super::*;
 
     #[test]
-    fn system_override_resolved_none() {
+    fn system_override_as_str_none() {
         let s = SystemOverride { system: None };
-        assert_eq!(s.resolved(), None);
+        assert_eq!(s.as_str(), None);
     }
 
     #[test]
-    fn system_override_resolved_some() {
+    fn system_override_as_str_some() {
         let s = SystemOverride {
             system: Some("aarch64-linux".to_string()),
         };
-        assert_eq!(s.resolved(), Some("aarch64-linux"));
+        assert_eq!(s.as_str(), Some("aarch64-linux"));
     }
 }

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -68,6 +68,18 @@ pub struct SystemOverride {
     pub system: Option<String>,
 }
 
+impl SystemOverride {
+    /// Returns the system override as a borrowed string slice, if set.
+    ///
+    /// Use this at the CLI boundary to pass a `Option<&str>` to SDK functions
+    /// without cloning the underlying `String`.
+    /// When `None`, the build backend falls back to `nix config show system`
+    /// at runtime (see `flox-build.mk`).
+    pub fn resolved(&self) -> Option<&str> {
+        self.system.as_deref()
+    }
+}
+
 #[derive(Bpaf, Clone)]
 pub struct Build {
     #[bpaf(external(dir_environment_select), fallback(Default::default()))]
@@ -171,7 +183,7 @@ impl Build {
                     env,
                     targets,
                     base_catalog_url_select,
-                    system_override.system,
+                    system_override.resolved(),
                 )
                 .await
             },
@@ -216,7 +228,7 @@ impl Build {
         mut env: ConcreteEnvironment,
         packages: Vec<String>,
         nixpkgs_url_select: Option<BaseCatalogUrlSelect>,
-        system_override: Option<String>,
+        system: Option<&str>,
     ) -> Result<()> {
         match &env {
             ConcreteEnvironment::Path(_) => (),
@@ -288,7 +300,7 @@ impl Build {
             &FLOX_INTERPRETER,
             &target_names,
             None,
-            system_override,
+            system,
         )?;
 
         let current_dir = env::current_dir()
@@ -1159,5 +1171,24 @@ mod test {
                 package_name
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod system_override_tests {
+    use super::*;
+
+    #[test]
+    fn system_override_resolved_none() {
+        let s = SystemOverride { system: None };
+        assert_eq!(s.resolved(), None);
+    }
+
+    #[test]
+    fn system_override_resolved_some() {
+        let s = SystemOverride {
+            system: Some("aarch64-linux".to_string()),
+        };
+        assert_eq!(s.resolved(), Some("aarch64-linux"));
     }
 }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -235,7 +235,7 @@ impl Publish {
         let build_metadata = check_build_metadata(
             &flox,
             &selected_base_nixpkgs_url,
-            publish_config.system_override.resolved(),
+            publish_config.system_override.as_str(),
             &publish_provider.env_metadata,
             &publish_provider.package_metadata.package,
         )?;

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -235,7 +235,7 @@ impl Publish {
         let build_metadata = check_build_metadata(
             &flox,
             &selected_base_nixpkgs_url,
-            publish_config.system_override.system,
+            publish_config.system_override.resolved(),
             &publish_provider.env_metadata,
             &publish_provider.package_metadata.package,
         )?;


### PR DESCRIPTION
## Proposed Changes

Centralizes `SystemOverride` resolution at the CLI boundary by adding a `resolved() -> Option<&str>` method and threading `Option<&str>` through the SDK instead of `Option<String>`.

Resolves CLI-9.

### Motivation

Two call sites (`commands/build.rs` and `commands/publish.rs`) both accessed `system_override.system` (the inner field) to pass to SDK functions that accepted `Option<String>`. The SDK functions then cloned the value internally. This change:

- Adds `SystemOverride::resolved() -> Option<&str>` as the single resolution point
- Changes `ManifestBuilder::build` and `check_build_metadata` to accept `Option<&str>`
- Eliminates the `.clone()` call in `check_build_metadata`'s forwarding to `builder.build()`

**No behavioral change.** When `None`, the `flox-build.mk` makefile falls back to `nix config show system` at runtime — that path is untouched.

### Files Changed

- `cli/flox/src/commands/build.rs` — adds `impl SystemOverride { pub fn resolved() }`, updates `Build::build` parameter from `Option<String>` to `Option<&str>`, adds unit tests
- `cli/flox-rust-sdk/src/providers/build.rs` — updates `ManifestBuilder::build` trait and `FloxBuildMk::build` impl
- `cli/flox-rust-sdk/src/providers/publish.rs` — updates `check_build_metadata` signature, drops `.clone()`
- `cli/flox/src/commands/publish.rs` — updates call site to use `.resolved()`

## Release Notes

N/A — internal refactor, no user-facing change.

---
*Via Forge (implementation-worker) • 637f380a*