### PR TITLE
fix: deactivate cleanups

### DIFF
--- a/cli/flox-activations/src/attach_diff.rs
+++ b/cli/flox-activations/src/attach_diff.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::path::Path;
 use std::process::Command;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use flox_core::activate::context::{ActivateCtx, AttachCtx, AttachProjectCtx};
 use flox_core::activate::vars::FLOX_ACTIVE_ENVIRONMENTS_VAR;
 use flox_core::util::default_nix_env_vars;
@@ -221,34 +222,35 @@ fn unset(name: impl AsRef<str>) -> Statement {
 /// - Restores variables that were removed during activation
 /// - Unsets `_FLOX_HOOK_DIFF` itself
 ///
-/// If `_FLOX_HOOK_DIFF` is not present or cannot be decoded, returns an empty vector.
-pub(crate) fn generate_deactivation_statements() -> Vec<Statement> {
+/// Returns an error if `_FLOX_HOOK_DIFF` is not set in the environment or
+/// cannot be decoded.
+pub(crate) fn generate_deactivation_statements() -> Result<Vec<Statement>> {
     let mut stmts = Vec::new();
 
-    // Decode _FLOX_HOOK_DIFF and restore environment variables
-    if let Ok(encoded_diff) = std::env::var(FLOX_HOOK_DIFF_VAR)
-        && let Ok(diff) = DiffSerializer::decode(&encoded_diff)
-    {
-        // Unset variables that were added during activation
-        for var_name in diff.added.iter().sorted() {
-            stmts.push(unset(var_name));
-        }
+    let encoded_diff = env::var(FLOX_HOOK_DIFF_VAR)
+        .context(format!("{} not set in environment", FLOX_HOOK_DIFF_VAR))?;
+    let diff = DiffSerializer::decode(&encoded_diff)
+        .context(format!("failed to decode {}", FLOX_HOOK_DIFF_VAR))?;
 
-        // Restore variables that were modified during activation
-        for (var_name, original_value) in diff.modified.iter().sorted_by_key(|(k, _)| *k) {
-            stmts.push(set_exported_unexpanded(var_name, original_value));
-        }
-
-        // Restore variables that were removed during activation
-        for (var_name, original_value) in diff.removed.iter().sorted_by_key(|(k, _)| *k) {
-            stmts.push(set_exported_unexpanded(var_name, original_value));
-        }
-
-        // Unset the diff variable itself
-        stmts.push(unset(FLOX_HOOK_DIFF_VAR));
+    // Unset variables that were added during activation
+    for var_name in diff.added.iter().sorted() {
+        stmts.push(unset(var_name));
     }
 
-    stmts
+    // Restore variables that were modified during activation
+    for (var_name, original_value) in diff.modified.iter().sorted_by_key(|(k, _)| *k) {
+        stmts.push(set_exported_unexpanded(var_name, original_value));
+    }
+
+    // Restore variables that were removed during activation
+    for (var_name, original_value) in diff.removed.iter().sorted_by_key(|(k, _)| *k) {
+        stmts.push(set_exported_unexpanded(var_name, original_value));
+    }
+
+    // Unset the diff variable itself
+    stmts.push(unset(FLOX_HOOK_DIFF_VAR));
+
+    Ok(stmts)
 }
 
 // ─── Inline set/unset NOT yet folded into AttachDiff ────────────────────────

--- a/cli/flox-activations/src/attach_diff/diff_serializer.rs
+++ b/cli/flox-activations/src/attach_diff/diff_serializer.rs
@@ -3,7 +3,11 @@ use std::io::{Read, Write};
 
 use anyhow::Result;
 use base64::Engine as _;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use shell_gen::Statement;
+
+use crate::attach_diff::{set_exported_unexpanded, unset};
 
 pub const FLOX_HOOK_DIFF_VAR: &str = "_FLOX_HOOK_DIFF";
 
@@ -43,6 +47,34 @@ impl DiffSerializer {
         let mut json = Vec::new();
         decoder.read_to_end(&mut json)?;
         Ok(serde_json::from_slice(&json)?)
+    }
+
+    /// Generates shell statements to restore the environment to its pre-activation state:
+    /// - Unsets variables that were added during activation
+    /// - Restores original values for variables that were modified
+    /// - Restores variables that were removed during activation
+    /// - Unsets `_FLOX_HOOK_DIFF` itself
+    pub(crate) fn generate_deactivation_statements(&self) -> Vec<Statement> {
+        let mut stmts = Vec::new();
+        // Unset variables that were added during activation
+        for var_name in self.added.iter().sorted() {
+            stmts.push(unset(var_name));
+        }
+
+        // Restore variables that were modified during activation
+        for (var_name, original_value) in self.modified.iter().sorted_by_key(|(k, _)| *k) {
+            stmts.push(set_exported_unexpanded(var_name, original_value));
+        }
+
+        // Restore variables that were removed during activation
+        for (var_name, original_value) in self.removed.iter().sorted_by_key(|(k, _)| *k) {
+            stmts.push(set_exported_unexpanded(var_name, original_value));
+        }
+
+        // Unset the diff variable itself
+        stmts.push(unset(FLOX_HOOK_DIFF_VAR));
+
+        stmts
     }
 }
 

--- a/cli/flox-activations/src/attach_diff/mod.rs
+++ b/cli/flox-activations/src/attach_diff/mod.rs
@@ -1,9 +1,10 @@
 use std::collections::{HashMap, HashSet};
-use std::env;
 use std::path::Path;
 use std::process::Command;
 
-use anyhow::{Context, Result};
+pub mod diff_serializer;
+
+use anyhow::Result;
 use flox_core::activate::context::{ActivateCtx, AttachCtx, AttachProjectCtx};
 use flox_core::activate::vars::FLOX_ACTIVE_ENVIRONMENTS_VAR;
 use flox_core::util::default_nix_env_vars;
@@ -12,9 +13,9 @@ use itertools::Itertools;
 use shell_gen::{GenerateShell, SetVar, Statement, UnsetVar};
 use tracing::debug;
 
+use crate::attach_diff::diff_serializer::{DiffSerializer, FLOX_HOOK_DIFF_VAR};
 use crate::cli::fix_paths::{fix_manpath_var, fix_path_var};
 use crate::cli::set_env_dirs::fix_env_dirs_var;
-use crate::diff_serializer::{DiffSerializer, FLOX_HOOK_DIFF_VAR};
 use crate::env_diff::EnvDiff;
 use crate::start_diff::StartDiff;
 use crate::vars_from_env::VarsFromEnvironment;
@@ -152,6 +153,13 @@ impl AttachDiff {
         })
     }
 
+    /// The encoded `_FLOX_HOOK_DIFF` string, if a pre-activation snapshot
+    /// was available when this `AttachDiff` was constructed.
+    #[cfg(test)]
+    pub fn encoded_diff(&self) -> Option<&str> {
+        self.encoded_diff.as_deref()
+    }
+
     /// Apply the activation environment to a Command.
     ///
     /// Sets all accumulated variables, removes all accumulated unsets,
