### PR TITLE
chore: remove flox/cli from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @flox/cli
 /cli/schemas/ @flox/cli @flox/floxhub


### PR DESCRIPTION
https://flox-dev.slack.com/archives/C054SAD6NLD/p1778690893715259

> We’re removing the flox/cli team from flox/flox CODEOWNERS so that we don’t automatically get code review pings. If you need review on a flox/flox PR from CLI committee, request review from flox/cli (or feel free to ping in #committee-cli) Otherwise we’re thinking a lot of PRs will get reviewed by the pods driving features
> 
> I’ll probably start requesting reviews from the pod-workflows GH team for feature PRs in flox/flox, not sure how other pods want to handle that