### PR TITLE
refactor(buildenv): reduce `nix build` invocations to 1 for the build/activate path

### DIFF
--- a/buildenv/README.md
+++ b/buildenv/README.md
@@ -3,8 +3,8 @@
 This directory is derived from the files in nixpkgs:pkgs/build-support/buildenv,
 modified to build multiple environment outputs:
 
-* `runtime`: the same env as created by nixpkgs `buildenv` upstream
-* `develop`: as above, but recurses to include links for all requisite packages
+* `run`: the same env as created by nixpkgs `buildenv` upstream
+* `dev`: as above, but recurses to include links for all requisite packages
 * `build-<pname>`: for each manifest build, creates env referring only to
   the "toplevel" packages, optionally filtered by `runtime-packages`
 
@@ -37,8 +37,8 @@ It took 0.061 seconds to realise the packages with pkgdb.
   {
     "drvPath": "/nix/store/qvv16w2mig6nwr7wdrn3ymm6dvwi9ci9-environment.drv",
     "outputs": {
-      "develop": "/nix/store/kqzy26j4ldsd0az4sbbpc0yd41b2rfvw-environment-develop",
-      "runtime": "/nix/store/warx31v9gmjadjdgdx2bskk1yr2wxl22-environment-runtime"
+      "dev": "/nix/store/kqzy26j4ldsd0az4sbbpc0yd41b2rfvw-environment-dev",
+      "run": "/nix/store/warx31v9gmjadjdgdx2bskk1yr2wxl22-environment-run"
     }
   }
 ]

--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -68,8 +68,8 @@ let
 
   # Calculate environment outputs.
   environmentOutputs = [
-    "runtime"
-    "develop"
+    "run"
+    "dev"
   ]
   ++ (builtins.map (buildId: "build-${buildId}") (builtins.attrNames buildSection));
 

