### PR TITLE
feat(deactivate): add code to unset prompt

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/set-prompt.bash
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.bash
@@ -4,45 +4,49 @@
 
 # Tweak the (already customized) prompt: add a flox indicator.
 _flox_set_prompt() {
-  if [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
-    local _esc="\x1b["
-    local colorReset="\[${_esc}0m\]"
-    local colorBold="\[${_esc}1m\]"
-    local colorPrompt1="\[${_esc}38;5;${FLOX_PROMPT_COLOR_1}m\]"
-    local colorPrompt2="\[${_esc}38;5;${FLOX_PROMPT_COLOR_2}m\]"
-    local _floxPrompt1="${colorPrompt1}flox"
-    local _floxPrompt2="${colorPrompt2}[$FLOX_PROMPT_ENVIRONMENTS]"
-    # nixpkgs#bash doesn't have readline, so the prompt gets garbled if we use escapes.
-    # Detect if we have readline by checking for progcomp; support for progcomp is
-    # disabled when readline is not present, see:
-    # https://git.savannah.gnu.org/cgit/bash.git/tree/bashline.c#n23
-    # Note that we set colors even if support for progcomp is compiled in, but it is
-    # turned off.
-    local _flox
-    if [[ $(shopt) =~ progcomp ]] && [[ "${NO_COLOR:-0}" == "0" ]]; then
-      _flox=$(echo -e -n "${colorBold}${FLOX_PROMPT-$_floxPrompt1} ${_floxPrompt2}${colorReset} ")
-    else
-      _flox=$(echo -e -n "${FLOX_PROMPT-flox} [$FLOX_PROMPT_ENVIRONMENTS] ")
-    fi
-
-    # Start by saving the original value of PS1.
-    if [ -z "${FLOX_SAVE_BASH_PS1:=}" ]; then
-      export FLOX_SAVE_BASH_PS1="$PS1"
-    fi
-    case "$FLOX_SAVE_BASH_PS1" in
-      # If the prompt contains an embedded newline,
-      # then insert the flox indicator immediately after
-      # the (first) newline.
-      *\\n*) PS1="${FLOX_SAVE_BASH_PS1/\\n/\\n$_flox}" ;;
-      *\\012*) PS1="${FLOX_SAVE_BASH_PS1/\\012/\\012$_flox}" ;;
-
-      # Otherwise, prepend the flox indicator.
-      *) PS1="$_flox$FLOX_SAVE_BASH_PS1" ;;
-    esac
+  local _esc="\x1b["
+  local colorReset="\[${_esc}0m\]"
+  local colorBold="\[${_esc}1m\]"
+  local colorPrompt1="\[${_esc}38;5;${FLOX_PROMPT_COLOR_1}m\]"
+  local colorPrompt2="\[${_esc}38;5;${FLOX_PROMPT_COLOR_2}m\]"
+  local _floxPrompt1="${colorPrompt1}flox"
+  local _floxPrompt2="${colorPrompt2}[$FLOX_PROMPT_ENVIRONMENTS]"
+  # nixpkgs#bash doesn't have readline, so the prompt gets garbled if we use escapes.
+  # Detect if we have readline by checking for progcomp; support for progcomp is
+  # disabled when readline is not present, see:
+  # https://git.savannah.gnu.org/cgit/bash.git/tree/bashline.c#n23
+  # Note that we set colors even if support for progcomp is compiled in, but it is
+  # turned off.
+  local _flox
+  if [[ $(shopt) =~ progcomp ]] && [[ "${NO_COLOR:-0}" == "0" ]]; then
+    _flox=$(echo -e -n "${colorBold}${FLOX_PROMPT-$_floxPrompt1} ${_floxPrompt2}${colorReset} ")
+  else
+    _flox=$(echo -e -n "${FLOX_PROMPT-flox} [$FLOX_PROMPT_ENVIRONMENTS] ")
   fi
+
+  # Start by saving the original value of PS1.
+  if [ -z "${FLOX_SAVE_BASH_PS1:=}" ]; then
+    export FLOX_SAVE_BASH_PS1="$PS1"
+  fi
+  case "$FLOX_SAVE_BASH_PS1" in
+    # If the prompt contains an embedded newline,
+    # then insert the flox indicator immediately after
+    # the (first) newline.
+    *\\n*) PS1="${FLOX_SAVE_BASH_PS1/\\n/\\n$_flox}" ;;
+    *\\012*) PS1="${FLOX_SAVE_BASH_PS1/\\012/\\012$_flox}" ;;
+
+    # Otherwise, prepend the flox indicator.
+    *) PS1="$_flox$FLOX_SAVE_BASH_PS1" ;;
+  esac
 }
 
