### PR TITLE
CI: community PR #4205 (Remove codecov action)

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -29,3 +29,4 @@ yes,mrswastik-robot,Swastik Patel,<swastikpatel29@gmail.com>
 yes,noor-latif,Noor Latif,<noor@latif.se>
 yes,martijnarts,Martijn Arts,<martijn@martijnarts.com>
 yes,electricalen,David Sawyer,<electricalen@gmail.com>
+yes,jsoref,Josh Soref,<jsoref@gmail.com>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,15 +183,6 @@ jobs:
           RUST_BACKTRACE: 1
         run: nix develop -L --no-update-lock-file --command just impure-tests
 
-      - name: "Upload CLI Unit Test Results"
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
-        if: ${{ !cancelled() && steps.unit-tests.outcome != 'skipped' }}
-        with:
-          disable_search: true
-          files: "./target/nextest/ci/junit.xml"
-          flags: "dev-unittests, ${{ matrix.test-tags }}, ${{ matrix.os }}"
-          verbose: true
-          use_oidc: true
       - name: "Check schemas are up to date"
         run: |
           nix develop -L --no-update-lock-file --command just gen-schemas
@@ -512,13 +503,3 @@ jobs:
           MATRIX_SYSTEM: ${{ matrix.system }}
           MATRIX_TEST_TAGS: ${{ matrix.test-tags }}
         run: ./.github/scripts/remote-execute-integration-tests.sh
-
-      - name: "Upload Bats Tests results"
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
-        if: ${{ !cancelled() }}
-        with:
-          disable_search: true
-          files: "./report.xml"
-          flags: "nix-integration-tests, ${{ matrix.test-tags }}, ${{ matrix.system }}"
-          verbose: true
-          use_oidc: true


### PR DESCRIPTION
Triggers CI for #4205 (commit 04eb931f4eb50ddef4f36f17c04f775eeb764b12).

External contributor PR from @jsoref. CLA accepted in-PR. Diff reviewed: removes two codecov/test-results-action upload steps from .github/workflows/ci.yml — no malicious CI content.

Will auto-close when #4205 merges with the same commit.

---
*Via Forge (interactive) • 8587f7bb*