### PR TITLE
refactor(buildenv): reduce mutation ops from 2 nix builds to 1

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -303,7 +303,8 @@ impl<State> CoreEnvironment<State> {
     }
 }
 
-/// Environment modifying methods do not link the new environment to an out path.
+/// Environment modifying methods accept an optional `out_link_prefix` and,
+/// when supplied, write activation symlinks as part of the in-transaction build.
 /// Since files referenced by the environment are ingested into the nix store,
 /// the same [CoreEnvironment] instance can be used
 /// even if the concrete [super::Environment] tracks the files in a different way
@@ -333,6 +334,7 @@ impl CoreEnvironment<ReadOnly> {
         &mut self,
         packages: &[PackageToInstall],
         flox: &Flox,
+        out_link_prefix: Option<&Path>,
     ) -> Result<InstallationAttempt, EnvironmentError> {
         let manifest = self.manifest(flox)?;
         // TODO: this could lead to double resolution and surprising errors
@@ -346,7 +348,8 @@ impl CoreEnvironment<ReadOnly> {
             None
         } else {
             let new_manifest = manifest.modify_packages(&modifications)?;
-            let (built_environments, _) = self.transact_with_manifest(&new_manifest, flox)?;
+            let (built_environments, _) =
+                self.transact_with_manifest(&new_manifest, flox, out_link_prefix)?;
             Some(built_environments)
         };
 
@@ -365,6 +368,7 @@ impl CoreEnvironment<ReadOnly> {
         &mut self,
         uninstall_specs: Vec<UninstallSpec>,
         flox: &Flox,
+        out_link_prefix: Option<&Path>,
     ) -> Result<UninstallationAttempt, EnvironmentError> {
         // TODO: this could lead to double resolution and surprising errors
         // (e.g. if you try to uninstall a package and we fail to resolve that package)
@@ -378,7 +382,7 @@ impl CoreEnvironment<ReadOnly> {
         let modifications = resolve_specs_to_modifications(&uninstall_specs, &manifest, &lockfile)?;
 
         let new_manifest = manifest.modify_packages(&modifications)?;
-        let (store_path, _) = self.transact_with_manifest(&new_manifest, flox)?;
+        let (store_path, _) = self.transact_with_manifest(&new_manifest, flox, out_link_prefix)?;
 
         // Collect the modified install ids that are still installed through includes
         let still_included = if let Some(compose) = &lockfile.compose {
@@ -401,7 +405,12 @@ impl CoreEnvironment<ReadOnly> {
     }
 
     /// Atomically edit this environment, ensuring that it still builds
-    pub fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError> {
+    pub fn edit(
+        &mut self,
+        flox: &Flox,
+        contents: String,
+        out_link_prefix: Option<&Path>,
+    ) -> Result<EditResult, EnvironmentError> {
         let maybe_up_to_date_lockfile = self.lockfile_if_up_to_date()?;
 
         // skip the edit if the contents are unchanged
@@ -425,7 +434,8 @@ impl CoreEnvironment<ReadOnly> {
                 (None, migrated)
             };
 
-        let (store_path, new_lockfile) = self.transact_with_manifest(&migrated_manifest, flox)?;
+        let (store_path, new_lockfile) =
+            self.transact_with_manifest(&migrated_manifest, flox, out_link_prefix)?;
 
         Ok(EditResult::Changed {
             old_lockfile: Box::new(old_lockfile),
@@ -522,6 +532,7 @@ impl CoreEnvironment<ReadOnly> {
         flox: &Flox,
         groups_or_iids: &[&str],
         write_lockfile: bool,
+        out_link_prefix: Option<&Path>,
     ) -> Result<UpgradeResult, EnvironmentError> {
         tracing::debug!(to_upgrade = groups_or_iids.join(","), "upgrading");
         let manifest = self.manifest(flox)?;
@@ -541,7 +552,8 @@ impl CoreEnvironment<ReadOnly> {
                 return Ok(result);
             }
 
-            let store_path = self.transact_with_lockfile_contents(lockfile_contents, flox)?;
+            let store_path =
+                self.transact_with_lockfile_contents(lockfile_contents, flox, out_link_prefix)?;
             result.store_path = Some(store_path);
         } else {
             let tmp_lockfile = tempfile::NamedTempFile::new_in(&flox.temp_dir)
@@ -669,6 +681,7 @@ impl CoreEnvironment<ReadOnly> {
         &mut self,
         flox: &Flox,
         to_upgrade: Vec<String>,
+        out_link_prefix: Option<&Path>,
     ) -> Result<UpgradeResult, EnvironmentError> {
         tracing::debug!(
             includes = to_upgrade.iter().join(","),
@@ -724,7 +737,8 @@ impl CoreEnvironment<ReadOnly> {
             return Ok(result);
         }
 
-        let store_path = self.transact_with_lockfile_contents(lockfile_contents, flox)?;
+        let store_path =
+            self.transact_with_lockfile_contents(lockfile_contents, flox, out_link_prefix)?;
         result.store_path = Some(store_path);
 
         Ok(result)
@@ -793,12 +807,23 @@ impl CoreEnvironment<ReadOnly> {
         Ok(())
     }
 
-    /// Attempt to transactionally replace the manifest contents
+    /// Attempt to transactionally replace the manifest contents.
+    ///
+    /// Passes `out_link_prefix` to the nix build so activation symlinks are
+    /// created as part of the single build inside this transaction rather than
+    /// requiring a second `build()` call from the caller.
+    ///
+    /// Note: symlinks are created during the temp-dir build before the directory
+    /// swap completes.  If `replace_with` fails after a successful build the
+    /// symlinks will have been updated to point at the new store path.  A
+    /// follow-up (#4339) replaces the directory-swap model with a file-level
+    /// transaction that eliminates this window.
     #[must_use = "don't discard the store path of built environments"]
     fn transact_with_manifest(
         &mut self,
         manifest: &Manifest<Migrated>,
         flox: &Flox,
+        out_link_prefix: Option<&Path>,
     ) -> Result<(BuildEnvOutputs, Lockfile), EnvironmentError> {
         debug!("transaction: validating services block");
         manifest.as_latest_schema().services.validate()?;
@@ -832,7 +857,7 @@ impl CoreEnvironment<ReadOnly> {
         temp_env.write_manifest_lockfile_pair(&writable_manifest, &lockfile)?;
 
         debug!("transaction: building environment");
-        let store_path = temp_env.build(flox, None)?;
+        let store_path = temp_env.build(flox, out_link_prefix)?;
 
         debug!("transaction: replacing environment");
         self.replace_with(temp_env)?;
@@ -849,6 +874,7 @@ impl CoreEnvironment<ReadOnly> {
         &mut self,
         lockfile_contents: impl AsRef<str>,
         flox: &Flox,
+        out_link_prefix: Option<&Path>,
     ) -> Result<BuildEnvOutputs, CoreEnvironmentError> {
         let tempdir = tempfile::tempdir_in(&flox.temp_dir)
             .map_err(CoreEnvironmentError::MakeSandbox)?
@@ -864,7 +890,7 @@ impl CoreEnvironment<ReadOnly> {
         temp_env.update_lockfile_with_contents(&lockfile_contents)?;
 
         debug!("transaction: building environment");
-        let store_path = temp_env.build(flox, None)?;
+        let store_path = temp_env.build(flox, out_link_prefix)?;
 
         debug!("transaction: replacing environment");
         self.replace_with(temp_env)?;
@@ -1333,7 +1359,7 @@ mod tests {
 
         flox.catalog_client =
             catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
-        env_view.edit(&flox, new_env_str.to_string()).unwrap();
+        env_view.edit(&flox, new_env_str.to_string(), None).unwrap();
 
         assert_eq!(
             env_view
@@ -1355,7 +1381,7 @@ mod tests {
         let mut env_view = new_core_environment(&flox, &same_manifest);
         env_view.lock(&flox).unwrap(); // Explicit lock
 
-        let result = env_view.edit(&flox, same_manifest).unwrap();
+        let result = env_view.edit(&flox, same_manifest, None).unwrap();
         assert_eq!(result, EditResult::Unchanged);
     }
 
@@ -1369,7 +1395,9 @@ mod tests {
         let mut env_view = new_core_environment(&flox, same_manifest);
         env_view.lock(&flox).unwrap(); // Explicit lock
 
-        let result = env_view.edit(&flox, same_manifest.to_string()).unwrap();
+        let result = env_view
+            .edit(&flox, same_manifest.to_string(), None)
+            .unwrap();
         assert_eq!(result, EditResult::Unchanged);
     }
 
@@ -1381,7 +1409,9 @@ mod tests {
         let same_manifest = "version = 1";
         let mut env_view = new_core_environment(&flox, same_manifest);
 
-        let result = env_view.edit(&flox, same_manifest.to_string()).unwrap();
+        let result = env_view
+            .edit(&flox, same_manifest.to_string(), None)
+            .unwrap();
         assert!(matches!(result, EditResult::Changed { .. }));
     }
 
@@ -1441,7 +1471,7 @@ mod tests {
 
         flox.catalog_client =
             catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
-        let result = env_view.edit(&flox, new_env_str.to_string()).unwrap();
+        let result = env_view.edit(&flox, new_env_str.to_string(), None).unwrap();
 
         assert!(matches!(result, EditResult::Changed { .. }));
         assert!(!result.reactivate_required().unwrap());
@@ -1459,7 +1489,7 @@ mod tests {
         on-activate = ""
         "#;
 
-        let result = env_view.edit(&flox, new_env_str.to_string()).unwrap();
+        let result = env_view.edit(&flox, new_env_str.to_string(), None).unwrap();
 
         assert!(result.reactivate_required().unwrap());
     }
@@ -1477,6 +1507,7 @@ mod tests {
                     CatalogPackage::from_str("hello").unwrap(),
                 )],
                 &flox,
+                None,
             )
             .unwrap();
 
@@ -1732,7 +1763,7 @@ mod tests {
             .get_mut("bad")
             .unwrap()
             .shutdown = None;
-        let res = env.transact_with_manifest(&manifest, &flox);
+        let res = env.transact_with_manifest(&manifest, &flox, None);
         assert!(matches!(
             res,
             Err(EnvironmentError::ManifestError(

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -317,7 +317,8 @@ impl Environment for ManagedEnvironment {
             })
             .collect();
 
-        let result = local_checkout.install(packages, flox)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = local_checkout.install(packages, flox, Some(out_link_prefix))?;
         if !result.modifications.is_empty() {
             let change = HistoryKind::Install { targets };
             generations
@@ -326,7 +327,7 @@ impl Environment for ManagedEnvironment {
             self.lock_pointer()?;
         }
         if result.built_environments.is_some() {
-            self.build(flox)?;
+            self.rendered_env_links.replace_legacy_links();
         }
 
         Ok(result)
@@ -359,7 +360,8 @@ impl Environment for ManagedEnvironment {
         }
 
         let targets: Vec<String> = specs.iter().map(|s| s.package_ref.clone()).collect();
-        let result = local_checkout.uninstall(specs, flox)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = local_checkout.uninstall(specs, flox, Some(out_link_prefix))?;
         let change = HistoryKind::Uninstall { targets };
 
         // It's an error to uninstall a package that isn't installed so if we
@@ -369,7 +371,7 @@ impl Environment for ManagedEnvironment {
             .map_err(ManagedEnvironmentError::CommitGeneration)?;
         self.lock_pointer()?;
         if result.built_environment_store_paths.is_some() {
-            self.build(flox)?;
+            self.rendered_env_links.replace_legacy_links();
         }
 
         Ok(result)
@@ -391,7 +393,8 @@ impl Environment for ManagedEnvironment {
 
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
 
-        let result = local_checkout.edit(flox, contents)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = local_checkout.edit(flox, contents, Some(out_link_prefix))?;
 
         match &result {
             EditResult::Changed { .. } => {
@@ -399,7 +402,7 @@ impl Environment for ManagedEnvironment {
                     .add_generation(&mut local_checkout, HistoryKind::Edit)
                     .map_err(ManagedEnvironmentError::CommitGeneration)?;
                 self.lock_pointer()?;
-                self.build(flox)?;
+                self.rendered_env_links.replace_legacy_links();
             },
             EditResult::Unchanged => {},
         }
@@ -415,7 +418,7 @@ impl Environment for ManagedEnvironment {
         groups_or_iids: &[&str],
     ) -> Result<UpgradeResult, EnvironmentError> {
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
-        let result = local_checkout.upgrade(flox, groups_or_iids, false)?;
+        let result = local_checkout.upgrade(flox, groups_or_iids, false, None)?; // dry-run: no out-link
         Ok(result)
     }
 
@@ -445,7 +448,8 @@ impl Environment for ManagedEnvironment {
             ))?
         }
 
-        let result = local_checkout.upgrade(flox, groups_or_iids, true)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = local_checkout.upgrade(flox, groups_or_iids, true, Some(out_link_prefix))?;
         if !result.diff().is_empty() {
             let change = HistoryKind::Upgrade {
                 targets: result.packages().collect(),
@@ -455,6 +459,9 @@ impl Environment for ManagedEnvironment {
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
 
             self.lock_pointer()?;
+        }
+        if result.store_path.is_some() {
+            self.rendered_env_links.replace_legacy_links();
         }
         Ok(result)
     }
@@ -485,8 +492,10 @@ impl Environment for ManagedEnvironment {
             ))?
         }
 
-        let result = local_checkout.include_upgrade(flox, to_upgrade.clone())?;
-        if !result.include_diff().is_empty() {
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result =
+            local_checkout.include_upgrade(flox, to_upgrade.clone(), Some(out_link_prefix))?;
+        if result.store_path.is_some() {
             let change = HistoryKind::IncludeUpgrade {
                 targets: to_upgrade,
             };
@@ -495,6 +504,7 @@ impl Environment for ManagedEnvironment {
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
 
             self.lock_pointer()?;
+            self.rendered_env_links.replace_legacy_links();
         }
 
         Ok(result)
@@ -548,7 +558,7 @@ impl Environment for ManagedEnvironment {
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
         // todo: ensure lockfile exists?
 
-        let store_paths = local_checkout.build(flox, Some(&out_link_prefix))?;
+        let store_paths = local_checkout.build(flox, Some(out_link_prefix))?;
         self.rendered_env_links.replace_legacy_links();
         Ok(store_paths)
     }
@@ -729,7 +739,7 @@ impl GenerationsExt for ManagedEnvironment {
             );
 
         let out_link_prefix = rendered_env_links.out_link_prefix();
-        core_environment.build(flox, Some(&out_link_prefix))?;
+        core_environment.build(flox, Some(out_link_prefix))?;
         rendered_env_links.replace_legacy_links();
 
         Ok(rendered_env_links)
@@ -1011,7 +1021,7 @@ impl ManagedEnvironment {
 
         // Ensure the created generation is valid
         let out_link_prefix = self.rendered_env_links.out_link_prefix();
-        local_checkout.build(flox, Some(&out_link_prefix))?;
+        local_checkout.build(flox, Some(out_link_prefix))?;
         self.rendered_env_links.replace_legacy_links();
 
         let mut generations = self.generations();
@@ -1649,10 +1659,7 @@ pub mod test_helpers {
         let floxmeta_branch = unusable_mock_floxmeta_branch();
         ManagedEnvironment {
             path: CanonicalPath::new(PathBuf::from("/")).unwrap(),
-            rendered_env_links: RenderedEnvironmentLinks::new_unchecked(
-                PathBuf::new(),
-                PathBuf::new(),
-            ),
+            rendered_env_links: RenderedEnvironmentLinks::new_unchecked(PathBuf::new()),
             pointer: ManagedPointer::new(
                 "owner".parse().unwrap(),
                 "test".parse().unwrap(),
@@ -2171,8 +2178,7 @@ mod test {
         let dot_flox_path = CanonicalPath::new(&dot_flox_path).unwrap();
 
         // dummy paths since we are not rendering the environment
-        let rendered_env_links =
-            RenderedEnvironmentLinks::new_unchecked(PathBuf::new(), PathBuf::new());
+        let rendered_env_links = RenderedEnvironmentLinks::new_unchecked(PathBuf::new());
 
         // create a mock remote
         let (test_pointer, _remote_path, remote) = create_mock_remote(flox.temp_dir.join("remote"));
@@ -2214,8 +2220,7 @@ mod test {
         let dot_flox_path = CanonicalPath::new(&dot_flox_path).unwrap();
 
         // dummy paths since we are not rendering the environment
-        let rendered_env_links =
-            RenderedEnvironmentLinks::new_unchecked(PathBuf::new(), PathBuf::new());
+        let rendered_env_links = RenderedEnvironmentLinks::new_unchecked(PathBuf::new());
 
         // create a mock remote
         let (test_pointer, _remote_path, remote) = create_mock_remote(flox.temp_dir.join("remote"));
@@ -2262,8 +2267,7 @@ mod test {
         let env2_dir = CanonicalPath::new(env2_dir).unwrap();
 
         // dummy paths since we are not rendering the environment
-        let rendered_env_links =
-            RenderedEnvironmentLinks::new_unchecked(PathBuf::new(), PathBuf::new());
+        let rendered_env_links = RenderedEnvironmentLinks::new_unchecked(PathBuf::new());
 
         // create a mock remote
         let (test_pointer, _remote_path, remote) = create_mock_remote(flox.temp_dir.join("remote"));

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -296,18 +296,38 @@ impl TryFrom<&ConcreteEnvironment> for ActivateEnvironmentRef {
 #[as_ref(forward)]
 pub struct RenderedEnvironmentLink(PathBuf);
 
+/// Append `suffix` to the final component of `prefix`, mirroring how
+/// `nix build` names an output link: `<out-link prefix><suffix>`
+/// (e.g. `…/system.name` + `-dev` -> `…/system.name-dev`).
+fn append_output_suffix(prefix: &Path, suffix: &str) -> PathBuf {
+    let mut name = prefix.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
 /// A pair of links to the dev and run variants of an environment.
 /// Refer to the documentation of [RenderedEnvironmentLink] for what guarantees
 /// the existence of these paths provides.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct RenderedEnvironmentLinks {
+    /// The `--out-link` prefix passed to `nix build`. With outputs named
+    /// `"dev"` and `"run"`, nix creates `<prefix>-dev` and `<prefix>-run`,
+    /// which are exactly `dev` and `run` below. Stored rather than re-derived
+    /// from `dev` so the prefix is always available and unambiguous.
+    out_link_prefix: PathBuf,
     pub dev: RenderedEnvironmentLink,
     pub run: RenderedEnvironmentLink,
 }
 
 impl RenderedEnvironmentLinks {
-    pub(crate) fn new_unchecked(dev: PathBuf, run: PathBuf) -> Self {
+    /// Construct from a `--out-link` prefix, deriving the dev and run links the
+    /// same way `nix build` does: by appending the output names `-dev` and
+    /// `-run` to the prefix.
+    pub(crate) fn new_unchecked(out_link_prefix: PathBuf) -> Self {
+        let dev = append_output_suffix(&out_link_prefix, "-dev");
+        let run = append_output_suffix(&out_link_prefix, "-run");
         Self {
+            out_link_prefix,
             dev: RenderedEnvironmentLink(dev),
             run: RenderedEnvironmentLink(run),
         }
@@ -318,11 +338,8 @@ impl RenderedEnvironmentLinks {
         name: impl AsRef<str>,
         system: &System,
     ) -> Self {
-        let dev_name = format!("{system}.{name}-dev", name = name.as_ref());
-        let dev_path = base_dir.join(dev_name);
-        let run_name = format!("{system}.{name}-run", name = name.as_ref());
-        let run_path = base_dir.join(run_name);
-        Self::new_unchecked(dev_path, run_path)
+        let prefix = base_dir.join(format!("{system}.{name}", name = name.as_ref()));
+        Self::new_unchecked(prefix)
     }
 
     pub fn new_in_base_dir_with_name_system_and_generation(
@@ -331,25 +348,19 @@ impl RenderedEnvironmentLinks {
         system: &System,
         generation: GenerationId,
     ) -> Self {
-        let dev_name = format!("{system}.{name}.gen{generation}-dev", name = name.as_ref());
-        let dev_path = base_dir.join(dev_name);
-        let run_name = format!("{system}.{name}.gen{generation}-run", name = name.as_ref());
-        let run_path = base_dir.join(run_name);
-        Self::new_unchecked(dev_path, run_path)
+        let prefix = base_dir.join(format!(
+            "{system}.{name}.gen{generation}",
+            name = name.as_ref()
+        ));
+        Self::new_unchecked(prefix)
     }
 
     /// Returns the `--out-link` prefix for `nix build`.
     ///
-    /// With outputs named `"dev"` and `"run"`, nix creates:
-    ///   `<prefix>-dev` and `<prefix>-run`
-    /// which exactly match `self.dev` and `self.run`.
-    pub fn out_link_prefix(&self) -> PathBuf {
-        let dev_path = self.dev.as_path().to_str().expect("paths are UTF-8");
-        PathBuf::from(
-            dev_path
-                .strip_suffix("-dev")
-                .expect("dev link always ends in -dev"),
-        )
+    /// With outputs named `"dev"` and `"run"`, nix creates `<prefix>-dev` and
+    /// `<prefix>-run`, which exactly match `self.dev` and `self.run`.
+    pub fn out_link_prefix(&self) -> &Path {
+        &self.out_link_prefix
     }
 
     /// Replace legacy dot-separator symlinks with redirect symlinks to the
@@ -1402,6 +1413,24 @@ mod test {
             err,
             EnvironmentError::ServicesSocketPathTooLong(_)
         ));
+    }
+
+    /// The dev and run links are the `--out-link` prefix with the nix output
+    /// names appended, and `out_link_prefix()` returns that prefix verbatim
+    /// rather than re-deriving it from the dev link.
+    #[test]
+    fn rendered_env_links_derives_dev_and_run_from_out_link_prefix() {
+        let prefix = PathBuf::from("/base/x86_64-linux.name");
+        let links = RenderedEnvironmentLinks::new_unchecked(prefix.clone());
+        assert_eq!(links.out_link_prefix(), prefix);
+        assert_eq!(
+            links.dev.as_path(),
+            Path::new("/base/x86_64-linux.name-dev")
+        );
+        assert_eq!(
+            links.run.as_path(),
+            Path::new("/base/x86_64-linux.name-run")
+        );
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -231,11 +231,11 @@ impl Environment for PathEnvironment {
         flox: &Flox,
     ) -> Result<InstallationAttempt, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
-        let result = env_view.install(packages, flox)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = env_view.install(packages, flox, Some(out_link_prefix))?;
         if result.built_environments.is_some() {
-            self.build(flox)?;
+            self.rendered_env_links.replace_legacy_links();
         }
-
         Ok(result)
     }
 
@@ -250,20 +250,21 @@ impl Environment for PathEnvironment {
         flox: &Flox,
     ) -> Result<UninstallationAttempt, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
-        let result = env_view.uninstall(specs, flox)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = env_view.uninstall(specs, flox, Some(out_link_prefix))?;
         if result.built_environment_store_paths.is_some() {
-            self.build(flox)?;
+            self.rendered_env_links.replace_legacy_links();
         }
-
         Ok(result)
     }
 
     /// Atomically edit this environment, ensuring that it still builds
     fn edit(&mut self, flox: &Flox, contents: String) -> Result<EditResult, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
-        let result = env_view.edit(flox, contents)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = env_view.edit(flox, contents, Some(out_link_prefix))?;
         if matches!(&result, EditResult::Changed { .. }) {
-            self.build(flox)?;
+            self.rendered_env_links.replace_legacy_links();
         }
         Ok(result)
     }
@@ -275,7 +276,7 @@ impl Environment for PathEnvironment {
         groups_or_iids: &[&str],
     ) -> Result<UpgradeResult, EnvironmentError> {
         let mut env_view = self.as_core_environment_mut()?;
-        let result = env_view.upgrade(flox, groups_or_iids, false)?;
+        let result = env_view.upgrade(flox, groups_or_iids, false, None)?; // dry-run: no out-link
         Ok(result)
     }
 
@@ -287,11 +288,11 @@ impl Environment for PathEnvironment {
     ) -> Result<UpgradeResult, EnvironmentError> {
         tracing::debug!(to_upgrade = groups_or_iids.join(","), "upgrading");
         let mut env_view = self.as_core_environment_mut()?;
-        let result = env_view.upgrade(flox, groups_or_iids, true)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = env_view.upgrade(flox, groups_or_iids, true, Some(out_link_prefix))?;
         if result.store_path.is_some() {
-            self.build(flox)?;
+            self.rendered_env_links.replace_legacy_links();
         }
-
         Ok(result)
     }
 
@@ -306,11 +307,11 @@ impl Environment for PathEnvironment {
             "upgrading included environments"
         );
         let mut env_view = self.as_core_environment_mut()?;
-        let result = env_view.include_upgrade(flox, to_upgrade)?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let result = env_view.include_upgrade(flox, to_upgrade, Some(out_link_prefix))?;
         if result.store_path.is_some() {
-            self.build(flox)?;
+            self.rendered_env_links.replace_legacy_links();
         }
-
         Ok(result)
     }
 
@@ -350,10 +351,10 @@ impl Environment for PathEnvironment {
     /// Uses `ensure_locked` to skip a catalog round-trip and lockfile
     /// rewrite when the lockfile is already current.
     fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError> {
-        let out_link_prefix = self.rendered_env_links.out_link_prefix();
         let mut env_view = self.as_core_environment_mut()?;
+        let out_link_prefix = self.rendered_env_links.out_link_prefix();
         env_view.ensure_locked(flox)?;
-        let store_paths = env_view.build(flox, Some(&out_link_prefix))?;
+        let store_paths = env_view.build(flox, Some(out_link_prefix))?;
         self.rendered_env_links.replace_legacy_links();
         Ok(store_paths)
     }
@@ -525,7 +526,7 @@ impl PathEnvironment {
         // symlinks via --out-link, so no separate link step is needed.
         if matches!(customization.packages.as_deref(), Some([_, ..])) {
             let out_link_prefix = environment.rendered_env_links.out_link_prefix();
-            env_view.build(flox, Some(&out_link_prefix))?;
+            env_view.build(flox, Some(out_link_prefix))?;
         }
 
         Ok(environment)
@@ -859,7 +860,7 @@ pub mod tests {
         let mut env_view =
             CoreEnvironment::new(env.path.join(ENV_DIR_NAME), env.include_fetcher().unwrap());
         let out_link_prefix = env.rendered_env_links.out_link_prefix();
-        env_view.build(&flox, Some(&out_link_prefix)).unwrap();
+        env_view.build(&flox, Some(out_link_prefix)).unwrap();
 
         assert!(!env.needs_rebuild().unwrap());
 


### PR DESCRIPTION
## Summary

* Threads `out_link_prefix: Option<&Path>` through `transact_with_manifest` and `transact_with_lockfile_contents` so the single build inside each transaction creates activation symlinks directly via `nix build --out-link`.
* Removes the separate outer `self.build(flox)?` call that previously ran after every install/uninstall/edit/upgrade/include_upgrade in both `PathEnvironment` and `ManagedEnvironment`, replacing it with `replace_legacy_links()` when the environment was actually modified.
* Stores the `--out-link` prefix structurally in `RenderedEnvironmentLinks` as a field rather than re-deriving it. The prefix is now the source of truth: `dev` and `run` are derived from it the same way `nix build` names outputs, by appending `-dev` and `-run`. `RenderedEnvironmentLinks::out_link_prefix()` returns the stored `&Path` infallibly, replacing the previous implementation that recovered the prefix by stripping `-dev` from the dev link and panicked (`expect`) on any non-UTF-8 or non-conforming path.
* Fixes `ManagedEnvironment::include_upgrade`: the generation-commit condition was `!result.include_diff().is_empty()` while the symlink-update condition was `result.store_path.is_some()` — a schema-migration-only lockfile change would update symlinks but commit no generation, leaving the activated environment pointing to a state with no generation record. Both conditions are now unified under `result.store_path.is_some()`.

The directory-level transaction model (`replace_with`) is retained in this PR. The file-level transaction that eliminates the small race window introduced here (symlinks written before swap completes) is in the stacked #4339.

Closes flox/flox#4308

## Release Notes

`flox upgrade` and `flox activate --remote` (`include_upgrade`) now correctly create activation symlinks on the first run in an environment that has never been built locally. Previously symlinks were silently skipped until the next `flox install` or `flox edit`.

## Test plan

- [X] All existing unit tests pass (`just unit-tests`)
- [X] Install/uninstall/edit/upgrade a path environment and verify activation symlinks are created correctly
- [X] Same for a managed environment

## Follow-up

* #4339 — file-level transaction + NFS lock (replaces the directory-swap model used here)
* #4330 — add tests asserting symlinks are created/updated during mutation ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)
