### PR TITLE
fix(publish): build from git clone --shared instead of Nix store copy

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -8,7 +8,7 @@ use flox_catalog::BaseCatalogUrl;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::lockfile::Lockfile;
 use flox_manifest::parsed::Inner;
-use flox_manifest::parsed::common::DEFAULT_GROUP_NAME;
+use flox_manifest::parsed::common::{BuildSandbox, DEFAULT_GROUP_NAME};
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -626,19 +626,19 @@ pub struct ExpressionBuildMetadata {
 }
 
 /// The kind of a package target,
-/// i.e. whether a pacakge is sourced from the manifest or a nix expression.
+/// i.e. whether a package is sourced from the manifest or a nix expression.
 ///
-/// While not relevant to the build itself,
-/// publishing pacakges may differ depending on the kind.
-/// For example [super::publish::check_package_metadata]
-/// needs to infer the base catalog url
-/// from the installed packages in the  top-level group
-/// for manifest builds, while expression builds
-/// are assigned their base nixpkgs url in coordination with the catalog API
+/// The kind is used during publishing: [super::publish::check_package_metadata]
+/// needs to infer the base catalog url from the installed packages in the
+/// top-level group for manifest builds, while expression builds are assigned
+/// their base nixpkgs url in coordination with the catalog API.
+/// The sandbox mode stored on [PackageTargetKind::ManifestBuild] additionally
+/// controls whether [super::publish::check_build_metadata] runs the build in
+/// an ephemeral clone or the original checkout.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PackageTargetKind {
     ExpressionBuild(ExpressionBuildMetadata),
-    ManifestBuild,
+    ManifestBuild { sandbox: Option<BuildSandbox> },
 }
 
 impl PackageTargetKind {
@@ -647,7 +647,7 @@ impl PackageTargetKind {
     }
 
     pub fn is_manifest_build(&self) -> bool {
-        matches!(self, PackageTargetKind::ManifestBuild)
+        matches!(self, PackageTargetKind::ManifestBuild { .. })
     }
 }
 
@@ -729,8 +729,12 @@ impl PackageTargets {
         targets.extend(
             environment_packages
                 .inner()
-                .keys()
-                .map(|name| (name.to_string(), PackageTargetKind::ManifestBuild)),
+                .iter()
+                .map(|(name, descriptor)| {
+                    (name.to_string(), PackageTargetKind::ManifestBuild {
+                        sandbox: descriptor.sandbox.clone(),
+                    })
+                }),
         );
 
         for (expression_build_target, expression_build_metadata) in nix_expression_packages {

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -581,6 +581,56 @@ impl GitCommandProvider {
         })
     }
 
