### PR TITLE
fix(activations): add adaptive startup backoff

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -30,3 +30,4 @@ yes,noor-latif,Noor Latif,<noor@latif.se>
 yes,martijnarts,Martijn Arts,<martijn@martijnarts.com>
 yes,electricalen,David Sawyer,<electricalen@gmail.com>
 yes,jsoref,Josh Soref,<jsoref@gmail.com>
+yes,sarendipitee,Saren Dipitee,<saren@dumstruckk.com>

--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -24,6 +24,54 @@ use crate::vars_from_env::VarsFromEnvironment;
 
 pub const NO_REMOVE_ACTIVATION_FILES: &str = "_FLOX_NO_REMOVE_ACTIVATION_FILES";
 
+const INITIAL_ACTIVATION_RETRY_DELAY: Duration = Duration::from_millis(25);
+const MAX_ACTIVATION_RETRY_DELAY: Duration = Duration::from_secs(2);
+const ACTIVATION_WARNING_INITIAL_DELAY: Duration = Duration::from_secs(3);
+const ACTIVATION_WARNING_INTERVAL: Duration = Duration::from_secs(15);
+
+#[derive(Debug)]
+struct ActivationRetryBackoff {
+    next_retry_delay: Duration,
+    blocked_since: Instant,
+    next_warning_at: Instant,
+}
+
+impl ActivationRetryBackoff {
+    fn new(now: Instant) -> Self {
+        Self {
+            next_retry_delay: INITIAL_ACTIVATION_RETRY_DELAY,
+            blocked_since: now,
+            next_warning_at: now + ACTIVATION_WARNING_INITIAL_DELAY,
+        }
+    }
+
+    fn next_wait(&mut self, now: Instant) -> ActivationRetryWait {
+        let retry_delay = self.next_retry_delay;
+        self.next_retry_delay = self
+            .next_retry_delay
+            .saturating_mul(2)
+            .min(MAX_ACTIVATION_RETRY_DELAY);
+
+        let blocked_for = if now >= self.next_warning_at {
+            self.next_warning_at = now + ACTIVATION_WARNING_INTERVAL;
+            Some(now.duration_since(self.blocked_since))
+        } else {
+            None
+        };
+
+        ActivationRetryWait {
+            retry_delay,
+            blocked_for,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ActivationRetryWait {
+    retry_delay: Duration,
+    blocked_for: Option<Duration>,
+}
+
 #[derive(Debug, Args)]
 pub struct ActivateArgs {
     /// Path to JSON file containing activation data
@@ -128,9 +176,7 @@ impl ActivateArgs {
         subsystem_verbosity: u32,
         vars_from_env: &VarsFromEnvironment,
     ) -> Result<StartIdentifier, anyhow::Error> {
-        let retry_delay = Duration::from_millis(200);
-        let warning_interval = Duration::from_secs(5);
-        let mut last_warning: Option<Instant> = None;
+        let mut retry_backoff: Option<ActivationRetryBackoff> = None;
 
         let deactivate_hint = "To stop using this environment, run 'flox deactivate'";
 
@@ -164,18 +210,18 @@ impl ActivateArgs {
                     pid: blocking_pid, ..
                 } => {
                     let now = Instant::now();
-                    let should_warn =
-                        last_warning.is_none_or(|t| now.duration_since(t) >= warning_interval);
+                    let wait = retry_backoff
+                        .get_or_insert_with(|| ActivationRetryBackoff::new(now))
+                        .next_wait(now);
 
-                    if should_warn {
+                    if let Some(blocked_for) = wait.blocked_for {
                         eprintln!(
-                            "⚠️  Waiting for another activation to complete (blocked by PID {})...",
-                            blocking_pid
+                            "⚠️  Activation is blocked by another startup (PID {blocking_pid}).\nRetrying automatically after waiting {} seconds.",
+                            blocked_for.as_secs()
                         );
-                        last_warning = Some(now);
                     }
 
-                    std::thread::sleep(retry_delay);
+                    std::thread::sleep(wait.retry_delay);
                 },
             }
         }
@@ -249,5 +295,65 @@ impl ActivateArgs {
                 Ok(StartOrAttachResult::AlreadyStarting { pid, start_id })
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activation_retry_backoff_grows_to_cap() {
+        let start = Instant::now();
+        let mut backoff = ActivationRetryBackoff::new(start);
+
+        let waits = (0..9)
+            .map(|_| backoff.next_wait(start).retry_delay)
+            .collect::<Vec<_>>();
+
+        assert_eq!(waits, vec![
+            Duration::from_millis(25),
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            Duration::from_millis(200),
+            Duration::from_millis(400),
+            Duration::from_millis(800),
+            Duration::from_millis(1600),
+            Duration::from_secs(2),
+            Duration::from_secs(2),
+        ]);
+    }
+
+    #[test]
+    fn activation_retry_warning_is_delayed_and_repeated_less_often() {
+        let start = Instant::now();
+        let mut backoff = ActivationRetryBackoff::new(start);
+
+        assert_eq!(backoff.next_wait(start), ActivationRetryWait {
+            retry_delay: Duration::from_millis(25),
+            blocked_for: None,
+        });
+        assert_eq!(
+            backoff.next_wait(start + ACTIVATION_WARNING_INITIAL_DELAY),
+            ActivationRetryWait {
+                retry_delay: Duration::from_millis(50),
+                blocked_for: Some(ACTIVATION_WARNING_INITIAL_DELAY),
+            }
+        );
+        assert_eq!(
+            backoff.next_wait(start + ACTIVATION_WARNING_INITIAL_DELAY + Duration::from_secs(14)),
+            ActivationRetryWait {
+                retry_delay: Duration::from_millis(100),
+                blocked_for: None,
+            }
+        );
+        assert_eq!(
+            backoff
+                .next_wait(start + ACTIVATION_WARNING_INITIAL_DELAY + ACTIVATION_WARNING_INTERVAL),
+            ActivationRetryWait {
+                retry_delay: Duration::from_millis(200),
+                blocked_for: Some(ACTIVATION_WARNING_INITIAL_DELAY + ACTIVATION_WARNING_INTERVAL),
+            }
+        );
     }
 }

--- a/cli/flox/doc-auto-activate/flox-config.md
+++ b/cli/flox/doc-auto-activate/flox-config.md
@@ -116,6 +116,13 @@ flox config --set 'trusted_environments."owner/name"' trust
 `disable_metrics`
 :   Disable collecting and sending usage metrics.
 
+`disable_update_checks`
+:   Disable Flox CLI version update checks and activate-time environment
+    upgrade checks. When set to `true`, Flox does not check
+    `downloads.flox.dev` for CLI updates and does not start background
+    upgrade checks during `flox activate`.
+    (default: false)
+
 `floxhub_token`
 :   Token to authenticate on FloxHub.
 
@@ -169,3 +176,8 @@ flox config --set 'trusted_environments."owner/name"' trust
 :   Variable for disabling the collection/sending of metrics data.
     If set to `true`, prevents Flox from submitting basic metrics information
     such as a unique token and the subcommand issued.
+
+`$FLOX_DISABLE_UPDATE_CHECKS`
+:   Variable for disabling Flox CLI version update checks and activate-time
+    environment upgrade checks. If set to `true`, prevents update checks from
+    running.

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -92,6 +92,13 @@ flox config --set 'trusted_environments."owner/name"' trust
 `disable_metrics`
 :   Disable collecting and sending usage metrics.
 
+`disable_update_checks`
+:   Disable Flox CLI version update checks and activate-time environment
+    upgrade checks. When set to `true`, Flox does not check
+    `downloads.flox.dev` for CLI updates and does not start background
+    upgrade checks during `flox activate`.
+    (default: false)
+
 `floxhub_token`
 :   Token to authenticate on FloxHub.
 
@@ -152,3 +159,8 @@ flox config --set 'trusted_environments."owner/name"' trust
 :   Variable for disabling the collection/sending of metrics data.
     If set to `true`, prevents Flox from submitting basic metrics information
     such as a unique token and the subcommand issued.
+
+`$FLOX_DISABLE_UPDATE_CHECKS`
+:   Variable for disabling Flox CLI version update checks and activate-time
+    environment upgrade checks. If set to `true`, prevents update checks from
+    running.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -245,26 +245,29 @@ impl Activate {
             },
         };
 
-        if (invocation_type == InvocationType::Interactive
-            || invocation_type == InvocationType::InPlace)
-            && config.flox.upgrade_notifications.unwrap_or(true)
-        {
+        if should_notify_about_upgrades(&config, &invocation_type) {
             // Read the results of a previous upgrade check
             // and print a message if an upgrade is available.
             notify_upgrades_if_available(&flox, &mut concrete_environment, &self.environment)?;
+        } else if config.flox.disable_update_checks() {
+            debug!("Upgrade checks disabled");
         } else {
             debug!("Upgrade notification disabled");
         }
 
-        // Spawn a detached process to check for upgrades in the background.
-        let environment =
-            UninitializedEnvironment::from_concrete_environment(&concrete_environment);
-        spawn_detached_check_for_upgrades_process(
-            &environment,
-            None,
-            &concrete_environment.log_path()?,
-            None,
-        )?;
+        if should_check_for_activation_upgrades(&config) {
+            // Spawn a detached process to check for upgrades in the background.
+            let environment =
+                UninitializedEnvironment::from_concrete_environment(&concrete_environment);
+            spawn_detached_check_for_upgrades_process(
+                &environment,
+                None,
+                &concrete_environment.log_path()?,
+                None,
+            )?;
+        } else {
+            debug!("Skipping upgrade check because update checks are disabled");
+        }
 
         options
             .activate(
@@ -679,6 +682,19 @@ impl ActivateOptions {
     }
 }
 
+fn should_notify_about_upgrades(config: &Config, invocation_type: &InvocationType) -> bool {
+    !config.flox.disable_update_checks()
+        && matches!(
+            invocation_type,
+            InvocationType::Interactive | InvocationType::InPlace
+        )
+        && config.flox.upgrade_notifications.unwrap_or(true)
+}
+
+fn should_check_for_activation_upgrades(config: &Config) -> bool {
+    !config.flox.disable_update_checks()
+}
+
 /// Notify the user of available upgrades
 ///
 /// Upon activation flox will start a detached process to check for upgrades.
@@ -1006,6 +1022,41 @@ mod tests {
     fn test_conflicting_service_flags_are_rejected() {
         let options = activate_options_with_flags(true, true);
         assert!(options.validate_service_flags().is_err());
+    }
+
+    #[test]
+    fn upgrade_notifications_enabled_by_default_for_interactive_activation() {
+        let config = Config::default();
+
+        assert!(should_notify_about_upgrades(
+            &config,
+            &InvocationType::Interactive
+        ));
+    }
+
+    #[test]
+    fn upgrade_notifications_disabled_by_legacy_notification_config() {
+        let mut config = Config::default();
+        config.flox.upgrade_notifications = Some(false);
+
+        assert!(!should_notify_about_upgrades(
+            &config,
+            &InvocationType::Interactive
+        ));
+        assert!(should_check_for_activation_upgrades(&config));
+    }
+
+    #[test]
+    fn update_checks_disabled_suppresses_activation_upgrade_checks() {
+        let mut config = Config::default();
+        config.flox.disable_update_checks = Some(true);
+        config.flox.upgrade_notifications = Some(true);
+
+        assert!(!should_notify_about_upgrades(
+            &config,
+            &InvocationType::Interactive
+        ));
+        assert!(!should_check_for_activation_upgrades(&config));
     }
 }
 

--- a/cli/flox/src/commands/check_for_upgrades.rs
+++ b/cli/flox/src/commands/check_for_upgrades.rs
@@ -18,6 +18,7 @@ use time::{Duration, OffsetDateTime};
 use tracing::{debug, info_span, instrument};
 
 use super::UninitializedEnvironment;
+use crate::config::Config;
 use crate::subcommand_metric;
 
 /// By default check once a day
@@ -50,6 +51,11 @@ impl CheckForUpgrades {
     #[instrument(name = "check-upgrade", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
         subcommand_metric!("check-upgrade");
+
+        if Config::parse()?.flox.disable_update_checks() {
+            debug!("Update checks disabled. Skipping.");
+            return Ok(());
+        }
 
         // For catalog requests made by this command, set the QoS to background.
         // Eventually we might want to prioritize these requests differently,
@@ -269,6 +275,8 @@ pub fn spawn_detached_check_for_upgrades_process(
 #[cfg(test)]
 mod tests {
 
+    use std::fs;
+
     use flox_rust_sdk::flox::test_helpers::flox_instance;
     use flox_rust_sdk::models::environment::UpgradeResult;
     use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment_from_env_files;
@@ -357,5 +365,39 @@ mod tests {
             &info.upgrade_result.new_lockfile,
             info.upgrade_result.old_lockfile.as_ref().unwrap()
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn handle_skips_when_update_checks_are_disabled() {
+        let (flox, _tempdir) = flox_instance();
+
+        let environment =
+            new_path_environment_from_env_files(&flox, GENERATED_DATA.join("envs/hello"));
+        let cache_path = environment.cache_path().unwrap();
+        let environment = UninitializedEnvironment::from_concrete_environment(&environment.into());
+
+        let config_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            config_dir.path().join("flox.toml"),
+            "disable_update_checks = true\n",
+        )
+        .unwrap();
+
+        temp_env::async_with_vars(
+            [("FLOX_CONFIG_DIR", Some(config_dir.path().to_str().unwrap()))],
+            async move {
+                CheckForUpgrades {
+                    check_timeout: DEFAULT_TIMEOUT_SECONDS,
+                    environment,
+                }
+                .handle(flox)
+                .await
+                .unwrap();
+            },
+        )
+        .await;
+
+        let upgrade_information = UpgradeInformationGuard::read_in(cache_path).unwrap();
+        assert!(upgrade_information.info().is_none());
     }
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1527,26 +1527,6 @@ fn is_current_dir(environment: &UninitializedEnvironment) -> Result<bool> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cli_update_checks_enabled_by_default() {
-        let config = Config::default();
-
-        assert!(should_check_for_cli_updates(&config));
-    }
-
-    #[test]
-    fn disabled_update_checks_suppress_cli_update_checks() {
-        let mut config = Config::default();
-        config.flox.disable_update_checks = Some(true);
-
-        assert!(!should_check_for_cli_updates(&config));
-    }
-}
-
 /// Render a merged or included `Manifest` to a string for displaying to the user.
 ///
 /// `Environment::manifest_contents` should be used for non-composition
@@ -1580,4 +1560,24 @@ fn render_composition_manifest(manifest: &Manifest<TypedOnly>) -> Result<String>
     toml_edit::visit_mut::visit_document_mut(&mut Visitor::new_for_document(), &mut document);
 
     Ok(document.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_update_checks_enabled_by_default() {
+        let config = Config::default();
+
+        assert!(should_check_for_cli_updates(&config));
+    }
+
+    #[test]
+    fn disabled_update_checks_suppress_cli_update_checks() {
+        let mut config = Config::default();
+        config.flox.disable_update_checks = Some(true);
+
+        assert!(!should_check_for_cli_updates(&config));
+    }
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -211,6 +211,7 @@ impl FloxArgs {
         // `temp_dir` will automatically be removed from disk when the function returns
         let temp_dir = TempDir::new_in(process_dir)?;
 
+        let check_for_cli_updates = should_check_for_cli_updates(&config);
         let update_channel = config.flox.installer_channel.clone();
 
         // Given no command, skip initialization and print welcome message
@@ -221,22 +222,26 @@ impl FloxArgs {
             .unwrap_or_default();
             let active_environments = activated_environments();
             print_welcome_message(envs, active_environments);
-            UpdateNotification::check_for_and_print_update_notification(
-                &config.flox.cache_dir,
-                &update_channel,
-            )
-            .await;
+            if check_for_cli_updates {
+                UpdateNotification::check_for_and_print_update_notification(
+                    &config.flox.cache_dir,
+                    &update_channel,
+                )
+                .await;
+            } else {
+                debug!("Skipping CLI update check because update checks are disabled");
+            }
             return Ok(());
         }
 
         let cache_dir = config.flox.cache_dir.clone();
 
-        let check_for_update_handle = {
+        let check_for_update_handle = check_for_cli_updates.then(|| {
             let update_channel = update_channel.clone();
             tokio::spawn(async move {
                 UpdateNotification::check_for_update(cache_dir, &update_channel).await
             })
-        };
+        });
 
         if !config.flox.disable_metrics {
             debug!("Metrics collection enabled");
@@ -349,11 +354,18 @@ impl FloxArgs {
             // command but before an error is printed for an unsuccessful command.
             // That's a bit weird,
             // but I'm not sure it's worth a refactor.
-            match check_for_update_handle.await {
-                Ok(update_notification) => {
-                    UpdateNotification::handle_update_result(update_notification, &update_channel);
-                },
-                Err(e) => debug!("Failed to check for CLI update: {}", display_chain(&e)),
+            if let Some(check_for_update_handle) = check_for_update_handle {
+                match check_for_update_handle.await {
+                    Ok(update_notification) => {
+                        UpdateNotification::handle_update_result(
+                            update_notification,
+                            &update_channel,
+                        );
+                    },
+                    Err(e) => debug!("Failed to check for CLI update: {}", display_chain(&e)),
+                }
+            } else {
+                debug!("Skipping CLI update check because update checks are disabled");
             }
 
             result
@@ -467,6 +479,10 @@ impl FloxArgs {
             Ok(token) => token,
         }
     }
+}
+
+fn should_check_for_cli_updates(config: &Config) -> bool {
+    !config.flox.disable_update_checks()
 }
 
 /// Print general welcome message with short usage instructions
@@ -1508,6 +1524,26 @@ fn is_current_dir(environment: &UninitializedEnvironment) -> Result<bool> {
             Ok(is_current)
         },
         UninitializedEnvironment::Remote(_) => Ok(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_update_checks_enabled_by_default() {
+        let config = Config::default();
+
+        assert!(should_check_for_cli_updates(&config));
+    }
+
+    #[test]
+    fn disabled_update_checks_suppress_cli_update_checks() {
+        let mut config = Config::default();
+        config.flox.disable_update_checks = Some(true);
+
+        assert!(!should_check_for_cli_updates(&config));
     }
 }
 

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -47,6 +47,12 @@ pub struct FloxConfig {
     /// Prefer `Flox.metrics_device_uuid.is_some()` if both are available.
     #[serde(default)]
     pub disable_metrics: bool,
+
+    /// Disable Flox CLI version and environment upgrade checks.
+    ///
+    /// (default: false)
+    pub disable_update_checks: Option<bool>,
+
     /// Directory where flox should store ephemeral data (default:
     /// `$XDG_CACHE_HOME/flox` e.g. `~/.cache/flox`)
     pub cache_dir: PathBuf,
@@ -190,6 +196,13 @@ pub enum AutoActivate {
 pub enum AutoActivationPreference {
     Allow,
     Deny,
+}
+
+impl FloxConfig {
+    /// Whether Flox CLI version and environment upgrade checks are disabled.
+    pub fn disable_update_checks(&self) -> bool {
+        self.disable_update_checks.unwrap_or(false)
+    }
 }
 
 impl Display for InstallerChannel {
@@ -689,6 +702,21 @@ mod tests {
         assert_eq!(config.flox.floxhub_url, Some(floxhub_url.parse().unwrap()));
         assert!(config.flox.disable_metrics);
         assert_eq!(config.flox.search_limit, Some(search_limit));
+    }
+
+    #[test]
+    fn disable_update_checks_env_override_is_parsed() {
+        let user_config_dir = tempfile::tempdir().unwrap();
+
+        fs::write(user_config_dir.path().join(FLOX_CONFIG_FILE), "").unwrap();
+
+        let config = Config::parse_with(&mock_flox_dirs(), user_config_dir.path(), None, [(
+            "FLOX_DISABLE_UPDATE_CHECKS".into(),
+            "true".into(),
+        )])
+        .unwrap();
+
+        assert!(config.flox.disable_update_checks());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add adaptive startup backoff for activation retries
- branch currently also contains the disable-update-checks commits because it is stacked on that branch
- update related config and command documentation already present in the branch diff