### PR TITLE
feat(deactivate): use invocation type and parent PID for detach logic (DEV-82)

### DIFF
--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -1,0 +1,262 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, anyhow};
+use clap::Args;
+use flox_core::activations::{
+    StartIdentifier,
+    read_activations_json,
+    state_json_path,
+    write_activations_json,
+};
+use tracing::trace;
+
+use crate::Error;
+
+/// Detach a PID from an activation, updating state.json accordingly.
+///
+/// This is the deferred equivalent of the inline detach that was previously
+/// performed inside `flox deactivate --print-script`. By emitting a
+/// `flox-activations detach` command in the deactivation script and having
+/// the shell eval it, we keep the binary side-effect-free during
+/// `--print-script` and avoid needing a state.json schema version bump.
+#[derive(Debug, Args)]
+pub struct DetachArgs {
+    #[arg(help = "The base directory for activation state.")]
+    #[arg(long, value_name = "PATH")]
+    pub activation_state_dir: PathBuf,
+    #[arg(help = "The PID of the shell detaching from the activation.")]
+    #[arg(short, long, value_name = "PID")]
+    pub pid: i32,
+}
+
+impl DetachArgs {
+    pub fn handle(self) -> Result<(), Error> {
+        let activations_json_path = state_json_path(&self.activation_state_dir);
+
+        let (activation_state_opt, lock) = read_activations_json(&activations_json_path)
+            .with_context(|| {
+                format!(
+                    "failed to read state.json at '{}'",
+                    activations_json_path.display()
+                )
+            })?;
+
+        let Some(mut state) = activation_state_opt else {
+            return Err(anyhow!(
+                "No activation state found at '{}'; cannot detach PID {}",
+                activations_json_path.display(),
+                self.pid
+            ));
+        };
+
+        let empty_start_id = state.detach(self.pid);
+
+        // Per ActivationState::detach doc contract: update_ready_after_detach
+        // must be called after detach, but only when there are still
+        // attached PIDs (the function panics on an empty map).
+        if !state.attached_pids_is_empty() {
+            state.update_ready_after_detach();
+        }
+
+        // Write back only when there are still attached PIDs or an
+        // executive; otherwise the executive will clean up naturally.
+        if !state.attached_pids_is_empty() || state.executive_started() {
+            write_activations_json(&state, &activations_json_path, lock)
+                .context("failed to write state.json after detach")?;
+        }
+
+        // If this was the last PID for its start, remove the start state dir.
+        // This mirrors watcher::cleanup_pid which does the same cleanup.
+        if let Some(start_id) = empty_start_id {
+            remove_start_state_dir(&start_id, &self.activation_state_dir)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Remove the start state directory for the given start identifier if it
+/// exists. Mirrors the cleanup done in `watcher::cleanup_pid` when the last
+/// PID for a start exits via process-exit monitoring.
+fn remove_start_state_dir(
+    start_id: &StartIdentifier,
+    activation_state_dir: &Path,
+) -> Result<(), Error> {
+    let state_dir = start_id
+        .start_state_dir(activation_state_dir)
+        .context("failed to compute start state dir path")?;
+
+    if state_dir.exists() {
+        trace!(?state_dir, "removing empty start state dir after detach");
+        std::fs::remove_dir_all(&state_dir).with_context(|| {
+            format!("failed to remove start state dir '{}'", state_dir.display())
+        })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use flox_core::activate::context::InvocationType;
+    use flox_core::activate::mode::ActivateMode;
+    use flox_core::activations::test_helpers::{read_activation_state, write_activation_state};
+    use flox_core::activations::{ActivationState, StartIdentifier, activation_state_dir_path};
+    use tempfile::TempDir;
+
+    use super::DetachArgs;
+
+    fn make_state_with_pid(
+        dot_flox_path: &std::path::Path,
+        pid: i32,
+        invocation_type: InvocationType,
+    ) -> ActivationState {
+        let mut state = ActivationState::new(
+            &ActivateMode::default(),
+            Some(dot_flox_path),
+            dot_flox_path.join("run/default"),
+        );
+        state.set_executive_pid(1);
+        let start_id = StartIdentifier::new("/nix/store/test");
+        state.start_or_attach(pid, &start_id.store_path, invocation_type);
+        state
+    }
+
+    /// Successful detach removes the PID from state.json.
+    #[test]
+    fn successful_detach_removes_pid() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = tmp.path().join(".flox");
+        let pid = 12345_i32;
+
+        let state = make_state_with_pid(&dot_flox_path, pid, InvocationType::InPlace);
+        write_activation_state(tmp.path(), &dot_flox_path, state);
+
+        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+
+        let args = DetachArgs {
+            activation_state_dir,
+            pid,
+        };
+        args.handle().expect("detach should succeed");
+
+        let updated = read_activation_state(tmp.path(), &dot_flox_path);
+        assert!(
+            !updated.is_pid_attached(pid),
+            "PID should be removed from state.json after detach"
+        );
+    }
+
+    /// When there is no state.json, detach returns an error.
+    #[test]
+    fn no_state_json_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = PathBuf::from("/nonexistent/.flox");
+        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+
+        // Create the dir so lock acquisition succeeds, but don't write state.json.
+        std::fs::create_dir_all(&activation_state_dir).unwrap();
+
+        let args = DetachArgs {
+            activation_state_dir,
+            pid: 42,
+        };
+        let result = args.handle();
+        assert!(
+            result.is_err(),
+            "detach should fail when state.json is absent"
+        );
+    }
+
+    /// When the last PID detaches and there is no executive, state is not
+    /// written (the executive will clean up naturally).
+    #[test]
+    fn last_pid_detach_skips_write() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = tmp.path().join(".flox");
+        let pid = 12345_i32;
+
+        // Build a state with an executive_pid but no running executive,
+        // so executive_started() returns true (ensuring the write path).
+        // For this test we want to confirm the *no-executive* path is
+        // skipped, so use a state where executive_started() is false.
+        let mut state = ActivationState::new(
+            &ActivateMode::default(),
+            Some(&dot_flox_path),
+            dot_flox_path.join("run/default"),
+        );
+        // Do NOT set an executive pid — executive_started() will be false.
+        let start_id = StartIdentifier::new("/nix/store/test");
+        state.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
+        write_activation_state(tmp.path(), &dot_flox_path, state);
+
+        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+
+        let state_json_path = flox_core::activations::state_json_path(&activation_state_dir);
+
+        // Record mtime before detach
+        let before_mtime = std::fs::metadata(&state_json_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let args = DetachArgs {
+            activation_state_dir,
+            pid,
+        };
+        args.handle().expect("detach should succeed");
+
+        // If state.json was NOT rewritten, mtime should be unchanged.
+        // (On fast machines this might be the same second — use file existence
+        //  plus an explicit content check as the signal instead.)
+        let updated_state = read_activation_state(tmp.path(), &dot_flox_path);
+        assert!(
+            !updated_state.is_pid_attached(pid),
+            "PID should not appear in state after detach"
+        );
+        // The file should still exist (written by write_activation_state above)
+        // but we care mainly that the PID is gone.
+        let _ = before_mtime; // suppress unused-variable warning
+    }
+
+    /// When the last PID for a start detaches, the start state directory is removed.
+    #[test]
+    fn last_pid_detach_removes_start_state_dir() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = tmp.path().join(".flox");
+        let pid = 12345_i32;
+
+        let mut state = ActivationState::new(
+            &ActivateMode::default(),
+            Some(&dot_flox_path),
+            dot_flox_path.join("run/default"),
+        );
+        state.set_executive_pid(1);
+        let start_id = StartIdentifier::new("/nix/store/test");
+        state.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
+        write_activation_state(tmp.path(), &dot_flox_path, state);
+
+        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+
+        // Create the start state directory that should be cleaned up.
+        let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
+        std::fs::create_dir_all(&start_state_dir).unwrap();
+        assert!(
+            start_state_dir.exists(),
+            "start state dir should exist before detach"
+        );
+
+        let args = DetachArgs {
+            activation_state_dir,
+            pid,
+        };
+        args.handle().expect("detach should succeed");
+
+        assert!(
+            !start_state_dir.exists(),
+            "start state dir should be removed after the last PID detaches"
+        );
+    }
+}

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -1,14 +1,8 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, anyhow};
 use clap::Args;
-use flox_core::activations::{
-    StartIdentifier,
-    read_activations_json,
-    state_json_path,
-    write_activations_json,
-};
-use tracing::trace;
+use flox_core::activations::{read_activations_json, state_json_path, write_activations_json};
 
 use crate::Error;
 
@@ -56,44 +50,27 @@ impl DetachArgs {
         // attached PIDs (the function panics on an empty map).
         if !state.attached_pids_is_empty() {
             state.update_ready_after_detach();
+            // Remove the start-state dir only when other PIDs remain.
+            // When PIDs are still present, the executive cannot call
+            // cleanup_all (which renames the parent dir), so there is no
+            // race window here.  When this is the last PID overall,
+            // the executive cleans up everything via StateFileChanged →
+            // cleanup_all after we write below.
+            if let Some(ref start_id) = empty_start_id {
+                start_id
+                    .remove_start_state_dir(&self.activation_state_dir)
+                    .context("failed to remove start state dir after detach")?;
+            }
         }
 
-        // Write back only when there are still attached PIDs or an
-        // executive; otherwise the executive will clean up naturally.
-        if !state.attached_pids_is_empty() || state.executive_started() {
-            write_activations_json(&state, &activations_json_path, lock)
-                .context("failed to write state.json after detach")?;
-        }
-
-        // If this was the last PID for its start, remove the start state dir.
-        // This mirrors watcher::cleanup_pid which does the same cleanup.
-        if let Some(start_id) = empty_start_id {
-            remove_start_state_dir(&start_id, &self.activation_state_dir)?;
-        }
+        // Always write: state.detach() has already mutated in-memory state.
+        // The executive is always running at detach time.  When 0 PIDs remain
+        // it will observe the change via StateFileChanged and call cleanup_all.
+        write_activations_json(&state, &activations_json_path, lock)
+            .context("failed to write state.json after detach")?;
 
         Ok(())
     }
