### PR TITLE
refactor(build): unify success messages across subcommands

### DIFF
--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -211,7 +211,10 @@ impl Build {
         let builder = FloxBuildMk::new(&flox, &base_dir, &expression_ref, &flox_env_build_outputs);
         builder.clean(&target_names)?;
 
-        message::created("Clean completed successfully");
+        message::updated(format!(
+            "Cleaned build targets: {}",
+            target_names.iter().join(", ")
+        ));
 
         Ok(())
     }
@@ -308,18 +311,16 @@ impl Build {
             .flatten_ok()
             .collect::<Result<Vec<_>, _>>()?;
 
-        let success_prefix = "Builds completed successfully.";
-
         match links_to_print.as_slice() {
             // This case shouldnt occur with the current FloxBuildMk backend,
             // which either errors earlier if nothing will be built,
             // or produces at least one link.
             // Handle anyway for completeness and to avoid erros in case the above changes.
-            [] => message::info(format!("{success_prefix} No outputs created")),
-            [link] => message::created(format!("{success_prefix} Output created: {link}",)),
+            [] => message::info("Completed build with no outputs"),
+            [link] => message::created(format!("Built output: {link}")),
             links => message::created(formatdoc! {"
-                {success_prefix}
-                Outputs created: {}",
+                Built outputs:
+                {}",
                 links.join(", ")
             }),
         }
@@ -413,7 +414,7 @@ impl Build {
         std::fs::write(&package_file, package_content).context("Failed to write package file")?;
 
         message::created(format!(
-            "Package '{}' imported to {}",
+            "Imported package '{}' to {}",
             installable,
             package_file.display()
         ));
@@ -448,7 +449,13 @@ impl Build {
         let config = read_config(&config_path)?;
         let lockfile = lock_config(&config, &flox.catalog_client).await?;
 
-        write_lock(&lockfile, config_path.with_extension("lock"))?;
+        let lockfile_path = config_path.with_extension("lock");
+        write_lock(&lockfile, &lockfile_path)?;
+
+        message::updated(format!(
+            "Updated catalog lockfile at {}",
+            lockfile_path.display()
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Three of the four `flox build` subcommands already emitted a success line; `flox build update-catalogs` returned `Ok(())` silently, leaving users unable to distinguish success from a silent failure without checking exit codes. The gap became user-visible once PR #4183 unhid the command.

This change rewords the existing messages to share a single active-voice template (`"<past-participle> <subject>[ <preposition> <target>]"`) and adds a matching message to `update_catalogs`:

| Subcommand | Before | After | Helper |
|---|---|---|---|
| `clean` | `Clean completed successfully` | `Cleaned build targets: <targets>` | `updated` (✔) |
| `build` | `Builds completed successfully. Output created: …` | `Built output: <link>` (single) / `Built outputs:` + comma-joined list (multi) / `Completed build with no outputs` (defensive, unreachable) | `created` (⚡︎) |
| `import-nixpkgs` | `Package 'X' imported to <path>` | `Imported package 'X' to <path>` | `created` (⚡︎) |
| `update-catalogs` | _(silent)_ | `Updated catalog lockfile at <path>` | `updated` (✔) |

The helper choice follows the codebase's intent-based mapping: `message::created` (⚡︎ yellow) for `build` and `import-nixpkgs`, which produce new artifacts; `message::updated` (✔ green) for `clean` (matching `gc.rs:86`) and `update-catalogs` (matching `publish.rs:292`), which modify or refresh existing state. The empty-build arm uses `message::info` because nothing was actually produced.

A small drive-by tidy in `update_catalogs`: `config_path.with_extension("lock")` was computed twice, so it's now bound to a local.

Resolves [ECO-54](https://linear.app/floxdotdev/issue/ECO-54/review-success-message-ux-for-similar-operations).

### Test plan

- [x] `cargo fmt --package flox`: clean
- [x] `cargo clippy --package flox -- -D warnings`: clean
- [x] `cargo test --package flox --bin flox commands::build`: 14/14 pass, including the five `import_nixpkgs_*` tests
- [x] Manual smoke test in a scratch path environment, observed output:
  ```
  $ flox build update-catalogs                       # no nix-builds.toml
  ! No catalog inputs defined in this project.
  …

  $ flox build update-catalogs                       # version=1 + empty [catalogs]
  ✔ Updated catalog lockfile at /…/.flox/nix-builds.lock

  $ flox build hello                                 # minimal [build] section
  …
  ⚡︎ Built output: ./result-hello

  $ flox build clean
  ✔ Cleaned build targets: hello
  ```
  `import-nixpkgs` was not exercised live (it would require a nixpkgs prefetch); the reword is a single-string change covered by the unit tests above. The empty-build arm is defensive and cannot fire with the current backend.

No integration tests exercise `flox build` end-to-end, and a `grep` against `cli/tests/` confirmed no bats files assert on the prior strings, so this is a no-risk wording change on that axis.
