### PR TITLE
test(deactivate): drop obsolete tcsh skips

### DIFF
--- a/cli/tests/deactivate.bats
+++ b/cli/tests/deactivate.bats
@@ -131,7 +131,6 @@ EOF
 
 # bats test_tags=deactivate
 @test "deactivate restores environment variables (tcsh)" {
-  skip "tcsh fails due to FLOX_PROMPT_ENVIRONMENTS undefined variable issue"
   project_setup
   MANIFEST_CONTENTS="$(cat << "EOF"
 version = 1
@@ -274,7 +273,6 @@ EOF
 
 # bats test_tags=deactivate
 @test "deactivate unsets added variables (tcsh)" {
-  skip "tcsh fails due to FLOX_PROMPT_ENVIRONMENTS undefined variable issue"
   project_setup
   MANIFEST_CONTENTS="$(cat << "EOF"
 version = 1


### PR DESCRIPTION
## Summary

Drops the two `skip` lines in `cli/tests/deactivate.bats` that cited the tcsh `FLOX_PROMPT_ENVIRONMENTS undefined variable` bug. That bug was fixed in `aabdd49f9` (merged via #4289), which taught `set-prompt.tcsh` to handle the unset case.

The test bodies already use the safe `if/then/endif` pattern, so dropping the `skip` is the entire fix — no other changes needed.

## Test plan

- [x] `just integ-tests deactivate.bats -- --filter \"(tcsh)\"` — passes locally on aarch64-darwin (both \`deactivate restores environment variables (tcsh)\` and \`deactivate unsets added variables (tcsh)\`).
- [ ] CI green on \`remote (!containerize)\` jobs across linux + darwin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)