-}
-
-/// Remove the start state directory for the given start identifier if it
-/// exists. Mirrors the cleanup done in `watcher::cleanup_pid` when the last
-/// PID for a start exits via process-exit monitoring.
-fn remove_start_state_dir(
-    start_id: &StartIdentifier,
-    activation_state_dir: &Path,
-) -> Result<(), Error> {
-    let state_dir = start_id
-        .start_state_dir(activation_state_dir)
-        .context("failed to compute start state dir path")?;
-
-    if state_dir.exists() {
-        trace!(?state_dir, "removing empty start state dir after detach");
-        std::fs::remove_dir_all(&state_dir).with_context(|| {
-            format!("failed to remove start state dir '{}'", state_dir.display())
-        })?;
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -103,7 +80,12 @@ mod test {
     use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::{read_activation_state, write_activation_state};
-    use flox_core::activations::{ActivationState, StartIdentifier, activation_state_dir_path};
+    use flox_core::activations::{
+        ActivationState,
+        StartIdentifier,
+        StartOrAttachResult,
+        activation_state_dir_path,
+    };
     use tempfile::TempDir;
 
     use super::DetachArgs;
@@ -170,37 +152,18 @@ mod test {
         );
     }
 
-    /// When the last PID detaches and there is no executive, state is not
-    /// written (the executive will clean up naturally).
+    /// Detach always writes state.json, even when the last PID is removed.
+    /// The executive observes the change via StateFileChanged and calls cleanup_all.
     #[test]
-    fn last_pid_detach_skips_write() {
+    fn last_pid_detach_writes_state() {
         let tmp = TempDir::new().unwrap();
         let dot_flox_path = tmp.path().join(".flox");
         let pid = 12345_i32;
 
-        // Build a state with an executive_pid but no running executive,
-        // so executive_started() returns true (ensuring the write path).
-        // For this test we want to confirm the *no-executive* path is
-        // skipped, so use a state where executive_started() is false.
-        let mut state = ActivationState::new(
-            &ActivateMode::default(),
-            Some(&dot_flox_path),
-            dot_flox_path.join("run/default"),
-        );
-        // Do NOT set an executive pid — executive_started() will be false.
-        let start_id = StartIdentifier::new("/nix/store/test");
-        state.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
+        let state = make_state_with_pid(&dot_flox_path, pid, InvocationType::InPlace);
         write_activation_state(tmp.path(), &dot_flox_path, state);
 
         let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
-
-        let state_json_path = flox_core::activations::state_json_path(&activation_state_dir);
-
-        // Record mtime before detach
-        let before_mtime = std::fs::metadata(&state_json_path)
-            .unwrap()
-            .modified()
-            .unwrap();
 
         let args = DetachArgs {
             activation_state_dir,
@@ -208,55 +171,68 @@ mod test {
         };
         args.handle().expect("detach should succeed");
 
-        // If state.json was NOT rewritten, mtime should be unchanged.
-        // (On fast machines this might be the same second — use file existence
-        //  plus an explicit content check as the signal instead.)
-        let updated_state = read_activation_state(tmp.path(), &dot_flox_path);
+        let updated = read_activation_state(tmp.path(), &dot_flox_path);
         assert!(
-            !updated_state.is_pid_attached(pid),
-            "PID should not appear in state after detach"
+            !updated.is_pid_attached(pid),
+            "PID should be absent from state.json after detach"
         );
-        // The file should still exist (written by write_activation_state above)
-        // but we care mainly that the PID is gone.
-        let _ = before_mtime; // suppress unused-variable warning
     }
 
-    /// When the last PID for a start detaches, the start state directory is removed.
+    /// When the last PID for a start detaches but other PIDs remain (attached
+    /// to different starts), the empty start's state directory is removed.
+    /// When this is the last PID overall, the executive handles dir cleanup via
+    /// StateFileChanged → cleanup_all.
     #[test]
-    fn last_pid_detach_removes_start_state_dir() {
+    fn start_state_dir_removed_when_other_pids_remain() {
         let tmp = TempDir::new().unwrap();
         let dot_flox_path = tmp.path().join(".flox");
-        let pid = 12345_i32;
+        let pid1 = 12345_i32; // will be detached — last PID for start_id1
+        let pid2 = 99999_i32; // stays attached to a different start
 
+        // Build a state with pid1 on start_id1 and pid2 on start_id2 so that
+        // after detaching pid1, attached_pids is not empty (pid2 remains).
         let mut state = ActivationState::new(
             &ActivateMode::default(),
             Some(&dot_flox_path),
             dot_flox_path.join("run/default"),
         );
         state.set_executive_pid(1);
-        let start_id = StartIdentifier::new("/nix/store/test");
-        state.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
+
+        // Attach pid1 → starts start_id1, ready becomes Starting(pid1, start_id1)
+        let r1 = state.start_or_attach(pid1, "/nix/store/test1", InvocationType::InPlace);
+        let StartOrAttachResult::Start {
+            start_id: start_id1,
+        } = r1
+        else {
+            panic!("expected Start for pid1");
+        };
+        // Mark ready so pid2 can trigger a fresh Start on a different store path
+        state.set_ready(&start_id1);
+
+        // Attach pid2 with a different store path → starts start_id2
+        state.start_or_attach(pid2, "/nix/store/test2", InvocationType::InPlace);
+
         write_activation_state(tmp.path(), &dot_flox_path, state);
 
         let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
 
-        // Create the start state directory that should be cleaned up.
-        let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
-        std::fs::create_dir_all(&start_state_dir).unwrap();
+        // Create start_id1's directory on disk (the one that should be removed).
+        let start_state_dir1 = start_id1.start_state_dir(&activation_state_dir).unwrap();
+        std::fs::create_dir_all(&start_state_dir1).unwrap();
         assert!(
-            start_state_dir.exists(),
+            start_state_dir1.exists(),
             "start state dir should exist before detach"
         );
 
         let args = DetachArgs {
             activation_state_dir,
-            pid,
+            pid: pid1,
         };
         args.handle().expect("detach should succeed");
 
         assert!(
-            !start_state_dir.exists(),
-            "start state dir should be removed after the last PID detaches"
+            !start_state_dir1.exists(),
+            "start state dir for detached start should be removed when other PIDs remain"
         );
     }
 }

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -108,7 +108,7 @@ mod test {
 
         let updated = read_activation_state(tmp.path(), &dot_flox_path);
         assert!(
-            !updated.is_pid_attached(pid),
+            updated.attached_pids_is_empty(),
             "PID should be removed from state.json after detach"
         );
     }

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -43,29 +43,19 @@ impl DetachArgs {
             ));
         };
 
-        let empty_start_id = state.detach(self.pid);
+        let empty_start_id = state.detach(self.pid)?;
 
-        // Per ActivationState::detach doc contract: update_ready_after_detach
-        // must be called after detach, but only when there are still
-        // attached PIDs (the function panics on an empty map).
-        if !state.attached_pids_is_empty() {
-            state.update_ready_after_detach();
-            // Remove the start-state dir only when other PIDs remain.
-            // When PIDs are still present, the executive cannot call
-            // cleanup_all (which renames the parent dir), so there is no
-            // race window here.  When this is the last PID overall,
-            // the executive cleans up everything via StateFileChanged →
-            // cleanup_all after we write below.
-            if let Some(ref start_id) = empty_start_id {
-                start_id
-                    .remove_start_state_dir(&self.activation_state_dir)
-                    .context("failed to remove start state dir after detach")?;
-            }
+        // In the executive we only remove start state dir when we know
+        // cleanup_all won't trigger, but we can't know whether or not
+        // cleanup_all will trigger here because we're about to drop the lock.
+        // It won't hurt to remove this directory
+        if let Some(ref start_id) = empty_start_id {
+            start_id
+                .remove_start_state_dir(&self.activation_state_dir)
+                .context("failed to remove start state dir after detach")?;
         }
 
-        // Always write: state.detach() has already mutated in-memory state.
-        // The executive is always running at detach time.  When 0 PIDs remain
-        // it will observe the change via StateFileChanged and call cleanup_all.
+        // This should trigger the executive to check if it needs to cleanup
         write_activations_json(&state, &activations_json_path, lock)
             .context("failed to write state.json after detach")?;
 
@@ -75,8 +65,6 @@ impl DetachArgs {
 
 #[cfg(test)]
 mod test {
-    use std::path::PathBuf;
-
     use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::{read_activation_state, write_activation_state};
@@ -90,22 +78,6 @@ mod test {
 
     use super::DetachArgs;
 
-    fn make_state_with_pid(
-        dot_flox_path: &std::path::Path,
-        pid: i32,
-        invocation_type: InvocationType,
-    ) -> ActivationState {
-        let mut state = ActivationState::new(
-            &ActivateMode::default(),
-            Some(dot_flox_path),
-            dot_flox_path.join("run/default"),
-        );
-        state.set_executive_pid(1);
-        let start_id = StartIdentifier::new("/nix/store/test");
-        state.start_or_attach(pid, &start_id.store_path, invocation_type);
-        state
-    }
-
     /// Successful detach removes the PID from state.json.
     #[test]
     fn successful_detach_removes_pid() {
@@ -113,8 +85,18 @@ mod test {
         let dot_flox_path = tmp.path().join(".flox");
         let pid = 12345_i32;
 
-        let state = make_state_with_pid(&dot_flox_path, pid, InvocationType::InPlace);
+        let mut state = ActivationState::new(
+            &ActivateMode::default(),
+            Some(dot_flox_path.clone()),
+            dot_flox_path.join("run/default"),
+        );
+        state.set_executive_pid(1);
+        let start_id = StartIdentifier::new("/nix/store/test");
+        state.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
         write_activation_state(tmp.path(), &dot_flox_path, state);
+        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+        let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
+        std::fs::create_dir_all(&start_state_dir).unwrap();
 
         let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
 
@@ -131,39 +113,37 @@ mod test {
         );
     }
 
-    /// When there is no state.json, detach returns an error.
+    /// When the last PID overall detaches, its start state dir is removed
+    /// immediately rather than deferred to the executive's cleanup_all — so a
+    /// racing activation that supersedes this start can't leave it orphaned.
     #[test]
-    fn no_state_json_returns_error() {
-        let tmp = TempDir::new().unwrap();
-        let dot_flox_path = PathBuf::from("/nonexistent/.flox");
-        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
-
-        // Create the dir so lock acquisition succeeds, but don't write state.json.
-        std::fs::create_dir_all(&activation_state_dir).unwrap();
-
-        let args = DetachArgs {
-            activation_state_dir,
-            pid: 42,
-        };
-        let result = args.handle();
-        assert!(
-            result.is_err(),
-            "detach should fail when state.json is absent"
-        );
-    }
-
-    /// Detach always writes state.json, even when the last PID is removed.
-    /// The executive observes the change via StateFileChanged and calls cleanup_all.
-    #[test]
-    fn last_pid_detach_writes_state() {
+    fn start_state_dir_removed_when_last_pid_detaches() {
         let tmp = TempDir::new().unwrap();
         let dot_flox_path = tmp.path().join(".flox");
         let pid = 12345_i32;
 
-        let state = make_state_with_pid(&dot_flox_path, pid, InvocationType::InPlace);
+        let mut state = ActivationState::new(
+            &ActivateMode::default(),
+            Some(&dot_flox_path),
+            dot_flox_path.join("run/default"),
+        );
+        state.set_executive_pid(1);
+        let StartOrAttachResult::Start { start_id } =
+            state.start_or_attach(pid, "/nix/store/test", InvocationType::InPlace)
+        else {
+            panic!("expected Start for pid");
+        };
+
         write_activation_state(tmp.path(), &dot_flox_path, state);
 
         let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+
+        let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
+        std::fs::create_dir_all(&start_state_dir).unwrap();
+        assert!(
+            start_state_dir.exists(),
+            "start state dir should exist before detach"
+        );
 
         let args = DetachArgs {
             activation_state_dir,
@@ -171,68 +151,9 @@ mod test {
         };
         args.handle().expect("detach should succeed");
 
-        let updated = read_activation_state(tmp.path(), &dot_flox_path);
         assert!(
-            !updated.is_pid_attached(pid),
-            "PID should be absent from state.json after detach"
-        );
-    }
-
-    /// When the last PID for a start detaches but other PIDs remain (attached
-    /// to different starts), the empty start's state directory is removed.
-    /// When this is the last PID overall, the executive handles dir cleanup via
-    /// StateFileChanged → cleanup_all.
-    #[test]
-    fn start_state_dir_removed_when_other_pids_remain() {
-        let tmp = TempDir::new().unwrap();
-        let dot_flox_path = tmp.path().join(".flox");
-        let pid1 = 12345_i32; // will be detached — last PID for start_id1
-        let pid2 = 99999_i32; // stays attached to a different start
-
-        // Build a state with pid1 on start_id1 and pid2 on start_id2 so that
-        // after detaching pid1, attached_pids is not empty (pid2 remains).
-        let mut state = ActivationState::new(
-            &ActivateMode::default(),
-            Some(&dot_flox_path),
-            dot_flox_path.join("run/default"),
-        );
-        state.set_executive_pid(1);
-
-        // Attach pid1 → starts start_id1, ready becomes Starting(pid1, start_id1)
-        let r1 = state.start_or_attach(pid1, "/nix/store/test1", InvocationType::InPlace);
-        let StartOrAttachResult::Start {
-            start_id: start_id1,
-        } = r1
-        else {
-            panic!("expected Start for pid1");
-        };
-        // Mark ready so pid2 can trigger a fresh Start on a different store path
-        state.set_ready(&start_id1);
-
-        // Attach pid2 with a different store path → starts start_id2
-        state.start_or_attach(pid2, "/nix/store/test2", InvocationType::InPlace);
-
-        write_activation_state(tmp.path(), &dot_flox_path, state);
-
-        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
-
-        // Create start_id1's directory on disk (the one that should be removed).
-        let start_state_dir1 = start_id1.start_state_dir(&activation_state_dir).unwrap();
-        std::fs::create_dir_all(&start_state_dir1).unwrap();
-        assert!(
-            start_state_dir1.exists(),
-            "start state dir should exist before detach"
-        );
-
-        let args = DetachArgs {
-            activation_state_dir,
-            pid: pid1,
-        };
-        args.handle().expect("detach should succeed");
-
-        assert!(
-            !start_state_dir1.exists(),
-            "start state dir for detached start should be removed when other PIDs remain"
+            !start_state_dir.exists(),
+            "start state dir should be removed when the last PID detaches"
         );
     }
 }

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -641,9 +641,15 @@ mod test {
 
     /// Test that handle_process_exited is a no-op when the PID is not in state.json.
     ///
-    /// This can happen when --remove-pid removes a PID from state.json, but the
-    /// executive still has a watcher running for that PID. When the process eventually
-    /// exits and the executive receives a ProcessExited event, it should be a no-op.
+    /// This can happen in two cases:
+    /// 1. --remove-pid removes a PID from state.json, but the
+    ///    executive still has a watcher running for that PID.
+    /// 2. `flox-activations detach` removes a PID from state.json
+    ///
+    /// In either case, when the process eventually exits and the executive
+    /// receives a ProcessExited event, it should be a no-op.
+    ///
+    /// We mimic scenario 1 here
     #[test]
     fn process_exited_noop_for_pid_not_in_state() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -235,13 +235,31 @@ fn run_event_loop(
             },
             Ok(ExecutiveEvent::StateFileChanged) => {
                 debug!("state.json changed, checking for new PIDs to monitor");
-                let (state, _lock) = read_activations_json(&state_json_path)?;
+                let (state, lock) = read_activations_json(&state_json_path)?;
                 let Some(activations) = state else {
                     bail!("executive shouldn't be running when state.json doesn't exist");
                 };
                 coordinator
                     .ensure_monitoring_pids(activations.all_attached_pids_and_expiration())
                     .context("failed to ensure monitoring PIDs")?;
+                // When `detach` removes the last PID (e.g., in-place deactivation
+                // where the shell process is still alive), trigger cleanup now
+                // rather than waiting for the process to exit — which could be a
+                // very long time.  This mirrors ProcessExited → watcher::cleanup_pid
+                // → attached_pids_is_empty() → cleanup_all, but fires proactively
+                // on the state-file change instead.
+                if activations.attached_pids_is_empty() {
+                    info!("all PIDs gone after state.json change, running cleanup");
+                    cleanup_all(
+                        (activations, lock),
+                        &process_compose_bin,
+                        &socket_path,
+                        &activation_state_dir,
+                    )
+                    .context("cleanup failed after StateFileChanged with empty PIDs")?;
+                    return Ok(());
+                }
+                // lock drops here when PIDs remain
             },
             Ok(ExecutiveEvent::SigChld) => {
                 reap_orphaned_children();
@@ -791,5 +809,59 @@ mod test {
         );
 
         stop_process(proc);
+    }
+
+    /// When state.json is updated such that all PIDs are gone (e.g., by
+    /// `flox-activations detach` for an in-place deactivation where the shell
+    /// process is still alive), the monitoring loop should trigger cleanup
+    /// immediately via StateFileChanged rather than waiting for ProcessExited.
+    #[test]
+    fn state_file_change_triggers_cleanup_when_no_pids() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let runtime_dir = temp_dir.path();
+        let dot_flox_path = PathBuf::from(".flox");
+        let flox_env = dot_flox_path.join("run/test");
+        let store_path = "store_path".to_string();
+
+        // Create activation state with a PID but then write it with 0 PIDs
+        // (simulating what happens after `flox-activations detach` removes
+        // the last PID while the process is still running).
+        let mut state =
+            ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
+        let result = state.start_or_attach(1, &store_path, InvocationType::Interactive);
+        let StartOrAttachResult::Start { start_id, .. } = result else {
+            panic!("Expected Start")
+        };
+        state.set_ready(&start_id);
+        // Detach the PID in-memory so the written state has 0 attached PIDs.
+        let _ = state.detach(1);
+        write_activation_state(runtime_dir, &dot_flox_path, state);
+
+        let activation_state_directory = activation_state_dir_path(runtime_dir, &dot_flox_path);
+        assert!(
+            activation_state_directory.exists(),
+            "state directory should exist before the event loop"
+        );
+
+        // Inject a StateFileChanged event so the loop reacts as if the file
+        // had just been written by `detach`.
+        let coordinator = EventCoordinator::new().unwrap();
+        coordinator.inject_event(ExecutiveEvent::StateFileChanged);
+
+        let (attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
+
+        run_event_loop(
+            attach,
+            project,
+            activation_state_directory.clone(),
+            coordinator,
+            0,
+        )
+        .expect("event loop should exit cleanly after cleanup");
+
+        assert!(
+            !activation_state_directory.exists(),
+            "state directory should be removed after cleanup via StateFileChanged"
+        );
     }
 }

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -10,7 +10,7 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use flox_core::activations::{ActivationState, read_activations_json, write_activations_json};
 use flox_core::proc_status::pid_is_running;
 use fslock::LockFile;
@@ -57,9 +57,7 @@ pub fn cleanup_pid(
     // 2. The environment was not modified
     // But I think for now it's simpler to just treat all start_ids the same.
     if let Some(start_id) = empty_start_id {
-        let state_dir = start_id.start_state_dir(activation_state_dir)?;
-        trace!(?state_dir, "removing empty activation state dir");
-        std::fs::remove_dir_all(state_dir).context("failed to remove start state dir")?;
+        start_id.remove_start_state_dir(activation_state_dir)?;
     }
 
     if modified {

--- a/cli/flox-activations/src/cli/mod.rs
+++ b/cli/flox-activations/src/cli/mod.rs
@@ -6,6 +6,7 @@ use flox_core::vars::FLOX_VERSION_STRING;
 
 pub mod activate;
 pub mod attach;
+pub mod detach;
 pub mod executive;
 mod fix_fpath;
 pub mod fix_paths;
@@ -14,6 +15,7 @@ mod profile_scripts;
 pub mod set_env_dirs;
 
 use activate::ActivateArgs;
+use detach::DetachArgs;
 use executive::ExecutiveArgs;
 use fix_fpath::FixFpathArgs;
 use fix_paths::FixPathsArgs;
@@ -47,6 +49,8 @@ pub enum Command {
     Attach(AttachArgs),
     #[command(about = "Activate a Flox environment.")]
     Activate(ActivateArgs),
+    #[command(about = "Detach a PID from an activation, updating state.json.")]
+    Detach(DetachArgs),
     #[command(about = "Start an activation and then run the executive")]
     Executive(ExecutiveArgs),
     #[command(about = "Print sourceable output fixing PATH and MANPATH for a shell.")]

--- a/cli/flox-activations/src/deactivate.rs
+++ b/cli/flox-activations/src/deactivate.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use shell_gen::ShellWithPath;
+use shell_gen::{Shell, ShellWithPath};
 
 use crate::attach_diff::diff_serializer::{DiffSerializer, FLOX_HOOK_DIFF_VAR};
 use crate::gen_rc::bash::{BashStartupArgs, generate_bash_profile_commands};
@@ -32,7 +32,8 @@ use crate::gen_rc::{Action, DeactivateCtx};
 ///
 /// After the per-shell env-var restoration, emits a `flox-activations detach`
 /// command so that state.json is updated when the caller eval's the script.
-/// `$$` expands to the caller's PID at eval time.
+/// The shell-specific self-PID variable expands to the caller's PID at
+/// eval time.
 pub fn generate_deactivate_script(
     shell: ShellWithPath,
     writer: &mut impl Write,
@@ -49,6 +50,9 @@ pub fn generate_deactivate_script(
         activate_d,
         restore_diff,
     };
+
+    // Capture the shell variant before consuming `shell` in the match below.
+    let shell_variant = Shell::from(shell.clone());
 
     match shell {
         ShellWithPath::Bash(_) => {
@@ -69,11 +73,13 @@ pub fn generate_deactivate_script(
         },
     }?;
 
-    // Emit the detach command using the shell's self-PID variable ($$).
-    // The caller eval's this output, so $$ expands to the caller's PID.
+    // Emit the detach command using the shell-appropriate self-PID variable
+    // so that the expression expands correctly when the caller eval's the
+    // output.  `$$` is correct for bash/zsh/tcsh; fish uses `$fish_pid`.
+    let pid_var = shell_variant.self_pid_var();
     writeln!(
         writer,
-        r#""{}" detach --activation-state-dir "{}" --pid $$;"#,
+        r#""{}" detach --activation-state-dir "{}" --pid {pid_var};"#,
         flox_activations_bin.display(),
         activation_state_dir.display(),
     )?;

--- a/cli/flox-activations/src/deactivate.rs
+++ b/cli/flox-activations/src/deactivate.rs
@@ -30,12 +30,15 @@ use crate::gen_rc::{Action, DeactivateCtx};
 /// Returns an error if `_FLOX_HOOK_DIFF` is not set in the environment or
 /// cannot be decoded.
 ///
-/// This function captures all environment variables so all downstream code is
-/// easily unit testable.
+/// After the per-shell env-var restoration, emits a `flox-activations detach`
+/// command so that state.json is updated when the caller eval's the script.
+/// `$$` expands to the caller's PID at eval time.
 pub fn generate_deactivate_script(
     shell: ShellWithPath,
     writer: &mut impl Write,
     interpreter_path: impl AsRef<Path>,
+    flox_activations_bin: &Path,
+    activation_state_dir: &Path,
 ) -> Result<()> {
     let activate_d = interpreter_path.as_ref().join("activate.d");
     let encoded_diff = env::var(FLOX_HOOK_DIFF_VAR)
@@ -64,5 +67,16 @@ pub fn generate_deactivate_script(
             let action: Action<TcshStartupArgs> = Action::Deactivate(ctx);
             generate_tcsh_profile_commands(&action, writer)
         },
-    }
+    }?;
+
+    // Emit the detach command using the shell's self-PID variable ($$).
+    // The caller eval's this output, so $$ expands to the caller's PID.
+    writeln!(
+        writer,
+        r#""{}" detach --activation-state-dir "{}" --pid $$;"#,
+        flox_activations_bin.display(),
+        activation_state_dir.display(),
+    )?;
+
+    Ok(())
 }

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use flox_core::activate::context::InvocationType;
-use shell_gen::{GenerateShell, Shell, source_file};
+use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded, source_file};
 
 use crate::attach_diff::{todo_drop_set_exported_unexpanded, todo_drop_unset};
 use crate::gen_rc::{Action, RM};
@@ -99,6 +99,21 @@ pub fn generate_bash_profile_commands(
             // TODO: we shouldn't be exporting these in the first place
             // Although note that unsetting the prompt depends on these being
             // set
+        },
+    }
+
+    // Emit _FLOX_INVOCATION_TYPE as a shell-local (non-exported) variable so
+    // that `flox deactivate --print-script` can distinguish interactive
+    // subshells from in-place activations without reading state.json.
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(set_unexported_unexpanded(
+                "_FLOX_INVOCATION_TYPE",
+                format!("{}", args.invocation_type),
+            ));
+        },
+        Action::Deactivate(_) => {
+            stmts.push(todo_drop_unset("_FLOX_INVOCATION_TYPE"));
         },
     }
 
@@ -279,6 +294,7 @@ mod tests {
             export _activate_d=/interpreter/activate.d;
             export _flox_activations=/flox_activations;
             export _flox_activate_tracer=TRACER;
+            _FLOX_INVOCATION_TYPE=interactive;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             eval "$('/flox_activations' set-env-dirs --shell bash --flox-env "/flox_env" --env-dirs "${FLOX_ENV_DIRS:-}")";
             eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")";
@@ -310,6 +326,7 @@ mod tests {
             export _activate_d=/interpreter/activate.d;
             export _flox_activations=/flox_activations;
             export _flox_activate_tracer=TRACER;
+            _FLOX_INVOCATION_TYPE=inplace;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             eval "$('/flox_activations' set-env-dirs --shell bash --flox-env "/flox_env" --env-dirs "${FLOX_ENV_DIRS:-}")";
             eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")";
@@ -341,6 +358,7 @@ mod tests {
             export MODIFIED_VAR=MODIFIED_ORIGINAL;
             export DELETED_VAR=DELETED_ORIGINAL;
             unset _FLOX_HOOK_DIFF;
+            unset _FLOX_INVOCATION_TYPE;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             set -h;
         "#]]

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -326,7 +326,7 @@ mod tests {
             export _activate_d=/interpreter/activate.d;
             export _flox_activations=/flox_activations;
             export _flox_activate_tracer=TRACER;
-            _FLOX_INVOCATION_TYPE=inplace;
+            _FLOX_INVOCATION_TYPE=in_place;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             eval "$('/flox_activations' set-env-dirs --shell bash --flox-env "/flox_env" --env-dirs "${FLOX_ENV_DIRS:-}")";
             eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")";

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -4,9 +4,9 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use flox_core::activate::context::{AutoActivateFishMode, InvocationType};
-use shell_gen::{GenerateShell, Shell};
+use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded};
 
-use crate::attach_diff::todo_drop_set_exported_unexpanded;
+use crate::attach_diff::{todo_drop_set_exported_unexpanded, todo_drop_unset};
 use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating fish startup commands
@@ -83,6 +83,21 @@ pub fn generate_fish_profile_commands(
             // TODO: we shouldn't be exporting these in the first place
             // Although note that unsetting the prompt depends on these being
             // set
+        },
+    }
+
+    // Emit _FLOX_INVOCATION_TYPE as a shell-local (non-exported) variable so
+    // that `flox deactivate --print-script` can distinguish interactive
+    // subshells from in-place activations without reading state.json.
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(set_unexported_unexpanded(
+                "_FLOX_INVOCATION_TYPE",
+                format!("{}", args.invocation_type),
+            ));
+        },
+        Action::Deactivate(_) => {
+            stmts.push(todo_drop_unset("_FLOX_INVOCATION_TYPE"));
         },
     }
 
@@ -260,6 +275,7 @@ mod tests {
             set -gx _activate_d /interpreter/activate.d;
             set -gx _flox_activations /flox_activations;
             set -gx _flox_activate_tracer TRACER;
+            set -g _FLOX_INVOCATION_TYPE interactive;
             if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
             set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);
             /flox_activations set-env-dirs --shell fish --flox-env "/flox_env" --env-dirs "$FLOX_ENV_DIRS" | source;
@@ -293,6 +309,7 @@ mod tests {
             set -gx _activate_d /interpreter/activate.d;
             set -gx _flox_activations /flox_activations;
             set -gx _flox_activate_tracer TRACER;
+            set -g _FLOX_INVOCATION_TYPE inplace;
             if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
             set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);
             /flox_activations set-env-dirs --shell fish --flox-env "/flox_env" --env-dirs "$FLOX_ENV_DIRS" | source;
@@ -326,6 +343,7 @@ mod tests {
             set -gx MODIFIED_VAR MODIFIED_ORIGINAL;
             set -gx DELETED_VAR DELETED_ORIGINAL;
             set -e _FLOX_HOOK_DIFF;
+            set -e _FLOX_INVOCATION_TYPE;
             if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
         "#]]
         .assert_eq(&output);

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -309,7 +309,7 @@ mod tests {
             set -gx _activate_d /interpreter/activate.d;
             set -gx _flox_activations /flox_activations;
             set -gx _flox_activate_tracer TRACER;
-            set -g _FLOX_INVOCATION_TYPE inplace;
+            set -g _FLOX_INVOCATION_TYPE in_place;
             if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
             set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);
             /flox_activations set-env-dirs --shell fish --flox-env "/flox_env" --env-dirs "$FLOX_ENV_DIRS" | source;

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use flox_core::activate::context::InvocationType;
-use shell_gen::{GenerateShell, Shell};
+use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded};
 
 use crate::attach_diff::todo_drop_set_exported_unexpanded;
 use crate::gen_rc::{Action, RM};
@@ -76,6 +76,23 @@ pub fn generate_tcsh_profile_commands(
             // TODO: we shouldn't be exporting these in the first place
             // Although note that unsetting the prompt depends on these being
             // set
+        },
+    }
+
+    // Emit _FLOX_INVOCATION_TYPE as a shell-local (non-exported) variable so
+    // that `flox deactivate --print-script` can distinguish interactive
+    // subshells from in-place activations without reading state.json.
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(set_unexported_unexpanded(
+                "_FLOX_INVOCATION_TYPE",
+                format!("{}", args.invocation_type),
+            ));
+        },
+        Action::Deactivate(_) => {
+            // tcsh uses `set` (not setenv) for shell-local vars, so the
+            // corresponding teardown is `unset` (not `unsetenv`).
+            stmts.push("unset _FLOX_INVOCATION_TYPE;".to_stmt());
         },
     }
 
@@ -269,6 +286,7 @@ mod tests {
             setenv _activate_d /interpreter/activate.d;
             setenv _flox_activations /flox_activations;
             setenv _flox_activate_tracer TRACER;
+            set _FLOX_INVOCATION_TYPE = interactive;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
             if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";
             eval "`'/flox_activations' set-env-dirs --shell tcsh --flox-env '/flox_env' --env-dirs $FLOX_ENV_DIRS:q`";
@@ -304,6 +322,7 @@ mod tests {
             setenv _activate_d /interpreter/activate.d;
             setenv _flox_activations /flox_activations;
             setenv _flox_activate_tracer TRACER;
+            set _FLOX_INVOCATION_TYPE = inplace;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
             if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";
             eval "`'/flox_activations' set-env-dirs --shell tcsh --flox-env '/flox_env' --env-dirs $FLOX_ENV_DIRS:q`";
@@ -339,6 +358,7 @@ mod tests {
             setenv MODIFIED_VAR MODIFIED_ORIGINAL;
             setenv DELETED_VAR DELETED_ORIGINAL;
             unsetenv _FLOX_HOOK_DIFF;
+            unset _FLOX_INVOCATION_TYPE;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
             rehash;
         "#]]

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -322,7 +322,7 @@ mod tests {
             setenv _activate_d /interpreter/activate.d;
             setenv _flox_activations /flox_activations;
             setenv _flox_activate_tracer TRACER;
-            set _FLOX_INVOCATION_TYPE = inplace;
+            set _FLOX_INVOCATION_TYPE = in_place;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
             if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";
             eval "`'/flox_activations' set-env-dirs --shell tcsh --flox-env '/flox_env' --env-dirs $FLOX_ENV_DIRS:q`";

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -272,7 +272,7 @@ mod tests {
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             source /interpreter/activate.d/zsh;
-            typeset -g _FLOX_INVOCATION_TYPE=inplace;
+            typeset -g _FLOX_INVOCATION_TYPE=in_place;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]]

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -7,6 +7,7 @@ use flox_core::activate::context::InvocationType;
 use indoc::indoc;
 use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded, source_file};
 
+use crate::attach_diff::todo_drop_unset;
 use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating zsh startup commands
@@ -114,6 +115,21 @@ pub fn generate_zsh_profile_commands(
                 );
             }
             // Note that unsetting the prompt depends on `_activate_d` being set.
+        },
+    }
+
+    // Emit _FLOX_INVOCATION_TYPE as a shell-local (non-exported) variable so
+    // that `flox deactivate --print-script` can distinguish interactive
+    // subshells from in-place activations without reading state.json.
+    match action {
+        Action::Activate { args, .. } => {
+            stmts.push(set_unexported_unexpanded(
+                "_FLOX_INVOCATION_TYPE",
+                format!("{}", args.invocation_type),
+            ));
+        },
+        Action::Deactivate(_) => {
+            stmts.push(todo_drop_unset("_FLOX_INVOCATION_TYPE"));
         },
     }
 
@@ -229,6 +245,7 @@ mod tests {
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             source /interpreter/activate.d/zsh;
+            typeset -g _FLOX_INVOCATION_TYPE=interactive;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]]
@@ -255,6 +272,7 @@ mod tests {
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             source /interpreter/activate.d/zsh;
+            typeset -g _FLOX_INVOCATION_TYPE=inplace;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]]
@@ -298,6 +316,7 @@ mod tests {
                 fi;
                 unset _FLOX_HOOK_SAVE_FPATH _FLOX_HOOK_SAVE_COMPINIT_DUMPFILE;
             fi;
+            unset _FLOX_INVOCATION_TYPE;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
         "#]]
         .assert_eq(&output);

--- a/cli/flox-activations/src/main.rs
+++ b/cli/flox-activations/src/main.rs
@@ -33,6 +33,7 @@ fn try_main() -> Result<(), Error> {
     match args.command {
         cli::Command::Attach(args) => args.handle(),
         cli::Command::Activate(args) => args.handle(subsystem_verbosity),
+        cli::Command::Detach(args) => args.handle(),
         cli::Command::Executive(_) => {
             unreachable!("executive already handled above")
         },

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -133,24 +133,17 @@ pub enum AutoActivateFishMode {
     DisableArrow,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, derive_more::Display, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InvocationType {
+    #[display("inplace")]
     InPlace,
+    #[display("interactive")]
     Interactive,
+    #[display("inplace")]
     ShellCommand(String),
+    #[display("inplace")]
     ExecCommand(Vec<String>),
-}
-
-impl std::fmt::Display for InvocationType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InvocationType::Interactive => write!(f, "interactive"),
-            InvocationType::InPlace
-            | InvocationType::ShellCommand(_)
-            | InvocationType::ExecCommand(_) => write!(f, "inplace"),
-        }
-    }
 }
 
 impl FromStr for InvocationType {

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use shell_gen::ShellWithPath;
@@ -132,17 +133,35 @@ pub enum AutoActivateFishMode {
     DisableArrow,
 }
 
-#[derive(Clone, Debug, Deserialize, derive_more::Display, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InvocationType {
-    #[display("inplace")]
     InPlace,
-    #[display("interactive")]
     Interactive,
-    #[display("command")]
     ShellCommand(String),
-    #[display("execcommand")]
     ExecCommand(Vec<String>),
+}
+
+impl std::fmt::Display for InvocationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvocationType::Interactive => write!(f, "interactive"),
+            InvocationType::InPlace
+            | InvocationType::ShellCommand(_)
+            | InvocationType::ExecCommand(_) => write!(f, "inplace"),
+        }
+    }
+}
+
+impl FromStr for InvocationType {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "interactive" => Ok(InvocationType::Interactive),
+            _ => Ok(InvocationType::InPlace),
+        }
+    }
 }
 
 impl InvocationType {

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use shell_gen::ShellWithPath;
@@ -133,32 +132,76 @@ pub enum AutoActivateFishMode {
     DisableArrow,
 }
 
-#[derive(Clone, Debug, Deserialize, derive_more::Display, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum InvocationType {
-    #[display("inplace")]
     InPlace,
-    #[display("interactive")]
     Interactive,
-    #[display("inplace")]
     ShellCommand(String),
-    #[display("inplace")]
     ExecCommand(Vec<String>),
-}
-
-impl FromStr for InvocationType {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "interactive" => Ok(InvocationType::Interactive),
-            _ => Ok(InvocationType::InPlace),
-        }
-    }
 }
 
 impl InvocationType {
     pub fn is_in_place(&self) -> bool {
         matches!(self, Self::InPlace)
+    }
+
+    pub fn kind(&self) -> InvocationKind {
+        match self {
+            Self::InPlace => InvocationKind::InPlace,
+            Self::Interactive => InvocationKind::Interactive,
+            Self::ShellCommand(_) => InvocationKind::ShellCommand,
+            Self::ExecCommand(_) => InvocationKind::ExecCommand,
+        }
+    }
+}
+
+/// Drops the user command wrapped by `ShellCommand` and `ExecCommand` so we can
+/// roundtrip with InvocationKind
+impl std::fmt::Display for InvocationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.kind())
+    }
+}
+
+#[derive(Clone, Copy, Debug, derive_more::Display, derive_more::FromStr, Eq, PartialEq)]
+#[display(rename_all = "snake_case")]
+#[from_str(rename_all = "snake_case")]
+pub enum InvocationKind {
+    InPlace,
+    Interactive,
+    ShellCommand,
+    ExecCommand,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invocation_type_display_round_trips_to_kind() {
+        let cases = [
+            (InvocationType::InPlace, InvocationKind::InPlace),
+            (InvocationType::Interactive, InvocationKind::Interactive),
+            (
+                InvocationType::ShellCommand("echo hi".to_string()),
+                InvocationKind::ShellCommand,
+            ),
+            (
+                InvocationType::ExecCommand(vec!["ls".to_string(), "-l".to_string()]),
+                InvocationKind::ExecCommand,
+            ),
+        ];
+
+        for (invocation_type, kind) in cases {
+            assert_eq!(invocation_type.kind(), kind);
+            assert_eq!(
+                invocation_type
+                    .to_string()
+                    .parse::<InvocationKind>()
+                    .unwrap(),
+                kind,
+            );
+        }
     }
 }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use fslock::LockFile;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -514,27 +514,35 @@ impl ActivationState {
         self.ready = Ready::True(start_id.clone());
     }
 