-_flox_set_prompt
+if [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
+  _flox_set_prompt
+elif [ -n "${FLOX_SAVE_BASH_PS1:-}" ]; then
+  # Restore the prompt when no environments should be in the prompt
+  PS1="$FLOX_SAVE_BASH_PS1"
+  unset FLOX_SAVE_BASH_PS1
+fi
 unset -f _flox_set_prompt
 
 "$_flox_activate_tracer" "$_activate_d/set-prompt.bash" END

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.bash
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.bash
@@ -3,45 +3,46 @@
 "$_flox_activate_tracer" "$_activate_d/set-prompt.bash" START
 
 # Tweak the (already customized) prompt: add a flox indicator.
+_flox_set_prompt() {
+  if [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
+    local _esc="\x1b["
+    local colorReset="\[${_esc}0m\]"
+    local colorBold="\[${_esc}1m\]"
+    local colorPrompt1="\[${_esc}38;5;${FLOX_PROMPT_COLOR_1}m\]"
+    local colorPrompt2="\[${_esc}38;5;${FLOX_PROMPT_COLOR_2}m\]"
+    local _floxPrompt1="${colorPrompt1}flox"
+    local _floxPrompt2="${colorPrompt2}[$FLOX_PROMPT_ENVIRONMENTS]"
+    # nixpkgs#bash doesn't have readline, so the prompt gets garbled if we use escapes.
+    # Detect if we have readline by checking for progcomp; support for progcomp is
+    # disabled when readline is not present, see:
+    # https://git.savannah.gnu.org/cgit/bash.git/tree/bashline.c#n23
+    # Note that we set colors even if support for progcomp is compiled in, but it is
+    # turned off.
+    local _flox
+    if [[ $(shopt) =~ progcomp ]] && [[ "${NO_COLOR:-0}" == "0" ]]; then
+      _flox=$(echo -e -n "${colorBold}${FLOX_PROMPT-$_floxPrompt1} ${_floxPrompt2}${colorReset} ")
+    else
+      _flox=$(echo -e -n "${FLOX_PROMPT-flox} [$FLOX_PROMPT_ENVIRONMENTS] ")
+    fi
 
-_esc="\x1b["
-colorReset="\[${_esc}0m\]"
-colorBold="\[${_esc}1m\]"
-colorPrompt1="\[${_esc}38;5;${FLOX_PROMPT_COLOR_1}m\]"
-colorPrompt2="\[${_esc}38;5;${FLOX_PROMPT_COLOR_2}m\]"
-_floxPrompt1="${colorPrompt1}flox"
-_floxPrompt2="${colorPrompt2}[$FLOX_PROMPT_ENVIRONMENTS]"
-# nixpkgs#bash doesn't have readline, so the prompt gets garbled if we use escapes.
-# Detect if we have readline by checking for progcomp; support for progcomp is
-# disabled when readline is not present, see:
-# https://git.savannah.gnu.org/cgit/bash.git/tree/bashline.c#n23
-# Note that we set colors even if support for progcomp is compiled in, but it is
-# turned off.
-if [[ $(shopt) =~ progcomp ]] && [[ "${NO_COLOR:-0}" == "0" ]]; then
-  _flox=$(echo -e -n "${colorBold}${FLOX_PROMPT-$_floxPrompt1} ${_floxPrompt2}${colorReset} ")
-else
-  _flox=$(echo -e -n "${FLOX_PROMPT-flox} [$FLOX_PROMPT_ENVIRONMENTS] ")
-fi
+    # Start by saving the original value of PS1.
+    if [ -z "${FLOX_SAVE_BASH_PS1:=}" ]; then
+      export FLOX_SAVE_BASH_PS1="$PS1"
+    fi
+    case "$FLOX_SAVE_BASH_PS1" in
+      # If the prompt contains an embedded newline,
+      # then insert the flox indicator immediately after
+      # the (first) newline.
+      *\\n*) PS1="${FLOX_SAVE_BASH_PS1/\\n/\\n$_flox}" ;;
+      *\\012*) PS1="${FLOX_SAVE_BASH_PS1/\\012/\\012$_flox}" ;;
 
-unset _esc colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
-
-if [ -n "$_flox" ] && [ -n "${PS1:-}" ] && [ "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
-  # Start by saving the original value of PS1.
-  if [ -z "${FLOX_SAVE_BASH_PS1:=}" ]; then
-    export FLOX_SAVE_BASH_PS1="$PS1"
+      # Otherwise, prepend the flox indicator.
+      *) PS1="$_flox$FLOX_SAVE_BASH_PS1" ;;
+    esac
   fi
-  case "$FLOX_SAVE_BASH_PS1" in
-    # If the prompt contains an embedded newline,
-    # then insert the flox indicator immediately after
-    # the (first) newline.
-    *\\n*) PS1="${FLOX_SAVE_BASH_PS1/\\n/\\n$_flox}" ;;
-    *\\012*) PS1="${FLOX_SAVE_BASH_PS1/\\012/\\012$_flox}" ;;
+}
 
