### PR TITLE
prototype: port auto-activate cd-in/cd-out roundtrip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,9 +1548,11 @@ name = "flox-core"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base64",
  "blake3",
  "crossterm 0.29.0",
  "derive_more",
+ "flate2",
  "fslock",
  "indoc",
  "log",

--- a/cli/flox-activations/src/attach_diff.rs
+++ b/cli/flox-activations/src/attach_diff.rs
@@ -406,6 +406,43 @@ fn fixed_vars_to_export(
     ])
 }
 
+/// Assemble an activate command for auto-activation (hook-env path).
+///
+/// Unlike `assemble_activate_command`, this takes component parts instead of
+/// a full `ActivateCtx`, since auto-start doesn't have shell/invocation_type.
+/// Uses `VarsFromEnvironment::get()` because auto-start inherits the shell
+/// environment via hook-env.
+pub(crate) fn assemble_auto_activate_command(
+    attach_ctx: &AttachCtx,
+    project_ctx: Option<&AttachProjectCtx>,
+    mode: &flox_core::activate::mode::ActivateMode,
+    start_state_dir: &Path,
+) -> Command {
+    let vars_from_env = VarsFromEnvironment::get().unwrap_or(VarsFromEnvironment {
+        flox_env_dirs: None,
+        path: None,
+        manpath: None,
+        full_env: None,
+    });
+
+    let mut command = Command::new(attach_ctx.interpreter_path.join("activate"));
+
+    // Set environment variables for the activate script.
+    let single_sets = single_set_envs(attach_ctx);
+    command.envs(&single_sets);
+    let double_sets = double_set_envs(attach_ctx, project_ctx);
+    command.envs(&double_sets.additions);
+    for var in &double_sets.deletions {
+        command.env_remove(var);
+    }
+    command.envs(non_in_place_exports(attach_ctx, 0, vars_from_env));
+
+    command.arg("--env").arg(&attach_ctx.env);
+    command.arg("--mode").arg(mode.to_string());
+    command.args(["--start-state-dir", &start_state_dir.to_string_lossy()]);
+    command
+}
+
 /// The activate_tracer is set from the FLOX_ACTIVATE_TRACE env var.
 /// If that env var is empty then activate_tracer is set to the full path of the `true` command in the PATH.
 /// If that env var is not empty and refers to an executable then then activate_tracer is set to that value.

--- a/cli/flox-activations/src/cli/auto_detach.rs
+++ b/cli/flox-activations/src/cli/auto_detach.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+use flox_core::activations::{read_activations_json, state_json_path, write_activations_json};
+use tracing::debug;
+
+#[derive(Debug, Args)]
+pub struct AutoDetachArgs {
+    /// Shell PID to detach from the activation
+    #[arg(long)]
+    pub pid: i32,
+
+    /// Path to the activation state directory
+    #[arg(long)]
+    pub activation_state_dir: PathBuf,
+}
+
+impl AutoDetachArgs {
+    pub fn handle(self) -> Result<(), anyhow::Error> {
+        let activations_json_path = state_json_path(&self.activation_state_dir);
+
+        let (activations_opt, lock) = read_activations_json(&activations_json_path)?;
+
+        let Some(mut activations) = activations_opt else {
+            debug!(
+                pid = self.pid,
+                "no activation state found, nothing to detach"
+            );
+            return Ok(());
+        };
+
+        debug!(pid = self.pid, "detaching PID from activation state");
+        activations.detach(self.pid);
+
+        // Only write back if there are still attached PIDs or the executive
+        // is running. The executive will handle full cleanup when the last
+        // PID detaches.
+        if !activations.attached_pids_is_empty() || activations.executive_running() {
+            write_activations_json(&activations, &activations_json_path, lock)?;
+        } else {
+            // No PIDs and no executive — just drop the lock.
+            // The state will be cleaned up naturally.
+            drop(lock);
+        }
+
+        Ok(())
+    }
+}

--- a/cli/flox-activations/src/cli/auto_start.rs
+++ b/cli/flox-activations/src/cli/auto_start.rs
@@ -1,0 +1,251 @@
+use std::fs::{self, DirBuilder};
+use std::os::unix::fs::DirBuilderExt;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, bail};
+use clap::Args;
+use flox_core::activate::context::{AutoStartCtx, AutoStartResult, InvocationType};
+use flox_core::activations::{
+    ActivationState,
+    StartIdentifier,
+    StartOrAttachResult,
+    read_activations_json,
+    state_json_path,
+    write_activations_json,
+};
+use flox_core::hook_state::OnActivateEnvDiff;
+use signal_hook::consts::{SIGCHLD, SIGUSR1};
+use signal_hook::iterator::Signals;
+use tracing::{debug, warn};
+
+use crate::attach_diff::assemble_auto_activate_command;
+use crate::start::{spawn_executive, start_services_with_new_process_compose, wait_for_executive};
+use crate::start_diff::{ENV_DIFF_END_JSON, StartDiff};
+
+#[derive(Debug, Args)]
+pub struct AutoStartArgs {
+    /// Shell PID to register with the activation
+    #[arg(long)]
+    pub pid: i32,
+
+    /// Path to JSON file containing AutoStartCtx
+    #[arg(long)]
+    pub activate_data: PathBuf,
+}
+
+impl AutoStartArgs {
+    pub fn handle(self) -> Result<(), anyhow::Error> {
+        let contents = fs::read_to_string(&self.activate_data)?;
+        let ctx: AutoStartCtx = serde_json::from_str(&contents)?;
+
+        // Clean up the context file
+        let _ = fs::remove_file(&self.activate_data);
+
+        let (start_id, is_new) = self.start_or_attach(&ctx)?;
+
+        // Compute hook env diff for new starts
+        let (hook_env_diff, start_state_dir_str) = if is_new {
+            let start_state_dir = start_id.start_state_dir(&ctx.activation_state_dir)?;
+            let diff = if start_state_dir.join(ENV_DIFF_END_JSON).exists() {
+                let start_diff = StartDiff::from_files(&start_state_dir)?;
+                Some(OnActivateEnvDiff {
+                    additions: start_diff.additions().clone(),
+                    deletions: start_diff.deletions().to_vec(),
+                })
+            } else {
+                None
+            };
+            (diff, Some(start_state_dir.display().to_string()))
+        } else {
+            (None, None)
+        };
+
+        let result = AutoStartResult {
+            status: "ok".to_string(),
+            start_id: serde_json::to_string(&start_id)?,
+            is_new,
+            hook_env_diff,
+            start_state_dir: start_state_dir_str,
+        };
+        println!("{}", serde_json::to_string(&result)?);
+
+        Ok(())
+    }
+
+    fn start_or_attach(
+        &self,
+        ctx: &AutoStartCtx,
+    ) -> Result<(StartIdentifier, bool), anyhow::Error> {
+        let retry_delay = Duration::from_millis(200);
+        let warning_interval = Duration::from_secs(5);
+        let mut last_warning: Option<Instant> = None;
+
+        loop {
+            match self.try_start_or_attach(ctx)? {
+                StartOrAttachResult::Start { start_id, .. } => {
+                    return Ok((start_id, true));
+                },
+                StartOrAttachResult::Attach { start_id, .. } => {
+                    return Ok((start_id, false));
+                },
+                StartOrAttachResult::AlreadyStarting {
+                    pid: blocking_pid, ..
+                } => {
+                    let now = Instant::now();
+                    let should_warn =
+                        last_warning.is_none_or(|t| now.duration_since(t) >= warning_interval);
+
+                    if should_warn {
+                        eprintln!(
+                            "Waiting for another activation to complete (blocked by PID {})...",
+                            blocking_pid
+                        );
+                        last_warning = Some(now);
+                    }
+
+                    std::thread::sleep(retry_delay);
+                },
+            }
+        }
+    }
+
+    fn try_start_or_attach(
+        &self,
+        ctx: &AutoStartCtx,
+    ) -> Result<StartOrAttachResult, anyhow::Error> {
+        let activations_json_path = state_json_path(&ctx.activation_state_dir);
+        let (activations_opt, lock) = read_activations_json(&activations_json_path)?;
+
+        let mut activations = activations_opt.unwrap_or_else(|| {
+            debug!("no existing activation state, creating new one");
+            ActivationState::new(
+                &ctx.mode,
+                Some(&ctx.project_ctx.dot_flox_path),
+                &ctx.attach_ctx.env,
+            )
+        });
+
+        // Reset state if executive is not running
+        if !activations.executive_running() {
+            debug!("discarding activation state due to executive not running");
+            activations = ActivationState::new(
+                &ctx.mode,
+                Some(&ctx.project_ctx.dot_flox_path),
+                &ctx.attach_ctx.env,
+            );
+        }
+
+        match activations.start_or_attach(self.pid, &ctx.store_path, InvocationType::Interactive) {
+            StartOrAttachResult::Start { start_id } => {
+                let result = self.do_start(
+                    ctx,
+                    start_id,
+                    &mut activations,
+                    &activations_json_path,
+                    lock,
+                )?;
+                Ok(result)
+            },
+            StartOrAttachResult::Attach { start_id } => {
+                write_activations_json(&activations, &activations_json_path, lock)?;
+                Ok(StartOrAttachResult::Attach { start_id })
+            },
+            StartOrAttachResult::AlreadyStarting { pid, start_id } => {
+                drop(lock);
+                Ok(StartOrAttachResult::AlreadyStarting { pid, start_id })
+            },
+        }
+    }
+
+    fn do_start(
+        &self,
+        ctx: &AutoStartCtx,
+        start_id: StartIdentifier,
+        activations: &mut ActivationState,
+        activations_json_path: &std::path::Path,
+        lock: fslock::LockFile,
+    ) -> Result<StartOrAttachResult, anyhow::Error> {
+        let start_state_dir = start_id.start_state_dir(&ctx.activation_state_dir)?;
+        DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&start_state_dir)?;
+
+        // Spawn executive if not already running
+        let new_executive = if !activations.executive_started() {
+            let signals = Signals::new([SIGCHLD, SIGUSR1])?;
+            let exec_pid = spawn_executive(
+                &ctx.attach_ctx,
+                &ctx.project_ctx,
+                &ctx.activation_state_dir,
+                &start_state_dir,
+                ctx.metrics_uuid,
+            )?;
+            activations.set_executive_pid(exec_pid.as_raw());
+            Some((exec_pid, signals))
+        } else {
+            None
+        };
+
+        write_activations_json(activations, activations_json_path, lock)?;
+
+        if let Some((exec_pid, signals)) = new_executive {
+            wait_for_executive(exec_pid, signals)?;
+        }
+
+        // Run on-activate hooks via the activate script
+        let mut start_command = assemble_auto_activate_command(
+            &ctx.attach_ctx,
+            Some(&ctx.project_ctx),
+            &ctx.mode,
+            &start_state_dir,
+        );
+        debug!(
+            "spawning activate script for auto-activation: {:?}",
+            start_command
+        );
+        let status = start_command.spawn()?.wait()?;
+        if !status.success() {
+            bail!("Running hook.on-activate failed during auto-activation");
+        }
+
+        if !start_state_dir.join(ENV_DIFF_END_JSON).exists() {
+            bail!(
+                "The hook.on-activate script did not complete normally during \
+                 auto-activation.\n\
+                 Review your script for the use of:\n\
+                 - 'exit' commands, which should be replaced with 'return'\n\
+                 - 'exec' commands, which should be run in a subshell: \
+                 '(exec command)'"
+            );
+        }
+
+        // Re-acquire lock to mark ready
+        let (activations_opt, lock) = read_activations_json(activations_json_path)?;
+        let mut activations = activations_opt.expect("state.json should exist");
+        activations.set_ready(&start_id);
+        write_activations_json(&activations, activations_json_path, lock)?;
+
+        // Start services if configured (non-fatal)
+        if !ctx.project_ctx.services_to_start.is_empty()
+            && !ctx.project_ctx.flox_services_socket.exists()
+        {
+            debug!(
+                services = ?ctx.project_ctx.services_to_start,
+                "starting services for auto-activation"
+            );
+            if let Err(e) = start_services_with_new_process_compose(
+                &ctx.activation_state_dir,
+                &ctx.project_ctx.process_compose_bin,
+                &ctx.project_ctx.flox_services_socket,
+                &ctx.project_ctx.services_to_start,
+            ) {
+                warn!("failed to start services during auto-activation: {e}");
+                eprintln!("flox: warning: failed to start services: {e}");
+            }
+        }
+
+        Ok(StartOrAttachResult::Start { start_id })
+    }
+}

--- a/cli/flox-activations/src/cli/mod.rs
+++ b/cli/flox-activations/src/cli/mod.rs
@@ -6,6 +6,8 @@ use flox_core::vars::FLOX_VERSION_STRING;
 
 pub mod activate;
 pub mod attach;
+pub mod auto_detach;
+pub mod auto_start;
 pub mod executive;
 mod fix_fpath;
 pub mod fix_paths;
@@ -14,6 +16,8 @@ mod profile_scripts;
 pub mod set_env_dirs;
 
 use activate::ActivateArgs;
+use auto_detach::AutoDetachArgs;
+use auto_start::AutoStartArgs;
 use executive::ExecutiveArgs;
 use fix_fpath::FixFpathArgs;
 use fix_paths::FixPathsArgs;
