### PR TITLE
test: fixes for running in a container

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3504,14 +3504,13 @@ PIDs of the running activations: ${ACTIVATION_PID}"
   case "$NIX_SYSTEM" in
     *-linux)
       VIM_MAN="$(realpath "$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man/man1/vim.1.gz")"
-      run $_man --path vim
-      assert_failure
-      refute_output "$VIM_MAN"
-
       EMACS_MAN="$(realpath "$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man/man1/emacs.1.gz")"
-      run $_man --path emacs
-      assert_failure
-      refute_output "$EMACS_MAN"
+
+      # Neither environment starts out in MANPATH
+      run $_man --path
+      assert_success
+      refute_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
+      refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man.*"
 
       # vim gets added to MANPATH
       _man=$_man FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "$_man --path vim > output; echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4054,7 +4054,9 @@ Setting PATH from ${rc_file}"
 
   # Pre-fetch without a timeout.
   # Skip the test if we're running a release
-  if ! OUTPUT=$(nix build "github:flox/flox/v${FLOX_LATEST_VERSION}" 2>&1); then
+  if ! OUTPUT=$(nix build \
+    --extra-experimental-features 'nix-command flakes' \
+    "github:flox/flox/v${FLOX_LATEST_VERSION}" 2>&1); then
     if [[ "$OUTPUT" == *"No commit found for SHA: v${FLOX_LATEST_VERSION}"* ]]; then
       skip "skipping compatibility check for what is likely a release commit"
     else

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -407,7 +407,9 @@ EOF
 # bats test_tags=edit:install-store-path
 @test "'flox edit' install-store-path" {
   "$FLOX_BIN" init
-  hello_store_path="$(nix build "github:nixos/nixpkgs/$TEST_NIXPKGS_REV_NEW#hello^out" --no-link --print-out-paths)"
+  hello_store_path="$(nix build \
+    --extra-experimental-features 'nix-command flakes' \
+    "github:nixos/nixpkgs/$TEST_NIXPKGS_REV_NEW#hello^out" --no-link --print-out-paths)"
 
   run "$FLOX_BIN" edit -f <(echo "
     version = 1

--- a/cli/tests/flox-nixpkgs.bats
+++ b/cli/tests/flox-nixpkgs.bats
@@ -13,7 +13,9 @@ load setup_suite.bash
 # ---------------------------------------------------------------------------- #
 
 @test "'github' fetcher does NOT set 'allowUnfree' and 'allowBroken'" {
-  run --separate-stderr nix --option plugin-files "$NIX_PLUGINS" \
+  run --separate-stderr nix \
+    --extra-experimental-features 'nix-command flakes' \
+    --option plugin-files "$NIX_PLUGINS" \
     eval --expr "let
     nixpkgs = builtins.getFlake \"github:NixOS/nixpkgs/$TEST_NIXPKGS_REV_NEW\";
     inherit (nixpkgs.legacyPackages.x86_64-linux) config;
@@ -25,7 +27,9 @@ load setup_suite.bash
 # ---------------------------------------------------------------------------- #
 
 @test "'flox-nixpkgs' fetcher sets 'allowUnfree' and 'allowBroken'" {
-  run --separate-stderr nix --option plugin-files "$NIX_PLUGINS" \
+  run --separate-stderr nix \
+    --extra-experimental-features 'nix-command flakes' \
+    --option plugin-files "$NIX_PLUGINS" \
     eval --expr "let
     nixpkgs = builtins.getFlake
                 \"flox-nixpkgs:v0/flox/$TEST_NIXPKGS_REV_NEW\";
@@ -38,7 +42,9 @@ load setup_suite.bash
 # ---------------------------------------------------------------------------- #
 
 @test "'flox-nixpkgs' and 'github' 'outPaths' match" {
-  run --separate-stderr nix --option plugin-files "$NIX_PLUGINS" \
+  run --separate-stderr nix \
+    --extra-experimental-features 'nix-command flakes' \
+    --option plugin-files "$NIX_PLUGINS" \
     eval --expr "let
     fp0 = builtins.getFlake
             \"flox-nixpkgs\:v0/flox/$TEST_NIXPKGS_REV_NEW\";

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -419,7 +419,9 @@ EOF
 # bats test_tags=install:install-store-path
 @test "'flox install' install-store-path" {
   "$FLOX_BIN" init
-  hello_store_path="$(nix build "github:nixos/nixpkgs/$TEST_NIXPKGS_REV_NEW#hello^out" --no-link --print-out-paths)"
+  hello_store_path="$(nix build \
+    --extra-experimental-features 'nix-command flakes' \
+    "github:nixos/nixpkgs/$TEST_NIXPKGS_REV_NEW#hello^out" --no-link --print-out-paths)"
 
   PROJECT_DIR="$(realpath "$PROJECT_DIR")"
   run "$FLOX_BIN" install "$hello_store_path"
@@ -437,7 +439,9 @@ EOF
 # bats test_tags=install:install-store-path
 @test "'flox install' install-store-path from link" {
  "$FLOX_BIN" init
-  vim_store_path="$(nix build "github:nixos/nixpkgs/$TEST_NIXPKGS_REV_NEW#vim^out" --out-link ./result-vim --print-out-paths)"
+  vim_store_path="$(nix build \
+    --extra-experimental-features 'nix-command flakes' \
+    "github:nixos/nixpkgs/$TEST_NIXPKGS_REV_NEW#vim^out" --out-link ./result-vim --print-out-paths)"
 
   PROJECT_DIR="$(realpath "$PROJECT_DIR")"
   run "$FLOX_BIN" install "./result-vim"

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -896,8 +896,10 @@ EOF
   export _FLOX_SERVICES_ACTIVATE_TIMEOUT=0.1
 
   # process-compose will never be able to create this socket,
-  # which looks the same as taking a long time to create the socket
-  export _FLOX_SERVICES_SOCKET_OVERRIDE="/no_permission.sock"
+  # which looks the same as taking a long time to create the socket.
+  # Use a path under a non-existent directory so creating the socket fails even
+  # when running this test as root.
+  export _FLOX_SERVICES_SOCKET_OVERRIDE="/nonexistent_dir/does_not_exist.sock"
   run "$FLOX_BIN" activate -s -- true
   assert_output "✘ ERROR: Failed to start services: process-compose socket not ready"
 }


### PR DESCRIPTION
- **test(activate): don't assume man vim doesn't exist**
  Assert we haven't added packages to MANPATH yet rather than asserting
  they can't be found at all.
  
  man pages can be found from PATH:
  ```
  -bash-5.3# MANPATH= /root/.nix-profile/bin/man --path vim
  /nix/store/zr6gjyldjzk29jwpihpclh12xy307dzm-vim-9.1.1869/share/man/man1/vim.1.gz
  -bash-5.3# MANPATH= PATH= /root/.nix-profile/bin/man --path vim
  No manual entry for vim
  ```
  
  On a host with vim discoverable from PATH, this was causing the test to
  fail.
  

- **test: enable experimental features**
  Enable experimental features when relying on them in integration tests.
  
  On hosts without experimental features enabled, these tests currently
  fail.
  

- **test(services): fix test failing when run as root**
  If running this test as root (e.g. in a container), the socket can currently be
  created. Move the socket to a non-existent directory so the test passes when
  running as root as well.
  