### PR TITLE
feat(activations): capture invocation type in state.json (DEV-78)

### DIFF
--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -137,7 +137,12 @@ impl ActivateArgs {
         let mut last_warning: Option<Instant> = None;
 
         loop {
-            match self.try_start_or_attach(context, subsystem_verbosity, vars_from_env)? {
+            match self.try_start_or_attach(
+                context,
+                invocation_type,
+                subsystem_verbosity,
+                vars_from_env,
+            )? {
                 StartOrAttachResult::Start { start_id, .. } => {
                     if *invocation_type == InvocationType::Interactive {
                         updated(
@@ -189,6 +194,7 @@ impl ActivateArgs {
     fn try_start_or_attach(
         &self,
         context: &ActivateCtx,
+        invocation_type: &InvocationType,
         subsystem_verbosity: u32,
         vars_from_env: &VarsFromEnvironment,
     ) -> Result<StartOrAttachResult, anyhow::Error> {
@@ -232,7 +238,11 @@ impl ActivateArgs {
         }
 
         let pid = std::process::id() as i32;
-        match activations.start_or_attach(pid, &context.flox_activate_store_path) {
+        match activations.start_or_attach(
+            pid,
+            &context.flox_activate_store_path,
+            invocation_type.clone(),
+        ) {
             StartOrAttachResult::Start { start_id } => start(
                 context,
                 subsystem_verbosity,

--- a/cli/flox-activations/src/cli/attach.rs
+++ b/cli/flox-activations/src/cli/attach.rs
@@ -99,6 +99,7 @@ mod test {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
+    use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::*;
     use flox_core::activations::{ActivationState, StartOrAttachResult, activation_state_dir_path};
@@ -120,7 +121,7 @@ mod test {
         // Create an activation with a PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid, &store_path);
+        let result = state.start_or_attach(pid, &store_path, InvocationType::Interactive);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -166,7 +167,7 @@ mod test {
         // Create an activation with the old PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(old_pid, &store_path);
+        let result = state.start_or_attach(old_pid, &store_path, InvocationType::Interactive);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -466,6 +466,7 @@ fn cleanup_all(
 mod test {
     use std::collections::BTreeMap;
 
+    use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::{read_activation_state, write_activation_state};
     use flox_core::activations::{ActivationState, StartOrAttachResult, activation_state_dir_path};
@@ -514,7 +515,7 @@ mod test {
         // Create an ActivationState with one PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid, &store_path);
+        let result = state.start_or_attach(pid, &store_path, InvocationType::Interactive);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -570,7 +571,7 @@ mod test {
         // Create an ActivationState with one PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid, &store_path);
+        let result = state.start_or_attach(pid, &store_path, InvocationType::Interactive);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -642,7 +643,7 @@ mod test {
         // Create an ActivationState with pid1 attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid1, &store_path);
+        let result = state.start_or_attach(pid1, &store_path, InvocationType::Interactive);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -741,7 +742,7 @@ mod test {
         // Create state with this PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid, &store_path);
+        let result = state.start_or_attach(pid, &store_path, InvocationType::Interactive);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -77,6 +77,7 @@ pub mod test {
     use std::process::{Child, Command};
     use std::time::Duration;
 
+    use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::write_activation_state;
     use flox_core::activations::{StartOrAttachResult, activation_state_dir_path, state_json_path};
@@ -153,12 +154,12 @@ pub mod test {
         // Create an ActivationState with two PIDs attached to the same start_id
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid1, &store_path);
+        let result = state.start_or_attach(pid1, &store_path, InvocationType::Interactive);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
         state.set_ready(&start_id);
-        let result = state.start_or_attach(pid2, &store_path);
+        let result = state.start_or_attach(pid2, &store_path, InvocationType::Interactive);
         assert!(matches!(result, StartOrAttachResult::Attach { .. }));
 
         write_activation_state(runtime_dir.path(), &dot_flox_path, state);
@@ -200,7 +201,7 @@ pub mod test {
         // Start and set ready for store_path_1
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid1, &store_path_1);
+        let result = state.start_or_attach(pid1, &store_path_1, InvocationType::Interactive);
         let StartOrAttachResult::Start {
             start_id: start_id_1,
             ..
@@ -211,7 +212,7 @@ pub mod test {
         state.set_ready(&start_id_1);
 
         // Start and set ready for store_path_2
-        let result = state.start_or_attach(pid2, &store_path_2);
+        let result = state.start_or_attach(pid2, &store_path_2, InvocationType::Interactive);
         let StartOrAttachResult::Start {
             start_id: start_id_2,
             ..

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -132,7 +132,7 @@ pub enum AutoActivateFishMode {
     DisableArrow,
 }
 
-#[derive(Clone, Debug, Deserialize, derive_more::Display, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, derive_more::Display, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InvocationType {
     #[display("inplace")]

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -1462,7 +1462,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn replace_attachment_preserves_invocation_type_on_timeout() {
+        fn replace_attachment_preserves_invocation_type_with_expiration() {
             let start_id = StartIdentifier::new("/nix/store/path1");
             let mut activations = make_activations(Ready::True(start_id.clone()));
             let pid = 123;

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -11,6 +11,7 @@ use serde_json::{Value, json};
 use time::OffsetDateTime;
 use tracing::{debug, trace};
 
+use crate::activate::context::InvocationType;
 use crate::activate::mode::ActivateMode;
 use crate::proc_status::pid_is_running;
 use crate::{Version, path_hash};
@@ -331,6 +332,7 @@ impl StartIdentifier {
 pub struct Attachment {
     start_id: StartIdentifier,
     expiration: Option<OffsetDateTime>,
+    invocation_type: InvocationType,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -356,7 +358,7 @@ struct EnvironmentInfo {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ActivationState {
-    version: Version<3>,
+    version: Version<4>,
     info: EnvironmentInfo,
     mode: ActivateMode,
     ready: Ready,
@@ -406,6 +408,7 @@ impl ActivationState {
                 let Attachment {
                     expiration,
                     start_id,
+                    invocation_type: _,
                 } = attachment;
                 acc.entry(start_id.clone())
                     .or_default()
@@ -442,6 +445,7 @@ impl ActivationState {
         &mut self,
         pid: Pid,
         store_path: impl AsRef<Path>,
+        invocation_type: InvocationType,
     ) -> StartOrAttachResult {
         if let Ready::Starting(starting_pid, ref start_id) = self.ready
             && pid_is_running(starting_pid)
@@ -458,11 +462,12 @@ impl ActivationState {
                 self.attach(pid, Attachment {
                     start_id: start_id.clone(),
                     expiration: None,
+                    invocation_type,
                 });
                 StartOrAttachResult::Attach { start_id }
             },
             Ready::False | Ready::True(_) | Ready::Starting(_, _) => {
-                let start_id = self.start(pid, &store_path);
+                let start_id = self.start(pid, &store_path, invocation_type);
                 StartOrAttachResult::Start { start_id }
             },
         }
@@ -568,11 +573,17 @@ impl ActivationState {
         }
     }
 
-    fn start(&mut self, pid: Pid, store_path: impl AsRef<Path>) -> StartIdentifier {
+    fn start(
+        &mut self,
+        pid: Pid,
+        store_path: impl AsRef<Path>,
+        invocation_type: InvocationType,
+    ) -> StartIdentifier {
         let start_id = StartIdentifier::new(store_path);
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: None,
+            invocation_type,
         };
 
         debug!(pid, ?start_id, "starting new activation");
@@ -677,6 +688,7 @@ impl ActivationState {
         let new_attachment = Attachment {
             start_id,
             expiration,
+            invocation_type: old_attachment.invocation_type,
         };
 
         self.attached_pids.insert(new_pid, new_attachment);
@@ -719,12 +731,14 @@ fn parse_versioned_activation_state(content: &str) -> Result<Option<ActivationSt
 
     match version_check.version.as_u64() {
         // Current version.
-        Some(3) => {
+        Some(4) => {
             let state: ActivationState =
                 serde_json::from_str(content).context("Failed to parse state.json")?;
             Ok(Some(state))
         },
         // Versions 1 and 2 were stored in a different path so we don't need to handle migrations.
+        // Version 3 shares the current path but is no longer supported; mismatched files are
+        // either errored (running PIDs/executive) or discarded.
         // This also handles the case where someone upgrades and then downgrades Flox.
         _ => {
             let running = extract_running_pids_from_json(content)?;
@@ -878,6 +892,7 @@ mod tests {
         Attachment {
             start_id,
             expiration: None,
+            invocation_type: InvocationType::Interactive,
         }
     }
 
@@ -944,7 +959,11 @@ mod tests {
             let store_path = PathBuf::from("/nix/store/test");
 
             // Start activation with first PID
-            let result = activations.start_or_attach(proc_running.id() as i32, &store_path);
+            let result = activations.start_or_attach(
+                proc_running.id() as i32,
+                &store_path,
+                InvocationType::Interactive,
+            );
             let start_id = match result {
                 StartOrAttachResult::Start { start_id, .. } => start_id,
                 _ => panic!("Expected Start"),
@@ -954,7 +973,11 @@ mod tests {
             activations.set_ready(&start_id);
 
             // Attach second PID
-            activations.start_or_attach(proc_stopped.id() as i32, &store_path);
+            activations.start_or_attach(
+                proc_stopped.id() as i32,
+                &store_path,
+                InvocationType::Interactive,
+            );
 
             stop_process(proc_stopped);
 
@@ -975,7 +998,8 @@ mod tests {
             let store_path2 = PathBuf::from("/nix/store/path2");
 
             // Start activation with first store path
-            let result = activations.start_or_attach(100, &store_path1);
+            let result =
+                activations.start_or_attach(100, &store_path1, InvocationType::Interactive);
             let start_id1 = match result {
                 StartOrAttachResult::Start { start_id, .. } => start_id,
                 _ => panic!("Expected Start"),
@@ -985,10 +1009,11 @@ mod tests {
             activations.set_ready(&start_id1);
 
             // Attach second PID to same start_id
-            activations.start_or_attach(200, &store_path1);
+            activations.start_or_attach(200, &store_path1, InvocationType::Interactive);
 
             // Start activation with second store path (creates new start_id)
-            let result = activations.start_or_attach(300, &store_path2);
+            let result =
+                activations.start_or_attach(300, &store_path2, InvocationType::Interactive);
             let start_id2 = match result {
                 StartOrAttachResult::Start { start_id, .. } => start_id,
                 _ => panic!("Expected Start"),
@@ -1015,7 +1040,7 @@ mod tests {
             let mut activations = make_activations(Ready::False);
 
             let pid = 123;
-            let result = activations.start_or_attach(pid, &store_path);
+            let result = activations.start_or_attach(pid, &store_path, InvocationType::Interactive);
 
             let start_id = match result {
                 StartOrAttachResult::Start { start_id } => start_id,
@@ -1041,7 +1066,8 @@ mod tests {
             let mut activations = make_activations(Ready::True(start_id.clone()));
 
             let pid = 123;
-            let result = activations.start_or_attach(pid, &start_id.store_path);
+            let result =
+                activations.start_or_attach(pid, &start_id.store_path, InvocationType::Interactive);
 
             match result {
                 StartOrAttachResult::Attach { start_id: id } => {
@@ -1064,7 +1090,7 @@ mod tests {
             let mut activations = make_activations(Ready::True(existing));
 
             let pid = 123;
-            let result = activations.start_or_attach(pid, &new_path);
+            let result = activations.start_or_attach(pid, &new_path, InvocationType::Interactive);
 
             let start_id = match result {
                 StartOrAttachResult::Start { start_id } => start_id,
@@ -1091,7 +1117,8 @@ mod tests {
             let start_id = StartIdentifier::new("/nix/store/path1");
             let mut activations = make_activations(Ready::Starting(pid, start_id.clone()));
 
-            let result = activations.start_or_attach(123, &start_id.store_path);
+            let result =
+                activations.start_or_attach(123, &start_id.store_path, InvocationType::Interactive);
 
             match result {
                 StartOrAttachResult::AlreadyStarting {
@@ -1124,7 +1151,11 @@ mod tests {
                 make_activations(Ready::Starting(stopped_pid, old_start_id.clone()));
 
             let pid = 123;
-            let result = activations.start_or_attach(pid, &old_start_id.store_path);
+            let result = activations.start_or_attach(
+                pid,
+                &old_start_id.store_path,
+                InvocationType::Interactive,
+            );
 
             let new_start_id = match result {
                 StartOrAttachResult::Start { start_id } => start_id,
@@ -1150,7 +1181,11 @@ mod tests {
             let mut activations = make_activations(Ready::True(start_id.clone()));
 
             for pid in [100, 200, 300].iter() {
-                let result = activations.start_or_attach(*pid, &start_id.store_path);
+                let result = activations.start_or_attach(
+                    *pid,
+                    &start_id.store_path,
+                    InvocationType::Interactive,
+                );
                 match result {
                     StartOrAttachResult::Attach { start_id: id } => {
                         assert_eq!(id, start_id);
@@ -1179,7 +1214,7 @@ mod tests {
             let store_path = PathBuf::from("/nix/store/path1");
 
             let pid = 123;
-            let result = activations.start_or_attach(pid, &store_path);
+            let result = activations.start_or_attach(pid, &store_path, InvocationType::Interactive);
             let start_id = match result {
                 StartOrAttachResult::Start { start_id, .. } => start_id,
                 _ => panic!("Expected Start"),
@@ -1192,7 +1227,8 @@ mod tests {
             activations.set_ready(&start_id);
 
             // Attach same PID again - should replace existing attachment
-            let result = activations.start_or_attach(pid, &start_id.store_path);
+            let result =
+                activations.start_or_attach(pid, &start_id.store_path, InvocationType::Interactive);
 
             match result {
                 StartOrAttachResult::Attach { start_id: id } => {
@@ -1221,6 +1257,7 @@ mod tests {
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: Some(expiration),
+            invocation_type: InvocationType::Interactive,
         };
         activations.attach(pid, attachment);
 
@@ -1243,6 +1280,7 @@ mod tests {
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: Some(expiration),
+            invocation_type: InvocationType::Interactive,
         };
         activations.attach(pid, attachment);
 
@@ -1415,6 +1453,204 @@ mod tests {
             assert_eq!(err.to_string(), expected_msg);
 
             stop_process(exec_proc);
+        }
+
+        /// V3 used the same path as V4 but is no longer supported. With running
+        /// PIDs the read errors so the user knows to exit their old shells before
+        /// upgrading.
+        #[test]
+        fn parse_versioned_activation_state_v3_with_running_pids_errors() {
+            let proc = start_process();
+            let pid = proc.id() as i32;
+
+            let json = json!({
+                "version": 3,
+                "mode": "dev",
+                "ready": false,
+                "executive_pid": EXECUTIVE_NOT_STARTED,
+                "attached_pids": {
+                    pid.to_string(): {},
+                },
+            })
+            .to_string();
+
+            let err = parse_versioned_activation_state(&json).unwrap_err();
+            let expected_msg = formatdoc! {"
+                This environment has already been activated with an incompatible version of 'flox'.
+
+                Exit all activations of the environment and try again.
+                PIDs of the running activations: {pid}",
+            };
+            assert_eq!(err.to_string(), expected_msg);
+
+            stop_process(proc);
+        }
+
+        /// V3 state.json with no running PIDs or executive is discarded so the
+        /// upgraded flox can write a fresh V4 state file.
+        #[test]
+        fn parse_versioned_activation_state_v3_no_running_pids_discards() {
+            let proc = start_process();
+            let pid = proc.id();
+            stop_process(proc);
+
+            let json = json!({
+                "version": 3,
+                "mode": "dev",
+                "ready": false,
+                "executive_pid": EXECUTIVE_NOT_STARTED,
+                "attached_pids": {
+                    pid.to_string(): {},
+                },
+            })
+            .to_string();
+
+            let result = parse_versioned_activation_state(&json).unwrap();
+            assert_eq!(result, None, "should discard pre-V4 state");
+        }
+    }
+
+    mod invocation_type {
+        use super::*;
+
+        fn attachment_with(invocation_type: InvocationType) -> Attachment {
+            Attachment {
+                start_id: StartIdentifier::new("/nix/store/path"),
+                expiration: None,
+                invocation_type,
+            }
+        }
+
+        #[test]
+        fn attachment_roundtrips_in_place() {
+            let attachment = attachment_with(InvocationType::InPlace);
+            let json = serde_json::to_string(&attachment).unwrap();
+            let parsed: Attachment = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, attachment);
+        }
+
+        #[test]
+        fn attachment_roundtrips_interactive() {
+            let attachment = attachment_with(InvocationType::Interactive);
+            let json = serde_json::to_string(&attachment).unwrap();
+            let parsed: Attachment = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, attachment);
+        }
+
+        #[test]
+        fn attachment_roundtrips_shell_command() {
+            let attachment = attachment_with(InvocationType::ShellCommand("echo hi".to_string()));
+            let json = serde_json::to_string(&attachment).unwrap();
+            let parsed: Attachment = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, attachment);
+        }
+
+        #[test]
+        fn attachment_roundtrips_exec_command() {
+            let attachment = attachment_with(InvocationType::ExecCommand(vec![
+                "ls".to_string(),
+                "-l".to_string(),
+            ]));
+            let json = serde_json::to_string(&attachment).unwrap();
+            let parsed: Attachment = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, attachment);
+        }
+
+        #[test]
+        fn start_or_attach_records_invocation_type_on_start() {
+            let store_path = PathBuf::from("/nix/store/path1");
+            let mut activations = make_activations(Ready::False);
+
+            let pid = 123;
+            let result = activations.start_or_attach(
+                pid,
+                &store_path,
+                InvocationType::ShellCommand("echo hi".to_string()),
+            );
+            let start_id = match result {
+                StartOrAttachResult::Start { start_id } => start_id,
+                _ => panic!("Expected Start, got {:?}", result),
+            };
+
+            let expected = Attachment {
+                start_id,
+                expiration: None,
+                invocation_type: InvocationType::ShellCommand("echo hi".to_string()),
+            };
+            assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
+        }
+
+        #[test]
+        fn start_or_attach_records_invocation_type_on_attach() {
+            let start_id = StartIdentifier::new("/nix/store/path1");
+            let mut activations = make_activations(Ready::True(start_id.clone()));
+
+            let pid = 123;
+            let result =
+                activations.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
+            match result {
+                StartOrAttachResult::Attach { start_id: id } => assert_eq!(id, start_id),
+                _ => panic!("Expected Attach, got {:?}", result),
+            }
+
+            let expected = Attachment {
+                start_id,
+                expiration: None,
+                invocation_type: InvocationType::InPlace,
+            };
+            assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
+        }
+
+        #[test]
+        fn replace_attachment_preserves_invocation_type_on_timeout() {
+            let start_id = StartIdentifier::new("/nix/store/path1");
+            let mut activations = make_activations(Ready::True(start_id.clone()));
+            let pid = 123;
+            activations.attach(pid, Attachment {
+                start_id: start_id.clone(),
+                expiration: None,
+                invocation_type: InvocationType::ExecCommand(vec!["ls".to_string()]),
+            });
+
+            let now = OffsetDateTime::now_utc();
+            let expiration = now + Duration::from_secs(60);
+            activations
+                .replace_attachment(start_id.clone(), pid, pid, Some(expiration))
+                .unwrap();
+
+            let expected = Attachment {
+                start_id,
+                expiration: Some(expiration),
+                invocation_type: InvocationType::ExecCommand(vec!["ls".to_string()]),
+            };
+            assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
+        }
+
+        #[test]
+        fn replace_attachment_preserves_invocation_type_on_pid_swap() {
+            let start_id = StartIdentifier::new("/nix/store/path1");
+            let mut activations = make_activations(Ready::True(start_id.clone()));
+            let old_pid = 123;
+            let new_pid = 456;
+            activations.attach(old_pid, Attachment {
+                start_id: start_id.clone(),
+                expiration: None,
+                invocation_type: InvocationType::InPlace,
+            });
+
+            activations
+                .replace_attachment(start_id.clone(), old_pid, new_pid, None)
+                .unwrap();
+
+            let expected = Attachment {
+                start_id,
+                expiration: None,
+                invocation_type: InvocationType::InPlace,
+            };
+            assert_eq!(
+                activations.attached_pids,
+                BTreeMap::from([(new_pid, expected)])
+            );
         }
     }
 }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -332,7 +332,11 @@ impl StartIdentifier {
 pub struct Attachment {
     start_id: StartIdentifier,
     expiration: Option<OffsetDateTime>,
-    invocation_type: InvocationType,
+    // Optional until the V4 schema bump ships alongside the consumer
+    // (DEV-82); a missing field deserializes to `None` so old state.json
+    // files written before this field existed round-trip cleanly.
+    #[serde(default)]
+    invocation_type: Option<InvocationType>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -358,7 +362,7 @@ struct EnvironmentInfo {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ActivationState {
-    version: Version<4>,
+    version: Version<3>,
     info: EnvironmentInfo,
     mode: ActivateMode,
     ready: Ready,
@@ -462,7 +466,7 @@ impl ActivationState {
                 self.attach(pid, Attachment {
                     start_id: start_id.clone(),
                     expiration: None,
-                    invocation_type,
+                    invocation_type: Some(invocation_type),
                 });
                 StartOrAttachResult::Attach { start_id }
             },
@@ -583,7 +587,7 @@ impl ActivationState {
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: None,
-            invocation_type,
+            invocation_type: Some(invocation_type),
         };
 
         debug!(pid, ?start_id, "starting new activation");
@@ -731,14 +735,12 @@ fn parse_versioned_activation_state(content: &str) -> Result<Option<ActivationSt
 
     match version_check.version.as_u64() {
         // Current version.
-        Some(4) => {
+        Some(3) => {
             let state: ActivationState =
                 serde_json::from_str(content).context("Failed to parse state.json")?;
             Ok(Some(state))
         },
         // Versions 1 and 2 were stored in a different path so we don't need to handle migrations.
-        // Version 3 shares the current path but is no longer supported; mismatched files are
-        // either errored (running PIDs/executive) or discarded.
         // This also handles the case where someone upgrades and then downgrades Flox.
         _ => {
             let running = extract_running_pids_from_json(content)?;
@@ -892,7 +894,7 @@ mod tests {
         Attachment {
             start_id,
             expiration: None,
-            invocation_type: InvocationType::Interactive,
+            invocation_type: Some(InvocationType::Interactive),
         }
     }
 
@@ -1257,7 +1259,7 @@ mod tests {
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: Some(expiration),
-            invocation_type: InvocationType::Interactive,
+            invocation_type: Some(InvocationType::Interactive),
         };
         activations.attach(pid, attachment);
 
@@ -1280,7 +1282,7 @@ mod tests {
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: Some(expiration),
-            invocation_type: InvocationType::Interactive,
+            invocation_type: Some(InvocationType::Interactive),
         };
         activations.attach(pid, attachment);
 
@@ -1336,10 +1338,10 @@ mod tests {
     mod version_handling {
         use super::*;
 
-        // V3 is the previous schema and shares the current state.json
-        // path. Earlier versions used a different path so aren't
-        // reachable through `parse_versioned_activation_state`.
-        const OLD_VERSION: Version<3> = Version;
+        // Technically we'd never encounter this exact Version because we
+        // changed the path of the state file during the 2025-12/2026-01
+        // activation rewrite.
+        const OLD_VERSION: Version<2> = Version;
 
         #[test]
         fn parse_versioned_activation_state_roundtrip() {
@@ -1478,7 +1480,7 @@ mod tests {
             let expected = Attachment {
                 start_id,
                 expiration: None,
-                invocation_type: InvocationType::ShellCommand("echo hi".to_string()),
+                invocation_type: Some(InvocationType::ShellCommand("echo hi".to_string())),
             };
             assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
         }
@@ -1499,7 +1501,7 @@ mod tests {
             let expected = Attachment {
                 start_id,
                 expiration: None,
-                invocation_type: InvocationType::InPlace,
+                invocation_type: Some(InvocationType::InPlace),
             };
             assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
         }
@@ -1512,7 +1514,7 @@ mod tests {
             activations.attach(pid, Attachment {
                 start_id: start_id.clone(),
                 expiration: None,
-                invocation_type: InvocationType::ExecCommand(vec!["ls".to_string()]),
+                invocation_type: Some(InvocationType::ExecCommand(vec!["ls".to_string()])),
             });
 
             let now = OffsetDateTime::now_utc();
@@ -1524,7 +1526,7 @@ mod tests {
             let expected = Attachment {
                 start_id,
                 expiration: Some(expiration),
-                invocation_type: InvocationType::ExecCommand(vec!["ls".to_string()]),
+                invocation_type: Some(InvocationType::ExecCommand(vec!["ls".to_string()])),
             };
             assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
         }
@@ -1538,7 +1540,7 @@ mod tests {
             activations.attach(old_pid, Attachment {
                 start_id: start_id.clone(),
                 expiration: None,
-                invocation_type: InvocationType::InPlace,
+                invocation_type: Some(InvocationType::InPlace),
             });
 
             activations
@@ -1548,12 +1550,31 @@ mod tests {
             let expected = Attachment {
                 start_id,
                 expiration: None,
-                invocation_type: InvocationType::InPlace,
+                invocation_type: Some(InvocationType::InPlace),
             };
             assert_eq!(
                 activations.attached_pids,
                 BTreeMap::from([(new_pid, expected)])
             );
+        }
+
+        /// Forward-compat with V3 state.json written by older flox binaries
+        /// (pre-DEV-78) that did not include `invocation_type` on attachments.
+        /// Delete this test when the V4 schema bump lands and the field becomes
+        /// required.
+        #[test]
+        fn deserialize_attachment_without_invocation_type_yields_none() {
+            let json = json!({
+                "start_id": {
+                    "store_path": "/nix/store/path1",
+                    "timestamp": 0,
+                },
+                "expiration": null,
+            })
+            .to_string();
+
+            let attachment: Attachment = serde_json::from_str(&json).unwrap();
+            assert_eq!(attachment.invocation_type, None);
         }
     }
 }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -1336,10 +1336,10 @@ mod tests {
     mod version_handling {
         use super::*;
 
-        // Technically we'd never encounter this exact Version because we
-        // changed the path of the state file during the 2025-12/2026-01
-        // activation rewrite.
-        const OLD_VERSION: Version<2> = Version;
+        // V3 is the previous schema and shares the current state.json
+        // path. Earlier versions used a different path so aren't
+        // reachable through `parse_versioned_activation_state`.
+        const OLD_VERSION: Version<3> = Version;
 
         #[test]
         fn parse_versioned_activation_state_roundtrip() {
@@ -1454,107 +1454,10 @@ mod tests {
 
             stop_process(exec_proc);
         }
-
-        /// V3 used the same path as V4 but is no longer supported. With running
-        /// PIDs the read errors so the user knows to exit their old shells before
-        /// upgrading.
-        #[test]
-        fn parse_versioned_activation_state_v3_with_running_pids_errors() {
-            let proc = start_process();
-            let pid = proc.id() as i32;
-
-            let json = json!({
-                "version": 3,
-                "mode": "dev",
-                "ready": false,
-                "executive_pid": EXECUTIVE_NOT_STARTED,
-                "attached_pids": {
-                    pid.to_string(): {},
-                },
-            })
-            .to_string();
-
-            let err = parse_versioned_activation_state(&json).unwrap_err();
-            let expected_msg = formatdoc! {"
-                This environment has already been activated with an incompatible version of 'flox'.
-
-                Exit all activations of the environment and try again.
-                PIDs of the running activations: {pid}",
-            };
-            assert_eq!(err.to_string(), expected_msg);
-
-            stop_process(proc);
-        }
-
-        /// V3 state.json with no running PIDs or executive is discarded so the
-        /// upgraded flox can write a fresh V4 state file.
-        #[test]
-        fn parse_versioned_activation_state_v3_no_running_pids_discards() {
-            let proc = start_process();
-            let pid = proc.id();
-            stop_process(proc);
-
-            let json = json!({
-                "version": 3,
-                "mode": "dev",
-                "ready": false,
-                "executive_pid": EXECUTIVE_NOT_STARTED,
-                "attached_pids": {
-                    pid.to_string(): {},
-                },
-            })
-            .to_string();
-
-            let result = parse_versioned_activation_state(&json).unwrap();
-            assert_eq!(result, None, "should discard pre-V4 state");
-        }
     }
 
     mod invocation_type {
         use super::*;
-
-        fn attachment_with(invocation_type: InvocationType) -> Attachment {
-            Attachment {
-                start_id: StartIdentifier::new("/nix/store/path"),
-                expiration: None,
-                invocation_type,
-            }
-        }
-
-        #[test]
-        fn attachment_roundtrips_in_place() {
-            let attachment = attachment_with(InvocationType::InPlace);
-            let json = serde_json::to_string(&attachment).unwrap();
-            let parsed: Attachment = serde_json::from_str(&json).unwrap();
-            assert_eq!(parsed, attachment);
-        }
-
-        #[test]
-        fn attachment_roundtrips_interactive() {
-            let attachment = attachment_with(InvocationType::Interactive);
-            let json = serde_json::to_string(&attachment).unwrap();
-            let parsed: Attachment = serde_json::from_str(&json).unwrap();
-            assert_eq!(parsed, attachment);
-        }
-
-        #[test]
-        fn attachment_roundtrips_shell_command() {
-            let attachment = attachment_with(InvocationType::ShellCommand("echo hi".to_string()));
-            let json = serde_json::to_string(&attachment).unwrap();
-            let parsed: Attachment = serde_json::from_str(&json).unwrap();
-            assert_eq!(parsed, attachment);
-        }
-
-        #[test]
-        fn attachment_roundtrips_exec_command() {
-            let attachment = attachment_with(InvocationType::ExecCommand(vec![
-                "ls".to_string(),
-                "-l".to_string(),
-            ]));
-            let json = serde_json::to_string(&attachment).unwrap();
-            let parsed: Attachment = serde_json::from_str(&json).unwrap();
-            assert_eq!(parsed, attachment);
-        }
 
         #[test]
         fn start_or_attach_records_invocation_type_on_start() {

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -1462,51 +1462,6 @@ mod tests {
         use super::*;
 
         #[test]
-        fn start_or_attach_records_invocation_type_on_start() {
-            let store_path = PathBuf::from("/nix/store/path1");
-            let mut activations = make_activations(Ready::False);
-
-            let pid = 123;
-            let result = activations.start_or_attach(
-                pid,
-                &store_path,
-                InvocationType::ShellCommand("echo hi".to_string()),
-            );
-            let start_id = match result {
-                StartOrAttachResult::Start { start_id } => start_id,
-                _ => panic!("Expected Start, got {:?}", result),
-            };
-
-            let expected = Attachment {
-                start_id,
-                expiration: None,
-                invocation_type: Some(InvocationType::ShellCommand("echo hi".to_string())),
-            };
-            assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
-        }
-
-        #[test]
-        fn start_or_attach_records_invocation_type_on_attach() {
-            let start_id = StartIdentifier::new("/nix/store/path1");
-            let mut activations = make_activations(Ready::True(start_id.clone()));
-
-            let pid = 123;
-            let result =
-                activations.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
-            match result {
-                StartOrAttachResult::Attach { start_id: id } => assert_eq!(id, start_id),
-                _ => panic!("Expected Attach, got {:?}", result),
-            }
-
-            let expected = Attachment {
-                start_id,
-                expiration: None,
-                invocation_type: Some(InvocationType::InPlace),
-            };
-            assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
-        }
-
-        #[test]
         fn replace_attachment_preserves_invocation_type_on_timeout() {
             let start_id = StartIdentifier::new("/nix/store/path1");
             let mut activations = make_activations(Ready::True(start_id.clone()));

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4026,7 +4026,12 @@ attach_previous_release() {
   shell="${1?}"
   mode="${2?}"
 
-  incrementing_version_this_release="false"
+  # Set to "true" in the PR that bumps `activations.json` schema version, so
+  # the previous-release tests assert the incompatible-version error. Flip
+  # back to "false" once `FLOX_LATEST_VERSION` is a release that writes the
+  # bumped version (both prev and current then share a schema, so attach
+  # should succeed again).
+  incrementing_version_this_release="true"
 
   echo "$HOOK_ONLY_ONCE" | "$FLOX_BIN" edit -f -
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4026,12 +4026,7 @@ attach_previous_release() {
   shell="${1?}"
   mode="${2?}"
 
-  # Set to "true" in the PR that bumps `activations.json` schema version, so
-  # the previous-release tests assert the incompatible-version error. Flip
-  # back to "false" once `FLOX_LATEST_VERSION` is a release that writes the
-  # bumped version (both prev and current then share a schema, so attach
-  # should succeed again).
-  incrementing_version_this_release="true"
+  incrementing_version_this_release="false"
 
   echo "$HOOK_ONLY_ONCE" | "$FLOX_BIN" edit -f -
 


### PR DESCRIPTION
## Summary

- Adds `invocation_type: Option<InvocationType>` to `Attachment` so each attached PID's invocation kind (`Interactive`, `InPlace`, `ShellCommand`, `ExecCommand`) is recorded in `state.json` when present.
- Threads `invocation_type` through `ActivationState::start_or_attach` / `start` and preserves it across `replace_attachment` (no new `--invocation-type` arg on the `flox-activations attach` subcommand; the value is established once at activate time and carried forward).
- **Keeps schema at `Version<3>`.** The V4 bump is deferred to the DEV-82 PR that ships the consumer side, so users only see the "restart your activations" disruption once, paired with the actual feature.

Linear: [DEV-78](https://linear.app/floxdotdev/issue/DEV-78/capture-invocation-type-in-statejson)
Blocks: DEV-82

## Why the V4 bump is deferred

Bumping V3 → V4 in this PR alone would force every user to restart their activations on upgrade — for a field they can't yet use. The consumer (DEV-82, gated by `flox.features.auto_activate`) is not shipping in the same release. Per [Matthew's review feedback](https://github.com/flox/flox/pull/4248#discussion_r3251352952), deferring the bump means users see "here's a new feature, please restart your activations" rather than "please restart your activations now, the feature comes later."

The field is wrapped in `Option<InvocationType>` with `#[serde(default)]`. Both directions are safe:
- Older flox reading new `state.json`: serde drops the unknown key (no `#[serde(deny_unknown_fields)]` on `Attachment`).
- New flox reading older `state.json`: missing field deserializes as `None`.

New attachments created by this branch get `Some(invocation_type)`; `replace_attachment` preserves whatever value is there (`None` stays `None`). One new test, `deserialize_attachment_without_invocation_type_yields_none`, locks in the forward-compat contract for the duration of the deferral.

## Out of scope (handled in DEV-82)

- Consumer that reads `invocation_type` during `flox deactivate`.
- Replacing the `_FLOX_HOOK_DIRS` check in `handle_auto_deactivate`.
- Any change to `auto_activate` feature-flag gating itself.
- The `Version<3>` → `Version<4>` schema bump (see scope below).

## Scope of the eventual V4 bump (in the DEV-82 PR)

Mechanical, contained to two files:

1. `cli/flox-core/src/activations.rs`:
   - Drop `Option<>` and `#[serde(default)]` from `Attachment.invocation_type`.
   - Bump `ActivationState.version: Version<3>` → `Version<4>` and the `parse_versioned_activation_state` match arm.
   - Repoint `OLD_VERSION` (in `mod version_handling` tests) to `Version<3>`.
   - Unwrap `Some(...)` at every `Attachment { … }` literal.
   - Delete the `deserialize_attachment_without_invocation_type_yields_none` forward-compat test.
2. `cli/tests/activate.bats`: flip `incrementing_version_this_release` to `"true"`.

The migration tests for the V3 → V4 transition (running PIDs error / no-running-PIDs discard) get added there too, exercising the existing version-mismatch logic in `parse_versioned_activation_state`.

## Test plan

- [x] `nix develop -c just unit-tests` — 991 passed, 0 failed (includes the new forward-compat test)
- [x] `nix develop -c cargo clippy --workspace --all-targets` — clean
- [x] `nix develop -c cargo fmt --check` — clean
- [x] Forward-compat verified manually: new flox attaching to a `state.json` written by an older flox (no `invocation_type` field) deserializes existing attachments with `invocation_type: None` and adds its own with `Some(...)`.
- [ ] Manual: with stale `~/.cache/flox/run/activations` cleared, `flox activate` records `"invocation_type": "interactive"` for a subshell, `"inplace"` for `eval "$(flox activate -d <path>)"`, `"command"` for `flox activate -- echo hi`.
- [ ] `nix develop -c just integ-tests activate.bats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)