### PR TITLE
fix(auth): skip token expiry warning for non-Auth0 modes

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -42,6 +42,7 @@ use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::{Manifest, TypedOnly};
 use flox_rust_sdk::flox::{
     AuthContext,
+    AuthnMode,
     DEFAULT_FLOXHUB_URL,
     FLOX_VERSION,
     Flox,
@@ -271,45 +272,7 @@ impl FloxArgs {
             git_url_override,
         )?;
 
-        let floxhub_token = config
-            .flox
-            .floxhub_token
-            .as_deref()
-            .and_then(|s| {
-                if s.is_empty() {
-                    None
-                } else {
-                    Some(FloxhubToken::from_str(s))
-                }
-            })
-            .transpose();
-
-        let floxhub_token = match floxhub_token {
-            Err(FloxhubTokenError::InvalidToken(token_error)) => {
-                message::error(formatdoc! {"
-                    Your FloxHub token is invalid: {token_error}
-                    You may need to log in again.
-                "});
-                if let Err(e) =
-                    update_config(&config.flox.config_dir, "floxhub_token", None::<String>)
-                {
-                    debug!("Could not remove token from user config: {e}");
-                }
-                None
-            },
-            Ok(Some(token)) if token.is_expired() => {
-                if !matches!(
-                    self.command,
-                    Some(Commands::Admin(AdminCommands::Auth(auth::Auth::Login)))
-                ) {
-                    message::warning(
-                        "Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.",
-                    );
-                }
-                Some(token)
-            },
-            Ok(token) => token,
-        };
+        let floxhub_token = self.resolve_floxhub_token(&config);
 
         let metrics_device_uuid = (!config.flox.disable_metrics)
             .then(|| read_metrics_uuid(&config).ok())
@@ -419,6 +382,59 @@ impl FloxArgs {
         }
 
         result
+    }
+
+    /// Parse and validate the configured `floxhub_token`, returning `None` and
+    /// emitting any user-facing warnings as a side effect.
+    ///
+    /// Returns `None` immediately when the configured authn mode does not use
+    /// the token (e.g. Kerberos) — in that case the token in `flox.toml` is
+    /// not consumed by the auth pipeline, so warning about its state — or
+    /// rewriting the user's config — would be misleading.
+    fn resolve_floxhub_token(&self, config: &Config) -> Option<FloxhubToken> {
+        if !matches!(config.flox.floxhub_authn_mode, AuthnMode::Auth0) {
+            return None;
+        }
+
+        let parsed = config
+            .flox
+            .floxhub_token
+            .as_deref()
+            .and_then(|s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(FloxhubToken::from_str(s))
+                }
+            })
+            .transpose();
+
+        match parsed {
+            Err(FloxhubTokenError::InvalidToken(token_error)) => {
+                message::error(formatdoc! {"
+                    Your FloxHub token is invalid: {token_error}
+                    You may need to log in again.
+                "});
+                if let Err(e) =
+                    update_config(&config.flox.config_dir, "floxhub_token", None::<String>)
+                {
+                    debug!("Could not remove token from user config: {e}");
+                }
+                None
+            },
+            Ok(Some(token)) if token.is_expired() => {
+                if !matches!(
+                    self.command,
+                    Some(Commands::Admin(AdminCommands::Auth(auth::Auth::Login)))
+                ) {
+                    message::warning(
+                        "Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.",
+                    );
+                }
+                Some(token)
+            },
+            Ok(token) => token,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Move the `floxhub_token` parse/validate logic out of `FloxArgs::handle` and into a new `FloxArgs::resolve_floxhub_token` helper that fails fast with `None` when `floxhub_authn_mode` isn't `Auth0`.
- Result: the "Your FloxHub token has expired" warning (and the invalid-token error + auto-deletion of the stale token from `flox.toml`) no longer fires when the configured mode is Kerberos. The token has no bearing on auth in that mode, so reading and complaining about it was purely cosmetic noise.

Fixes [CLI-46](https://linear.app/floxdotdev/issue/CLI-46).

## Test plan

- [x] On a host with `floxhub_authn_mode = "kerberos"` and a stale/expired `floxhub_token` in `~/.config/flox/flox.toml`, run `flox activate` (or any command) and confirm no "token expired" warning is printed.
- [x] On the default `floxhub_authn_mode = "auth0"` config with an expired token, confirm the warning still fires.
- [x] With the expired token + `auth0` mode, confirm `flox auth login` still suppresses the warning (preserved behavior).
- [x] With an unparseable `floxhub_token` value in `auth0` mode, confirm the invalid-token error fires and the token is cleared from config.
- [x] With the same unparseable value but `kerberos` mode, confirm no error fires and the config is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)