@@ -211,46 +219,6 @@ fn set_exported_expanded(name: impl AsRef<str>, value: impl AsRef<str>) -> State
 // in gen_rc that we don't capture for `flox deactivate`
 fn unset(name: impl AsRef<str>) -> Statement {
     UnsetVar::new(name).to_stmt()
-}
-
-/// Generate deactivation statements by decoding `_FLOX_HOOK_DIFF` from the environment.
-///
-/// This function reads the `_FLOX_HOOK_DIFF` environment variable, decodes it,
-/// and generates shell statements to restore the environment to its pre-activation state:
-/// - Unsets variables that were added during activation
-/// - Restores original values for variables that were modified
-/// - Restores variables that were removed during activation
-/// - Unsets `_FLOX_HOOK_DIFF` itself
-///
-/// Returns an error if `_FLOX_HOOK_DIFF` is not set in the environment or
-/// cannot be decoded.
-pub(crate) fn generate_deactivation_statements() -> Result<Vec<Statement>> {
-    let mut stmts = Vec::new();
-
-    let encoded_diff = env::var(FLOX_HOOK_DIFF_VAR)
-        .context(format!("{} not set in environment", FLOX_HOOK_DIFF_VAR))?;
-    let diff = DiffSerializer::decode(&encoded_diff)
-        .context(format!("failed to decode {}", FLOX_HOOK_DIFF_VAR))?;
-
-    // Unset variables that were added during activation
-    for var_name in diff.added.iter().sorted() {
-        stmts.push(unset(var_name));
-    }
-
-    // Restore variables that were modified during activation
-    for (var_name, original_value) in diff.modified.iter().sorted_by_key(|(k, _)| *k) {
-        stmts.push(set_exported_unexpanded(var_name, original_value));
-    }
-
-    // Restore variables that were removed during activation
-    for (var_name, original_value) in diff.removed.iter().sorted_by_key(|(k, _)| *k) {
-        stmts.push(set_exported_unexpanded(var_name, original_value));
-    }
-
-    // Unset the diff variable itself
-    stmts.push(unset(FLOX_HOOK_DIFF_VAR));
-
-    Ok(stmts)
 }
 
 // ─── Inline set/unset NOT yet folded into AttachDiff ────────────────────────

--- a/cli/flox-activations/src/deactivate.rs
+++ b/cli/flox-activations/src/deactivate.rs
@@ -4,22 +4,24 @@
 //! the environment to its pre-activation state by decoding and applying the
 //! `_FLOX_HOOK_DIFF` variable captured during activation.
 
+use std::env;
 use std::io::Write;
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use shell_gen::ShellWithPath;
 
-use crate::gen_rc::Action;
+use crate::attach_diff::diff_serializer::{DiffSerializer, FLOX_HOOK_DIFF_VAR};
 use crate::gen_rc::bash::{BashStartupArgs, generate_bash_profile_commands};
 use crate::gen_rc::fish::{FishStartupArgs, generate_fish_profile_commands};
 use crate::gen_rc::tcsh::{TcshStartupArgs, generate_tcsh_profile_commands};
 use crate::gen_rc::zsh::{ZshStartupArgs, generate_zsh_profile_commands};
+use crate::gen_rc::{Action, DeactivateCtx};
 
 /// Generate a deactivation script for the specified shell.
 ///
-/// This reads the `_FLOX_HOOK_DIFF` environment variable (if present),
-/// decodes it, and generates shell commands to:
+/// This reads the `_FLOX_HOOK_DIFF` environment variable, decodes it,
+/// and generates shell commands to:
 /// - Unset variables that were added during activation
 /// - Restore variables that were modified during activation
 /// - Restore variables that were removed during activation
@@ -27,28 +29,39 @@ use crate::gen_rc::zsh::{ZshStartupArgs, generate_zsh_profile_commands};
 ///
 /// Returns an error if `_FLOX_HOOK_DIFF` is not set in the environment or
 /// cannot be decoded.