-    /// Detach a PID from an activation.
+    /// Detach a PID from an activation, updating ready as needed.
     ///
     /// Returns `Some(start_id)` if this was the last attachment for that
     /// `StartIdentifier` (i.e. the caller should clean up the start state
     /// directory), or `None` if there are still other PIDs attached to the
     /// same start.
-    ///
-    /// `update_ready_after_detach` must still be called after this when
-    /// there are remaining attached PIDs.
-    pub fn detach(&mut self, pid: Pid) -> Option<StartIdentifier> {
+    pub fn detach(&mut self, pid: Pid) -> Result<Option<StartIdentifier>, Error> {
         let removed = self.attached_pids.remove(&pid);
         debug!(pid, ?removed, "detaching from activation");
 
-        let attachment = removed?;
+        let Some(attachment) = removed else {
+            bail!("PID {} is not attached to the activation", pid);
+        };
 
         let start_id = attachment.start_id;
 
         // Return the start_id only when no remaining attachment references it.
         let has_remaining = self.attached_pids.values().any(|a| a.start_id == start_id);
 
-        if has_remaining { None } else { Some(start_id) }
+        // Only update ready state if there are still attached PIDs
+        if !self.attached_pids.is_empty() {
+            self.update_ready_after_detach();
+        }
+
+        if has_remaining {
+            Ok(None)
+        } else {
+            Ok(Some(start_id))
+        }
     }
 
     /// Clean up a specific terminated PID
@@ -574,19 +582,20 @@ impl ActivationState {
         }
 
         tracing::info!(pid, "detaching terminated PID");
-        let empty_start_id = self.detach(pid);
-
-        // Only update ready state if there are still attached PIDs
-        if !self.attached_pids.is_empty() {
-            self.update_ready_after_detach();
-        }
+        let Ok(empty_start_id) = self.detach(pid) else {
+            debug!(
+                pid,
+                "PID not found in attached_pids, this should be unreachable"
+            );
+            return (None, false);
+        };
 
         (empty_start_id, true)
     }
 