@@ -47,6 +51,10 @@ pub enum Command {
     Attach(AttachArgs),
     #[command(about = "Activate a Flox environment.")]
     Activate(ActivateArgs),
+    #[command(about = "Register a shell PID and run on-activate hooks.")]
+    AutoStart(AutoStartArgs),
+    #[command(about = "Detach a shell PID from an activation.")]
+    AutoDetach(AutoDetachArgs),
     #[command(about = "Start an activation and then run the executive")]
     Executive(ExecutiveArgs),
     #[command(about = "Print sourceable output fixing PATH and MANPATH for a shell.")]

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -33,6 +33,8 @@ fn try_main() -> Result<(), Error> {
     match args.command {
         cli::Command::Attach(args) => args.handle(),
         cli::Command::Activate(args) => args.handle(subsystem_verbosity),
+        cli::Command::AutoStart(args) => args.handle(),
+        cli::Command::AutoDetach(args) => args.handle(),
         cli::Command::Executive(_) => {
             unreachable!("executive already handled above")
         },

--- a/cli/flox-activations/src/start.rs
+++ b/cli/flox-activations/src/start.rs
@@ -182,7 +182,7 @@ fn signal_new_process_compose(
     Ok(())
 }
 
-fn spawn_executive(
+pub(crate) fn spawn_executive(
     attach: &AttachCtx,
     project: &AttachProjectCtx,
     activation_state_dir: &Path,
@@ -231,7 +231,10 @@ fn spawn_executive(
 /// Wait for the executive to signal that it has started by sending SIGUSR1.
 /// If the executive dies, then we error.
 /// Signals should have been registered for SIGCHLD and SIGUSR1
-fn wait_for_executive(child_pid: Pid, mut signals: Signals) -> Result<(), anyhow::Error> {
+pub(crate) fn wait_for_executive(
+    child_pid: Pid,
+    mut signals: Signals,
+) -> Result<(), anyhow::Error> {
     debug!(
         "Awaiting SIGUSR1 from child process with PID: {}",
         child_pid

--- a/cli/flox-core/Cargo.toml
+++ b/cli/flox-core/Cargo.toml
@@ -8,7 +8,9 @@ ignored = ["proptest"]
 
 [dependencies]
 anyhow.workspace = true
+base64.workspace = true
 blake3.workspace = true
+flate2.workspace = true
 crossterm.workspace = true
 derive_more.workspace = true
 fslock.workspace = true

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -150,3 +150,41 @@ impl InvocationType {
         matches!(self, Self::InPlace)
     }
 }
+
+/// Composes `AttachCtx` and `AttachProjectCtx` so that `auto_start` can pass
+/// them directly to `spawn_executive` and `assemble_auto_activate_command`
+/// without reconstructing them from flat fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutoStartCtx {
+    pub attach_ctx: AttachCtx,
+    pub project_ctx: AttachProjectCtx,
+
+    /// Nix store path for the built environment
+    pub store_path: String,
+
+    /// Base directory for this environment's activation state
+    pub activation_state_dir: PathBuf,
+
+    /// The activation mode (dev or run)
+    pub mode: ActivateMode,
+
+    /// The metrics UUID for Sentry user identification.
+    #[serde(default)]
+    pub metrics_uuid: Option<Uuid>,
+}
+
+/// Result returned on stdout (as JSON) by `flox-activations auto-start`.
+/// Parsed by `hook-env` to merge on-activate env diff and track state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutoStartResult {
+    pub status: String,
+    pub start_id: String,
+    pub is_new: bool,
+    /// Environment variable changes produced by on-activate hooks
+    /// (only when is_new=true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hook_env_diff: Option<crate::hook_state::OnActivateEnvDiff>,
+    /// Start state directory path (only when is_new=true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_state_dir: Option<String>,
+}

--- a/cli/flox-core/src/hook_state.rs
+++ b/cli/flox-core/src/hook_state.rs
@@ -1,0 +1,427 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use flate2::Compression;
+use flate2::read::ZlibDecoder;
+use flate2::write::ZlibEncoder;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+/// Serialize a value to JSON, zlib compress, then base64url encode (no padding).
+fn compress_to_base64<T: Serialize>(val: &T) -> Result<String> {
+    let json = serde_json::to_string(val).context("failed to serialize to JSON")?;
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(json.as_bytes())
+        .context("failed to zlib compress")?;
+    let compressed = encoder
+        .finish()
+        .context("failed to finish zlib compression")?;
+    Ok(URL_SAFE_NO_PAD.encode(&compressed))
+}
+
+/// Deserialize from base64url encoded, zlib compressed JSON.
+fn decompress_from_base64<T: DeserializeOwned>(encoded: &str) -> Result<T> {
+    let compressed = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .context("failed to base64url decode")?;
+    let mut decoder = ZlibDecoder::new(&compressed[..]);
+    let mut json = String::new();
+    decoder
+        .read_to_string(&mut json)
+        .context("failed to zlib decompress")?;
+    serde_json::from_str(&json).context("failed to deserialize from JSON")
+}
+
+pub const HOOK_VAR_DIFF: &str = "_FLOX_HOOK_DIFF";
+pub const HOOK_VAR_DIRS: &str = "_FLOX_HOOK_DIRS";
+pub const HOOK_VAR_WATCHES: &str = "_FLOX_HOOK_WATCHES";
+pub const HOOK_VAR_SUPPRESSED: &str = "_FLOX_HOOK_SUPPRESSED";
+pub const HOOK_VAR_NOTIFIED: &str = "_FLOX_HOOK_NOTIFIED";
+pub const HOOK_VAR_CWD: &str = "_FLOX_HOOK_CWD";
+pub const HOOK_VAR_ACTIVATIONS: &str = "_FLOX_HOOK_ACTIVATIONS";
+pub const HOOK_VAR_EXCLUDE_DIRS: &str = "_FLOX_HOOK_EXCLUDE_DIRS";
+pub const HOOK_VAR_EXCLUDE_NAMES: &str = "_FLOX_HOOK_EXCLUDE_NAMES";
+
+/// Environment variable changes produced by on-activate hooks.
+/// Passed from `flox-activations` back to `hook-env` via `AutoStartResult`,
+/// and cached in `ActivationInfo` for cd-away-and-back without re-running hooks.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct OnActivateEnvDiff {
+    pub additions: HashMap<String, String>,
+    pub deletions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct HookDiff {
+    pub additions: HashMap<String, String>,
+    pub modifications: HashMap<String, String>,
+    pub deletions: HashMap<String, String>,
+}
+
+impl HookDiff {
+    /// Compute the diff between a pristine environment and a new environment.
+    ///
+    /// - `additions`: keys in `new_env` but not in `pristine`
+    /// - `modifications`: keys in both with different values (stores the ORIGINAL value)
+    /// - `deletions`: keys in `pristine` but not in `new_env` (stores the ORIGINAL value)
+    pub fn compute(pristine: &HashMap<String, String>, new_env: &HashMap<String, String>) -> Self {
+        let mut additions = HashMap::new();
+        let mut modifications = HashMap::new();
+        let mut deletions = HashMap::new();
+
+        for (key, new_val) in new_env {
+            match pristine.get(key) {
+                Some(orig_val) if orig_val != new_val => {
+                    modifications.insert(key.clone(), orig_val.clone());
+                },
+                None => {
+                    additions.insert(key.clone(), new_val.clone());
+                },
+                _ => {},
+            }
+        }
+
+        for (key, orig_val) in pristine {
+            if !new_env.contains_key(key) {
+                deletions.insert(key.clone(), orig_val.clone());
+            }
+        }
+
+        Self {
+            additions,
+            modifications,
+            deletions,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.additions.is_empty() && self.modifications.is_empty() && self.deletions.is_empty()
+    }
+
+    /// Serialize to JSON, zlib compress, then base64url encode (no padding).
+    pub fn serialize(&self) -> Result<String> {
+        compress_to_base64(self)
+    }
+
+    /// Deserialize from base64url encoded, zlib compressed JSON.
+    /// An empty string returns the default (empty) HookDiff.
+    pub fn deserialize(encoded: &str) -> Result<Self> {
+        if encoded.is_empty() {
+            return Ok(Self::default());
+        }
+        decompress_from_base64(encoded)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WatchEntry {
+    pub path: PathBuf,
+    pub mtime: Option<u64>,
+}
+
+/// Per-environment activation info tracked by hook-env.
+/// Maps dot_flox_path to the activation state directory and store path
+/// so that auto-detach knows where to find the activation state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ActivationTracking {
+    pub entries: HashMap<PathBuf, ActivationInfo>,
+    /// Cache of activation info for environments the user has cd'd away from.
+    /// Preserves on_activate_diff so cd-back doesn't re-run hooks.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub detached_cache: HashMap<PathBuf, ActivationInfo>,
+}
+
+/// Metadata for a single auto-activated environment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActivationInfo {
+    /// Base directory for this environment's activation state
+    pub activation_state_dir: PathBuf,
+    /// Nix store path for the built environment
+    pub store_path: String,
+    /// Start state directory for the current activation
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_state_dir: Option<PathBuf>,
+    /// Cached on-activate hook env diff (avoids re-running hooks on cd-back)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_activate_diff: Option<OnActivateEnvDiff>,
+}
+
+impl ActivationTracking {
+    /// Serialize to JSON, zlib compress, then base64url encode (no padding).
+    pub fn serialize(&self) -> Result<String> {
+        if self.entries.is_empty() && self.detached_cache.is_empty() {
+            return Ok(String::new());
+        }
+        compress_to_base64(self)
+    }
+
+    /// Deserialize from base64url encoded, zlib compressed JSON.
+    /// An empty string returns the default (empty) ActivationTracking.
+    pub fn deserialize(encoded: &str) -> Result<Self> {
+        if encoded.is_empty() {
+            return Ok(Self::default());
+        }
+        decompress_from_base64(encoded)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HookState {
+    pub diff: HookDiff,
+    pub active_dirs: Vec<PathBuf>,
+    pub watches: Vec<WatchEntry>,
+    pub suppressed_dirs: Vec<PathBuf>,
+    pub notified_dirs: Vec<PathBuf>,
+    pub last_cwd: Option<PathBuf>,
+    pub activation_tracking: ActivationTracking,
+}
+
+impl HookState {
+    /// Read hook state from environment variables.
+    pub fn from_env() -> Result<Self> {
+        let diff_str = std::env::var(HOOK_VAR_DIFF).unwrap_or_default();
+        let diff = HookDiff::deserialize(&diff_str).context("failed to parse _FLOX_HOOK_DIFF")?;
+
+        let dirs_str = std::env::var(HOOK_VAR_DIRS).unwrap_or_default();
+        let active_dirs = Self::parse_path_list(&dirs_str);
+
+        let watches_str = std::env::var(HOOK_VAR_WATCHES).unwrap_or_default();
+        let watches: Vec<WatchEntry> = if watches_str.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(&watches_str).context("failed to parse _FLOX_HOOK_WATCHES")?
+        };
+
+        let suppressed_str = std::env::var(HOOK_VAR_SUPPRESSED).unwrap_or_default();
+        let suppressed_dirs = Self::parse_path_list(&suppressed_str);
+
+        let notified_str = std::env::var(HOOK_VAR_NOTIFIED).unwrap_or_default();
+        let notified_dirs = Self::parse_path_list(&notified_str);
+
+        let last_cwd = std::env::var(HOOK_VAR_CWD)
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from);
+
+        let activations_str = std::env::var(HOOK_VAR_ACTIVATIONS).unwrap_or_default();
+        let activation_tracking = ActivationTracking::deserialize(&activations_str)
+            .context("failed to parse _FLOX_HOOK_ACTIVATIONS")?;
+
+        Ok(Self {
+            diff,
+            active_dirs,
+            watches,
+            suppressed_dirs,
+            notified_dirs,
+            last_cwd,
+            activation_tracking,
+        })
+    }
+
+    /// Check if any watched file has changed by comparing current mtime to recorded mtime.
+    pub fn watches_changed(&self) -> bool {
+        for entry in &self.watches {
+            let current_mtime = std::fs::metadata(&entry.path)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs());
+            if current_mtime != entry.mtime {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Serialize a list of paths as a JSON array string.
+    ///
+    /// Uses JSON instead of colon-separated format to correctly handle
+    /// paths containing colons (e.g. `/home/user/my:project/.flox`).
+    pub fn format_path_list(paths: &[PathBuf]) -> String {
+        if paths.is_empty() {
+            return String::new();
+        }
+        serde_json::to_string(paths).unwrap_or_default()
+    }
+
+    /// Deserialize a list of paths from a JSON array string.
+    /// Falls back to colon-separated parsing for backward compatibility
+    /// with state written before the JSON migration.
+    /// An empty string returns an empty list.
+    pub fn parse_path_list(s: &str) -> Vec<PathBuf> {
+        if s.is_empty() {
+            return Vec::new();
+        }
+        // Try JSON first (new format)
+        if let Ok(paths) = serde_json::from_str::<Vec<PathBuf>>(s) {
+            return paths;
+        }
+        // Fall back to colon-separated (legacy format, for in-flight sessions)
+        s.split(':').map(PathBuf::from).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_addition() {
+        let pristine = HashMap::new();
+        let mut new_env = HashMap::new();
+        new_env.insert("FOO".to_string(), "bar".to_string());
+
+        let diff = HookDiff::compute(&pristine, &new_env);
+        assert_eq!(diff, HookDiff {
+            additions: HashMap::from([("FOO".to_string(), "bar".to_string())]),
+            modifications: HashMap::new(),
+            deletions: HashMap::new(),
+        });
+    }
+
+    #[test]
+    fn test_compute_modification() {
+        let mut pristine = HashMap::new();
+        pristine.insert("FOO".to_string(), "old".to_string());
+        let mut new_env = HashMap::new();
+        new_env.insert("FOO".to_string(), "new".to_string());
+
+        let diff = HookDiff::compute(&pristine, &new_env);
+        assert_eq!(diff, HookDiff {
+            additions: HashMap::new(),
+            modifications: HashMap::from([("FOO".to_string(), "old".to_string())]),
+            deletions: HashMap::new(),
+        });
+    }
+
+    #[test]
+    fn test_compute_deletion() {
+        let mut pristine = HashMap::new();
+        pristine.insert("FOO".to_string(), "bar".to_string());
+        let new_env = HashMap::new();
+
+        let diff = HookDiff::compute(&pristine, &new_env);
+        assert_eq!(diff, HookDiff {
+            additions: HashMap::new(),
+            modifications: HashMap::new(),
+            deletions: HashMap::from([("FOO".to_string(), "bar".to_string())]),
+        });
+    }
+
+    #[test]
+    fn test_compute_no_change() {
+        let mut pristine = HashMap::new();
+        pristine.insert("FOO".to_string(), "bar".to_string());
+        let mut new_env = HashMap::new();
+        new_env.insert("FOO".to_string(), "bar".to_string());
+
+        let diff = HookDiff::compute(&pristine, &new_env);
+        assert_eq!(diff, HookDiff::default());
+    }
+
+    #[test]
+    fn test_serialize_deserialize_roundtrip() {
+        let diff = HookDiff {
+            additions: HashMap::from([("NEW".to_string(), "val".to_string())]),
+            modifications: HashMap::from([("MOD".to_string(), "orig".to_string())]),
+            deletions: HashMap::from([("DEL".to_string(), "gone".to_string())]),
+        };
+
+        let encoded = diff.serialize().unwrap();
+        let decoded = HookDiff::deserialize(&encoded).unwrap();
+        assert_eq!(decoded, diff);
+    }
+
+    #[test]
+    fn test_deserialize_empty_string() {
+        let diff = HookDiff::deserialize("").unwrap();
+        assert_eq!(diff, HookDiff::default());
+    }
+
+    #[test]
+    fn test_path_list_roundtrip() {
+        let paths = vec![
+            PathBuf::from("/home/user/.flox/env1"),
+            PathBuf::from("/home/user/.flox/env2"),
+        ];
+        let serialized = HookState::format_path_list(&paths);
+        let deserialized = HookState::parse_path_list(&serialized);
+        assert_eq!(deserialized, paths);
+    }
+
+    #[test]
+    fn test_parse_empty_path_list() {
+        let paths = HookState::parse_path_list("");
+        assert_eq!(paths, Vec::<PathBuf>::new());
+    }
+
+    #[test]
+    fn test_path_list_with_colons() {
+        let paths = vec![
+            PathBuf::from("/home/user/my:project/.flox"),
+            PathBuf::from("/home/user/normal/.flox"),
+        ];
+        let serialized = HookState::format_path_list(&paths);
+        let deserialized = HookState::parse_path_list(&serialized);
+        assert_eq!(deserialized, paths);
+    }
+
+    #[test]
+    fn test_path_list_with_spaces() {
+        let paths = vec![
+            PathBuf::from("/home/First Last/project/.flox"),
+            PathBuf::from("/home/user/my project/.flox"),
+        ];
+        let serialized = HookState::format_path_list(&paths);
+        let deserialized = HookState::parse_path_list(&serialized);
+        assert_eq!(deserialized, paths);
+    }
+
+    #[test]
+    fn test_path_list_legacy_colon_format() {
+        // Backward compatibility: parsing legacy colon-separated format
+        let legacy = "/home/user/.flox/env1:/home/user/.flox/env2";
+        let paths = HookState::parse_path_list(legacy);
+        assert_eq!(paths, vec![
+            PathBuf::from("/home/user/.flox/env1"),
+            PathBuf::from("/home/user/.flox/env2"),
+        ]);
+    }
+
+    #[test]
+    fn test_activation_tracking_serialize_deserialize_roundtrip() {
+        let mut tracking = ActivationTracking::default();
+        tracking
+            .entries
+            .insert(PathBuf::from("/home/user/project/.flox"), ActivationInfo {
+                activation_state_dir: PathBuf::from(
+                    "/run/user/1000/flox/activations/abc12345-project",
+                ),
+                store_path: "/nix/store/abc-env".to_string(),
+                start_state_dir: None,
+                on_activate_diff: None,
+            });
+
+        let encoded = tracking.serialize().unwrap();
+        let decoded = ActivationTracking::deserialize(&encoded).unwrap();
+        assert_eq!(decoded, tracking);
+    }
+
+    #[test]
+    fn test_activation_tracking_deserialize_empty_string() {
+        let tracking = ActivationTracking::deserialize("").unwrap();
+        assert_eq!(tracking, ActivationTracking::default());
+    }
+
+    #[test]
+    fn test_activation_tracking_serialize_empty_returns_empty_string() {
+        let tracking = ActivationTracking::default();
+        let encoded = tracking.serialize().unwrap();
+        assert_eq!(encoded, "");
+    }
+}

--- a/cli/flox-core/src/lib.rs
+++ b/cli/flox-core/src/lib.rs
@@ -2,10 +2,13 @@ pub mod activate;
 pub mod activations;
 pub mod canonical_path;
 pub mod data;
+pub mod hook_state;
+pub mod preference;
 #[cfg(feature = "proc_status")]
 pub mod proc_status;
 pub mod process_compose;
 pub mod sentry;
+pub mod trust;
 pub mod util;
 pub mod vars;
 mod version;

--- a/cli/flox-core/src/preference.rs
+++ b/cli/flox-core/src/preference.rs
@@ -1,0 +1,220 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Full BLAKE3 hex output length for preference hashes.
+/// Uses the same length as trust hashes for consistency, though preference
+/// hashes are not security-sensitive (they key on path only).
+const PREFERENCE_HASH_CHARS: usize = 64;
+
+/// Status of auto-activation preference for a `.flox` environment path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PreferenceStatus {
+    Allowed,
+    Denied,
+    Unregistered,
+}
+
+/// Manages allowed/denied preference files that control whether the user
+/// wants auto-activation for a `.flox` environment.
+///
+/// Unlike [`TrustManager`](crate::trust::TrustManager), preference is **not
+/// content-sensitive**: the hash key is `blake3(absolute_path + "\n")` (path
+/// only), so manifest changes do not affect the preference.
+///
+/// A single record per environment is maintained: `allow()` removes any
+/// `denied/` file, and `deny()` removes any `allowed/` file.
+#[derive(Clone, Debug)]
+pub struct PreferenceManager {
+    allowed_dir: PathBuf,
+    denied_dir: PathBuf,
+}
+
+impl PreferenceManager {
+    pub fn new(state_dir: impl AsRef<Path>) -> Self {
+        let base = state_dir.as_ref().join("preference");
+        Self {
+            allowed_dir: base.join("allowed"),
+            denied_dir: base.join("denied"),
+        }
+    }
+
+    /// Check whether a `.flox` path has auto-activation allowed, denied,
+    /// or unregistered.
+    ///
+    /// Denied takes priority over allowed (though in practice only one
+    /// file should exist at a time).
+    pub fn check(&self, dot_flox_path: impl AsRef<Path>) -> Result<PreferenceStatus> {
+        let dot_flox_path = dot_flox_path.as_ref();
+        let abs = fs::canonicalize(dot_flox_path)
+            .with_context(|| format!("canonicalizing {}", dot_flox_path.display()))?;
+
+        let hash = self.path_hash(&abs);
+        if self.denied_dir.join(&hash).exists() {
+            return Ok(PreferenceStatus::Denied);
+        }
+        if self.allowed_dir.join(&hash).exists() {
+            return Ok(PreferenceStatus::Allowed);
+        }
+
+        Ok(PreferenceStatus::Unregistered)
+    }
+
+    /// Allow auto-activation for a `.flox` path. Removes any existing
+    /// denied file.
+    pub fn allow(&self, dot_flox_path: impl AsRef<Path>) -> Result<()> {
+        let dot_flox_path = dot_flox_path.as_ref();
+        let abs = fs::canonicalize(dot_flox_path)
+            .with_context(|| format!("canonicalizing {}", dot_flox_path.display()))?;
+
+        let hash = self.path_hash(&abs);
+
+        // Remove any denied file first
+        let denied_file = self.denied_dir.join(&hash);
+        if denied_file.exists() {
+            fs::remove_file(&denied_file)
+                .with_context(|| format!("removing denied file {}", denied_file.display()))?;
+        }
+
+        fs::create_dir_all(&self.allowed_dir)
+            .with_context(|| format!("creating {}", self.allowed_dir.display()))?;
+
+        let allowed_file = self.allowed_dir.join(&hash);
+        fs::write(&allowed_file, abs.display().to_string())
+            .with_context(|| format!("writing allowed file {}", allowed_file.display()))?;
+
+        Ok(())
+    }
+
+    /// Deny auto-activation for a `.flox` path. Removes any existing
+    /// allowed file.
+    pub fn deny(&self, dot_flox_path: impl AsRef<Path>) -> Result<()> {
+        let dot_flox_path = dot_flox_path.as_ref();
+        let abs = fs::canonicalize(dot_flox_path)
+            .with_context(|| format!("canonicalizing {}", dot_flox_path.display()))?;
+
+        let hash = self.path_hash(&abs);
+
+        // Remove any allowed file first
+        let allowed_file = self.allowed_dir.join(&hash);
+        if allowed_file.exists() {
+            fs::remove_file(&allowed_file)
+                .with_context(|| format!("removing allowed file {}", allowed_file.display()))?;
+        }
+
+        fs::create_dir_all(&self.denied_dir)
+            .with_context(|| format!("creating {}", self.denied_dir.display()))?;
+
+        let denied_file = self.denied_dir.join(&hash);
+        fs::write(&denied_file, "")
+            .with_context(|| format!("writing denied file {}", denied_file.display()))?;
+
+        Ok(())
+    }
+
+    /// Compute the path hash: `blake3(absolute_path + "\n")`, truncated to
+    /// [`PREFERENCE_HASH_CHARS`].
+    fn path_hash(&self, abs_path: &Path) -> String {
+        let input = format!("{}\n", abs_path.display());
+        let mut hex = blake3::hash(input.as_bytes()).to_hex();
+        hex.truncate(PREFERENCE_HASH_CHARS);
+        hex.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a minimal `.flox/env/manifest.toml` inside `dir`.
+    fn create_dot_flox(dir: &Path) -> PathBuf {
+        let dot_flox = dir.join(".flox");
+        let env_dir = dot_flox.join("env");
+        fs::create_dir_all(&env_dir).unwrap();
+        fs::write(env_dir.join("manifest.toml"), "[install]").unwrap();
+        dot_flox
+    }
+
+    #[test]
+    fn unregistered_by_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        let dot_flox = create_dot_flox(tmp.path());
+
+        let mgr = PreferenceManager::new(&state_dir);
+        assert_eq!(
+            mgr.check(&dot_flox).unwrap(),
+            PreferenceStatus::Unregistered
+        );
+    }
+
+    #[test]
+    fn allow_then_check() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        let dot_flox = create_dot_flox(tmp.path());
+
+        let mgr = PreferenceManager::new(&state_dir);
+        mgr.allow(&dot_flox).unwrap();
+
+        assert_eq!(mgr.check(&dot_flox).unwrap(), PreferenceStatus::Allowed);
+    }
+
+    #[test]
+    fn deny_then_check() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        let dot_flox = create_dot_flox(tmp.path());
+
+        let mgr = PreferenceManager::new(&state_dir);
+        mgr.deny(&dot_flox).unwrap();
+
+        assert_eq!(mgr.check(&dot_flox).unwrap(), PreferenceStatus::Denied);
+    }
+
+    #[test]
+    fn allow_after_deny() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        let dot_flox = create_dot_flox(tmp.path());
+
+        let mgr = PreferenceManager::new(&state_dir);
+        mgr.deny(&dot_flox).unwrap();
+        assert_eq!(mgr.check(&dot_flox).unwrap(), PreferenceStatus::Denied);
+
+        mgr.allow(&dot_flox).unwrap();
+        assert_eq!(mgr.check(&dot_flox).unwrap(), PreferenceStatus::Allowed);
+    }
+
+    #[test]
+    fn deny_after_allow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        let dot_flox = create_dot_flox(tmp.path());
+
+        let mgr = PreferenceManager::new(&state_dir);
+        mgr.allow(&dot_flox).unwrap();
+        assert_eq!(mgr.check(&dot_flox).unwrap(), PreferenceStatus::Allowed);
+
+        mgr.deny(&dot_flox).unwrap();
+        assert_eq!(mgr.check(&dot_flox).unwrap(), PreferenceStatus::Denied);
+    }
+
+    #[test]
+    fn not_content_sensitive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        let dot_flox = create_dot_flox(tmp.path());
+
+        let mgr = PreferenceManager::new(&state_dir);
+        mgr.allow(&dot_flox).unwrap();
+        assert_eq!(mgr.check(&dot_flox).unwrap(), PreferenceStatus::Allowed);
+
+        // Modify the manifest — preference should remain allowed
+        let manifest_path = dot_flox.join("env").join("manifest.toml");
+        fs::write(&manifest_path, "[install]\nhello = {}").unwrap();
+
+        assert_eq!(mgr.check(&dot_flox).unwrap(), PreferenceStatus::Allowed);
+    }
+}

--- a/cli/flox-core/src/trust.rs
+++ b/cli/flox-core/src/trust.rs
@@ -1,0 +1,287 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Full BLAKE3 hex output length for trust hashes (security-sensitive).
+/// Unlike [`N_HASH_CHARS`](crate::N_HASH_CHARS) (8 chars / 32 bits) used for
+/// non-security path hashing, trust hashes use the full 64 hex chars (256 bits)
+/// to prevent brute-force forgery of manifest trust tokens.
+const TRUST_HASH_CHARS: usize = 64;
+
+/// Status of trust for a `.flox` environment path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TrustStatus {
+    Trusted,
+    Denied,
+    Unknown(PathBuf),
+}
+
+/// Manages allow/deny trust files that control auto-activation of `.flox`
+/// environments.
+///
+/// Allow files are keyed on `blake3(absolute_path + "\n" + manifest_content)`,
+/// so manifest changes revoke trust. Deny files are keyed on
+/// `blake3(absolute_path + "\n")` and persist regardless of manifest content.
+/// Deny always takes priority over allow.
+#[derive(Clone, Debug)]
+pub struct TrustManager {
+    allowed_dir: PathBuf,
+    denied_dir: PathBuf,
+}
+
+impl TrustManager {
+    pub fn new(data_dir: impl AsRef<Path>) -> Self {
+        let base = data_dir.as_ref().join("trust");
+        Self {
+            allowed_dir: base.join("allowed"),
+            denied_dir: base.join("denied"),
+        }
+    }
+
+    /// Check whether a `.flox` path is trusted, denied, or unknown.
+    ///
+    /// Deny takes priority over allow. Allow is content-sensitive: if the
+    /// manifest has changed since `trust()` was called, the status reverts to
+    /// `Unknown`.
+    pub fn check(&self, dot_flox_path: impl AsRef<Path>) -> Result<TrustStatus> {
+        let dot_flox_path = dot_flox_path.as_ref();
+        let abs = fs::canonicalize(dot_flox_path)
+            .with_context(|| format!("canonicalizing {}", dot_flox_path.display()))?;
+
+        let deny_hash = self.deny_hash(&abs);
+        if self.denied_dir.join(&deny_hash).exists() {
+            return Ok(TrustStatus::Denied);
+        }
+
+        let manifest_path = abs.join("env").join("manifest.toml");
+        let manifest_content = fs::read_to_string(&manifest_path)
+            .with_context(|| format!("reading manifest at {}", manifest_path.display()))?;
+        let allow_hash = self.allow_hash(&abs, &manifest_content);
+        if self.allowed_dir.join(&allow_hash).exists() {
+            return Ok(TrustStatus::Trusted);
+        }
+
+        Ok(TrustStatus::Unknown(abs))
+    }
+
+    /// Mark a `.flox` path as trusted. Removes any existing deny file.
+    ///
+    /// The allow file stores the canonical path so that `deny()` can later
+    /// scan and remove stale allow files for the same environment.
+    pub fn trust(&self, dot_flox_path: impl AsRef<Path>) -> Result<()> {
+        let dot_flox_path = dot_flox_path.as_ref();
+        let abs = fs::canonicalize(dot_flox_path)
+            .with_context(|| format!("canonicalizing {}", dot_flox_path.display()))?;
+
+        let manifest_path = abs.join("env").join("manifest.toml");
+        let manifest_content = fs::read_to_string(&manifest_path)
+            .with_context(|| format!("reading manifest at {}", manifest_path.display()))?;
+
+        // Remove any deny file first
+        let deny_file = self.denied_dir.join(self.deny_hash(&abs));
+        if deny_file.exists() {
+            fs::remove_file(&deny_file)
+                .with_context(|| format!("removing deny file {}", deny_file.display()))?;
+        }
+
+        fs::create_dir_all(&self.allowed_dir)
+            .with_context(|| format!("creating {}", self.allowed_dir.display()))?;
+
+        let allow_file = self
+            .allowed_dir
+            .join(self.allow_hash(&abs, &manifest_content));
+        // Store the canonical path inside the allow file so `deny()` can
+        // identify and remove stale allow files for the same environment.
+        fs::write(&allow_file, abs.display().to_string())
+            .with_context(|| format!("writing allow file {}", allow_file.display()))?;
+
+        Ok(())
+    }
+
+    /// Mark a `.flox` path as denied. Removes any existing allow files.
+    pub fn deny(&self, dot_flox_path: impl AsRef<Path>) -> Result<()> {
+        let dot_flox_path = dot_flox_path.as_ref();
+        let abs = fs::canonicalize(dot_flox_path)
+            .with_context(|| format!("canonicalizing {}", dot_flox_path.display()))?;
+
+        // Remove any allow files for this path (any manifest content)
+        self.remove_allow_files_for_path(&abs)?;
+
+        fs::create_dir_all(&self.denied_dir)
+            .with_context(|| format!("creating {}", self.denied_dir.display()))?;
+
+        let deny_file = self.denied_dir.join(self.deny_hash(&abs));
+        fs::write(&deny_file, "")
+            .with_context(|| format!("writing deny file {}", deny_file.display()))?;
+
+        Ok(())
+    }
+
+    /// Compute the allow hash: `blake3(absolute_path + "\n" + manifest_content)`,
+    /// truncated to [`TRUST_HASH_CHARS`].
+    fn allow_hash(&self, abs_path: &Path, manifest_content: &str) -> String {
+        let input = format!("{}\n{}", abs_path.display(), manifest_content);
+        let mut hex = blake3::hash(input.as_bytes()).to_hex();
+        hex.truncate(TRUST_HASH_CHARS);
+        hex.to_string()
+    }
+
+    /// Compute the deny hash: `blake3(absolute_path + "\n")`, truncated to
+    /// [`TRUST_HASH_CHARS`].
+    fn deny_hash(&self, abs_path: &Path) -> String {
+        let input = format!("{}\n", abs_path.display());
+        let mut hex = blake3::hash(input.as_bytes()).to_hex();
+        hex.truncate(TRUST_HASH_CHARS);
+        hex.to_string()
+    }
+
+    /// Remove all allow files that match a given path (across any manifest
+    /// content). Scans allow files whose content matches the canonical path.
+    /// In practice the directory is small, so this linear scan is acceptable.
+    fn remove_allow_files_for_path(&self, abs_path: &Path) -> Result<()> {
+        let abs_str = abs_path.display().to_string();
+        let entries = match fs::read_dir(&self.allowed_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => {
+                return Err(e).with_context(|| format!("reading {}", self.allowed_dir.display()));
+            },
+        };
+        for entry in entries {
+            let entry = entry?;
+            if let Ok(content) = fs::read_to_string(entry.path())
+                && content.trim() == abs_str
+            {
+                fs::remove_file(entry.path()).with_context(|| {
+                    format!("removing stale allow file {}", entry.path().display())
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a minimal `.flox/env/manifest.toml` inside `dir`.
+    fn create_dot_flox(dir: &Path, manifest: &str) -> PathBuf {
+        let dot_flox = dir.join(".flox");
+        let env_dir = dot_flox.join("env");
+        fs::create_dir_all(&env_dir).unwrap();
+        fs::write(env_dir.join("manifest.toml"), manifest).unwrap();
+        dot_flox
+    }
+
+    #[test]
+    fn unknown_by_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dot_flox = create_dot_flox(tmp.path(), "[install]");
+
+        let mgr = TrustManager::new(&data_dir);
+        let status = mgr.check(&dot_flox).unwrap();
+
+        let canonical = fs::canonicalize(&dot_flox).unwrap();
+        assert_eq!(status, TrustStatus::Unknown(canonical));
+    }
+
+    #[test]
+    fn trust_then_check() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dot_flox = create_dot_flox(tmp.path(), "[install]");
+
+        let mgr = TrustManager::new(&data_dir);
+        mgr.trust(&dot_flox).unwrap();
+
+        assert_eq!(mgr.check(&dot_flox).unwrap(), TrustStatus::Trusted);
+    }
+
+    #[test]
+    fn deny_then_check() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dot_flox = create_dot_flox(tmp.path(), "[install]");
+
+        let mgr = TrustManager::new(&data_dir);
+        mgr.deny(&dot_flox).unwrap();
+
+        assert_eq!(mgr.check(&dot_flox).unwrap(), TrustStatus::Denied);
+    }
+
+    #[test]
+    fn deny_overrides_trust() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dot_flox = create_dot_flox(tmp.path(), "[install]");
+
+        let mgr = TrustManager::new(&data_dir);
+        mgr.trust(&dot_flox).unwrap();
+        mgr.deny(&dot_flox).unwrap();
+
+        assert_eq!(mgr.check(&dot_flox).unwrap(), TrustStatus::Denied);
+    }
+
+    #[test]
+    fn trust_after_deny() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dot_flox = create_dot_flox(tmp.path(), "[install]");
+
+        let mgr = TrustManager::new(&data_dir);
+        mgr.deny(&dot_flox).unwrap();
+        assert_eq!(mgr.check(&dot_flox).unwrap(), TrustStatus::Denied);
+
+        mgr.trust(&dot_flox).unwrap();
+        assert_eq!(mgr.check(&dot_flox).unwrap(), TrustStatus::Trusted);
+    }
+
+    #[test]
+    fn deny_cleans_up_stale_allow_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dot_flox = create_dot_flox(tmp.path(), "[install]");
+
+        let mgr = TrustManager::new(&data_dir);
+
+        // Trust with one manifest, then change manifest and trust again.
+        // This creates two allow files for the same path.
+        mgr.trust(&dot_flox).unwrap();
+        let manifest_path = dot_flox.join("env").join("manifest.toml");
+        fs::write(&manifest_path, "[install]\nhello = {}").unwrap();
+        mgr.trust(&dot_flox).unwrap();
+
+        // Count allow files: should be 2
+        let allow_count = fs::read_dir(&mgr.allowed_dir).unwrap().count();
+        assert_eq!(allow_count, 2);
+
+        // Deny should remove both allow files
+        mgr.deny(&dot_flox).unwrap();
+        let allow_count = fs::read_dir(&mgr.allowed_dir).unwrap().count();
+        assert_eq!(allow_count, 0);
+    }
+
+    #[test]
+    fn manifest_change_revokes_trust() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dot_flox = create_dot_flox(tmp.path(), "[install]");
+
+        let mgr = TrustManager::new(&data_dir);
+        mgr.trust(&dot_flox).unwrap();
+        assert_eq!(mgr.check(&dot_flox).unwrap(), TrustStatus::Trusted);
+
+        // Modify the manifest
+        let manifest_path = dot_flox.join("env").join("manifest.toml");
+        fs::write(&manifest_path, "[install]\nhello = {}").unwrap();
+
+        let canonical = fs::canonicalize(&dot_flox).unwrap();
+        assert_eq!(
+            mgr.check(&dot_flox).unwrap(),
+            TrustStatus::Unknown(canonical)
+        );
+    }
+}

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -964,11 +964,8 @@ pub fn find_dot_flox(initial_dir: &Path) -> Result<Option<DotFlox>, EnvironmentE
 /// Unlike `find_dot_flox`, this function does not stop at git boundaries —
 /// it walks the full ancestor chain so that auto-activation can discover
 /// all environments the user may have entered.
-pub fn find_all_dot_flox(
-    initial_dir: &Path,
-) -> Result<Vec<DotFlox>, EnvironmentError> {
-    let path =
-        CanonicalPath::new(initial_dir).map_err(EnvironmentError::StartDiscoveryDir)?;
+pub fn find_all_dot_flox(initial_dir: &Path) -> Result<Vec<DotFlox>, EnvironmentError> {
+    let path = CanonicalPath::new(initial_dir).map_err(EnvironmentError::StartDiscoveryDir)?;
 
     let mut results = Vec::new();
     for ancestor in path.ancestors() {

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -958,6 +958,49 @@ pub fn find_dot_flox(initial_dir: &Path) -> Result<Option<DotFlox>, EnvironmentE
     Ok(None)
 }
 
+/// Walk the directory ancestry and collect every `.flox` directory found,
+/// returned outermost-first (i.e. in the order they should be activated).
+///
+/// Unlike `find_dot_flox`, this function does not stop at git boundaries —
+/// it walks the full ancestor chain so that auto-activation can discover
+/// all environments the user may have entered.
+pub fn find_all_dot_flox(
+    initial_dir: &Path,
+) -> Result<Vec<DotFlox>, EnvironmentError> {
+    let path =
+        CanonicalPath::new(initial_dir).map_err(EnvironmentError::StartDiscoveryDir)?;
+
+    let mut results = Vec::new();
+    for ancestor in path.ancestors() {
+        let tentative_dot_flox = ancestor.join(DOT_FLOX);
+        debug!(
+            "find_all_dot_flox: looking for .flox: path={}",
+            tentative_dot_flox.display()
+        );
+
+        if tentative_dot_flox.exists() {
+            match DotFlox::open_in(ancestor) {
+                Ok(dot_flox) => {
+                    debug!(
+                        "find_all_dot_flox: .flox found: path={}",
+                        tentative_dot_flox.display()
+                    );
+                    results.push(dot_flox);
+                },
+                Err(err) => {
+                    debug!(
+                        "find_all_dot_flox: skipping invalid .flox at {}: {err}",
+                        tentative_dot_flox.display()
+                    );
+                },
+            }
+        }
+    }
+
+    results.reverse();
+    Ok(results)
+}
+
 /// Return a path to the services socket given a unique identifier
 ///
 /// Socket paths cannot exceed 104 characters on macOS

--- a/cli/flox/src/commands/allow.rs
+++ b/cli/flox/src/commands/allow.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use bpaf::Bpaf;
+use flox_core::preference::PreferenceManager;
+use flox_core::trust::TrustManager;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::{EnvironmentPointer, find_dot_flox};
+
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[derive(Bpaf, Clone, Debug)]
+pub struct Allow {
+    /// Path to the .flox directory to allow (defaults to current directory)
+    #[bpaf(long, argument("PATH"), optional)]
+    path: Option<PathBuf>,
+}
+
+impl Allow {
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("allow");
+
+        let search_dir = match &self.path {
+            Some(p) => p.clone(),
+            None => std::env::current_dir()?,
+        };
+        let dot_flox = find_dot_flox(&search_dir)?;
+
+        let Some(dot_flox) = dot_flox else {
+            bail!(
+                "No '.flox' environment found at '{}' or any parent directory.\n\
+                 Use 'flox init' to create one.",
+                search_dir.display()
+            );
+        };
+
+        let preference_manager = PreferenceManager::new(&flox.state_dir);
+        preference_manager.allow(&dot_flox.path)?;
+
+        // For local environments, trust is implicit when allowing
+        if matches!(dot_flox.pointer, EnvironmentPointer::Path(_)) {
+            let trust_manager = TrustManager::new(&flox.data_dir);
+            trust_manager.trust(&dot_flox.path)?;
+        }
+
+        message::updated(format!(
+            "Allowed auto-activation for environment at '{}'",
+            dot_flox.path.display()
+        ));
+
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/deny.rs
+++ b/cli/flox/src/commands/deny.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use bpaf::Bpaf;
+use flox_core::preference::PreferenceManager;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::find_dot_flox;
+
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[derive(Bpaf, Clone, Debug)]
+pub struct Deny {
+    /// Path to the .flox directory to deny (defaults to current directory)
+    #[bpaf(long, argument("PATH"), optional)]
+    path: Option<PathBuf>,
+}
+
+impl Deny {
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("deny");
+
+        let search_dir = match &self.path {
+            Some(p) => p.clone(),
+            None => std::env::current_dir()?,
+        };
+        let dot_flox = find_dot_flox(&search_dir)?;
+
+        let Some(dot_flox) = dot_flox else {
+            bail!(
+                "No '.flox' environment found at '{}' or any parent directory.\n\
+                 Use 'flox init' to create one.",
+                search_dir.display()
+            );
+        };
+
+        let preference_manager = PreferenceManager::new(&flox.state_dir);
+        preference_manager.deny(&dot_flox.path)?;
+
+        message::updated(format!(
+            "Denied auto-activation for environment at '{}'",
+            dot_flox.path.display()
+        ));
+
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/exit.rs
+++ b/cli/flox/src/commands/exit.rs
@@ -1,18 +1,40 @@
 use anyhow::Result;
 use bpaf::Bpaf;
+use flox_core::activate::vars::FLOX_ACTIVE_ENVIRONMENTS_VAR;
+use flox_core::hook_state::{
+    HOOK_VAR_ACTIVATIONS,
+    HOOK_VAR_DIFF,
+    HOOK_VAR_DIRS,
+    HOOK_VAR_SUPPRESSED,
+    HOOK_VAR_WATCHES,
+    HookState,
+};
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::UninitializedEnvironment;
 use indoc::{formatdoc, indoc};
+use shell_gen::{GenerateShell, SetVar, Shell, UnsetVar};
 
+use super::hook_env::{emit_revert, spawn_auto_detach};
 use super::{activated_environments, uninitialized_environment_description};
 use crate::subcommand_metric;
 use crate::utils::message;
 
 #[derive(Bpaf, Clone)]
-pub struct Exit {}
+pub struct Exit {
+    /// Shell to generate deactivation commands for
+    #[bpaf(long, argument("shell"), optional)]
+    pub shell: Option<String>,
+}
 
 impl Exit {
     pub fn handle(self, _flox: Flox) -> Result<()> {
         subcommand_metric!("exit");
+
+        let in_auto_activation = std::env::var(HOOK_VAR_DIRS).is_ok_and(|v| !v.is_empty());
+
+        if in_auto_activation {
+            return self.handle_auto_deactivate();
+        }
 
         let active_environments = activated_environments();
         let last_active = active_environments.last_active();
@@ -30,6 +52,69 @@ impl Exit {
         message::info(formatdoc! {"
             Exit the currently active environment {} by typing 'exit' to exit your current shell or close your terminal.
         ", uninitialized_environment_description(&last_active)?});
+
+        Ok(())
+    }
+
+    fn handle_auto_deactivate(self) -> Result<()> {
+        let shell: Shell = self
+            .shell
+            .as_deref()
+            .unwrap_or("bash")
+            .parse()
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "unsupported shell: {}",
+                    self.shell.as_deref().unwrap_or("bash")
+                )
+            })?;
+
+        let state = HookState::from_env()?;
+        let mut stdout = std::io::stdout().lock();
+
+        // Revert the diff and restore the prompt.
+        emit_revert(&state.diff, shell, &mut stdout)?;
+
+        // Only suppress the innermost (CWD-nearest) directory so that
+        // `flox deactivate` peels off one environment at a time.
+        let mut suppressed = state.suppressed_dirs.clone();
+        if let Some(innermost) = state.active_dirs.last() {
+            if !suppressed.contains(innermost) {
+                suppressed.push(innermost.clone());
+            }
+
+            // Detach shell PID from the activation state for this environment.
+            let shell_pid = std::os::unix::process::parent_id() as i32;
+            if let Some(info) = state.activation_tracking.entries.get(innermost) {
+                spawn_auto_detach(shell_pid, &info.activation_state_dir);
+            }
+
+            // Remove the deactivated env from _FLOX_ACTIVE_ENVIRONMENTS
+            let mut active_envs = activated_environments();
+            active_envs.retain(|env| {
+                if let UninitializedEnvironment::DotFlox(d) = env {
+                    d.path != *innermost
+                } else {
+                    true
+                }
+            });
+            SetVar::exported_no_expansion(FLOX_ACTIVE_ENVIRONMENTS_VAR, active_envs.to_string())
+                .generate_with_newline(shell, &mut stdout)?;
+        }
+        let suppressed_str = HookState::format_path_list(&suppressed);
+        SetVar::exported_no_expansion(HOOK_VAR_SUPPRESSED, &suppressed_str)
+            .generate_with_newline(shell, &mut stdout)?;
+
+        // Clear hook state variables.
+        UnsetVar::new(HOOK_VAR_DIFF).generate_with_newline(shell, &mut stdout)?;
+        UnsetVar::new(HOOK_VAR_DIRS).generate_with_newline(shell, &mut stdout)?;
+        UnsetVar::new(HOOK_VAR_WATCHES).generate_with_newline(shell, &mut stdout)?;
+        UnsetVar::new(HOOK_VAR_ACTIVATIONS).generate_with_newline(shell, &mut stdout)?;
+
+        eprintln!(
+            "flox: environment deactivated for this session. \
+             Use 'flox deny' to permanently prevent auto-activation."
+        );
 
         Ok(())
     }

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -33,7 +33,6 @@ use flox_core::trust::{TrustManager, TrustStatus};
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::parsed::Inner;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::lock_manifest::LockResult;
 use flox_rust_sdk::models::environment::{
     DotFlox,
     Environment,
@@ -41,6 +40,7 @@ use flox_rust_sdk::models::environment::{
     UninitializedEnvironment,
     find_all_dot_flox,
 };
+use flox_rust_sdk::providers::lock_manifest::LockResult;
 use flox_rust_sdk::providers::services::process_compose::PROCESS_COMPOSE_BIN;
 use flox_rust_sdk::utils::FLOX_INTERPRETER;
 use regex::Regex;
@@ -244,9 +244,7 @@ fn is_fast_path(
             let preference_changed = state
                 .active_dirs
                 .iter()
-                .any(|dir| {
-                    !matches!(preference_manager.check(dir), Ok(PreferenceStatus::Allowed))
-                });
+                .any(|dir| !matches!(preference_manager.check(dir), Ok(PreferenceStatus::Allowed)));
             (trust_changed, preference_changed)
         },
     };
@@ -321,8 +319,7 @@ fn filter_by_eligibility(
                         if notified_dirs.contains(&dot_flox.path.to_path_buf()) {
                             continue;
                         }
-                        let is_local =
-                            matches!(dot_flox.pointer, EnvironmentPointer::Path(_));
+                        let is_local = matches!(dot_flox.pointer, EnvironmentPointer::Path(_));
                         if prompt_auto_activate(
                             &dot_flox.path,
                             preference_manager,
@@ -775,31 +772,28 @@ fn resolve_env_vars(dot_flox: &DotFlox, flox: &Flox) -> Result<ResolvedEnv> {
         LockResult::Changed(l) => l,
         LockResult::Unchanged(l) => l,
     };
-    let (services_to_start, cuda_detection) =
-        match lockfile.migrated_manifest() {
-            Ok(manifest) => {
-                let latest = manifest.as_latest_schema();
-                let auto_start =
-                    latest.services.auto_start.unwrap_or(false);
-                let services = if auto_start {
-                    let services_for_system =
-                        latest.services.copy_for_system(&flox.system);
-                    services_for_system
-                        .inner()
-                        .keys()
-                        .cloned()
-                        .collect::<Vec<String>>()
-                } else {
-                    Vec::new()
-                };
-                let cuda = latest.options.cuda_detection;
-                (services, cuda)
-            },
-            Err(e) => {
-                debug!("failed to read services from manifest: {e}");
-                (Vec::new(), None)
-            },
-        };
+    let (services_to_start, cuda_detection) = match lockfile.migrated_manifest() {
+        Ok(manifest) => {
+            let latest = manifest.as_latest_schema();
+            let auto_start = latest.services.auto_start.unwrap_or(false);
+            let services = if auto_start {
+                let services_for_system = latest.services.copy_for_system(&flox.system);
+                services_for_system
+                    .inner()
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<String>>()
+            } else {
+                Vec::new()
+            };
+            let cuda = latest.options.cuda_detection;
+            (services, cuda)
+        },
+        Err(e) => {
+            debug!("failed to read services from manifest: {e}");
+            (Vec::new(), None)
+        },
+    };
 
     let cuda_detection_str = match cuda_detection {
         Some(false) => "0".to_string(),

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -1,33 +1,1387 @@
-use std::borrow::Cow;
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result};
 use bpaf::Bpaf;
+use flox_core::activate::context::{AttachCtx, AttachProjectCtx, AutoStartCtx, AutoStartResult};
+use flox_core::activate::mode::ActivateMode;
+use flox_core::activate::vars::{FLOX_ACTIVATIONS_BIN, FLOX_ACTIVE_ENVIRONMENTS_VAR};
+use flox_core::activations::activation_state_dir_path;
+use flox_core::hook_state::{
+    ActivationInfo,
+    ActivationTracking,
+    HOOK_VAR_ACTIVATIONS,
+    HOOK_VAR_CWD,
+    HOOK_VAR_DIFF,
+    HOOK_VAR_DIRS,
+    HOOK_VAR_EXCLUDE_DIRS,
+    HOOK_VAR_EXCLUDE_NAMES,
+    HOOK_VAR_NOTIFIED,
+    HOOK_VAR_SUPPRESSED,
+    HOOK_VAR_WATCHES,
+    HookDiff,
+    HookState,
+    OnActivateEnvDiff,
+    WatchEntry,
+};
+use flox_core::preference::{PreferenceManager, PreferenceStatus};
+use flox_core::trust::{TrustManager, TrustStatus};
+use flox_manifest::interfaces::AsLatestSchema;
+use flox_manifest::parsed::Inner;
 use flox_rust_sdk::flox::Flox;
-use shell_gen::Shell;
+use flox_rust_sdk::providers::lock_manifest::LockResult;
+use flox_rust_sdk::models::environment::{
+    DotFlox,
+    Environment,
+    EnvironmentPointer,
+    UninitializedEnvironment,
+    find_all_dot_flox,
+};
+use flox_rust_sdk::providers::services::process_compose::PROCESS_COMPOSE_BIN;
+use flox_rust_sdk::utils::FLOX_INTERPRETER;
+use regex::Regex;
+use shell_gen::{GenerateShell, SetVar, Shell, UnsetVar};
+use tracing::{debug, error};
 
-#[derive(Debug, Clone, Bpaf)]
+use crate::config::{AutoActivate, Config};
+use crate::utils::active_environments::activated_environments;
+use crate::utils::colors::{INDIGO_300, INDIGO_400};
+
+#[derive(Bpaf, Clone, Debug)]
 pub struct HookEnv {
     /// Shell to emit hook-env code for (bash, zsh, fish, tcsh)
     #[bpaf(long("shell"), argument("SHELL"))]
-    shell: Shell,
+    shell: String,
 }
 
 impl HookEnv {
-    pub fn handle(self, flox: Flox) -> Result<()> {
-        if !flox.features.auto_activate {
-            bail!(
-                "'hook-env' requires the auto_activate feature flag. Set FLOX_FEATURES_AUTO_ACTIVATE=true."
-            );
+    pub fn handle(self, config: Config, flox: Flox) -> Result<()> {
+        let shell: Shell = self
+            .shell
+            .parse()
+            .map_err(|_| anyhow::anyhow!("unsupported shell: {}", self.shell))?;
+
+        let state = HookState::from_env()?;
+        let cwd = std::env::current_dir().context("failed to get current directory")?;
+
+        // Discover .flox dirs in ancestor chain.
+        let discovered = find_all_dot_flox(&cwd).unwrap_or_else(|e| {
+            debug!("find_all_dot_flox failed: {e}");
+            Vec::new()
+        });
+
+        let trust_manager = TrustManager::new(&flox.data_dir);
+        let preference_manager = PreferenceManager::new(&flox.state_dir);
+        // Default to Allowed when not explicitly configured
+        let auto_activate_config = config
+            .flox
+            .auto_activate
+            .as_ref()
+            .unwrap_or(&AutoActivate::Allowed);
+
+        if is_fast_path(
+            &state,
+            &cwd,
+            &discovered,
+            &trust_manager,
+            &preference_manager,
+            auto_activate_config,
+        ) {
+            return Ok(());
         }
-        // Temporary: set _FLOX_HOOK_FIRED so we can verify the hook fires.
-        // This will be replaced by real environment activation logic.
-        let cwd = std::env::current_dir()?.to_string_lossy().to_string();
-        let escaped_cwd = shell_escape::escape(Cow::Borrowed(&cwd));
-        match self.shell {
-            Shell::Bash | Shell::Zsh => println!("export _FLOX_HOOK_FIRED={escaped_cwd};"),
-            Shell::Fish => println!("set -gx _FLOX_HOOK_FIRED {escaped_cwd};"),
-            Shell::Tcsh => println!("setenv _FLOX_HOOK_FIRED {escaped_cwd};"),
+
+        let (mut trusted_dot_flox, suppressed_dirs, notified_dirs) = filter_by_eligibility(
+            &state,
+            &cwd,
+            &discovered,
+            &trust_manager,
+            &preference_manager,
+            auto_activate_config,
+        );
+
+        // Filter out environments that are manually activated via `flox activate`
+        // subshells — these are tracked by _FLOX_HOOK_EXCLUDE_DIRS.
+        let exclude_dirs: Vec<PathBuf> = std::env::var(HOOK_VAR_EXCLUDE_DIRS)
+            .unwrap_or_default()
+            .split(':')
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .collect();
+        trusted_dot_flox.retain(|d| !exclude_dirs.contains(&d.path));
+
+        let new_active_dirs: Vec<PathBuf> =
+            trusted_dot_flox.iter().map(|d| d.path.clone()).collect();
+
+        // Check if the set of active dirs actually changed.
+        let dirs_changed = new_active_dirs != state.active_dirs;
+        let watches_changed = state.watches_changed();
+
+        if !dirs_changed && !watches_changed {
+            let notified_changed = notified_dirs != state.notified_dirs;
+            let suppressed_changed = suppressed_dirs != state.suppressed_dirs;
+            let cwd_changed = state.last_cwd.as_ref() != Some(&cwd);
+
+            if !cwd_changed && !notified_changed && !suppressed_changed {
+                // Nothing changed at all.
+                return Ok(());
+            }
+            // Only CWD/notified/suppressed changed — update tracking without
+            // re-resolving all environments (avoids redundant lock/build/symlink
+            // reads).
+            let mut stdout = std::io::stdout().lock();
+
+            // On the first hook-env call in a subshell (last_cwd is None),
+            // emit the prompt so that manually-activated environments show
+            // the PS1 prefix. Without this, neither set-prompt.zsh/bash
+            // (which defers to hook-env when exclude vars are set) nor the
+            // full update path (which isn't reached) would set the prompt.
+            if state.last_cwd.is_none() {
+                let all_names = build_prompt_names(&trusted_dot_flox);
+                emit_prompt(&all_names, shell, &mut stdout)?;
+            }
+
+            if cwd_changed {
+                SetVar::exported_no_expansion(HOOK_VAR_CWD, cwd.display().to_string())
+                    .generate_with_newline(shell, &mut stdout)?;
+            }
+            if notified_changed {
+                let notified_str = HookState::format_path_list(&notified_dirs);
+                SetVar::exported_no_expansion(HOOK_VAR_NOTIFIED, &notified_str)
+                    .generate_with_newline(shell, &mut stdout)?;
+            }
+            if suppressed_changed {
+                let suppressed_str = HookState::format_path_list(&suppressed_dirs);
+                SetVar::exported_no_expansion(HOOK_VAR_SUPPRESSED, &suppressed_str)
+                    .generate_with_newline(shell, &mut stdout)?;
+            }
+            return Ok(());
         }
+
+        let mut stdout = std::io::stdout().lock();
+
+        // Revert previous diff.
+        emit_revert(&state.diff, shell, &mut stdout)?;
+
+        // Build new env vars and manage activation lifecycle.
+        let (new_tracking, combined_env, path_additions, env_dirs_additions, new_watches) =
+            manage_activations(&state, &trusted_dot_flox, &flox)?;
+
+        // Merge PATH/FLOX_ENV_DIRS/MANPATH additions and compute diff.
+        let (new_diff, combined_env) = compute_new_diff(
+            &state.diff,
+            combined_env,
+            path_additions,
+            env_dirs_additions,
+        );
+
+        // Emit new exports.
+        emit_apply(&new_diff, &combined_env, shell, &mut stdout)?;
+
+        // Build unified prompt with both excluded (manually-activated) and
+        // auto-activated environment names, then emit it.
+        let all_names = build_prompt_names(&trusted_dot_flox);
+        emit_prompt(&all_names, shell, &mut stdout)?;
+
+        // Emit updated state variables.
+        emit_state_vars(
+            &HookStateUpdate {
+                diff: &new_diff,
+                active_dirs: &new_active_dirs,
+                watches: &new_watches,
+                suppressed_dirs: &suppressed_dirs,
+                notified_dirs: &notified_dirs,
+                cwd: &cwd,
+                trusted_dot_flox: &trusted_dot_flox,
+                prev_active_dirs: &state.active_dirs,
+                activation_tracking: &new_tracking,
+            },
+            shell,
+            &mut stdout,
+        )?;
+
         Ok(())
+    }
+}
+
+/// Fast path: CWD unchanged AND no watched files changed AND the set of
+/// discovered .flox dirs hasn't changed AND trust/preference status hasn't
+/// changed for any active dir → no work needed.
+fn is_fast_path(
+    state: &HookState,
+    cwd: &Path,
+    discovered: &[DotFlox],
+    trust_manager: &TrustManager,
+    preference_manager: &PreferenceManager,
+    auto_activate_config: &AutoActivate,
+) -> bool {
+    // Filter out excluded dirs (manually-activated subshell environments)
+    // so the fast-path comparison matches the filtered active_dirs.
+    let exclude_dirs: Vec<PathBuf> = std::env::var(HOOK_VAR_EXCLUDE_DIRS)
+        .unwrap_or_default()
+        .split(':')
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .collect();
+    let discovered_dirs: Vec<PathBuf> = discovered
+        .iter()
+        .filter(|d| !exclude_dirs.contains(&d.path))
+        .map(|d| d.path.clone())
+        .collect();
+    let watches_changed = state.watches_changed();
+
+    // For Allowed mode, trust/preference checks are skipped (always trusted)
+    let (trust_changed, preference_changed) = match auto_activate_config {
+        AutoActivate::Allowed => (false, false),
+        AutoActivate::Prompt => {
+            let trust_changed = state
+                .active_dirs
+                .iter()
+                .any(|dir| !matches!(trust_manager.check(dir), Ok(TrustStatus::Trusted)));
+            let preference_changed = state
+                .active_dirs
+                .iter()
+                .any(|dir| {
+                    !matches!(preference_manager.check(dir), Ok(PreferenceStatus::Allowed))
+                });
+            (trust_changed, preference_changed)
+        },
+    };
+
+    state.last_cwd.as_deref() == Some(cwd)
+        && !watches_changed
+        && discovered_dirs == state.active_dirs
+        && !trust_changed
+        && !preference_changed
+}
+
+/// Filter discovered environments by preference, trust, and suppression status.
+///
+/// Two-gate model: an environment must have both (a) auto-activation enabled
+/// (preference gate) and (b) be trusted (security gate) to be eligible.
+/// In Allowed mode, both gates are bypassed.
+///
+/// Returns (eligible_dot_flox, suppressed_dirs, notified_dirs).
+fn filter_by_eligibility(
+    state: &HookState,
+    cwd: &Path,
+    discovered: &[DotFlox],
+    trust_manager: &TrustManager,
+    preference_manager: &PreferenceManager,
+    auto_activate_config: &AutoActivate,
+) -> (Vec<DotFlox>, Vec<PathBuf>, Vec<PathBuf>) {
+    // Prune suppressed dirs: only keep those that are still ancestors of CWD.
+    let suppressed_dirs: Vec<PathBuf> = state
+        .suppressed_dirs
+        .iter()
+        .filter(|s| cwd.starts_with(s.parent().unwrap_or(s)))
+        .cloned()
+        .collect();
+
+    // Prune notified dirs to those still relevant to CWD.
+    let mut notified_dirs: Vec<PathBuf> = state
+        .notified_dirs
+        .iter()
+        .filter(|n| cwd.starts_with(n.parent().unwrap_or(n)))
+        .cloned()
+        .collect();
+
+    let mut eligible_dot_flox: Vec<DotFlox> = Vec::new();
+
+    for dot_flox in discovered {
+        if suppressed_dirs.contains(&dot_flox.path) {
+            debug!(path = %dot_flox.path.display(), "suppressed, skipping");
+            continue;
+        }
+
+        match auto_activate_config {
+            AutoActivate::Allowed => {
+                // In Allowed mode, skip preference and trust gates entirely.
+                eligible_dot_flox.push(dot_flox.clone());
+            },
+            AutoActivate::Prompt => {
+                // Gate 1: Preference check
+                let preference_ok = match preference_manager.check(&dot_flox.path) {
+                    Ok(PreferenceStatus::Allowed) => true,
+                    Ok(PreferenceStatus::Denied) => {
+                        debug!(path = %dot_flox.path.display(), "preference denied, skipping");
+                        emit_eligibility_notice(
+                            cwd,
+                            &dot_flox.path,
+                            "Auto-activation is denied. Run 'flox allow' to re-enable.",
+                            &mut notified_dirs,
+                        );
+                        continue;
+                    },
+                    Ok(PreferenceStatus::Unregistered) => {
+                        // Already prompted/notified this session — don't prompt again
+                        if notified_dirs.contains(&dot_flox.path.to_path_buf()) {
+                            continue;
+                        }
+                        let is_local =
+                            matches!(dot_flox.pointer, EnvironmentPointer::Path(_));
+                        if prompt_auto_activate(
+                            &dot_flox.path,
+                            preference_manager,
+                            trust_manager,
+                            is_local,
+                        ) {
+                            true
+                        } else {
+                            // Non-interactive fallback or user said no
+                            emit_eligibility_notice(
+                                cwd,
+                                &dot_flox.path,
+                                "Run 'flox allow' to auto-activate this environment.",
+                                &mut notified_dirs,
+                            );
+                            continue;
+                        }
+                    },
+                    Err(e) => {
+                        debug!(path = %dot_flox.path.display(), "preference check failed: {e}");
+                        continue;
+                    },
+                };
+
+                if !preference_ok {
+                    continue;
+                }
+
+                // Gate 2: Trust check
+                // For local environments, trust is implicit (set by `flox allow`).
+                let is_local = matches!(dot_flox.pointer, EnvironmentPointer::Path(_));
+                if is_local {
+                    eligible_dot_flox.push(dot_flox.clone());
+                } else {
+                    // Managed/remote environments require explicit trust
+                    match trust_manager.check(&dot_flox.path) {
+                        Ok(TrustStatus::Trusted) => {
+                            eligible_dot_flox.push(dot_flox.clone());
+                        },
+                        Ok(TrustStatus::Denied) => {
+                            debug!(path = %dot_flox.path.display(), "trust denied, skipping");
+                            emit_eligibility_notice(
+                                cwd,
+                                &dot_flox.path,
+                                "Environment is not trusted. Run 'flox activate -t' to trust it.",
+                                &mut notified_dirs,
+                            );
+                        },
+                        Ok(TrustStatus::Unknown(_)) => {
+                            emit_eligibility_notice(
+                                cwd,
+                                &dot_flox.path,
+                                "Environment is not trusted. Run 'flox activate -t' to trust it.",
+                                &mut notified_dirs,
+                            );
+                        },
+                        Err(e) => {
+                            debug!(
+                                path = %dot_flox.path.display(),
+                                "trust check failed: {e}"
+                            );
+                        },
+                    }
+                }
+            },
+        }
+    }
+
+    (eligible_dot_flox, suppressed_dirs, notified_dirs)
+}
+
+/// Check whether we can prompt the user from within the hook.
+///
+/// In all shell hooks, `hook-env` runs inside `$()` so stdout is captured.
+/// But stdin is inherited from the interactive shell and stderr goes to
+/// the terminal, so we can prompt via stderr and read from stdin.
+fn can_prompt_from_hook() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
+
+/// Prompt the user whether to auto-activate an environment.
+/// Returns true if the user accepted. Persists the preference on acceptance
+/// or decline (as Denied), so the decision survives across shell sessions.
+fn prompt_auto_activate(
+    dot_flox_path: &Path,
+    preference_manager: &PreferenceManager,
+    trust_manager: &TrustManager,
+    is_local: bool,
+) -> bool {
+    if !can_prompt_from_hook() {
+        return false;
+    }
+    let project_dir = dot_flox_path.parent().unwrap_or(dot_flox_path);
+    eprint!(
+        "Auto-activate environment in {}? [y/N] ",
+        project_dir.display()
+    );
+    let _ = std::io::stderr().flush();
+
+    let mut input = String::new();
+    match std::io::stdin().read_line(&mut input) {
+        Ok(_) if input.trim().eq_ignore_ascii_case("y") => {
+            // Persist the preference
+            let _ = preference_manager.allow(dot_flox_path);
+            if is_local {
+                let _ = trust_manager.trust(dot_flox_path);
+            }
+            true
+        },
+        Ok(_) => {
+            // User explicitly declined — persist so it survives across sessions.
+            let _ = preference_manager.deny(dot_flox_path);
+            false
+        },
+        Err(_) => false,
+    }
+}
+
+/// Emit an eligibility notification message for an environment,
+/// deduplicating by path.
+fn emit_eligibility_notice(
+    cwd: &Path,
+    dot_flox_path: &Path,
+    message: &str,
+    notified_dirs: &mut Vec<PathBuf>,
+) {
+    if notified_dirs.contains(&dot_flox_path.to_path_buf()) {
+        return;
+    }
+    let _ = cwd; // reserved for future use
+    eprintln!(
+        "flox: environment at '{}': {message}",
+        dot_flox_path.display()
+    );
+    notified_dirs.push(dot_flox_path.to_path_buf());
+}
+
+/// Result of `manage_activations`: tracking state, combined env vars, PATH
+/// additions, FLOX_ENV_DIRS additions, and updated watch entries.
+type ActivationResult = (
+    ActivationTracking,
+    HashMap<String, String>,
+    Vec<String>,
+    Vec<String>,
+    Vec<WatchEntry>,
+);
+
+/// Build new env vars from all trusted environments and manage activation
+/// lifecycle (PID registration, executive spawning, detach/reattach).
+fn manage_activations(
+    state: &HookState,
+    trusted_dot_flox: &[DotFlox],
+    flox: &Flox,
+) -> Result<ActivationResult> {
+    let shell_pid = std::os::unix::process::parent_id() as i32;
+    let prev_tracking = &state.activation_tracking;
+    let mut new_tracking = ActivationTracking::default();
+
+    let mut combined_env: HashMap<String, String> = HashMap::new();
+    let mut path_additions: Vec<String> = Vec::new();
+    let mut env_dirs_additions: Vec<String> = Vec::new();
+    let mut new_watches: Vec<WatchEntry> = Vec::new();
+
+    for dot_flox in trusted_dot_flox {
+        // Watch the manifest file for changes.
+        let manifest_path = dot_flox.path.join("env").join("manifest.toml");
+        new_watches.push(WatchEntry {
+            path: manifest_path.clone(),
+            mtime: std::fs::metadata(&manifest_path)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs()),
+        });
+
+        match resolve_env_vars(dot_flox, flox) {
+            Ok(resolved) => {
+                // Check if this environment is already tracked with the same store path.
+                let already_tracked = prev_tracking
+                    .entries
+                    .get(&dot_flox.path)
+                    .is_some_and(|info| info.store_path == resolved.store_path);
+
+                // Check if this environment is in the detached cache (cd-away-and-back).
+                let cached = prev_tracking
+                    .detached_cache
+                    .get(&dot_flox.path)
+                    .filter(|info| info.store_path == resolved.store_path)
+                    .cloned();
+
+                let activation_state_dir =
+                    activation_state_dir_path(&flox.runtime_dir, &dot_flox.path);
+
+                if already_tracked {
+                    // Case 1: Subsequent prompt, same dir - carry forward existing info
+                    let info = prev_tracking.entries[&dot_flox.path].clone();
+                    // Re-apply cached on-activate diff
+                    apply_on_activate_diff(&info.on_activate_diff, &mut combined_env);
+                    new_tracking.entries.insert(dot_flox.path.clone(), info);
+                } else if let Some(cached_info) = cached {
+                    // Case 2: cd-away-and-back - re-attach PID, use cached diff
+                    let auto_result =
+                        spawn_auto_start(shell_pid, dot_flox, &resolved, &activation_state_dir);
+
+                    if auto_result.as_ref().is_some_and(|r| r.is_new) {
+                        // Activation was recreated — use fresh result
+                        let result = auto_result.as_ref().unwrap();
+                        apply_on_activate_diff(&result.hook_env_diff, &mut combined_env);
+                        new_tracking
+                            .entries
+                            .insert(dot_flox.path.clone(), ActivationInfo {
+                                activation_state_dir: activation_state_dir.clone(),
+                                store_path: resolved.store_path.clone(),
+                                start_state_dir: result.start_state_dir.as_ref().map(PathBuf::from),
+                                on_activate_diff: result.hook_env_diff.clone(),
+                            });
+                    } else {
+                        // Re-apply cached on-activate diff (hooks don't re-run)
+                        apply_on_activate_diff(&cached_info.on_activate_diff, &mut combined_env);
+                        new_tracking
+                            .entries
+                            .insert(dot_flox.path.clone(), cached_info);
+                    }
+                } else {
+                    // Case 3: Truly new or store path changed - run hooks
+                    let auto_result =
+                        spawn_auto_start(shell_pid, dot_flox, &resolved, &activation_state_dir);
+
+                    let (on_activate_diff, start_state_dir) = if let Some(ref result) = auto_result
+                    {
+                        apply_on_activate_diff(&result.hook_env_diff, &mut combined_env);
+                        (
+                            result.hook_env_diff.clone(),
+                            result.start_state_dir.as_ref().map(PathBuf::from),
+                        )
+                    } else {
+                        (None, None)
+                    };
+
+                    new_tracking
+                        .entries
+                        .insert(dot_flox.path.clone(), ActivationInfo {
+                            activation_state_dir,
+                            store_path: resolved.store_path.clone(),
+                            start_state_dir,
+                            on_activate_diff,
+                        });
+                }
+
+                // Collect the FLOX_ENV value for FLOX_ENV_DIRS computation.
+                env_dirs_additions.push(resolved.flox_env.clone());
+
+                for (k, v) in resolved.vars {
+                    match k.as_str() {
+                        "_FLOX_PATH_ADD" | "_FLOX_SBIN_ADD" => {
+                            path_additions.push(v);
+                        },
+                        _ => {
+                            combined_env.insert(k, v);
+                        },
+                    }
+                }
+            },
+            Err(e) => {
+                debug!(
+                    path = %dot_flox.path.display(),
+                    "failed to resolve environment: {e}"
+                );
+                eprintln!(
+                    "flox: failed to resolve environment at '{}': {e}",
+                    dot_flox.path.display()
+                );
+            },
+        }
+    }
+
+    // Detach from environments that are no longer active and cache their info.
+    for (path, info) in &prev_tracking.entries {
+        if !new_tracking.entries.contains_key(path) {
+            spawn_auto_detach(shell_pid, &info.activation_state_dir);
+            // Move to detached cache so cd-back can reuse on_activate_diff
+            new_tracking
+                .detached_cache
+                .insert(path.clone(), info.clone());
+        }
+    }
+
+    // Carry forward detached cache entries whose activation state dir still exists.
+    for (path, info) in &prev_tracking.detached_cache {
+        if !new_tracking.entries.contains_key(path)
+            && !new_tracking.detached_cache.contains_key(path)
+            && info.activation_state_dir.exists()
+        {
+            new_tracking
+                .detached_cache
+                .insert(path.clone(), info.clone());
+        }
+    }
+
+    Ok((
+        new_tracking,
+        combined_env,
+        path_additions,
+        env_dirs_additions,
+        new_watches,
+    ))
+}
+
+/// Compute the environment diff as if `emit_revert` had already run.
+fn compute_new_diff(
+    old_diff: &HookDiff,
+    mut combined_env: HashMap<String, String>,
+    path_additions: Vec<String>,
+    env_dirs_additions: Vec<String>,
+) -> (HookDiff, HashMap<String, String>) {
+    // Merge all environment bin/sbin dirs into a single PATH.
+    if !path_additions.is_empty() {
+        let base_path = reverted_env_var("PATH", old_diff).unwrap_or_default();
+        let new_path = format!("{}:{}", path_additions.join(":"), base_path);
+        combined_env.insert("PATH".to_string(), new_path);
+    }
+
+    // Compute FLOX_ENV_DIRS from all auto-activated environments.
+    if !env_dirs_additions.is_empty() {
+        let base_env_dirs = combined_env
+            .get("FLOX_ENV_DIRS")
+            .cloned()
+            .or_else(|| reverted_env_var("FLOX_ENV_DIRS", old_diff))
+            .unwrap_or_default();
+        let new_env_dirs = if base_env_dirs.is_empty() {
+            env_dirs_additions.join(":")
+        } else {
+            format!("{}:{}", env_dirs_additions.join(":"), base_env_dirs)
+        };
+        combined_env.insert("FLOX_ENV_DIRS".to_string(), new_env_dirs);
+
+        // Compute MANPATH from the new FLOX_ENV_DIRS.
+        let base_manpath = combined_env
+            .get("MANPATH")
+            .cloned()
+            .or_else(|| reverted_env_var("MANPATH", old_diff))
+            .unwrap_or_default();
+        let man_dirs: Vec<String> = env_dirs_additions
+            .iter()
+            .map(|d| format!("{d}/share/man"))
+            .collect();
+        let mut new_manpath = if base_manpath.is_empty() {
+            man_dirs.join(":")
+        } else {
+            format!("{}:{}", man_dirs.join(":"), base_manpath)
+        };
+        // Ensure trailing colon so the standard man page search path is included.
+        let has_trailing = new_manpath.ends_with(':');
+        let has_double = new_manpath.contains("::");
+        let has_leading = new_manpath.starts_with(':');
+        if !(has_trailing || has_double || has_leading) {
+            new_manpath.push(':');
+        }
+        combined_env.insert("MANPATH".to_string(), new_manpath);
+    }
+
+    // Compute the new diff against the *reverted* process env.
+    let mut additions = HashMap::new();
+    let mut modifications = HashMap::new();
+
+    for (key, new_val) in &combined_env {
+        match reverted_env_var(key, old_diff) {
+            Some(orig_val) if orig_val != *new_val => {
+                modifications.insert(key.clone(), orig_val);
+            },
+            None => {
+                additions.insert(key.clone(), new_val.clone());
+            },
+            _ => {},
+        }
+    }
+
+    let new_diff = HookDiff {
+        additions,
+        modifications,
+        deletions: HashMap::new(),
+    };
+
+    (new_diff, combined_env)
+}
+
+/// Apply cached on-activate hook env diff into the combined environment.
+fn apply_on_activate_diff(
+    diff: &Option<OnActivateEnvDiff>,
+    combined_env: &mut HashMap<String, String>,
+) {
+    if let Some(diff) = diff {
+        for (k, v) in &diff.additions {
+            combined_env.insert(k.clone(), v.clone());
+        }
+        for k in &diff.deletions {
+            combined_env.remove(k);
+        }
+    }
+}
+
+/// Compute the value an environment variable would have after reverting the
+/// previous diff.
+fn reverted_env_var(key: &str, old_diff: &HookDiff) -> Option<String> {
+    if old_diff.additions.contains_key(key) {
+        None
+    } else if let Some(orig_val) = old_diff.modifications.get(key) {
+        Some(orig_val.clone())
+    } else if let Some(orig_val) = old_diff.deletions.get(key) {
+        Some(orig_val.clone())
+    } else {
+        std::env::var(key).ok()
+    }
+}
+
+/// Result of resolving an environment, containing both env vars and metadata.
+struct ResolvedEnv {
+    /// Environment variables to set
+    vars: HashMap<String, String>,
+    /// Nix store path for the built environment
+    store_path: String,
+    /// Mode link path (FLOX_ENV value)
+    flox_env: String,
+    /// Cache path for the environment
+    env_cache: PathBuf,
+    /// Log directory for the environment
+    flox_env_log_dir: PathBuf,
+    /// Project path for the environment
+    env_project: PathBuf,
+    /// Services socket path
+    flox_services_socket: PathBuf,
+    /// Service names to start with process-compose
+    services_to_start: Vec<String>,
+    /// CUDA detection setting from manifest options ("0" or "1")
+    cuda_detection: String,
+}
+
+/// Resolve environment variables from a built environment.
+fn resolve_env_vars(dot_flox: &DotFlox, flox: &Flox) -> Result<ResolvedEnv> {
+    let mut env = UninitializedEnvironment::DotFlox(dot_flox.clone())
+        .into_concrete_environment(flox, None)?;
+
+    // Ensure the environment is locked and built.
+    eprintln!(
+        "flox: resolving environment '{}'...",
+        dot_flox.pointer.name()
+    );
+    let lockfile = match env.lockfile(flox)? {
+        LockResult::Changed(l) => l,
+        LockResult::Unchanged(l) => l,
+    };
+    let (services_to_start, cuda_detection) =
+        match lockfile.migrated_manifest() {
+            Ok(manifest) => {
+                let latest = manifest.as_latest_schema();
+                let auto_start =
+                    latest.services.auto_start.unwrap_or(false);
+                let services = if auto_start {
+                    let services_for_system =
+                        latest.services.copy_for_system(&flox.system);
+                    services_for_system
+                        .inner()
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<String>>()
+                } else {
+                    Vec::new()
+                };
+                let cuda = latest.options.cuda_detection;
+                (services, cuda)
+            },
+            Err(e) => {
+                debug!("failed to read services from manifest: {e}");
+                (Vec::new(), None)
+            },
+        };
+
+    let cuda_detection_str = match cuda_detection {
+        Some(false) => "0".to_string(),
+        _ => "1".to_string(),
+    };
+
+    let rendered_links = env.rendered_env_links(flox)?;
+    let link = rendered_links.for_mode(&ActivateMode::Dev);
+
+    let env_cache = env.cache_path()?.into_inner();
+    let flox_env_log_dir = env.log_path()?.to_path_buf();
+    let env_project = env.project_path()?;
+    let flox_services_socket = env.services_socket_path(flox)?;
+
+    // Resolve the symlink to the actual store path.
+    let link_path: &std::path::Path = link.as_ref();
+    let store_path = std::fs::read_link(link_path).unwrap_or_else(|_| link_path.to_path_buf());
+
+    let mut vars = HashMap::new();
+
+    // Set FLOX_ENV to the link path.
+    let flox_env = link_path.display().to_string();
+    vars.insert("FLOX_ENV".to_string(), flox_env.clone());
+
+    vars.insert(
+        "FLOX_ENV_CACHE".to_string(),
+        env_cache.display().to_string(),
+    );
+    vars.insert(
+        "FLOX_ENV_PROJECT".to_string(),
+        env_project.display().to_string(),
+    );
+    vars.insert(
+        "FLOX_ENV_DESCRIPTION".to_string(),
+        dot_flox.pointer.name().to_string(),
+    );
+    vars.insert(
+        "_FLOX_ENV_CUDA_DETECTION".to_string(),
+        cuda_detection_str.clone(),
+    );
+
+    // Collect bin and sbin directories as PATH additions.
+    let bin = store_path.join("bin");
+    if bin.exists() {
+        vars.insert("_FLOX_PATH_ADD".to_string(), bin.display().to_string());
+    }
+    let sbin = store_path.join("sbin");
+    if sbin.exists() {
+        vars.insert("_FLOX_SBIN_ADD".to_string(), sbin.display().to_string());
+    }
+
+    // Parse activate.d/envrc for exported variables.
+    let envrc = store_path.join("activate.d").join("envrc");
+    if envrc.exists()
+        && let Ok(contents) = std::fs::read_to_string(&envrc)
+    {
+        static EXPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r#"^export\s+([A-Za-z_][A-Za-z0-9_]*)="(.*)"$"#).expect("valid regex")
+        });
+        let export_re = &*EXPORT_RE;
+        for line in contents.lines() {
+            if let Some(caps) = export_re.captures(line) {
+                let name = caps[1].to_string();
+                let value = caps[2].to_string();
+                if name != "PATH" {
+                    vars.insert(name, value);
+                }
+            }
+        }
+    }
+
+    Ok(ResolvedEnv {
+        vars,
+        store_path: store_path.display().to_string(),
+        flox_env,
+        env_cache,
+        flox_env_log_dir,
+        env_project,
+        flox_services_socket,
+        services_to_start,
+        cuda_detection: cuda_detection_str,
+    })
+}
+
+/// Emit shell commands to revert the previous HookDiff.
+pub(crate) fn emit_revert(diff: &HookDiff, shell: Shell, writer: &mut impl Write) -> Result<()> {
+    // Unset additions (they were added, so remove them).
+    for name in diff.additions.keys() {
+        UnsetVar::new(name).generate_with_newline(shell, writer)?;
+    }
+    // Restore modifications to their original values.
+    for (name, orig_val) in &diff.modifications {
+        SetVar::exported_no_expansion(name, orig_val).generate_with_newline(shell, writer)?;
+    }
+    // Restore deletions (they were deleted, so re-export them).
+    for (name, orig_val) in &diff.deletions {
+        SetVar::exported_no_expansion(name, orig_val).generate_with_newline(shell, writer)?;
+    }
+    // Restore the saved prompt.
+    emit_prompt_restore(shell, writer)?;
+    Ok(())
+}
+
+/// Emit shell commands to apply a new HookDiff.
+fn emit_apply(
+    diff: &HookDiff,
+    new_env: &HashMap<String, String>,
+    shell: Shell,
+    writer: &mut impl Write,
+) -> Result<()> {
+    for (name, val) in &diff.additions {
+        SetVar::exported_no_expansion(name, val).generate_with_newline(shell, writer)?;
+    }
+    for name in diff.modifications.keys() {
+        if let Some(new_val) = new_env.get(name) {
+            SetVar::exported_no_expansion(name, new_val).generate_with_newline(shell, writer)?;
+        }
+    }
+    Ok(())
+}
+
+/// All state needed to emit `_FLOX_HOOK_*` variables in a single struct.
+#[derive(Debug)]
+struct HookStateUpdate<'a> {
+    diff: &'a HookDiff,
+    active_dirs: &'a [PathBuf],
+    watches: &'a [WatchEntry],
+    suppressed_dirs: &'a [PathBuf],
+    notified_dirs: &'a [PathBuf],
+    cwd: &'a Path,
+    trusted_dot_flox: &'a [DotFlox],
+    /// .flox dirs that were auto-activated on the *previous* hook-env call.
+    prev_active_dirs: &'a [PathBuf],
+    /// Per-environment activation tracking for PID lifecycle management.
+    activation_tracking: &'a ActivationTracking,
+}
+
+/// Emit updated _FLOX_HOOK_* state variables.
+fn emit_state_vars(
+    update: &HookStateUpdate<'_>,
+    shell: Shell,
+    writer: &mut impl Write,
+) -> Result<()> {
+    let diff_encoded = update.diff.serialize()?;
+    SetVar::exported_no_expansion(HOOK_VAR_DIFF, &diff_encoded)
+        .generate_with_newline(shell, writer)?;
+
+    let dirs_str = HookState::format_path_list(update.active_dirs);
+    SetVar::exported_no_expansion(HOOK_VAR_DIRS, &dirs_str).generate_with_newline(shell, writer)?;
+
+    let watches_json =
+        serde_json::to_string(update.watches).context("failed to serialize watches")?;
+    SetVar::exported_no_expansion(HOOK_VAR_WATCHES, &watches_json)
+        .generate_with_newline(shell, writer)?;
+
+    let suppressed_str = HookState::format_path_list(update.suppressed_dirs);
+    SetVar::exported_no_expansion(HOOK_VAR_SUPPRESSED, &suppressed_str)
+        .generate_with_newline(shell, writer)?;
+
+    let notified_str = HookState::format_path_list(update.notified_dirs);
+    SetVar::exported_no_expansion(HOOK_VAR_NOTIFIED, &notified_str)
+        .generate_with_newline(shell, writer)?;
+
+    SetVar::exported_no_expansion(HOOK_VAR_CWD, update.cwd.display().to_string())
+        .generate_with_newline(shell, writer)?;
+
+    // Build _FLOX_ACTIVE_ENVIRONMENTS from the auto-activated environments,
+    // preserving any manually-activated environments.
+    let mut active_envs = activated_environments();
+
+    let new_auto_paths: Vec<PathBuf> = update
+        .trusted_dot_flox
+        .iter()
+        .map(|d| d.path.clone())
+        .collect();
+
+    active_envs.retain(|env| {
+        if let UninitializedEnvironment::DotFlox(d) = env {
+            !new_auto_paths.contains(&d.path) && !update.prev_active_dirs.contains(&d.path)
+        } else {
+            true
+        }
+    });
+
+    // Prepend auto-activated environments.
+    for dot_flox in update.trusted_dot_flox.iter() {
+        active_envs.set_last_active(
+            UninitializedEnvironment::DotFlox(dot_flox.clone()),
+            None,
+            ActivateMode::Dev,
+        );
+    }
+
+    SetVar::exported_no_expansion(FLOX_ACTIVE_ENVIRONMENTS_VAR, active_envs.to_string())
+        .generate_with_newline(shell, writer)?;
+
+    // Emit activation tracking for PID lifecycle management.
+    let activations_encoded = update
+        .activation_tracking
+        .serialize()
+        .context("failed to serialize activation tracking")?;
+    SetVar::exported_no_expansion(HOOK_VAR_ACTIVATIONS, &activations_encoded)
+        .generate_with_newline(shell, writer)?;
+
+    Ok(())
+}
+
+/// Build a list of environment names for the prompt.
+fn build_prompt_names(trusted_dot_flox: &[DotFlox]) -> Vec<String> {
+    let exclude_names: Vec<String> = std::env::var(HOOK_VAR_EXCLUDE_NAMES)
+        .unwrap_or_default()
+        .split(':')
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+
+    let auto_names: Vec<String> = trusted_dot_flox
+        .iter()
+        .rev()
+        .map(|d| d.pointer.name().to_string())
+        .collect();
+
+    [exclude_names, auto_names].concat()
+}
+
+/// Emit shell-specific code to modify the prompt with active environment names.
+fn emit_prompt(env_names: &[String], shell: Shell, writer: &mut impl Write) -> Result<()> {
+    if env_names.is_empty() {
+        return Ok(());
+    }
+
+    if std::env::var("_FLOX_SET_PROMPT").as_deref() == Ok("false") {
+        return Ok(());
+    }
+
+    let sanitized: Vec<String> = env_names
+        .iter()
+        .map(|name| {
+            name.chars()
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
+                .collect()
+        })
+        .collect();
+    let env_list = sanitized.join(" ");
+
+    let no_color = std::env::var("NO_COLOR")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
+
+    let flox_prompt = std::env::var("FLOX_PROMPT").unwrap_or_else(|_| "flox".to_string());
+
+    let color1 = INDIGO_400.to_ansi256();
+    let color2 = INDIGO_300.to_ansi256();
+
+    match shell {
+        Shell::Zsh => {
+            if no_color {
+                writeln!(
+                    writer,
+                    r#"if [ -z "${{_FLOX_HOOK_SAVE_PS1+x}}" ]; then _FLOX_HOOK_SAVE_PS1="$PS1"; fi;
+PS1="{flox_prompt} [{env_list}] $_FLOX_HOOK_SAVE_PS1";"#,
+                )?;
+            } else {
+                writeln!(
+                    writer,
+                    r#"if [ -z "${{_FLOX_HOOK_SAVE_PS1+x}}" ]; then _FLOX_HOOK_SAVE_PS1="$PS1"; fi;
+PS1="%B%F{{{color1}}}{flox_prompt}%f%b %F{{{color2}}}[{env_list}]%f $_FLOX_HOOK_SAVE_PS1";"#,
+                    color1 = color1,
+                    color2 = color2,
+                )?;
+            }
+        },
+        Shell::Bash => {
+            if no_color {
+                writeln!(
+                    writer,
+                    r#"if [ -z "${{_FLOX_HOOK_SAVE_PS1+x}}" ]; then _FLOX_HOOK_SAVE_PS1="$PS1"; fi;
+_flox_prefix="{flox_prompt} [{env_list}] ";
+case "$_FLOX_HOOK_SAVE_PS1" in *\\n*) PS1="${{_FLOX_HOOK_SAVE_PS1/\\n/\\n$_flox_prefix}}" ;; *\\012*) PS1="${{_FLOX_HOOK_SAVE_PS1/\\012/\\012$_flox_prefix}}" ;; *) PS1="$_flox_prefix$_FLOX_HOOK_SAVE_PS1" ;; esac;
+unset _flox_prefix;"#,
+                )?;
+            } else {
+                writeln!(
+                    writer,
+                    r#"if [ -z "${{_FLOX_HOOK_SAVE_PS1+x}}" ]; then _FLOX_HOOK_SAVE_PS1="$PS1"; fi;
+_flox_prefix="\[\x1b[1m\]\[\x1b[38;5;{color1}m\]{flox_prompt}\[\x1b[0m\] \[\x1b[38;5;{color2}m\][{env_list}]\[\x1b[0m\] ";
+case "$_FLOX_HOOK_SAVE_PS1" in *\\n*) PS1="${{_FLOX_HOOK_SAVE_PS1/\\n/\\n$_flox_prefix}}" ;; *\\012*) PS1="${{_FLOX_HOOK_SAVE_PS1/\\012/\\012$_flox_prefix}}" ;; *) PS1="$_flox_prefix$_FLOX_HOOK_SAVE_PS1" ;; esac;
+unset _flox_prefix;"#,
+                    color1 = color1,
+                    color2 = color2,
+                )?;
+            }
+        },
+        Shell::Fish => {
+            if no_color {
+                writeln!(
+                    writer,
+                    r#"if not set -q _FLOX_HOOK_SAVE_PROMPT; functions -q fish_prompt; and functions --copy fish_prompt _flox_hook_saved_prompt; set -g _FLOX_HOOK_SAVE_PROMPT 1; end;
+function fish_prompt; echo -n '{flox_prompt} [{env_list}] '; _flox_hook_saved_prompt; end;"#,
+                )?;
+            } else {
+                writeln!(
+                    writer,
+                    r#"if not set -q _FLOX_HOOK_SAVE_PROMPT; functions -q fish_prompt; and functions --copy fish_prompt _flox_hook_saved_prompt; set -g _FLOX_HOOK_SAVE_PROMPT 1; end;
+function fish_prompt; set_color --bold; set_color 875fff; echo -n '{flox_prompt}'; set_color normal; echo -n ' '; set_color af87ff; echo -n '[{env_list}]'; set_color normal; echo -n ' '; _flox_hook_saved_prompt; end;"#,
+                )?;
+            }
+        },
+        Shell::Tcsh => {
+            if no_color {
+                writeln!(
+                    writer,
+                    r#"if ( ! $?_FLOX_HOOK_SAVE_PROMPT ) setenv _FLOX_HOOK_SAVE_PROMPT "$prompt";
+set prompt = "{flox_prompt} [{env_list}] $_FLOX_HOOK_SAVE_PROMPT";"#,
+                )?;
+            } else {
+                writeln!(
+                    writer,
+                    r#"if ( ! $?_FLOX_HOOK_SAVE_PROMPT ) setenv _FLOX_HOOK_SAVE_PROMPT "$prompt";
+set prompt = "%{{\033[1m\033[38;5;{color1}m%}}{flox_prompt}%{{\033[0m%}} %{{\033[38;5;{color2}m%}}[{env_list}]%{{\033[0m%}} $_FLOX_HOOK_SAVE_PROMPT";"#,
+                    color1 = color1,
+                    color2 = color2,
+                )?;
+            }
+        },
+    }
+    Ok(())
+}
+
+/// Emit shell-specific code to restore the prompt to its original value.
+pub(crate) fn emit_prompt_restore(shell: Shell, writer: &mut impl Write) -> Result<()> {
+    match shell {
+        Shell::Zsh | Shell::Bash => {
+            writeln!(
+                writer,
+                r#"if [ -n "${{_FLOX_HOOK_SAVE_PS1+x}}" ]; then PS1="$_FLOX_HOOK_SAVE_PS1"; unset _FLOX_HOOK_SAVE_PS1; fi;"#,
+            )?;
+        },
+        Shell::Fish => {
+            writeln!(
+                writer,
+                r#"if set -q _FLOX_HOOK_SAVE_PROMPT; functions -q _flox_hook_saved_prompt; and functions --copy _flox_hook_saved_prompt fish_prompt; functions --erase _flox_hook_saved_prompt; set -e _FLOX_HOOK_SAVE_PROMPT; end;"#,
+            )?;
+        },
+        Shell::Tcsh => {
+            writeln!(
+                writer,
+                r#"if ( $?_FLOX_HOOK_SAVE_PROMPT ) then; set prompt = "$_FLOX_HOOK_SAVE_PROMPT"; unsetenv _FLOX_HOOK_SAVE_PROMPT; endif;"#,
+            )?;
+        },
+    }
+    Ok(())
+}
+
+/// Re-trust an environment after a manifest change so auto-activation isn't
+/// revoked. Logs on failure rather than propagating the error.
+pub(crate) fn trust_or_log(data_dir: impl AsRef<Path>, dot_flox_path: impl AsRef<Path>) {
+    let trust_mgr = TrustManager::new(data_dir);
+    if let Err(e) = trust_mgr.trust(dot_flox_path) {
+        tracing::debug!("failed to re-trust environment: {e}");
+    }
+}
+
+/// Spawn `flox-activations auto-start` to register the shell PID, spawn an
+/// executive, run on-activate hooks, and optionally start services.
+/// Returns `AutoStartResult` on success, or `None` on failure (non-fatal).
+fn spawn_auto_start(
+    shell_pid: i32,
+    dot_flox: &DotFlox,
+    resolved: &ResolvedEnv,
+    activation_state_dir: &Path,
+) -> Option<AutoStartResult> {
+    let ctx = AutoStartCtx {
+        attach_ctx: AttachCtx {
+            env: resolved.flox_env.clone(),
+            env_cache: resolved.env_cache.clone(),
+            env_description: dot_flox.pointer.name().to_string(),
+            flox_active_environments: String::new(),
+            prompt_color_1: String::new(),
+            prompt_color_2: String::new(),
+            flox_prompt_environments: String::new(),
+            set_prompt: false,
+            flox_env_cuda_detection: resolved.cuda_detection.clone(),
+            interpreter_path: FLOX_INTERPRETER.clone(),
+        },
+        project_ctx: AttachProjectCtx {
+            env_project: resolved.env_project.clone(),
+            dot_flox_path: dot_flox.path.clone(),
+            flox_env_log_dir: resolved.flox_env_log_dir.clone(),
+            process_compose_bin: PathBuf::from(&*PROCESS_COMPOSE_BIN),
+            flox_services_socket: resolved.flox_services_socket.clone(),
+            services_to_start: resolved.services_to_start.clone(),
+        },
+        store_path: resolved.store_path.clone(),
+        activation_state_dir: activation_state_dir.to_path_buf(),
+        mode: ActivateMode::Dev,
+        metrics_uuid: None,
+    };
+
+    // Write context to a temp file
+    let temp_file = match tempfile::NamedTempFile::with_prefix_in(
+        "auto_start_ctx_",
+        activation_state_dir
+            .parent()
+            .unwrap_or(activation_state_dir),
+    ) {
+        Ok(f) => f,
+        Err(e) => {
+            error!("failed to create temp file for auto-start: {e}");
+            return None;
+        },
+    };
+
+    if let Err(e) = serde_json::to_writer(&temp_file, &ctx) {
+        error!("failed to write auto-start context: {e}");
+        return None;
+    }
+
+    let ctx_path = temp_file.path().to_path_buf();
+    if let Err(e) = temp_file.keep() {
+        error!("failed to persist auto-start context file: {e}");
+        return None;
+    }
+
+    let mut child = match Command::new(&*FLOX_ACTIVATIONS_BIN)
+        .args([
+            "auto-start",
+            "--pid",
+            &shell_pid.to_string(),
+            "--activate-data",
+            &ctx_path.to_string_lossy(),
+        ])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "flox: warning: failed to start activation for '{}': {e}",
+                dot_flox.path.display()
+            );
+            let _ = std::fs::remove_file(&ctx_path);
+            return None;
+        },
+    };
+
+    // Read stdout/stderr in background threads to prevent pipe buffer deadlock.
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+
+    let stdout_handle = std::thread::spawn(move || {
+        stdout_pipe
+            .map(|mut p| {
+                let mut buf = Vec::new();
+                let _ = std::io::Read::read_to_end(&mut p, &mut buf);
+                buf
+            })
+            .unwrap_or_default()
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        stderr_pipe
+            .map(|mut p| {
+                let mut buf = Vec::new();
+                let _ = std::io::Read::read_to_end(&mut p, &mut buf);
+                buf
+            })
+            .unwrap_or_default()
+    });
+
+    // Poll for exit with a timeout.
+    const AUTO_START_TIMEOUT: Duration = Duration::from_secs(30);
+    let deadline = Instant::now() + AUTO_START_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    eprintln!(
+                        "flox: activation timed out for '{}' ({}s limit)",
+                        dot_flox.path.display(),
+                        AUTO_START_TIMEOUT.as_secs()
+                    );
+                    let _ = std::fs::remove_file(&ctx_path);
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            },
+            Err(e) => {
+                eprintln!(
+                    "flox: warning: failed to wait for activation of '{}': {e}",
+                    dot_flox.path.display()
+                );
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = std::fs::remove_file(&ctx_path);
+                return None;
+            },
+        }
+    };
+
+    let stdout = stdout_handle.join().unwrap_or_default();
+    let stderr = stderr_handle.join().unwrap_or_default();
+
+    // Clean up temp file if it still exists
+    let _ = std::fs::remove_file(&ctx_path);
+
+    let status = status.unwrap();
+    if status.success() {
+        let stdout_str = String::from_utf8_lossy(&stdout);
+        match serde_json::from_str::<AutoStartResult>(stdout_str.trim()) {
+            Ok(auto_result) => {
+                debug!(
+                    path = %dot_flox.path.display(),
+                    is_new = auto_result.is_new,
+                    "auto-start completed successfully"
+                );
+                Some(auto_result)
+            },
+            Err(e) => {
+                eprintln!(
+                    "flox: warning: on-activate hooks and services may be skipped for '{}' (parse error)",
+                    dot_flox.path.display()
+                );
+                debug!(
+                    path = %dot_flox.path.display(),
+                    "failed to parse auto-start result: {e}"
+                );
+                None
+            },
+        }
+    } else {
+        let stderr_str = String::from_utf8_lossy(&stderr);
+        if !stderr_str.is_empty() {
+            eprintln!("{}", stderr_str.trim());
+        }
+        debug!(
+            path = %dot_flox.path.display(),
+            code = ?status.code(),
+            "auto-start exited with non-zero status"
+        );
+        None
+    }
+}
+
+/// Spawn `flox-activations auto-detach` to remove the shell PID from activation
+/// state. Fire-and-forget: errors are logged to debug.
+pub(crate) fn spawn_auto_detach(shell_pid: i32, activation_state_dir: &Path) {
+    let result = Command::new(&*FLOX_ACTIVATIONS_BIN)
+        .args([
+            "auto-detach",
+            "--pid",
+            &shell_pid.to_string(),
+            "--activation-state-dir",
+            &activation_state_dir.to_string_lossy(),
+        ])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .status();
+
+    match result {
+        Ok(status) if status.success() => {
+            debug!("auto-detach completed successfully");
+        },
+        Ok(status) => {
+            debug!(
+                code = ?status.code(),
+                "auto-detach exited with non-zero status"
+            );
+        },
+        Err(e) => {
+            debug!("failed to spawn auto-detach: {e}");
+        },
     }
 }

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -241,6 +241,10 @@ async fn init_local_environment(
         PathEnvironment::init(path_pointer, dir, &customization, flox)?
     };
 
