### PR TITLE
[NOT READY FOR HUMAN REVIEW] feat(deactivate): revert command hashing (DEV-86)

### DIFF
--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -174,10 +174,7 @@ pub fn generate_bash_profile_commands(
             // other flox environments remain active — the outer env
             // still wants hashing off. `_FLOX_ACTIVE_ENVIRONMENTS` is
             // updated by the env-diff restore above (DEV-77).
-            stmts.push(
-                "if [ -z \"${_FLOX_ACTIVE_ENVIRONMENTS:-}\" ]; then set -h; fi;"
-                    .to_stmt(),
-            );
+            stmts.push("if [ -z \"${_FLOX_ACTIVE_ENVIRONMENTS:-}\" ]; then set -h; fi;".to_stmt());
         },
     }
 

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -170,7 +170,8 @@ pub fn generate_bash_profile_commands(
             stmts.push("set +h".to_stmt());
         },
         Action::Deactivate { .. } => {
-            // TODO: decide whether to restore prior hashing state.
+            // Re-enable command hashing (bash default).
+            stmts.push("set -h".to_stmt());
         },
     }
 
@@ -315,6 +316,7 @@ mod tests {
         let output = render_deactivate();
         expect![[r#"
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
+            set -h
         "#]]
         .assert_eq(&output);
     }

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -170,8 +170,14 @@ pub fn generate_bash_profile_commands(
             stmts.push("set +h".to_stmt());
         },
         Action::Deactivate { .. } => {
-            // Re-enable command hashing (bash default).
-            stmts.push("set -h".to_stmt());
+            // Re-enable command hashing (bash default), but only if no
+            // other flox environments remain active — the outer env
+            // still wants hashing off. `_FLOX_ACTIVE_ENVIRONMENTS` is
+            // updated by the env-diff restore above (DEV-77).
+            stmts.push(
+                "if [ -z \"${_FLOX_ACTIVE_ENVIRONMENTS:-}\" ]; then set -h; fi;"
+                    .to_stmt(),
+            );
         },
     }
 
@@ -316,7 +322,7 @@ mod tests {
         let output = render_deactivate();
         expect![[r#"
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
-            set -h
+            if [ -z "${_FLOX_ACTIVE_ENVIRONMENTS:-}" ]; then set -h; fi;
         "#]]
         .assert_eq(&output);
     }

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -161,7 +161,8 @@ pub fn generate_tcsh_profile_commands(
             stmts.push("unhash;".to_stmt());
         },
         Action::Deactivate { .. } => {
-            // TODO: decide whether to restore prior hashing state.
+            // Re-enable command hashing by rebuilding the hash table.
+            stmts.push("rehash;".to_stmt());
         },
     }
 
@@ -311,6 +312,7 @@ mod tests {
         let output = render_deactivate();
         expect![[r#"
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
+            rehash;
         "#]]
         .assert_eq(&output);
     }

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -161,8 +161,12 @@ pub fn generate_tcsh_profile_commands(
             stmts.push("unhash;".to_stmt());
         },
         Action::Deactivate { .. } => {
-            // Re-enable command hashing by rebuilding the hash table.
-            stmts.push("rehash;".to_stmt());
+            // Re-enable command hashing by rebuilding the hash table,
+            // but only if no other flox environments remain active —
+            // the outer env still wants hashing off.
+            // `_FLOX_ACTIVE_ENVIRONMENTS` is updated by the env-diff
+            // restore above (DEV-77).
+            stmts.push("if (! $?_FLOX_ACTIVE_ENVIRONMENTS) rehash;".to_stmt());
         },
     }
 
@@ -312,7 +316,7 @@ mod tests {
         let output = render_deactivate();
         expect![[r#"
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
-            rehash;
+            if (! $?_FLOX_ACTIVE_ENVIRONMENTS) rehash;
         "#]]
         .assert_eq(&output);
     }

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -58,9 +58,14 @@ pub fn generate_zsh_profile_commands(
             stmts.push(source_file(args.activate_d.join("zsh")));
         },
         Action::Deactivate { .. } => {
-            // Re-enable command hashing (zsh defaults).
-            stmts.push("setopt hashcmds;".to_stmt());
-            stmts.push("setopt hashdirs;".to_stmt());
+            // Re-enable command hashing (zsh defaults), but only if no
+            // other flox environments remain active — the outer env
+            // still wants hashing off. `_FLOX_ACTIVE_ENVIRONMENTS` is
+            // updated by the env-diff restore above (DEV-77).
+            stmts.push(
+                "if [[ -z \"${_FLOX_ACTIVE_ENVIRONMENTS:-}\" ]]; then setopt hashcmds; setopt hashdirs; fi;"
+                    .to_stmt(),
+            );
             // TODO: undo the rest of activate.d/zsh (FPATH, `_flox_rehash` hook).
             // Note that unsetting the prompt depends on `_activate_d` being set.
         },
@@ -207,8 +212,7 @@ mod tests {
     fn generate_zsh_profile_commands_deactivate() {
         let output = render_deactivate();
         expect![[r#"
-            setopt hashcmds;
-            setopt hashdirs;
+            if [[ -z "${_FLOX_ACTIVE_ENVIRONMENTS:-}" ]]; then setopt hashcmds; setopt hashdirs; fi;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
         "#]]
         .assert_eq(&output);

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -58,9 +58,11 @@ pub fn generate_zsh_profile_commands(
             stmts.push(source_file(args.activate_d.join("zsh")));
         },
         Action::Deactivate { .. } => {
-            // TODO: undo everything in activate_d/zsh
-            // Although note that unsetting the prompt depends on these being
-            // set
+            // Re-enable command hashing (zsh defaults).
+            stmts.push("setopt hashcmds;".to_stmt());
+            stmts.push("setopt hashdirs;".to_stmt());
+            // TODO: undo the rest of activate.d/zsh (FPATH, `_flox_rehash` hook).
+            // Note that unsetting the prompt depends on `_activate_d` being set.
         },
     }
 
@@ -205,6 +207,8 @@ mod tests {
     fn generate_zsh_profile_commands_deactivate() {
         let output = render_deactivate();
         expect![[r#"
+            setopt hashcmds;
+            setopt hashdirs;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
         "#]]
         .assert_eq(&output);


### PR DESCRIPTION
## Proposed Changes

Activation disables command hashing across shells so that newly installed flox packages are found immediately (bash `set +h`, zsh `setopt nohashcmds; setopt nohashdirs`, tcsh `unhash`). Without a deactivate counterpart, a shell that activates then deactivates a flox env permanently pays the un-cached `$PATH`-walk cost on every command — and in tcsh's case the hash table stays empty indefinitely.

This PR teaches `flox deactivate --print-script` to re-enable the shell defaults:

| Shell | Activate (existing) | Deactivate (new) |
|-------|--------------------|------------------|
| bash  | `set +h`           | `set -h`         |
| zsh   | `setopt nohashcmds; setopt nohashdirs` (in `activate.d/zsh:119-120`) | `setopt hashcmds; setopt hashdirs` |
| tcsh  | `unhash;`          | `rehash;`        |
| fish  | n/a — fish doesn't use this style of cache | n/a |

Each restore is gated on `_FLOX_ACTIVE_ENVIRONMENTS` being empty after the env-diff restore above. In a nested-activation stack (env A then B, deactivate B), the inner deactivate would otherwise re-enable hashing while the outer env still wants it disabled. Mirrors the conditional approach in `set-prompt.{shell}` (PR #4265), which gates prompt restoration on `FLOX_PROMPT_ENVIRONMENTS`. The gate depends on env-diff restore (DEV-77); until that lands the gate is a conservative no-op rather than incorrectly aggressive.

### Restore-to-default, not restore-to-original

This PR restores hashing to the **shell defaults**, not to whatever the user actually had before `flox activate`. If a user had `set +h` in their `.bashrc` for some reason, our deactivate would override their preference back to `-h`. The activate-side accepts the same asymmetry (it assumes defaults at start) and saving/restoring exact prior state would mean adding new `_FLOX_HOOK_SAVE_*` env vars per shell.

Filed as [DEV-101](https://linear.app/floxdotdev/issue/DEV-101/preserve-original-hashing-state-across-activatedeactivate) (Triage) for a team discussion on whether to extend `_FLOX_HOOK_DIFF` to capture shell-process state or commit to per-feature save vars. tcsh's hash table has no introspection so any future fix would be bash/zsh-only. For the common case, restore-to-default is correct.

Snapshots in `gen_rc/{bash,zsh,tcsh}.rs` updated. Resolves one checklist item of [DEV-86](https://linear.app/floxdotdev/issue/DEV-86/revert-more-profile-actions-in-flox-deactivate). Two sibling PRs remain (`profile.deactivate.\$shell`, FPATH).

## Release Notes

N/A