### PR TITLE
feat: Add auto-activation preference subcommands

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -50,6 +50,7 @@ use super::{
     environment_select,
 };
 use crate::commands::check_for_upgrades::spawn_detached_check_for_upgrades_process;
+use crate::commands::general::update_config;
 use crate::commands::services::ServicesCommandsError;
 use crate::commands::{
     EnvironmentSelectError,
@@ -59,7 +60,7 @@ use crate::commands::{
     render_composition_manifest,
     uninitialized_environment_description,
 };
-use crate::config::{Config, EnvironmentPromptConfig};
+use crate::config::{AutoActivationPreference, Config, EnvironmentPromptConfig};
 use crate::utils::errors::format_diverged_metadata;
 use crate::utils::message;
 use crate::utils::openers::CliShellExt;
@@ -681,11 +682,8 @@ impl Activate {
                 AutoActivationSubcommand::Allow => "allow",
                 AutoActivationSubcommand::Deny => "deny",
             };
-            bail!("Unknown command '{}'.", cmd_name);
+            bail!("'{}' requires the auto_activate feature flag. Set FLOX_FEATURES_AUTO_ACTIVATE=true.", cmd_name);
         }
-
-        use crate::commands::general::update_config;
-        use crate::config::AutoActivationPreference;
 
         let concrete_environment = self
             .environment
@@ -701,7 +699,7 @@ impl Activate {
         };
 
         let path_str = env_path.display().to_string();
-        let key = format!("auto_activation_preferences.{}", path_str);
+        let key = format!("auto_activate_environments.{}", path_str);
         update_config(&config.flox.config_dir, key, Some(preference))?;
 
         let description = environment_description(&concrete_environment)?;

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -93,8 +93,17 @@ pub enum CommandSelect {
     },
 }
 