+    // Auto-trust the newly created local environment so it can be
+    // auto-activated when the user visits the directory again.
+    super::hook_env::trust_or_log(&flox.data_dir, env.dot_flox_path());
+
     let env_in_git_repo = GitCommandProvider::discover(dir).is_ok();
 
     message::created(format!(

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -372,7 +372,7 @@ impl FloxArgs {
                 Commands::Share(args) => args.handle(config, flox).await,
                 Commands::Admin(args) => args.handle(config, flox).await,
                 Commands::Agent(args) => args.handle(flox),
-                Commands::Internal(args) => args.handle(flox).await,
+                Commands::Internal(args) => args.handle(config, flox).await,
             };
 
             // This will print the update notification after output from a successful
@@ -858,7 +858,7 @@ enum InternalCommands {
 }
 
 impl InternalCommands {
-    async fn handle(self, flox: Flox) -> Result<()> {
+    async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
             InternalCommands::ResetMetrics(args) => args.handle(flox).await?,
             InternalCommands::Upload(args) => args.handle(flox).await?,
@@ -867,7 +867,7 @@ impl InternalCommands {
             InternalCommands::Exit(args) => args.handle(flox)?,
             InternalCommands::ActivationState(args) => args.handle(flox).await?,
             InternalCommands::ServicesSocket(args) => args.handle(flox).await?,
-            InternalCommands::HookEnv(args) => args.handle(flox)?,
+            InternalCommands::HookEnv(args) => args.handle(config, flox)?,
         }
         Ok(())
     }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1,11 +1,13 @@
 mod activate;
 mod activation_state;
+mod allow;
 mod auth;
 mod build;
 mod check_for_upgrades;
 mod containerize;
 mod deactivate;
 mod delete;
+mod deny;
 mod edit;
 mod envs;
 mod exit;
@@ -570,6 +572,14 @@ enum UseCommands {
         )]
         services::ServicesCommands,
     ),
+
+    /// Allow auto-activation for a Flox environment
+    #[bpaf(command)]
+    Allow(#[bpaf(external(allow::allow))] allow::Allow),
+
+    /// Deny auto-activation for a Flox environment
+    #[bpaf(command)]
+    Deny(#[bpaf(external(deny::deny))] deny::Deny),
 }
 
 impl UseCommands {
@@ -577,6 +587,8 @@ impl UseCommands {
         match self {
             UseCommands::Activate(args) => args.handle(config, flox).await?,
             UseCommands::Services(args) => args.handle(config, flox).await?,
+            UseCommands::Allow(args) => args.handle(flox)?,
+            UseCommands::Deny(args) => args.handle(flox)?,
         }
         Ok(())
     }

--- a/cli/flox/src/utils/active_environments.rs
+++ b/cli/flox/src/utils/active_environments.rs
@@ -111,6 +111,14 @@ impl ActiveEnvironments {
     pub fn iter(&self) -> impl Iterator<Item = &UninitializedEnvironment> {
         self.0.iter().map(|active| &active.environment)
     }
+
+    /// Retain only environments for which the predicate returns true.
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&UninitializedEnvironment) -> bool,
+    {
+        self.0.retain(|active| f(&active.environment));
+    }
 }
 
 impl Display for ActiveEnvironments {


### PR DESCRIPTION
## Summary

Ports the auto-activate cd-in/cd-out roundtrip from the older
`feat/auto-activation` branch onto the `prototype/flox-agent` base.

### What this enables

- **cd into a directory with `.flox/`**: shell prompt hook runs
  `flox hook-env` which calls `flox-activations auto-start` to register
  the shell PID, spawn the executive, run `hook.on-activate`, and emit
  PATH/env var exports back to the shell
- **cd out of the directory**: hook runs `flox hook-env` which calls
  `flox-activations auto-detach` to unregister the shell PID, and emits
  revert commands to restore the previous env vars
- **`flox allow`** / **`flox deny`**: manual preference control for
  Prompt mode
- Default config (`AutoActivate::Allowed`) activates immediately without
  any prompting or trust gates

### Key adaptations from feat branch

- `AutoActivate::Allowed/Prompt` (main) vs `AutoActivateConfig::Prompt/Never`
  (feat): Allowed mode bypasses all preference/trust gates
- `lockfile.migrated_manifest().as_latest_schema()` for manifest access
  (main API) vs `manifest.migrate_typed_only()` + `.options()/.services()`
  (feat API)
- `StartDiff::from_files()` instead of `EnvDiff::from_files()` for hook
  env diff computation
- Added `ActiveEnvironments::retain()` method (was missing from main)
- `InvocationType::Interactive` added to `start_or_attach` call (new 3rd arg)

## Test Plan

- [ ] `cd` into a directory with `.flox/` → prompt shows env name
- [ ] `cd` out of that directory → prompt reverts
- [ ] `flox allow` and `flox deny` commands are accessible
- [ ] `cargo build` succeeds with no errors
- [ ] `cargo fmt` produces no diffs
- [ ] `cargo clippy` passes

## Notes

This is a prototype branch — TDD and full edge-case coverage are
intentionally skipped per prototype mode conventions.

Refs: prototype/flox-agent

---
*Via Forge (implementation-worker) • f773093b*