+///
+/// This function captures all environment variables so all downstream code is
+/// easily unit testable.
 pub fn generate_deactivate_script(
     shell: ShellWithPath,
     writer: &mut impl Write,
     interpreter_path: impl AsRef<Path>,
 ) -> Result<()> {
     let activate_d = interpreter_path.as_ref().join("activate.d");
+    let encoded_diff = env::var(FLOX_HOOK_DIFF_VAR)
+        .context(format!("{} not set in environment", FLOX_HOOK_DIFF_VAR))?;
+    let restore_diff = DiffSerializer::decode(&encoded_diff)
+        .context(format!("Failed to decode {}", FLOX_HOOK_DIFF_VAR))?;
+    let ctx = DeactivateCtx {
+        activate_d,
+        restore_diff,
+    };
 
     match shell {
         ShellWithPath::Bash(_) => {
-            let action: Action<BashStartupArgs> = Action::Deactivate { activate_d };
+            let action: Action<BashStartupArgs> = Action::Deactivate(ctx);
             generate_bash_profile_commands(&action, writer)
         },
         ShellWithPath::Zsh(_) => {
-            let action: Action<ZshStartupArgs> = Action::Deactivate { activate_d };
+            let action: Action<ZshStartupArgs> = Action::Deactivate(ctx);
             generate_zsh_profile_commands(&action, writer)
         },
         ShellWithPath::Fish(_) => {
-            let action: Action<FishStartupArgs> = Action::Deactivate { activate_d };
+            let action: Action<FishStartupArgs> = Action::Deactivate(ctx);
             generate_fish_profile_commands(&action, writer)
         },
         ShellWithPath::Tcsh(_) => {
-            let action: Action<TcshStartupArgs> = Action::Deactivate { activate_d };
+            let action: Action<TcshStartupArgs> = Action::Deactivate(ctx);
             generate_tcsh_profile_commands(&action, writer)
         },
     }

--- a/cli/flox-activations/src/deactivate.rs
+++ b/cli/flox-activations/src/deactivate.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 use std::path::Path;
 
 use anyhow::Result;
-use shell_gen::{Shell, ShellWithPath};
+use shell_gen::ShellWithPath;
 
 use crate::gen_rc::Action;
 use crate::gen_rc::bash::{BashStartupArgs, generate_bash_profile_commands};
@@ -25,32 +25,29 @@ use crate::gen_rc::zsh::{ZshStartupArgs, generate_zsh_profile_commands};
 /// - Restore variables that were removed during activation
 /// - Unset `_FLOX_HOOK_DIFF` itself
 ///
-/// If `_FLOX_HOOK_DIFF` is not present or cannot be decoded, this function
-/// generates an empty script (no-op), making it safe to call even when not
-/// in an activated environment.
+/// Returns an error if `_FLOX_HOOK_DIFF` is not set in the environment or
+/// cannot be decoded.
 pub fn generate_deactivate_script(
     shell: ShellWithPath,
     writer: &mut impl Write,
     interpreter_path: impl AsRef<Path>,
 ) -> Result<()> {
-    let shell_type = Shell::from(shell);
-
     let activate_d = interpreter_path.as_ref().join("activate.d");
 
-    match shell_type {
-        Shell::Bash => {
+    match shell {
+        ShellWithPath::Bash(_) => {
             let action: Action<BashStartupArgs> = Action::Deactivate { activate_d };
             generate_bash_profile_commands(&action, writer)
         },
-        Shell::Zsh => {
+        ShellWithPath::Zsh(_) => {
             let action: Action<ZshStartupArgs> = Action::Deactivate { activate_d };
             generate_zsh_profile_commands(&action, writer)
         },
-        Shell::Fish => {
+        ShellWithPath::Fish(_) => {
             let action: Action<FishStartupArgs> = Action::Deactivate { activate_d };
             generate_fish_profile_commands(&action, writer)
         },
-        Shell::Tcsh => {
+        ShellWithPath::Tcsh(_) => {
             let action: Action<TcshStartupArgs> = Action::Deactivate { activate_d };
             generate_tcsh_profile_commands(&action, writer)
         },

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -76,7 +76,7 @@ pub fn generate_bash_profile_commands(
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
         Action::Deactivate { .. } => {
-            stmts.extend(attach_diff::generate_deactivation_statements());
+            stmts.extend(attach_diff::generate_deactivation_statements()?);
         },
     }
 

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use shell_gen::{GenerateShell, Shell, source_file};
 
-use crate::attach_diff::{self, todo_drop_set_exported_unexpanded, todo_drop_unset};
+use crate::attach_diff::{todo_drop_set_exported_unexpanded, todo_drop_unset};
 use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating bash startup commands
@@ -44,7 +44,7 @@ pub fn generate_bash_profile_commands(
                 stmts.push("set -x".to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: emit `set -x` when tracelevel >= 2
         },
     }
@@ -65,7 +65,7 @@ pub fn generate_bash_profile_commands(
                 stmts.push(todo_drop_unset("_flox_sourcing_rc"));
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // No-op: no way to undo bashrc sourcing
         },
     }
@@ -75,8 +75,8 @@ pub fn generate_bash_profile_commands(
         Action::Activate { args, attach_diff } => {
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
-        Action::Deactivate { .. } => {
-            stmts.extend(attach_diff::generate_deactivation_statements()?);
+        Action::Deactivate(ctx) => {
+            stmts.extend(ctx.restore_diff.generate_deactivation_statements());
         },
     }
 
@@ -95,7 +95,7 @@ pub fn generate_bash_profile_commands(
                 &args.flox_activate_tracer,
             ));
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: we shouldn't be exporting these in the first place
             // Although note that unsetting the prompt depends on these being
             // set
@@ -110,7 +110,7 @@ pub fn generate_bash_profile_commands(
         Action::Activate { args, .. } => args
             .set_prompt
             .then(|| args.activate_d.join("set-prompt.bash")),
-        Action::Deactivate { activate_d } => Some(activate_d.join("set-prompt.bash")),
+        Action::Deactivate(ctx) => Some(ctx.activate_d.join("set-prompt.bash")),
     };
     if let Some(set_prompt_path) = set_prompt_path {
         // We could consult set_prompt, but hypothetically that config value
@@ -142,7 +142,7 @@ pub fn generate_bash_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // No-op: covered by environment restoration above
         },
     }
@@ -154,7 +154,7 @@ pub fn generate_bash_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: run profile.deactivate.bash
         },
     }
@@ -167,7 +167,7 @@ pub fn generate_bash_profile_commands(
         Action::Activate { .. } => {
             stmts.push("set +h".to_stmt());
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: decide whether to restore prior hashing state.
         },
     }
@@ -179,7 +179,7 @@ pub fn generate_bash_profile_commands(
                 stmts.push("set +x".to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: set +x
         },
     }
@@ -193,7 +193,7 @@ pub fn generate_bash_profile_commands(
                 stmts.push(format!("{RM} {};", escaped_path).to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // No-op: deactivate has no rc file to remove.
         },
     }
@@ -214,7 +214,7 @@ pub fn generate_bash_profile_commands(
                 write!(writer, "{}", crate::hook::bash_hook(&args.flox_bin))?;
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: unregister the auto-activate hook
         },
     }
@@ -228,7 +228,12 @@ mod tests {
     use shell_gen::ShellWithPath;
 
     use super::*;
-    use crate::gen_rc::test_helpers::{render_normalized, test_startup_ctx};
+    use crate::gen_rc::test_helpers::{
+        render_normalized,
+        strip_volatile_deactivate,
+        test_deactivate_ctx,
+        test_startup_ctx,
+    };
 
     // NOTE: For these `expect!` tests, run unit tests with `UPDATE_EXPECT=1`
     //  to have it automatically update the expected value when the implementation
@@ -241,12 +246,12 @@ mod tests {
     }
 
     fn render_deactivate() -> String {
-        let action = Action::<BashStartupArgs>::Deactivate {
-            activate_d: PathBuf::from("/interpreter/activate.d"),
-        };
+        let shell = ShellWithPath::Bash(PathBuf::from("/bin/bash"));
+        let action = Action::<BashStartupArgs>::Deactivate(test_deactivate_ctx(shell, true));
         let mut buf = Vec::new();
         generate_bash_profile_commands(&action, &mut buf).expect("generator should succeed");
-        String::from_utf8(buf).expect("output should be utf-8")
+        let output = String::from_utf8(buf).expect("output should be utf-8");
+        strip_volatile_deactivate(&output)
     }
 
     #[test]
@@ -263,6 +268,7 @@ mod tests {
             export FLOX_ENV_CACHE=/flox_env_cache;
             export FLOX_ENV_DESCRIPTION=env_description;
             export FLOX_ENV_PROJECT=/flox_env_project;
+            export MODIFIED_VAR=MODIFIED_VALUE;
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             export _activate_d=/interpreter/activate.d;
@@ -293,6 +299,7 @@ mod tests {
             export FLOX_ENV_CACHE=/flox_env_cache;
             export FLOX_ENV_DESCRIPTION=env_description;
             export FLOX_ENV_PROJECT=/flox_env_project;
+            export MODIFIED_VAR=MODIFIED_VALUE;
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             export _activate_d=/interpreter/activate.d;
@@ -312,6 +319,23 @@ mod tests {
     fn generate_bash_profile_deactivate() {
         let output = render_deactivate();
         expect![[r#"
+            unset ADDED_VAR;
+            unset FLOX_ACTIVATE_START_SERVICES;
+            unset FLOX_ENV;
+            unset FLOX_ENV_CACHE;
+            unset FLOX_ENV_DESCRIPTION;
+            unset FLOX_ENV_DIRS;
+            unset FLOX_ENV_PROJECT;
+            unset FLOX_PROMPT_COLOR_1;
+            unset FLOX_PROMPT_COLOR_2;
+            unset FLOX_PROMPT_ENVIRONMENTS;
+            unset MANPATH;
+            unset PATH;
+            unset QUOTED_VAR;
+            unset _FLOX_ACTIVE_ENVIRONMENTS;
+            export MODIFIED_VAR=MODIFIED_ORIGINAL;
+            export DELETED_VAR=DELETED_ORIGINAL;
+            unset _FLOX_HOOK_DIFF;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
         "#]]
         .assert_eq(&output);

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -60,7 +60,7 @@ pub fn generate_fish_profile_commands(
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
         Action::Deactivate { .. } => {
-            stmts.extend(attach_diff::generate_deactivation_statements());
+            stmts.extend(attach_diff::generate_deactivation_statements()?);
         },
     }
 

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use flox_core::activate::context::{AutoActivateFishMode, InvocationType};
 use shell_gen::{GenerateShell, Shell};
 
-use crate::attach_diff::{self, todo_drop_set_exported_unexpanded};
+use crate::attach_diff::todo_drop_set_exported_unexpanded;
 use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating fish startup commands
@@ -44,7 +44,7 @@ pub fn generate_fish_profile_commands(
                 stmts.push(todo_drop_set_exported_unexpanded("fish_trace", "1").to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: emit `set -gx fish_trace 1` when tracelevel >= 2
         },
     }
@@ -59,8 +59,8 @@ pub fn generate_fish_profile_commands(
         Action::Activate { args, attach_diff } => {
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
-        Action::Deactivate { .. } => {
-            stmts.extend(attach_diff::generate_deactivation_statements()?);
+        Action::Deactivate(ctx) => {
+            stmts.extend(ctx.restore_diff.generate_deactivation_statements());
         },
     }
 
@@ -79,7 +79,7 @@ pub fn generate_fish_profile_commands(
                 &args.flox_activate_tracer,
             ));
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: we shouldn't be exporting these in the first place
             // Although note that unsetting the prompt depends on these being
             // set
@@ -94,7 +94,7 @@ pub fn generate_fish_profile_commands(
         Action::Activate { args, .. } => args
             .set_prompt
             .then(|| args.activate_d.join("set-prompt.fish")),
-        Action::Deactivate { activate_d } => Some(activate_d.join("set-prompt.fish")),
+        Action::Deactivate(ctx) => Some(ctx.activate_d.join("set-prompt.fish")),
     };
     if let Some(set_prompt_path) = set_prompt_path {
         // We could consult set_prompt, but hypothetically that config value
@@ -134,7 +134,7 @@ pub fn generate_fish_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // No-op: covered by environment restoration above
         },
     }
@@ -150,7 +150,7 @@ pub fn generate_fish_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: run profile.deactivate.fish
         },
     }
@@ -165,7 +165,7 @@ pub fn generate_fish_profile_commands(
                 stmts.push("set -gx fish_trace 0;".to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: set -gx fish_trace 0
         },
     }
@@ -179,7 +179,7 @@ pub fn generate_fish_profile_commands(
                 stmts.push(format!("{RM} {};", escaped_path).to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // No-op: deactivate has no rc file to remove.
         },
     }
@@ -203,7 +203,7 @@ pub fn generate_fish_profile_commands(
                 write!(writer, "{}", crate::hook::fish_hook(&args.flox_bin))?;
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: unregister the auto-activate hook
         },
     }
@@ -217,7 +217,12 @@ mod tests {
     use shell_gen::ShellWithPath;
 
     use super::*;
-    use crate::gen_rc::test_helpers::{render_normalized, test_startup_ctx};
+    use crate::gen_rc::test_helpers::{
+        render_normalized,
+        strip_volatile_deactivate,
+        test_deactivate_ctx,
+        test_startup_ctx,
+    };
 
     // NOTE: For these `expect!` tests, run unit tests with `UPDATE_EXPECT=1`
     //  to have it automatically update the expected value when the implementation
@@ -230,12 +235,12 @@ mod tests {
     }
 
     fn render_deactivate() -> String {
-        let action = Action::<FishStartupArgs>::Deactivate {
-            activate_d: PathBuf::from("/interpreter/activate.d"),
-        };
+        let shell = ShellWithPath::Fish(PathBuf::from("/fish"));
+        let action = Action::<FishStartupArgs>::Deactivate(test_deactivate_ctx(shell, true));
         let mut buf = Vec::new();
         generate_fish_profile_commands(&action, &mut buf).expect("generator should succeed");
-        String::from_utf8(buf).expect("output should be utf-8")
+        let output = String::from_utf8(buf).expect("output should be utf-8");
+        strip_volatile_deactivate(&output)
     }
 
     #[test]
@@ -249,6 +254,7 @@ mod tests {
             set -gx FLOX_ENV_CACHE /flox_env_cache;
             set -gx FLOX_ENV_DESCRIPTION env_description;
             set -gx FLOX_ENV_PROJECT /flox_env_project;
+            set -gx MODIFIED_VAR MODIFIED_VALUE;
             set -gx QUOTED_VAR 'QUOTED'\''VALUE';
             set -e DELETED_VAR;
             set -gx _activate_d /interpreter/activate.d;
@@ -281,6 +287,7 @@ mod tests {
             set -gx FLOX_ENV_CACHE /flox_env_cache;
             set -gx FLOX_ENV_DESCRIPTION env_description;
             set -gx FLOX_ENV_PROJECT /flox_env_project;
+            set -gx MODIFIED_VAR MODIFIED_VALUE;
             set -gx QUOTED_VAR 'QUOTED'\''VALUE';
             set -e DELETED_VAR;
             set -gx _activate_d /interpreter/activate.d;
@@ -302,6 +309,23 @@ mod tests {
     fn generate_fish_profile_deactivate() {
         let output = render_deactivate();
         expect![[r#"
+            set -e ADDED_VAR;
+            set -e FLOX_ACTIVATE_START_SERVICES;
+            set -e FLOX_ENV;
+            set -e FLOX_ENV_CACHE;
+            set -e FLOX_ENV_DESCRIPTION;
+            set -e FLOX_ENV_DIRS;
+            set -e FLOX_ENV_PROJECT;
+            set -e FLOX_PROMPT_COLOR_1;
+            set -e FLOX_PROMPT_COLOR_2;
+            set -e FLOX_PROMPT_ENVIRONMENTS;
+            set -e MANPATH;
+            set -e PATH;
+            set -e QUOTED_VAR;
+            set -e _FLOX_ACTIVE_ENVIRONMENTS;
+            set -gx MODIFIED_VAR MODIFIED_ORIGINAL;
+            set -gx DELETED_VAR DELETED_ORIGINAL;
+            set -e _FLOX_HOOK_DIFF;
             if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
         "#]]
         .assert_eq(&output);

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -6,6 +6,7 @@ use flox_core::activate::context::ActivateCtx;
 const RM: &str = concat!(env!("COREUTILS"), "/bin/rm");
 
 use crate::attach_diff::AttachDiff;
+use crate::attach_diff::diff_serializer::DiffSerializer;
 use crate::gen_rc::bash::BashStartupArgs;
 use crate::gen_rc::fish::FishStartupArgs;
 use crate::gen_rc::tcsh::TcshStartupArgs;
@@ -20,7 +21,15 @@ pub mod zsh;
 #[derive(Debug, Clone)]
 pub enum Action<A> {
     Activate { args: A, attach_diff: AttachDiff },
-    Deactivate { activate_d: PathBuf },
+    Deactivate(DeactivateCtx),
+}
+
+/// Context for shell deactivation, shared across all shell flavors.
+#[derive(Debug, Clone)]
+pub struct DeactivateCtx {
+    pub activate_d: PathBuf,
+    /// Decoded from `_FLOX_HOOK_DIFF`
+    pub restore_diff: DiffSerializer,
 }
 
 #[derive(Debug, Clone)]
@@ -50,8 +59,9 @@ pub(crate) mod test_helpers {
     use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
     use shell_gen::ShellWithPath;
 
-    use super::StartupCtx;
+    use super::{DeactivateCtx, StartupCtx};
     use crate::attach::{startup_ctx, write_to_writer};
+    use crate::attach_diff::diff_serializer::DiffSerializer;
     use crate::start_diff::StartDiff;
     use crate::vars_from_env::VarsFromEnvironment;
 
@@ -101,18 +111,25 @@ pub(crate) mod test_helpers {
             flox_bin: "/flox".to_string(),
             auto_activate_fish_mode: None,
         };
+        let deleted_var = "DELETED_VAR".to_string();
+        let modified_var = "MODIFIED_VAR".to_string();
         let start_diff = StartDiff::from_parts(
             HashMap::from([
                 ("ADDED_VAR".to_string(), "ADDED_VALUE".to_string()),
+                (modified_var.clone(), "MODIFIED_VALUE".to_string()),
                 ("QUOTED_VAR".to_string(), "QUOTED'VALUE".to_string()),
             ]),
-            vec!["DELETED_VAR".to_string()],
+            vec![deleted_var.clone()],
         );
+        let full_env = HashMap::from([
+            (deleted_var.clone(), "DELETED_ORIGINAL".to_string()),
+            (modified_var.clone(), "MODIFIED_ORIGINAL".to_string()),
+        ]);
         let vars_from_env = VarsFromEnvironment {
             flox_env_dirs: None,
             path: None,
             manpath: None,
-            full_env: None,
+            full_env: Some(full_env),
         };
         let rc_path = Some(PathBuf::from("/path/to/rc/file"));
         startup_ctx(
@@ -130,6 +147,48 @@ pub(crate) mod test_helpers {
         .expect("test fixture should build")
     }
 
+    /// Build a `DeactivateCtx` for tests of `gen_rc/*`.
+    ///
+    /// Reuses the encoded `_FLOX_HOOK_DIFF` produced by `test_startup_ctx`
+    /// so the deactivate snapshot reflects exactly what activation would
+    /// have captured.
+    pub fn test_deactivate_ctx(shell: ShellWithPath, is_in_place: bool) -> DeactivateCtx {
+        let startup = test_startup_ctx(shell, is_in_place);
+        let encoded_diff = startup
+            .attach_diff
+            .encoded_diff()
+            .expect("test_startup_ctx should produce an encoded diff")
+            .to_string();
+        let restore_diff =
+            DiffSerializer::decode(&encoded_diff).expect("encoded diff should decode successfully");
+        DeactivateCtx {
+            activate_d: PathBuf::from("/interpreter/activate.d"),
+            restore_diff,
+        }
+    }
+
+    /// Strip lines referencing platform-specific or
+    /// environment-dependent variables from rendered deactivate
+    /// output.
+    pub fn strip_volatile_deactivate(output: &str) -> String {
+        const VOLATILE: &[&str] = &[
+            "LOCALE_ARCHIVE",
+            "NIX_SSL_CERT_FILE",
+            "PATH_LOCALE",
+            "SSL_CERT_FILE",
+        ];
+        let trailing_newline = output.ends_with('\n');
+        let mut filtered = output
+            .lines()
+            .filter(|l| !VOLATILE.iter().any(|v| l.contains(v)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if trailing_newline {
+            filtered.push('\n');
+        }
+        filtered
+    }
+
     /// Render `ctx` via `write_to_writer`, stripping platform specific lines
     /// and replacing /nix/store hashes
     pub fn render_normalized(ctx: &StartupCtx) -> String {
@@ -137,6 +196,7 @@ pub(crate) mod test_helpers {
         const HASH_LEN: usize = 32;
         let mut buf = Vec::new();
         write_to_writer(ctx, &mut buf).expect("write_to_writer should succeed");
+
         // flox-activations could be cargo compiled rather than a /nix/store path
         let flox_activations_bin = FLOX_ACTIVATIONS_BIN.display().to_string();
         let mut normalized =
@@ -159,12 +219,14 @@ pub(crate) mod test_helpers {
         }
 
         // Drop platform specific or environment variable dependent variables
+        // and the opaque `_FLOX_HOOK_DIFF` blob
         // TODO: should we move those to vars_from_environment?
         const VOLATILE: &[&str] = &[
             "LOCALE_ARCHIVE",
             "NIX_SSL_CERT_FILE",
             "PATH_LOCALE",
             "SSL_CERT_FILE",
+            "_FLOX_HOOK_DIFF",
         ];
         let trailing_newline = normalized.ends_with('\n');
         let mut filtered = normalized

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use shell_gen::{GenerateShell, Shell};
 
-use crate::attach_diff::{self, todo_drop_set_exported_unexpanded};
+use crate::attach_diff::todo_drop_set_exported_unexpanded;
 use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating tcsh startup commands
@@ -42,7 +42,7 @@ pub fn generate_tcsh_profile_commands(
                 stmts.push("set verbose".to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: emit `set verbose` when tracelevel >= 2
         },
     }
@@ -52,8 +52,8 @@ pub fn generate_tcsh_profile_commands(
         Action::Activate { args, attach_diff } => {
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
-        Action::Deactivate { .. } => {
-            stmts.extend(attach_diff::generate_deactivation_statements()?);
+        Action::Deactivate(ctx) => {
+            stmts.extend(ctx.restore_diff.generate_deactivation_statements());
         },
     }
 
@@ -72,7 +72,7 @@ pub fn generate_tcsh_profile_commands(
                 &args.flox_activate_tracer,
             ));
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: we shouldn't be exporting these in the first place
             // Although note that unsetting the prompt depends on these being
             // set
@@ -87,7 +87,7 @@ pub fn generate_tcsh_profile_commands(
         Action::Activate { args, .. } => args
             .set_prompt
             .then(|| args.activate_d.join("set-prompt.tcsh")),
-        Action::Deactivate { activate_d } => Some(activate_d.join("set-prompt.tcsh")),
+        Action::Deactivate(ctx) => Some(ctx.activate_d.join("set-prompt.tcsh")),
     };
     if let Some(set_prompt_path) = set_prompt_path {
         // We could consult set_prompt, but hypothetically that config value
@@ -124,7 +124,7 @@ pub fn generate_tcsh_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // No-op: covered by environment restoration above
         },
     }
@@ -147,7 +147,7 @@ pub fn generate_tcsh_profile_commands(
                 args.flox_activations.display()
             ).to_stmt());
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: run profile.deactivate.tcsh
         },
     }
@@ -160,7 +160,7 @@ pub fn generate_tcsh_profile_commands(
         Action::Activate { .. } => {
             stmts.push("unhash;".to_stmt());
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: decide whether to restore prior hashing state.
         },
     }
@@ -172,7 +172,7 @@ pub fn generate_tcsh_profile_commands(
                 stmts.push("unset verbose;".to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: unset verbose
         },
     }
@@ -186,7 +186,7 @@ pub fn generate_tcsh_profile_commands(
                 stmts.push(format!("{RM} {};", escaped_path).to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // No-op: deactivate has no rc file to remove.
         },
     }
@@ -207,7 +207,7 @@ pub fn generate_tcsh_profile_commands(
                 write!(writer, "{}", crate::hook::tcsh_hook(&args.flox_bin))?;
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: unregister the auto-activate hook
         },
     }
@@ -221,7 +221,12 @@ mod tests {
     use shell_gen::ShellWithPath;
 
     use super::*;
-    use crate::gen_rc::test_helpers::{render_normalized, test_startup_ctx};
+    use crate::gen_rc::test_helpers::{
+        render_normalized,
+        strip_volatile_deactivate,
+        test_deactivate_ctx,
+        test_startup_ctx,
+    };
 
     // NOTE: For these `expect!` tests, run unit tests with `UPDATE_EXPECT=1`
     //  to have it automatically update the expected value when the implementation
@@ -234,12 +239,12 @@ mod tests {
     }
 
     fn render_deactivate() -> String {
-        let action = Action::<TcshStartupArgs>::Deactivate {
-            activate_d: PathBuf::from("/interpreter/activate.d"),
-        };
+        let shell = ShellWithPath::Tcsh(PathBuf::from("/bin/tcsh"));
+        let action = Action::<TcshStartupArgs>::Deactivate(test_deactivate_ctx(shell, true));
         let mut buf = Vec::new();
         generate_tcsh_profile_commands(&action, &mut buf).expect("generator should succeed");
-        String::from_utf8(buf).expect("output should be utf-8")
+        let output = String::from_utf8(buf).expect("output should be utf-8");
+        strip_volatile_deactivate(&output)
     }
 
     #[test]
@@ -253,6 +258,7 @@ mod tests {
             setenv FLOX_ENV_CACHE /flox_env_cache;
             setenv FLOX_ENV_DESCRIPTION env_description;
             setenv FLOX_ENV_PROJECT /flox_env_project;
+            setenv MODIFIED_VAR MODIFIED_VALUE;
             setenv QUOTED_VAR 'QUOTED'\''VALUE';
             unsetenv DELETED_VAR;
             setenv _activate_d /interpreter/activate.d;
@@ -287,6 +293,7 @@ mod tests {
             setenv FLOX_ENV_CACHE /flox_env_cache;
             setenv FLOX_ENV_DESCRIPTION env_description;
             setenv FLOX_ENV_PROJECT /flox_env_project;
+            setenv MODIFIED_VAR MODIFIED_VALUE;
             setenv QUOTED_VAR 'QUOTED'\''VALUE';
             unsetenv DELETED_VAR;
             setenv _activate_d /interpreter/activate.d;
@@ -310,6 +317,23 @@ mod tests {
     fn generate_tcsh_profile_deactivate() {
         let output = render_deactivate();
         expect![[r#"
+            unsetenv ADDED_VAR;
+            unsetenv FLOX_ACTIVATE_START_SERVICES;
+            unsetenv FLOX_ENV;
+            unsetenv FLOX_ENV_CACHE;
+            unsetenv FLOX_ENV_DESCRIPTION;
+            unsetenv FLOX_ENV_DIRS;
+            unsetenv FLOX_ENV_PROJECT;
+            unsetenv FLOX_PROMPT_COLOR_1;
+            unsetenv FLOX_PROMPT_COLOR_2;
+            unsetenv FLOX_PROMPT_ENVIRONMENTS;
+            unsetenv MANPATH;
+            unsetenv PATH;
+            unsetenv QUOTED_VAR;
+            unsetenv _FLOX_ACTIVE_ENVIRONMENTS;
+            setenv MODIFIED_VAR MODIFIED_ORIGINAL;
+            setenv DELETED_VAR DELETED_ORIGINAL;
+            unsetenv _FLOX_HOOK_DIFF;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
         "#]]
         .assert_eq(&output);

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -53,7 +53,7 @@ pub fn generate_tcsh_profile_commands(
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
         Action::Deactivate { .. } => {
-            stmts.extend(attach_diff::generate_deactivation_statements());
+            stmts.extend(attach_diff::generate_deactivation_statements()?);
         },
     }
 

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded, source_file};
 
-use crate::attach_diff;
 use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating zsh startup commands
@@ -38,7 +37,7 @@ pub fn generate_zsh_profile_commands(
                 args.activate_d.display().to_string(),
             ));
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: we might not need to set these in the first place
         },
     }
@@ -48,8 +47,8 @@ pub fn generate_zsh_profile_commands(
         Action::Activate { args, attach_diff } => {
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
-        Action::Deactivate { .. } => {
-            stmts.extend(attach_diff::generate_deactivation_statements()?);
+        Action::Deactivate(ctx) => {
+            stmts.extend(ctx.restore_diff.generate_deactivation_statements());
         },
     }
 
@@ -58,7 +57,7 @@ pub fn generate_zsh_profile_commands(
         Action::Activate { args, .. } => {
             stmts.push(source_file(args.activate_d.join("zsh")));
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: undo everything in activate_d/zsh
             // Although note that unsetting the prompt depends on these being
             // set
@@ -73,7 +72,7 @@ pub fn generate_zsh_profile_commands(
         Action::Activate { args, .. } => args
             .set_prompt
             .then(|| args.activate_d.join("set-prompt.zsh")),
-        Action::Deactivate { activate_d } => Some(activate_d.join("set-prompt.zsh")),
+        Action::Deactivate(ctx) => Some(ctx.activate_d.join("set-prompt.zsh")),
     };
     if let Some(set_prompt_path) = set_prompt_path {
         // We could consult set_prompt, but hypothetically that config value
@@ -97,7 +96,7 @@ pub fn generate_zsh_profile_commands(
                 stmts.push(format!("{RM} {};", escaped_path).to_stmt());
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // No-op: deactivate has no rc file to remove.
         },
     }
@@ -121,7 +120,7 @@ pub fn generate_zsh_profile_commands(
                 write!(writer, "{}", crate::hook::zsh_hook(&args.flox_bin))?;
             }
         },
-        Action::Deactivate { .. } => {
+        Action::Deactivate(_) => {
             // TODO: unregister the auto-activate hook
         },
     }
@@ -135,7 +134,12 @@ mod tests {
     use shell_gen::ShellWithPath;
 
     use super::*;
-    use crate::gen_rc::test_helpers::{render_normalized, test_startup_ctx};
+    use crate::gen_rc::test_helpers::{
+        render_normalized,
+        strip_volatile_deactivate,
+        test_deactivate_ctx,
+        test_startup_ctx,
+    };
 
     // NOTE: For these `expect!` tests, run unit tests with `UPDATE_EXPECT=1`
     //  to have it automatically update the expected value when the implementation
@@ -148,12 +152,12 @@ mod tests {
     }
 
     fn render_deactivate() -> String {
-        let action = Action::<ZshStartupArgs>::Deactivate {
-            activate_d: PathBuf::from("/interpreter/activate.d"),
-        };
+        let shell = ShellWithPath::Zsh(PathBuf::from("/bin/zsh"));
+        let action = Action::<ZshStartupArgs>::Deactivate(test_deactivate_ctx(shell, true));
         let mut buf = Vec::new();
         generate_zsh_profile_commands(&action, &mut buf).expect("generator should succeed");
-        String::from_utf8(buf).expect("output should be utf-8")
+        let output = String::from_utf8(buf).expect("output should be utf-8");
+        strip_volatile_deactivate(&output)
     }
 
     #[test]
@@ -168,6 +172,7 @@ mod tests {
             export FLOX_ENV_CACHE=/flox_env_cache;
             export FLOX_ENV_DESCRIPTION=env_description;
             export FLOX_ENV_PROJECT=/flox_env_project;
+            export MODIFIED_VAR=MODIFIED_VALUE;
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             source /interpreter/activate.d/zsh;
@@ -193,6 +198,7 @@ mod tests {
             export FLOX_ENV_CACHE=/flox_env_cache;
             export FLOX_ENV_DESCRIPTION=env_description;
             export FLOX_ENV_PROJECT=/flox_env_project;
+            export MODIFIED_VAR=MODIFIED_VALUE;
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             source /interpreter/activate.d/zsh;
@@ -206,6 +212,23 @@ mod tests {
     fn generate_zsh_profile_commands_deactivate() {
         let output = render_deactivate();
         expect![[r#"
+            unset ADDED_VAR;
+            unset FLOX_ACTIVATE_START_SERVICES;
+            unset FLOX_ENV;
+            unset FLOX_ENV_CACHE;
+            unset FLOX_ENV_DESCRIPTION;
+            unset FLOX_ENV_DIRS;
+            unset FLOX_ENV_PROJECT;
+            unset FLOX_PROMPT_COLOR_1;
+            unset FLOX_PROMPT_COLOR_2;
+            unset FLOX_PROMPT_ENVIRONMENTS;
+            unset MANPATH;
+            unset PATH;
+            unset QUOTED_VAR;
+            unset _FLOX_ACTIVE_ENVIRONMENTS;
+            export MODIFIED_VAR=MODIFIED_ORIGINAL;
+            export DELETED_VAR=DELETED_ORIGINAL;
+            unset _FLOX_HOOK_DIFF;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
         "#]]
         .assert_eq(&output);

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -49,7 +49,7 @@ pub fn generate_zsh_profile_commands(
             stmts.extend(attach_diff.generate_statements(args.invocation_type.is_in_place()));
         },
         Action::Deactivate { .. } => {
-            stmts.extend(attach_diff::generate_deactivation_statements());
+            stmts.extend(attach_diff::generate_deactivation_statements()?);
         },
     }
 

--- a/cli/flox-activations/src/lib.rs
+++ b/cli/flox-activations/src/lib.rs
@@ -2,7 +2,6 @@ pub mod attach;
 pub mod attach_diff;
 pub mod cli;
 pub mod deactivate;
-pub mod diff_serializer;
 pub mod env_diff;
 pub mod gen_rc;
 pub mod hook;

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -2,7 +2,6 @@ use std::io::{BufWriter, stdout};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::LazyLock;
 use std::{env, fs};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -39,7 +38,6 @@ use flox_rust_sdk::providers::services::process_compose::{PROCESS_COMPOSE_BIN, P
 use flox_rust_sdk::providers::upgrade_checks::UpgradeInformationGuard;
 use flox_rust_sdk::utils::FLOX_INTERPRETER;
 use indoc::{formatdoc, indoc};
-use shell_gen::ShellWithPath;
 use tracing::{debug, trace, warn};
 
 use super::{
@@ -61,16 +59,10 @@ use crate::commands::{
     uninitialized_environment_description,
 };
 use crate::config::{AutoActivationPreference, Config, EnvironmentPromptConfig};
+use crate::utils::detect_shell::{detect_shell_for_in_place, detect_shell_for_subshell};
 use crate::utils::errors::format_diverged_metadata;
 use crate::utils::message;
-use crate::utils::openers::CliShellExt;
 use crate::{Exit, environment_subcommand_metric, subcommand_metric, utils};
-
-pub static INTERACTIVE_BASH_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
-    PathBuf::from(
-        env::var("INTERACTIVE_BASH_BIN").unwrap_or(env!("INTERACTIVE_BASH_BIN").to_string()),
-    )
-});
 
 #[derive(Debug, Clone, Bpaf)]
 pub enum CommandSelect {
@@ -508,9 +500,9 @@ impl ActivateOptions {
         );
 
         let shell = if invocation_type == InvocationType::InPlace {
-            Self::detect_shell_for_in_place()?
+            detect_shell_for_in_place()?
         } else {
-            Self::detect_shell_for_subshell()
+            detect_shell_for_subshell()
         };
         subcommand_metric!("activate", "shell" = shell.to_string());
 
@@ -603,43 +595,6 @@ impl ActivateOptions {
         }
     }
 
-    /// Detect the shell to use for activation
-    ///
-    /// Used to determine shell for
-    /// `flox activate` and `flox activate -- CMD`
-    ///
-    /// Returns the first shell found in the following order:
-    /// 1. FLOX_SHELL environment variable
-    /// 2. SHELL environment variable
-    /// 3. Parent process shell
-    /// 4. Default to bash bundled with flox
-    fn detect_shell_for_subshell() -> ShellWithPath {
-        Self::detect_shell_for_subshell_with(ShellWithPath::detect_from_parent_process)
-    }
-
-    /// Utility method for testing implementing the logic of shell detection
-    /// for subshells, generically over a parent shell detection function.
-    fn detect_shell_for_subshell_with(
-        parent_shell_fn: impl Fn() -> Result<ShellWithPath>,
-    ) -> ShellWithPath {
-        ShellWithPath::detect_from_env("FLOX_SHELL")
-            .or_else(|err| {
-                debug!("Failed to detect shell from FLOX_SHELL: {err}");
-                ShellWithPath::detect_from_env("SHELL")
-            })
-            .or_else(|err| {
-                debug!("Failed to detect shell from SHELL: {err}");
-                parent_shell_fn()
-            })
-            .unwrap_or_else(|err| {
-                debug!("Failed to detect shell from parent process: {err}");
-                warn!(
-                    "Failed to detect shell from environment or parent process. Defaulting to bash"
-                );
-                ShellWithPath::Bash(INTERACTIVE_BASH_BIN.clone())
-            })
-    }
-
     /// Determine which services to start on activation.
     ///
     /// Services are started when `--start-services` is set or when the manifest
@@ -697,28 +652,6 @@ impl ActivateOptions {
         }
 
         services_for_system.inner().keys().cloned().collect()
-    }
-
-    /// Detect the shell to use for in-place activation
-    ///
-    /// Used to determine shell for `eval "$(flox activate)"`,
-    /// `flox activate --print-script`, and
-    /// when adding activation of a default environment to RC files.
-    pub(crate) fn detect_shell_for_in_place() -> Result<ShellWithPath> {
-        Self::detect_shell_for_in_place_with(ShellWithPath::detect_from_parent_process)
-    }
-
-    /// Utility method for testing implementing the logic of shell detection
-    /// for in-place activation, generically over a parent shell detection function.
-    fn detect_shell_for_in_place_with(
-        parent_shell_fn: impl Fn() -> Result<ShellWithPath>,
-    ) -> Result<ShellWithPath> {
-        ShellWithPath::detect_from_env("FLOX_SHELL")
-            .or_else(|_| parent_shell_fn())
-            .or_else(|err| {
-                warn!("Failed to detect shell from environment: {err}");
-                ShellWithPath::detect_from_env("SHELL")
-            })
     }
 
     /// Construct the environment list for the shell prompt
@@ -990,69 +923,6 @@ mod tests {
             pointer: EnvironmentPointer::Path(PathPointer::new("wichtig".parse().unwrap())),
         })
     });
-
-    const SHELL_SET: (&'_ str, Option<&'_ str>) = ("SHELL", Some("/shell/bash"));
-    const FLOX_SHELL_SET: (&'_ str, Option<&'_ str>) = ("FLOX_SHELL", Some("/flox_shell/bash"));
-    const SHELL_UNSET: (&'_ str, Option<&'_ str>) = ("SHELL", None);
-    const FLOX_SHELL_UNSET: (&'_ str, Option<&'_ str>) = ("FLOX_SHELL", None);
-    const PARENT_DETECTED: &dyn Fn() -> Result<ShellWithPath> =
-        &|| Ok(ShellWithPath::Bash("/parent/bash".into()));
-    const PARENT_UNDETECTED: &dyn Fn() -> Result<ShellWithPath> =
-        &|| Err(anyhow::anyhow!("parent shell detection failed"));
-
-    #[test]
-    fn test_detect_shell_for_subshell() {
-        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_SET], || {
-            let shell = ActivateOptions::detect_shell_for_subshell_with(|| unreachable!());
-            assert_eq!(shell, ShellWithPath::Bash("/shell/bash".into()));
-        });
-
-        temp_env::with_vars([FLOX_SHELL_SET, SHELL_SET], || {
-            let shell = ActivateOptions::detect_shell_for_subshell_with(|| unreachable!());
-            assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
-        });
-
-        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
-            let shell = ActivateOptions::detect_shell_for_subshell_with(PARENT_DETECTED);
-            assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
-        });
-
-        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
-            let shell = ActivateOptions::detect_shell_for_subshell_with(PARENT_UNDETECTED);
-            assert_eq!(shell, ShellWithPath::Bash(INTERACTIVE_BASH_BIN.clone()));
-        });
-    }
-
-    #[test]
-    fn test_detect_shell_for_in_place() {
-        // $SHELL is used as a fallback only if parent detection fails
-        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_SET], || {
-            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
-            assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
-
-            // fall back to $SHELL if parent detection fails
-            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_UNDETECTED).unwrap();
-            assert_eq!(shell, ShellWithPath::Bash("/shell/bash".into()));
-        });
-
-        // $FLOX_SHELL takes precedence over $SHELL and detected parent shell
-        temp_env::with_vars([FLOX_SHELL_SET, SHELL_SET], || {
-            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
-            assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
-
-            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_UNDETECTED).unwrap();
-            assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
-        });
-
-        // if both $FLOX_SHELL and $SHELL are unset, we should fail iff parent detection fails
-        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
-            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
-            assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
-
-            let shell = ActivateOptions::detect_shell_for_in_place_with(PARENT_UNDETECTED);
-            assert!(shell.is_err());
-        });
-    }
 
     #[test]
     fn test_shell_prompt_empty_without_active_environments() {

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -7,8 +7,8 @@ use flox_rust_sdk::utils::FLOX_INTERPRETER;
 use indoc::{formatdoc, indoc};
 
 use super::{activated_environments, uninitialized_environment_description};
-use crate::commands::activate::ActivateOptions;
 use crate::subcommand_metric;
+use crate::utils::detect_shell::detect_shell_for_in_place;
 use crate::utils::message;
 
 #[derive(Bpaf, Clone)]
@@ -27,9 +27,7 @@ impl Deactivate {
         subcommand_metric!("deactivate");
 
         if self.print_script {
-            // TODO: might make sense to move detect_shell_for_in_place
-            // off ActivateOptions
-            let shell = ActivateOptions::detect_shell_for_in_place()?;
+            let shell = detect_shell_for_in_place()?;
 
             // Generate and print the deactivation script
             let mut writer = BufWriter::new(stdout());

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -49,13 +49,13 @@ use tracing::{debug, info_span, instrument, span, warn};
 
 use super::services::warn_manifest_changes_for_services;
 use super::{EnvironmentSelect, environment_select};
-use crate::commands::activate::ActivateOptions;
 use crate::commands::{
     ConcreteEnvironment,
     EnvironmentSelectError,
     ensure_auth,
     environment_description,
 };
+use crate::utils::detect_shell::detect_shell_for_in_place;
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::didyoumean::{DidYouMean, InstallSuggestion};
 use crate::utils::errors::format_error;
@@ -671,7 +671,7 @@ fn package_list_for_prompt(packages: &[PackageToInstall]) -> Option<String> {
 }
 
 fn prompt_to_modify_rc_file() -> Result<bool, anyhow::Error> {
-    let shell = ActivateOptions::detect_shell_for_in_place()?;
+    let shell = detect_shell_for_in_place()?;
     let shell_cmd = match shell {
         // TODO: should we use source <(flox activate --default) for bash?
         // There are unicode quoting issues with the current form

--- a/cli/flox/src/utils/detect_shell.rs
+++ b/cli/flox/src/utils/detect_shell.rs
@@ -1,0 +1,140 @@
+use std::env;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use anyhow::Result;
+use shell_gen::ShellWithPath;
+use tracing::{debug, warn};
+
+use crate::utils::openers::CliShellExt;
+
+pub static INTERACTIVE_BASH_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
+    PathBuf::from(
+        env::var("INTERACTIVE_BASH_BIN").unwrap_or(env!("INTERACTIVE_BASH_BIN").to_string()),
+    )
+});
+
+/// Detect the shell to use for activation
+///
+/// Used to determine shell for
+/// `flox activate` and `flox activate -- CMD`
+///
+/// Returns the first shell found in the following order:
+/// 1. FLOX_SHELL environment variable
+/// 2. SHELL environment variable
+/// 3. Parent process shell
+/// 4. Default to bash bundled with flox
+pub(crate) fn detect_shell_for_subshell() -> ShellWithPath {
+    detect_shell_for_subshell_with(ShellWithPath::detect_from_parent_process)
+}
+
+/// Utility method for testing implementing the logic of shell detection
+/// for subshells, generically over a parent shell detection function.
+fn detect_shell_for_subshell_with(
+    parent_shell_fn: impl Fn() -> Result<ShellWithPath>,
+) -> ShellWithPath {
+    ShellWithPath::detect_from_env("FLOX_SHELL")
+        .or_else(|err| {
+            debug!("Failed to detect shell from FLOX_SHELL: {err}");
+            ShellWithPath::detect_from_env("SHELL")
+        })
+        .or_else(|err| {
+            debug!("Failed to detect shell from SHELL: {err}");
+            parent_shell_fn()
+        })
+        .unwrap_or_else(|err| {
+            debug!("Failed to detect shell from parent process: {err}");
+            warn!("Failed to detect shell from environment or parent process. Defaulting to bash");
+            ShellWithPath::Bash(INTERACTIVE_BASH_BIN.clone())
+        })
+}
+
+/// Detect the shell to use for in-place activation
+///
+/// Used to determine shell for `eval "$(flox activate)"`,
+/// `flox activate --print-script`, and
+/// when adding activation of a default environment to RC files.
+pub(crate) fn detect_shell_for_in_place() -> Result<ShellWithPath> {
+    detect_shell_for_in_place_with(ShellWithPath::detect_from_parent_process)
+}
+
+/// Utility method for testing implementing the logic of shell detection
+/// for in-place activation, generically over a parent shell detection function.
+fn detect_shell_for_in_place_with(
+    parent_shell_fn: impl Fn() -> Result<ShellWithPath>,
+) -> Result<ShellWithPath> {
+    ShellWithPath::detect_from_env("FLOX_SHELL")
+        .or_else(|_| parent_shell_fn())
+        .or_else(|err| {
+            warn!("Failed to detect shell from environment: {err}");
+            ShellWithPath::detect_from_env("SHELL")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SHELL_SET: (&'_ str, Option<&'_ str>) = ("SHELL", Some("/shell/bash"));
+    const FLOX_SHELL_SET: (&'_ str, Option<&'_ str>) = ("FLOX_SHELL", Some("/flox_shell/bash"));
+    const SHELL_UNSET: (&'_ str, Option<&'_ str>) = ("SHELL", None);
+    const FLOX_SHELL_UNSET: (&'_ str, Option<&'_ str>) = ("FLOX_SHELL", None);
+    const PARENT_DETECTED: &dyn Fn() -> Result<ShellWithPath> =
+        &|| Ok(ShellWithPath::Bash("/parent/bash".into()));
+    const PARENT_UNDETECTED: &dyn Fn() -> Result<ShellWithPath> =
+        &|| Err(anyhow::anyhow!("parent shell detection failed"));
+
+    #[test]
+    fn detect_shell_for_subshell() {
+        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_SET], || {
+            let shell = detect_shell_for_subshell_with(|| unreachable!());
+            assert_eq!(shell, ShellWithPath::Bash("/shell/bash".into()));
+        });
+
+        temp_env::with_vars([FLOX_SHELL_SET, SHELL_SET], || {
+            let shell = detect_shell_for_subshell_with(|| unreachable!());
+            assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
+        });
+
+        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
+            let shell = detect_shell_for_subshell_with(PARENT_DETECTED);
+            assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
+        });
+
+        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
+            let shell = detect_shell_for_subshell_with(PARENT_UNDETECTED);
+            assert_eq!(shell, ShellWithPath::Bash(INTERACTIVE_BASH_BIN.clone()));
+        });
+    }
+
+    #[test]
+    fn detect_shell_for_in_place() {
+        // $SHELL is used as a fallback only if parent detection fails
+        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_SET], || {
+            let shell = detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
+            assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
+
+            // fall back to $SHELL if parent detection fails
+            let shell = detect_shell_for_in_place_with(PARENT_UNDETECTED).unwrap();
+            assert_eq!(shell, ShellWithPath::Bash("/shell/bash".into()));
+        });
+
+        // $FLOX_SHELL takes precedence over $SHELL and detected parent shell
+        temp_env::with_vars([FLOX_SHELL_SET, SHELL_SET], || {
+            let shell = detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
+            assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
+
+            let shell = detect_shell_for_in_place_with(PARENT_UNDETECTED).unwrap();
+            assert_eq!(shell, ShellWithPath::Bash("/flox_shell/bash".into()));
+        });
+
+        // if both $FLOX_SHELL and $SHELL are unset, we should fail iff parent detection fails
+        temp_env::with_vars([FLOX_SHELL_UNSET, SHELL_UNSET], || {
+            let shell = detect_shell_for_in_place_with(PARENT_DETECTED).unwrap();
+            assert_eq!(shell, ShellWithPath::Bash("/parent/bash".into()));
+
+            let shell = detect_shell_for_in_place_with(PARENT_UNDETECTED);
+            assert!(shell.is_err());
+        });
+    }
+}

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -7,6 +7,7 @@ use flox_core::util::default_nix_env_vars;
 
 pub mod active_environments;
 pub mod colors;
+pub mod detect_shell;
 pub mod dialog;
 pub mod didyoumean;
 pub mod errors;


### PR DESCRIPTION
- **fix: minor deactivate cleanups**
  - Don't convert ShellWithPath -> Shell for no reason
  - Add error handling to generate_deactivation_statements
  

- **fix: move shell detection logic to util**
  This is now used by both activate and deactivate, so move it off
  ActivateOptions into util

-  **refactor(deactivate): introduce DeactivateCtx**

    We're going to need to pass a few things into the gen_rc functions, so
    collect them in one DeactivateCtx struct.

    Move the decoded DiffSerializer onto DeactivateCtx because it makes
    sense to error early and for the inner unit testable functions to
    operate on human readable data.

    Update the deactivate tests to use a more realistic DeactivateCtx so
    those tests provide some more value.
  