### PR TITLE
fix(catalog): use correct separator in BaseCatalogUrl::as_flake_ref

### DIFF
--- a/cli/flox-catalog/src/types.rs
+++ b/cli/flox-catalog/src/types.rs
@@ -352,7 +352,9 @@ pub struct BaseCatalogUrl(String);
 
 impl BaseCatalogUrl {
     pub fn as_flake_ref(&self) -> Result<Url, BaseCatalogUrlError> {
-        Url::parse(&format!("git+{}&shallow=1", self.0.as_str())).map_err(BaseCatalogUrlError)
+        let mut url = Url::parse(&format!("git+{}", self.0)).map_err(BaseCatalogUrlError)?;
+        url.query_pairs_mut().append_pair("shallow", "1");
+        Ok(url)
     }
 
     pub fn rev(&self) -> Option<String> {
@@ -529,5 +531,25 @@ mod tests {
         let context = [("valid_systems".to_string(), "".to_string())].into();
         let systems = ResolutionMessage::valid_systems_from_context(&context);
         assert_eq!(systems, Vec::<String>::new());
+    }
+
+    #[test]
+    fn as_flake_ref_with_query_string_appends_ampersand() {
+        let url = BaseCatalogUrl::from("https://github.com/flox/nixpkgs?rev=abc123");
+        let flake_ref = url.as_flake_ref().expect("should parse");
+        assert_eq!(
+            flake_ref.as_str(),
+            "git+https://github.com/flox/nixpkgs?rev=abc123&shallow=1"
+        );
+    }
+
+    #[test]
+    fn as_flake_ref_plain_https_no_query_appends_question_mark() {
+        let url = BaseCatalogUrl::from("https://github.com/NixOS/nixpkgs");
+        let flake_ref = url.as_flake_ref().expect("should parse");
+        assert_eq!(
+            flake_ref.as_str(),
+            "git+https://github.com/NixOS/nixpkgs?shallow=1"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`BaseCatalogUrl::as_flake_ref` previously appended `&shallow=1` unconditionally, assuming the input URL already contained a `?` query string. That assumption held for catalog-server output (`{base_url}?rev={rev}`) but produced a malformed URL whenever the input lacked a query string — Nix percent-encoded the `&shallow=1` into `%26shallow%3D1` and rejected the flake input as unsupported.

The fix uses the `url` crate's `query_pairs_mut().append_pair("shallow", "1")` so separator selection, encoding, and merging with any existing query are handled by the URL library rather than by string formatting.

## Context

This surfaced via the factory build coordinator, which (incorrectly) sent `--nixpkgs-url github:flox/nixpkgs/<rev>` — a bare flake shorthand with the rev as a path segment and no query string. The producer side will be fixed separately to emit the catalog-server shape, but `as_flake_ref` shouldn't silently produce malformed flake refs when its input doesn't match an undocumented invariant.

## Tests

Two new tests in `cli/flox-catalog/src/types.rs` pin the exact output string for the realistic catalog-server input shapes:

- existing `?rev=` query → `...?rev=abc123&shallow=1`
- plain https with no query → `...?shallow=1`

## Test plan

- [x] `nix develop -c cargo test -p flox-catalog` — 29 passed, 0 failed
- [x] `nix develop -c cargo clippy -p flox-catalog --all-targets -- -D warnings` — clean
- [x] `nix develop -c cargo fmt -p flox-catalog -- --check` — clean

---
*Via Forge (interactive) • c698bb07*