+    /// Clone a local repository into `dest` using `--shared` and check out `rev`.
+    ///
+    /// `--shared` means the clone's object store is backed by `source` via a
+    /// `.git/objects/info/alternates` reference rather than copying or
+    /// hardlinking objects.  This has two advantages over a plain local clone:
+    ///
+    /// * It is fast and space-efficient regardless of whether `source` and
+    ///   `dest` are on the same filesystem (a plain clone falls back to
+    ///   copying all objects when they are not).
+    /// * Build scripts get full access to history, tags, `git describe`, and
+    ///   `git ls-files` because all objects are reachable through the
+    ///   alternates pointer.
+    ///
+    /// The alternates pointer is safe here because this clone is only used
+    /// for `sandbox = "off"` manifest builds, where Nix does not apply
+    /// filesystem namespace isolation.  The build process therefore has
+    /// unrestricted access to the host filesystem and can always follow the
+    /// alternates path back to `source`.  (For `sandbox = "pure"` builds a
+    /// `git+file://` flake ref is used instead so that Nix can import the
+    /// source into the store before applying its sandbox.)
+    pub fn clone_shared_rev(
+        source: impl AsRef<Path>,
+        dest: impl AsRef<Path>,
+        rev: &str,
+    ) -> Result<Self, GitCommandError> {
+        let options = GitCommandOptions::default();
+
+        let mut clone_cmd = options.new_command();
+        clone_cmd
+            .arg("clone")
+            .arg("--quiet")
+            .arg("--shared")
+            .arg("--no-checkout")
+            .arg(source.as_ref())
+            .arg(dest.as_ref());
+        GitCommandProvider::run_command(&mut clone_cmd)?;
+
+        let clone = GitCommandProvider {
+            options,
+            workdir: Some(dest.as_ref().to_path_buf()),
+            path: dest.as_ref().to_path_buf(),
+        };
+
+        let mut checkout_cmd = clone.new_command();
+        checkout_cmd.arg("checkout").arg("--quiet").arg(rev);
+        GitCommandProvider::run_command(&mut checkout_cmd)?;
+
+        Ok(clone)
+    }
+
     /// Clone a branch from a remote repository using default options
     pub fn clone_branch(
         origin: impl AsRef<OsStr>,

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -21,13 +21,12 @@ use flox_catalog::{
     UserDerivationInfo,
 };
 use flox_manifest::lockfile::Lockfile;
+use flox_manifest::parsed::common::BuildSandbox;
 use git_url_parse::GitUrl;
 use indexmap::IndexSet;
 use indoc::{formatdoc, indoc};
 use itertools::Itertools;
-use nef_lock_catalog::LockOptions;
-use nef_lock_catalog::lock::{NixFlakeref, lock_url_with_options};
-use serde_json::json;
+use nef_lock_catalog::lock::NixFlakeref;
 use thiserror::Error;
 use tracing::{debug, instrument};
 use url::Url;
@@ -42,11 +41,12 @@ use super::build::{
     PackageTargetKind,
     find_toplevel_group_nixpkgs,
 };
+use super::buildenv::BuildEnvOutputs;
 use super::git::{GitCommandError, GitCommandGetOriginError, GitCommandProvider, StatusInfo};
 use super::nix_auth::{AuthError, AuthProvider, CatalogAuth, NixCopyAuth};
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
-use crate::models::environment::{Environment, EnvironmentError, copy_dir_recursive, open_path};
+use crate::models::environment::{Environment, EnvironmentError, open_path};
 use crate::providers::git::GitProvider;
 use crate::providers::nix::nix_base_command;
 use crate::providers::nix_auth::catalog_auth_to_envs;
@@ -179,23 +179,6 @@ pub struct CheckedEnvironmentMetadata {
     // This field isn't "pub", so no one outside this module can construct this struct. That helps
     // ensure that we can only make this struct as a result of doing the "right thing."
     _private: (),
-}
-
-impl CheckedEnvironmentMetadata {
-    /// Create a canonical flakeref for NEF builds from the metadata collected for the git remote.
-    fn remote_flakeref(&self) -> Result<NixFlakeref, PublishError> {
-        let value = json! ({
-          "type": "git",
-          "url": self.build_repo_meta.url.as_str(),
-          "rev": self.build_repo_meta.rev,
-          "dir": self.rel_expression_build_base_dir.to_string_lossy()
-        });
-        NixFlakeref::try_from(value.clone()).map_err(|e| {
-            PublishError::Catchall(format!(
-                "internal constructed flakeref should be valid.\nvalue: {value}\nerror: {e}"
-            ))
-        })
-    }
 }
 
 /// Ensures that the required metadata for publishing is consistent from the build process
@@ -696,7 +679,7 @@ where
             narinfos_source_version: None,
             build_type: match self.package_metadata.package.kind() {
                 PackageTargetKind::ExpressionBuild(_) => BuildType::Nef,
-                PackageTargetKind::ManifestBuild => BuildType::Manifest,
+                PackageTargetKind::ManifestBuild { .. } => BuildType::Manifest,
             }
             .into(),
             dot_flox_dir: self
@@ -881,11 +864,26 @@ fn convert_build_result_to_build_metadata(
     })
 }
 
-/// Collect metadata needed for publishing that is obtained from the build output
+/// Collect metadata needed for publishing that is obtained from the build output.
 ///
 /// Notably, [CheckedBuildMetadata] obtained from this function testifies:
-/// * That the remote source is accessible
 /// * That the package can be built
