### PR TITLE
perf(buildenv): move stat check to before semaphore acquisition

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -649,9 +649,9 @@ where
         span: Span,
         semaphore: &Semaphore,
     ) -> Result<(), BuildEnvError> {
-        let _guard = semaphore.wait();
-
-        // Fast path: all outputs already present on disk.
+        // Fast path: all outputs already present on disk.  Stat checks are
+        // cheap and don't need concurrency limiting, so check before acquiring
+        // a semaphore slot.
         if locked_pkg
             .outputs
             .values()
@@ -659,6 +659,8 @@ where
         {
             return Ok(());
         }
+
+        let _guard = semaphore.wait();
 
         // Attempt to download the store paths associated with the package outputs.
         let all_valid_after_build_or_substitution = {
@@ -820,12 +822,14 @@ where
         parent_span: Span,
         semaphore: &Semaphore,
     ) -> Result<(), BuildEnvError> {
-        let _guard = semaphore.wait();
-
-        // Fast path: already present on disk.
+        // Fast path: already present on disk.  Stat checks are cheap and
+        // don't need concurrency limiting, so check before acquiring a
+        // semaphore slot.
         if path_is_present(locked.store_path.as_str()) {
             return Ok(());
         }
+
+        let _guard = semaphore.wait();
 
         let valid = {
             let span = info_span!(


### PR DESCRIPTION
## Summary

In `realise_single_base_catalog_pkg` and `realise_single_store_path`, the fast-path `path_is_present()` check was executing while holding a semaphore slot. Since `path_is_present` is a single `stat(2)` syscall, it needs no concurrency limiting.

Moving it before `semaphore.wait()` means paths already on disk skip the semaphore entirely, keeping all slots available for the slow paths that actually spawn `nix build` subprocesses. Under a warm cache this reduces semaphore contention for the packages that do need fetching.

Closes #4306

## Test plan

- [ ] Existing unit tests pass (`just unit-tests`)
- [ ] No change in behaviour for paths not already on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)