-#[derive(Bpaf, Clone, Copy)]
-pub enum AutoActivationSubcommand {
+#[derive(Bpaf, Clone)]
+pub struct Activate {
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    pub environment: EnvironmentSelect,
+
+    #[bpaf(external(activate_subcommand_or_options))]
+    pub subcommand_or_options: ActivateSubcommandOrOptions,
+}
+
+#[derive(Bpaf, Clone)]
+pub enum ActivateSubcommandOrOptions {
     /// Allow auto-activation for an environment
     #[bpaf(command, hide)]
     Allow,
@@ -102,16 +111,15 @@ pub enum AutoActivationSubcommand {
     /// Deny auto-activation for an environment
     #[bpaf(command, hide)]
     Deny,
+
+    ActivateOptions {
+        #[bpaf(external(activate_options))]
+        options: ActivateOptions,
+    },
 }
 
 #[derive(Bpaf, Clone)]
-pub struct Activate {
-    #[bpaf(external(auto_activation_subcommand), optional)]
-    pub auto_activation_subcommand: Option<AutoActivationSubcommand>,
-
-    #[bpaf(external(environment_select), fallback(Default::default()))]
-    pub environment: EnvironmentSelect,
-
+pub struct ActivateOptions {
     /// Trust a remote environment temporarily for this activation, including
     /// the includes of any remote environments.
     #[bpaf(long, short)]
@@ -142,7 +150,7 @@ pub struct Activate {
     pub command: Option<CommandSelect>,
 }
 
-impl Activate {
+impl ActivateOptions {
     /// Validate that `--start-services` and `--no-start-services` are not
     /// used together, since they are mutually exclusive.
     fn validate_service_flags(&self) -> Result<()> {
@@ -151,20 +159,38 @@ impl Activate {
         }
         Ok(())
     }
+}
 
+impl Activate {
     pub async fn handle(self, mut config: Config, mut flox: Flox) -> Result<()> {
-        // Handle auto-activation subcommands first
-        if let Some(subcommand) = self.auto_activation_subcommand {
-            return self
-                .handle_auto_activation_subcommand(subcommand, config, flox)
-                .await;
+        match self.subcommand_or_options {
+            ActivateSubcommandOrOptions::Allow => {
+                return self
+                    .handle_auto_activation_subcommand(
+                        AutoActivationSubcommand::Allow,
+                        config,
+                        flox,
+                    )
+                    .await;
+            },
+            ActivateSubcommandOrOptions::Deny => {
+                return self
+                    .handle_auto_activation_subcommand(AutoActivationSubcommand::Deny, config, flox)
+                    .await;
+            },
+            ActivateSubcommandOrOptions::ActivateOptions { ref options } => {
+                options.validate_service_flags()?;
+            },
         }
 
-        self.validate_service_flags()?;
+        let ActivateSubcommandOrOptions::ActivateOptions { options } = self.subcommand_or_options
+        else {
+            unreachable!()
+        };
 
         let mut concrete_environment = match self
             .environment
-            .to_concrete_environment(&mut flox, self.generation)
+            .to_concrete_environment(&mut flox, options.generation)
             .await
         {
             Ok(concrete_environment) => concrete_environment,
@@ -182,12 +208,16 @@ impl Activate {
         environment_subcommand_metric!(
             "activate",
             concrete_environment,
-            start_services = self.start_services,
-            mode = self.mode.clone().unwrap_or(ActivateMode::Dev).to_string()
+            start_services = options.start_services,
+            mode = options
+                .mode
+                .clone()
+                .unwrap_or(ActivateMode::Dev)
+                .to_string()
         );
 
         if let ConcreteEnvironment::Remote(ref env) = concrete_environment
-            && !self.trust
+            && !options.trust
         {
             ensure_environment_trust(
                 &mut config,
@@ -201,9 +231,9 @@ impl Activate {
             .await?;
         }
 
-        let invocation_type = match self.command {
+        let invocation_type = match options.command {
             None => {
-                if self.print_script || !stdout().is_tty() {
+                if options.print_script || !stdout().is_tty() {
                     InvocationType::InPlace
                 } else {
                     InvocationType::Interactive
@@ -247,16 +277,67 @@ impl Activate {
             None,
         )?;
 
-        self.activate(
-            config,
-            flox,
-            concrete_environment,
-            invocation_type,
-            Vec::new(),
-        )
-        .await
+        options
+            .activate(
+                config,
+                flox,
+                concrete_environment,
+                invocation_type,
+                Vec::new(),
+            )
+            .await
     }
 
+    async fn handle_auto_activation_subcommand(
+        self,
+        subcommand: AutoActivationSubcommand,
+        config: Config,
+        mut flox: Flox,
+    ) -> Result<()> {
+        if !flox.features.auto_activate {
+            let cmd_name = match subcommand {
+                AutoActivationSubcommand::Allow => "allow",
+                AutoActivationSubcommand::Deny => "deny",
+            };
+            bail!(
+                "'{}' requires the auto_activate feature flag. Set FLOX_FEATURES_AUTO_ACTIVATE=true.",
+                cmd_name
+            );
+        }
+
+        let concrete_environment = self
+            .environment
+            .to_concrete_environment(&mut flox, None)
+            .await
+            .context("Failed to find environment")?;
+
+        let verb = match subcommand {
+            AutoActivationSubcommand::Allow => {
+                allow(&config, &concrete_environment)?;
+                "allowed"
+            },
+            AutoActivationSubcommand::Deny => {
+                deny(&config, &concrete_environment)?;
+                "denied"
+            },
+        };
+
+        let description = environment_description(&concrete_environment)?;
+        message::updated(formatdoc! {"
+            Auto-activation {verb} for {description}.
+        "});
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AutoActivationSubcommand {
+    Allow,
+    Deny,
+}
+
+impl ActivateOptions {
     /// This function contains the bulk of the implementation for
     /// Activate::handle,
     /// but it allows us to create an activation for use by `services start` or
@@ -670,45 +751,6 @@ impl Activate {
 
         prompt_envs.join(" ")
     }
-
-    async fn handle_auto_activation_subcommand(
-        self,
-        subcommand: AutoActivationSubcommand,
-        config: Config,
-        mut flox: Flox,
-    ) -> Result<()> {
-        if !flox.features.auto_activate {
-            let cmd_name = match subcommand {
-                AutoActivationSubcommand::Allow => "allow",
-                AutoActivationSubcommand::Deny => "deny",
-            };
-            bail!("'{}' requires the auto_activate feature flag. Set FLOX_FEATURES_AUTO_ACTIVATE=true.", cmd_name);
-        }
-
-        let concrete_environment = self
-            .environment
-            .to_concrete_environment(&mut flox, None)
-            .await
-            .context("Failed to find environment")?;
-
-        let verb = match subcommand {
-            AutoActivationSubcommand::Allow => {
-                allow(&config, &concrete_environment)?;
-                "allowed"
-            },
-            AutoActivationSubcommand::Deny => {
-                deny(&config, &concrete_environment)?;
-                "denied"
-            },
-        };
-
-        let description = environment_description(&concrete_environment)?;
-        message::updated(formatdoc! {"
-            Auto-activation {verb} for {description}.
-        "});
-
-        Ok(())
-    }
 }
 
 /// Notify the user of available upgrades
@@ -926,6 +968,7 @@ pub fn deny(config: &Config, concrete_environment: &ConcreteEnvironment) -> Resu
 ///
 /// Returns true if the environment is explicitly allowed or has no preference set.
 /// Returns false if the environment is explicitly denied.
+#[allow(dead_code)]
 pub fn is_allowed(config: &Config, concrete_environment: &ConcreteEnvironment) -> Result<bool> {
     let env_path = concrete_environment.parent_path()?;
     let preference = config.flox.auto_activate_environments.get(&env_path);
@@ -971,22 +1014,22 @@ mod tests {
     #[test]
     fn test_detect_shell_for_subshell() {
         temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_SET], || {
-            let shell = Activate::detect_shell_for_subshell_with(|| unreachable!());
+            let shell = ActivateOptions::detect_shell_for_subshell_with(|| unreachable!());
             assert_eq!(shell, ShellWithPath::Bash("/shell/bash".into()));
         });
 
         temp_env::with_vars([FLOX_SHELL_SET, SHELL_SET], || {
-            let shell = Activate::detect_shell_for_subshell_with(|| unreachable!());
+            let shell = ActivateOptions::detect_shell_for_subshell_with(|| unreachable!());
             assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
         });
 
         temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
-            let shell = Activate::detect_shell_for_subshell_with(PARENT_DETECTED);
+            let shell = ActivateOptions::detect_shell_for_subshell_with(PARENT_DETECTED);
             assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
         });
 
         temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
-            let shell = Activate::detect_shell_for_subshell_with(PARENT_UNDETECTED);
+            let shell = ActivateOptions::detect_shell_for_subshell_with(PARENT_UNDETECTED);
             assert_eq!(shell, ShellWithPath::Bash(INTERACTIVE_BASH_BIN.clone()));
         });
     }
@@ -995,29 +1038,29 @@ mod tests {
     fn test_detect_shell_for_in_place() {
         // $SHELL is used as a fallback only if parent detection fails
         temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_SET], || {
-            let shell = Activate::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
+            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
             assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
 
             // fall back to $SHELL if parent detection fails
-            let shell = Activate::detect_shell_for_in_place_with(PARENT_UNDETECTED).unwrap();
+            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_UNDETECTED).unwrap();
             assert_eq!(shell, ShellWithPath::Bash("/shell/bash".into()));
         });
 
         // $FLOX_SHELL takes precedence over $SHELL and detected parent shell
         temp_env::with_vars([FLOX_SHELL_SET, SHELL_SET], || {
-            let shell = Activate::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
+            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
             assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
 
-            let shell = Activate::detect_shell_for_in_place_with(PARENT_UNDETECTED).unwrap();
+            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_UNDETECTED).unwrap();
             assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
         });
 
         // if both $FLOX_SHELL and $SHELL are unset, we should fail iff parent detection fails
         temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
-            let shell = Activate::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
+            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
             assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
 
-            let shell = Activate::detect_shell_for_in_place_with(PARENT_UNDETECTED);
+            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_UNDETECTED);
             assert!(shell.is_err());
         });
     }
@@ -1025,7 +1068,7 @@ mod tests {
     #[test]
     fn test_shell_prompt_empty_without_active_environments() {
         let active_environments = ActiveEnvironments::default();
-        let prompt = Activate::make_prompt_environments(false, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(false, &active_environments);
 
         assert_eq!(prompt, "");
     }
@@ -1036,11 +1079,11 @@ mod tests {
         active_environments.set_last_active(DEFAULT_ENV.clone(), None, ActivateMode::Dev);
 
         // with `hide_default_prompt = false` we should see the default environment
-        let prompt = Activate::make_prompt_environments(false, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(false, &active_environments);
         assert_eq!(prompt, "default".to_string());
 
         // with `hide_default_prompt = true` we should not see the default environment
-        let prompt = Activate::make_prompt_environments(true, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
         assert_eq!(prompt, "");
     }
 
@@ -1051,19 +1094,20 @@ mod tests {
         active_environments.set_last_active(NON_DEFAULT_ENV.clone(), None, ActivateMode::Dev);
 
         // with `hide_default_prompt = false` we should see the default environment
-        let prompt = Activate::make_prompt_environments(false, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(false, &active_environments);
         assert_eq!(prompt, "wichtig default".to_string());
 
         // with `hide_default_prompt = true` we should not see the default environment
-        let prompt = Activate::make_prompt_environments(true, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
         assert_eq!(prompt, "wichtig".to_string());
     }
 
-    /// Build a minimal Activate with only the service-related flags set.
-    fn activate_with_flags(start_services: bool, no_start_services: bool) -> Activate {
-        Activate {
-            auto_activation_subcommand: None,
-            environment: EnvironmentSelect::default(),
+    /// Build minimal ActivateOptions with only the service-related flags set.
+    fn activate_options_with_flags(
+        start_services: bool,
+        no_start_services: bool,
+    ) -> ActivateOptions {
+        ActivateOptions {
             trust: false,
             print_script: false,
             start_services,
@@ -1076,8 +1120,8 @@ mod tests {
 
     #[test]
     fn test_conflicting_service_flags_are_rejected() {
-        let activate = activate_with_flags(true, true);
-        assert!(activate.validate_service_flags().is_err());
+        let options = activate_options_with_flags(true, true);
+        assert!(options.validate_service_flags().is_err());
     }
 }
 
@@ -1102,7 +1146,7 @@ mod upgrade_notification_tests {
     #[test]
     fn no_notification_printed_if_absent() {
         let (flox, _tempdir) = flox_instance();
-        
+
         let (subscriber, writer) = test_subscriber_message_only();
 
         let environment =

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -92,8 +92,22 @@ pub enum CommandSelect {
     },
 }
 
+#[derive(Bpaf, Clone, Copy)]
+pub enum AutoActivationSubcommand {
+    /// Allow auto-activation for an environment
+    #[bpaf(command, hide)]
+    Allow,
+
+    /// Deny auto-activation for an environment
+    #[bpaf(command, hide)]
+    Deny,
+}
+
 #[derive(Bpaf, Clone)]
 pub struct Activate {
+    #[bpaf(external(auto_activation_subcommand), optional)]
+    pub auto_activation_subcommand: Option<AutoActivationSubcommand>,
+
     #[bpaf(external(environment_select), fallback(Default::default()))]
     pub environment: EnvironmentSelect,
 
@@ -138,6 +152,13 @@ impl Activate {
     }
 
     pub async fn handle(self, mut config: Config, mut flox: Flox) -> Result<()> {
+        // Handle auto-activation subcommands first
+        if let Some(subcommand) = self.auto_activation_subcommand {
+            return self
+                .handle_auto_activation_subcommand(subcommand, config, flox)
+                .await;
+        }
+
         self.validate_service_flags()?;
 
         let mut concrete_environment = match self
@@ -648,6 +669,48 @@ impl Activate {
 
         prompt_envs.join(" ")
     }
+
+    async fn handle_auto_activation_subcommand(
+        self,
+        subcommand: AutoActivationSubcommand,
+        config: Config,
+        mut flox: Flox,
+    ) -> Result<()> {
+        if !flox.features.auto_activate {
+            let cmd_name = match subcommand {
+                AutoActivationSubcommand::Allow => "allow",
+                AutoActivationSubcommand::Deny => "deny",
+            };
+            bail!("Unknown command '{}'.", cmd_name);
+        }
+
+        use crate::commands::general::update_config;
+        use crate::config::AutoActivationPreference;
+
+        let concrete_environment = self
+            .environment
+            .to_concrete_environment(&mut flox, None)
+            .await
+            .context("Failed to find environment")?;
+
+        let env_path = concrete_environment.parent_path()?;
+
+        let (preference, verb) = match subcommand {
+            AutoActivationSubcommand::Allow => (AutoActivationPreference::Allow, "allowed"),
+            AutoActivationSubcommand::Deny => (AutoActivationPreference::Deny, "denied"),
+        };
+
+        let path_str = env_path.display().to_string();
+        let key = format!("auto_activation_preferences.{}", path_str);
+        update_config(&config.flox.config_dir, key, Some(preference))?;
+
+        let description = environment_description(&concrete_environment)?;
+        message::updated(formatdoc! {"
+            Auto-activation {verb} for {description}.
+        "});
+
+        Ok(())
+    }
 }
 
 /// Notify the user of available upgrades
@@ -957,6 +1020,7 @@ mod tests {
     /// Build a minimal Activate with only the service-related flags set.
     fn activate_with_flags(start_services: bool, no_start_services: bool) -> Activate {
         Activate {
+            auto_activation_subcommand: None,
             environment: EnvironmentSelect::default(),
             trust: false,
             print_script: false,

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -691,16 +691,16 @@ impl Activate {
             .await
             .context("Failed to find environment")?;
 
-        let env_path = concrete_environment.parent_path()?;
-
-        let (preference, verb) = match subcommand {
-            AutoActivationSubcommand::Allow => (AutoActivationPreference::Allow, "allowed"),
-            AutoActivationSubcommand::Deny => (AutoActivationPreference::Deny, "denied"),
+        let verb = match subcommand {
+            AutoActivationSubcommand::Allow => {
+                allow(&config, &concrete_environment)?;
+                "allowed"
+            },
+            AutoActivationSubcommand::Deny => {
+                deny(&config, &concrete_environment)?;
+                "denied"
+            },
         };
-
-        let path_str = env_path.display().to_string();
-        let key = format!("auto_activate_environments.{}", path_str);
-        update_config(&config.flox.config_dir, key, Some(preference))?;
 
         let description = environment_description(&concrete_environment)?;
         message::updated(formatdoc! {"
@@ -892,6 +892,50 @@ fn notify_environment_upgrades(
     Ok(())
 }
 
+/// Allow auto-activation for an environment by updating the config.
+///
+/// Writes the allow preference to the config file for the environment's parent path.
+pub fn allow(config: &Config, concrete_environment: &ConcreteEnvironment) -> Result<()> {
+    let env_path = concrete_environment.parent_path()?;
+    let path_str = env_path.display().to_string();
+    let key = format!("auto_activate_environments.{}", path_str);
+    update_config(
+        &config.flox.config_dir,
+        key,
+        Some(AutoActivationPreference::Allow),
+    )?;
+    Ok(())
+}
+
+/// Deny auto-activation for an environment by updating the config.
+///
+/// Writes the deny preference to the config file for the environment's parent path.
+pub fn deny(config: &Config, concrete_environment: &ConcreteEnvironment) -> Result<()> {
+    let env_path = concrete_environment.parent_path()?;
+    let path_str = env_path.display().to_string();
+    let key = format!("auto_activate_environments.{}", path_str);
+    update_config(
+        &config.flox.config_dir,
+        key,
+        Some(AutoActivationPreference::Deny),
+    )?;
+    Ok(())
+}
+
+/// Check if auto-activation is allowed for an environment.
+///
+/// Returns true if the environment is explicitly allowed or has no preference set.
+/// Returns false if the environment is explicitly denied.
+pub fn is_allowed(config: &Config, concrete_environment: &ConcreteEnvironment) -> Result<bool> {
+    let env_path = concrete_environment.parent_path()?;
+    let preference = config.flox.auto_activate_environments.get(&env_path);
+
+    match preference {
+        Some(AutoActivationPreference::Deny) => Ok(false),
+        Some(AutoActivationPreference::Allow) | None => Ok(true),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::LazyLock;
@@ -1058,6 +1102,7 @@ mod upgrade_notification_tests {
     #[test]
     fn no_notification_printed_if_absent() {
         let (flox, _tempdir) = flox_instance();
+        
         let (subscriber, writer) = test_subscriber_message_only();
 
         let environment =

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -49,7 +49,7 @@ use tracing::{debug, info_span, instrument, span, warn};
 
 use super::services::warn_manifest_changes_for_services;
 use super::{EnvironmentSelect, environment_select};
-use crate::commands::activate::Activate;
+use crate::commands::activate::ActivateOptions;
 use crate::commands::{
     ConcreteEnvironment,
     EnvironmentSelectError,
@@ -671,7 +671,7 @@ fn package_list_for_prompt(packages: &[PackageToInstall]) -> Option<String> {
 }
 
 fn prompt_to_modify_rc_file() -> Result<bool, anyhow::Error> {
-    let shell = Activate::detect_shell_for_in_place()?;
+    let shell = ActivateOptions::detect_shell_for_in_place()?;
     let shell_cmd = match shell {
         // TODO: should we use source <(flox activate --default) for bash?
         // There are unicode quoting issues with the current form

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -563,10 +563,9 @@ enum UseCommands {
 impl UseCommands {
     async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
-            UseCommands::Activate(args) => args.handle(config, flox).await?,
-            UseCommands::Services(args) => args.handle(config, flox).await?,
+            UseCommands::Activate(args) => args.handle(config, flox).await,
+            UseCommands::Services(args) => args.handle(config, flox).await,
         }
-        Ok(())
     }
 }
 

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -24,7 +24,7 @@ use super::{
     UninitializedEnvironment,
     activated_environments,
 };
-use crate::commands::activate::{Activate, CommandSelect};
+use crate::commands::activate::{ActivateOptions, CommandSelect};
 use crate::commands::display_help;
 use crate::config::Config;
 use crate::utils::message;
@@ -358,7 +358,7 @@ fn processes_by_name_or_default_to_all<'a>(
 pub async fn start_services_with_new_process_compose(
     config: Config,
     flox: Flox,
-    environment_select: EnvironmentSelect,
+    _environment_select: EnvironmentSelect,
     mut concrete_environment: ConcreteEnvironment,
     activate_mode: ActivateMode,
     names: &[String],
@@ -396,9 +396,7 @@ pub async fn start_services_with_new_process_compose(
         names.to_vec()
     };
 
-    Activate {
-        auto_activation_subcommand: None,
-        environment: environment_select,
+    ActivateOptions {
         // We currently only check for trust for remote environments,
         // but set this to false in case that changes.
         trust: false,

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -397,6 +397,7 @@ pub async fn start_services_with_new_process_compose(
     };
 
     Activate {
+        auto_activation_subcommand: None,
         environment: environment_select,
         // We currently only check for trust for remote environments,
         // but set this to false in case that changes.

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -131,7 +131,7 @@ pub struct FloxConfig {
     /// Per-directory auto-activation preferences.
     /// Maps absolute paths to explicit allow/deny decisions.
     #[serde(default)]
-    pub auto_activation_preferences: HashMap<PathBuf, AutoActivationPreference>,
+    pub auto_activate_environments: HashMap<PathBuf, AutoActivationPreference>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -127,6 +127,11 @@ pub struct FloxConfig {
     /// Controls how the fish shell hook responds to directory changes.
     /// Possible values: `eval_on_arrow` (default), `eval_after_arrow`, `disable_arrow`.
     pub auto_activate_fish_mode: Option<AutoActivateFishMode>,
+
+    /// Per-directory auto-activation preferences.
+    /// Maps absolute paths to explicit allow/deny decisions.
+    #[serde(default)]
+    pub auto_activation_preferences: HashMap<PathBuf, AutoActivationPreference>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -172,6 +177,14 @@ pub enum AutoActivate {
     #[default]
     Allowed,
     Prompt,
+}
+
+/// Auto-activation preference for a specific directory
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AutoActivationPreference {
+    Allow,
+    Deny,
 }
 
 impl Display for InstallerChannel {


### PR DESCRIPTION
This adds `flox activate allow` and `flox activate deny` subcommands to set per-directory auto-activation preferences (behind auto_activate flag), closes [DEV-48](https://linear.app/floxdotdev/issue/DEV-48)