-    # Otherwise, prepend the flox indicator.
-    *) PS1="$_flox$FLOX_SAVE_BASH_PS1" ;;
-  esac
-fi
-
-unset _flox
+_flox_set_prompt
+unset -f _flox_set_prompt
 
 "$_flox_activate_tracer" "$_activate_d/set-prompt.bash" END

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.fish
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.fish
@@ -23,6 +23,10 @@ if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS"
         set -l original_prompt (flox_saved_fish_prompt | string collect --no-trim-newlines)
         printf "%s %s\n" $_flox $original_prompt
     end
+else if functions -q flox_saved_fish_prompt
+    # Restore the prompt when no environments should be in the prompt
+    functions --copy flox_saved_fish_prompt fish_prompt
+    functions --erase flox_saved_fish_prompt
 end
 
 "$_flox_activate_tracer" "$_activate_d/set-prompt.fish" END

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.tcsh
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.tcsh
@@ -1,33 +1,31 @@
 $_flox_activate_tracer $_activate_d/set-prompt.tcsh START
 
 # Tweak the (already customized) prompt: add a flox indicator.
-if ( ! $?FLOX_PROMPT ) then
-    set FLOX_PROMPT = "flox"
-endif
-
-set colorReset = "%{\033[0m%}"
-set colorBold = "%{\033[1m%}"
-set colorPrompt1 = "%{\033[38;5;""$FLOX_PROMPT_COLOR_1""m%}"
-set colorPrompt2 = "%{\033[38;5;""$FLOX_PROMPT_COLOR_2""m%}"
-set _floxPrompt1 = "$colorPrompt1""$FLOX_PROMPT"
-set _floxPrompt2 = "$colorPrompt2""[$FLOX_PROMPT_ENVIRONMENTS]"
-
-if $?NO_COLOR then
-    set _flox = "flox [$FLOX_PROMPT_ENVIRONMENTS]"
-else
-    set _flox = "$colorBold$_floxPrompt1 $_floxPrompt2$colorReset"
-endif
-
-unset _esc colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
-
-# Save the current 'tcsh_prompt' if not already saved.
 if ( $?prompt && "$FLOX_PROMPT_ENVIRONMENTS" != "" ) then
+    if ( ! $?FLOX_PROMPT ) then
+        set FLOX_PROMPT = "flox"
+    endif
+
+    set colorReset = "%{\033[0m%}"
+    set colorBold = "%{\033[1m%}"
+    set colorPrompt1 = "%{\033[38;5;""$FLOX_PROMPT_COLOR_1""m%}"
+    set colorPrompt2 = "%{\033[38;5;""$FLOX_PROMPT_COLOR_2""m%}"
+    set _floxPrompt1 = "$colorPrompt1""$FLOX_PROMPT"
+    set _floxPrompt2 = "$colorPrompt2""[$FLOX_PROMPT_ENVIRONMENTS]"
+
+    if $?NO_COLOR then
+        set _flox = "flox [$FLOX_PROMPT_ENVIRONMENTS]"
+    else
+        set _flox = "$colorBold$_floxPrompt1 $_floxPrompt2$colorReset"
+    endif
+
+    # Save the current 'tcsh_prompt' if not already saved.
     if ( ! $?FLOX_SAVE_TCSH_PROMPT ) then
         setenv FLOX_SAVE_TCSH_PROMPT "$prompt"
     endif
     set prompt = "$_flox $FLOX_SAVE_TCSH_PROMPT"
-endif
 
-unset _flox
+    unset _flox colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
+endif
 
 $_flox_activate_tracer $_activate_d/set-prompt.tcsh END

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.tcsh
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.tcsh
@@ -26,6 +26,10 @@ if ( $?prompt && "$FLOX_PROMPT_ENVIRONMENTS" != "" ) then
     set prompt = "$_flox $FLOX_SAVE_TCSH_PROMPT"
 
     unset _flox colorReset colorBold colorPrompt1 colorPrompt2 _floxPrompt1 _floxPrompt2
