### PR TITLE
docs(man): add catalog cross-refs to `flox-build` and `flox-publish`

### DIFF
--- a/cli/flox/doc/flox-build.md
+++ b/cli/flox/doc/flox-build.md
@@ -88,6 +88,19 @@ The `build.<package>.version` field can be specified in one of the following way
 1. **as read from a file**: `version.file = "<path>"`
 1. **as returned by a command**: `version.command = "<cmd> <args>"`
 
+### Catalog imports for Nix expression builds
+
+Nix expression builds (packages defined as `.nix` files under `.flox/pkgs/`)
+can depend on packages from external catalogs.
+Declare catalog sources in
+[`nix-builds.toml(5)`](./nix-builds.toml.md),
+then run `flox build update-catalogs` to resolve and lock them.
+The resulting lockfile pins every catalog to a specific revision,
+ensuring reproducible builds.
+
+See [`flox-build-update-catalogs(1)`](./flox-build-update-catalogs.md)
+and [`nix-builds.toml(5)`](./nix-builds.toml.md) for details.
+
 # OPTIONS
 
 `<package>`
@@ -96,9 +109,15 @@ The `build.<package>.version` field can be specified in one of the following way
     in the environment's `manifest.toml`.
 
 `--stability <stability>`
-:   Perform a nix expression build using a base package set of the given stability
-    as tracked by the catalog server.
-    Can not be used with manifest base builds.
+:   Perform a nix expression build using a base package set of the given
+    stability as tracked by the catalog server.
+    A stability (e.g., `"stable"`) identifies a curated nixpkgs revision
+    managed by the catalog server.
+    When omitted, the base package set is derived from the environment's
+    `toplevel` group; if no `toplevel` group exists, the `"stable"`
+    stability is used by default.
+    An explicit `--stability` value overrides both of these defaults.
+    Cannot be used with manifest builds.
 
 
 ```{.include}

--- a/cli/flox/doc/flox-publish.md
+++ b/cli/flox/doc/flox-publish.md
@@ -83,6 +83,12 @@ personal Catalog, the package would appear in `flox search` as `myuser/hello`.
 When installing the package, it is downloaded directly from the Catalog Store
 that it was published to.
 
+Published packages on FloxHub are also available as catalog imports for
+Nix expression builds.
+Other environments can declare a FloxHub catalog in
+[`nix-builds.toml(5)`](./nix-builds.toml.md) and reference the published
+packages directly from `.nix` expressions under `.flox/pkgs/`.
+
 ## Sharing published packages
 
 a package published to an individual user's Catalog may only be seen and
@@ -111,9 +117,15 @@ Note that this is a paid feature available with Flox for Teams.
     'flox config'.
 
 `--stability <stability>`
-:   Perform a nix expression build using a base package set of the given stability
-    as tracked by the catalog server.
-    Can not be used with manifest base builds.
+:   Perform a nix expression build using a base package set of the given
+    stability as tracked by the catalog server.
+    A stability (e.g., `"stable"`) identifies a curated nixpkgs revision
+    managed by the catalog server.
+    When omitted, the base package set is derived from the environment's
+    `toplevel` group; if no `toplevel` group exists, the `"stable"`
+    stability is used by default.
+    An explicit `--stability` value overrides both of these defaults.
+    Cannot be used with manifest builds.
 
 ```{.include}
 ./include/dir-environment-options.md
@@ -123,5 +135,7 @@ Note that this is a paid feature available with Flox for Teams.
 # SEE ALSO
 
 [`flox-build(1)`](./flox-build.md)
+[`flox-build-update-catalogs(1)`](./flox-build-update-catalogs.md)
 [`flox-activate(1)`](./flox-activate.md)
 [`manifest.toml(5)`](./manifest.toml.md)
+[`nix-builds.toml(5)`](./nix-builds.toml.md)


### PR DESCRIPTION
## Summary

- Add "Catalog imports for Nix expression builds" subsection to `flox-build` describing `update-catalogs` and `nix-builds.toml`
- Expand `--stability` option in both `flox-build` and `flox-publish` with resolution behavior (explicit flag > toplevel group > `"stable"` default)
- Add FloxHub catalog import note to `flox-publish` connecting the publish pipeline to the build pipeline
- Cross-reference `flox-build-update-catalogs` and `nix-builds.toml` from `flox-publish`

Closes ECO-48.

### Test plan

- [x] Verify man page rendering (`just build-manpages`)
- [x] Confirm all cross-reference links resolve to existing files