### PR TITLE
feat: add skeleton and skill for adding beta subcommands

### DIFF
--- a/.claude/skills/adding-beta-subcommand/SKILL.md
+++ b/.claude/skills/adding-beta-subcommand/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: adding-beta-subcommand
+description: Use when adding a new beta CLI subcommand to flox, which could also be called an experimental or unstable subcommand. This should be used when adding a command to the `beta` crate that respects the `beta` feature flag.
+---
+
+# Adding a new beta subcommand
+
+Beta subcommands are top-level `flox <name>` commands. The
+`Commands::Beta` arm in `cli/flox/src/commands/mod.rs` checks
+`flox.features.beta` once before dispatching, so individual handlers shouldn't
+re-check it.
+
+## When not to use this skill
+
+- Adding a subcommand under an existing top-level command (e.g.
+  `flox build subcommand`). This skill is
+  only for new top-level `flox <name>` commands gated by
+  `features.beta`.
+- Promoting a beta command to stable — that's a separate move out of
+  the `beta` crate.
+
+Two crates are involved, by design:
+
+- **`cli/beta`** — owns the args struct and `handle()` body. Plain
+  bpaf-derived structs; no `command` or `hide` attributes.
+- **`cli/flox/src/commands/beta.rs`** — owns the `BetaCommands` enum where
+  the command name, `hide`, and dispatch live. This is the reviewed
+  surface that enforces beta commands stay hidden from `flox --help`.
+
+## Steps
+
+1. **Create the args + handler** in `cli/beta/src/<snake_name>.rs`.
+   Mirror `cli/beta/src/beta_enabled.rs`:
+   - `#[derive(Bpaf, Clone, Debug)]` struct holding any options/args.
+   - **No `#[bpaf(command(...))]` and no `#[bpaf(hide)]` on the struct.**
+     Those attributes live on the variant in the CLI crate.
+   - `pub async fn handle(self, flox: Flox) -> Result<()>` with
+     `#[instrument(name = "<command-name>", skip_all)]`.
+   - Do **not** check `flox.features.beta` — already gated in the CLI.
+
+2. **Register the module** in `cli/beta/src/lib.rs`:
+   `pub mod <snake_name>;`
+
+3. **Wire up the command** in `cli/flox/src/commands/beta.rs`:
+   - Add a variant to `BetaCommands`. Use `command("<kebab-name>")` and
+     **always** include `hide` on the enum variant
+     `#[bpaf(hide)]` is not sufficient on its own; without per-variant
+     `hide` the subcommand leaks into `flox --help`. (Verify with the
+     check in step 4.)
+
+     ```rust
+     #[bpaf(command("<kebab-name>"), hide)]
+     <CamelName>(#[bpaf(external(<snake_name>::<snake_name>))] <snake_name>::<CamelName>),
+     ```
+
+   - Add a match arm to `BetaCommands::handle`:
+
+     ```rust
+     BetaCommands::<CamelName>(args) => args.handle(flox).await,
+     ```
+
+4. **Verify**, inside a worktree (per the repo `AGENTS.md`) and inside
+   `nix develop` (or wrap each command with `nix develop -c` if not
+   already in the shell — `cargo` and friends are not on bare PATH):
+   - `cargo build -p flox`
+   - `./target/debug/flox <kebab-name>` → exits non-zero with:
+     ```
+     Enable beta features to run this command:
+       flox config --set features.beta true
+     ```
+   - `FLOX_FEATURES_BETA=true ./target/debug/flox <kebab-name>` → runs
+     the handler.
+   - `./target/debug/flox --help` → the new command must **not** appear.
+     If it does, `hide` is missing from the variant.
+
+## Conventions
+
+- Beta commands may freely depend on `flox-rust-sdk`, but when adding beta commands, strive to leave `flox-rust-sdk` code unchanged. Any code in the beta crate doesn't need to be reviewed for stability, but any code changes in other crates will require more thorough review which will make it slower to add the beta command.
+- If we need to share code between `beta` and `flox` crates, we may need to
+  factor it out to avoid a cyclic dependency.
+  Note that this will increase review burden.
+- Don't put beta-only logic in `flox` or `flox-rust-sdk`; keep it in
+  the `beta` crate.
+- Integration tests are not required for beta commands while they
+  remain gated.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "beta"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bpaf",
+ "flox-rust-sdk",
+ "tracing",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1429,7 @@ name = "flox"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "beta",
  "bpaf",
  "chrono",
  "close_fds",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "cli/beta",
     "cli/catalog-api-v1",
     "cli/flox",
     "cli/flox-rust-sdk",
@@ -26,6 +27,7 @@ version = "0.0.0"
 anyhow = "1"
 async-stream = "0.3.6"
 blake3 = "1.8.2"
+beta = { path = "cli/beta" }
 bpaf = { version = "0.9.24", features = ["derive", "autocomplete"] }
 catalog-api-v1 = { path = "cli/catalog-api-v1" }
 flox-catalog = { path = "cli/flox-catalog" }

