### PR TITLE
fix: add missing subcommand metrics

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -308,10 +308,12 @@ impl Activate {
 
         let verb = match subcommand {
             AutoActivate::Allow => {
+                environment_subcommand_metric!("activate::allow", concrete_environment);
                 allow(&config, &concrete_environment)?;
                 "allowed"
             },
             AutoActivate::Deny => {
+                environment_subcommand_metric!("activate::deny", concrete_environment);
                 deny(&config, &concrete_environment)?;
                 "denied"
             },

--- a/cli/flox/src/commands/gc.rs
+++ b/cli/flox/src/commands/gc.rs
@@ -69,7 +69,7 @@ use flox_rust_sdk::models::env_registry;
 use flox_rust_sdk::providers::nix::nix_base_command;
 use tracing::{Span, debug, info_span, instrument, trace};
 
-use crate::message;
+use crate::{message, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Gc {}
@@ -77,6 +77,8 @@ pub struct Gc {}
 impl Gc {
     #[instrument(skip_all)]
     pub fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("gc");
+
         let span = info_span!("collecting_garbage", progress = "Collecting garbage");
         let _guard = span.enter();
         env_registry::garbage_collect(&flox)?;

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -5,6 +5,8 @@ use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 use shell_gen::Shell;
 
+use crate::subcommand_metric;
+
 #[derive(Debug, Clone, Bpaf)]
 pub struct HookEnv {
     /// Shell to emit hook-env code for (bash, zsh, fish, tcsh)
@@ -19,6 +21,13 @@ impl HookEnv {
                 "'hook-env' requires the auto_activate feature flag. Set FLOX_FEATURES_AUTO_ACTIVATE=true."
             );
         }
+
+        // TODO: when we add auto-activation logic, we should probably skip this
+        // on the fast path and only add it when we're making a meaningful change.
+        // We could also consider counting unique environments or something
+        // instead of recording every single run of this command.
+        subcommand_metric!("hook-env");
+
         // Temporary: set _FLOX_HOOK_FIRED so we can verify the hook fires.
         // This will be replaced by real environment activation logic.
         let cwd = std::env::current_dir()?.to_string_lossy().to_string();


### PR DESCRIPTION
We've overlooked adding metrics for `hook-env`, `activate allow`, and
`activate deny` while working on auto activate.

Also add a metric for gc which was also missing.