+else if ( $?FLOX_SAVE_TCSH_PROMPT ) then
+    # Restore the prompt when no environments should be in the prompt
+    set prompt = "$FLOX_SAVE_TCSH_PROMPT"
+    unsetenv FLOX_SAVE_TCSH_PROMPT
 endif
 
 $_flox_activate_tracer $_activate_d/set-prompt.tcsh END

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.zsh
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.zsh
@@ -2,35 +2,39 @@
 
 # Tweak the (already customized) prompt: add a flox indicator.
 _flox_set_prompt() {
-  if [ -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
-    local _floxPrompt1="${FLOX_PROMPT-flox}"
-    local _floxPrompt2="[$FLOX_PROMPT_ENVIRONMENTS]"
-    if [[ "${NO_COLOR:-0}" == "0" ]]; then
-      _floxPrompt1="%B%F{${FLOX_PROMPT_COLOR_1}}${_floxPrompt1}%f%b"
-      _floxPrompt2="%F{${FLOX_PROMPT_COLOR_2}}${_floxPrompt2}%f"
-    fi
-    local _flox="${_floxPrompt1} ${_floxPrompt2} "
-
-    # Start by saving the original value of PS1.
-    if [ -z "${FLOX_SAVE_ZSH_PS1:=}" ]; then
-      export FLOX_SAVE_ZSH_PS1="$PS1"
-    fi
-    case "$FLOX_SAVE_ZSH_PS1" in
-      # If the prompt contains an embedded newline,
-      # then insert the flox indicator immediately after
-      # the (first) newline.
-      *\\n*) PS1="${FLOX_SAVE_ZSH_PS1/\\n/\\n$_flox}" ;;
-      *\\012*) PS1="${FLOX_SAVE_ZSH_PS1/\\012/\\012$_flox}" ;;
-
-      # Otherwise, prepend the flox indicator.
-      *) PS1="$_flox$FLOX_SAVE_ZSH_PS1" ;;
-    esac
-
-    # TODO: figure out zsh way of setting window and icon title.
+  local _floxPrompt1="${FLOX_PROMPT-flox}"
+  local _floxPrompt2="[$FLOX_PROMPT_ENVIRONMENTS]"
+  if [[ "${NO_COLOR:-0}" == "0" ]]; then
+    _floxPrompt1="%B%F{${FLOX_PROMPT_COLOR_1}}${_floxPrompt1}%f%b"
+    _floxPrompt2="%F{${FLOX_PROMPT_COLOR_2}}${_floxPrompt2}%f"
   fi
+  local _flox="${_floxPrompt1} ${_floxPrompt2} "
+
+  # Start by saving the original value of PS1.
+  if [ -z "${FLOX_SAVE_ZSH_PS1:=}" ]; then
+    export FLOX_SAVE_ZSH_PS1="$PS1"
+  fi
+  case "$FLOX_SAVE_ZSH_PS1" in
+    # If the prompt contains an embedded newline,
+    # then insert the flox indicator immediately after
+    # the (first) newline.
+    *\\n*) PS1="${FLOX_SAVE_ZSH_PS1/\\n/\\n$_flox}" ;;
+    *\\012*) PS1="${FLOX_SAVE_ZSH_PS1/\\012/\\012$_flox}" ;;
+
+    # Otherwise, prepend the flox indicator.
+    *) PS1="$_flox$FLOX_SAVE_ZSH_PS1" ;;
+  esac
+
+  # TODO: figure out zsh way of setting window and icon title.
 }
 
-_flox_set_prompt
+if [ -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
+  _flox_set_prompt
+elif [ -n "${FLOX_SAVE_ZSH_PS1:-}" ]; then
+  # Restore the prompt when no environments should be in the prompt
+  PS1="$FLOX_SAVE_ZSH_PS1"
+  unset FLOX_SAVE_ZSH_PS1
+fi
 unset -f _flox_set_prompt
 
 "$_flox_activate_tracer" "$_activate_d/set-prompt.zsh" END

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.zsh
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.zsh
@@ -1,36 +1,36 @@
 "$_flox_activate_tracer" "$_activate_d/set-prompt.zsh" START
 
 # Tweak the (already customized) prompt: add a flox indicator.
+_flox_set_prompt() {
+  if [ -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
+    local _floxPrompt1="${FLOX_PROMPT-flox}"
+    local _floxPrompt2="[$FLOX_PROMPT_ENVIRONMENTS]"
+    if [[ "${NO_COLOR:-0}" == "0" ]]; then
+      _floxPrompt1="%B%F{${FLOX_PROMPT_COLOR_1}}${_floxPrompt1}%f%b"
+      _floxPrompt2="%F{${FLOX_PROMPT_COLOR_2}}${_floxPrompt2}%f"
+    fi
+    local _flox="${_floxPrompt1} ${_floxPrompt2} "
 
-_floxPrompt1="${FLOX_PROMPT-flox}"
-_floxPrompt2="[$FLOX_PROMPT_ENVIRONMENTS]"
+    # Start by saving the original value of PS1.
+    if [ -z "${FLOX_SAVE_ZSH_PS1:=}" ]; then
+      export FLOX_SAVE_ZSH_PS1="$PS1"
+    fi
+    case "$FLOX_SAVE_ZSH_PS1" in
+      # If the prompt contains an embedded newline,
+      # then insert the flox indicator immediately after
+      # the (first) newline.
+      *\\n*) PS1="${FLOX_SAVE_ZSH_PS1/\\n/\\n$_flox}" ;;
+      *\\012*) PS1="${FLOX_SAVE_ZSH_PS1/\\012/\\012$_flox}" ;;
 
-if [[ "${NO_COLOR:-0}" == "0" ]]; then
-  _floxPrompt1="%B%F{${FLOX_PROMPT_COLOR_1}}${_floxPrompt1}%f%b"
-  _floxPrompt2="%F{${FLOX_PROMPT_COLOR_2}}${_floxPrompt2}%f"
-fi
+      # Otherwise, prepend the flox indicator.
+      *) PS1="$_flox$FLOX_SAVE_ZSH_PS1" ;;
+    esac
 
