### PR TITLE
refactor(activate): prep for profile deactivation

### DIFF
--- a/cli/flox-activations/src/attach.rs
+++ b/cli/flox-activations/src/attach.rs
@@ -17,11 +17,11 @@ use tracing::debug;
 use crate::attach_diff::{AttachDiff, activate_tracer};
 use crate::cli::activate::NO_REMOVE_ACTIVATION_FILES;
 use crate::cli::attach::{AttachArgs, AttachExclusiveArgs};
-use crate::gen_rc::bash::{BashStartupArgs, generate_bash_startup_commands};
-use crate::gen_rc::fish::{FishStartupArgs, generate_fish_startup_commands};
-use crate::gen_rc::tcsh::{TcshStartupArgs, generate_tcsh_startup_commands};
-use crate::gen_rc::zsh::{ZshStartupArgs, generate_zsh_startup_commands};
-use crate::gen_rc::{StartupArgs, StartupCtx};
+use crate::gen_rc::bash::{BashStartupArgs, generate_bash_profile_commands};
+use crate::gen_rc::fish::{FishStartupArgs, generate_fish_profile_commands};
+use crate::gen_rc::tcsh::{TcshStartupArgs, generate_tcsh_profile_commands};
+use crate::gen_rc::zsh::{ZshStartupArgs, generate_zsh_profile_commands};
+use crate::gen_rc::{Action, ShellStartupArgs, StartupCtx};
 use crate::start_diff::StartDiff;
 use crate::vars_from_env::VarsFromEnvironment;
 
