### PR TITLE
docs: add auto-start to man pages

### DIFF
--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -15,7 +15,7 @@ flox [<general-options>] activate
      [-d=<path> | -r=<owner>/<name>]
      [-t]
      [--print-script]
-     [-s]
+     [--start-services | --no-start-services]
      [-m=(dev|run)]
      [-g=<generation>]
      [-c=<shell command> | -- <exec command>...]
@@ -104,6 +104,9 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
    If no services are running, the services from the manifest will be started,
    otherwise a warning will displayed and activation will continue.
 
+   To start services by default without requiring `-s`, set
+   `services.auto-start = true` in the manifest.
+
    This flag is currently incompatible with "in-place" activations,
    but this feature will be added in the future.
 
@@ -112,6 +115,9 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
 
    A remote environment can only have a single set of running services,
    regardless of how many times the environment is activated concurrently.
+
+`--no-start-services`
+:  Don't start services even if configured in manifest with `auto-start = true`.
 
 `-m (dev|run)`, `--mode (dev|run)`
 :  Activate the environment in either "dev" or "run" mode.

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -107,9 +107,6 @@ See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
    To start services by default without requiring `-s`, set
    `services.auto-start = true` in the manifest.
 
-   This flag is currently incompatible with "in-place" activations,
-   but this feature will be added in the future.
-
    The services started with this flag will be cleaned up once the last
    activation of this environment terminates.
 

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -473,7 +473,13 @@ vars.PGPORT = "9001"
 This would define a service called `database` that configures and starts a
 PostgreSQL database.
 
-The full set of options is show below:
+Top-level options for the `[services]` block are:
+
+`auto-start`
+:   Whether to start all services automatically on `flox activate`.
+    Can be suppressed with `--no-start-services`.
+
+The full set of options for an individual service descriptor is:
 ```
 ServiceDescriptor ::= {
   command    = STRING


### PR DESCRIPTION
- **docs: add auto-start to man pages**
  We missed this when we added the feature
  

- **docs: drop stale note about in-place services**
  Services have been supported with in-place activations since
  96be27cf6b677bb2c71d085a0f9c1eedbee99980
  