-_flox="${_floxPrompt1} ${_floxPrompt2} "
-
-if [ -n "$_flox" -a -n "${PS1:-}" -a "${FLOX_PROMPT_ENVIRONMENTS:-}" != "" ]; then
-  # Start by saving the original value of PS1.
-  if [ -z "${FLOX_SAVE_ZSH_PS1:=}" ]; then
-    export FLOX_SAVE_ZSH_PS1="$PS1"
+    # TODO: figure out zsh way of setting window and icon title.
   fi
-  case "$FLOX_SAVE_ZSH_PS1" in
-    # If the prompt contains an embedded newline,
-    # then insert the flox indicator immediately after
-    # the (first) newline.
-    *\\n*) PS1="${FLOX_SAVE_ZSH_PS1/\\n/\\n$_flox}" ;;
-    *\\012*) PS1="${FLOX_SAVE_ZSH_PS1/\\012/\\012$_flox}" ;;
+}
 
-    # Otherwise, prepend the flox indicator.
-    *) PS1="$_flox$FLOX_SAVE_ZSH_PS1" ;;
-  esac
-
-  # TODO: figure out zsh way of setting window and icon title.
-fi
-
-unset _flox _floxPrompt1 _floxPrompt2
+_flox_set_prompt
+unset -f _flox_set_prompt
 
 "$_flox_activate_tracer" "$_activate_d/set-prompt.zsh" END

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -44,7 +44,7 @@ pub fn generate_bash_profile_commands(
                 stmts.push("set -x".to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: emit `set -x` when tracelevel >= 2
         },
     }
@@ -65,7 +65,7 @@ pub fn generate_bash_profile_commands(
                 stmts.push(todo_drop_unset("_flox_sourcing_rc"));
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // No-op: no way to undo bashrc sourcing
         },
     }
@@ -75,7 +75,7 @@ pub fn generate_bash_profile_commands(
         Action::Activate { args, attach_diff } => {
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: decode `_FLOX_HOOK_DIFF` and emit restores — unset
             // additions, restore prior values for modifications and
             // removals, then unset `_FLOX_HOOK_DIFF` itself.
@@ -97,29 +97,35 @@ pub fn generate_bash_profile_commands(
                 &args.flox_activate_tracer,
             ));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: we shouldn't be exporting these in the first place
+            // Although note that unsetting the prompt depends on these being
+            // set
         },
     }
 
-    // Set the prompt if we're in an interactive shell.
-    match action {
-        Action::Activate { args, .. } => {
-            if args.set_prompt {
-                let set_prompt_path = args.activate_d.join("set-prompt.bash");
-                stmts.push(
-                    format!(
-                        "if [ -t 1 ]; then source '{}'; fi;",
-                        set_prompt_path.display()
-                    )
-                    .to_stmt(),
-                );
-            }
-        },
-        Action::Deactivate => {
-            // TODO: revert the prompt.
-        },
-    }
+    // Source set-prompt.bash if we're in an interactive shell
+    // set-prompt.bash handles both setting and unsetting
+    // Note for deactivate this must come after reverting environment
+    // variables (which includes FLOX_PROMPT_ENVIRONMENTS)
+    let set_prompt_path = match action {
+        Action::Activate { args, .. } => args
+            .set_prompt
+            .then(|| args.activate_d.join("set-prompt.bash")),
+        Action::Deactivate { activate_d } => Some(activate_d.join("set-prompt.bash")),
+    };
+    if let Some(set_prompt_path) = set_prompt_path {
+        // We could consult set_prompt, but hypothetically that config value
+        // could change between activation and deactivation, and sourcing
+        // set-prompt won't hurt
+        stmts.push(
+            format!(
+                "if [ -t 1 ]; then source '{}'; fi;",
+                set_prompt_path.display()
+            )
+            .to_stmt(),
+        );
+    };
 
     // We already customized the PATH and MANPATH, but the user and system
     // dotfiles may have changed them, so finish by doing this again.
@@ -138,7 +144,7 @@ pub fn generate_bash_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // No-op: covered by environment restoration above
         },
     }
@@ -150,7 +156,7 @@ pub fn generate_bash_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: run profile.deactivate.bash
         },
     }
@@ -163,7 +169,7 @@ pub fn generate_bash_profile_commands(
         Action::Activate { .. } => {
             stmts.push("set +h".to_stmt());
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: decide whether to restore prior hashing state.
         },
     }
