### PR TITLE
feat: add debugging flox decode-hook-diff command

### DIFF
--- a/cli/flox/src/commands/decode_hook_diff.rs
+++ b/cli/flox/src/commands/decode_hook_diff.rs
@@ -1,0 +1,22 @@
+use anyhow::{Context, Result};
+use bpaf::Bpaf;
+use flox_activations::attach_diff::diff_serializer::{DiffSerializer, FLOX_HOOK_DIFF_VAR};
+
+/// Decode the `_FLOX_HOOK_DIFF` environment variable into pretty-printed JSON.
+///
+/// `_FLOX_HOOK_DIFF` is set during activation as zlib-compressed, base64url
+/// JSON of the environment diff used to restore the shell on deactivation.
+/// This hidden command makes that opaque value readable for debugging.
+#[derive(Bpaf, Clone, Debug)]
+pub struct DecodeHookDiff {}
+
+impl DecodeHookDiff {
+    pub fn handle(self) -> Result<()> {
+        let encoded = std::env::var(FLOX_HOOK_DIFF_VAR)
+            .context(format!("{FLOX_HOOK_DIFF_VAR} not set in environment"))?;
+        let diff = DiffSerializer::decode(&encoded)
+            .context(format!("Failed to decode {FLOX_HOOK_DIFF_VAR}"))?;
+        println!("{}", serde_json::to_string_pretty(&diff)?);
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -6,6 +6,7 @@ mod build;
 mod check_for_upgrades;
 mod containerize;
 mod deactivate;
+mod decode_hook_diff;
 mod delete;
 mod edit;
 mod envs;
@@ -832,6 +833,12 @@ enum InternalCommands {
     /// Compute env changes for auto-activation (called on every prompt)
     #[bpaf(command("hook-env"), hide)]
     HookEnv(#[bpaf(external(hook_env::hook_env))] hook_env::HookEnv),
+
+    /// Decode the _FLOX_HOOK_DIFF environment variable to JSON for debugging
+    #[bpaf(command("decode-hook-diff"), hide)]
+    DecodeHookDiff(
+        #[bpaf(external(decode_hook_diff::decode_hook_diff))] decode_hook_diff::DecodeHookDiff,
+    ),
 }
 
 impl InternalCommands {
@@ -845,6 +852,7 @@ impl InternalCommands {
             InternalCommands::ActivationState(args) => args.handle(flox).await?,
             InternalCommands::ServicesSocket(args) => args.handle(flox).await?,
             InternalCommands::HookEnv(args) => args.handle(flox)?,
+            InternalCommands::DecodeHookDiff(args) => args.handle()?,
         }
         Ok(())
     }


### PR DESCRIPTION
Add a hidden debugging command that decodes _FLOX_HOOK_DIFF and pretty
prints JSON.

This will be helpful for debugging and follows the pattern of `flox
activation-state`