-    /// set ready to False if there are no more PIDs attached to the current start
-    /// should only be called when there are some attached PIDs
-    pub fn update_ready_after_detach(&mut self) {
+    /// Set ready to False if there are no more PIDs attached to the current start
+    /// Should only be called when there are some attached PIDs
+    fn update_ready_after_detach(&mut self) {
         if self.attached_pids.is_empty() {
             unreachable!("should remove all state when there are no more attached PIDs");
         }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -326,6 +326,26 @@ impl StartIdentifier {
 
         Ok(activation_state_dir.as_ref().join(dir_name))
     }
+
+    /// Remove the start state directory for this identifier if it exists.
+    ///
+    /// Shared cleanup utility used by both `detach` (when PIDs remain for other
+    /// starts) and `watcher::cleanup_pid` (when a process exits). The no-op on
+    /// a missing directory makes this safe to call idempotently.
+    pub fn remove_start_state_dir(
+        &self,
+        activation_state_dir: impl AsRef<Path>,
+    ) -> Result<(), Error> {
+        let state_dir = self
+            .start_state_dir(activation_state_dir)
+            .context("failed to compute start state dir path")?;
+        if state_dir.exists() {
+            std::fs::remove_dir_all(&state_dir).with_context(|| {
+                format!("failed to remove start state dir '{}'", state_dir.display())
+            })?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1537,6 +1557,41 @@ mod tests {
 
             let attachment: Attachment = serde_json::from_str(&json).unwrap();
             assert_eq!(attachment.invocation_type, None);
+        }
+    }
+
+    mod start_identifier {
+        use super::*;
+
+        /// `remove_start_state_dir` removes the directory when it exists.
+        #[test]
+        fn remove_start_state_dir_removes_existing_dir() {
+            let tmp = TempDir::new().unwrap();
+            let start_id = StartIdentifier::new("/nix/store/test-pkg");
+            let state_dir = start_id.start_state_dir(tmp.path()).unwrap();
+            std::fs::create_dir_all(&state_dir).unwrap();
+            assert!(state_dir.exists(), "directory should exist before removal");
+
+            start_id
+                .remove_start_state_dir(tmp.path())
+                .expect("removal should succeed");
+
+            assert!(
+                !state_dir.exists(),
+                "directory should be gone after removal"
+            );
+        }
+
+        /// `remove_start_state_dir` is a no-op when the directory doesn't exist.
+        #[test]
+        fn remove_start_state_dir_noop_when_absent() {
+            let tmp = TempDir::new().unwrap();
+            let start_id = StartIdentifier::new("/nix/store/test-pkg");
+
+            // Directory was never created.
+            start_id
+                .remove_start_state_dir(tmp.path())
+                .expect("removal should succeed even when dir is absent");
         }
     }
 }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -328,10 +328,6 @@ impl StartIdentifier {
     }
 
     /// Remove the start state directory for this identifier if it exists.
-    ///
-    /// Shared cleanup utility used by both `detach` (when PIDs remain for other
-    /// starts) and `watcher::cleanup_pid` (when a process exits). The no-op on
-    /// a missing directory makes this safe to call idempotently.
     pub fn remove_start_state_dir(
         &self,
         activation_state_dir: impl AsRef<Path>,
@@ -339,11 +335,10 @@ impl StartIdentifier {
         let state_dir = self
             .start_state_dir(activation_state_dir)
             .context("failed to compute start state dir path")?;
-        if state_dir.exists() {
-            std::fs::remove_dir_all(&state_dir).with_context(|| {
-                format!("failed to remove start state dir '{}'", state_dir.display())
-            })?;
-        }
+        trace!(?state_dir, "removing empty activation state dir");
+        std::fs::remove_dir_all(&state_dir).with_context(|| {
+            format!("failed to remove start state dir '{}'", state_dir.display())
+        })?;
         Ok(())
     }
 }
@@ -451,11 +446,6 @@ impl ActivationState {
             .iter()
             .map(|(pid, attachment)| (*pid, attachment.expiration))
             .collect()
-    }
-
-    /// Returns `true` if the given PID is currently attached to this activation.
-    pub fn is_pid_attached(&self, pid: Pid) -> bool {
-        self.attached_pids.contains_key(&pid)
     }
 
     /// Returns the current activation mode
@@ -1566,41 +1556,6 @@ mod tests {
 
             let attachment: Attachment = serde_json::from_str(&json).unwrap();
             assert_eq!(attachment.invocation_type, None);
-        }
-    }
-
-    mod start_identifier {
-        use super::*;
-
-        /// `remove_start_state_dir` removes the directory when it exists.
-        #[test]
-        fn remove_start_state_dir_removes_existing_dir() {
-            let tmp = TempDir::new().unwrap();
-            let start_id = StartIdentifier::new("/nix/store/test-pkg");
-            let state_dir = start_id.start_state_dir(tmp.path()).unwrap();
-            std::fs::create_dir_all(&state_dir).unwrap();
-            assert!(state_dir.exists(), "directory should exist before removal");
-
-            start_id
-                .remove_start_state_dir(tmp.path())
-                .expect("removal should succeed");
-
-            assert!(
-                !state_dir.exists(),
-                "directory should be gone after removal"
-            );
-        }
-
-        /// `remove_start_state_dir` is a no-op when the directory doesn't exist.
-        #[test]
-        fn remove_start_state_dir_noop_when_absent() {
-            let tmp = TempDir::new().unwrap();
-            let start_id = StartIdentifier::new("/nix/store/test-pkg");
-
-            // Directory was never created.
-            start_id
-                .remove_start_state_dir(tmp.path())
-                .expect("removal should succeed even when dir is absent");
         }
     }
 }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -433,6 +433,11 @@ impl ActivationState {
             .collect()
     }
 
