### PR TITLE
feat(deactivate): revert _flox_rehash, command hashing, and FPATH (DEV-86)

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -57,6 +57,28 @@ source <($_flox_activations fix-fpath --colon-separated-fpath "$FPATH" --env-dir
 new_fpath="$FPATH"
 
 if [ "$old_fpath" != "$new_fpath" ]; then
+  # Snapshot pre-activation state so `flox deactivate` can restore it.
+  # The `+set` guard preserves the outermost activation's snapshot
+  # through nesting (empty FPATH must be preserved as-is).
+  #
+  # Saving FPATH is necessary because zsh ties it to the `fpath` array
+  # internally and doesn't export it, so the `_FLOX_HOOK_DIFF` env-var
+  # diff captured by flox can't see it. We save `$old_fpath` because
+  # `$FPATH` has already been modified by `fix-fpath` above.
+  #
+  # `$_comp_dumpfile` is zsh-internal and set only after compinit has
+  # run, so its presence is a reliable proxy for "user had compinit
+  # initialized." If they didn't, deactivate must skip compinit entirely
+  # — running a bare `compinit` on exit could emit "insecure directories"
+  # prompts they never saw before, or write a dumpfile to a path they
+  # never picked.
+  if [ -z "${_FLOX_HOOK_SAVE_FPATH+set}" ]; then
+    export _FLOX_HOOK_SAVE_FPATH="$old_fpath"
+    if [ -n "${_comp_dumpfile+set}" ]; then
+      export _FLOX_HOOK_SAVE_COMPINIT_DUMPFILE="${_comp_dumpfile:-}"
+    fi
+  fi
+
   autoload -U compinit
   declare -a _flox_compinit_args=()
 

--- a/cli/flox-activations/src/attach_diff/diff_serializer.rs
+++ b/cli/flox-activations/src/attach_diff/diff_serializer.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Write};
 
 use anyhow::Result;
 use base64::Engine as _;
+use flox_core::activate::vars::FLOX_ACTIVE_ENVIRONMENTS_VAR;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use shell_gen::Statement;
@@ -76,6 +77,26 @@ impl DiffSerializer {
 
         stmts
     }
+
+    /// True when restoring this diff would leave `_FLOX_ACTIVE_ENVIRONMENTS`
+    /// empty or unset — i.e., this deactivate is undoing the outermost
+    /// activation. Per-shell teardown (hashing, FPATH, precmd hook removal)
+    /// is gated on this.
+    ///
+    /// Activation always sets `_FLOX_ACTIVE_ENVIRONMENTS` via
+    /// `single_set_envs`, so the diff will have it in `added` (first
+    /// activation, no prior value) or `modified` (nested, with the prior
+    /// outer value). The trailing `false` covers the logically-impossible
+    /// case that activation didn't set it.
+    pub(crate) fn is_outermost_deactivate(&self) -> bool {
+        if self.added.contains(FLOX_ACTIVE_ENVIRONMENTS_VAR) {
+            return true;
+        }
+        if let Some(active_environments) = self.modified.get(FLOX_ACTIVE_ENVIRONMENTS_VAR) {
+            return active_environments.is_empty();
+        }
+        false
+    }
 }
 
 #[cfg(test)]
