### PR TITLE
Review suggestions for 4266

### DIFF
--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -108,7 +108,7 @@ mod test {
 
         let updated = read_activation_state(tmp.path(), &dot_flox_path);
         assert!(
-            !updated.is_pid_attached(pid),
+            updated.attached_pids_is_empty(),
             "PID should be removed from state.json after detach"
         );
     }

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -43,29 +43,19 @@ impl DetachArgs {
             ));
         };
 
-        let empty_start_id = state.detach(self.pid);
+        let empty_start_id = state.detach(self.pid)?;
 
-        // Per ActivationState::detach doc contract: update_ready_after_detach
-        // must be called after detach, but only when there are still
-        // attached PIDs (the function panics on an empty map).
-        if !state.attached_pids_is_empty() {
-            state.update_ready_after_detach();
-            // Remove the start-state dir only when other PIDs remain.
-            // When PIDs are still present, the executive cannot call
-            // cleanup_all (which renames the parent dir), so there is no
-            // race window here.  When this is the last PID overall,
-            // the executive cleans up everything via StateFileChanged →
-            // cleanup_all after we write below.
-            if let Some(ref start_id) = empty_start_id {
-                start_id
-                    .remove_start_state_dir(&self.activation_state_dir)
-                    .context("failed to remove start state dir after detach")?;
-            }
+        // In the executive we only remove start state dir when we know
+        // cleanup_all won't trigger, but we can't know whether or not
+        // cleanup_all will trigger here because we're about to drop the lock.
+        // It won't hurt to remove this directory
+        if let Some(ref start_id) = empty_start_id {
+            start_id
+                .remove_start_state_dir(&self.activation_state_dir)
+                .context("failed to remove start state dir after detach")?;
         }
 
-        // Always write: state.detach() has already mutated in-memory state.
-        // The executive is always running at detach time.  When 0 PIDs remain
-        // it will observe the change via StateFileChanged and call cleanup_all.
+        // This should trigger the executive to check if it needs to cleanup
         write_activations_json(&state, &activations_json_path, lock)
             .context("failed to write state.json after detach")?;
 
@@ -75,8 +65,6 @@ impl DetachArgs {
 
 #[cfg(test)]
 mod test {
-    use std::path::PathBuf;
-
     use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::{read_activation_state, write_activation_state};
@@ -90,22 +78,6 @@ mod test {
 
     use super::DetachArgs;
 
-    fn make_state_with_pid(
-        dot_flox_path: &std::path::Path,
-        pid: i32,
-        invocation_type: InvocationType,
-    ) -> ActivationState {
-        let mut state = ActivationState::new(
-            &ActivateMode::default(),
-            Some(dot_flox_path),
-            dot_flox_path.join("run/default"),
-        );
-        state.set_executive_pid(1);
-        let start_id = StartIdentifier::new("/nix/store/test");
-        state.start_or_attach(pid, &start_id.store_path, invocation_type);
-        state
-    }
-
     /// Successful detach removes the PID from state.json.
     #[test]
     fn successful_detach_removes_pid() {
@@ -113,8 +85,18 @@ mod test {
         let dot_flox_path = tmp.path().join(".flox");
         let pid = 12345_i32;
 
-        let state = make_state_with_pid(&dot_flox_path, pid, InvocationType::InPlace);
+        let mut state = ActivationState::new(
+            &ActivateMode::default(),
+            Some(dot_flox_path.clone()),
+            dot_flox_path.join("run/default"),
+        );
+        state.set_executive_pid(1);
+        let start_id = StartIdentifier::new("/nix/store/test");
+        state.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
         write_activation_state(tmp.path(), &dot_flox_path, state);
+        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+        let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
+        std::fs::create_dir_all(&start_state_dir).unwrap();
 
         let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
 
@@ -131,39 +113,37 @@ mod test {
         );
     }
 
-    /// When there is no state.json, detach returns an error.
+    /// When the last PID overall detaches, its start state dir is removed
+    /// immediately rather than deferred to the executive's cleanup_all — so a
+    /// racing activation that supersedes this start can't leave it orphaned.
     #[test]
-    fn no_state_json_returns_error() {
-        let tmp = TempDir::new().unwrap();
-        let dot_flox_path = PathBuf::from("/nonexistent/.flox");
-        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
-
-        // Create the dir so lock acquisition succeeds, but don't write state.json.
-        std::fs::create_dir_all(&activation_state_dir).unwrap();
-
-        let args = DetachArgs {
-            activation_state_dir,
-            pid: 42,
-        };
-        let result = args.handle();
-        assert!(
-            result.is_err(),
-            "detach should fail when state.json is absent"
-        );
-    }
-
-    /// Detach always writes state.json, even when the last PID is removed.
-    /// The executive observes the change via StateFileChanged and calls cleanup_all.
-    #[test]
-    fn last_pid_detach_writes_state() {
+    fn start_state_dir_removed_when_last_pid_detaches() {
         let tmp = TempDir::new().unwrap();
         let dot_flox_path = tmp.path().join(".flox");
         let pid = 12345_i32;
 
-        let state = make_state_with_pid(&dot_flox_path, pid, InvocationType::InPlace);
+        let mut state = ActivationState::new(
+            &ActivateMode::default(),
+            Some(&dot_flox_path),
+            dot_flox_path.join("run/default"),
+        );
+        state.set_executive_pid(1);
+        let StartOrAttachResult::Start { start_id } =
+            state.start_or_attach(pid, "/nix/store/test", InvocationType::InPlace)
+        else {
+            panic!("expected Start for pid");
+        };
+
         write_activation_state(tmp.path(), &dot_flox_path, state);
 
         let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+
+        let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
+        std::fs::create_dir_all(&start_state_dir).unwrap();
+        assert!(
+            start_state_dir.exists(),
+            "start state dir should exist before detach"
+        );
 
         let args = DetachArgs {
             activation_state_dir,
@@ -171,68 +151,9 @@ mod test {
         };
         args.handle().expect("detach should succeed");
 
-        let updated = read_activation_state(tmp.path(), &dot_flox_path);
         assert!(
-            !updated.is_pid_attached(pid),
-            "PID should be absent from state.json after detach"
-        );
-    }
-
-    /// When the last PID for a start detaches but other PIDs remain (attached
-    /// to different starts), the empty start's state directory is removed.
-    /// When this is the last PID overall, the executive handles dir cleanup via
-    /// StateFileChanged → cleanup_all.
-    #[test]
-    fn start_state_dir_removed_when_other_pids_remain() {
-        let tmp = TempDir::new().unwrap();
-        let dot_flox_path = tmp.path().join(".flox");
-        let pid1 = 12345_i32; // will be detached — last PID for start_id1
-        let pid2 = 99999_i32; // stays attached to a different start
-
-        // Build a state with pid1 on start_id1 and pid2 on start_id2 so that
-        // after detaching pid1, attached_pids is not empty (pid2 remains).
-        let mut state = ActivationState::new(
-            &ActivateMode::default(),
-            Some(&dot_flox_path),
-            dot_flox_path.join("run/default"),
-        );
-        state.set_executive_pid(1);
-
-        // Attach pid1 → starts start_id1, ready becomes Starting(pid1, start_id1)
-        let r1 = state.start_or_attach(pid1, "/nix/store/test1", InvocationType::InPlace);
-        let StartOrAttachResult::Start {
-            start_id: start_id1,
-        } = r1
-        else {
-            panic!("expected Start for pid1");
-        };
-        // Mark ready so pid2 can trigger a fresh Start on a different store path
-        state.set_ready(&start_id1);
-
-        // Attach pid2 with a different store path → starts start_id2
-        state.start_or_attach(pid2, "/nix/store/test2", InvocationType::InPlace);
-
-        write_activation_state(tmp.path(), &dot_flox_path, state);
-
-        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
-
-        // Create start_id1's directory on disk (the one that should be removed).
-        let start_state_dir1 = start_id1.start_state_dir(&activation_state_dir).unwrap();
-        std::fs::create_dir_all(&start_state_dir1).unwrap();
-        assert!(
-            start_state_dir1.exists(),
-            "start state dir should exist before detach"
-        );
-
-        let args = DetachArgs {
-            activation_state_dir,
-            pid: pid1,
-        };
-        args.handle().expect("detach should succeed");
-
-        assert!(
-            !start_state_dir1.exists(),
-            "start state dir for detached start should be removed when other PIDs remain"
+            !start_state_dir.exists(),
+            "start state dir should be removed when the last PID detaches"
         );
     }
 }

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -641,9 +641,15 @@ mod test {
 
     /// Test that handle_process_exited is a no-op when the PID is not in state.json.
     ///
-    /// This can happen when --remove-pid removes a PID from state.json, but the
-    /// executive still has a watcher running for that PID. When the process eventually
-    /// exits and the executive receives a ProcessExited event, it should be a no-op.
+    /// This can happen in two cases:
+    /// 1. --remove-pid removes a PID from state.json, but the
+    ///    executive still has a watcher running for that PID.
+    /// 2. `flox-activations detach` removes a PID from state.json
+    ///
+    /// In either case, when the process eventually exits and the executive
+    /// receives a ProcessExited event, it should be a no-op.
+    ///
+    /// We mimic scenario 1 here
     #[test]
     fn process_exited_noop_for_pid_not_in_state() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -326,7 +326,7 @@ mod tests {
             export _activate_d=/interpreter/activate.d;
             export _flox_activations=/flox_activations;
             export _flox_activate_tracer=TRACER;
-            _FLOX_INVOCATION_TYPE=inplace;
+            _FLOX_INVOCATION_TYPE=in_place;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             eval "$('/flox_activations' set-env-dirs --shell bash --flox-env "/flox_env" --env-dirs "${FLOX_ENV_DIRS:-}")";
             eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")";

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -309,7 +309,7 @@ mod tests {
             set -gx _activate_d /interpreter/activate.d;
             set -gx _flox_activations /flox_activations;
             set -gx _flox_activate_tracer TRACER;
-            set -g _FLOX_INVOCATION_TYPE inplace;
+            set -g _FLOX_INVOCATION_TYPE in_place;
             if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
             set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);
             /flox_activations set-env-dirs --shell fish --flox-env "/flox_env" --env-dirs "$FLOX_ENV_DIRS" | source;

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -322,7 +322,7 @@ mod tests {
             setenv _activate_d /interpreter/activate.d;
             setenv _flox_activations /flox_activations;
             setenv _flox_activate_tracer TRACER;
-            set _FLOX_INVOCATION_TYPE = inplace;
+            set _FLOX_INVOCATION_TYPE = in_place;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
             if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";
             eval "`'/flox_activations' set-env-dirs --shell tcsh --flox-env '/flox_env' --env-dirs $FLOX_ENV_DIRS:q`";

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -272,7 +272,7 @@ mod tests {
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             source /interpreter/activate.d/zsh;
-            typeset -g _FLOX_INVOCATION_TYPE=inplace;
+            typeset -g _FLOX_INVOCATION_TYPE=in_place;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]]

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use shell_gen::ShellWithPath;
@@ -133,32 +132,76 @@ pub enum AutoActivateFishMode {
     DisableArrow,
 }
 
-#[derive(Clone, Debug, Deserialize, derive_more::Display, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum InvocationType {
-    #[display("inplace")]
     InPlace,
-    #[display("interactive")]
     Interactive,
-    #[display("inplace")]
     ShellCommand(String),
-    #[display("inplace")]
     ExecCommand(Vec<String>),
-}
-
-impl FromStr for InvocationType {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "interactive" => Ok(InvocationType::Interactive),
-            _ => Ok(InvocationType::InPlace),
-        }
-    }
 }
 
 impl InvocationType {
     pub fn is_in_place(&self) -> bool {
         matches!(self, Self::InPlace)
+    }
+
+    pub fn kind(&self) -> InvocationKind {
+        match self {
+            Self::InPlace => InvocationKind::InPlace,
+            Self::Interactive => InvocationKind::Interactive,
+            Self::ShellCommand(_) => InvocationKind::ShellCommand,
+            Self::ExecCommand(_) => InvocationKind::ExecCommand,
+        }
+    }
+}
+
+/// Drops the user command wrapped by `ShellCommand` and `ExecCommand` so we can
+/// roundtrip with InvocationKind
+impl std::fmt::Display for InvocationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.kind())
+    }
+}
+
+#[derive(Clone, Copy, Debug, derive_more::Display, derive_more::FromStr, Eq, PartialEq)]
+#[display(rename_all = "snake_case")]
+#[from_str(rename_all = "snake_case")]
+pub enum InvocationKind {
+    InPlace,
+    Interactive,
+    ShellCommand,
+    ExecCommand,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invocation_type_display_round_trips_to_kind() {
+        let cases = [
+            (InvocationType::InPlace, InvocationKind::InPlace),
+            (InvocationType::Interactive, InvocationKind::Interactive),
+            (
+                InvocationType::ShellCommand("echo hi".to_string()),
+                InvocationKind::ShellCommand,
+            ),
+            (
+                InvocationType::ExecCommand(vec!["ls".to_string(), "-l".to_string()]),
+                InvocationKind::ExecCommand,
+            ),
+        ];
+
+        for (invocation_type, kind) in cases {
+            assert_eq!(invocation_type.kind(), kind);
+            assert_eq!(
+                invocation_type
+                    .to_string()
+                    .parse::<InvocationKind>()
+                    .unwrap(),
+                kind,
+            );
+        }
     }
 }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use fslock::LockFile;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -514,27 +514,35 @@ impl ActivationState {
         self.ready = Ready::True(start_id.clone());
     }
 
-    /// Detach a PID from an activation.
+    /// Detach a PID from an activation, updating ready as needed.
     ///
     /// Returns `Some(start_id)` if this was the last attachment for that
     /// `StartIdentifier` (i.e. the caller should clean up the start state
     /// directory), or `None` if there are still other PIDs attached to the
     /// same start.
-    ///
-    /// `update_ready_after_detach` must still be called after this when
-    /// there are remaining attached PIDs.
-    pub fn detach(&mut self, pid: Pid) -> Option<StartIdentifier> {
+    pub fn detach(&mut self, pid: Pid) -> Result<Option<StartIdentifier>, Error> {
         let removed = self.attached_pids.remove(&pid);
         debug!(pid, ?removed, "detaching from activation");
 
-        let attachment = removed?;
+        let Some(attachment) = removed else {
+            bail!("PID {} is not attached to the activation", pid);
+        };
 
         let start_id = attachment.start_id;
 
         // Return the start_id only when no remaining attachment references it.
         let has_remaining = self.attached_pids.values().any(|a| a.start_id == start_id);
 
-        if has_remaining { None } else { Some(start_id) }
+        // Only update ready state if there are still attached PIDs
+        if !self.attached_pids.is_empty() {
+            self.update_ready_after_detach();
+        }
+
+        if has_remaining {
+            Ok(None)
+        } else {
+            Ok(Some(start_id))
+        }
     }
 
     /// Clean up a specific terminated PID
@@ -574,19 +582,20 @@ impl ActivationState {
         }
 
         tracing::info!(pid, "detaching terminated PID");
-        let empty_start_id = self.detach(pid);
-
-        // Only update ready state if there are still attached PIDs
-        if !self.attached_pids.is_empty() {
-            self.update_ready_after_detach();
-        }
+        let Ok(empty_start_id) = self.detach(pid) else {
+            debug!(
+                pid,
+                "PID not found in attached_pids, this should be unreachable"
+            );
+            return (None, false);
+        };
 
         (empty_start_id, true)
     }
 
-    /// set ready to False if there are no more PIDs attached to the current start
-    /// should only be called when there are some attached PIDs
-    pub fn update_ready_after_detach(&mut self) {
+    /// Set ready to False if there are no more PIDs attached to the current start
+    /// Should only be called when there are some attached PIDs
+    fn update_ready_after_detach(&mut self) {
         if self.attached_pids.is_empty() {
             unreachable!("should remove all state when there are no more attached PIDs");
         }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -328,10 +328,6 @@ impl StartIdentifier {
     }
 
     /// Remove the start state directory for this identifier if it exists.
-    ///
-    /// Shared cleanup utility used by both `detach` (when PIDs remain for other
-    /// starts) and `watcher::cleanup_pid` (when a process exits). The no-op on
-    /// a missing directory makes this safe to call idempotently.
     pub fn remove_start_state_dir(
         &self,
         activation_state_dir: impl AsRef<Path>,
@@ -339,11 +335,10 @@ impl StartIdentifier {
         let state_dir = self
             .start_state_dir(activation_state_dir)
             .context("failed to compute start state dir path")?;
-        if state_dir.exists() {
-            std::fs::remove_dir_all(&state_dir).with_context(|| {
-                format!("failed to remove start state dir '{}'", state_dir.display())
-            })?;
-        }
+        trace!(?state_dir, "removing empty activation state dir");
+        std::fs::remove_dir_all(&state_dir).with_context(|| {
+            format!("failed to remove start state dir '{}'", state_dir.display())
+        })?;
         Ok(())
     }
 }
@@ -451,11 +446,6 @@ impl ActivationState {
             .iter()
             .map(|(pid, attachment)| (*pid, attachment.expiration))
             .collect()
-    }
-
-    /// Returns `true` if the given PID is currently attached to this activation.
-    pub fn is_pid_attached(&self, pid: Pid) -> bool {
-        self.attached_pids.contains_key(&pid)
     }
 
     /// Returns the current activation mode
@@ -1566,41 +1556,6 @@ mod tests {
 
             let attachment: Attachment = serde_json::from_str(&json).unwrap();
             assert_eq!(attachment.invocation_type, None);
-        }
-    }
-
-    mod start_identifier {
-        use super::*;
-
-        /// `remove_start_state_dir` removes the directory when it exists.
-        #[test]
-        fn remove_start_state_dir_removes_existing_dir() {
-            let tmp = TempDir::new().unwrap();
-            let start_id = StartIdentifier::new("/nix/store/test-pkg");
-            let state_dir = start_id.start_state_dir(tmp.path()).unwrap();
-            std::fs::create_dir_all(&state_dir).unwrap();
-            assert!(state_dir.exists(), "directory should exist before removal");
-
-            start_id
-                .remove_start_state_dir(tmp.path())
-                .expect("removal should succeed");
-
-            assert!(
-                !state_dir.exists(),
-                "directory should be gone after removal"
-            );
-        }
-
-        /// `remove_start_state_dir` is a no-op when the directory doesn't exist.
-        #[test]
-        fn remove_start_state_dir_noop_when_absent() {
-            let tmp = TempDir::new().unwrap();
-            let start_id = StartIdentifier::new("/nix/store/test-pkg");
-
-            // Directory was never created.
-            start_id
-                .remove_start_state_dir(tmp.path())
-                .expect("removal should succeed even when dir is absent");
         }
     }
 }

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -1,9 +1,9 @@
 use std::io::{BufWriter, Write, stdout};
 use std::str::FromStr;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
-use flox_core::activate::context::InvocationType;
+use flox_core::activate::context::InvocationKind;
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
 use flox_core::activations::activation_state_dir_path;
 use flox_rust_sdk::flox::Flox;
@@ -87,32 +87,41 @@ impl Deactivate {
 
         let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
 
-        // Interactive subshell: just emit `exit;`. The shell exits and the
-        // executive monitors the PID, cleaning up state.json when it goes away.
-        let is_interactive = InvocationType::from_str(&invocation_type)
-            .unwrap_or(InvocationType::InPlace)
-            == InvocationType::Interactive;
-
         let mut writer = BufWriter::new(stdout());
 
-        if is_interactive {
-            write!(writer, "exit;")?;
-            return Ok(());
+        if invocation_type.is_empty() {
+            bail!("cannot deactivate for empty INVOCATION_TYPE")
         }
 
-        // In-place activation: restore env vars first, then emit a shell
-        // command that calls `flox-activations detach` so state.json is
-        // updated after the script is eval'd by the caller.
-        flox_activations::deactivate::generate_deactivate_script(
-            shell,
-            &mut writer,
-            &*FLOX_INTERPRETER,
-            &FLOX_ACTIVATIONS_BIN,
-            &activation_state_dir,
-        )
-        .context("failed to generate deactivation script")?;
+        let invocation_kind = InvocationKind::from_str(&invocation_type)
+            .context("could not determine invocation type".to_string())?;
 
-        Ok(())
+        match invocation_kind {
+            InvocationKind::Interactive => {
+                // Interactive subshell: just emit `exit;`. The shell exits and the
+                // executive monitors the PID, cleaning up state.json when it goes
+                // away.
+                write!(writer, "exit;")?;
+                Ok(())
+            },
+            InvocationKind::InPlace | InvocationKind::ShellCommand => {
+                // In-place activation: restore env vars first, then emit a shell
+                // command that calls `flox-activations detach` so state.json is
+                // updated after the script is eval'd by the caller.
+                flox_activations::deactivate::generate_deactivate_script(
+                    shell,
+                    &mut writer,
+                    &*FLOX_INTERPRETER,
+                    &FLOX_ACTIVATIONS_BIN,
+                    &activation_state_dir,
+                )
+                .context("failed to generate deactivation script")
+            },
+            InvocationKind::ExecCommand => {
+                // This should be unreachable because we shouldn't set _FLOX_INVOCATION_TYPE to exec_command
+                bail!("cannot deactivate an exec command activation");
+            },
+        }
     }
 
     pub fn old_exit(self, _flox: Flox) -> Result<()> {
@@ -136,73 +145,5 @@ impl Deactivate {
         ", uninitialized_environment_description(&last_active)?});
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::io::BufWriter;
-
-    use super::*;
-
-    fn is_interactive(invocation_type: &str) -> bool {
-        InvocationType::from_str(invocation_type).unwrap_or(InvocationType::InPlace)
-            == InvocationType::Interactive
-    }
-
-    // Helper to call handle_print_script with a given invocation type and
-    // capture the output. We bypass `handle()` because it checks flox features.
-
-    /// Confirm that `"interactive"` as the invocation type emits exactly `exit;`.
-    #[test]
-    fn interactive_invocation_type_emits_exit() {
-        // We can't call handle_print_script directly in unit tests because it
-        // calls activated_environments() (reads env vars) and
-        // detect_shell_for_in_place() (reads env vars). Instead we test the
-        // logic inline:
-        assert!(
-            is_interactive("interactive"),
-            "\"interactive\" should be detected as interactive"
-        );
-
-        let mut buf = Vec::new();
-        {
-            let mut writer = BufWriter::new(&mut buf);
-            if is_interactive("interactive") {
-                write!(writer, "exit;").unwrap();
-            }
-        }
-        assert_eq!(
-            String::from_utf8(buf).unwrap(),
-            "exit;",
-            "interactive invocation type should emit exactly 'exit;'"
-        );
-    }
-
-    /// Confirm that `"inplace"` does NOT emit `exit`.
-    #[test]
-    fn inplace_invocation_type_emits_no_exit() {
-        assert!(
-            !is_interactive("inplace"),
-            "\"inplace\" should not be detected as interactive"
-        );
-    }
-
-    /// Confirm that an empty string defaults to in-place (not interactive).
-    #[test]
-    fn empty_invocation_type_defaults_to_inplace() {
-        assert!(
-            !is_interactive(""),
-            "empty invocation type should default to in-place"
-        );
-    }
-
-    /// Confirm that an unknown string defaults to in-place (not interactive).
-    #[test]
-    fn unknown_invocation_type_defaults_to_inplace() {
-        assert!(
-            !is_interactive("totally-unknown"),
-            "unknown invocation type should default to in-place"
-        );
     }
 }


### PR DESCRIPTION
- **fix: clear ready and reclaim start dir on last detach**
  DetachArgs::handle and ActivationState::cleanup_pid both performed the
  same "detach a PID, then update ready only when attachments remain"
  sequence (update_ready_after_detach panics on an empty map), so the
  guard contract was duplicated at both call sites. Fold it into detach
  itself.
  
  While doing so, fix an orphaned-directory window in the deferred-detach
  path. Previously, when the last PID detached, handle() kept the start
  state dir and left ready = True(start_id), relying on the executive's
  cleanup_all to tear everything down. But the detach CLI drops the lock
  before the executive reacts: if another activation for a different store
  path attaches first, it supersedes the start, the executive then sees
  PIDs and skips cleanup_all, and the old start's dir is orphaned until the
  next whole-dir teardown.
  
  Have detach set ready = False once no PIDs remain, and remove the emptied
  start's dir unconditionally in handle(). With ready cleared, a racing
  reattach starts fresh instead of reusing the removed dir, so eager
  removal is safe and the orphan window is closed. cleanup_all is unchanged
  and still tears down the rest; it holds the lock and re-checks
  attached_pids, so it never deletes a live activation.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  

- **fix(activate): add InvocationKind discriminant for invocation-type round-trip**
  `InvocationType`'s `Display` (written to `_FLOX_INVOCATION_TYPE`) strips the
  command payload, so the value can't be deserialized back into the rich enum.
  
  Add a payload-free `InvocationKind` discriminant that owns the wire format:
  its `snake_case` variant names drive both `Display` and a derived `FromStr`
  (`#[from_str(rename_all = "snake_case")]`), so there are no hand-maintained
  parse strings. `InvocationType` now serializes via the same `snake_case`
  convention and its `Display` delegates to `self.kind()`, so the discriminant
  round-trips losslessly — unlike the payload-carrying enum, which cannot be
  reconstructed from its name alone. Add `InvocationType::kind()`; drop the old
  buggy `FromStr` (which collapsed every non-"interactive" value to `InPlace`)
  and the unused `displayed_interactive` helper.
  
  Tests pin the round-trip and lock the exact snake_case wire format.
  
  Note: does not compile in isolation — the matching `deactivate.rs` read-side
  update follows in the next commit.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  

- **fix: misc cleanup**
  