### PR TITLE
[NOT READY FOR HUMAN REVIEW] feat(deactivate): revert FPATH and refresh completions (DEV-86)

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -27,6 +27,18 @@ fi
 # reload completions below.
 old_fpath="$FPATH"
 
+# Save the pre-activation FPATH so `flox deactivate` can restore it.
+# Guarded with `+set` so nested activations don't clobber the outermost
+# original (empty FPATH must be preserved as-is).
+#
+# This save mechanism is necessary because FPATH is typically not
+# exported in zsh — it's tied to the `fpath` array and managed by the
+# shell internally — so the `_FLOX_HOOK_DIFF` env-var diff captured by
+# flox can't see it.
+if [ -z "${_FLOX_HOOK_SAVE_FPATH+set}" ]; then
+  export _FLOX_HOOK_SAVE_FPATH="$FPATH"
+fi
+
 # We already customized the PATH and MANPATH, but the user and system
 # dotfiles may have changed them, so finish by doing this again.
 # We need to restore FLOX_ENV_DIRS before fixing fpath since fpath uses

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -63,14 +63,6 @@ pub fn generate_zsh_profile_commands(
             // being deactivated. `_FLOX_HOOK_SAVE_FPATH` is captured
             // by `activate.d/zsh`. `_FLOX_ACTIVE_ENVIRONMENTS` is
             // updated by the env-diff restore above (DEV-77).
-            //
-            // Why not the env-diff? FPATH is typically not exported
-            // in zsh — it's tied to the `fpath` array and managed
-            // internally — so `_FLOX_HOOK_DIFF` can't see it.
-            //
-            // Use `fpath=(...)` rather than `FPATH=` per the comment
-            // in `activate.d/zsh` — and because `unset FPATH` would
-            // also unset the tied `fpath` array, breaking completion.
             stmts.push(
                 "if [[ -z \"${_FLOX_ACTIVE_ENVIRONMENTS:-}\" && -n \"${_FLOX_HOOK_SAVE_FPATH+set}\" ]]; then fpath=(${(s/:/)_FLOX_HOOK_SAVE_FPATH}); autoload -U compinit; compinit; unset _FLOX_HOOK_SAVE_FPATH; fi;"
                     .to_stmt(),

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -58,9 +58,25 @@ pub fn generate_zsh_profile_commands(
             stmts.push(source_file(args.activate_d.join("zsh")));
         },
         Action::Deactivate { .. } => {
-            // TODO: undo everything in activate_d/zsh
-            // Although note that unsetting the prompt depends on these being
-            // set
+            // Restore the pre-activation FPATH (and re-run compinit
+            // so completions match) when the outermost flox env is
+            // being deactivated. `_FLOX_HOOK_SAVE_FPATH` is captured
+            // by `activate.d/zsh`. `_FLOX_ACTIVE_ENVIRONMENTS` is
+            // updated by the env-diff restore above (DEV-77).
+            //
+            // Why not the env-diff? FPATH is typically not exported
+            // in zsh — it's tied to the `fpath` array and managed
+            // internally — so `_FLOX_HOOK_DIFF` can't see it.
+            //
+            // Use `fpath=(...)` rather than `FPATH=` per the comment
+            // in `activate.d/zsh` — and because `unset FPATH` would
+            // also unset the tied `fpath` array, breaking completion.
+            stmts.push(
+                "if [[ -z \"${_FLOX_ACTIVE_ENVIRONMENTS:-}\" && -n \"${_FLOX_HOOK_SAVE_FPATH+set}\" ]]; then fpath=(${(s/:/)_FLOX_HOOK_SAVE_FPATH}); autoload -U compinit; compinit; unset _FLOX_HOOK_SAVE_FPATH; fi;"
+                    .to_stmt(),
+            );
+            // TODO: undo the rest of activate.d/zsh (hashing setopts, `_flox_rehash` hook).
+            // Note that unsetting the prompt depends on `_activate_d` being set.
         },
     }
 
@@ -205,6 +221,7 @@ mod tests {
     fn generate_zsh_profile_commands_deactivate() {
         let output = render_deactivate();
         expect![[r#"
+            if [[ -z "${_FLOX_ACTIVE_ENVIRONMENTS:-}" && -n "${_FLOX_HOOK_SAVE_FPATH+set}" ]]; then fpath=(${(s/:/)_FLOX_HOOK_SAVE_FPATH}); autoload -U compinit; compinit; unset _FLOX_HOOK_SAVE_FPATH; fi;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
         "#]]
         .assert_eq(&output);


### PR DESCRIPTION
## Proposed Changes

Activation in zsh modifies the `fpath` array (via `fix-fpath` in `activate.d/zsh`), which auto-syncs to `FPATH` via zsh's tied-parameter mechanism. Without a deactivate counterpart, flox env entries linger in `fpath` after deactivation, leaving stale or broken completions.

This PR captures the pre-activation `FPATH` in `activate.d/zsh` as `_FLOX_HOOK_SAVE_FPATH` (with a `+set` guard so nested activations don't clobber the outermost original), and on deactivate restores `fpath` from it and re-runs `compinit` so the completion system rebuilds against the restored fpath.

### Why a save var instead of `_FLOX_HOOK_DIFF`?

The env-diff approach was tried first and rejected after empirical testing. `FPATH` is typically **not exported** in zsh — it's tied to the `fpath` array and managed by the shell internally — so the `_FLOX_HOOK_DIFF` capture (taken from the flox process's parent env) can't see it. Decoding `_FLOX_HOOK_DIFF` from a real activation showed `FPATH` as `added` (i.e. "didn't exist before"), which would lead env-diff restore to `unset FPATH`. Per zsh docs, unsetting one half of a tied pair unsets both, **breaking completion entirely**.

The save-var pattern mirrors `FLOX_SAVE_*_PS1` from [PR #4265](https://github.com/flox/flox/pull/4265), for the same underlying reason: shell-managed state that isn't in the exported environment needs a shell-side save mechanism. Consolidating both into the env-diff would require extending it to capture shell-process state — a redesign tracked separately (see e.g. [DEV-101](https://linear.app/floxdotdev/issue/DEV-101)).

### Nesting

Restore is gated on `_FLOX_ACTIVE_ENVIRONMENTS` being empty (outermost deactivate, no nested envs remain). Until env-diff restore (DEV-77) wires `_FLOX_ACTIVE_ENVIRONMENTS` updates through, the gate is a conservative no-op rather than incorrectly aggressive.

The `+set` guard on the activate-side save means only the outermost activation captures pre-state — nested activations preserve the original.

### Why `fpath=(…)` not `FPATH=…`?

Two reasons:
1. The comment in `activate.d/zsh:42-53` documents that setting `FPATH` directly can have surprising zsh-startup behavior.
2. `unset FPATH` (which env-diff restore would emit if it tracked FPATH) would also unset the tied `fpath` array, breaking the completion system entirely.

Using `fpath=(…)` (the array form) updates `FPATH` via the tied-parameter mechanism and is the safe direction.

### Other shells

bash, tcsh, and fish have no FPATH equivalent that flox is touching — fish has `fish_function_path` managed differently, bash has no concept, tcsh has nothing. No changes needed there.

## Validation

Manually verified end-to-end in a real zsh shell:
- `_FLOX_HOOK_SAVE_FPATH` captures pre-activation FPATH on the first activation.
- Nested activations preserve the outermost save (`+set` guard works).
- Gated-skip simulation leaves the save intact when outer envs remain.
- Outermost-deactivate simulation restores FPATH, re-runs compinit, and unsets the save var.
- After also restoring PATH (which DEV-77 will handle), env-specific commands no longer tab-complete.

Snapshot in `gen_rc/zsh.rs` updated. Resolves the third checklist item of [DEV-86](https://linear.app/floxdotdev/issue/DEV-86/revert-more-profile-actions-in-flox-deactivate). One sibling PR remains (\`profile.deactivate.\$shell\`).

## Release Notes

N/A