@@ -105,5 +126,43 @@ mod tests {
         let decoded = DiffSerializer::decode(&encoded).expect("decode should succeed");
 
         assert_eq!(original, decoded);
+    }
+
+    fn diff_with(
+        added: &[&str],
+        modified: &[(&str, &str)],
+        removed: &[(&str, &str)],
+    ) -> DiffSerializer {
+        DiffSerializer {
+            added: make_keys(added),
+            modified: make_env(modified),
+            removed: make_env(removed),
+        }
+    }
+
+    #[test]
+    fn outermost_on_first_activation() {
+        // First activation: pre-activation env had no `_FLOX_ACTIVE_ENVIRONMENTS`,
+        // so activation puts it in `added`. Post-restore: unset → outermost.
+        let diff = diff_with(&[FLOX_ACTIVE_ENVIRONMENTS_VAR], &[], &[]);
+        assert!(diff.is_outermost_deactivate());
+    }
+
+    #[test]
+    fn not_outermost_on_nested_activation() {
+        // Nested activation: pre-activation env already had an outer
+        // `_FLOX_ACTIVE_ENVIRONMENTS`, so activation puts it in `modified`
+        // with that outer value. Post-restore: outer value → not outermost.
+        let diff = diff_with(&[], &[(FLOX_ACTIVE_ENVIRONMENTS_VAR, "/outer/env")], &[]);
+        assert!(!diff.is_outermost_deactivate());
+    }
+
+    #[test]
+    fn outermost_when_modified_to_empty() {
+        // Pre-activation env had `_FLOX_ACTIVE_ENVIRONMENTS=""` (set but
+        // empty). Activation puts it in `modified` with empty value.
+        // Post-restore: empty string → still outermost.
+        let diff = diff_with(&[], &[(FLOX_ACTIVE_ENVIRONMENTS_VAR, "")], &[]);
+        assert!(diff.is_outermost_deactivate());
     }
 }

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -167,8 +167,13 @@ pub fn generate_bash_profile_commands(
         Action::Activate { .. } => {
             stmts.push("set +h".to_stmt());
         },
-        Action::Deactivate(_) => {
-            // TODO: decide whether to restore prior hashing state.
+        Action::Deactivate(ctx) => {
+            // Re-enable command hashing (bash default), but only if no
+            // other flox environments remain active — the outer env
+            // still wants hashing off.
+            if ctx.restore_diff.is_outermost_deactivate() {
+                stmts.push("set -h;".to_stmt());
+            }
         },
     }
 
@@ -337,6 +342,7 @@ mod tests {
             export DELETED_VAR=DELETED_ORIGINAL;
             unset _FLOX_HOOK_DIFF;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
+            set -h;
         "#]]
         .assert_eq(&output);
     }

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -160,8 +160,13 @@ pub fn generate_tcsh_profile_commands(
         Action::Activate { .. } => {
             stmts.push("unhash;".to_stmt());
         },
-        Action::Deactivate(_) => {
-            // TODO: decide whether to restore prior hashing state.
+        Action::Deactivate(ctx) => {
+            // Re-enable command hashing by rebuilding the hash table,
+            // but only if no other flox environments remain active —
+            // the outer env still wants hashing off.
+            if ctx.restore_diff.is_outermost_deactivate() {
+                stmts.push("rehash;".to_stmt());
+            }
         },
     }
 
@@ -335,6 +340,7 @@ mod tests {
             setenv DELETED_VAR DELETED_ORIGINAL;
             unsetenv _FLOX_HOOK_DIFF;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
+            rehash;
         "#]]
         .assert_eq(&output);
     }

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use flox_core::activate::context::InvocationType;
+use indoc::indoc;
 use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded, source_file};
 
 use crate::gen_rc::{Action, RM};
@@ -57,10 +58,62 @@ pub fn generate_zsh_profile_commands(
         Action::Activate { args, .. } => {
             stmts.push(source_file(args.activate_d.join("zsh")));
         },
-        Action::Deactivate(_) => {
-            // TODO: undo everything in activate_d/zsh
-            // Although note that unsetting the prompt depends on these being
-            // set
+        Action::Deactivate(ctx) => {
+            // Teardown happens in inverse order of activate.d/zsh:
+            // (1) drop the `_flox_rehash` precmd hook, (2) restore
+            // hashing setopts, (3) restore FPATH + re-run compinit.
+            if ctx.restore_diff.is_outermost_deactivate() {
+                // Undo the `_flox_rehash` precmd hook installed by activate.d/zsh.
+                // Guard `unfunction` on the function existing so we don't emit
+                // "no such hash table element" if the user removed it
+                // themselves mid-session; `add-zsh-hook -d` is already silent
+                // for an unregistered hook.
+                stmts.push(
+                    indoc! {r#"
+                        if [[ -o interactive ]]; then
+                            autoload -Uz add-zsh-hook;
+                            add-zsh-hook -d precmd _flox_rehash;
+                            if (( ${+functions[_flox_rehash]} )); then
+                                unfunction _flox_rehash;
+                            fi;
+                        fi;"#}
+                    .to_stmt(),
+                );
+                // Re-enable command hashing (zsh defaults).
+                stmts.push("setopt hashcmds; setopt hashdirs;".to_stmt());
+                // Restore the pre-activation FPATH and (if the user had
+                // compinit initialized pre-flox) re-run their compinit so
+                // completions match. Both `_FLOX_HOOK_SAVE_FPATH` and
+                // `_FLOX_HOOK_SAVE_COMPINIT_DUMPFILE` are captured by
+                // `activate.d/zsh` only when fpath actually changed; the
+                // dumpfile is captured only when the user had compinit
+                // initialized pre-flox.
+                //
+                // We honor the user's pre-flox compinit state rather than
+                // running a bare `compinit`, so users with `compinit -u` /
+                // `-d <custom>` / no compinit at all don't see surprising
+                // behavior on deactivate.
+                //
+                // NOTE on cost: `compinit` rebuilds the completion dump,
+                // which can be tens of ms on large `fpath` setups. If
+                // deactivate latency ends up monitored, one option is to
+                // cache the compinit result keyed on an `fpath` hash and
+                // skip the rebuild when the hash matches the activate-time
+                // capture.
+                stmts.push(
+                    indoc! {r#"
+                        if [[ -n "${_FLOX_HOOK_SAVE_FPATH+set}" ]]; then
+                            FPATH="$_FLOX_HOOK_SAVE_FPATH";
+                            if [[ -n "${_FLOX_HOOK_SAVE_COMPINIT_DUMPFILE:-}" ]]; then
+                                autoload -U compinit;
+                                compinit -d "$_FLOX_HOOK_SAVE_COMPINIT_DUMPFILE";
+                            fi;
+                            unset _FLOX_HOOK_SAVE_FPATH _FLOX_HOOK_SAVE_COMPINIT_DUMPFILE;
+                        fi;"#}
+                    .to_stmt(),
+                );
+            }
+            // Note that unsetting the prompt depends on `_activate_d` being set.
         },
     }
 
@@ -229,6 +282,22 @@ mod tests {
             export MODIFIED_VAR=MODIFIED_ORIGINAL;
             export DELETED_VAR=DELETED_ORIGINAL;
             unset _FLOX_HOOK_DIFF;
+            if [[ -o interactive ]]; then
+                autoload -Uz add-zsh-hook;
+                add-zsh-hook -d precmd _flox_rehash;
+                if (( ${+functions[_flox_rehash]} )); then
+                    unfunction _flox_rehash;
+                fi;
+            fi;
+            setopt hashcmds; setopt hashdirs;
+            if [[ -n "${_FLOX_HOOK_SAVE_FPATH+set}" ]]; then
+                FPATH="$_FLOX_HOOK_SAVE_FPATH";
+                if [[ -n "${_FLOX_HOOK_SAVE_COMPINIT_DUMPFILE:-}" ]]; then
+                    autoload -U compinit;
+                    compinit -d "$_FLOX_HOOK_SAVE_COMPINIT_DUMPFILE";
+                fi;
+                unset _FLOX_HOOK_SAVE_FPATH _FLOX_HOOK_SAVE_COMPINIT_DUMPFILE;
+            fi;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
         "#]]
         .assert_eq(&output);

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1031,6 +1031,36 @@ EOF
   assert_output --partial "Loading dump file skipped, regenerating"
 }
 
+# bats test_tags=activate,activate:rc:zsh
+@test "zsh: deactivate restores pre-activation completions" {
+  project_setup
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/fd.yaml" \
+    "$FLOX_BIN" install fd
+
+  # A developer-shell auto-activation can leak `_FLOX_HOOK_*` vars into
+  # bats; if they're set, activate.d/zsh treats this as a nested
+  # activation and skips the dumpfile snapshot, so deactivate has
+  # nothing to restore. CI inherits a clean env; clearing here keeps
+  # the test reproducible locally.
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  unset _FLOX_HOOK_SAVE_FPATH _FLOX_HOOK_SAVE_COMPINIT_DUMPFILE _FLOX_HOOK_DIFF
+  run zsh -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(command -v zsh)
+    autoload -Uz compinit
+    compinit
+    print -- \"baseline: \${_comps[fd]:-none}\"
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    print -- \"activated: \${_comps[fd]:-none}\"
+    eval \"\$($FLOX_BIN deactivate --print-script)\"
+    print -- \"deactivated: \${_comps[fd]:-none}\"
+  "
+  assert_success
+  assert_line "baseline: none"
+  assert_line "activated: _fd"
+  assert_line "deactivated: none"
+}
+
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:envVar:bash


### PR DESCRIPTION
## Proposed Changes

Addresses the first checklist items of [DEV-86](https://linear.app/floxdotdev/issue/DEV-86/revert-more-profile-actions-in-flox-deactivate).

### Teardown commits

| Commit | Concern | Activate-side counterpart |
|--------|---------|---------------------------|
| `feat(deactivate): revert _flox_rehash precmd hook` | Drops the `_flox_rehash` precmd hook that calls `hash -r` in interactive zsh shells | `add-zsh-hook precmd _flox_rehash` in `activate.d/zsh` |
| `feat(deactivate): re-enable command hashing on outermost deactivate` | Restores bash `set -h`, zsh `setopt hashcmds; setopt hashdirs`, tcsh `rehash` | bash `set +h`, zsh `setopt nohashcmds; setopt nohashdirs`, tcsh `unhash` |
| `feat(deactivate): restore FPATH and refresh completions in zsh` | Restores `fpath` from `_FLOX_HOOK_SAVE_FPATH` and re-runs compinit | `fix-fpath` (which auto-syncs to `FPATH` via zsh's tied-parameter mechanism) |

Each restore is gated on `_FLOX_ACTIVE_ENVIRONMENTS` being empty/unset so nested activations don't restore prematurely. Until DEV-77 wires env-diff restore for that variable, the gates are conservative no-ops rather than incorrectly aggressive.

**Restore-to-default, not restore-to-original** for command hashing: if a user had `set +h` in `.bashrc`, our deactivate restores to `-h`. Saving exact prior state would need new save vars per shell. Tracked as [DEV-101](https://linear.app/floxdotdev/issue/DEV-101/preserve-original-hashing-state-across-activatedeactivate).

### Review-feedback commits

| Commit | Review thread it addresses |
|--------|-----------------------------|
| `fix(deactivate): widen tcsh _FLOX_ACTIVE_ENVIRONMENTS gate to set-or-empty` | tcsh `(! $?VAR)` only matches unset; bash/zsh match unset *or* empty. Widened tcsh with short-circuit `(! $?VAR \|\| "$VAR" == "")` |
| `feat(deactivate): honor user's pre-flox compinit state on zsh deactivate` | Bare `compinit` could emit "insecure directories" prompts for users with customized completion setups. Now captures `_FLOX_HOOK_SAVE_COMPINIT_{DUMPFILE,INITIALIZED}` on activate; restores by re-running with the user's `-d` path or skipping if they never ran compinit |
| `docs(deactivate): note compinit rebuild cost on zsh deactivate` | Adds a comment noting compinit's rebuild cost (tens of ms on large `fpath`) and a future-optimization sketch |

## Test plan

- [x] `just unit-tests gen_rc` — 12/12 pass
- [x] `cargo clippy -p flox-activations --all-targets` — clean
- [x] `just format` — clean
- [ ] Manual smoke in zsh: customized `compinit -d <custom>` setup → activate → deactivate; verify save vars set/cleared and no "insecure directories" prompt
- [ ] Manual smoke in zsh: fresh shell with no `compinit` → activate → deactivate; verify compinit skipped on restore
- [ ] Manual smoke in tcsh: `_FLOX_ACTIVE_ENVIRONMENTS=""` (set-but-empty) → confirm `rehash` fires
- [ ] End-to-end blocked on `flox deactivate --print-script` (DEV-77)

## Release Notes

N/A