@@ -175,7 +181,7 @@ pub fn generate_bash_profile_commands(
                 stmts.push("set +x".to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: set +x
         },
     }
@@ -189,7 +195,7 @@ pub fn generate_bash_profile_commands(
                 stmts.push(format!("{RM} {};", escaped_path).to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // No-op: deactivate has no rc file to remove.
         },
     }
@@ -210,7 +216,7 @@ pub fn generate_bash_profile_commands(
                 write!(writer, "{}", crate::hook::bash_hook(&args.flox_bin))?;
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: unregister the auto-activate hook
         },
     }
@@ -237,7 +243,9 @@ mod tests {
     }
 
     fn render_deactivate() -> String {
-        let action = Action::<BashStartupArgs>::Deactivate;
+        let action = Action::<BashStartupArgs>::Deactivate {
+            activate_d: PathBuf::from("/interpreter/activate.d"),
+        };
         let mut buf = Vec::new();
         generate_bash_profile_commands(&action, &mut buf).expect("generator should succeed");
         String::from_utf8(buf).expect("output should be utf-8")
@@ -305,6 +313,9 @@ mod tests {
     #[test]
     fn generate_bash_profile_deactivate() {
         let output = render_deactivate();
-        expect![""].assert_eq(&output);
+        expect![[r#"
+            if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
+        "#]]
+        .assert_eq(&output);
     }
 }

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -44,7 +44,7 @@ pub fn generate_fish_profile_commands(
                 stmts.push(todo_drop_set_exported_unexpanded("fish_trace", "1").to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: emit `set -gx fish_trace 1` when tracelevel >= 2
         },
     }
@@ -59,7 +59,7 @@ pub fn generate_fish_profile_commands(
         Action::Activate { args, attach_diff } => {
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: decode `_FLOX_HOOK_DIFF` and emit restores.
         },
     }
@@ -79,25 +79,29 @@ pub fn generate_fish_profile_commands(
                 &args.flox_activate_tracer,
             ));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: we shouldn't be exporting these in the first place
+            // Although note that unsetting the prompt depends on these being
+            // set
         },
     }
 
-    // Set the prompt if we're in an interactive shell.
-    match action {
-        Action::Activate { args, .. } => {
-            if args.set_prompt {
-                let set_prompt_path = args.activate_d.join("set-prompt.fish");
-                stmts.push(
-                    format!("if isatty 1; source '{}'; end;", set_prompt_path.display()).to_stmt(),
-                );
-            }
-        },
-        Action::Deactivate => {
-            // TODO: revert the prompt.
-        },
-    }
+    // Source set-prompt.fish if we're in an interactive shell
+    // set-prompt.fish handles both setting and unsetting
+    // Note for deactivate this must come after reverting environment
+    // variables (which includes FLOX_PROMPT_ENVIRONMENTS)
+    let set_prompt_path = match action {
+        Action::Activate { args, .. } => args
+            .set_prompt
+            .then(|| args.activate_d.join("set-prompt.fish")),
+        Action::Deactivate { activate_d } => Some(activate_d.join("set-prompt.fish")),
+    };
+    if let Some(set_prompt_path) = set_prompt_path {
+        // We could consult set_prompt, but hypothetically that config value
+        // could change between activation and deactivation, and sourcing
+        // set-prompt won't hurt
+        stmts.push(format!("if isatty 1; source '{}'; end;", set_prompt_path.display()).to_stmt());
+    };
 
     // We already customized the PATH and MANPATH, but the user and system
     // dotfiles may have changed them, so finish by doing this again.
@@ -130,7 +134,7 @@ pub fn generate_fish_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // No-op: covered by environment restoration above
         },
     }
@@ -146,7 +150,7 @@ pub fn generate_fish_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: run profile.deactivate.fish
         },
     }
@@ -161,7 +165,7 @@ pub fn generate_fish_profile_commands(
                 stmts.push("set -gx fish_trace 0;".to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: set -gx fish_trace 0
         },
     }
@@ -175,7 +179,7 @@ pub fn generate_fish_profile_commands(
                 stmts.push(format!("{RM} {};", escaped_path).to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // No-op: deactivate has no rc file to remove.
         },
     }
@@ -199,7 +203,7 @@ pub fn generate_fish_profile_commands(
                 write!(writer, "{}", crate::hook::fish_hook(&args.flox_bin))?;
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: unregister the auto-activate hook
         },
     }
