### PR TITLE
feat(auth): set http.emptyAuth=true for Kerberos git operations

### DIFF
--- a/cli/flox-rust-sdk/src/providers/git_auth.rs
+++ b/cli/flox-rust-sdk/src/providers/git_auth.rs
@@ -11,45 +11,54 @@ pub trait GitCommandOptionsExt {
     /// Matches on the variant because git genuinely needs different behavior
     /// per auth type:
     /// - Auth0 (bearer): inline credential helper with the token
-    /// - Kerberos: no-op (kerberized git uses the ccache directly)
+    /// - Kerberos: set `http.emptyAuth=true` so libcurl performs the SPNEGO
+    ///   Negotiate handshake against the remote; credentials themselves come
+    ///   from the ccache
     /// - No material: empty credential helper to prevent pinentry fallback
     fn authenticate(&mut self, auth_context: &AuthContext, git_url: &Url);
 }
 
 impl GitCommandOptionsExt for GitCommandOptions {
     fn authenticate(&mut self, auth_context: &AuthContext, git_url: &Url) {
-        let token = match auth_context {
-            AuthContext::Auth0(Some(token)) => {
-                if token.is_expired() {
-                    tracing::debug!("FloxHub token is expired, sending for identification");
-                } else {
-                    tracing::debug!("using valid FloxHub token");
-                }
-                token.secret()
-            },
-            AuthContext::Kerberos(Some(_)) => {
-                tracing::debug!("Kerberos mode — git auth handled natively via ccache");
-                return;
-            },
-            AuthContext::Kerberos(None) => {
-                tracing::warn!(
-                    "Kerberos mode but no ticket available — git operations will likely fail; run 'kinit'"
-                );
-                return;
-            },
-            AuthContext::Auth0(None) => {
-                tracing::debug!("no credential available for git auth");
-                ""
-            },
-        };
+        match auth_context {
+            AuthContext::Auth0(maybe_token) => {
+                let token = match maybe_token {
+                    Some(token) => {
+                        if token.is_expired() {
+                            tracing::debug!("FloxHub token is expired, sending for identification");
+                        } else {
+                            tracing::debug!("using valid FloxHub token");
+                        }
+                        token.secret()
+                    },
+                    None => {
+                        tracing::debug!("no credential available for git auth");
+                        ""
+                    },
+                };
 
-        self.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token);
-        self.add_config_flag(
-            &format!("credential.{git_url}.helper"),
-            format!(
-                r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#
-            ),
-        );
+                self.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token);
+                self.add_config_flag(
+                    &format!("credential.{git_url}.helper"),
+                    format!(
+                        r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#
+                    ),
+                );
+            },
+            AuthContext::Kerberos(material) => {
+                match material {
+                    Some(_) => {
+                        tracing::debug!("Kerberos mode — git auth handled natively via ccache");
+                    },
+                    None => {
+                        tracing::warn!(
+                            "Kerberos mode but no ticket available — git operations will likely fail; run 'kinit'"
+                        );
+                    },
+                }
+                self.add_config_flag("http.emptyAuth", "true");
+            },
+        }
     }
 }
 
@@ -100,23 +109,27 @@ mod tests {
     }
 
     #[test]
-    fn kerberos_with_material_is_noop() {
+    fn kerberos_with_material_sets_empty_auth() {
         let auth = AuthContext::Kerberos(Some(flox_catalog::KerberosMaterial {
             principal: "user@REALM".to_string(),
             generate_token: std::sync::Arc::new(|_| Ok("token".to_string())),
         }));
         let mut options = GitCommandOptions::default();
-        let expected = GitCommandOptions::default();
+
+        let mut expected = GitCommandOptions::default();
+        expected.add_config_flag("http.emptyAuth", "true");
 
         options.authenticate(&auth, &test_url());
         assert_eq!(options, expected);
     }
 
     #[test]
-    fn kerberos_without_material_is_noop() {
+    fn kerberos_without_material_sets_empty_auth() {
         let auth = AuthContext::Kerberos(None);
         let mut options = GitCommandOptions::default();
-        let expected = GitCommandOptions::default();
+
+        let mut expected = GitCommandOptions::default();
+        expected.add_config_flag("http.emptyAuth", "true");
 
         options.authenticate(&auth, &test_url());
         assert_eq!(options, expected);


### PR DESCRIPTION
## Summary
- Inject `-c http.emptyAuth=true` into every git invocation routed through `GitCommandOptionsExt::authenticate` when the active auth mode is Kerberos, so libcurl will perform the SPNEGO Negotiate handshake against a SPNEGO-terminating remote (e.g. nginx in front of gitolite).
- Refactored `authenticate` to dispatch on auth kind at the top level; the Kerberos arm now owns its own logic (set the flag, log appropriately) instead of short-circuiting out of a token-producing match.
- Non-Kerberos auth modes are unchanged.

## Why
Without `http.emptyAuth=true`, curl refuses to send an empty `Authorization:` header even when the server returns `WWW-Authenticate: Negotiate`, so Kerberos-authenticated `flox push` / `flox pull` fails before the SPNEGO exchange ever starts. Today, customers work around this by wrapping the bundled `git` binary via the internal `GIT_PKG` override (see the playground at `*/setup.sh:41-51`). That escape hatch leaks Nix-managed paths, breaks reproducibility, and isn't a customer surface.

Closes [ENT-124](https://linear.app/floxdotdev/issue/ENT-124).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `treefmt --fail-on-change`
- [x] `cargo test -p flox-rust-sdk providers::git_auth` — 4 passed (Auth0 with/without token, Kerberos with/without material; the two Kerberos tests assert `http.emptyAuth=true` is set on `GitCommandOptions`).
- [x] Integration check on a Kerberos-terminating remote (playground / on-prem nginx + gitolite) — drop the `/opt/git-krb` wrapper and confirm `flox push` / `flox pull` succeed using only the bundled `git`.