### PR TITLE
test: surface tracing diagnostics in CI test output via libtest capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,6 +1682,8 @@ dependencies = [
  "nix",
  "proptest",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1204,7 +1204,7 @@ mod tests {
 
     use anyhow::Context;
     use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
-    use flox_test_utils::GENERATED_DATA;
+    use flox_test_utils::{GENERATED_DATA, init_tracing};
     use indoc::{formatdoc, indoc};
 
     use super::test_helpers::*;
@@ -3410,6 +3410,7 @@ mod tests {
     /// Test that cmake can make use of the CMAKE_PREFIX_PATH variable as
     /// set by etc-profiles.
     async fn build_can_use_cmake(sandbox: bool) {
+        init_tracing();
         let package_name = String::from("hello-cmake");
         // from: test_data/input_data/build/hello-cmake/HelloTarget/share/hello/HelloTarget.cmake
         let file_name = String::from("hello.txt");

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1369,12 +1369,14 @@ fn join_realise_results(
 
 #[cfg(test)]
 mod test_helpers {
+    pub(super) use flox_test_utils::init_tracing;
     use tempfile::TempDir;
 
     use super::*;
     use crate::providers::nix_auth::NixAuth;
 
     pub(super) fn buildenv_instance() -> BuildEnvNix<TempDir, NixAuth> {
+        init_tracing();
         let tempdir = TempDir::new().unwrap();
         let auth = NixAuth::from_tempdir_and_token(TempDir::new().unwrap(), None);
         BuildEnvNix::new(tempdir, auth)

--- a/cli/flox-test-utils/Cargo.toml
+++ b/cli/flox-test-utils/Cargo.toml
@@ -12,6 +12,8 @@ indoc.workspace = true
 dirs.workspace = true
 proptest.workspace = true
 chrono.workspace = true
+tracing-subscriber.workspace = true
+tracing.workspace = true
 
 # flox-core = { workspace = true, features = ["proc_status"]}
 

--- a/cli/flox-test-utils/src/lib.rs
+++ b/cli/flox-test-utils/src/lib.rs
@@ -26,6 +26,22 @@ pub static GENERATED_DATA: LazyLock<PathBuf> =
 pub static MANUALLY_GENERATED: LazyLock<PathBuf> =
     LazyLock::new(|| PathBuf::from(std::env::var("MANUALLY_GENERATED").unwrap()));
 
+/// Initialise a tracing subscriber for the current test binary.
+///
+/// Routes tracing events (`warn!`, `debug!`, etc.) through Rust's test-capture
+/// infrastructure so they appear in the output of *failing* tests without
+/// cluttering passing ones. Safe to call from any number of tests in the same
+/// binary; `try_init` is a no-op if a subscriber is already installed.
+///
+/// Call this at the top of any test that exercises code paths where tracing
+/// events would aid diagnosis of failures.
+pub fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_max_level(tracing::Level::DEBUG)
+        .try_init();
+}
+
 // Modifications to `rexpect`:
 // - The built-in reader used by `rexpect` has a hard-coded sleep interval of 100ms,
 //   so a command that's even 1ms later than the `wait_for_prompt` call will take


### PR DESCRIPTION
## Summary

Rust's `warn!` and `debug!` macros emit tracing events that are invaluable
for diagnosing test failures, but by default they go to stderr and are mixed
in with all other output regardless of which test produced them. When a CI
run shows a failure, the relevant trace lines are difficult to locate and are
often omitted entirely by the test harness.

This PR adds `flox_test_utils::init_tracing()`, a one-call test helper that
routes all tracing events through libtest's per-test capture buffer. Output
is shown only for **failing** tests, under their "stdout" section — invisible
during passing runs, immediately visible when a test fails.

```rust
pub fn init_tracing() {
    let _ = tracing_subscriber::fmt()
        .with_test_writer()
        .with_max_level(tracing::Level::DEBUG)
        .try_init();
}
```

`try_init` is idempotent, so it is safe to call from multiple tests in the
same binary. Tests that use a shared `buildenv_instance()` helper get it
automatically; tests that exercise code paths directly (without going through
the shared helper) call it explicitly at the top of the test body.

## Motivation

This work was extracted from PR #4282, where it was introduced to help
diagnose an intermittent test failure in `build_can_use_cmake`. The tracing
output — `nix path-info --json` results and per-path stat confirmations — made
it possible to definitively identify that certain store paths were present on
the local filesystem but unregistered in the Nix daemon's store database.
That diagnosis led directly to a targeted fix for a long-standing CI race
condition where cached store content restored outside the Nix daemon caused
`buildenv.nix` to fail with an opaque substitution error.

Without captured tracing output, the root cause would have remained hidden
behind a generic nix build error across many CI runs.

## Changes

- `cli/flox-test-utils/src/lib.rs` — adds `init_tracing()` public helper;
  adds `tracing` and `tracing-subscriber` as dependencies
- `cli/flox-rust-sdk/src/providers/buildenv.rs` — calls `init_tracing()` in
  `test_helpers::buildenv_instance()`, covering all build, realise, and
  buildenv tests that construct a `BuildEnvNix` instance
- `cli/flox-rust-sdk/src/providers/build.rs` — calls `init_tracing()` in
  `build_can_use_cmake()`, the specific test that motivated this work

## Test plan

- [ ] CI passes on this branch
- [ ] Manually confirm that a deliberately-broken test shows `warn!`/`debug!`
  output under its failure section and not under passing tests

🤖 Generated with [Claude Code](https://claude.ai/code)