### PR TITLE
fix: add /usr/bin/env compatibility symlink

### DIFF
--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -820,14 +820,6 @@ if ($manifest) {
             }
         }
 
-        # Symlink /bin/env to /usr/bin/env (for compat)
-        if (-e "$out/bin/env" && !-e "$out/usr/bin/env") {
-            mkpath("$out/usr/bin") or die "cannot create directory `$out/usr/bin': $!";
-            symlink "../../bin/env", "$out/usr/bin/env" ||
-                die "error creating link `$out/usr/bin/env': $!";
-            $nrLinks++;
-        }
-
         info("created %d symlinks in '%s' environment in %.06f seconds",
             $nrLinks, $envName, tv_interval ( $t0 ));
 

--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -820,6 +820,14 @@ if ($manifest) {
             }
         }
 
+        # Symlink /bin/env to /usr/bin/env (for compat)
+        if (-e "$out/bin/env" && !-e "$out/usr/bin/env") {
+            mkpath("$out/usr/bin") or die "cannot create directory `$out/usr/bin': $!";
+            symlink "../../bin/env", "$out/usr/bin/env" ||
+                die "error creating link `$out/usr/bin/env': $!";
+            $nrLinks++;
+        }
+
         info("created %d symlinks in '%s' environment in %.06f seconds",
             $nrLinks, $envName, tv_interval ( $t0 ));
 

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -165,6 +165,10 @@ let
         mkdir -m 1777 tmp
         mkdir -m 1770 run
         mkdir -p -m 1770 run/flox
+        if [ -e bin/env ] && [ ! -e usr/bin/env ]; then
+          mkdir -p usr/bin
+          ln -s ../../bin/env usr/bin/env
+        fi
       '';
 
       # symlinkJoin fails when drv contains a symlinked bin directory, so wrap in an additional buildEnv.

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -167,7 +167,7 @@ let
         mkdir -p -m 1770 run/flox
         if [ -e bin/env ] && [ ! -e usr/bin/env ]; then
           mkdir -p usr/bin
-          ln -s ../../bin/env usr/bin/env
+          ln -s ${containerPkgs.coreutils}/bin/env usr/bin/env
         fi
       '';
 


### PR DESCRIPTION
## Proposed Changes

Adds a symlink for /usr/bin/env for compatibility purposes.

Fixes #4128

## Release Notes

N/A