--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -707,16 +707,16 @@ if ($manifest) {
 
         # Construct data sets for each environment to be rendered by the
         # builder.pl script.
-        # Both the "runtime" and "develop" environments take _the same set of packages_,
-        # but the "develop" environment also recursively links the "propagated-build-inputs".
+        # Both the "run" and "dev" environments take _the same set of packages_,
+        # but the "dev" environment also recursively links the "propagated-build-inputs".
         my @outputData = (
             {
-              "name" => "runtime",
+              "name" => "run",
               "pkgs" => packagesToPkgs($manifest, \@developPackages),
               "recurse" => 0
             },
             {
-              "name" => "develop",
+              "name" => "dev",
               "pkgs" => packagesToPkgs($manifest, \@developPackages),
               "recurse" => 1
             }

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -37,14 +37,7 @@ use super::{
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
 use crate::models::environment::install::compute_install_modifications;
-use crate::providers::buildenv::{
-    self,
-    BuildEnv,
-    BuildEnvError,
-    BuildEnvNix,
-    BuildEnvOutputs,
-    BuiltStorePath,
-};
+use crate::providers::buildenv::{BuildEnv, BuildEnvError, BuildEnvNix, BuildEnvOutputs};
 use crate::providers::lock_manifest::{LockManifest, LockResult, ResolutionFailure, ResolveError};
 use crate::providers::nix_auth::{AuthError, NixAuth};
 use crate::providers::services::process_compose::{ServiceError, maybe_make_service_config_file};
@@ -277,24 +270,20 @@ impl<State> CoreEnvironment<State> {
     /// It's included in the [ReadOnly] struct for ergonomic reasons
     /// and because it doesn't modify the manifest.
     ///
-    /// Does not lock the manifest or link the environment to an out path.
-    /// Each should be done explicitly if necessary by the caller
-    /// using [Self::lock] and [Self::link]:
+    /// Does not lock the manifest.
+    /// Call [Self::lock] explicitly before building if the lockfile may be stale.
     ///
-    /// ```ignore
-    /// # use flox_rust_sdk::models::environment::CoreEnvironment;
-    /// # use flox_rust_sdk::flox::Flox;
-    /// let flox: Flox = unimplemented!();
-    /// let core_env: CoreEnvironment = unimplemented!();
-    ///
-    /// core_env.lock(&flox).unwrap();
-    /// let store_path = core_env.build(&flox).unwrap();
-    /// core_env
-    ///     .link(&flox, "/path/to/out-link", &Some(store_path))
-    ///     .unwrap();
-    /// ```
+    /// Pass `out_link_prefix` to have `nix build` register GC roots and write
+    /// the activation symlinks atomically as part of the build.  The prefix
+    /// must be `<run_dir>/<system>.<name>`; nix appends `-dev` and `-run` to
+    /// produce the two output symlinks.  Pass `None` for validate-only or
+    /// pre-flight builds where no symlinks or GC roots are needed.
     #[must_use = "don't discard the store paths of built environments"]
-    pub fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, CoreEnvironmentError> {
+    pub fn build(
+        &mut self,
+        flox: &Flox,
+        out_link_prefix: Option<&Path>,
+    ) -> Result<BuildEnvOutputs, CoreEnvironmentError> {
         let lockfile_path = CanonicalPath::new(self.lockfile_path())
             .map_err(CoreEnvironmentError::BadLockfilePath)?;
         let lockfile = Lockfile::read_from_file(&lockfile_path)?;
@@ -302,31 +291,19 @@ impl<State> CoreEnvironment<State> {
         let service_config_path = maybe_make_service_config_file(flox, &lockfile)?;
 
         let auth = NixAuth::from_flox(flox).map_err(CoreEnvironmentError::Auth)?;
+
         let outputs = BuildEnvNix::new(auth).build(
             &flox.catalog_client,
             &lockfile_path,
             service_config_path,
+            out_link_prefix,
         )?;
         debug!(?outputs, "built environment");
         Ok(outputs)
     }
 }
 
-impl CoreEnvironment<()> {
-    /// Create a new out-link for the environment at the given path with a
-    /// store-path obtained from [Self::build].
-    pub fn link(
-        out_link_path: impl AsRef<Path>,
-        store_path: &BuiltStorePath,
-    ) -> Result<(), CoreEnvironmentError> {
-        buildenv::create_gc_root_in([store_path.as_path()], out_link_path)?;
-
-        Ok(())
-    }
-}
-
 /// Environment modifying methods do not link the new environment to an out path.
-/// Linking should be done by the caller.
 /// Since files referenced by the environment are ingested into the nix store,
 /// the same [CoreEnvironment] instance can be used
 /// even if the concrete [super::Environment] tracks the files in a different way
@@ -516,7 +493,7 @@ impl CoreEnvironment<ReadOnly> {
             },
         };
 
-        let build_attempt = temp_env.build(flox);
+        let build_attempt = temp_env.build(flox, None);
 
         debug!("transaction: replacing environment");
         self.replace_with(temp_env)?;
@@ -576,7 +553,7 @@ impl CoreEnvironment<ReadOnly> {
             // Neither do we depend on services, so we pass `None`
             let auth = NixAuth::from_flox(flox).map_err(EnvironmentError::Auth)?;
             let _ = BuildEnvNix::new(auth)
-                .build(&flox.catalog_client, tmp_lockfile.path(), None)
+                .build(&flox.catalog_client, tmp_lockfile.path(), None, None)
                 .map_err(|e| EnvironmentError::Core(CoreEnvironmentError::BuildEnv(e)))?;
         }
 
@@ -855,7 +832,7 @@ impl CoreEnvironment<ReadOnly> {
         temp_env.write_manifest_lockfile_pair(&writable_manifest, &lockfile)?;
 
         debug!("transaction: building environment");
-        let store_path = temp_env.build(flox)?;
+        let store_path = temp_env.build(flox, None)?;
 
         debug!("transaction: replacing environment");
         self.replace_with(temp_env)?;
@@ -887,7 +864,7 @@ impl CoreEnvironment<ReadOnly> {
         temp_env.update_lockfile_with_contents(&lockfile_contents)?;
 
         debug!("transaction: building environment");
-        let store_path = temp_env.build(flox)?;
+        let store_path = temp_env.build(flox, None)?;
 
         debug!("transaction: replacing environment");
         self.replace_with(temp_env)?;
@@ -1423,7 +1400,7 @@ mod tests {
         temp_env.lock(&flox).unwrap();
         env_view.replace_with(temp_env).unwrap();
 
-        let result = env_view.build(&flox).unwrap_err();
+        let result = env_view.build(&flox, None).unwrap_err();
 
         assert!(result.is_incompatible_system_error());
     }
@@ -1444,8 +1421,8 @@ mod tests {
         env.lock(&flox).unwrap();
 
         // Build the environment and verify that the config file exists
-        let store_path = env.build(&flox).unwrap();
-        let config_path = store_path.develop.join(SERVICE_CONFIG_FILENAME);
+        let store_path = env.build(&flox, None).unwrap();
+        let config_path = store_path.dev.join(SERVICE_CONFIG_FILENAME);
         assert!(config_path.exists());
     }
 
@@ -1592,23 +1569,20 @@ mod tests {
         flox.catalog_client =
             catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
 
+        let out_link = env_path.path().with_extension("out-link");
+        std::fs::create_dir_all(&out_link).expect("create out-link dir");
+        let out_link = CanonicalPath::new(&out_link).expect("canonicalize out-link dir");
+
         env_view.lock(&flox).expect("locking should succeed");
-        let store_path = env_view.build(&flox).expect("build should succeed");
-        CoreEnvironment::link(
-            env_path.path().with_extension("out-link"),
-            &store_path.develop,
-        )
-        .expect("link should succeed");
+        // Use a prefix so nix writes <prefix>-dev and <prefix>-run symlinks.
+        let prefix = out_link.join("env");
+        env_view
+            .build(&flox, Some(&prefix))
+            .expect("build should succeed");
 
         // very rudimentary check that the environment manifest built correctly
         // and linked to the out-link.
-        assert!(
-            env_path
-                .path()
-                .with_extension("out-link")
-                .join("bin/hello")
-                .exists()
-        );
+        assert!(out_link.join("env-dev").join("bin/hello").exists());
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -325,8 +325,8 @@ impl Environment for ManagedEnvironment {
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
             self.lock_pointer()?;
         }
-        if let Some(store_paths) = &result.built_environments {
-            self.link(store_paths)?;
+        if result.built_environments.is_some() {
+            self.build(flox)?;
         }
 
         Ok(result)
@@ -368,8 +368,8 @@ impl Environment for ManagedEnvironment {
             .add_generation(&mut local_checkout, change)
             .map_err(ManagedEnvironmentError::CommitGeneration)?;
         self.lock_pointer()?;
-        if let Some(store_paths) = &result.built_environment_store_paths {
-            self.link(store_paths)?;
+        if result.built_environment_store_paths.is_some() {
+            self.build(flox)?;
         }
 
         Ok(result)
@@ -394,15 +394,12 @@ impl Environment for ManagedEnvironment {
         let result = local_checkout.edit(flox, contents)?;
 
         match &result {
-            EditResult::Changed {
-                built_environment_store_paths,
-                ..
-            } => {
+            EditResult::Changed { .. } => {
                 generations
                     .add_generation(&mut local_checkout, HistoryKind::Edit)
                     .map_err(ManagedEnvironmentError::CommitGeneration)?;
                 self.lock_pointer()?;
-                self.link(built_environment_store_paths)?;
+                self.build(flox)?;
             },
             EditResult::Unchanged => {},
         }
@@ -520,12 +517,10 @@ impl Environment for ManagedEnvironment {
             .map_err(ManagedEnvironmentError::Core)?
             .expect("lockfile presence checked");
 
-        let rendered_env_lockfile_path =
-            self.rendered_env_links.development.join(LOCKFILE_FILENAME);
+        let rendered_env_lockfile_path = self.rendered_env_links.dev.join(LOCKFILE_FILENAME);
 
         let mut build_and_link = || -> Result<(), EnvironmentError> {
-            let store_paths = self.build(flox)?;
-            self.link(&store_paths)?;
+            self.build(flox)?;
             Ok(())
         };
 
@@ -549,17 +544,13 @@ impl Environment for ManagedEnvironment {
     }
 
     fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError> {
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
         // todo: ensure lockfile exists?
 
-        Ok(local_checkout.build(flox)?)
-    }
-
-    fn link(&mut self, store_paths: &BuildEnvOutputs) -> Result<(), EnvironmentError> {
-        CoreEnvironment::link(&self.rendered_env_links.development, &store_paths.develop)?;
-        CoreEnvironment::link(&self.rendered_env_links.runtime, &store_paths.runtime)?;
-
-        Ok(())
+        let store_paths = local_checkout.build(flox, Some(&out_link_prefix))?;
+        self.rendered_env_links.replace_legacy_links();
+        Ok(store_paths)
     }
 
     /// Returns .flox/cache
@@ -680,8 +671,7 @@ impl GenerationsExt for ManagedEnvironment {
         // update the rendered environment
         self.lock_pointer()?;
         self.reset_local_env_to_current_generation(flox)?;
-        let buildenv_paths = self.build(flox)?;
-        self.link(&buildenv_paths)?;
+        self.build(flox)?;
 
         Ok(())
     }
@@ -723,8 +713,6 @@ impl GenerationsExt for ManagedEnvironment {
         let mut core_environment =
             generation_rw.get_generation(*generation, self.include_fetcher.clone());
 
-        let store_paths = core_environment.build(flox)?;
-
         let run_dir = &self.path.join(GCROOTS_DIR_NAME);
         if !run_dir.exists() {
             std::fs::create_dir_all(run_dir).map_err(ManagedEnvironmentError::CreateLinksDir)?;
@@ -740,8 +728,9 @@ impl GenerationsExt for ManagedEnvironment {
                 generation,
             );
 
-        CoreEnvironment::link(&rendered_env_links.development, &store_paths.develop)?;
-        CoreEnvironment::link(&rendered_env_links.runtime, &store_paths.runtime)?;
+        let out_link_prefix = rendered_env_links.out_link_prefix();
+        core_environment.build(flox, Some(&out_link_prefix))?;
+        rendered_env_links.replace_legacy_links();
 
         Ok(rendered_env_links)
     }
@@ -1021,10 +1010,9 @@ impl ManagedEnvironment {
         local_checkout.lock(flox)?;
 
         // Ensure the created generation is valid
-        let store_paths = local_checkout.build(flox)?;
-
-        // TODO: should use self.link but that returns an EnvironmentError
-        self.link(&store_paths)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        local_checkout.build(flox, Some(&out_link_prefix))?;
+        self.rendered_env_links.replace_legacy_links();
 
         let mut generations = self.generations();
         let mut generations = generations
@@ -1283,7 +1271,7 @@ impl ManagedEnvironment {
 
         // Ensure the environment builds before we push it
         core_environment
-            .build(flox)
+            .build(flox, None)
             .map_err(ManagedEnvironmentError::Build)?;
 
         // Ensure that the environment does not include other local ennvironments
@@ -1439,7 +1427,7 @@ impl ManagedEnvironment {
                 .map_err(|_| ManagedEnvironmentError::CheckoutOutOfSync)?
                 .into();
             local_checkout
-                .build(flox)
+                .build(flox, None)
                 .map_err(ManagedEnvironmentError::Build)?;
 
             check_for_local_includes(&lockfile)?;
@@ -1538,8 +1526,7 @@ impl ManagedEnvironment {
 
         if is_uptodate && !checkout_valid && force {
             self.reset_local_env_to_current_generation(flox)?;
-            let store_paths = self.build(flox)?;
-            self.link(&store_paths)?;
+            self.build(flox)?;
 
             return Ok(PullResult::Updated);
         } else if is_uptodate {
@@ -1580,8 +1567,7 @@ impl ManagedEnvironment {
         // update the pointer lockfile and build
         self.lock_pointer()?;
         self.reset_local_env_to_current_generation(flox)?;
-        let store_paths = self.build(flox)?;
-        self.link(&store_paths)?;
+        self.build(flox)?;
 
         Ok(PullResult::Updated)
     }

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -180,14 +180,12 @@ pub trait Environment: Send {
         flox: &Flox,
     ) -> Result<RenderedEnvironmentLinks, EnvironmentError>;
 
-    /// Build the environment and return the built store paths
-    /// for the development and runtime variants,
+    /// Build the environment, write the activation symlinks, register GC roots,
+    /// and return the built store paths for the development and runtime variants,
     /// as well as runtime environments of the manifest builds defined in this environment.
     ///
-    /// This does not link the environment, but may lock the environment, if necessary.
+    /// May lock the environment if necessary.
     fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError>;
-
-    fn link(&mut self, store_paths: &BuildEnvOutputs) -> Result<(), EnvironmentError>;
 
     /// Return a path to store transient data,
     /// such as temporary files created by the environment hooks or the environment itself,
@@ -298,20 +296,20 @@ impl TryFrom<&ConcreteEnvironment> for ActivateEnvironmentRef {
 #[as_ref(forward)]
 pub struct RenderedEnvironmentLink(PathBuf);
 
-/// A pair of links to the development and runtime variants of an environment.
+/// A pair of links to the dev and run variants of an environment.
 /// Refer to the documentation of [RenderedEnvironmentLink] for what guarantees
 /// the existence of these paths provides.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct RenderedEnvironmentLinks {
-    pub development: RenderedEnvironmentLink,
-    pub runtime: RenderedEnvironmentLink,
+    pub dev: RenderedEnvironmentLink,
+    pub run: RenderedEnvironmentLink,
 }
 
 impl RenderedEnvironmentLinks {
-    pub(crate) fn new_unchecked(development: PathBuf, runtime: PathBuf) -> Self {
+    pub(crate) fn new_unchecked(dev: PathBuf, run: PathBuf) -> Self {
         Self {
-            development: RenderedEnvironmentLink(development),
-            runtime: RenderedEnvironmentLink(runtime),
+            dev: RenderedEnvironmentLink(dev),
+            run: RenderedEnvironmentLink(run),
         }
     }
 
@@ -320,11 +318,11 @@ impl RenderedEnvironmentLinks {
         name: impl AsRef<str>,
         system: &System,
     ) -> Self {
-        let development_name = format!("{system}.{name}.dev", name = name.as_ref());
-        let development_path = base_dir.join(development_name);
-        let runtime_name = format!("{system}.{name}.run", name = name.as_ref());
-        let runtime_path = base_dir.join(runtime_name);
-        Self::new_unchecked(development_path, runtime_path)
+        let dev_name = format!("{system}.{name}-dev", name = name.as_ref());
+        let dev_path = base_dir.join(dev_name);
+        let run_name = format!("{system}.{name}-run", name = name.as_ref());
+        let run_path = base_dir.join(run_name);
+        Self::new_unchecked(dev_path, run_path)
     }
 
     pub fn new_in_base_dir_with_name_system_and_generation(
@@ -333,18 +331,87 @@ impl RenderedEnvironmentLinks {
         system: &System,
         generation: GenerationId,
     ) -> Self {
-        let development_name = format!("{system}.{name}.gen{generation}.dev", name = name.as_ref());
-        let development_path = base_dir.join(development_name);
-        let runtime_name = format!("{system}.{name}.gen{generation}.run", name = name.as_ref());
-        let runtime_path = base_dir.join(runtime_name);
-        Self::new_unchecked(development_path, runtime_path)
+        let dev_name = format!("{system}.{name}.gen{generation}-dev", name = name.as_ref());
+        let dev_path = base_dir.join(dev_name);
+        let run_name = format!("{system}.{name}.gen{generation}-run", name = name.as_ref());
+        let run_path = base_dir.join(run_name);
+        Self::new_unchecked(dev_path, run_path)
+    }
+
+    /// Returns the `--out-link` prefix for `nix build`.
+    ///
+    /// With outputs named `"dev"` and `"run"`, nix creates:
+    ///   `<prefix>-dev` and `<prefix>-run`
+    /// which exactly match `self.dev` and `self.run`.
+    pub fn out_link_prefix(&self) -> PathBuf {
+        let dev_path = self.dev.as_path().to_str().expect("paths are UTF-8");
+        PathBuf::from(
+            dev_path
+                .strip_suffix("-dev")
+                .expect("dev link always ends in -dev"),
+        )
+    }
+
+    /// Replace legacy dot-separator symlinks with redirect symlinks to the
+    /// new dash-separator ones.
+    ///
+    /// Previous versions of Flox used `<system>.<name>.dev` and
+    /// `<system>.<name>.run` as activation symlink names.  This method checks
+    /// for those old names in the same directory and, if found, replaces them
+    /// with symlinks that point to the current `<system>.<name>-dev` /
+    /// `<system>.<name>-run` names so that scripts or tooling holding old
+    /// paths continue to resolve correctly.
+    ///
+    /// Errors are logged at debug level and do not propagate; this is a
+    /// best-effort compatibility shim and must not fail the build.
+    pub fn replace_legacy_links(&self) {
+        for (new_link, suffix) in [(self.dev.as_path(), "dev"), (self.run.as_path(), "run")] {
+            let Some(parent) = new_link.parent() else {
+                continue;
+            };
+            let Some(new_name) = new_link.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let Some(stem) = new_name.strip_suffix(&format!("-{suffix}")) else {
+                continue;
+            };
+            let old_path = parent.join(format!("{stem}.{suffix}"));
+            if !old_path.is_symlink() {
+                continue;
+            }
+            // Only replace symlinks that point into the Nix store.  Relative
+            // redirect symlinks created by a previous run of this function
+            // already point to the correct dash-separator name and must not be
+            // deleted and recreated on every build.
+            let points_to_store = std::fs::read_link(&old_path)
+                .ok()
+                .and_then(|t| t.into_os_string().into_string().ok())
+                .is_some_and(|t| t.starts_with("/nix/store/"));
+            if !points_to_store {
+                continue;
+            }
+            if let Err(e) = std::fs::remove_file(&old_path) {
+                debug!(path=?old_path, error=%e, "failed to remove legacy environment link");
+                continue;
+            }
+            if new_link.is_symlink()
+                && let Err(e) = std::os::unix::fs::symlink(new_name, &old_path)
+            {
+                debug!(
+                    path=?old_path,
+                    target=new_name,
+                    error=%e,
+                    "failed to create legacy compatibility link"
+                );
+            }
+        }
     }
 
     /// Returns the built environment path for an activation mode.
     pub fn for_mode(self, mode: &ActivateMode) -> RenderedEnvironmentLink {
         match mode {
-            ActivateMode::Dev => self.development,
-            ActivateMode::Run => self.runtime,
+            ActivateMode::Dev => self.dev,
+            ActivateMode::Run => self.run,
         }
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -232,8 +232,8 @@ impl Environment for PathEnvironment {
     ) -> Result<InstallationAttempt, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
         let result = env_view.install(packages, flox)?;
-        if let Some(ref store_paths) = result.built_environments {
-            self.link(store_paths)?;
+        if result.built_environments.is_some() {
+            self.build(flox)?;
         }
 
         Ok(result)
@@ -251,8 +251,8 @@ impl Environment for PathEnvironment {
     ) -> Result<UninstallationAttempt, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
         let result = env_view.uninstall(specs, flox)?;
-        if let Some(ref store_paths) = result.built_environment_store_paths {
-            self.link(store_paths)?;
+        if result.built_environment_store_paths.is_some() {
+            self.build(flox)?;
         }
 
         Ok(result)
@@ -262,14 +262,8 @@ impl Environment for PathEnvironment {
     fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
         let result = env_view.edit(flox, contents)?;
-        match &result {
-            EditResult::Changed {
-                built_environment_store_paths,
-                ..
-            } => {
-                self.link(built_environment_store_paths)?;
-            },
-            EditResult::Unchanged => {},
+        if matches!(&result, EditResult::Changed { .. }) {
+            self.build(flox)?;
         }
         Ok(result)
     }
@@ -294,8 +288,8 @@ impl Environment for PathEnvironment {
         tracing::debug!(to_upgrade = groups_or_iids.join(","), "upgrading");
         let mut env_view = self.as_core_environment_mut()?;
         let result = env_view.upgrade(flox, groups_or_iids, true)?;
-        if let Some(ref store_paths) = result.store_path {
-            self.link(store_paths)?;
+        if result.store_path.is_some() {
+            self.build(flox)?;
         }
 
         Ok(result)
@@ -313,8 +307,8 @@ impl Environment for PathEnvironment {
         );
         let mut env_view = self.as_core_environment_mut()?;
         let result = env_view.include_upgrade(flox, to_upgrade)?;
-        if let Some(ref store_paths) = result.store_path {
-            self.link(store_paths)?;
+        if result.store_path.is_some() {
+            self.build(flox)?;
         }
 
         Ok(result)
@@ -345,8 +339,7 @@ impl Environment for PathEnvironment {
         let out_paths = self.rendered_env_links.clone();
 
         if self.needs_rebuild()? {
-            let store_paths = self.build(flox)?;
-            self.link(&store_paths)?;
+            self.build(flox)?;
         }
 
         Ok(out_paths)
@@ -357,17 +350,12 @@ impl Environment for PathEnvironment {
     /// Uses `ensure_locked` to skip a catalog round-trip and lockfile
     /// rewrite when the lockfile is already current.
     fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError> {
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
         let mut env_view = self.as_core_environment_mut()?;
         env_view.ensure_locked(flox)?;
-        let store_paths = env_view.build(flox)?;
+        let store_paths = env_view.build(flox, Some(&out_link_prefix))?;
+        self.rendered_env_links.replace_legacy_links();
         Ok(store_paths)
-    }
-
-    fn link(&mut self, store_paths: &BuildEnvOutputs) -> Result<(), EnvironmentError> {
-        CoreEnvironment::link(&self.rendered_env_links.development, &store_paths.develop)?;
-        CoreEnvironment::link(&self.rendered_env_links.runtime, &store_paths.runtime)?;
-
-        Ok(())
     }
 
     /// Returns .flox/cache
@@ -519,7 +507,7 @@ impl PathEnvironment {
             )?
         };
 
-        let mut environment = Self::write_new_unchecked(
+        let environment = Self::write_new_unchecked(
             flox,
             pointer,
             dot_flox_parent_path,
@@ -533,10 +521,11 @@ impl PathEnvironment {
         );
         env_view.lock(flox)?;
 
-        // Build+link only when packages are present
+        // Build only when packages are present; nix writes the activation
+        // symlinks via --out-link, so no separate link step is needed.
         if matches!(customization.packages.as_deref(), Some([_, ..])) {
-            let store_paths = env_view.build(flox)?;
-            environment.link(&store_paths)?;
+            let out_link_prefix = environment.rendered_env_links.out_link_prefix();
+            env_view.build(flox, Some(&out_link_prefix))?;
         }
 
         Ok(environment)
@@ -614,8 +603,7 @@ impl PathEnvironment {
             return Ok(true);
         };
 
-        let rendered_env_lockfile_path =
-            self.rendered_env_links.development.join(LOCKFILE_FILENAME);
+        let rendered_env_lockfile_path = self.rendered_env_links.dev.join(LOCKFILE_FILENAME);
 
         let Ok(rendered_env_lockfile_path) = CanonicalPath::new(rendered_env_lockfile_path) else {
             return Ok(true);
@@ -857,7 +845,7 @@ pub mod tests {
         let environment_temp_dir = tempfile::tempdir_in(&temp_dir).unwrap();
         let pointer = PathPointer::new("test".parse().unwrap());
 
-        let mut env = PathEnvironment::init(
+        let env = PathEnvironment::init(
             pointer,
             environment_temp_dir.path(),
             &InitCustomization::default(),
@@ -870,8 +858,8 @@ pub mod tests {
         // build the environment -> out link is created -> no rebuild necessary
         let mut env_view =
             CoreEnvironment::new(env.path.join(ENV_DIR_NAME), env.include_fetcher().unwrap());
-        let store_paths = env_view.build(&flox).unwrap();
-        env.link(&store_paths).unwrap();
+        let out_link_prefix = env.rendered_env_links.out_link_prefix();
+        env_view.build(&flox, Some(&out_link_prefix)).unwrap();
 
         assert!(!env.needs_rebuild().unwrap());
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -235,24 +235,24 @@ impl RemoteEnvironment {
                 let base_dir =
                     CanonicalPath::new(gcroots_dir).expect("gcroots_dir is not a valid path");
 
-                let old_links = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
-                    &base_dir,
-                    pointer.name.as_ref(),
-                    &flox.system,
-                );
+                // Legacy links used dot separators: <system>.<name>.dev / <system>.<name>.run
+                let old_dev =
+                    base_dir.join(format!("{}.{}.dev", flox.system, pointer.name.as_ref()));
+                let old_run =
+                    base_dir.join(format!("{}.{}.run", flox.system, pointer.name.as_ref()));
 
-                if old_links.dev.is_symlink() {
+                if old_dev.is_symlink() {
                     debug!(
-                        out_link=?old_links.dev,
+                        out_link=?old_dev,
                         "deleting legacy outlink");
-                    std::fs::remove_file(&old_links.dev)
+                    std::fs::remove_file(&old_dev)
                         .map_err(RemoteEnvironmentError::DeleteOldOutLink)?;
                 }
-                if old_links.run.is_symlink() {
+                if old_run.is_symlink() {
                     debug!(
-                        out_link=?old_links.run,
+                        out_link=?old_run,
                         "deleting legacy outlink");
-                    std::fs::remove_file(&old_links.run)
+                    std::fs::remove_file(&old_run)
                         .map_err(RemoteEnvironmentError::DeleteOldOutLink)?;
                 }
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -46,7 +46,6 @@ use crate::models::environment::floxmeta_branch::{
 use crate::models::environment::generations::SyncToGenerationResult;
 use crate::models::environment::managed_environment::GENERATION_LOCK_FILENAME;
 use crate::models::environment::path_environment::{InitCustomization, PathEnvironment};
-use crate::providers::buildenv::BuildEnvOutputs;
 use crate::providers::lock_manifest::LockResult;
 
 const REMOTE_ENVIRONMENT_BASE_DIR: &str = "remote";
@@ -242,18 +241,18 @@ impl RemoteEnvironment {
                     &flox.system,
                 );
 
-                if old_links.development.is_symlink() {
+                if old_links.dev.is_symlink() {
                     debug!(
-                        out_link=?old_links.development,
+                        out_link=?old_links.dev,
                         "deleting legacy outlink");
-                    std::fs::remove_file(&old_links.development)
+                    std::fs::remove_file(&old_links.dev)
                         .map_err(RemoteEnvironmentError::DeleteOldOutLink)?;
                 }
-                if old_links.runtime.is_symlink() {
+                if old_links.run.is_symlink() {
                     debug!(
-                        out_link=?old_links.runtime,
+                        out_link=?old_links.run,
                         "deleting legacy outlink");
-                    std::fs::remove_file(&old_links.runtime)
+                    std::fs::remove_file(&old_links.run)
                         .map_err(RemoteEnvironmentError::DeleteOldOutLink)?;
                 }
 
@@ -456,10 +455,6 @@ impl Environment for RemoteEnvironment {
         flox: &Flox,
     ) -> Result<crate::providers::buildenv::BuildEnvOutputs, EnvironmentError> {
         self.inner.build(flox)
-    }
-
-    fn link(&mut self, store_paths: &BuildEnvOutputs) -> Result<(), EnvironmentError> {
-        self.inner.link(store_paths)
     }
 
     fn cache_path(&self) -> Result<CanonicalPath, EnvironmentError> {

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -3273,12 +3273,12 @@ mod tests {
               # shell tracing so that all we get from the build is the output.
               set +x
               # Report where we find a representative executable from each pkg.
-              # Print this to stdout so that we can assert it in the test, but
-              # do not embed these paths in the output because those packages
-              # are not expected to be present in the final closure.
+              # Write to stderr so that all diagnostic output shares one fd with
+              # the shell-tracing output (set +x also writes to stderr); mixing
+              # stdout and stderr produces a non-deterministic ordering.
               for i in bash cat find grep sed; do
                 path="$(type -p $i)"
-                echo "found $i in $path"
+                echo "found $i in $path" >&2
               done
               # Create a valid executable in $out/bin for a clean build.
               mkdir -p $out/bin
@@ -3311,13 +3311,9 @@ mod tests {
         let re = regex::Regex::new(&expected_pattern).unwrap();
 
         // Assert that the expected output is present in the build output.
-        // Note that this output will appear in the stdout for the local
-        // build and stderr for the sandbox build.
-        let output_stream = if sandbox {
-            output.stderr
-        } else {
-            output.stdout
-        };
+        // The echo statements write to stderr, so the output is always in
+        // output.stderr regardless of sandbox mode.
+        let output_stream = output.stderr;
         if !re.is_match(&output_stream) {
             pretty_assertions::assert_eq!(
                 output_stream,

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -316,7 +316,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
 
         command.arg(format!(
             "FLOX_ENV={}",
-            self.built_environments.develop.display()
+            self.built_environments.dev.display()
         ));
         command.arg(format!(
             "FLOX_ENV_OUTPUTS={}",
@@ -435,7 +435,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         // TODO: is this even necessary, or can we detect build outputs instead?
         command.arg(format!(
             "FLOX_ENV={}",
-            self.built_environments.develop.display()
+            self.built_environments.dev.display()
         ));
 
         // TODO: is this even necessary, or can we detect build outputs instead?
@@ -852,7 +852,7 @@ pub mod test_helpers {
         )
         .build(
             &toplevel_or_common_nixpkgs,
-            &env.rendered_env_links(flox).unwrap().development,
+            &env.rendered_env_links(flox).unwrap().dev,
             &[PackageTargetName::new_unchecked(&package)],
             build_cache,
             None,

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1,9 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fmt::Display;
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::sync::LazyLock;
 use std::thread::ScopedJoinHandle;
 use std::{env, fmt};
@@ -26,9 +25,9 @@ use pollster::FutureExt as _;
 use rsevents_extra::Semaphore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::{Span, debug, info_span, instrument, trace, warn};
+use tracing::{Span, debug, info_span, instrument, warn};
 
-use super::nix::{self, nix_base_command};
+use super::nix::nix_base_command;
 use super::nix_auth::{AuthError, AuthProvider};
 use crate::data::System;
 use crate::models::nix_plugins::NIX_PLUGINS;
@@ -141,9 +140,6 @@ pub enum BuildEnvError {
     #[error("Failed to call 'nix build'")]
     CallNixBuild(#[source] std::io::Error),
 
-    #[error("Failed to write nix arguments to stdin")]
-    WriteNixStdin(#[source] std::io::Error),
-
     /// An error that occurred while deserializing the output of the `nix build` command.
     #[error("Failed to deserialize 'nix build' output:\n{output}\nError: {err}")]
     ReadOutputs {
@@ -201,8 +197,8 @@ pub enum BuildEnvError {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct BuildEnvOutputs {
-    pub develop: BuiltStorePath,
-    pub runtime: BuiltStorePath,
+    pub dev: BuiltStorePath,
+    pub run: BuiltStorePath,
     /// A map of additional built store paths.
     /// These are the runtime environments for each manifest build.
     /// The main consumer of this is [super::build::FloxBuildMk].
@@ -215,8 +211,8 @@ impl BuildEnvOutputs {
     /// Returns the built environment path for an activation mode.
     pub fn for_mode(self, mode: &ActivateMode) -> BuiltStorePath {
         match mode {
-            ActivateMode::Dev => self.develop,
-            ActivateMode::Run => self.runtime,
+            ActivateMode::Dev => self.dev,
+            ActivateMode::Run => self.run,
         }
     }
 }
@@ -232,6 +228,7 @@ pub trait BuildEnv {
         client: &impl ClientTrait,
         lockfile: &Path,
         service_config_path: Option<PathBuf>,
+        out_link_prefix: Option<&Path>,
     ) -> Result<BuildEnvOutputs, BuildEnvError>;
 }
 
@@ -880,7 +877,7 @@ where
     /// the `buildenv.nix` expression.
     ///
     /// The `buildenv.nix` reads the lockfile and composes
-    /// an environment derivation, with outputs for the `develop` and `runtime` modes,
+    /// an environment derivation, with outputs for the `dev` and `run` modes,
     /// as well as additional outputs for each manifest build.
     /// Note that the `buildenv.nix` expression **does not** build any of the packages!
     /// Instead it will exclusively use the store paths of the packages,
@@ -893,9 +890,15 @@ where
         &self,
         lockfile_path: &Path,
         service_config_path: Option<PathBuf>,
+        out_link_prefix: Option<&Path>,
     ) -> Result<BuildEnvOutputs, BuildEnvError> {
         let mut nix_build_command = Self::base_command();
-        nix_build_command.args(["build", "--no-link", "--offline", "--json"]);
+        nix_build_command.args(["build", "--offline", "--json"]);
+        if let Some(prefix) = out_link_prefix {
+            nix_build_command.arg("--out-link").arg(prefix);
+        } else {
+            nix_build_command.arg("--no-link");
+        }
         nix_build_command.arg("--file").arg(&*BUILDENV_NIX);
         nix_build_command
             .arg("--argstr")
@@ -928,7 +931,9 @@ where
             });
 
         if let Ok([build_env_result]) = build_env_result {
-            return Ok(build_env_result.outputs);
+            let outputs = build_env_result.outputs;
+            remove_build_output_symlinks(out_link_prefix, &outputs);
+            return Ok(outputs);
         }
 
         // Preexisting store paths produced by the build may have been (partially) swept away.
@@ -954,13 +959,76 @@ where
         }
 
         let [build_env_result]: [BuildEnvResultRaw; 1] = serde_json::from_slice(&output.stdout)
-            .inspect_err(|_| debug!("failed to deserialize output on second try"))
+            .inspect_err(|_| {
+                debug!("failed to deserialize output on second try");
+                remove_build_output_symlinks_by_scan(out_link_prefix);
+            })
             .map_err(|err| BuildEnvError::ReadOutputs {
                 output: String::from_utf8_lossy(&output.stdout).to_string(),
                 err,
             })?;
         let outputs = build_env_result.outputs;
+        remove_build_output_symlinks(out_link_prefix, &outputs);
         Ok(outputs)
+    }
+}
+
+/// Remove the `<prefix>-build-*` symlinks that `nix build --out-link` creates
+/// for manifest build outputs.
+///
+/// `nix build --out-link <prefix>` writes a symlink for every derivation
+/// output: `<prefix>-run`, `<prefix>-dev`, and — for environments with build
+/// sections — `<prefix>-build-<id>` for each manifest build output.  The
+/// `build-*` symlinks clutter `.flox/run/`.  We delete them immediately after
+/// the build — this also removes the GC roots for those outputs, which is
+/// intentional.  The store paths are captured in
+/// `outputs.manifest_build_runtimes` before deletion.
+fn remove_build_output_symlinks(out_link_prefix: Option<&Path>, outputs: &BuildEnvOutputs) {
+    let Some(prefix) = out_link_prefix else {
+        return;
+    };
+    for key in outputs.manifest_build_runtimes.keys() {
+        let mut link_name = prefix.as_os_str().to_owned();
+        link_name.push("-");
+        link_name.push(key.as_str());
+        let link_path = PathBuf::from(link_name);
+        if link_path.is_symlink()
+            && let Err(e) = std::fs::remove_file(&link_path)
+        {
+            debug!(path=?link_path, error=%e, "failed to remove build output symlink from run dir");
+        }
+    }
+}
+
+/// Fallback version of [`remove_build_output_symlinks`] for the error path,
+/// where we have a prefix but no parsed outputs to iterate over.  Scans the
+/// parent directory and removes any symlink whose name starts with
+/// `<prefix_filename>-build-`.
+fn remove_build_output_symlinks_by_scan(out_link_prefix: Option<&Path>) {
+    let Some(prefix) = out_link_prefix else {
+        return;
+    };
+    let Some(parent) = prefix.parent() else {
+        return;
+    };
+    let Some(prefix_name) = prefix.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+    let scan_prefix = format!("{prefix_name}-build-");
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if name_str.starts_with(&scan_prefix)
+            && entry.path().is_symlink()
+            && let Err(e) = std::fs::remove_file(entry.path())
+        {
+            debug!(path=?entry.path(), error=%e, "failed to remove build output symlink from run dir");
+        }
     }
 }
 
@@ -1197,6 +1265,7 @@ where
         client: &impl ClientTrait,
         lockfile_path: &Path,
         service_config_path: Option<PathBuf>,
+        out_link_prefix: Option<&Path>,
     ) -> Result<BuildEnvOutputs, BuildEnvError> {
         // Note: currently used in a single integration test to verify,
         // that the buildenv is not called a second time for remote environments,
@@ -1271,7 +1340,7 @@ where
                     .collect()
             },
             || all_env_paths.clone(),
-            || self.call_buildenv_nix(lockfile_path, service_config_path.clone()),
+            || self.call_buildenv_nix(lockfile_path, service_config_path.clone(), out_link_prefix),
         )
     }
 }
@@ -1313,82 +1382,6 @@ pub fn get_installed_outputs(package: &PackageToList) -> Result<Vec<String>, Man
         },
         None => Ok(outputs_to_install.clone().unwrap_or(all_outputs)),
     }
-}
-
-/// Create GC roots for the given store paths.
-/// All provided paths must exist and be valid.
-/// Used by `CoreEnvironment::link()` to protect the final out-link.
-///
-/// Gc roots are created in the provided `gc_root_base_dir`
-/// with a unique prefix _per call_ to this function:
-///
-/// ```text
-/// <basedir>/
-///     gc-root.rqw2rr3-1
-///     gc-root.rqw2rr3-2
-///     gc-root.rqw2rr3-3
-///     gc-root.i1343ca-1   # separate call to create_gc_root_in()
-/// ```
-///
-/// as they would otherwise override exiting roots.
-/// It is advisable to place the <basedir> under `/tmp`
-/// to allow paths to be GC'd eventually if they are otherwise unused.
-pub(crate) fn create_gc_root_in(
-    paths: impl IntoIterator<Item = impl AsRef<Path>>,
-    gc_root_prefix: impl AsRef<Path>,
-) -> Result<(), BuildEnvError> {
-    let paths = paths
-        .into_iter()
-        .map(|p| p.as_ref().to_string_lossy().into_owned())
-        .collect::<HashSet<_>>();
-
-    if paths.is_empty() {
-        debug!("no paths to create gc roots for, skipping");
-        return Ok(());
-    }
-
-    let mut command = nix::nix_base_command();
-    command.stdin(Stdio::piped());
-    command.stderr(Stdio::piped());
-    command.stdout(Stdio::piped());
-    command.args(["build", "--stdin"]);
-    // avoid substitution or builds
-    command.args(["--offline", "-j", "0"]);
-    command.arg("--out-link");
-    command.arg(gc_root_prefix.as_ref());
-
-    let paths_arg = paths
-        .iter()
-        .map(|s| s.as_str())
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    debug!(
-        cmd = format!("echo '{}' | {}", paths_arg, command.display()),
-        "bulk setting gc roots for store_paths"
-    );
-
-    let mut child = command.spawn().map_err(BuildEnvError::CallNixBuild)?;
-    let stdin = child.stdin.as_mut().unwrap();
-
-    for path in paths.iter() {
-        trace!(%path, "setting gc root for store path");
-        writeln!(stdin, "{path}").map_err(BuildEnvError::WriteNixStdin)?;
-    }
-
-    stdin.flush().map_err(BuildEnvError::WriteNixStdin)?;
-
-    let output = child
-        .wait_with_output()
-        .map_err(BuildEnvError::CallNixBuild)?;
-
-    if !output.status.success() {
-        return Err(BuildEnvError::Link(
-            String::from_utf8_lossy(&output.stderr).into_owned(),
-        ));
-    }
-
-    Ok(())
 }
 
 /// Join all realise (download) thread handles, returning the first error encountered.
@@ -2161,17 +2154,17 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/hello/manifest.lock");
         let client = MockClient::new();
-        buildenv.build(&client, &lockfile_path, None).unwrap()
+        buildenv.build(&client, &lockfile_path, None, None).unwrap()
     });
 
     #[test]
     fn build_contains_binaries() {
         let result = &*BUILDENV_RESULT_SIMPLE_PACKAGE;
-        let runtime = &result.runtime;
+        let runtime = &result.run;
         assert!(runtime.join("bin/hello").exists());
         assert!(runtime.join("bin/hello").is_executable_file());
 
-        let develop = result.develop.as_ref();
+        let develop = result.dev.as_ref();
         assert!(develop.join("bin/hello").exists());
         assert!(develop.join("bin/hello").is_executable_file());
     }
@@ -2179,12 +2172,12 @@ mod buildenv_tests {
     #[test]
     fn build_contains_activate_files() {
         let result = &*BUILDENV_RESULT_SIMPLE_PACKAGE;
-        let runtime = &result.runtime;
+        let runtime = &result.run;
         assert!(runtime.join("activate").exists());
         assert!(runtime.join("activate.d/zsh").exists());
         assert!(runtime.join("etc/profile.d").is_dir());
 
-        let develop = &result.develop;
+        let develop = &result.dev;
         assert!(develop.join("activate").exists());
         assert!(develop.join("activate.d/zsh").exists());
         assert!(develop.join("etc/profile.d").is_dir());
@@ -2193,10 +2186,10 @@ mod buildenv_tests {
     #[test]
     fn build_contains_lockfile() {
         let result = &*BUILDENV_RESULT_SIMPLE_PACKAGE;
-        let runtime = &result.runtime;
+        let runtime = &result.run;
         assert!(runtime.join("manifest.lock").exists());
 
-        let develop = &result.develop;
+        let develop = &result.dev;
         assert!(develop.join("manifest.lock").exists());
     }
     #[test]
@@ -2204,10 +2197,10 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/build-noop/manifest.lock");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None).unwrap();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
 
-        let runtime = result.runtime.as_ref();
-        let develop = result.develop.as_ref();
+        let runtime = result.run.as_ref();
+        let develop = result.dev.as_ref();
         let build_hello = result.manifest_build_runtimes.get("build-hello").unwrap();
 
         assert!(runtime.join("package-builds.d/hello").exists());
@@ -2220,12 +2213,12 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/kitchen_sink/manifest.lock");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None).unwrap();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
 
-        let runtime = &result.runtime;
+        let runtime = &result.run;
         assert!(runtime.join("activate.d/hook-on-activate").exists());
 
-        let develop = &result.develop;
+        let develop = &result.dev;
         assert!(develop.join("activate.d/hook-on-activate").exists());
     }
 
@@ -2234,9 +2227,9 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/kitchen_sink/manifest.lock");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None).unwrap();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
 
-        for output in [&result.runtime, &result.develop] {
+        for output in [&result.run, &result.dev] {
             for shell in ["common", "zsh", "fish", "bash", "tcsh"] {
                 assert!(
                     output.join(format!("activate.d/profile-{shell}")).exists(),
@@ -2251,8 +2244,8 @@ mod buildenv_tests {
     fn verify_contents_of_requisites_txt() {
         let result = &*BUILDENV_RESULT_SIMPLE_PACKAGE;
 
-        let runtime = result.runtime.as_ref();
-        let develop = result.develop.as_ref();
+        let runtime = result.run.as_ref();
+        let develop = result.dev.as_ref();
 
         for out_path in [runtime, develop] {
             let requisites_path = out_path.join("requisites.txt");
@@ -2286,7 +2279,7 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/vim-vim-full-conflict.yaml");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None);
+        let result = buildenv.build(&client, &lockfile_path, None, None);
         let err = result.expect_err("conflicting packages should fail to build");
 
         let BuildEnvError::Build(output) = err else {
@@ -2308,7 +2301,7 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/vim-vim-full-conflict-resolved.yaml");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None);
+        let result = buildenv.build(&client, &lockfile_path, None, None);
         assert!(
             result.is_ok(),
             "conflicting packages should be resolved by priority: {}",
@@ -2323,7 +2316,7 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = MANUALLY_GENERATED.join("buildenv/lockfiles/null_fields/manifest.lock");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None);
+        let result = buildenv.build(&client, &lockfile_path, None, None);
         assert!(
             result.is_ok(),
             "environment should render succesfully: {}",
@@ -2344,10 +2337,10 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = MANUALLY_GENERATED.join("buildenv/lockfiles/vars_escape/manifest.lock");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None).unwrap();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
 
-        let runtime = result.runtime.as_ref();
-        let develop = result.develop.as_ref();
+        let runtime = result.run.as_ref();
+        let develop = result.dev.as_ref();
 
         for envrc_path in [
             runtime.join("activate.d/envrc"),
@@ -2365,10 +2358,10 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/build-runtime-all-toplevel.yaml");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None).unwrap();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
 
-        let runtime = result.runtime.as_ref();
-        let develop = result.develop.as_ref();
+        let runtime = result.run.as_ref();
+        let develop = result.dev.as_ref();
         let build_myhello = result.manifest_build_runtimes.get("build-myhello").unwrap();
 
         assert!(runtime.join("bin/hello").is_executable_file());
@@ -2389,10 +2382,10 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/build-runtime-packages-only-hello.yaml");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None).unwrap();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
 
-        let runtime = result.runtime.as_ref();
-        let develop = result.develop.as_ref();
+        let runtime = result.run.as_ref();
+        let develop = result.dev.as_ref();
         let build_myhello = result.manifest_build_runtimes.get("build-myhello").unwrap();
 
         assert!(runtime.join("bin/hello").is_executable_file());
@@ -2413,7 +2406,7 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/build-runtime-packages-not-toplevel.yaml");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None);
+        let result = buildenv.build(&client, &lockfile_path, None, None);
         let err = result.expect_err("build should fail if non-toplevel packages are selected");
 
         let BuildEnvError::Build(output) = err else {
@@ -2435,7 +2428,7 @@ mod buildenv_tests {
         let buildenv = buildenv_instance();
         let lockfile_path = GENERATED_DATA.join("envs/build-runtime-packages-not-found.yaml");
         let client = MockClient::new();
-        let result = buildenv.build(&client, &lockfile_path, None);
+        let result = buildenv.build(&client, &lockfile_path, None, None);
         let err = result.expect_err("build should fail if nonexistent packages are selected");
 
         let BuildEnvError::Build(output) = err else {
@@ -2460,7 +2453,7 @@ mod buildenv_tests {
         // Get a v2 lockfile with no outputs specified (should use outputs_to_install)
         let lockfile_path = GENERATED_DATA.join("envs/bash_v1_10_0_default/manifest.lock");
 
-        let result = buildenv.build(&client, &lockfile_path, None);
+        let result = buildenv.build(&client, &lockfile_path, None, None);
         assert!(
             result.is_ok(),
             "environment should build successfully: {}",
@@ -2468,8 +2461,8 @@ mod buildenv_tests {
         );
 
         let outputs = result.unwrap();
-        let runtime = outputs.runtime.as_ref();
-        let develop = outputs.develop.as_ref();
+        let runtime = outputs.run.as_ref();
+        let develop = outputs.dev.as_ref();
 
         // For the `bash` package the full list of outputs is:
         //
@@ -2536,7 +2529,7 @@ mod buildenv_tests {
         // Get a v2 lockfile with outputs = "all"
         let lockfile_path = GENERATED_DATA.join("envs/bash_v1_10_0_all/manifest.lock");
 
-        let result = buildenv.build(&client, &lockfile_path, None);
+        let result = buildenv.build(&client, &lockfile_path, None, None);
         assert!(
             result.is_ok(),
             "environment should build successfully: {}",
@@ -2544,8 +2537,8 @@ mod buildenv_tests {
         );
 
         let outputs = result.unwrap();
-        let runtime = outputs.runtime.as_ref();
-        let develop = outputs.develop.as_ref();
+        let runtime = outputs.run.as_ref();
+        let develop = outputs.dev.as_ref();
 
         // For the `bash` package the full list of outputs is:
         //
@@ -2604,7 +2597,7 @@ mod buildenv_tests {
         // Get a v2 lockfile with outputs = ["out"]
         let lockfile_path = GENERATED_DATA.join("envs/bash_v1_10_0_out/manifest.lock");
 
-        let result = buildenv.build(&client, &lockfile_path, None);
+        let result = buildenv.build(&client, &lockfile_path, None, None);
         assert!(
             result.is_ok(),
             "environment should build successfully: {}",
@@ -2612,8 +2605,8 @@ mod buildenv_tests {
         );
 
         let outputs = result.unwrap();
-        let runtime = outputs.runtime.as_ref();
-        let develop = outputs.develop.as_ref();
+        let runtime = outputs.run.as_ref();
+        let develop = outputs.dev.as_ref();
 
         // For the `bash` package the full list of outputs is:
         //
@@ -2756,8 +2749,8 @@ mod materialise_retry_tests {
 
     fn fake_outputs() -> BuildEnvOutputs {
         BuildEnvOutputs {
-            develop: BuiltStorePath(PathBuf::from("/nix/store/fake-develop")),
-            runtime: BuiltStorePath(PathBuf::from("/nix/store/fake-runtime")),
+            dev: BuiltStorePath(PathBuf::from("/nix/store/fake-develop")),
+            run: BuiltStorePath(PathBuf::from("/nix/store/fake-runtime")),
             manifest_build_runtimes: HashMap::new(),
         }
     }

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -902,7 +902,7 @@ pub fn check_build_metadata(
 
     let build_results = builder.build(
         &base_nixpkgs_url.as_flake_ref()?,
-        &built_environments.develop,
+        &built_environments.dev,
         &[pkg.name()],
         Some(false),
         system_override,

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -187,8 +187,7 @@ impl Edit {
 
                 // The current generation already has a lock,
                 // so we can skip locking.
-                let store_path = generations_environment.build(&flox)?;
-                generations_environment.link(&store_path)?;
+                generations_environment.build(&flox)?;
 
                 message::updated("Environment changes reset to current generation.");
             },

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -350,8 +350,7 @@ impl Pull {
         } else {
             // The pulled generation already has a lock,
             // so we can skip locking.
-            env.build(flox)
-                .and_then(|store_paths| env.link(&store_paths))
+            env.build(flox).map(|_| ())
         };
 
         let resolution = Self::handle_pull_result(

--- a/cli/tests/activate-mode.bats
+++ b/cli/tests/activate-mode.bats
@@ -59,11 +59,11 @@ function set_manifest_mode() {
 }
 
 function assert_dev_mode() {
-  assert_output --partial "${NIX_SYSTEM}.${PROJECT_NAME}.dev"
+  assert_output --partial "${NIX_SYSTEM}.${PROJECT_NAME}-dev"
 }
 
 function assert_run_mode() {
-  assert_output --partial "${NIX_SYSTEM}.${PROJECT_NAME}.run"
+  assert_output --partial "${NIX_SYSTEM}.${PROJECT_NAME}-run"
 }
 
 @test "activate defaults to dev mode" {
@@ -146,7 +146,7 @@ EOF
   "$FLOX_BIN" edit -n "runtime_project" # give it a stable name
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/almonds.yaml" "$FLOX_BIN" install almonds
   run "$FLOX_BIN" activate -m run -c "which almonds"
-  assert_output --partial ".flox/run/$NIX_SYSTEM.runtime_project.run/bin/almonds"
+  assert_output --partial ".flox/run/$NIX_SYSTEM.runtime_project-run/bin/almonds"
 }
 
 @test "runtime: remains in runtime mode as bottom layer" {

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -394,18 +394,18 @@ EOF
 
   # Test running the activate script directly in various forms.
   export _FLOX_SHELL_FORCE="bash"
-  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.run/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.run -c :
+  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-run/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-run -c :
   assert_success
   assert_output --partial "sourcing hook.on-activate"
-  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev -c :
+  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev -c :
   assert_success
-  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev -c true
+  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev -c true
   assert_success
-  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev --command true
+  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev --command true
   assert_success
-  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev true
+  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev true
   assert_success
-  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev -- true
+  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev -- true
   assert_success
 }
 
@@ -415,10 +415,10 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml" "$FLOX_BIN" install hello
 
   # Verify that running the activate script directly can access installed packages.
-  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev -- hello
+  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev -- hello
   assert_success
   assert_output --partial "Hello, world!"
-  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev --command hello
+  NO_COLOR=1 run $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/activate --env $PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev --command hello
   assert_success
   assert_output --partial "Hello, world!"
 }
@@ -1302,7 +1302,7 @@ sets_NIX_SSL_CERT_FILE() {
 sourcing hook.on-activate
 sourcing profile.common
 sourcing profile.bash
-hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello
+hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/hello
 baz
 EOF
 }
@@ -1327,7 +1327,7 @@ Setting PATH from config.fish
 sourcing hook.on-activate
 sourcing profile.common
 sourcing profile.fish
-hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello
+hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/hello
 baz
 EOF
 }
@@ -1352,7 +1352,7 @@ Setting PATH from .tcshrc
 sourcing hook.on-activate
 sourcing profile.common
 sourcing profile.tcsh
-hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello
+hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/hello
 baz
 EOF
 }
@@ -1377,7 +1377,7 @@ Setting PATH from .zshenv
 sourcing hook.on-activate
 sourcing profile.common
 sourcing profile.zsh
-hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello
+hello is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/hello
 baz
 EOF
 }
@@ -1500,7 +1500,7 @@ EOF
 
   run -- "$FLOX_BIN" activate -c 'echo PYTHONPATH is "$PYTHONPATH"'
   assert_success
-  assert_line "PYTHONPATH is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/lib/python3.11/site-packages"
+  assert_line "PYTHONPATH is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/lib/python3.11/site-packages"
 
   run -- "$FLOX_BIN" activate -c 'echo PIP_CONFIG_FILE is "$PIP_CONFIG_FILE"'
   assert_success
@@ -2744,7 +2744,7 @@ EOF
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/fish_3_2_2.yaml" \
     "$FLOX_BIN" install fish@3.2.2
 
-  FLOX_SHELL="./.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/fish" run "$FLOX_BIN" activate -c "echo \$FISH_VERSION"
+  FLOX_SHELL="./.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/fish" run "$FLOX_BIN" activate -c "echo \$FISH_VERSION"
   assert_success
   # fish doesn't have the equivalent of set -e, so refute "Error"
   refute_output --partial Error
@@ -2779,7 +2779,7 @@ EOF
   echo "$MANIFEST_CONTENTS" | _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml" \
     "$FLOX_BIN" edit -f -
 
-  hello_path="$(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello"
+  hello_path="$(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/hello"
   run /bin/bash -c "eval \"\$(\"$FLOX_BIN\" activate)\" && which hello"
   assert_success
   assert_output - <<EOF
@@ -3537,14 +3537,14 @@ PIDs of the running activations: ${ACTIVATION_PID}"
 
   case "$NIX_SYSTEM" in
     *-linux)
-      VIM_MAN="$(realpath "$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man/man1/vim.1.gz")"
-      EMACS_MAN="$(realpath "$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man/man1/emacs.1.gz")"
+      VIM_MAN="$(realpath "$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim-dev/share/man/man1/vim.1.gz")"
+      EMACS_MAN="$(realpath "$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/share/man/man1/emacs.1.gz")"
 
       # Neither environment starts out in MANPATH
       run $_man --path
       assert_success
-      refute_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
-      refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man.*"
+      refute_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim-dev/share/man.*"
+      refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/share/man.*"
 
       # vim gets added to MANPATH
       _man=$_man FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "$_man --path vim > output; echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
@@ -3568,26 +3568,26 @@ PIDs of the running activations: ${ACTIVATION_PID}"
       # Neither environment starts out in MANPATH
       run /usr/bin/manpath
       assert_success
-      refute_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
-      refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man.*"
+      refute_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim-dev/share/man.*"
+      refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/share/man.*"
 
       # vim gets added to MANPATH
       FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "/usr/bin/manpath > output && echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
       cat activate_started_fifo
       run cat output
       assert_success
-      assert_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
-      refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man.*"
+      assert_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim-dev/share/man.*"
+      refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/share/man.*"
 
       # emacs gets added to MANPATH, and then a nested attach also adds vim
       FLOX_SHELL=bash "$FLOX_BIN" activate -d emacs -c \
         "/usr/bin/manpath > output_1 && \"$FLOX_BIN\" activate -d vim -c '/usr/bin/manpath > output_2'"
       run cat output_1
-      refute_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
-      assert_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man.*"
+      refute_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim-dev/share/man.*"
+      assert_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/share/man.*"
       run cat output_2
-      assert_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim.dev/share/man.*"
-      assert_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/share/man.*"
+      assert_output --regexp ".*$PROJECT_DIR/vim/.flox/run/$NIX_SYSTEM.vim-dev/share/man.*"
+      assert_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/share/man.*"
       ;;
     *)
       echo "unsupported system: $NIX_SYSTEM"
@@ -3614,29 +3614,29 @@ PIDs of the running activations: ${ACTIVATION_PID}"
   mkfifo "$TEARDOWN_FIFO"
 
   run command -v vim
-  refute_output "$(realpath "$PROJECT_DIR")/vim/.flox/run/$NIX_SYSTEM.vim.dev/bin/vim"
+  refute_output "$(realpath "$PROJECT_DIR")/vim/.flox/run/$NIX_SYSTEM.vim-dev/bin/vim"
 
   run command -v emacs
-  refute_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/bin/emacs"
+  refute_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/bin/emacs"
 
   FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "command -v vim > output; echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
   cat activate_started_fifo
 
   run cat output
   assert_success
-  assert_output "$(realpath "$PROJECT_DIR")/vim/.flox/run/$NIX_SYSTEM.vim.dev/bin/vim"
+  assert_output "$(realpath "$PROJECT_DIR")/vim/.flox/run/$NIX_SYSTEM.vim-dev/bin/vim"
 
   "$FLOX_BIN" activate -d emacs -c \
     'command -v emacs > output_emacs_1; "$FLOX_BIN" activate -d vim -c "command -v vim > output_vim && command -v emacs > output_emacs_2 || true"'
   run cat output_emacs_1
   assert_success
-  assert_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/bin/emacs"
+  assert_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/bin/emacs"
   run cat output_vim
   assert_success
-  assert_output "$(realpath "$PROJECT_DIR")/vim/.flox/run/$NIX_SYSTEM.vim.dev/bin/vim"
+  assert_output "$(realpath "$PROJECT_DIR")/vim/.flox/run/$NIX_SYSTEM.vim-dev/bin/vim"
   run cat output_emacs_2
   assert_success
-  assert_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs.dev/bin/emacs"
+  assert_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/bin/emacs"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -3721,7 +3721,7 @@ EOF
     set -euo pipefail
     _expect="$(command -v expect)"
     eval "$("$FLOX_BIN" activate -d default)"
-    if ! [[ "$PATH" =~ $PROJECT_DIR/default/.flox/run/.*.default.dev/bin ]]; then # to double check we activated the default environment
+    if ! [[ "$PATH" =~ $PROJECT_DIR/default/.flox/run/.*.default-dev/bin ]]; then # to double check we activated the default environment
       echo "default not in PATH: $PATH"
       exit 1
     fi
@@ -3729,7 +3729,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --regexp "project/.flox/run/.*.project.dev/bin.*default/.flox/run/.*.default.dev/bin"
+  assert_output --regexp "project/.flox/run/.*.project-dev/bin.*default/.flox/run/.*.default-dev/bin"
 }
 
 @test "tcsh: repeat activation in .tcshrc doesn't break aliases" {
@@ -3825,7 +3825,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --regexp "$PROJECT_DIR/project/.flox/run/.*.project.dev/bin.*$PROJECT_DIR/default/.flox/run/.*.default.dev/bin"
+  assert_output --regexp "$PROJECT_DIR/project/.flox/run/.*.project-dev/bin.*$PROJECT_DIR/default/.flox/run/.*.default-dev/bin"
 }
 
 @test "fish: repeat activation in config.fish doesn't break aliases" {
@@ -3898,7 +3898,7 @@ EOF
   FISH="$(which fish)"
   EXPECT="$(which expect)"
   run fish <(cat <<EOF
-    if not string match -r -- '$PROJECT_DIR/default/.flox/run/.*\.default\.dev/bin' "\$PATH"
+    if not string match -r -- '$PROJECT_DIR/default/.flox/run/.*\.default\-dev/bin' "\$PATH"
       echo "default not in PATH: \$PATH"
       exit 1
     end
@@ -3906,7 +3906,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --regexp "$PROJECT_DIR/project/.flox/run/.*.project.dev/bin.*$PROJECT_DIR/default/.flox/run/.*.default.dev/bin"
+  assert_output --regexp "$PROJECT_DIR/project/.flox/run/.*.project-dev/bin.*$PROJECT_DIR/default/.flox/run/.*.default-dev/bin"
 }
 
 zsh_repeat_activation_aliases() {
@@ -4003,7 +4003,7 @@ EOF
   EXPECT="$(which expect)"
   run zsh -i <(cat <<EOF
     set -euo pipefail
-    if ! [[ "\$PATH" =~ $PROJECT_DIR/default/.flox/run/.*.default.dev/bin ]]; then # to double check we activated the default environment
+    if ! [[ "\$PATH" =~ $PROJECT_DIR/default/.flox/run/.*.default-dev/bin ]]; then # to double check we activated the default environment
       echo "default not in PATH: \$PATH"
       exit 1
     fi
@@ -4011,7 +4011,7 @@ EOF
 EOF
 )
   assert_success
-  assert_output --regexp "$PROJECT_DIR/project/.flox/run/.*.project.dev/bin.*$PROJECT_DIR/default/.flox/run/.*.default.dev/bin"
+  assert_output --regexp "$PROJECT_DIR/project/.flox/run/.*.project-dev/bin.*$PROJECT_DIR/default/.flox/run/.*.default-dev/bin"
 }
 
 @test "zsh: repeat activation in .zshrc creates correct PATH ordering" {
@@ -4056,7 +4056,33 @@ attach_previous_release() {
   shell="${1?}"
   mode="${2?}"
 
+  # Set to "true" in the PR that bumps activations.json schema version (e.g.
+  # Version<3> -> Version<4>), so the previous-release tests assert the
+  # incompatible-version error instead of a successful attach.
+  # Set back to "false" once FLOX_LATEST_VERSION is a release that already
+  # writes the bumped schema version (both versions share the same schema, so
+  # attach should succeed).
+  #
+  # The activation state schema is still Version<3> in this release (same as
+  # v1.12.1), so the current binary can attach to a previous-release activation.
   incrementing_version_this_release="false"
+
+  # The GC root symlink naming convention changed in this release from
+  # dot-separator (<system>.<name>.dev / <system>.<name>.run) to
+  # dash-separator (<system>.<name>-dev / <system>.<name>-run).  The previous
+  # release (v1.12.1) creates symlinks with the old naming; the current binary
+  # looks for symlinks with the new naming.  Cross-version attach fails to find
+  # the existing GC root symlinks, causing it to start a new activation instead
+  # of attaching and making the test fail for the wrong reason.
+  #
+  # Set to "true" whenever the buildenv format changes and FLOX_LATEST_VERSION
+  # still points to a release that uses the old format.  Set back to "false"
+  # once FLOX_LATEST_VERSION is a release that already uses the new format
+  # (so both sides use the same GC root symlink paths and attachment succeeds).
+  buildenv_format_changed_this_release="true"
+  if [ "$buildenv_format_changed_this_release" = "true" ]; then
+    skip "buildenv output format changed in this release; cross-version attach requires matching GC root symlink paths (set buildenv_format_changed_this_release=false once FLOX_LATEST_VERSION uses the new format)"
+  fi
 
   echo "$HOOK_ONLY_ONCE" | "$FLOX_BIN" edit -f -
 
@@ -4112,7 +4138,14 @@ Setting PATH from ${rc_file}"
 
   # Longer timeout to allow for `nix run` locking.
   background_pid="$!"
-  wait_for_background_activation "$background_pid" 15s
+  if ! wait_for_background_activation "$background_pid" 15s; then
+    # If the previous release failed to build the environment (e.g. because the
+    # buildenv output format changed), skip rather than fail.
+    if grep -q "Failed to build environment" output 2>/dev/null; then
+      skip "Previous release cannot build environment with current buildenv format"
+    fi
+    exit 1
+  fi
   run cat output
   # This the only place we use `--partial` because we only want to know that the
   # intial activation started.
@@ -4613,12 +4646,12 @@ EOF
 
   # Assert on both activations to ensure that we really got an in-place activation first.
   assert_output - << EOF
-FLOX_ENV: ${PROJECT_DIR_CANONICAL}/${PROJECT_DEFAULT}/.flox/run/${NIX_SYSTEM}.${PROJECT_DEFAULT}.${MODE}
+FLOX_ENV: ${PROJECT_DIR_CANONICAL}/${PROJECT_DEFAULT}/.flox/run/${NIX_SYSTEM}.${PROJECT_DEFAULT}-${MODE}
 FLOX_ENV_CACHE: ${PROJECT_DIR_CANONICAL}/${PROJECT_DEFAULT}/.flox/cache
 FLOX_ENV_PROJECT: ${PROJECT_DIR_CANONICAL}/${PROJECT_DEFAULT}
 FLOX_ENV_DESCRIPTION: ${PROJECT_DEFAULT}
 ---
-FLOX_ENV: ${PROJECT_DIR_CANONICAL}/${PROJECT_USER}/.flox/run/${NIX_SYSTEM}.${PROJECT_USER}.${MODE}
+FLOX_ENV: ${PROJECT_DIR_CANONICAL}/${PROJECT_USER}/.flox/run/${NIX_SYSTEM}.${PROJECT_USER}-${MODE}
 FLOX_ENV_CACHE: ${PROJECT_DIR_CANONICAL}/${PROJECT_USER}/.flox/cache
 FLOX_ENV_PROJECT: ${PROJECT_DIR_CANONICAL}/${PROJECT_USER}
 FLOX_ENV_DESCRIPTION: ${PROJECT_USER}
@@ -4762,8 +4795,8 @@ nested_activation_setup() {
   "$FLOX_BIN" init -d outer
 
   proj="$(realpath "$PROJECT_DIR")"
-  export default_stub="$proj/default/.flox/run/$NIX_SYSTEM.default.dev"
-  export outer_stub="$proj/outer/.flox/run/$NIX_SYSTEM.outer.dev"
+  export default_stub="$proj/default/.flox/run/$NIX_SYSTEM.default-dev"
+  export outer_stub="$proj/outer/.flox/run/$NIX_SYSTEM.outer-dev"
 }
 
 # Produces the command that will run an in-place activation in a particular
@@ -5423,7 +5456,7 @@ success"
   LOCK_HASH_1=$(sha256sum .flox/env/manifest.lock | awk '{print $1}')
   LOCK_MTIME_1=$(stat -c %Y .flox/env/manifest.lock)
 
-  LINK_TARGET_1=$(readlink ".flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev")
+  LINK_TARGET_1=$(readlink ".flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev")
 
   # Second activate — must be a complete no-op.
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml" \
@@ -5432,7 +5465,7 @@ success"
   LOCK_HASH_2=$(sha256sum .flox/env/manifest.lock | awk '{print $1}')
   LOCK_MTIME_2=$(stat -c %Y .flox/env/manifest.lock)
 
-  LINK_TARGET_2=$(readlink ".flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev")
+  LINK_TARGET_2=$(readlink ".flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev")
 
   # All three signals must be identical between activations.
   assert_equal "$LOCK_HASH_1"    "$LOCK_HASH_2"

--- a/cli/tests/build-wrapper.bats
+++ b/cli/tests/build-wrapper.bats
@@ -82,7 +82,7 @@ EOF
   # The wrapped program should pass through FLOX_ENV_DIRS
   run "$FLOX_BIN" activate -d consumer -- print-FLOX_ENV_DIRS
   assert_success
-  assert_output --regexp ".*consumer/.flox/run/$NIX_SYSTEM.consumer.dev"
+  assert_output --regexp ".*consumer/.flox/run/$NIX_SYSTEM.consumer-dev"
 }
 
 # Check that
@@ -109,7 +109,7 @@ EOF
   # Double check toml module can be found with environment activated
   run "$FLOX_BIN" activate -d consumer -- python3 -c "import toml; print(toml.__path__)"
   assert_success
-  assert_output --regexp "\['.*consumer/.flox/run/$NIX_SYSTEM.consumer.dev/lib/python3.13/site-packages/toml'\]"
+  assert_output --regexp "\['.*consumer/.flox/run/$NIX_SYSTEM.consumer-dev/lib/python3.13/site-packages/toml'\]"
 
   # Wrapped program can find requests but not toml
   run "$FLOX_BIN" activate -d consumer -- print-modules

--- a/cli/tests/edit.bats
+++ b/cli/tests/edit.bats
@@ -422,7 +422,7 @@ EOF
   PROJECT_DIR="$(realpath "$PROJECT_DIR")"
   run "$FLOX_BIN" activate -- bash -c 'command -v hello'
   assert_success
-  assert_output "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}.dev/bin/hello"
+  assert_output "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev/bin/hello"
 
   run "$FLOX_BIN" activate -- bash -c 'realpath "$(command -v hello)"'
   assert_success

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -318,7 +318,7 @@ Upstream:
   export PROJECT_DIR="$(realpath "$PROJECT_DIR")"
   run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -c 'command -v hello'
   assert_success
-  assert_output --regexp "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}.dev/bin/hello"
+  assert_output --regexp "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev/bin/hello"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -97,8 +97,8 @@ EOF
   run --separate-stderr "$FLOX_BIN" install hello --reference "$OWNER/test"
   assert_success
 
-  assert [ -h "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox/run/$NIX_SYSTEM.test.dev" ]
-  assert [ -h "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox/run/$NIX_SYSTEM.test.run" ]
+  assert [ -h "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox/run/$NIX_SYSTEM.test-dev" ]
+  assert [ -h "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox/run/$NIX_SYSTEM.test-run" ]
 }
 
 # bats test_tags=hermetic,remote,remote:outlink
@@ -186,7 +186,7 @@ EOF
   export FLOX_CACHE_DIR="$(realpath $FLOX_CACHE_DIR)"
   run "$FLOX_BIN" activate --trust --reference "$OWNER/test" -c 'command -v hello'
   assert_success
-  assert_output --partial "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox/run/$NIX_SYSTEM.test.dev/bin/hello"
+  assert_output --partial "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox/run/$NIX_SYSTEM.test-dev/bin/hello"
 }
 
 # We need to trust the remote environment before we can activate it.

--- a/cli/tests/install.bats
+++ b/cli/tests/install.bats
@@ -125,8 +125,9 @@ EOF
   run "$FLOX_BIN" install hello
   assert_success
   assert_output --partial "✔ 'hello' installed to environment"
-  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello" ]
-  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.run/bin/hello" ]
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/hello" ]
+  assert_success
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-run/bin/hello" ]
   assert_success
 }
 
@@ -226,8 +227,8 @@ EOF
 
   # The composer's dev environment should expose bash's `man` output (from
   # the override) but not its `out` output (which the include provides).
-  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer.dev/share/man/man1/bash.1.gz" ]
-  [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer.dev/bin/bash" ]
+  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer-dev/share/man/man1/bash.1.gz" ]
+  [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer-dev/bin/bash" ]
 
   # Adding `out` on top should merge with the existing `man` override.
   run "$FLOX_BIN" install -i bash "bashNonInteractive^out"
@@ -239,8 +240,8 @@ EOF
   outputs="$(tomlq -r -c '.install.bash.outputs' < "$MANIFEST_PATH")"
   assert_equal "$outputs" '["man","out"]'
 
-  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer.dev/share/man/man1/bash.1.gz" ]
-  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer.dev/bin/bash" ]
+  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer-dev/share/man/man1/bash.1.gz" ]
+  [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.composer-dev/bin/bash" ]
 }
 
 # This is also checking we can build an unfree package
@@ -478,7 +479,7 @@ EOF
 
   run "$FLOX_BIN" activate -- bash -c 'command -v hello'
   assert_success
-  assert_output "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}.dev/bin/hello"
+  assert_output "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev/bin/hello"
 
   run "$FLOX_BIN" activate -- bash -c 'realpath "$(command -v hello)"'
   assert_success
@@ -498,7 +499,7 @@ EOF
 
   run "$FLOX_BIN" activate -- bash -c 'command -v vim'
   assert_success
-  assert_output "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}.dev/bin/vim"
+  assert_output "${PROJECT_DIR}/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev/bin/vim"
 
   run "$FLOX_BIN" activate -- bash -c 'realpath "$(command -v vim)"'
   assert_success

--- a/cli/tests/uninstall.bats
+++ b/cli/tests/uninstall.bats
@@ -93,11 +93,11 @@ teardown() {
   run "$FLOX_BIN" install hello
   assert_success
   assert_output --partial "✔ 'hello' installed to environment"
-  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello" ]
+  run [ -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/hello" ]
   assert_success
   run "$FLOX_BIN" uninstall hello
   assert_success
-  run [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME.dev/bin/hello" ]
+  run [ ! -e "$PROJECT_DIR/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/bin/hello" ]
   assert_success
 }
 


### PR DESCRIPTION
## Proposed Changes

When building a Flox environment, the previous build+link cycle made 3 nix invocations:
  1. `buildenv.nix` to build the environment (no symlinks)
  2. `nix build --stdin --out-link <env>/.flox/run/<system>.<name>.dev`
  3. `nix build --stdin --out-link <env>/.flox/run/<system>.<name>.run`

This PR collapses all of that into a single nix invocation:

  `nix build buildenv.nix --out-link .flox/run/<system>.<name>`

`buildenv.nix` now declares outputs `["run", "dev"]` (renamed from `["runtime", "develop"]` to match the arguments of `flox activate --mode`). With those output names, nix appends the output name as a suffix for each non-`"out"` output, creating:

  `.flox/run/<system>.<name>-run`  ->  run-mode store path  (GC root registered)
  `.flox/run/<system>.<name>-dev`  ->  dev-mode store path  (GC root registered)

The link-name separator therefore changes from dot to dash (e.g. `<system>.<name>.dev` -> `<system>.<name>-dev`), which is why the output names were renamed: the old `"runtime"`/`"develop"` names would have produced `"-runtime"`/`"-develop"` suffixes that don't match the `activate --mode` flags.

**Build/activate path: 1 nix invocation per build+link cycle (down from 3).**
Mutation operations (install/uninstall/edit/upgrade) go from 3 to 2; reducing these to 1 is tracked in #4308.

## Other changes

- `BuildEnvOutputs` fields renamed: `develop`->`dev`, `runtime`->`run`
- `RenderedEnvironmentLinks` fields renamed: `development`->`dev`, `runtime`->`run`
- `RenderedEnvironmentLinks::out_link_prefix()` added to derive the `--out-link` argument
- `CoreEnvironment::build()` now accepts `out_link_prefix: Option<&Path>`; callers that produce real activation symlinks pass `Some(prefix)`; validation-only builds (push pre-flight, transactional temp envs) pass `None`
- After transactional modifications (install/uninstall/edit/upgrade), callers invoke `build()` a second time to update symlinks and register GC roots; the second call is fast because nix returns the cached derivation
- `builder.pl` updated to use `"run"`/`"dev"` output names
- `create_gc_root_in()` and the `WriteNixStdin` error variant removed
- `CoreEnvironment::link()` and `Environment::link()` removed entirely
- After each build with `--out-link`, `<prefix>-build-<id>` symlinks created by nix for manifest build outputs are deleted from `.flox/run/`; deleting these symlinks also removes the GC roots for those outputs, which is intentional (store paths are captured in `BuildEnvOutputs` before deletion)
- After each build with `--out-link`, legacy dot-separator symlinks (`<system>.<name>.dev` / `<system>.<name>.run` and generation-qualified variants `<system>.<name>.genN.dev` / `<system>.<name>.genN.run`) are replaced with redirect symlinks pointing to the new dash-separator names, preserving forward compatibility for tooling holding old paths. Remote environments instead delete the old symlinks on open (pre-existing behavior).

## Notable gaps / test coverage

- Cross-version activation-attach tests are skipped for this release via the `buildenv_format_changed_this_release` flag in `activate.bats`. The GC-root symlink naming changed (dot→dash), so the previous release and the current binary produce different symlink paths and the attach test would fail for the wrong reason. The flag must be flipped back to `false` once `FLOX_LATEST_VERSION` points to a release that uses the new naming.

## Rebase note

This branch was originally stacked on #4282. That PR has now merged, and this branch has been rebased directly onto `origin/main`.

## Release Notes

<!-- NOTE: The activation symlink naming convention changed from dot-separator
(<system>.<name>.dev) to dash-separator (<system>.<name>-dev) in this release.
This is a user-visible change to paths that scripts or tooling may reference,
and cross-version attach is temporarily disabled in the test suite. This PR
requires a minor version bump. -->

* Improve performance of Flox environment creation by reducing `nix build` invocations from 3 to 1 per build+link cycle for the activate/build path.

Closes #4307