@@ -226,7 +230,9 @@ mod tests {
     }
 
     fn render_deactivate() -> String {
-        let action = Action::<FishStartupArgs>::Deactivate;
+        let action = Action::<FishStartupArgs>::Deactivate {
+            activate_d: PathBuf::from("/interpreter/activate.d"),
+        };
         let mut buf = Vec::new();
         generate_fish_profile_commands(&action, &mut buf).expect("generator should succeed");
         String::from_utf8(buf).expect("output should be utf-8")
@@ -295,6 +301,9 @@ mod tests {
     #[test]
     fn generate_fish_profile_deactivate() {
         let output = render_deactivate();
-        expect![""].assert_eq(&output);
+        expect![[r#"
+            if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
+        "#]]
+        .assert_eq(&output);
     }
 }

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -20,7 +20,7 @@ pub mod zsh;
 #[derive(Debug, Clone)]
 pub enum Action<A> {
     Activate { args: A, attach_diff: AttachDiff },
-    Deactivate,
+    Deactivate { activate_d: PathBuf },
 }
 
 #[derive(Debug, Clone)]

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -42,7 +42,7 @@ pub fn generate_tcsh_profile_commands(
                 stmts.push("set verbose".to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: emit `set verbose` when tracelevel >= 2
         },
     }
@@ -52,7 +52,7 @@ pub fn generate_tcsh_profile_commands(
         Action::Activate { args, attach_diff } => {
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: decode `_FLOX_HOOK_DIFF` and emit restores.
         },
     }
@@ -72,29 +72,35 @@ pub fn generate_tcsh_profile_commands(
                 &args.flox_activate_tracer,
             ));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: we shouldn't be exporting these in the first place
+            // Although note that unsetting the prompt depends on these being
+            // set
         },
     }
 
-    // Set the prompt if we're in an interactive shell.
-    match action {
-        Action::Activate { args, .. } => {
-            if args.set_prompt {
-                let set_prompt_path = args.activate_d.join("set-prompt.tcsh");
-                stmts.push(
-                    format!(
-                        "if ( $?tty ) then; source '{}'; endif;",
-                        set_prompt_path.display()
-                    )
-                    .to_stmt(),
-                );
-            }
-        },
-        Action::Deactivate => {
-            // TODO: revert the prompt.
-        },
-    }
+    // Source set-prompt.tcsh if we're in an interactive shell
+    // set-prompt.tcsh handles both setting and unsetting
+    // Note for deactivate this must come after reverting environment
+    // variables (which includes FLOX_PROMPT_ENVIRONMENTS)
+    let set_prompt_path = match action {
+        Action::Activate { args, .. } => args
+            .set_prompt
+            .then(|| args.activate_d.join("set-prompt.tcsh")),
+        Action::Deactivate { activate_d } => Some(activate_d.join("set-prompt.tcsh")),
+    };
+    if let Some(set_prompt_path) = set_prompt_path {
+        // We could consult set_prompt, but hypothetically that config value
+        // could change between activation and deactivation, and sourcing
+        // set-prompt won't hurt
+        stmts.push(
+            format!(
+                "if ( $?tty ) then; source '{}'; endif;",
+                set_prompt_path.display()
+            )
+            .to_stmt(),
+        );
+    };
 
     // We already customized the PATH and MANPATH, but the user and system
     // dotfiles may have changed them, so finish by doing this again.
@@ -118,7 +124,7 @@ pub fn generate_tcsh_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // No-op: covered by environment restoration above
         },
     }
@@ -141,7 +147,7 @@ pub fn generate_tcsh_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: run profile.deactivate.tcsh
         },
     }
@@ -154,7 +160,7 @@ pub fn generate_tcsh_profile_commands(
         Action::Activate { .. } => {
             stmts.push("unhash;".to_stmt());
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: decide whether to restore prior hashing state.
         },
     }
@@ -166,7 +172,7 @@ pub fn generate_tcsh_profile_commands(
                 stmts.push("unset verbose;".to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: unset verbose
         },
     }
@@ -180,7 +186,7 @@ pub fn generate_tcsh_profile_commands(
                 stmts.push(format!("{RM} {};", escaped_path).to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // No-op: deactivate has no rc file to remove.
         },
     }
@@ -201,7 +207,7 @@ pub fn generate_tcsh_profile_commands(
                 write!(writer, "{}", crate::hook::tcsh_hook(&args.flox_bin))?;
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: unregister the auto-activate hook
         },
     }
@@ -228,7 +234,9 @@ mod tests {
     }
 
     fn render_deactivate() -> String {
-        let action = Action::<TcshStartupArgs>::Deactivate;
+        let action = Action::<TcshStartupArgs>::Deactivate {
+            activate_d: PathBuf::from("/interpreter/activate.d"),
+        };
         let mut buf = Vec::new();
         generate_tcsh_profile_commands(&action, &mut buf).expect("generator should succeed");
         String::from_utf8(buf).expect("output should be utf-8")
@@ -301,6 +309,9 @@ mod tests {
     #[test]
     fn generate_tcsh_profile_deactivate() {
         let output = render_deactivate();
-        expect![""].assert_eq(&output);
+        expect![[r#"
+            if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
+        "#]]
+        .assert_eq(&output);
     }
 }

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -37,7 +37,7 @@ pub fn generate_zsh_profile_commands(
                 args.activate_d.display().to_string(),
             ));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: we might not need to set these in the first place
         },
     }