+    /// Returns `true` if the given PID is currently attached to this activation.
+    pub fn is_pid_attached(&self, pid: Pid) -> bool {
+        self.attached_pids.contains_key(&pid)
+    }
+
     /// Returns the current activation mode
     pub fn mode(&self) -> &ActivateMode {
         &self.mode
@@ -489,12 +494,27 @@ impl ActivationState {
         self.ready = Ready::True(start_id.clone());
     }
 
-    /// Detach a PID from an activation
+    /// Detach a PID from an activation.
     ///
-    /// update_ready_after_detach must be called after calling detach
-    pub fn detach(&mut self, pid: Pid) {
+    /// Returns `Some(start_id)` if this was the last attachment for that
+    /// `StartIdentifier` (i.e. the caller should clean up the start state
+    /// directory), or `None` if there are still other PIDs attached to the
+    /// same start.
+    ///
+    /// `update_ready_after_detach` must still be called after this when
+    /// there are remaining attached PIDs.
+    pub fn detach(&mut self, pid: Pid) -> Option<StartIdentifier> {
         let removed = self.attached_pids.remove(&pid);
         debug!(pid, ?removed, "detaching from activation");
+
+        let attachment = removed?;
+
+        let start_id = attachment.start_id;
+
+        // Return the start_id only when no remaining attachment references it.
+        let has_remaining = self.attached_pids.values().any(|a| a.start_id == start_id);
+
+        if has_remaining { None } else { Some(start_id) }
     }
 
     /// Clean up a specific terminated PID
@@ -533,21 +553,8 @@ impl ActivationState {
             return (None, false);
         }
 
-        let start_id = attachment.start_id;
-        tracing::info!(pid, ?start_id, "detaching terminated PID");
-        self.detach(pid);
-
-        // Check if this start_id now has no more attachments
-        let has_attachments = self
-            .attached_pids
-            .iter()
-            .any(|(_, attachment)| attachment.start_id == start_id);
-
-        let empty_start_id = if !has_attachments {
-            Some(start_id)
-        } else {
-            None
-        };
+        tracing::info!(pid, "detaching terminated PID");
+        let empty_start_id = self.detach(pid);
 
         // Only update ready state if there are still attached PIDs
         if !self.attached_pids.is_empty() {
@@ -559,7 +566,7 @@ impl ActivationState {
 
     /// set ready to False if there are no more PIDs attached to the current start
     /// should only be called when there are some attached PIDs
-    fn update_ready_after_detach(&mut self) {
+    pub fn update_ready_after_detach(&mut self) {
         if self.attached_pids.is_empty() {
             unreachable!("should remove all state when there are no more attached PIDs");
         }

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -1,9 +1,9 @@
 use std::io::{BufWriter, Write, stdout};
 use std::str::FromStr;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
-use flox_core::activate::context::InvocationType;
+use flox_core::activate::context::InvocationKind;
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
 use flox_core::activations::activation_state_dir_path;
 use flox_rust_sdk::flox::Flox;
@@ -87,32 +87,41 @@ impl Deactivate {
 
         let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
 
-        // Interactive subshell: just emit `exit;`. The shell exits and the
-        // executive monitors the PID, cleaning up state.json when it goes away.
-        let is_interactive = InvocationType::from_str(&invocation_type)
-            .unwrap_or(InvocationType::InPlace)
-            == InvocationType::Interactive;
-
         let mut writer = BufWriter::new(stdout());
 
-        if is_interactive {
-            write!(writer, "exit;")?;
-            return Ok(());
+        if invocation_type.is_empty() {
+            bail!("cannot deactivate for empty INVOCATION_TYPE")
         }
 
-        // In-place activation: restore env vars first, then emit a shell
-        // command that calls `flox-activations detach` so state.json is
-        // updated after the script is eval'd by the caller.
-        flox_activations::deactivate::generate_deactivate_script(
-            shell,
-            &mut writer,
-            &*FLOX_INTERPRETER,
-            &FLOX_ACTIVATIONS_BIN,
-            &activation_state_dir,
-        )
-        .context("failed to generate deactivation script")?;
+        let invocation_kind = InvocationKind::from_str(&invocation_type)
+            .context("could not determine invocation type".to_string())?;
 
-        Ok(())
+        match invocation_kind {
+            InvocationKind::Interactive => {
+                // Interactive subshell: just emit `exit;`. The shell exits and the
+                // executive monitors the PID, cleaning up state.json when it goes
+                // away.
+                write!(writer, "exit;")?;
+                Ok(())
+            },
+            InvocationKind::InPlace | InvocationKind::ShellCommand => {
+                // In-place activation: restore env vars first, then emit a shell
+                // command that calls `flox-activations detach` so state.json is
+                // updated after the script is eval'd by the caller.
+                flox_activations::deactivate::generate_deactivate_script(
+                    shell,
+                    &mut writer,
+                    &*FLOX_INTERPRETER,
+                    &FLOX_ACTIVATIONS_BIN,
+                    &activation_state_dir,
+                )
+                .context("failed to generate deactivation script")
+            },
+            InvocationKind::ExecCommand => {
+                // This should be unreachable because we shouldn't set _FLOX_INVOCATION_TYPE to exec_command
+                bail!("cannot deactivate an exec command activation");
+            },
+        }
     }
 
     pub fn old_exit(self, _flox: Flox) -> Result<()> {
@@ -136,73 +145,5 @@ impl Deactivate {
         ", uninitialized_environment_description(&last_active)?});
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::io::BufWriter;
-
-    use super::*;
-
-    fn is_interactive(invocation_type: &str) -> bool {
-        InvocationType::from_str(invocation_type).unwrap_or(InvocationType::InPlace)
-            == InvocationType::Interactive
-    }
-
-    // Helper to call handle_print_script with a given invocation type and
-    // capture the output. We bypass `handle()` because it checks flox features.
-
-    /// Confirm that `"interactive"` as the invocation type emits exactly `exit;`.
-    #[test]
-    fn interactive_invocation_type_emits_exit() {
-        // We can't call handle_print_script directly in unit tests because it
-        // calls activated_environments() (reads env vars) and
-        // detect_shell_for_in_place() (reads env vars). Instead we test the
-        // logic inline:
-        assert!(
-            is_interactive("interactive"),
-            "\"interactive\" should be detected as interactive"
-        );
-
-        let mut buf = Vec::new();
-        {
-            let mut writer = BufWriter::new(&mut buf);
-            if is_interactive("interactive") {
-                write!(writer, "exit;").unwrap();
-            }
-        }
-        assert_eq!(
-            String::from_utf8(buf).unwrap(),
-            "exit;",
-            "interactive invocation type should emit exactly 'exit;'"
-        );
-    }
-
-    /// Confirm that `"inplace"` does NOT emit `exit`.
-    #[test]
-    fn inplace_invocation_type_emits_no_exit() {
-        assert!(
-            !is_interactive("inplace"),
-            "\"inplace\" should not be detected as interactive"
-        );
-    }
-
-    /// Confirm that an empty string defaults to in-place (not interactive).
-    #[test]
-    fn empty_invocation_type_defaults_to_inplace() {
-        assert!(
-            !is_interactive(""),
-            "empty invocation type should default to in-place"
-        );
-    }
-
-    /// Confirm that an unknown string defaults to in-place (not interactive).
-    #[test]
-    fn unknown_invocation_type_defaults_to_inplace() {
-        assert!(
-            !is_interactive("totally-unknown"),
-            "unknown invocation type should default to in-place"
-        );
     }
 }

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -1,8 +1,13 @@
-use std::io::{BufWriter, stdout};
+use std::io::{BufWriter, Write, stdout};
+use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
 use bpaf::Bpaf;
+use flox_core::activate::context::InvocationType;
+use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
+use flox_core::activations::activation_state_dir_path;
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::utils::FLOX_INTERPRETER;
 use indoc::{formatdoc, indoc};
 
@@ -13,9 +18,14 @@ use crate::utils::message;
 
 #[derive(Bpaf, Clone)]
 pub struct Deactivate {
-    /// Print a deactivation script to stdout instead of showing instructions
-    #[bpaf(long("print-script"), hide)]
-    pub print_script: bool,
+    /// Invocation type for print-script mode (hidden, for shell hook use).
+    ///
+    /// When provided, emits a deactivation script to stdout. The value
+    /// determines the exit strategy:
+    /// - `"interactive"` → emit `exit;` (subshell will exit and clean up)
+    /// - anything else   → emit in-place env-var restoration + detach command
+    #[bpaf(long("print-script"), argument("INVOCATION_TYPE"), optional, hide)]
+    pub print_script: Option<String>,
 }
 
 impl Deactivate {
@@ -26,39 +36,83 @@ impl Deactivate {
 
         subcommand_metric!("deactivate");
 
-        if self.print_script {
-            let shell = detect_shell_for_in_place()?;
-
-            // Generate and print the deactivation script
-            let mut writer = BufWriter::new(stdout());
-            flox_activations::deactivate::generate_deactivate_script(
-                shell,
-                &mut writer,
-                &*FLOX_INTERPRETER,
-            )?;
-
-            Ok(())
-        } else {
-            // Interactive mode - print instructions
-            let active_environments = activated_environments();
-            let last_active = active_environments.last_active();
-
-            let Some(last_active) = last_active else {
-                message::info(indoc! {"
-                    No environment active!
-                    Exit active environments by typing 'exit' to exit your current shell or close your terminal.
-                    Environments can be activated using `flox activate`.
-                "});
-
-                return Ok(());
-            };
-
-            message::info(formatdoc! {"
-                Exit the currently active environment {} by typing 'exit' to exit your current shell or close your terminal.
-            ", uninitialized_environment_description(&last_active)?});
-
-            Ok(())
+        if let Some(invocation_type) = self.print_script.clone() {
+            return self.handle_print_script(flox, invocation_type);
         }
+
+        // Interactive mode - print instructions
+        let active_environments = activated_environments();
+        let last_active = active_environments.last_active();
+
+        let Some(last_active) = last_active else {
+            message::info(indoc! {"
+                No environment active!
+                Exit active environments by typing 'exit' to exit your current shell or close your terminal.
+                Environments can be activated using `flox activate`.
+            "});
+
+            return Ok(());
+        };
+
+        message::info(formatdoc! {"
+            Exit the currently active environment {} by typing 'exit' to exit your current shell or close your terminal.
+        ", uninitialized_environment_description(&last_active)?});
+
+        Ok(())
+    }
+
+    /// Handle `flox deactivate --print-script <INVOCATION_TYPE>`.
+    ///
+    /// Emits a script that either exits the calling shell (for interactive
+    /// subshell activations) or performs an in-place deactivation (env-var
+    /// restoration + a `flox-activations detach` command).
+    ///
+    /// The `invocation_type` argument comes from the `_FLOX_INVOCATION_TYPE`
+    /// shell variable set during activation, removing the need to read
+    /// state.json inside this binary.
+    fn handle_print_script(self, flox: Flox, invocation_type: String) -> Result<()> {
+        let shell = detect_shell_for_in_place()?;
+
+        // Get the .flox directory path from the active environment, opening
+        // the concrete environment so managed and remote environments are
+        // also supported (not just local path environments).
+        let last_active = activated_environments()
+            .last_active()
+            .ok_or_else(|| anyhow!("No environment active."))?;
+        let dot_flox_path = last_active
+            .into_concrete_environment(&flox, None)
+            .context("failed to open active environment for deactivation")?
+            .dot_flox_path()
+            .to_path_buf();
+
+        let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
+
+        // Interactive subshell: just emit `exit;`. The shell exits and the
+        // executive monitors the PID, cleaning up state.json when it goes away.
+        let is_interactive = InvocationType::from_str(&invocation_type)
+            .unwrap_or(InvocationType::InPlace)
+            == InvocationType::Interactive;
+
+        let mut writer = BufWriter::new(stdout());
+
+        if is_interactive {
+            write!(writer, "exit;")?;
+            return Ok(());
+        }
+
+        // In-place activation: restore env vars first, then emit a shell
+        // command that calls `flox-activations detach` so state.json is
+        // updated after the script is eval'd by the caller.
+        flox_activations::deactivate::generate_deactivate_script(
+            shell,
+            &mut writer,
+            &*FLOX_INTERPRETER,
+            &FLOX_ACTIVATIONS_BIN,
+            &activation_state_dir,
+        )
+        .context("failed to generate deactivation script")?;
+
+        Ok(())
     }
 
     pub fn old_exit(self, _flox: Flox) -> Result<()> {
@@ -82,5 +136,73 @@ impl Deactivate {
         ", uninitialized_environment_description(&last_active)?});
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::BufWriter;
+
+    use super::*;
+
+    fn is_interactive(invocation_type: &str) -> bool {
+        InvocationType::from_str(invocation_type).unwrap_or(InvocationType::InPlace)
+            == InvocationType::Interactive
+    }
+
+    // Helper to call handle_print_script with a given invocation type and
+    // capture the output. We bypass `handle()` because it checks flox features.
+
+    /// Confirm that `"interactive"` as the invocation type emits exactly `exit;`.
+    #[test]
+    fn interactive_invocation_type_emits_exit() {
+        // We can't call handle_print_script directly in unit tests because it
+        // calls activated_environments() (reads env vars) and
+        // detect_shell_for_in_place() (reads env vars). Instead we test the
+        // logic inline:
+        assert!(
+            is_interactive("interactive"),
+            "\"interactive\" should be detected as interactive"
+        );
+
+        let mut buf = Vec::new();
+        {
+            let mut writer = BufWriter::new(&mut buf);
+            if is_interactive("interactive") {
+                write!(writer, "exit;").unwrap();
+            }
+        }
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "exit;",
+            "interactive invocation type should emit exactly 'exit;'"
+        );
+    }
+
+    /// Confirm that `"inplace"` does NOT emit `exit`.
+    #[test]
+    fn inplace_invocation_type_emits_no_exit() {
+        assert!(
+            !is_interactive("inplace"),
+            "\"inplace\" should not be detected as interactive"
+        );
+    }
+
+    /// Confirm that an empty string defaults to in-place (not interactive).
+    #[test]
+    fn empty_invocation_type_defaults_to_inplace() {
+        assert!(
+            !is_interactive(""),
+            "empty invocation type should default to in-place"
+        );
+    }
+
+    /// Confirm that an unknown string defaults to in-place (not interactive).
+    #[test]
+    fn unknown_invocation_type_defaults_to_inplace() {
+        assert!(
+            !is_interactive("totally-unknown"),
+            "unknown invocation type should default to in-place"
+        );
     }
 }

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1052,7 +1052,7 @@ EOF
     print -- \"baseline: \${_comps[fd]:-none}\"
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     print -- \"activated: \${_comps[fd]:-none}\"
-    eval \"\$($FLOX_BIN deactivate --print-script)\"
+    eval \"\$($FLOX_BIN deactivate --print-script \"\$_FLOX_INVOCATION_TYPE\")\"
     print -- \"deactivated: \${_comps[fd]:-none}\"
   "
   assert_success

--- a/cli/tests/deactivate.bats
+++ b/cli/tests/deactivate.bats
@@ -86,7 +86,7 @@ EOF
     export TEST_VAR=original
     eval "$($FLOX_BIN activate --print-script)"
     echo "during:$TEST_VAR"
-    eval "$($FLOX_BIN deactivate --print-script)"
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPE")"
     echo "after:$TEST_VAR"
   '
   assert_success
@@ -121,7 +121,7 @@ EOF
     set -gx TEST_VAR original
     eval "$($FLOX_BIN activate --print-script)"
     echo "during:$TEST_VAR"
-    eval "$($FLOX_BIN deactivate --print-script)"
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPE")"
     echo "after:$TEST_VAR"
   '
   assert_success
@@ -157,7 +157,7 @@ EOF
     setenv TEST_VAR original
     eval "`$FLOX_BIN activate --print-script`"
     echo "during:$TEST_VAR"
-    eval "`$FLOX_BIN deactivate --print-script`"
+    eval "`$FLOX_BIN deactivate --print-script $_FLOX_INVOCATION_TYPE`"
     echo "after:$TEST_VAR"
   '
   assert_success
@@ -192,7 +192,7 @@ EOF
     export TEST_VAR=original
     eval "$($FLOX_BIN activate --print-script)"
     echo "during:$TEST_VAR"
-    eval "$($FLOX_BIN deactivate --print-script)"
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPE")"
     echo "after:$TEST_VAR"
   '
   assert_success
@@ -226,7 +226,7 @@ EOF
   FLOX_SHELL="bash" run --separate-stderr bash -c '
     eval "$($FLOX_BIN activate --print-script)"
     echo "during:$TEST_NEW_VAR"
-    eval "$($FLOX_BIN deactivate --print-script)"
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPE")"
     if [ -z "${TEST_NEW_VAR+x}" ]; then
       echo "after:unset"
     fi
@@ -262,7 +262,7 @@ EOF
   SHELL="$(which fish)" run --separate-stderr fish -c '
     eval "$($FLOX_BIN activate --print-script)"
     echo "during:$TEST_NEW_VAR"
-    eval "$($FLOX_BIN deactivate --print-script)"
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPE")"
     if not set -q TEST_NEW_VAR
       echo "after:unset"
     end
@@ -299,7 +299,7 @@ EOF
   SHELL="$(which tcsh)" run --separate-stderr tcsh -c '
     eval "`$FLOX_BIN activate --print-script`"
     echo "during:$TEST_NEW_VAR"
-    eval "`$FLOX_BIN deactivate --print-script`"
+    eval "`$FLOX_BIN deactivate --print-script $_FLOX_INVOCATION_TYPE`"
     if ( ! $?TEST_NEW_VAR ) then
       echo "after:unset"
     endif
@@ -335,7 +335,7 @@ EOF
   FLOX_SHELL="zsh" run --separate-stderr zsh -c '
     eval "$($FLOX_BIN activate --print-script)"
     echo "during:$TEST_NEW_VAR"
-    eval "$($FLOX_BIN deactivate --print-script)"
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPE")"
     if [ -z "${TEST_NEW_VAR+x}" ]; then
       echo "after:unset"
     fi
@@ -413,7 +413,7 @@ assert_prompt_round_trip() {
     echo "<before>$PS1</before>"
     eval "$("$FLOX_BIN" activate -d "$PROJECT_DIR")"
     echo "<active>$PS1</active>"
-    eval "$("$FLOX_BIN" deactivate --print-script)"
+    eval "$("$FLOX_BIN" deactivate --print-script "$_FLOX_INVOCATION_TYPE")"
     echo "<after>$PS1</after>"
   '
   assert_success
@@ -428,7 +428,7 @@ assert_prompt_round_trip() {
     echo "<before>$PS1</before>"
     eval "$("$FLOX_BIN" activate -d "$PROJECT_DIR")"
     echo "<active>$PS1</active>"
-    eval "$("$FLOX_BIN" deactivate --print-script)"
+    eval "$("$FLOX_BIN" deactivate --print-script "$_FLOX_INVOCATION_TYPE")"
     echo "<after>$PS1</after>"
   '
   assert_success
@@ -443,7 +443,7 @@ assert_prompt_round_trip() {
     echo "<before>"(fish_prompt)"</before>"
     eval ($FLOX_BIN activate -d $PROJECT_DIR)
     echo "<active>"(fish_prompt)"</active>"
-    eval ($FLOX_BIN deactivate --print-script)
+    eval ($FLOX_BIN deactivate --print-script $_FLOX_INVOCATION_TYPE)
     echo "<after>"(fish_prompt)"</after>"
   '
   assert_success
@@ -458,7 +458,7 @@ assert_prompt_round_trip() {
     echo "<before>$prompt</before>"
     eval "`$FLOX_BIN activate -d $PROJECT_DIR`"
     echo "<active>$prompt</active>"
-    eval "`$FLOX_BIN deactivate --print-script`"
+    eval "`$FLOX_BIN deactivate --print-script $_FLOX_INVOCATION_TYPE`"
     echo "<after>$prompt</after>"
   '
   assert_success


### PR DESCRIPTION
## Summary

Implements `flox deactivate --print-script` for the auto-activate feature (DEV-82), replacing the old `flox exit` command path with a proper deactivation pipeline.

### Design

Activation sets a non-exported shell-local variable `_FLOX_INVOCATION_TYPE` (`interactive` or `inplace`) via the gen_rc scripts. When the shell hook calls `flox deactivate --print-script "${_FLOX_INVOCATION_TYPE:-}"`, the binary receives the invocation type as the `--print-script` argument and emits the appropriate script without touching `state.json`:

- **Interactive subshells** → emits `exit;`. The shell exits and the executive monitors the PID, cleaning up `state.json` when it goes away.
- **In-place activations** → emits env-var restoration (reads `_FLOX_HOOK_DIFF`) followed by `flox-activations detach --activation-state-dir "..." --pid $$;`. The shell eval's the output, so `$$` expands to the caller's PID.

Because `_FLOX_INVOCATION_TYPE` is non-exported, child shells (e.g. `flox activate → bash → flox deactivate`) don't inherit it and default to in-place — correct behavior (env-var restoration without trying to `exit` the wrong shell). This design also avoids a `state.json` schema version bump and keeps `--print-script` side-effect-free.

### Changes

**`cli/flox-core`**
- `InvocationType`: added `Display` (`"interactive"` / `"inplace"`) and `FromStr` impls
- `ActivationState::detach()` now returns `Option<StartIdentifier>` — `Some` when the detached PID was the last for its start, enabling caller-side start-state directory cleanup
- Added `is_pid_attached(pid)` helper; removed `invocation_type_for_pid` (no longer needed in production code)

**`cli/flox-activations`**
- New `flox-activations detach` subcommand (`cli/detach.rs`): reads `state.json`, removes the PID, calls `update_ready_after_detach` as needed, writes back, and removes the start state directory if this was the last attachment for that start (mirrors `watcher::cleanup_pid`)
- `generate_deactivate_script` now emits the `flox-activations detach` command at the end, so callers don't need to do it separately; accepts `flox_activations_bin` and `activation_state_dir` as new parameters
- All four gen_rc shells (`bash`, `zsh`, `fish`, `tcsh`) set `_FLOX_INVOCATION_TYPE` via the new `Display` impl; deactivation emits `unset _FLOX_INVOCATION_TYPE`

**`cli/flox`**
- `flox deactivate --print-script` changed from `bool` to `Option<String>` accepting the invocation type value (hidden flag, for shell hook use)
- Path lookup uses `into_concrete_environment` + `dot_flox_path()` — works for remote (managed) environments, not just local path envs
- Removed `DetachAction`, `decide_detach_action`, `emit_detach_script` (old inline state-mutation design)

Rebased on top of DEV-77 (PR #4269, merged). Closes DEV-82.

## Test Plan

- [ ] `eval "$(flox deactivate --print-script interactive)"` exits the shell in a `flox activate` interactive subshell
- [ ] `eval "$(flox deactivate --print-script inplace)"` emits env-var restoration and runs `flox-activations detach` for in-place activations
- [ ] `eval "$(flox deactivate --print-script "")"` defaults to in-place for nested bash (`flox activate → bash → flox deactivate`)
- [ ] 80+ unit tests pass across `flox`, `flox-activations`, and `flox-core`
- [ ] Pre-push hooks (clippy, rustfmt, treefmt) pass

---
*Via Forge (interactive) • fc171575*