+///
+/// A `git+file://` flake ref pinned to the committed revision is always used as
+/// the Nix source reference.  Nix's git fetcher imports only the files returned
+/// by `git ls-files` — never the `.git` directory — so source copies in the
+/// store never contain git metadata.
+///
+/// The build working directory differs by sandbox mode:
+///
+/// * `sandbox = "off"` (or unset): an ephemeral `git clone --shared` provides
+///   a clean working tree (only tracked files, no extraneous workspace state).
+///   `--shared` is safe here because `sandbox = "off"` builds run without Nix
+///   filesystem namespace isolation, so the alternates pointer back to the
+///   source repository is always reachable.
+///
+/// * `sandbox = "pure"` or any expression build: the original local checkout is
+///   used as the build working directory.
 pub fn check_build_metadata(
     flox: &Flox,
     base_nixpkgs_url: &BaseCatalogUrl,
@@ -893,45 +891,15 @@ pub fn check_build_metadata(
     env_metadata: &CheckedEnvironmentMetadata,
     pkg: &PackageTarget,
 ) -> Result<CheckedBuildMetadata, PublishError> {
-    // Fetch remote sources based on the source info collected in `CheckedEnvironmentMetadata`.
-    // This serves several purposes:
-    // 1. It ensures that the source info we have is indeed valid and accessible
-    // 2. It provides a guaranteed clean checkout that is consistent
-    //    with reproduction/catalog import.
-    // 3. It reduces coupling of publish to _the_ local repo
-    let expression_ref = env_metadata.remote_flakeref()?;
-    let expression_ref_fetched = lock_url_with_options(&expression_ref, &LockOptions::default())
-        .map_err(|e| PublishError::Catchall(e.to_string()))?;
-    let expression_ref_locked = expression_ref_fetched.locked_flakeref();
-
-    // git clone into a temp directory
-    let clean_repo_path = tempfile::tempdir_in(&flox.temp_dir)
-        .map_err(|err| PublishError::Catchall(format!("could not create tempdir: {err}")))?
-        .keep();
-
-    // base dir and buildtime environments **for manifest builds**
-    // both are inferred from the fetched source,
-    // based on relative directories of the local environment.
-    // Similar assumptions are made by the NEF at  eval time.
-    let (base_dir, built_environments) = {
-        copy_dir_recursive(expression_ref_fetched.store_path(), &clean_repo_path, false)
-            .map_err(|e| PublishError::Catchall(e.to_string()))?;
-        let project_path =
-            CanonicalPath::new(clean_repo_path.join(env_metadata.rel_project_path.as_path()))
-                .map_err(|_err| {
-                    PublishError::UnsupportedEnvironmentState(
-                    "Flox project not found in clean checkout, is it tracked in the repository?"
-                        .to_string(),
-                )
-                })?;
-        let mut clean_build_env = open_path(flox, &project_path, None)
-            .map_err(|e| PublishError::UnsupportedEnvironmentState(e.to_string()))?;
-        (clean_build_env.parent_path()?, clean_build_env.build(flox)?)
+    let workdir = if sandbox_is_off(pkg) {
+        BuildWorkdir::SharedClone
+    } else {
+        BuildWorkdir::OriginalCheckout
     };
+    let (expression_ref, base_dir, built_environments) = build_source(flox, env_metadata, workdir)?;
 
-    let builder = FloxBuildMk::new(flox, &base_dir, &expression_ref_locked, &built_environments);
+    let builder = FloxBuildMk::new(flox, &base_dir, &expression_ref, &built_environments);
 
-    // Build the package and collect the outputs
     let build_results = builder.build(
         &base_nixpkgs_url.as_flake_ref()?,
         &built_environments.develop,
@@ -945,8 +913,99 @@ pub fn check_build_metadata(
             "No results returned from build command.".to_string(),
         ));
     }
-    let build_result = &build_results[0];
-    convert_build_result_to_build_metadata(build_result)
+    convert_build_result_to_build_metadata(&build_results[0])
+}
+
+/// Returns `true` when `pkg` is a manifest build whose sandbox mode is `off`
+/// (or unset, which defaults to off).
+fn sandbox_is_off(pkg: &PackageTarget) -> bool {
+    matches!(pkg.kind(), PackageTargetKind::ManifestBuild {
+        sandbox: None | Some(BuildSandbox::Off)
+    })
+}
+
+/// Whether the manifest build working directory should be an ephemeral shared
+/// clone or the original local checkout.
+#[derive(Debug, Clone)]
+enum BuildWorkdir {
+    /// `sandbox = "off"` (or unset): clone the repo so the build runs in a
+    /// clean working tree free of extraneous files.  `--shared` is safe here
+    /// because sandbox-off builds run without Nix filesystem namespace
+    /// isolation, so the alternates pointer back to the source repository is
+    /// always reachable.
+    SharedClone,
+    /// `sandbox = "pure"` or any expression build: use the original checkout
+    /// directly.  Nix's git fetcher (driven by the `git+file://` expression
+    /// ref) handles source isolation.
+    OriginalCheckout,
+}
+
+/// Set up the build source for manifest and expression builds.
+///
+/// Constructs a `git+file://` flake ref pinned to the committed revision for
+/// use as the Nix source reference in all cases.  Nix's git fetcher imports
+/// only the files returned by `git ls-files` — never the `.git` directory —
+/// so a source copy in the store never contains git metadata.
+///
+/// The build working directory differs by `workdir`:
+/// * [`BuildWorkdir::SharedClone`]: an ephemeral `git clone --shared` of the
+///   repository at the target revision provides a clean working tree.
+/// * [`BuildWorkdir::OriginalCheckout`]: the original local checkout is used
+///   directly; Nix's sandbox handles source isolation for expression builds
+///   and `sandbox = "pure"` manifest builds.
+fn build_source(
+    flox: &Flox,
+    env_metadata: &CheckedEnvironmentMetadata,
+    workdir: BuildWorkdir,
+) -> Result<(NixFlakeref, PathBuf, BuildEnvOutputs), PublishError> {
+    let dir = (!env_metadata
+        .rel_expression_build_base_dir
+        .as_os_str()
+        .is_empty())
+    .then_some(env_metadata.rel_expression_build_base_dir.as_path());
+
+    let expression_ref = NixFlakeref::from_local_git(
+        &env_metadata.repo_root_path,
+        &env_metadata.build_repo_meta.rev,
+        dir,
+    )
+    .map_err(|e| PublishError::Catchall(e.to_string()))?;
+
+    let project_root = match workdir {
+        BuildWorkdir::SharedClone => {
+            let repo_name = env_metadata.repo_root_path.file_name().ok_or_else(|| {
+                PublishError::Catchall("repo root path has no directory name".to_string())
+            })?;
+            let parent = tempfile::tempdir_in(&flox.temp_dir)
+                .map_err(|err| PublishError::Catchall(format!("could not create tempdir: {err}")))?
+                .keep();
+            let clone_dir = parent.join(repo_name);
+            GitCommandProvider::clone_shared_rev(
+                &env_metadata.repo_root_path,
+                &clone_dir,
+                &env_metadata.build_repo_meta.rev,
+            )?;
+            clone_dir
+        },
+        BuildWorkdir::OriginalCheckout => env_metadata.repo_root_path.clone(),
+    };
+
+    let not_found_msg = match workdir {
+        BuildWorkdir::SharedClone => {
+            "Flox project not found in clean checkout, is it tracked in the repository?"
+        },
+        BuildWorkdir::OriginalCheckout => "Flox project not found in repository.",
+    };
+    let project_path =
+        CanonicalPath::new(project_root.join(env_metadata.rel_project_path.as_path()))
+            .map_err(|_| PublishError::UnsupportedEnvironmentState(not_found_msg.to_string()))?;
+
+    let mut env = open_path(flox, &project_path, None)
+        .map_err(|e| PublishError::UnsupportedEnvironmentState(e.to_string()))?;
+    let built_environments = env.build(flox)?;
+    let base_dir = env.parent_path()?;
+
+    Ok((expression_ref, base_dir, built_environments))
 }
 
 /// Creates an error for a build repo that's in an invalid state.
@@ -1187,7 +1246,7 @@ pub fn check_package_metadata(
     // We should not need this, and allow for no base catalog page dependency.
     // But for now, requiring it simplifies resolution and model updates
     // significantly.
-    let base_catalog_ref = if pkg.kind() == &PackageTargetKind::ManifestBuild {
+    let base_catalog_ref = if pkg.kind().is_manifest_build() {
         toplevel_catalog_ref.cloned().ok_or_else(|| {
             PublishError::UnsupportedEnvironmentState("No packages in toplevel group".to_string())
         })?
@@ -1209,13 +1268,15 @@ pub mod tests {
     const EXAMPLE_PACKAGE_NAME: &str = "mypkg";
     const EXAMPLE_PACKAGE_NAME_MISSING_FIELDS: &str = "mypkg_missing_fields";
     static EXAMPLE_MANIFEST_PACKAGE_TARGET: LazyLock<PackageTarget> = LazyLock::new(|| {
-        PackageTarget::new_unchecked(EXAMPLE_PACKAGE_NAME, PackageTargetKind::ManifestBuild)
+        PackageTarget::new_unchecked(EXAMPLE_PACKAGE_NAME, PackageTargetKind::ManifestBuild {
+            sandbox: None,
+        })
     });
     static EXAMPLE_MANIFEST_PACKAGE_TARGET_MISSING_FIELDS: LazyLock<PackageTarget> =
         LazyLock::new(|| {
             PackageTarget::new_unchecked(
                 EXAMPLE_PACKAGE_NAME_MISSING_FIELDS,
-                PackageTargetKind::ManifestBuild,
+                PackageTargetKind::ManifestBuild { sandbox: None },
             )
         });
 
@@ -1554,6 +1615,62 @@ pub mod tests {
         assert_eq!(meta.license, None);
     }
 
+    /// Verify that `check_build_metadata` succeeds via the `build_source`
+    /// (`OriginalCheckout`) path when the manifest declares `sandbox = "pure"` for the package.
+    #[test]
+    fn check_build_meta_sandbox_pure() {
+        let (flox, _temp_dir_handle) = flox_instance();
+        let (_tempdir_handle, _remote_repo, remote_uri) = example_git_remote_repo();
+        let (env, git) = example_path_environment(&flox, Some(&remote_uri));
+
+        // Patch the manifest on disk to add sandbox = "pure" to mypkg so that
+        // flox-build.mk runs the build in pure sandbox mode.
+        let manifest_path = env.manifest_path(&flox).unwrap();
+        let manifest_content = std::fs::read_to_string(&manifest_path).unwrap();
+        let pure_manifest = manifest_content.replace(
+            "mypkg.version = \"1.0.2a\"",
+            "mypkg.version = \"1.0.2a\"\nmypkg.sandbox = \"pure\"",
+        );
+        assert!(
+            pure_manifest.contains("mypkg.sandbox = \"pure\""),
+            "manifest patch failed — did the fixture version string change?"
+        );
+        std::fs::write(&manifest_path, &pure_manifest).unwrap();
+
+        git.add(&[manifest_path.as_path()]).unwrap();
+        git.commit("set sandbox=pure").unwrap();
+        git.push("origin", false).unwrap();
+
+        // Pass a PackageTarget with sandbox=Pure so check_build_metadata
+        // takes the OriginalCheckout path without re-reading the manifest.
+        let pure_pkg =
+            PackageTarget::new_unchecked(EXAMPLE_PACKAGE_NAME, PackageTargetKind::ManifestBuild {
+                sandbox: Some(BuildSandbox::Pure),
+            });
+
+        let env_metadata = check_environment_metadata(&flox, &env).unwrap();
+        let meta = check_build_metadata(
+            &flox,
+            env_metadata.toplevel_catalog_ref.as_ref().unwrap(),
+            None,
+            &env_metadata,
+            &pure_pkg,
+        )
+        .unwrap();
+
+        // sandbox=pure builds produce a Nix derivation with both "out" and
+        // "log" outputs; only "out" is relevant and listed in outputs_to_install.
+        assert!(
+            meta.outputs
+                .iter()
+                .any(|o| o.name == "out" && o.store_path.starts_with("/nix/store/"))
+        );
+        assert_eq!(meta.outputs_to_install, Some(vec!["out".to_string()]));
+        assert_eq!(meta.pname, EXAMPLE_PACKAGE_NAME.to_string());
+        assert_eq!(meta.system.to_string(), flox.system);
+        assert_eq!(meta.version, Some("1.0.2a".to_string()));
+    }
+
     #[tokio::test]
     async fn publish_meta_only() {
         let (mut flox, _temp_dir_handle) = flox_instance();
@@ -1785,7 +1902,9 @@ pub mod tests {
 
         let package_metadata = PackageMetadata {
             base_catalog_ref: catalog_page_nixpkgs_https_url,
-            package: PackageTarget::new_unchecked(pkg_name, PackageTargetKind::ManifestBuild),
+            package: PackageTarget::new_unchecked(pkg_name, PackageTargetKind::ManifestBuild {
+                sandbox: None,
+            }),
             _private: (),
         };
 

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -801,7 +801,7 @@ mod test {
     fn manifest_builds_not_allowed_with_stabilities_present() {
         let mut packages = vec![PackageTarget::new_unchecked(
             "manifest",
-            PackageTargetKind::ManifestBuild,
+            PackageTargetKind::ManifestBuild { sandbox: None },
         )];
 
         let result = disallow_base_url_select_for_manifest_builds(&packages, true);
@@ -828,7 +828,7 @@ mod test {
     fn manifest_builds_allowed_with_stabilities_absent() {
         let mut packages = vec![PackageTarget::new_unchecked(
             "manifest",
-            PackageTargetKind::ManifestBuild,
+            PackageTargetKind::ManifestBuild { sandbox: None },
         )];
 
         let result = disallow_base_url_select_for_manifest_builds(&packages, false);
@@ -952,7 +952,7 @@ mod test {
     fn manifest_builds_do_not_require_git_repo() {
         let packages = vec![PackageTarget::new_unchecked(
             "manifest",
-            PackageTargetKind::ManifestBuild,
+            PackageTargetKind::ManifestBuild { sandbox: None },
         )];
         let base_dir = tempfile::tempdir().unwrap();
 

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -394,7 +394,7 @@ mod tests {
             target,
             PackageTarget::new_unchecked(
                 "hello",
-                flox_rust_sdk::providers::build::PackageTargetKind::ManifestBuild
+                flox_rust_sdk::providers::build::PackageTargetKind::ManifestBuild { sandbox: None }
             )
         );
     }
@@ -466,7 +466,7 @@ mod tests {
             target,
             PackageTarget::new_unchecked(
                 "hello2",
-                flox_rust_sdk::providers::build::PackageTargetKind::ManifestBuild
+                flox_rust_sdk::providers::build::PackageTargetKind::ManifestBuild { sandbox: None }
             )
         );
     }
@@ -497,7 +497,7 @@ mod tests {
             target,
             PackageTarget::new_unchecked(
                 "hello",
-                flox_rust_sdk::providers::build::PackageTargetKind::ManifestBuild
+                flox_rust_sdk::providers::build::PackageTargetKind::ManifestBuild { sandbox: None }
             )
         );
     }

--- a/cli/nef-lock-catalog/src/lock.rs
+++ b/cli/nef-lock-catalog/src/lock.rs
@@ -81,12 +81,29 @@ impl NixFlakeref {
     }
 
     pub fn from_git_with_dir(url: &Url, dir: Option<&Path>) -> Result<Self> {
-        json!({
-            "type": "git",
-            "url": url,
-            "dir": dir,
-        })
-        .try_into()
+        let mut map = serde_json::Map::new();
+        map.insert("type".into(), json!("git"));
+        map.insert("url".into(), json!(url));
+        if let Some(d) = dir {
+            map.insert("dir".into(), json!(d));
+        }
+        Value::Object(map).try_into()
+    }
+
+    /// Build a `git+file://` flake ref pointing at a local repository at a
+    /// specific revision.  Nix resolves this without network access, imports
+    /// the tree into the store, so builds can run with full sandbox isolation.
+    pub fn from_local_git(path: impl AsRef<Path>, rev: &str, dir: Option<&Path>) -> Result<Self> {
+        let url = Url::from_file_path(path.as_ref())
+            .map_err(|()| anyhow::anyhow!("path is not absolute: {}", path.as_ref().display()))?;
+        let mut map = serde_json::Map::new();
+        map.insert("type".into(), json!("git"));
+        map.insert("url".into(), json!(url));
+        map.insert("rev".into(), json!(rev));
+        if let Some(d) = dir {
+            map.insert("dir".into(), json!(d));
+        }
+        Value::Object(map).try_into()
     }
 
     pub fn as_url(&self) -> &Url {


### PR DESCRIPTION
## Proposed Changes

\`flox publish\` previously built the package from an ephemeral copy of the repository populated by a Nix store prefetch, which produced a plain directory with no git history. Build scripts calling \`git ls-files\` or \`git describe\` therefore failed, and the \`path:\` flake ref used as the Nix source reference copied the \`.git\` directory into the store — contrary to the Nix convention that store paths contain only source files.

This PR introduces a sandbox-aware source strategy:

**\`sandbox = "off"\` (or unset) manifest builds** run in an ephemeral \`git clone --shared\` of the local repository at the committed revision. The shared clone gives the build script a clean working tree with full git history (enabling \`git describe\`, \`git ls-files\`, etc.) while avoiding a full copy of git objects.

**\`sandbox = "pure"\` manifest builds and all NEF (expression) builds** use the original local checkout as the build working directory. Nix's git fetcher applies source isolation directly.

In both cases the **Nix source reference** is a \`git+file://\` flake ref pinned to the committed revision. Nix's git fetcher imports only the files returned by \`git ls-files\` — never the \`.git\` directory — so source copies in the store contain only tracked source files.

## Release Notes

* Enable use of \`git describe\` for setting version strings in manifest builds.
* Fix bug triggering unnecessary rebuilds with \`flox publish\`.