### PR TITLE
feat(events): add canonical telemetry event types (foundation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
 name = "flox-events"
 version = "0.0.0"
 dependencies = [
+ "derive_more",
  "serde",
  "serde_json",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
  "derive_more",
  "serde",
  "serde_json",
+ "serde_with",
  "time",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,6 +1586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flox-events"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "flox-manifest"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ sentry = { version = "0.38.1", features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-serde_with = "3.16.1"
+serde_with = { version = "3.16.1", features = ["time_0_3"] }
 serde_yaml = "0.9"
 shell-escape = "0.1.5"
 slug = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "cli/beta",
     "cli/catalog-api-v1",
     "cli/flox",
+    "cli/flox-events",
     "cli/flox-rust-sdk",
     "cli/flox-activations",
     "cli/flox-catalog",
@@ -42,6 +43,7 @@ enum_dispatch = "0.3.13"
 flate2 = "1.0"
 flox-activations = { path = "cli/flox-activations" }
 flox-core = { path = "cli/flox-core" }
+flox-events = { path = "cli/flox-events" }
 flox-rust-sdk = { path = "cli/flox-rust-sdk" }
 flox-test-utils = { path = "cli/flox-test-utils" }
 flox-manifest = { path = "cli/flox-manifest" }

--- a/cli/flox-events/Cargo.toml
+++ b/cli/flox-events/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 derive_more.workspace = true
 serde.workspace = true
+serde_with.workspace = true
 time.workspace = true
 uuid.workspace = true
 

--- a/cli/flox-events/Cargo.toml
+++ b/cli/flox-events/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "flox-events"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+serde.workspace = true
+time.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/cli/flox-events/Cargo.toml
+++ b/cli/flox-events/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+derive_more.workspace = true
 serde.workspace = true
 time.workspace = true
 uuid.workspace = true

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -3,9 +3,8 @@
 //! Types only. There is no sink, no context, and no emission machinery
 //! in this crate.
 
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 use time::OffsetDateTime;
-use time::format_description::well_known::Iso8601;
 use uuid::Uuid;
 
 /// A single telemetry event in the canonical envelope shape.
@@ -21,7 +20,7 @@ pub struct Event {
     /// Unique id for this event (used downstream for de-duplication).
     pub event_id: Uuid,
     /// When the event occurred.
-    #[serde(serialize_with = "serialize_iso8601")]
+    #[serde(with = "time::serde::iso8601")]
     pub event_timestamp: OffsetDateTime,
     /// The producer. Always `"cli"`.
     pub source: &'static str,
@@ -65,21 +64,17 @@ pub struct CliCommandRunPayload {}
 #[derive(Debug, Clone, Serialize)]
 pub struct CliCommandCompletedPayload {}
 
-fn serialize_iso8601<S: Serializer>(
-    timestamp: &OffsetDateTime,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    let formatted = timestamp
-        .format(&Iso8601::DEFAULT)
-        .map_err(serde::ser::Error::custom)?;
-    serializer.serialize_str(&formatted)
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
     use super::*;
+
+    /// The wire form of `OffsetDateTime::from_unix_timestamp(0)` under
+    /// `time::serde::iso8601` — the 6-digit-signed-year ISO 8601 extended
+    /// representation. Hardcoded so the test fails loudly if the `time`
+    /// crate ever changes its default ISO 8601 config.
+    const EPOCH_ISO8601: &str = "+001970-01-01T00:00:00.000000000Z";
 
     fn fixed_event(kind: EventKind) -> Event {
         Event {
@@ -94,13 +89,6 @@ mod tests {
         }
     }
 
-    fn iso8601_unix_zero() -> String {
-        OffsetDateTime::from_unix_timestamp(0)
-            .expect("0 is a valid unix timestamp")
-            .format(&Iso8601::DEFAULT)
-            .expect("Iso8601::DEFAULT formats successfully")
-    }
-
     #[test]
     fn command_run_serializes_to_canonical_envelope() {
         let value = serde_json::to_value(fixed_event(EventKind::CliCommandRun(
@@ -109,7 +97,7 @@ mod tests {
         .expect("event serializes");
         let expected = json!({
             "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": iso8601_unix_zero(),
+            "event_timestamp": EPOCH_ISO8601,
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
@@ -127,7 +115,7 @@ mod tests {
         .expect("event serializes");
         let expected = json!({
             "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": iso8601_unix_zero(),
+            "event_timestamp": EPOCH_ISO8601,
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
@@ -144,7 +132,7 @@ mod tests {
         let value = serde_json::to_value(event).expect("event serializes");
         let expected = json!({
             "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": iso8601_unix_zero(),
+            "event_timestamp": EPOCH_ISO8601,
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -46,8 +46,9 @@ pub struct Event {
 ///
 /// The dotted wire name on `#[serde(rename)]` is the single source of
 /// truth for each variant; call sites use the enum, never a string
-/// literal.
-#[derive(Debug, Clone, Serialize)]
+/// literal. `derive_more::From` is derived so a call site can pass a
+/// payload value directly to anything accepting `impl Into<EventKind>`.
+#[derive(Debug, Clone, Serialize, derive_more::From)]
 #[serde(tag = "event_type", content = "payload")]
 pub enum EventKind {
     #[serde(rename = "cli.command_run")]

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -4,6 +4,7 @@
 //! in this crate.
 
 use serde::Serialize;
+use serde_with::{TimestampMilliSeconds, serde_as};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -15,12 +16,18 @@ use uuid::Uuid;
 /// auth_subject?, event_type, payload}`.
 ///
 /// Serialize-only: the CLI produces events, it never reads them back.
+#[serde_as]
 #[derive(Debug, Clone, Serialize)]
 pub struct Event {
     /// Unique id for this event (used downstream for de-duplication).
     pub event_id: Uuid,
-    /// When the event occurred.
-    #[serde(with = "time::serde::iso8601")]
+    /// When the event occurred. Serialized as an integer millisecond
+    /// count since the Unix epoch — matches the downstream
+    /// `DateTime64(3, 'UTC')` storage granularity, avoids the
+    /// `f64`-mantissa precision loss that bites nanosecond timestamps
+    /// when consumers parse JSON numbers as floats, and avoids the
+    /// timezone-ambiguity class entirely (no offset, no DST gaps).
+    #[serde_as(as = "TimestampMilliSeconds<i64>")]
     pub event_timestamp: OffsetDateTime,
     /// The producer. Always `"cli"`.
     pub source: &'static str,
@@ -72,10 +79,9 @@ mod tests {
     use super::*;
 
     /// The wire form of `OffsetDateTime::from_unix_timestamp(0)` under
-    /// `time::serde::iso8601` — the 6-digit-signed-year ISO 8601 extended
-    /// representation. Hardcoded so the test fails loudly if the `time`
-    /// crate ever changes its default ISO 8601 config.
-    const EPOCH_ISO8601: &str = "+001970-01-01T00:00:00.000000000Z";
+    /// `TimestampMilliSeconds<i64>` — milliseconds since the Unix
+    /// epoch, where 1970-01-01T00:00:00Z is exactly 0.
+    const EPOCH_UNIX_MS: i64 = 0;
 
     fn fixed_event(kind: EventKind) -> Event {
         Event {
@@ -98,7 +104,7 @@ mod tests {
         .expect("event serializes");
         let expected = json!({
             "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": EPOCH_ISO8601,
+            "event_timestamp": EPOCH_UNIX_MS,
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
@@ -116,7 +122,7 @@ mod tests {
         .expect("event serializes");
         let expected = json!({
             "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": EPOCH_ISO8601,
+            "event_timestamp": EPOCH_UNIX_MS,
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
@@ -133,7 +139,7 @@ mod tests {
         let value = serde_json::to_value(event).expect("event serializes");
         let expected = json!({
             "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": EPOCH_ISO8601,
+            "event_timestamp": EPOCH_UNIX_MS,
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -1,0 +1,157 @@
+//! Canonical telemetry event types emitted by the flox CLI.
+//!
+//! Types only. There is no sink, no context, and no emission machinery
+//! in this crate.
+
+use serde::{Serialize, Serializer};
+use time::OffsetDateTime;
+use time::format_description::well_known::Iso8601;
+use uuid::Uuid;
+
+/// A single telemetry event in the canonical envelope shape.
+///
+/// `source` is always `"cli"`. `kind` carries the variant tag and its
+/// typed payload and is flattened into the envelope, so the wire shape
+/// is `{event_id, event_timestamp, source, invocation_id, device_id,
+/// auth_subject?, event_type, payload}`.
+///
+/// Serialize-only: the CLI produces events, it never reads them back.
+#[derive(Debug, Clone, Serialize)]
+pub struct Event {
+    /// Unique id for this event (used downstream for de-duplication).
+    pub event_id: Uuid,
+    /// When the event occurred.
+    #[serde(serialize_with = "serialize_iso8601")]
+    pub event_timestamp: OffsetDateTime,
+    /// The producer. Always `"cli"`.
+    pub source: &'static str,
+    /// Correlates every event emitted during one CLI invocation.
+    pub invocation_id: Uuid,
+    /// Stable per-installation id.
+    pub device_id: Uuid,
+    /// Pseudonymous authenticated-subject identifier — the OIDC/JWT
+    /// `sub` claim (sourced from the auth token) when known. Must not
+    /// contain email addresses, raw user handles, or token bytes — those
+    /// are PII and a different category from this field's pseudonymous-
+    /// identifier contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_subject: Option<String>,
+    /// The event variant and its typed payload. Flattened into the
+    /// envelope: the variant's `#[serde(rename)]` becomes `event_type`
+    /// and the variant's payload struct becomes `payload`.
+    #[serde(flatten)]
+    pub kind: EventKind,
+}
+
+/// The set of event variants the CLI emits.
+///
+/// The dotted wire name on `#[serde(rename)]` is the single source of
+/// truth for each variant; call sites use the enum, never a string
+/// literal.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event_type", content = "payload")]
+pub enum EventKind {
+    #[serde(rename = "cli.command_run")]
+    CliCommandRun(CliCommandRunPayload),
+    #[serde(rename = "cli.command_completed")]
+    CliCommandCompleted(CliCommandCompletedPayload),
+}
+
+/// Payload for [`EventKind::CliCommandRun`]. Serializes to `{}`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CliCommandRunPayload {}
+
+/// Payload for [`EventKind::CliCommandCompleted`]. Serializes to `{}`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CliCommandCompletedPayload {}
+
+fn serialize_iso8601<S: Serializer>(
+    timestamp: &OffsetDateTime,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let formatted = timestamp
+        .format(&Iso8601::DEFAULT)
+        .map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&formatted)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn fixed_event(kind: EventKind) -> Event {
+        Event {
+            event_id: Uuid::nil(),
+            event_timestamp: OffsetDateTime::from_unix_timestamp(0)
+                .expect("0 is a valid unix timestamp"),
+            source: "cli",
+            invocation_id: Uuid::nil(),
+            device_id: Uuid::nil(),
+            auth_subject: None,
+            kind,
+        }
+    }
+
+    fn iso8601_unix_zero() -> String {
+        OffsetDateTime::from_unix_timestamp(0)
+            .expect("0 is a valid unix timestamp")
+            .format(&Iso8601::DEFAULT)
+            .expect("Iso8601::DEFAULT formats successfully")
+    }
+
+    #[test]
+    fn command_run_serializes_to_canonical_envelope() {
+        let value = serde_json::to_value(fixed_event(EventKind::CliCommandRun(
+            CliCommandRunPayload {},
+        )))
+        .expect("event serializes");
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": iso8601_unix_zero(),
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.command_run",
+            "payload": {},
+        });
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn command_completed_serializes_to_canonical_envelope() {
+        let value = serde_json::to_value(fixed_event(EventKind::CliCommandCompleted(
+            CliCommandCompletedPayload {},
+        )))
+        .expect("event serializes");
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": iso8601_unix_zero(),
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.command_completed",
+            "payload": {},
+        });
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn auth_subject_serializes_when_present() {
+        let mut event = fixed_event(EventKind::CliCommandRun(CliCommandRunPayload {}));
+        event.auth_subject = Some("test-subject-7f3a".to_string());
+        let value = serde_json::to_value(event).expect("event serializes");
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": iso8601_unix_zero(),
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "auth_subject": "test-subject-7f3a",
+            "event_type": "cli.command_run",
+            "payload": {},
+        });
+        assert_eq!(value, expected);
+    }
+}


### PR DESCRIPTION

## What this is, and why it has no callers yet

This is the first PR in a planned sequence that moves the CLI's telemetry
emission to a structured event format on the new telemetry pipeline. It is
deliberately a **types-only foundation**: it introduces the event envelope
and its variant payloads in a small new `cli/flox-events/` crate, and
nothing else. There are no call sites and no behaviour change — the
existing `subcommand_metric!` path is entirely untouched, and the new types
are exercised only by their unit tests.

The sequence it anchors:

1. **This PR — the event types (no callers).** The `Event` envelope, the
   `EventKind` tagged enum, and the per-variant payload structs.
2. **First emission + delivery.** Mint a per-invocation id and emit one
   run/completed pair per invocation (replacing today's 2–4 uncorrelated
   events per command), wired through the existing
   `MetricsLayer → Hub → MetricsBuffer → Connection` pipeline in
   `cli/flox/src/utils/metrics.rs` so it inherits batching, deferred
   dispatch, and `activate`-exec-survival rather than reinventing them.
   Dormant in production until step 6.
3–5. **Instrument the subcommands (dormant).** Carry the per-command
   detail today's emission captures, retiring the pseudo-subcommands
   along the way.
6. **The switchover.** Repoint the telemetry endpoint constant at the new
   pipeline and disable the legacy send at the same point — single emit,
   never both. Gated on the downstream pipeline being proven to reproduce
   existing reporting.
7. **Cleanup.** Remove the dead legacy path.

Shipping the types first keeps each following PR small and focused, and
keeps this one trivially safe to review: it's pure additive type
definitions in a crate nothing depends on yet.

## How the pieces fit together

The target wire shape is a single structured envelope per emission:

```
{event_id, event_timestamp, source, invocation_id, device_id,
 auth_subject?, event_type, payload}
```

Three things in this PR realise that shape:

- **`Event`** — the envelope struct. Carries the correlation ids
  (`event_id` per emit, `invocation_id` per CLI run, `device_id` stable
  per installation), the timestamp, the producer (`source = "cli"`), and
  an optional pseudonymous authenticated subject (see below). It holds
  its variant in a `#[serde(flatten)]`-ed field, so the variant tag and
  payload appear at the top level rather than nested.
- **`EventKind`** — a `#[serde(tag = "event_type", content = "payload")]`
  enum with one variant per event the CLI emits. Each variant carries a
  typed payload struct. The dotted wire name on `#[serde(rename)]` is the
  single source of truth for each variant; call sites use the enum, never
  a string literal.
- **Per-variant payload structs** — `CliCommandRunPayload`,
  `CliCommandCompletedPayload`. Ship as empty structs in this PR; the
  per-command fields land alongside the call sites in the next PR.

The envelope fields exist to make events correlatable downstream:
`invocation_id` ties together every event from one command run,
`event_id` lets the pipeline de-duplicate, and `device_id` is the stable
per-install id.

## Decisions a reviewer will likely ask about

- **Why a new `flox-events` crate, not under `flox-rust-sdk`?** The
  types need to be reachable from both the `flox` binary and SDK-layer
  providers, and the right placement is a dedicated crate with no
  upward dependencies — anyone who needs to construct events depends on
  it without pulling in the rest of the SDK. The previous draft of this
  PR put the types inside `flox-rust-sdk`; that was the wrong home for
  a leaf type crate.
- **Typed payloads + `#[serde(flatten)]` preserves the wire shape.**
  The combination of `#[serde(flatten)]` on `Event.kind` and
  `#[serde(tag = "event_type", content = "payload")]` on `EventKind`
  flattens the variant out into the envelope, so a downstream consumer
  sees `event_type` and `payload` at the top level just like a
  hand-written envelope. The change vs the previous draft is
  **producer-side only**: payload contents become compile-time-typed
  per variant. Adding a new attribute remains a single-place change —
  extend the variant's payload struct in this crate. The ingest path
  needs no schema changes.
- **No sink, no context, no delivery layer in this PR.** Step 2 will
  build a separate `Hub`/`Buffer`/`Connection`/`Client` pipeline in
  `cli/flox/src/utils/metrics.rs` by **copying** the existing
  architecture pattern alongside it, typed to `Event` from the start
  — per the sink.rs review thread, "reusing, or even copying for now,
  as they will be replaced eventually." The valuable parts of the
  existing subsystem (fsync-on-append durability, batched HTTP,
  drop-on-flush, blocking-thread-with-timeout) are inherited by
  construction. Production dormancy comes from leaving the new
  pipeline's Client unset; cutover (step 6) is a Client set/unset
  swap. No `tracing_subscriber::Layer` step is copied — per the
  separate review note, routing typed payloads through `tracing` is
  awkward (`tracing::Value` doesn't fit custom types and the
  `valuable` feature is experimental), and the call sites already
  construct typed values so there's no decoupling left to buy. The
  previous draft introduced a parallel `EventSink` trait alongside
  the existing pipeline; this draft drops it. The emission API
  surface (a thin macro vs direct enum construction at the call
  site) is a step 2 choice.
- **No new endpoint constants or env vars.** When the switchover
  happens, the new path reuses the existing telemetry endpoint constant
  (repointed at the new pipeline at switchover) and the existing dev
  override — so this change adds no new public configuration surface.
- **`event_timestamp` is unix milliseconds (`i64`), not ISO 8601.**
  After landing the type as `OffsetDateTime` with
  `#[serde(with = "time::serde::iso8601")]` and reading your follow-up
  about nanosecond-precision loss when consumers parse JSON timestamps
  through `f64`, I switched the wire format to integer milliseconds
  via `serde_with::TimestampMilliSeconds<i64>`. The Rust type stays
  `OffsetDateTime` so the rest of the code is unchanged; only the
  serializer differs. This matches the consumer's actual storage
  granularity (`DateTime64(3, 'UTC')` is millisecond-precise), avoids
  the float-mantissa class (ms timestamps fit `f64` with five orders
  of magnitude of headroom), avoids timezone ambiguity entirely, and
  drops ~half the wire-byte size for the field. The consumer pipeline
  needs to expect an integer rather than a string on the wire — that's
  noted for the unified-metrics task 006 work.

- **The `auth_subject` field is pseudonymous-only.** Its doc comment
  states explicitly that it must never hold an email, raw user handle,
  or token bytes — only the opaque OIDC/JWT `sub` claim from the auth
  token. It is unset in this PR and populated by a later change; the
  invariant constrains whoever populates it.
- **Tests don't re-test serde.** One canonical-envelope roundtrip per
  variant exercises the rename through a real value while pinning the
  wire contract; a third test pins `auth_subject` serialization when
  present. Per-variant `EventKind`-to-string assertions would just
  duplicate the rename attribute table.

## Commits

- **feat(events): add canonical telemetry event types (foundation)**

  Adds the new `cli/flox-events/` crate. `Event` is the canonical
  envelope (`event_id`, `event_timestamp`, `source`, `invocation_id`,
  `device_id`, optional pseudonymous `auth_subject`, and a flattened
  `kind`). `EventKind` is a `#[serde(tag = "event_type", content =
  "payload")]` enum with `CliCommandRun` and `CliCommandCompleted`
  variants carrying typed payload structs; the dotted wire name on
  `#[serde(rename)]` is the single source of truth for each variant.

  No call site uses any of this yet — the new crate is exercised only
  by its unit tests (canonical-envelope roundtrip per variant plus the
  `auth_subject`-present case). The existing telemetry path is byte-
  for-byte untouched. Workspace `cargo build`, `clippy -D warnings`,
  `fmt --check`, and `cargo nextest run -p flox-events` all green;
  full impure unit suite green.

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
