### PR TITLE
test(activate): assert exact output

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1268,12 +1268,13 @@ sets_NIX_SSL_CERT_FILE() {
 
   run bash -c 'eval "$($FLOX_BIN activate)"; type hello; echo $foo'
   assert_success
-  assert_line "sourcing hook.on-activate"
-  assert_line "sourcing profile.common"
-  assert_line "sourcing profile.bash"
-  refute_line "sourcing profile.zsh"
-  assert_line --partial "hello is $(realpath $PROJECT_DIR)/.flox/run/"
-  assert_line "baz"
+  assert_output - <<EOF
+sourcing hook.on-activate
+sourcing profile.common
+sourcing profile.bash
+hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello
+baz
+EOF
 }
 
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:fish
@@ -1290,14 +1291,15 @@ sets_NIX_SSL_CERT_FILE() {
 
   run fish -c 'eval "$($FLOX_BIN activate)"; type hello; echo $foo'
   assert_success
-  assert_line "sourcing hook.on-activate"
-  assert_line "sourcing profile.common"
-  refute_line "sourcing profile.bash"
-  assert_line "sourcing profile.fish"
-  refute_line "sourcing profile.tcsh"
-  refute_line "sourcing profile.zsh"
-  assert_line --partial "hello is $(realpath $PROJECT_DIR)/.flox/run/"
-  assert_line "baz"
+  assert_output - <<EOF
+Sourcing config.fish
+Setting PATH from config.fish
+sourcing hook.on-activate
+sourcing profile.common
+sourcing profile.fish
+hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello
+baz
+EOF
 }
 
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:tcsh
@@ -1314,14 +1316,15 @@ sets_NIX_SSL_CERT_FILE() {
 
   run tcsh -c 'eval "`$FLOX_BIN activate`"; echo hello is `which hello`; echo $foo'
   assert_success
-  assert_line "sourcing hook.on-activate"
-  assert_line "sourcing profile.common"
-  refute_line "sourcing profile.bash"
-  refute_line "sourcing profile.fish"
-  assert_line "sourcing profile.tcsh"
-  refute_line "sourcing profile.zsh"
-  assert_line --partial "hello is $(realpath $PROJECT_DIR)/.flox/run/"
-  assert_line "baz"
+  assert_output - <<EOF
+Sourcing .tcshrc
+Setting PATH from .tcshrc
+sourcing hook.on-activate
+sourcing profile.common
+sourcing profile.tcsh
+hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello
+baz
+EOF
 }
 
 # bats test_tags=activate,activate:inplace-modifies,activate:inplace-modifies:zsh
@@ -1338,14 +1341,15 @@ sets_NIX_SSL_CERT_FILE() {
 
   run zsh -c 'eval "$("$FLOX_BIN" activate)"; type hello; echo $foo'
   assert_success
-  assert_line "sourcing hook.on-activate"
-  assert_line "sourcing profile.common"
-  refute_line "sourcing profile.bash"
-  refute_line "sourcing profile.fish"
-  refute_line "sourcing profile.tcsh"
-  assert_line "sourcing profile.zsh"
-  assert_line --partial "hello is $(realpath $PROJECT_DIR)/.flox/run/"
-  assert_line "baz"
+  assert_output - <<EOF
+Sourcing .zshenv
+Setting PATH from .zshenv
+sourcing hook.on-activate
+sourcing profile.common
+sourcing profile.zsh
+hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello
+baz
+EOF
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Assert exact output in the `...modifies the current shell...` tests.

I made this change while debugging what turned out to be a spurious tcsh
issue, but I think it's worth having complete assertions for at least
one in-place test, and "modifies the current shell" feels like the most
comprehensive test where it makes sense to do that.
