### PR TITLE
ci: skip fork-incompatible jobs on community PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,11 @@ jobs:
 
   nix-build:
     name: "Nix build"
+    # Fork PRs can't access the AWS OIDC / Tailscale secrets this job needs, so
+    # it can only fail. The required "Nix build (*)" contexts are posted on the
+    # same commit by the maintainer-run community-ci draft PR (CONTRIBUTING.md).
+    # Pushes, merge-queue runs, and same-repo PRs are unaffected.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: "ubuntu-latest"
     timeout-minutes: 120
 
@@ -282,6 +287,9 @@ jobs:
 
   nix-build-kerberos:
     name: "Verify Kerberos CLI build"
+    # Same as nix-build: fork PRs lack the secrets this job needs. The required
+    # "Verify Kerberos CLI build (*)" contexts come from the community-ci draft.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: "ubuntu-latest"
     timeout-minutes: 60
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   review:
-    if: ${{ !github.event.pull_request.draft }}
+    # Skip on fork PRs: the review needs CLAUDE_CODE_OAUTH_TOKEN, which isn't
+    # available to pull_request runs from forks, so it only fails.
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

GitHub withholds repository secrets from `pull_request` runs triggered by forks. Three CI jobs depend on those secrets and can therefore only fail on community (fork) PRs: **Nix build** and **Verify Kerberos CLI build** need the AWS OIDC + Tailscale remote-builder secrets, and **review** (Claude Code Review) needs `CLAUDE_CODE_OAUTH_TOKEN`. The result is a wall of red checks on every community PR (e.g. #4205) for jobs that were never going to run there. Per CONTRIBUTING.md, authoritative CI for community PRs is run by a maintainer via a `community-ci` draft PR on the upstream repo, which posts the real status checks against the same commit SHA.

## Change

Gate the three secret-dependent jobs off fork PRs with the standard head-repo check (`github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`). They keep running on pushes, merge-queue runs, and same-repo PRs; only fork PRs skip them.

## Why this is safe for the merge gate

`Nix build (*)` and `Verify Kerberos CLI build (*)` are required status checks in the `main` ruleset (no bypass actors). Gating them off forks does not weaken the gate: those contexts are still produced on the same commit SHA by the maintainer-run community-ci draft PR, which is what satisfies the gate today. Using a job-level skip rather than a vacuous green avoids posting a misleading "build passed" on code that never built.

## Intentionally unchanged

- Jobs that already pass on forks and give contributors real signal: **Nix Plugins**, **Nix expression tests**, **unit**.
- The lint job: fork linting is fixed separately by #4262 (fetch PR head via `refs/pull/...`), so it is left to run and pass rather than be skipped. This is the counterpart to the skip-based approach in #4247.
- `nix-build-bats-tests` (needs `nix-build`) cascades to skipped on forks automatically, as it does today.

## Effect on a community PR

Before: ~7 red checks (Nix build x4, Verify Kerberos x2, review). After: those show as skipped, the jobs that work still report green, and lint passes via #4262. Real validation continues through the community-ci draft.

## Verify before merge

- [ ] On a throwaway fork PR, confirm a skipped required check does not leave the PR stuck in "Expected — waiting for status." Job-level `if` still reports a `skipped` check run, and the community-ci draft supersedes it with a real success on the same SHA, but worth one empirical check given the strict no-bypass ruleset.
- [ ] Same-repo PR still runs Nix build, Verify Kerberos, and review.
- [ ] Merge-queue run still runs all jobs.

---
*Via Forge (interactive) • 24c0b34c*