### PR TITLE
fix(ci): fetch PR head via refs/pull so fork PRs lint

### DIFF
--- a/.github/workflows/nix-managed-lints.yml
+++ b/.github/workflows/nix-managed-lints.yml
@@ -45,18 +45,31 @@ jobs:
       - name: "Determine target branch ( PR )"
         if: ${{ github.event_name == 'pull_request' }}
         # Unlike `github.event.merge_group.base_ref`, `github.base_ref`
-        # only includes the final ref name
-        # prepend `refs/heads/` to match the format of
-        # `github.event.merge_group.base_ref`.
+        # only includes the final ref name; prepend `refs/heads/` to match
+        # the format of `github.event.merge_group.base_ref`.
+        #
+        # The PR head branch may live in a fork, so it is not guaranteed to
+        # exist on `origin`. Fetch it through `refs/pull/<number>/head`, which
+        # GitHub maintains on the base repo for every PR (fork or same-repo).
+        #
+        # Context values are passed via `env:` and referenced as shell
+        # variables rather than interpolated directly into `run:`, to avoid
+        # script injection from attacker-controlled values such as branch names.
+        env:
+          BASE_REF: "${{ github.base_ref }}"
+          PR_NUMBER: "${{ github.event.pull_request.number }}"
         run: |
-          echo 'TARGET_REF=refs/heads/${{ github.base_ref }}' >> "$GITHUB_ENV";
-          echo 'HEAD_REF=refs/heads/${{ github.head_ref }}' >> "$GITHUB_ENV";
+          echo "TARGET_REF=refs/heads/${BASE_REF}" >> "$GITHUB_ENV";
+          echo "HEAD_REF=refs/pull/${PR_NUMBER}/head" >> "$GITHUB_ENV";
 
       - name: "Fetch target branch ( Merge Queue )"
         if: ${{ github.event_name == 'merge_group' }}
+        env:
+          MERGE_GROUP_BASE_REF: "${{ github.event.merge_group.base_ref }}"
+          MERGE_GROUP_HEAD_REF: "${{ github.event.merge_group.head_ref }}"
         run: |
-          echo 'TARGET_REF=${{ github.event.merge_group.base_ref }}' >> "$GITHUB_ENV";
-          echo 'HEAD_REF=${{ github.event.merge_group.head_ref }}' >> "$GITHUB_ENV";
+          echo "TARGET_REF=${MERGE_GROUP_BASE_REF}" >> "$GITHUB_ENV";
+          echo "HEAD_REF=${MERGE_GROUP_HEAD_REF}" >> "$GITHUB_ENV";
 
       - name: "Set merge queue flag"
         if: ${{ github.event_name == 'merge_group' }}


### PR DESCRIPTION
## Problem

The Project Lints workflow fails on pull requests opened from forks. The "Fetch branches" step fetches the PR head branch by name from `origin` (which is flox/flox), with `HEAD_REF=refs/heads/<branch>`. A fork PR's branch only exists on the contributor's fork, never on flox/flox, so the fetch dies with `fatal: couldn't find remote ref refs/heads/<branch>`. This blocks linting on every community PR. Example: flox/flox PR 4205.

## Fix

Fetch the PR head through the `refs/pull/<number>/head` ref that GitHub maintains on the base repo for every PR. This ref resolves for both same-repo and fork PRs, so the head/base diff that `pre-commit` needs is always available. The merge-queue path is unchanged — its refs already live on `origin`.

## Hardening

While here, move `${{ github.* }}` expansions out of `run:` script bodies and into `env:` blocks, referencing them as quoted shell variables. Interpolating context values such as `github.base_ref` directly into a shell script is a script-injection risk (a crafted branch name runs as shell). The `env:`-then-`"$VAR"` pattern is the recommended GitHub Actions practice. Thanks to Josh Soref for both reports.

## Test plan

- [ ] Fork PR triggers Project Lints and the "Fetch branches" step succeeds
- [ ] Same-repo PR still lints
- [ ] Merge-queue run still lints

---
*Via Forge (interactive) • 24c0b34c*