### PR TITLE
fix(activations): skip auto-activate hook in command modes (DEV-94)

### DIFF
--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -125,7 +125,12 @@ pub fn generate_bash_startup_commands(
         stmt.generate_with_newline(Shell::Bash, writer)?;
     }
 
-    if args.auto_activate {
+    if args.auto_activate
+        && matches!(
+            args.invocation_type,
+            InvocationType::Interactive | InvocationType::InPlace
+        )
+    {
         write!(writer, "{}", crate::hook::bash_hook(&args.flox_bin))?;
     }
 

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -124,7 +124,12 @@ pub fn generate_fish_startup_commands(
         stmt.generate_with_newline(Shell::Fish, writer)?;
     }
 
-    if args.auto_activate {
+    if args.auto_activate
+        && matches!(
+            args.invocation_type,
+            InvocationType::Interactive | InvocationType::InPlace
+        )
+    {
         if let Some(mode) = &args.auto_activate_fish_mode {
             writeln!(writer, "set -gx FLOX_AUTO_ACTIVATE_FISH_MODE {mode};")?;
         }

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -125,7 +125,12 @@ pub fn generate_tcsh_startup_commands(
         stmt.generate_with_newline(Shell::Tcsh, writer)?;
     }
 
-    if args.auto_activate {
+    if args.auto_activate
+        && matches!(
+            args.invocation_type,
+            InvocationType::Interactive | InvocationType::InPlace
+        )
+    {
         write!(writer, "{}", crate::hook::tcsh_hook(&args.flox_bin))?;
     }
 

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -65,7 +65,12 @@ pub fn generate_zsh_startup_commands(
         stmt.generate_with_newline(Shell::Zsh, writer)?;
     }
 
-    if args.auto_activate {
+    if args.auto_activate
+        && matches!(
+            args.invocation_type,
+            InvocationType::Interactive | InvocationType::InPlace
+        )
+    {
         write!(writer, "{}", crate::hook::zsh_hook(&args.flox_bin))?;
     }
 


### PR DESCRIPTION
## Summary

- `flox activate -c` and `flox activate --` source the generated rc file once and exit, so installing the auto-activate prompt hook there is dead code. Gate each of the four shells' hook emission on `InvocationType::Interactive | InPlace`.
- Builds on f2f767567 (plumb InvocationType through to gen_rc); this PR is the consumer.

Linear: [DEV-94](https://linear.app/floxdotdev/issue/DEV-94/skip-auto-activate-shell-hook-in-command-mode)