### PR TITLE
test(buildenv): add tests for replace_legacy_links and build-output symlink cleanup

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1939,3 +1939,140 @@ mod migration_tests {
         .assert_eq(&composer_manifest_contents);
     }
 }
+
+#[cfg(test)]
+mod rendered_env_links_tests {
+    use std::os::unix::fs::symlink;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::models::environment::generations::GenerationId;
+
+    /// Build a `RenderedEnvironmentLinks` for a plain (non-generation) env,
+    /// pre-populate the directory with the new dash-separator symlinks and old
+    /// dot-separator symlinks pointing into the Nix store, call
+    /// `replace_legacy_links`, and assert the old symlinks are replaced with
+    /// relative redirects to the new names.
+    #[test]
+    fn replace_legacy_links_plain_replaces_store_dot_links_with_redirects() {
+        let dir = tempdir().unwrap();
+        let base_dir = CanonicalPath::new(dir.path()).unwrap();
+        let system = "x86_64-linux".to_string();
+        let name = "myenv";
+
+        let links = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &base_dir, name, &system,
+        );
+
+        // New dash-separator symlinks must exist for the redirect to be created.
+        symlink("/nix/store/new-dev-aaaaaaaaaaaa", links.dev.as_path()).unwrap();
+        symlink("/nix/store/new-run-aaaaaaaaaaaa", links.run.as_path()).unwrap();
+
+        // Old dot-separator symlinks pointing into the store.
+        let old_dev = base_dir.join(format!("{system}.{name}.dev"));
+        let old_run = base_dir.join(format!("{system}.{name}.run"));
+        symlink("/nix/store/old-dev-aaaaaaaaaaaa", &old_dev).unwrap();
+        symlink("/nix/store/old-run-aaaaaaaaaaaa", &old_run).unwrap();
+
+        links.replace_legacy_links();
+
+        // Old paths are now relative redirects to the dash-separator names.
+        assert_eq!(
+            std::fs::read_link(&old_dev).unwrap(),
+            PathBuf::from(format!("{system}.{name}-dev"))
+        );
+        assert_eq!(
+            std::fs::read_link(&old_run).unwrap(),
+            PathBuf::from(format!("{system}.{name}-run"))
+        );
+    }
+
+    /// Same as above but for generation-qualified links, pinning the invariant
+    /// that `new_in_base_dir_with_name_system_and_generation` produces names
+    /// ending in `-dev`/`-run` so that `replace_legacy_links` derives the
+    /// correct legacy stem `<system>.<name>.gen<N>`.
+    #[test]
+    fn replace_legacy_links_generation_replaces_store_dot_links_with_redirects() {
+        let dir = tempdir().unwrap();
+        let base_dir = CanonicalPath::new(dir.path()).unwrap();
+        let system = "x86_64-linux".to_string();
+        let name = "myenv";
+        let generation = GenerationId::from(3usize);
+
+        let links = RenderedEnvironmentLinks::new_in_base_dir_with_name_system_and_generation(
+            &base_dir, name, &system, generation,
+        );
+
+        symlink("/nix/store/new-dev-aaaaaaaaaaaa", links.dev.as_path()).unwrap();
+        symlink("/nix/store/new-run-aaaaaaaaaaaa", links.run.as_path()).unwrap();
+
+        let old_dev = base_dir.join(format!("{system}.{name}.gen{generation}.dev"));
+        let old_run = base_dir.join(format!("{system}.{name}.gen{generation}.run"));
+        symlink("/nix/store/old-dev-aaaaaaaaaaaa", &old_dev).unwrap();
+        symlink("/nix/store/old-run-aaaaaaaaaaaa", &old_run).unwrap();
+
+        links.replace_legacy_links();
+
+        assert_eq!(
+            std::fs::read_link(&old_dev).unwrap(),
+            PathBuf::from(format!("{system}.{name}.gen{generation}-dev"))
+        );
+        assert_eq!(
+            std::fs::read_link(&old_run).unwrap(),
+            PathBuf::from(format!("{system}.{name}.gen{generation}-run"))
+        );
+    }
+
+    /// When no legacy dot-separator symlinks are present, `replace_legacy_links`
+    /// is a no-op and must not create new dot-separator symlinks.
+    #[test]
+    fn replace_legacy_links_skips_when_no_legacy_symlink_present() {
+        let dir = tempdir().unwrap();
+        let base_dir = CanonicalPath::new(dir.path()).unwrap();
+        let system = "x86_64-linux".to_string();
+        let name = "myenv";
+
+        let links = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &base_dir, name, &system,
+        );
+
+        symlink("/nix/store/new-dev-aaaaaaaaaaaa", links.dev.as_path()).unwrap();
+        symlink("/nix/store/new-run-aaaaaaaaaaaa", links.run.as_path()).unwrap();
+
+        links.replace_legacy_links();
+
+        let old_dev = base_dir.join(format!("{system}.{name}.dev"));
+        assert!(!old_dev.exists() && !old_dev.is_symlink());
+    }
+
+    /// When the legacy symlink already points to the new dash-separator name
+    /// (i.e. it is already a redirect from a previous run), it must not be
+    /// touched — the `/nix/store/` guard prevents the re-creation cycle.
+    #[test]
+    fn replace_legacy_links_skips_when_legacy_symlink_is_already_redirect() {
+        let dir = tempdir().unwrap();
+        let base_dir = CanonicalPath::new(dir.path()).unwrap();
+        let system = "x86_64-linux".to_string();
+        let name = "myenv";
+
+        let links = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &base_dir, name, &system,
+        );
+
+        symlink("/nix/store/new-dev-aaaaaaaaaaaa", links.dev.as_path()).unwrap();
+        symlink("/nix/store/new-run-aaaaaaaaaaaa", links.run.as_path()).unwrap();
+
+        // Simulate a redirect that was already created by a previous build.
+        let old_dev = base_dir.join(format!("{system}.{name}.dev"));
+        symlink(format!("{system}.{name}-dev"), &old_dev).unwrap();
+
+        links.replace_legacy_links();
+
+        // Redirect target must be unchanged.
+        assert_eq!(
+            std::fs::read_link(&old_dev).unwrap(),
+            PathBuf::from(format!("{system}.{name}-dev"))
+        );
+    }
+}

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -2942,3 +2942,104 @@ mod materialise_retry_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod symlink_cleanup_tests {
+    use std::collections::HashMap;
+    use std::os::unix::fs::symlink;
+    use std::path::PathBuf;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn build_outputs_with_builds(keys: &[&str]) -> BuildEnvOutputs {
+        BuildEnvOutputs {
+            dev: BuiltStorePath(PathBuf::from("/nix/store/fake-dev")),
+            run: BuiltStorePath(PathBuf::from("/nix/store/fake-run")),
+            manifest_build_runtimes: keys
+                .iter()
+                .map(|k| {
+                    (
+                        k.to_string(),
+                        BuiltStorePath(PathBuf::from("/nix/store/fake")),
+                    )
+                })
+                .collect::<HashMap<_, _>>(),
+        }
+    }
+
+    /// `remove_build_output_symlinks` deletes each `<prefix>-<key>` symlink
+    /// and leaves other files in the directory untouched.
+    #[test]
+    fn remove_build_output_symlinks_deletes_build_symlinks() {
+        let dir = tempdir().unwrap();
+        let prefix = dir.path().join("x86_64-linux.myenv");
+
+        let build_link = dir.path().join("x86_64-linux.myenv-build-hello");
+        let unrelated = dir.path().join("x86_64-linux.myenv-dev");
+        symlink("/nix/store/fake-build", &build_link).unwrap();
+        symlink("/nix/store/fake-dev", &unrelated).unwrap();
+
+        let outputs = build_outputs_with_builds(&["build-hello"]);
+        remove_build_output_symlinks(Some(&prefix), &outputs);
+
+        assert!(!build_link.exists() && !build_link.is_symlink());
+        assert!(
+            unrelated.is_symlink(),
+            "unrelated symlink must be untouched"
+        );
+    }
+
+    /// When `out_link_prefix` is `None`, `remove_build_output_symlinks` is a no-op.
+    #[test]
+    fn remove_build_output_symlinks_noop_when_no_prefix() {
+        let dir = tempdir().unwrap();
+        let link = dir.path().join("x86_64-linux.myenv-build-hello");
+        symlink("/nix/store/fake-build", &link).unwrap();
+
+        let outputs = build_outputs_with_builds(&["build-hello"]);
+        remove_build_output_symlinks(None, &outputs);
+
+        assert!(
+            link.is_symlink(),
+            "symlink must survive when prefix is None"
+        );
+    }
+
+    /// `remove_build_output_symlinks_by_scan` removes all symlinks in the
+    /// parent directory whose names start with `<prefix_filename>-build-`.
+    #[test]
+    fn remove_build_output_symlinks_by_scan_deletes_matching_symlinks() {
+        let dir = tempdir().unwrap();
+        let prefix = dir.path().join("x86_64-linux.myenv");
+
+        let build_hello = dir.path().join("x86_64-linux.myenv-build-hello");
+        let build_foo = dir.path().join("x86_64-linux.myenv-build-foo");
+        let dev_link = dir.path().join("x86_64-linux.myenv-dev");
+        symlink("/nix/store/fake-build-hello", &build_hello).unwrap();
+        symlink("/nix/store/fake-build-foo", &build_foo).unwrap();
+        symlink("/nix/store/fake-dev", &dev_link).unwrap();
+
+        remove_build_output_symlinks_by_scan(Some(&prefix));
+
+        assert!(!build_hello.exists() && !build_hello.is_symlink());
+        assert!(!build_foo.exists() && !build_foo.is_symlink());
+        assert!(dev_link.is_symlink(), "-dev symlink must be untouched");
+    }
+
+    /// When `out_link_prefix` is `None`, `remove_build_output_symlinks_by_scan` is a no-op.
+    #[test]
+    fn remove_build_output_symlinks_by_scan_noop_when_no_prefix() {
+        let dir = tempdir().unwrap();
+        let link = dir.path().join("x86_64-linux.myenv-build-hello");
+        symlink("/nix/store/fake-build", &link).unwrap();
+
+        remove_build_output_symlinks_by_scan(None);
+
+        assert!(
+            link.is_symlink(),
+            "symlink must survive when prefix is None"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 4 unit tests for `RenderedEnvironmentLinks::replace_legacy_links()` in `mod.rs`:
  - Plain (non-generation) links: dot-separator store symlinks are replaced with relative redirects
  - Generation-qualified links: pins the invariant that `new_in_base_dir_with_name_system_and_generation` produces `-dev`/`-run`-suffixed names so `replace_legacy_links` derives the correct legacy stem
  - No-op when no legacy symlink exists (no spurious dot-separator links created)
  - No-op when legacy symlink is already a redirect (idempotency, `/nix/store/` guard)

- Adds 4 unit tests for `remove_build_output_symlinks` and `remove_build_output_symlinks_by_scan` in `buildenv.rs`:
  - `remove_build_output_symlinks` deletes `<prefix>-build-*` symlinks and leaves others untouched
  - `remove_build_output_symlinks` is a no-op when prefix is `None`
  - `remove_build_output_symlinks_by_scan` deletes all matching `<prefix>-build-*` symlinks found by directory scan
  - `remove_build_output_symlinks_by_scan` is a no-op when prefix is `None`

## Test plan

- [ ] `cargo test -p flox-rust-sdk -- rendered_env_links_tests` — 4 tests pass
- [ ] `cargo test -p flox-rust-sdk -- symlink_cleanup_tests` — 4 tests pass

Closes #4309, closes #4310.

🤖 Generated with [Claude Code](https://claude.ai/code)