@@ -47,7 +47,7 @@ pub fn generate_zsh_profile_commands(
         Action::Activate { args, attach_diff } => {
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: decode `_FLOX_HOOK_DIFF` and emit restores.
         },
     }
@@ -57,29 +57,35 @@ pub fn generate_zsh_profile_commands(
         Action::Activate { args, .. } => {
             stmts.push(source_file(args.activate_d.join("zsh")));
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: undo everything in activate_d/zsh
+            // Although note that unsetting the prompt depends on these being
+            // set
         },
     }
 
-    // Set the prompt if we're in an interactive shell.
-    match action {
-        Action::Activate { args, .. } => {
-            if args.set_prompt {
-                let set_prompt_path = args.activate_d.join("set-prompt.zsh");
-                stmts.push(
-                    format!(
-                        "if [[ -o interactive ]]; then source '{}'; fi;",
-                        set_prompt_path.display()
-                    )
-                    .to_stmt(),
-                );
-            }
-        },
-        Action::Deactivate => {
-            // TODO: revert the prompt.
-        },
-    }
+    // Source set-prompt.zsh if we're in an interactive shell
+    // set-prompt.zsh handles both setting and unsetting
+    // Note for deactivate this must come after reverting environment
+    // variables (which includes FLOX_PROMPT_ENVIRONMENTS)
+    let set_prompt_path = match action {
+        Action::Activate { args, .. } => args
+            .set_prompt
+            .then(|| args.activate_d.join("set-prompt.zsh")),
+        Action::Deactivate { activate_d } => Some(activate_d.join("set-prompt.zsh")),
+    };
+    if let Some(set_prompt_path) = set_prompt_path {
+        // We could consult set_prompt, but hypothetically that config value
+        // could change between activation and deactivation, and sourcing
+        // set-prompt won't hurt
+        stmts.push(
+            format!(
+                "if [[ -o interactive ]]; then source '{}'; fi;",
+                set_prompt_path.display()
+            )
+            .to_stmt(),
+        );
+    };
 
     // Self-destruct rc file
     match action {
@@ -90,7 +96,7 @@ pub fn generate_zsh_profile_commands(
                 stmts.push(format!("{RM} {};", escaped_path).to_stmt());
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // No-op: deactivate has no rc file to remove.
         },
     }
@@ -114,7 +120,7 @@ pub fn generate_zsh_profile_commands(
                 write!(writer, "{}", crate::hook::zsh_hook(&args.flox_bin))?;
             }
         },
-        Action::Deactivate => {
+        Action::Deactivate { .. } => {
             // TODO: unregister the auto-activate hook
         },
     }
@@ -141,7 +147,9 @@ mod tests {
     }
 
     fn render_deactivate() -> String {
-        let action = Action::<ZshStartupArgs>::Deactivate;
+        let action = Action::<ZshStartupArgs>::Deactivate {
+            activate_d: PathBuf::from("/interpreter/activate.d"),
+        };
         let mut buf = Vec::new();
         generate_zsh_profile_commands(&action, &mut buf).expect("generator should succeed");
         String::from_utf8(buf).expect("output should be utf-8")
@@ -196,6 +204,9 @@ mod tests {
     #[test]
     fn generate_zsh_profile_commands_deactivate() {
         let output = render_deactivate();
-        expect![""].assert_eq(&output);
+        expect![[r#"
+            if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
+        "#]]
+        .assert_eq(&output);
     }
 }


### PR DESCRIPTION
- **refactor(activate): cleanup set-prompt scripts**
  Move the prompt-construction code inside the if-branch where the prompt
  is actually set. There's no reason to run this code when not setting the
  prompt, and we'll also want to skip all this code when unsetting the
  prompt for deactivate in an upcoming commit.
  
  bash and zsh wrap the body in a _flox_set_prompt function so the
  temp vars can be declared with local instead of scrubbed by a
  trailing unset line. tcsh has no function/local mechanism, so it
  keeps an unset, but only inside the if-body, where the temps
  actually exist.
  
  The only logical change here is dropping `-n "$_flox"` for bash and zsh,
  but both of those shells set `_flox` to at least contain a space
  immediately prior to checking that condition, so it's unnecessary.
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  

- **feat(deactivate): add code to unset prompt**
  Update set-prompt scripts to unset the prompt when
  FLOX_PROMPT_ENVIRONMENTS is not set.
  
  If FLOX_PROMPT_ENVIRONMENTS is still set, they'll update the prompt to
  reflect it.
  
  We'll come back to testing once it's unblocked by `flox deactivate
  --print-script`
  