--- a/cli/beta/Cargo.toml
+++ b/cli/beta/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "beta"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+bpaf.workspace = true
+flox-rust-sdk.workspace = true
+tracing.workspace = true

--- a/cli/beta/src/beta_enabled.rs
+++ b/cli/beta/src/beta_enabled.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+#[derive(Bpaf, Clone, Debug)]
+pub struct BetaEnabled {
+    #[bpaf(long("option"), argument("arg"))]
+    option: Option<String>,
+}
+
+impl BetaEnabled {
+    #[instrument(name = "beta-enabled", skip_all)]
+    pub async fn handle(self, _flox: Flox) -> Result<()> {
+        println!("Beta features are enabled.");
+        if let Some(option) = self.option {
+            println!("'beta-enabled' was called with option '{}'", option);
+        }
+        Ok(())
+    }
+}

--- a/cli/beta/src/lib.rs
+++ b/cli/beta/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod beta_enabled;

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -96,6 +96,8 @@ pub struct Features {
     #[serde(default)]
     pub qa: bool,
     #[serde(default)]
+    pub beta: bool,
+    #[serde(default)]
     pub auto_activate: bool,
 }
 

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -8,6 +8,7 @@ ignored = ["sapling-renderdag"]
 
 [dependencies]
 anyhow.workspace = true
+beta.workspace = true
 bpaf.workspace = true
 chrono.workspace = true
 config.workspace = true

--- a/cli/flox/src/commands/beta.rs
+++ b/cli/flox/src/commands/beta.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+use bpaf::Parser;
+use flox_rust_sdk::flox::Flox;
+
+#[derive(Bpaf, Clone)]
+#[bpaf(hide)]
+pub enum BetaCommands {}
+
+pub fn beta_commands() -> impl Parser<BetaCommands> {
+    bpaf::fail::<BetaCommands>("no beta subcommands available")
+}
+
+impl BetaCommands {
+    pub async fn handle(self, _flox: Flox) -> Result<()> {
+        match self {}
+    }
+}

--- a/cli/flox/src/commands/beta.rs
+++ b/cli/flox/src/commands/beta.rs
@@ -1,17 +1,19 @@
 use anyhow::Result;
-use bpaf::Parser;
+use beta::beta_enabled;
+use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 
 #[derive(Bpaf, Clone)]
 #[bpaf(hide)]
-pub enum BetaCommands {}
-
-pub fn beta_commands() -> impl Parser<BetaCommands> {
-    bpaf::fail::<BetaCommands>("no beta subcommands available")
+pub enum BetaCommands {
+    #[bpaf(command("beta-enabled"), hide)]
+    BetaEnabled(#[bpaf(external(beta_enabled::beta_enabled))] beta_enabled::BetaEnabled),
 }
 
 impl BetaCommands {
-    pub async fn handle(self, _flox: Flox) -> Result<()> {
-        match self {}
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        match self {
+            BetaCommands::BetaEnabled(args) => args.handle(flox).await,
+        }
     }
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1,6 +1,7 @@
 mod activate;
 mod activation_state;
 mod auth;
+mod beta;
 mod build;
 mod check_for_upgrades;
 mod containerize;
@@ -366,6 +367,14 @@ impl FloxArgs {
                 Commands::Share(args) => args.handle(config, flox).await,
                 Commands::Admin(args) => args.handle(config, flox).await,
                 Commands::Internal(args) => args.handle(flox).await,
+                Commands::Beta(args) => {
+                    if !flox.features.beta {
+                        bail!(indoc! {"
+                        Enable beta features to run this command:
+                          flox config --set features.beta true"});
+                    }
+                    args.handle(flox).await
+                },
             };
 
             // This will print the update notification after output from a successful
@@ -469,6 +478,8 @@ enum Commands {
     Admin(#[bpaf(external(admin_commands))] AdminCommands),
 
     Internal(#[bpaf(external(internal_commands))] InternalCommands),
+
+    Beta(#[bpaf(external(beta::beta_commands))] beta::BetaCommands),
 }
 
 #[derive(Debug, Bpaf, Clone)]


### PR DESCRIPTION
- **feat: add beta feature flag and crate for gated subcommands**
  Adds a `beta` feature flag that we can use in the future to gate all beta
  features or subcommands.
  
  - Adds a new beta crate for adding beta code that we won't need to review
    in depth. A downside of this approach is that we won't be able to use
    code in the CLI crate in the beta crate. We can factor it out in the
    future if we need to. I think that overhead is probably worth forcing
    ourselves to think about the cross-crate API and the better isolation
  - Adds CLI boilerplate to dispatch to the beta crate, gating it all
    behind a check of the feature flag. Future command boilerplate
    additions will need minimal review
  - Add a skill for adding beta subcommands
  

- **feat: add `flox beta-enabled` test beta subcommand**
  Adds a beta subcommand `beta-enabled` that prints if beta features are enabled. This will provide a pattern for future commands to follow
  