@@ -137,7 +137,7 @@ pub(crate) fn startup_ctx(
     let set_prompt = ctx.attach_ctx.set_prompt;
 
     let args = match ctx.shell {
-        ShellWithPath::Bash(_) => StartupArgs::Bash(BashStartupArgs {
+        ShellWithPath::Bash(_) => ShellStartupArgs::Bash(BashStartupArgs {
             flox_activate_tracelevel: subsystem_verbosity,
             activate_d: ctx.attach_ctx.interpreter_path.join("activate.d"),
             flox_env: PathBuf::from(ctx.attach_ctx.env.clone()),
@@ -151,7 +151,7 @@ pub(crate) fn startup_ctx(
             flox_bin: ctx.flox_bin.clone(),
             set_prompt,
         }),
-        ShellWithPath::Fish(_) => StartupArgs::Fish(FishStartupArgs {
+        ShellWithPath::Fish(_) => ShellStartupArgs::Fish(FishStartupArgs {
             flox_activate_tracelevel: subsystem_verbosity,
             activate_d: ctx.attach_ctx.interpreter_path.join("activate.d"),
             flox_env: PathBuf::from(ctx.attach_ctx.env.clone()),
@@ -165,7 +165,7 @@ pub(crate) fn startup_ctx(
             auto_activate_fish_mode: ctx.auto_activate_fish_mode,
             set_prompt,
         }),
-        ShellWithPath::Tcsh(_) => StartupArgs::Tcsh(TcshStartupArgs {
+        ShellWithPath::Tcsh(_) => ShellStartupArgs::Tcsh(TcshStartupArgs {
             flox_activate_tracelevel: subsystem_verbosity,
             activate_d: ctx.attach_ctx.interpreter_path.join("activate.d"),
             flox_env: PathBuf::from(ctx.attach_ctx.env.clone()),
@@ -178,7 +178,7 @@ pub(crate) fn startup_ctx(
             flox_bin: ctx.flox_bin.clone(),
             set_prompt,
         }),
-        ShellWithPath::Zsh(_) => StartupArgs::Zsh(ZshStartupArgs {
+        ShellWithPath::Zsh(_) => ShellStartupArgs::Zsh(ZshStartupArgs {
             flox_activate_tracelevel: subsystem_verbosity,
             activate_d: ctx.attach_ctx.interpreter_path.join("activate.d"),
             invocation_type,
@@ -198,18 +198,35 @@ pub(crate) fn startup_ctx(
 }
 
 pub(crate) fn write_to_writer(ctx: &StartupCtx, writer: &mut impl std::io::Write) -> Result<()> {
-    match ctx.args {
-        StartupArgs::Bash(ref args) => {
-            generate_bash_startup_commands(args, &ctx.attach_diff, writer)?
+    let attach_diff = ctx.attach_diff.clone();
+    match &ctx.args {
+        ShellStartupArgs::Bash(args) => {
+            let action = Action::Activate {
+                args: args.clone(),
+                attach_diff,
+            };
+            generate_bash_profile_commands(&action, writer)?
         },
-        StartupArgs::Fish(ref args) => {
-            generate_fish_startup_commands(args, &ctx.attach_diff, writer)?
+        ShellStartupArgs::Fish(args) => {
+            let action = Action::Activate {
+                args: args.clone(),
+                attach_diff,
+            };
+            generate_fish_profile_commands(&action, writer)?
         },
-        StartupArgs::Tcsh(ref args) => {
-            generate_tcsh_startup_commands(args, &ctx.attach_diff, writer)?
+        ShellStartupArgs::Tcsh(args) => {
+            let action = Action::Activate {
+                args: args.clone(),
+                attach_diff,
+            };
+            generate_tcsh_profile_commands(&action, writer)?
         },
-        StartupArgs::Zsh(ref args) => {
-            generate_zsh_startup_commands(args, &ctx.attach_diff, writer)?
+        ShellStartupArgs::Zsh(args) => {
+            let action = Action::Activate {
+                args: args.clone(),
+                attach_diff,
+            };
+            generate_zsh_profile_commands(&action, writer)?
         },
     }
     Ok(())

--- a/cli/flox-activations/src/attach.rs
+++ b/cli/flox-activations/src/attach.rs
@@ -71,7 +71,6 @@ pub fn attach(
         invocation_type.clone(),
         rc_path,
         diff,
-        &start_state_dir,
         &tracer,
         subsystem_verbosity,
         vars_from_env,
@@ -111,7 +110,6 @@ pub(crate) fn startup_ctx(
     invocation_type: InvocationType,
     rc_path: Option<PathBuf>,
     start_diff: StartDiff,
-    start_state_dir: &Path,
     activate_tracer: &str,
     subsystem_verbosity: u32,
     vars_from_env: VarsFromEnvironment,
@@ -193,7 +191,6 @@ pub(crate) fn startup_ctx(
 
     Ok(StartupCtx {
         args,
-        start_state_dir: start_state_dir.to_path_buf(),
         rc_path,
         act_ctx: ctx,
         attach_diff,

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -6,8 +6,8 @@ use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use shell_gen::{GenerateShell, Shell, source_file};
 
-use crate::attach_diff::{AttachDiff, todo_drop_set_exported_unexpanded, todo_drop_unset};
-use crate::gen_rc::RM;
+use crate::attach_diff::{todo_drop_set_exported_unexpanded, todo_drop_unset};
+use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating bash startup commands
 #[derive(Debug, Clone)]
@@ -31,56 +31,94 @@ pub struct BashStartupArgs {
 // N.B. the output of these scripts may be eval'd with backticks which have
 // the effect of removing newlines from the output, so we must ensure that
 // the output is a valid shell script fragment when represented on a single line.
-pub fn generate_bash_startup_commands(
-    args: &BashStartupArgs,
-    attach_diff: &AttachDiff,
+pub fn generate_bash_profile_commands(
+    action: &Action<BashStartupArgs>,
     writer: &mut impl Write,
 ) -> Result<()> {
     let mut stmts = vec![];
 
     // Enable trace mode if requested
-    if args.flox_activate_tracelevel >= 2 {
-        stmts.push("set -x".to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            if args.flox_activate_tracelevel >= 2 {
+                stmts.push("set -x".to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // TODO: emit `set -x` when tracelevel >= 2
+        },
     }
 
     // The bashrc-sourcing dance must come before `attach_diff.generate_statements`
     // so a `flox activate` inside .bashrc can't override values
-    let should_source =
-        args.bashrc_path.is_some() && !args.invocation_type.is_in_place() && !args.flox_sourcing_rc;
-    if should_source {
-        stmts.push(todo_drop_set_exported_unexpanded(
-            "_flox_sourcing_rc",
-            "true",
-        ));
-        stmts.push(source_file(args.bashrc_path.as_ref().unwrap()));
-        stmts.push(todo_drop_unset("_flox_sourcing_rc"));
+    match action {
+        Action::Activate { args, .. } => {
+            let should_source = args.bashrc_path.is_some()
+                && !args.invocation_type.is_in_place()
+                && !args.flox_sourcing_rc;
+            if should_source {
+                stmts.push(todo_drop_set_exported_unexpanded(
+                    "_flox_sourcing_rc",
+                    "true",
+                ));
+                stmts.push(source_file(args.bashrc_path.as_ref().unwrap()));
+                stmts.push(todo_drop_unset("_flox_sourcing_rc"));
+            }
+        },
+        Action::Deactivate => {
+            // No-op: no way to undo bashrc sourcing
+        },
     }
 
-    stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
+    // Environment variables
+    match action {
+        Action::Activate { args, attach_diff } => {
+            stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
+        },
+        Action::Deactivate => {
+            // TODO: decode `_FLOX_HOOK_DIFF` and emit restores — unset
+            // additions, restore prior values for modifications and
+            // removals, then unset `_FLOX_HOOK_DIFF` itself.
+        },
+    }
 
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_activate_d",
-        args.activate_d.display().to_string(),
-    ));
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_flox_activations",
-        args.flox_activations.display().to_string(),
-    ));
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_flox_activate_tracer",
-        &args.flox_activate_tracer,
-    ));
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_activate_d",
+                args.activate_d.display().to_string(),
+            ));
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_flox_activations",
+                args.flox_activations.display().to_string(),
+            ));
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_flox_activate_tracer",
+                &args.flox_activate_tracer,
+            ));
+        },
+        Action::Deactivate => {
+            // TODO: we shouldn't be exporting these in the first place
+        },
+    }
 
     // Set the prompt if we're in an interactive shell.
-    if args.set_prompt {
-        let set_prompt_path = args.activate_d.join("set-prompt.bash");
-        stmts.push(
-            format!(
-                "if [ -t 1 ]; then source '{}'; fi;",
-                set_prompt_path.display()
-            )
-            .to_stmt(),
-        );
+    match action {
+        Action::Activate { args, .. } => {
+            if args.set_prompt {
+                let set_prompt_path = args.activate_d.join("set-prompt.bash");
+                stmts.push(
+                    format!(
+                        "if [ -t 1 ]; then source '{}'; fi;",
+                        set_prompt_path.display()
+                    )
+                    .to_stmt(),
+                );
+            }
+        },
+        Action::Deactivate => {
+            // TODO: revert the prompt.
+        },
     }
 
     // We already customized the PATH and MANPATH, but the user and system
@@ -88,50 +126,93 @@ pub fn generate_bash_startup_commands(
     // Use generation time _FLOX_ENV because we want to guarantee we activate the
     // environment we think we're activating. Use runtime FLOX_ENV_DIRS to allow
     // RC files to perform activations.
-    stmts.push(format!(
-        r#"eval "$('{}' set-env-dirs --shell bash --flox-env "{}" --env-dirs "${{FLOX_ENV_DIRS:-}}")";"#,
-        args.flox_activations.display(),
-        args.flox_env.display()
-    ).to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(format!(
+                r#"eval "$('{}' set-env-dirs --shell bash --flox-env "{}" --env-dirs "${{FLOX_ENV_DIRS:-}}")";"#,
+                args.flox_activations.display(),
+                args.flox_env.display()
+            ).to_stmt());
+            stmts.push(format!(
+                r#"eval "$('{}' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${{MANPATH:-}}")";"#,
+                args.flox_activations.display()
+            ).to_stmt());
+        },
+        Action::Deactivate => {
+            // No-op: covered by environment restoration above
+        },
+    }
 
-    stmts.push(format!(
-        r#"eval "$('{}' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${{MANPATH:-}}")";"#,
-        args.flox_activations.display()
-    ).to_stmt());
-
-    stmts.push(format!(
-        r#"eval "$('{}' profile-scripts --shell bash --already-sourced-env-dirs "${{_FLOX_SOURCED_PROFILE_SCRIPTS:-}}" --env-dirs "${{FLOX_ENV_DIRS:-}}")";"#,
-        args.flox_activations.display()
-    ).to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(format!(
+                r#"eval "$('{}' profile-scripts --shell bash --already-sourced-env-dirs "${{_FLOX_SOURCED_PROFILE_SCRIPTS:-}}" --env-dirs "${{FLOX_ENV_DIRS:-}}")";"#,
+                args.flox_activations.display()
+            ).to_stmt());
+        },
+        Action::Deactivate => {
+            // TODO: run profile.deactivate.bash
+        },
+    }
 
     // Disable command hashing to allow for newly installed flox packages
     // to be found immediately. We do this as the very last thing because
     // python venv activations can otherwise return nonzero return codes
     // when attempting to invoke `hash -r`.
-    stmts.push("set +h".to_stmt());
-
-    // Disable trace mode if it was enabled
-    if args.flox_activate_tracelevel >= 2 {
-        stmts.push("set +x".to_stmt());
+    match action {
+        Action::Activate { .. } => {
+            stmts.push("set +h".to_stmt());
+        },
+        Action::Deactivate => {
+            // TODO: decide whether to restore prior hashing state.
+        },
     }
 
-    if let Some(path) = args.clean_up.as_ref() {
-        let path_str = path.to_string_lossy();
-        let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
-        stmts.push(format!("{RM} {};", escaped_path).to_stmt());
+    // Disable trace mode if it was enabled
+    match action {
+        Action::Activate { args, .. } => {
+            if args.flox_activate_tracelevel >= 2 {
+                stmts.push("set +x".to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // TODO: set +x
+        },
+    }
+
+    // Self-destruct rc file
+    match action {
+        Action::Activate { args, .. } => {
+            if let Some(path) = args.clean_up.as_ref() {
+                let path_str = path.to_string_lossy();
+                let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
+                stmts.push(format!("{RM} {};", escaped_path).to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // No-op: deactivate has no rc file to remove.
+        },
     }
 
     for stmt in stmts {
         stmt.generate_with_newline(Shell::Bash, writer)?;
     }
 
-    if args.auto_activate
-        && matches!(
-            args.invocation_type,
-            InvocationType::Interactive | InvocationType::InPlace
-        )
-    {
-        write!(writer, "{}", crate::hook::bash_hook(&args.flox_bin))?;
+    // Auto-activate hook registration
+    match action {
+        Action::Activate { args, .. } => {
+            if args.auto_activate
+                && matches!(
+                    args.invocation_type,
+                    InvocationType::Interactive | InvocationType::InPlace
+                )
+            {
+                write!(writer, "{}", crate::hook::bash_hook(&args.flox_bin))?;
+            }
+        },
+        Action::Deactivate => {
+            // TODO: unregister the auto-activate hook
+        },
     }
 
     Ok(())
@@ -153,6 +234,13 @@ mod tests {
         let shell = ShellWithPath::Bash(PathBuf::from("/bin/bash"));
         let ctx = test_startup_ctx(shell, is_in_place);
         render_normalized(&ctx)
+    }
+
+    fn render_deactivate() -> String {
+        let action = Action::<BashStartupArgs>::Deactivate;
+        let mut buf = Vec::new();
+        generate_bash_profile_commands(&action, &mut buf).expect("generator should succeed");
+        String::from_utf8(buf).expect("output should be utf-8")
     }
 
     #[test]
@@ -212,5 +300,11 @@ mod tests {
             set +x
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]].assert_eq(&output);
+    }
+
+    #[test]
+    fn generate_bash_profile_deactivate() {
+        let output = render_deactivate();
+        expect![""].assert_eq(&output);
     }
 }

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -6,8 +6,8 @@ use anyhow::Result;
 use flox_core::activate::context::{AutoActivateFishMode, InvocationType};
 use shell_gen::{GenerateShell, Shell};
 
-use crate::attach_diff::{AttachDiff, todo_drop_set_exported_unexpanded};
-use crate::gen_rc::RM;
+use crate::attach_diff::todo_drop_set_exported_unexpanded;
+use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating fish startup commands
 #[derive(Debug, Clone)]
@@ -31,16 +31,22 @@ pub struct FishStartupArgs {
 // N.B. the output of these scripts may be eval'd with backticks which have
 // the effect of removing newlines from the output, so we must ensure that
 // the output is a valid shell script fragment when represented on a single line.
-pub fn generate_fish_startup_commands(
-    args: &FishStartupArgs,
-    attach_diff: &AttachDiff,
+pub fn generate_fish_profile_commands(
+    action: &Action<FishStartupArgs>,
     writer: &mut impl Write,
 ) -> Result<()> {
     let mut stmts = vec![];
 
     // Enable trace mode if requested
-    if args.flox_activate_tracelevel >= 2 {
-        stmts.push(todo_drop_set_exported_unexpanded("fish_trace", "1").to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            if args.flox_activate_tracelevel >= 2 {
+                stmts.push(todo_drop_set_exported_unexpanded("fish_trace", "1").to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // TODO: emit `set -gx fish_trace 1` when tracelevel >= 2
+        },
     }
 
     // The fish --init-command option allows us to source our startup
@@ -48,92 +54,154 @@ pub fn generate_fish_startup_commands(
     // is no requirement to go back and source the user's own config
     // as we do in bash.
 
-    stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
+    // Environment variables
+    match action {
+        Action::Activate { args, attach_diff } => {
+            stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
+        },
+        Action::Deactivate => {
+            // TODO: decode `_FLOX_HOOK_DIFF` and emit restores.
+        },
+    }
 
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_activate_d",
-        args.activate_d.display().to_string(),
-    ));
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_flox_activations",
-        args.flox_activations.display().to_string(),
-    ));
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_flox_activate_tracer",
-        &args.flox_activate_tracer,
-    ));
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_activate_d",
+                args.activate_d.display().to_string(),
+            ));
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_flox_activations",
+                args.flox_activations.display().to_string(),
+            ));
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_flox_activate_tracer",
+                &args.flox_activate_tracer,
+            ));
+        },
+        Action::Deactivate => {
+            // TODO: we shouldn't be exporting these in the first place
+        },
+    }
 
     // Set the prompt if we're in an interactive shell.
-    if args.set_prompt {
-        let set_prompt_path = args.activate_d.join("set-prompt.fish");
-        stmts.push(format!("if isatty 1; source '{}'; end;", set_prompt_path.display()).to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            if args.set_prompt {
+                let set_prompt_path = args.activate_d.join("set-prompt.fish");
+                stmts.push(
+                    format!("if isatty 1; source '{}'; end;", set_prompt_path.display()).to_stmt(),
+                );
+            }
+        },
+        Action::Deactivate => {
+            // TODO: revert the prompt.
+        },
     }
 
     // We already customized the PATH and MANPATH, but the user and system
     // dotfiles may have changed them, so finish by doing this again.
-
+    //
     // fish doesn't have {foo:-} syntax, so we need to provide a temporary variable
     // (foo_with_default) that is either the runtime (not generation-time) value
     // or the string 'empty'.
-    stmts.push(
-        r#"set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);"#.to_stmt()
-    );
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(
+                r#"set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);"#.to_stmt()
+            );
 
-    stmts.push(
-        format!(
-            r#"{} set-env-dirs --shell fish --flox-env "{}" --env-dirs "$FLOX_ENV_DIRS" | source;"#,
-            args.flox_activations.display(),
-            args.flox_env.display()
-        )
-        .to_stmt(),
-    );
+            stmts.push(
+                format!(
+                    r#"{} set-env-dirs --shell fish --flox-env "{}" --env-dirs "$FLOX_ENV_DIRS" | source;"#,
+                    args.flox_activations.display(),
+                    args.flox_env.display()
+                )
+                .to_stmt(),
+            );
 
-    stmts.push(
-        r#"set -gx MANPATH (if set -q MANPATH; echo "$MANPATH"; else; echo empty; end);"#.to_stmt(),
-    );
+            stmts.push(
+                r#"set -gx MANPATH (if set -q MANPATH; echo "$MANPATH"; else; echo empty; end);"#
+                    .to_stmt(),
+            );
 
-    stmts.push(format!(
-        r#"{} fix-paths --shell fish --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "$MANPATH" | source;"#,
-        args.flox_activations.display()
-    ).to_stmt());
+            stmts.push(format!(
+                r#"{} fix-paths --shell fish --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "$MANPATH" | source;"#,
+                args.flox_activations.display()
+            ).to_stmt());
+        },
+        Action::Deactivate => {
+            // No-op: covered by environment restoration above
+        },
+    }
 
-    stmts.push(
-        r#"set -g  _FLOX_SOURCED_PROFILE_SCRIPTS (if set -q _FLOX_SOURCED_PROFILE_SCRIPTS; echo "$_FLOX_SOURCED_PROFILE_SCRIPTS"; else; echo ""; end);"#.to_string()
-    .to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(
+                r#"set -g  _FLOX_SOURCED_PROFILE_SCRIPTS (if set -q _FLOX_SOURCED_PROFILE_SCRIPTS; echo "$_FLOX_SOURCED_PROFILE_SCRIPTS"; else; echo ""; end);"#.to_string()
+            .to_stmt());
 
-    stmts.push(format!(
-        r#"{} profile-scripts --shell fish --already-sourced-env-dirs  "$_FLOX_SOURCED_PROFILE_SCRIPTS" --env-dirs "$FLOX_ENV_DIRS" | source;"#,
-        args.flox_activations.display()
-    ).to_stmt());
+            stmts.push(format!(
+                r#"{} profile-scripts --shell fish --already-sourced-env-dirs  "$_FLOX_SOURCED_PROFILE_SCRIPTS" --env-dirs "$FLOX_ENV_DIRS" | source;"#,
+                args.flox_activations.display()
+            ).to_stmt());
+        },
+        Action::Deactivate => {
+            // TODO: run profile.deactivate.fish
+        },
+    }
 
     // fish does not use hashing in the same way bash does, so there's
     // nothing to be done here by way of that requirement.
 
     // Disable trace mode if it was enabled
-    if args.flox_activate_tracelevel >= 2 {
-        stmts.push("set -gx fish_trace 0;".to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            if args.flox_activate_tracelevel >= 2 {
+                stmts.push("set -gx fish_trace 0;".to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // TODO: set -gx fish_trace 0
+        },
     }
 
-    if let Some(path) = args.clean_up.as_ref() {
-        let path_str = path.to_string_lossy();
-        let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
-        stmts.push(format!("{RM} {};", escaped_path).to_stmt());
+    // Self-destruct rc file
+    match action {
+        Action::Activate { args, .. } => {
+            if let Some(path) = args.clean_up.as_ref() {
+                let path_str = path.to_string_lossy();
+                let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
+                stmts.push(format!("{RM} {};", escaped_path).to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // No-op: deactivate has no rc file to remove.
+        },
     }
 
     for stmt in stmts {
         stmt.generate_with_newline(Shell::Fish, writer)?;
     }
 
-    if args.auto_activate
-        && matches!(
-            args.invocation_type,
-            InvocationType::Interactive | InvocationType::InPlace
-        )
-    {
-        if let Some(mode) = &args.auto_activate_fish_mode {
-            writeln!(writer, "set -gx FLOX_AUTO_ACTIVATE_FISH_MODE {mode};")?;
-        }
-        write!(writer, "{}", crate::hook::fish_hook(&args.flox_bin))?;
+    // Auto-activate hook registration
+    match action {
+        Action::Activate { args, .. } => {
+            if args.auto_activate
+                && matches!(
+                    args.invocation_type,
+                    InvocationType::Interactive | InvocationType::InPlace
+                )
+            {
+                if let Some(mode) = &args.auto_activate_fish_mode {
+                    writeln!(writer, "set -gx FLOX_AUTO_ACTIVATE_FISH_MODE {mode};")?;
+                }
+                write!(writer, "{}", crate::hook::fish_hook(&args.flox_bin))?;
+            }
+        },
+        Action::Deactivate => {
+            // TODO: unregister the auto-activate hook
+        },
     }
 
     Ok(())
@@ -155,6 +223,13 @@ mod tests {
         let shell = ShellWithPath::Fish(PathBuf::from("/fish"));
         let ctx = test_startup_ctx(shell, is_in_place);
         render_normalized(&ctx)
+    }
+
+    fn render_deactivate() -> String {
+        let action = Action::<FishStartupArgs>::Deactivate;
+        let mut buf = Vec::new();
+        generate_fish_profile_commands(&action, &mut buf).expect("generator should succeed");
+        String::from_utf8(buf).expect("output should be utf-8")
     }
 
     #[test]
@@ -215,5 +290,11 @@ mod tests {
             set -gx fish_trace 0;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]].assert_eq(&output);
+    }
+
+    #[test]
+    fn generate_fish_profile_deactivate() {
+        let output = render_deactivate();
+        expect![""].assert_eq(&output);
     }
 }

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -29,7 +29,6 @@ pub enum StartupArgs {
 pub struct StartupCtx {
     pub args: StartupArgs,
     pub rc_path: Option<PathBuf>,
-    pub start_state_dir: PathBuf,
     pub act_ctx: ActivateCtx,
     pub attach_diff: AttachDiff,
 }
@@ -37,7 +36,7 @@ pub struct StartupCtx {
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use std::collections::HashMap;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
 
     use flox_core::activate::context::{ActivateCtx, AttachCtx, AttachProjectCtx, InvocationType};
     use flox_core::activate::mode::ActivateMode;
@@ -114,7 +113,6 @@ pub(crate) mod test_helpers {
             invocation_type,
             rc_path,
             start_diff,
-            Path::new("/start_state_dir"),
             "TRACER",
             3,
             vars_from_env,

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -16,8 +16,15 @@ pub mod fish;
 pub mod tcsh;
 pub mod zsh;
 
+/// Struct to container arguments needed by generate_*_profile_commands
 #[derive(Debug, Clone)]
-pub enum StartupArgs {
+pub enum Action<A> {
+    Activate { args: A, attach_diff: AttachDiff },
+    Deactivate,
+}
+
+#[derive(Debug, Clone)]
+pub enum ShellStartupArgs {
     Bash(BashStartupArgs),
     Fish(FishStartupArgs),
     Tcsh(TcshStartupArgs),
@@ -27,7 +34,7 @@ pub enum StartupArgs {
 /// Context for shell startup, shared between normal and container activations.
 #[derive(Debug)]
 pub struct StartupCtx {
-    pub args: StartupArgs,
+    pub args: ShellStartupArgs,
     pub rc_path: Option<PathBuf>,
     pub act_ctx: ActivateCtx,
     pub attach_diff: AttachDiff,

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -6,8 +6,8 @@ use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use shell_gen::{GenerateShell, Shell};
 
-use crate::attach_diff::{AttachDiff, todo_drop_set_exported_unexpanded};
-use crate::gen_rc::RM;
+use crate::attach_diff::todo_drop_set_exported_unexpanded;
+use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating tcsh startup commands
 #[derive(Debug, Clone)]
@@ -29,43 +29,71 @@ pub struct TcshStartupArgs {
 // N.B. the output of these scripts may be eval'd with backticks which have
 // the effect of removing newlines from the output, so we must ensure that
 // the output is a valid shell script fragment when represented on a single line.
-pub fn generate_tcsh_startup_commands(
-    args: &TcshStartupArgs,
-    attach_diff: &AttachDiff,
+pub fn generate_tcsh_profile_commands(
+    action: &Action<TcshStartupArgs>,
     writer: &mut impl Write,
 ) -> Result<()> {
     let mut stmts = vec![];
 
     // Enable trace mode if requested
-    if args.flox_activate_tracelevel >= 2 {
-        stmts.push("set verbose".to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            if args.flox_activate_tracelevel >= 2 {
+                stmts.push("set verbose".to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // TODO: emit `set verbose` when tracelevel >= 2
+        },
     }
 
-    stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
+    // Environment variables
+    match action {
+        Action::Activate { args, attach_diff } => {
+            stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
+        },
+        Action::Deactivate => {
+            // TODO: decode `_FLOX_HOOK_DIFF` and emit restores.
+        },
+    }
 
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_activate_d",
-        args.activate_d.display().to_string(),
-    ));
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_flox_activations",
-        args.flox_activations.display().to_string(),
-    ));
-    stmts.push(todo_drop_set_exported_unexpanded(
-        "_flox_activate_tracer",
-        &args.flox_activate_tracer,
-    ));
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_activate_d",
+                args.activate_d.display().to_string(),
+            ));
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_flox_activations",
+                args.flox_activations.display().to_string(),
+            ));
+            stmts.push(todo_drop_set_exported_unexpanded(
+                "_flox_activate_tracer",
+                &args.flox_activate_tracer,
+            ));
+        },
+        Action::Deactivate => {
+            // TODO: we shouldn't be exporting these in the first place
+        },
+    }
 
     // Set the prompt if we're in an interactive shell.
-    if args.set_prompt {
-        let set_prompt_path = args.activate_d.join("set-prompt.tcsh");
-        stmts.push(
-            format!(
-                "if ( $?tty ) then; source '{}'; endif;",
-                set_prompt_path.display()
-            )
-            .to_stmt(),
-        );
+    match action {
+        Action::Activate { args, .. } => {
+            if args.set_prompt {
+                let set_prompt_path = args.activate_d.join("set-prompt.tcsh");
+                stmts.push(
+                    format!(
+                        "if ( $?tty ) then; source '{}'; endif;",
+                        set_prompt_path.display()
+                    )
+                    .to_stmt(),
+                );
+            }
+        },
+        Action::Deactivate => {
+            // TODO: revert the prompt.
+        },
     }
 
     // We already customized the PATH and MANPATH, but the user and system
@@ -73,65 +101,109 @@ pub fn generate_tcsh_startup_commands(
     // Use generation time _FLOX_ENV because we want to guarantee we activate the
     // environment we think we're activating. Use runtime FLOX_ENV_DIRS to allow
     // RC files to perform activations.
-    stmts.push(r#"if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";"#.to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(r#"if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";"#.to_stmt());
 
-    stmts.push(format!(
-        r#"eval "`'{}' set-env-dirs --shell tcsh --flox-env '{}' --env-dirs $FLOX_ENV_DIRS:q`";"#,
-        args.flox_activations.display(),
-        args.flox_env.display(),
-    ).to_stmt());
+            stmts.push(format!(
+                r#"eval "`'{}' set-env-dirs --shell tcsh --flox-env '{}' --env-dirs $FLOX_ENV_DIRS:q`";"#,
+                args.flox_activations.display(),
+                args.flox_env.display(),
+            ).to_stmt());
 
-    stmts.push(r#"if (! $?MANPATH) setenv MANPATH "empty";"#.to_stmt());
+            stmts.push(r#"if (! $?MANPATH) setenv MANPATH "empty";"#.to_stmt());
 
-    stmts.push(format!(
-        r#"eval "`'{}' fix-paths --shell tcsh --env-dirs $FLOX_ENV_DIRS:q --path $PATH:q --manpath $MANPATH:q`";"#,
-        args.flox_activations.display()
-    ).to_stmt());
+            stmts.push(format!(
+                r#"eval "`'{}' fix-paths --shell tcsh --env-dirs $FLOX_ENV_DIRS:q --path $PATH:q --manpath $MANPATH:q`";"#,
+                args.flox_activations.display()
+            ).to_stmt());
+        },
+        Action::Deactivate => {
+            // No-op: covered by environment restoration above
+        },
+    }
 
     // Modern versions of tcsh support the ":Q" modifier for passing empty args
     // on the command line, but versions prior to 6.23 do not have a way to do
     // that, so to support these versions we will instead avoid passing the
     // --already-sourced-env-dirs argument altogether when there is no default
     // value to be passed.
-    stmts.push("set _already_sourced_args = ();".to_stmt());
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push("set _already_sourced_args = ();".to_stmt());
 
-    stmts.push(
-        r#"if ($?_FLOX_SOURCED_PROFILE_SCRIPTS) set _already_sourced_args = ( --already-sourced-env-dirs `echo $_FLOX_SOURCED_PROFILE_SCRIPTS:q` );"#.to_stmt()
-    );
+            stmts.push(
+                r#"if ($?_FLOX_SOURCED_PROFILE_SCRIPTS) set _already_sourced_args = ( --already-sourced-env-dirs `echo $_FLOX_SOURCED_PROFILE_SCRIPTS:q` );"#.to_stmt()
+            );
 
-    stmts.push(format!(
-        r#"eval "`'{}' profile-scripts --shell tcsh --env-dirs $FLOX_ENV_DIRS:q $_already_sourced_args:q`";"#,
-        args.flox_activations.display()
-    ).to_stmt());
+            stmts.push(format!(
+                r#"eval "`'{}' profile-scripts --shell tcsh --env-dirs $FLOX_ENV_DIRS:q $_already_sourced_args:q`";"#,
+                args.flox_activations.display()
+            ).to_stmt());
+        },
+        Action::Deactivate => {
+            // TODO: run profile.deactivate.tcsh
+        },
+    }
 
     // Disable command hashing to allow for newly installed flox packages
     // to be found immediately. We do this as the very last thing because
     // python venv activations can otherwise return nonzero return codes
     // when attempting to invoke `hash -r`.
-    stmts.push("unhash;".to_stmt());
-
-    // Disable trace mode if it was enabled
-    if args.flox_activate_tracelevel >= 2 {
-        stmts.push("unset verbose;".to_stmt());
+    match action {
+        Action::Activate { .. } => {
+            stmts.push("unhash;".to_stmt());
+        },
+        Action::Deactivate => {
+            // TODO: decide whether to restore prior hashing state.
+        },
     }
 
-    if let Some(path) = args.clean_up.as_ref() {
-        let path_str = path.to_string_lossy();
-        let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
-        stmts.push(format!("{RM} {};", escaped_path).to_stmt());
+    // Disable trace mode if it was enabled
+    match action {
+        Action::Activate { args, .. } => {
+            if args.flox_activate_tracelevel >= 2 {
+                stmts.push("unset verbose;".to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // TODO: unset verbose
+        },
+    }
+
+    // Self-destruct rc file
+    match action {
+        Action::Activate { args, .. } => {
+            if let Some(path) = args.clean_up.as_ref() {
+                let path_str = path.to_string_lossy();
+                let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
+                stmts.push(format!("{RM} {};", escaped_path).to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // No-op: deactivate has no rc file to remove.
+        },
     }
 
     for stmt in stmts {
         stmt.generate_with_newline(Shell::Tcsh, writer)?;
     }
 
-    if args.auto_activate
-        && matches!(
-            args.invocation_type,
-            InvocationType::Interactive | InvocationType::InPlace
-        )
-    {
-        write!(writer, "{}", crate::hook::tcsh_hook(&args.flox_bin))?;
+    // Auto-activate hook registration
+    match action {
+        Action::Activate { args, .. } => {
+            if args.auto_activate
+                && matches!(
+                    args.invocation_type,
+                    InvocationType::Interactive | InvocationType::InPlace
+                )
+            {
+                write!(writer, "{}", crate::hook::tcsh_hook(&args.flox_bin))?;
+            }
+        },
+        Action::Deactivate => {
+            // TODO: unregister the auto-activate hook
+        },
     }
 
     Ok(())
@@ -153,6 +225,13 @@ mod tests {
         let shell = ShellWithPath::Tcsh(PathBuf::from("/bin/tcsh"));
         let ctx = test_startup_ctx(shell, is_in_place);
         render_normalized(&ctx)
+    }
+
+    fn render_deactivate() -> String {
+        let action = Action::<TcshStartupArgs>::Deactivate;
+        let mut buf = Vec::new();
+        generate_tcsh_profile_commands(&action, &mut buf).expect("generator should succeed");
+        String::from_utf8(buf).expect("output should be utf-8")
     }
 
     #[test]
@@ -217,5 +296,11 @@ mod tests {
             unset verbose;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]].assert_eq(&output);
+    }
+
+    #[test]
+    fn generate_tcsh_profile_deactivate() {
+        let output = render_deactivate();
+        expect![""].assert_eq(&output);
     }
 }

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -6,8 +6,7 @@ use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded, source_file};
 
-use crate::attach_diff::AttachDiff;
-use crate::gen_rc::RM;
+use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating zsh startup commands
 #[derive(Debug, Clone)]
@@ -21,41 +20,79 @@ pub struct ZshStartupArgs {
     pub set_prompt: bool,
 }
 
-pub fn generate_zsh_startup_commands(
-    args: &ZshStartupArgs,
-    attach_diff: &AttachDiff,
+pub fn generate_zsh_profile_commands(
+    action: &Action<ZshStartupArgs>,
     writer: &mut impl Write,
 ) -> Result<()> {
     let mut stmts = vec![];
-    stmts.push(set_unexported_unexpanded(
-        "_flox_activate_tracelevel",
-        format!("{}", &args.flox_activate_tracelevel),
-    ));
-    stmts.push(set_unexported_unexpanded(
-        "_activate_d",
-        args.activate_d.display().to_string(),
-    ));
 
-    stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
-
-    stmts.push(source_file(args.activate_d.join("zsh")));
-
-    // Set the prompt if we're in an interactive shell.
-    if args.set_prompt {
-        let set_prompt_path = args.activate_d.join("set-prompt.zsh");
-        stmts.push(
-            format!(
-                "if [[ -o interactive ]]; then source '{}'; fi;",
-                set_prompt_path.display()
-            )
-            .to_stmt(),
-        );
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(set_unexported_unexpanded(
+                "_flox_activate_tracelevel",
+                format!("{}", &args.flox_activate_tracelevel),
+            ));
+            stmts.push(set_unexported_unexpanded(
+                "_activate_d",
+                args.activate_d.display().to_string(),
+            ));
+        },
+        Action::Deactivate => {
+            // TODO: we might not need to set these in the first place
+        },
     }
 
-    if let Some(path) = args.clean_up.as_ref() {
-        let path_str = path.to_string_lossy();
-        let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
-        stmts.push(format!("{RM} {};", escaped_path).to_stmt());
+    // Environment variables
+    match action {
+        Action::Activate { args, attach_diff } => {
+            stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
+        },
+        Action::Deactivate => {
+            // TODO: decode `_FLOX_HOOK_DIFF` and emit restores.
+        },
+    }
+
+    // Source the zsh activate.d entry point
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(source_file(args.activate_d.join("zsh")));
+        },
+        Action::Deactivate => {
+            // TODO: undo everything in activate_d/zsh
+        },
+    }
+
+    // Set the prompt if we're in an interactive shell.
+    match action {
+        Action::Activate { args, .. } => {
+            if args.set_prompt {
+                let set_prompt_path = args.activate_d.join("set-prompt.zsh");
+                stmts.push(
+                    format!(
+                        "if [[ -o interactive ]]; then source '{}'; fi;",
+                        set_prompt_path.display()
+                    )
+                    .to_stmt(),
+                );
+            }
+        },
+        Action::Deactivate => {
+            // TODO: revert the prompt.
+        },
+    }
+
+    // Self-destruct rc file
+    match action {
+        Action::Activate { args, .. } => {
+            if let Some(path) = args.clean_up.as_ref() {
+                let path_str = path.to_string_lossy();
+                let escaped_path = shell_escape::escape(Cow::Borrowed(path_str.as_ref()));
+                stmts.push(format!("{RM} {};", escaped_path).to_stmt());
+            }
+        },
+        Action::Deactivate => {
+            // No-op: deactivate has no rc file to remove.
+        },
     }
 
     // N.B. the output of these scripts may be eval'd with backticks which have
@@ -65,13 +102,21 @@ pub fn generate_zsh_startup_commands(
         stmt.generate_with_newline(Shell::Zsh, writer)?;
     }
 
-    if args.auto_activate
-        && matches!(
-            args.invocation_type,
-            InvocationType::Interactive | InvocationType::InPlace
-        )
-    {
-        write!(writer, "{}", crate::hook::zsh_hook(&args.flox_bin))?;
+    // Auto-activate hook registration
+    match action {
+        Action::Activate { args, .. } => {
+            if args.auto_activate
+                && matches!(
+                    args.invocation_type,
+                    InvocationType::Interactive | InvocationType::InPlace
+                )
+            {
+                write!(writer, "{}", crate::hook::zsh_hook(&args.flox_bin))?;
+            }
+        },
+        Action::Deactivate => {
+            // TODO: unregister the auto-activate hook
+        },
     }
 
     Ok(())
@@ -93,6 +138,13 @@ mod tests {
         let shell = ShellWithPath::Zsh(PathBuf::from("/bin/zsh"));
         let ctx = test_startup_ctx(shell, is_in_place);
         render_normalized(&ctx)
+    }
+
+    fn render_deactivate() -> String {
+        let action = Action::<ZshStartupArgs>::Deactivate;
+        let mut buf = Vec::new();
+        generate_zsh_profile_commands(&action, &mut buf).expect("generator should succeed");
+        String::from_utf8(buf).expect("output should be utf-8")
     }
 
     #[test]
@@ -139,5 +191,11 @@ mod tests {
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]]
         .assert_eq(&output);
+    }
+
+    #[test]
+    fn generate_zsh_profile_commands_deactivate() {
+        let output = render_deactivate();
+        expect![""].assert_eq(&output);
     }
 }


### PR DESCRIPTION
- **refactor(activate): drop dead start_state_dir**
  This is unused
  

- **refactor(activate): prep for profile deactivation**
  For deactive, we'll want a profile deactivate action for every activate
  action. This commit lays the groundwork by renaming
  generate_*_startup_commands to generate_*_profile_commands and
  introducing a pattern like:
  ```
  match action {
    Action::Activate { args, attach_diff } => {
      // do something
    },
    Action::Deactivate => {
      // undo something
    },
  }
  ```
  
  There are still a lot of things I don't like about how the gen_rc code
  is layed out and how we keep massaging data into so many different Ctx
  structs. But I think this is a small enough change that moves us forward
  without forcing more refactoring (besides, we can always come back for
  an activate refactor xP)
  
  I also considered some other alternatives for laying out activate and
  deactivate code:
  
  1. We could type every statment and enforce each statement has a
     deactivate action. Something like:
     ```
     struct Prompt;
     impl Action for Prompt {
       fn activate() {
         ...
       }
       fn deactivate() {
         ...
       }
     }
     ```
     But that would require a lot of boilerplate typing, it might split up
     script logic rather than keeping it all in one function (which for
     the time being I think is desirable), and it doesn't really enforce
     that much more than a match would
  
  2. We could have single `generate_profile_script` function that looked
     like:
     ```
     if activating {
       emit_prompt()
     } else {
       reset_prompt()
     }
  
     impl Shell for Bash {
       fn emit_prompt() {}
       fn reset_prompt() {}
     }
     ```
     - That would be nice but I'm not sure how it would handle custom steps for each shell
     - Would require a bunch of refactoring
  
  So I stuck with the approach in this commit, which might not be the best
  long term but I think it's good for now.
  