### PR TITLE
fix(auth): use local name mapping for Kerberos principal

### DIFF
--- a/cli/flox-catalog/src/auth/auth_context_factory/kerberos.rs
+++ b/cli/flox-catalog/src/auth/auth_context_factory/kerberos.rs
@@ -45,10 +45,13 @@ fn acquire_credential() -> Result<(String, Cred), AuthError> {
     let name = cred.name().map_err(|e| {
         AuthError::NotAuthenticated(format!("Failed to get Kerberos principal name: {e:?}"))
     })?;
-    let display = name.display_name().map_err(|e| {
-        AuthError::NotAuthenticated(format!("Failed to display Kerberos principal name: {e:?}"))
-    })?;
-    let principal = String::from_utf8_lossy(&display[..]).to_string();
+    let local = name
+        .local_name(Some(&GSS_MECH_KRB5))
+        .or_else(|_| name.display_name())
+        .map_err(|e| {
+            AuthError::NotAuthenticated(format!("Failed to resolve Kerberos local name: {e:?}"))
+        })?;
+    let principal = String::from_utf8_lossy(&local[..]).to_string();
     Ok((principal, cred))
 }
 


### PR DESCRIPTION
## Summary

- Use `Name::local_name()` (RFC 6680 `gss_localname()`) to map the Kerberos principal to a local username, matching the server-side nginx `krb5_aname_to_localname()` mapping
- Falls back to `display_name()` when local mapping rules are not configured
- Fixes the 404 in `flox publish`/`push`/`pull` when the raw Kerberos principal (e.g. `user-pkinit@REALM`) was used as the catalog name instead of the local username (e.g. `user`)

## Test plan

- [ ] Verify `flox publish` works in Kerberos environments (principal is mapped to local username)
- [ ] Verify `flox publish` still works in Auth0 environments (no regression)
- [ ] Verify fallback to `display_name()` when `auth_to_local` rules are not configured

Fixes ENT-109

🤖 Generated with [Claude Code](https://claude.com/claude-code)