### PR TITLE
buildenv: suppress build-* out-link symlinks for env-rendering builds

### DIFF
--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -72,7 +72,8 @@ let
   # declaring build-* outputs as derivation outputs and thereby suppress the
   # `<prefix>-build-*` out-link symlinks that `nix build --out-link` would
   # otherwise create.
-  environmentOutputs =
+  # Use a distinct name to avoid self-referential recursion in the let binding.
+  resolvedOutputs =
     if environmentOutputs != null then
       environmentOutputs
     else
@@ -292,7 +293,7 @@ assert lockfile."lockfile-version" != "0";
 builtins.derivation {
   inherit name;
   builder = "${floxBuildEnv}/lib/builder.pl";
-  outputs = environmentOutputs;
+  outputs = resolvedOutputs;
 
   # Pull in external attributes and those calculated above.
   inherit

--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -8,6 +8,7 @@
   manifestLock,
   name ? "environment",
   serviceConfigYaml ? null,
+  environmentOutputs ? null,
 }:
 let
   outdentScript = (import ./buildenvLib/default.nix).outdentText;
@@ -66,12 +67,20 @@ let
     else
       null;
 
-  # Calculate environment outputs.
-  environmentOutputs = [
-    "run"
-    "dev"
-  ]
-  ++ (builtins.map (buildId: "build-${buildId}") (builtins.attrNames buildSection));
+  # Calculate environment outputs. The caller may supply a restricted list via
+  # the `environmentOutputs` argument (e.g. `[ "run" "dev" ]`) to avoid
+  # declaring build-* outputs as derivation outputs and thereby suppress the
+  # `<prefix>-build-*` out-link symlinks that `nix build --out-link` would
+  # otherwise create.
+  environmentOutputs =
+    if environmentOutputs != null then
+      environmentOutputs
+    else
+      [
+        "run"
+        "dev"
+      ]
+      ++ (builtins.map (buildId: "build-${buildId}") (builtins.attrNames buildSection));
 
   createRenderedEnvironmentChunks = [
     # static chunks

--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -729,6 +729,12 @@ if ($manifest) {
             };
         }
 
+        # Filter to only outputs declared in the derivation.  When the caller
+        # supplies a restricted `environmentOutputs` argument (e.g. for
+        # env-rendering builds that only need "run" and "dev"), build-* entries
+        # will not appear in $nix_attrs->{"outputs"} and must be skipped.
+        @outputData = grep { defined $nix_attrs->{"outputs"}{$_->{"name"}} } @outputData;
+
         return \@outputData;
     }
 

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -896,6 +896,15 @@ where
         nix_build_command.args(["build", "--offline", "--json"]);
         if let Some(prefix) = out_link_prefix {
             nix_build_command.arg("--out-link").arg(prefix);
+            // Restrict derivation outputs to "run" and "dev" so that nix does
+            // not create `<prefix>-build-*` out-link symlinks for manifest build
+            // outputs. build-* outputs are not needed for environment rendering
+            // and their out-links would otherwise have to be deleted immediately
+            // after the build.
+            nix_build_command
+                .arg("--arg")
+                .arg("environmentOutputs")
+                .arg("[ \"run\" \"dev\" ]");
         } else {
             nix_build_command.arg("--no-link");
         }
@@ -912,17 +921,18 @@ where
         }
         debug!(cmd=%nix_build_command.display(), "building environment");
 
+        // defined inline as an implementation detail
+        #[derive(Debug, Clone, Deserialize)]
+        struct BuildEnvResultRaw {
+            outputs: BuildEnvOutputs,
+        }
+
         let output = nix_build_command
             .output()
             .map_err(BuildEnvError::CallNixBuild)?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(BuildEnvError::Build(stderr.to_string()));
-        }
-        // defined inline as an implementation detail
-        #[derive(Debug, Clone, Deserialize)]
-        struct BuildEnvResultRaw {
-            outputs: BuildEnvOutputs,
         }
         let build_env_result: Result<[BuildEnvResultRaw; 1], _> =
             serde_json::from_slice(&output.stdout).map_err(|err| BuildEnvError::ReadOutputs {
@@ -931,9 +941,7 @@ where
             });
 
         if let Ok([build_env_result]) = build_env_result {
-            let outputs = build_env_result.outputs;
-            remove_build_output_symlinks(out_link_prefix, &outputs);
-            return Ok(outputs);
+            return Ok(build_env_result.outputs);
         }
 
         // Preexisting store paths produced by the build may have been (partially) swept away.
@@ -959,76 +967,11 @@ where
         }
 
         let [build_env_result]: [BuildEnvResultRaw; 1] = serde_json::from_slice(&output.stdout)
-            .inspect_err(|_| {
-                debug!("failed to deserialize output on second try");
-                remove_build_output_symlinks_by_scan(out_link_prefix);
-            })
             .map_err(|err| BuildEnvError::ReadOutputs {
                 output: String::from_utf8_lossy(&output.stdout).to_string(),
                 err,
             })?;
-        let outputs = build_env_result.outputs;
-        remove_build_output_symlinks(out_link_prefix, &outputs);
-        Ok(outputs)
-    }
-}
-
-/// Remove the `<prefix>-build-*` symlinks that `nix build --out-link` creates
-/// for manifest build outputs.
-///
-/// `nix build --out-link <prefix>` writes a symlink for every derivation
-/// output: `<prefix>-run`, `<prefix>-dev`, and — for environments with build
-/// sections — `<prefix>-build-<id>` for each manifest build output.  The
-/// `build-*` symlinks clutter `.flox/run/`.  We delete them immediately after
-/// the build — this also removes the GC roots for those outputs, which is
-/// intentional.  The store paths are captured in
-/// `outputs.manifest_build_runtimes` before deletion.
-fn remove_build_output_symlinks(out_link_prefix: Option<&Path>, outputs: &BuildEnvOutputs) {
-    let Some(prefix) = out_link_prefix else {
-        return;
-    };
-    for key in outputs.manifest_build_runtimes.keys() {
-        let mut link_name = prefix.as_os_str().to_owned();
-        link_name.push("-");
-        link_name.push(key.as_str());
-        let link_path = PathBuf::from(link_name);
-        if link_path.is_symlink()
-            && let Err(e) = std::fs::remove_file(&link_path)
-        {
-            debug!(path=?link_path, error=%e, "failed to remove build output symlink from run dir");
-        }
-    }
-}
-
-/// Fallback version of [`remove_build_output_symlinks`] for the error path,
-/// where we have a prefix but no parsed outputs to iterate over.  Scans the
-/// parent directory and removes any symlink whose name starts with
-/// `<prefix_filename>-build-`.
-fn remove_build_output_symlinks_by_scan(out_link_prefix: Option<&Path>) {
-    let Some(prefix) = out_link_prefix else {
-        return;
-    };
-    let Some(parent) = prefix.parent() else {
-        return;
-    };
-    let Some(prefix_name) = prefix.file_name().and_then(|n| n.to_str()) else {
-        return;
-    };
-    let scan_prefix = format!("{prefix_name}-build-");
-    let Ok(entries) = std::fs::read_dir(parent) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let Some(name_str) = name.to_str() else {
-            continue;
-        };
-        if name_str.starts_with(&scan_prefix)
-            && entry.path().is_symlink()
-            && let Err(e) = std::fs::remove_file(entry.path())
-        {
-            debug!(path=?entry.path(), error=%e, "failed to remove build output symlink from run dir");
-        }
+        Ok(build_env_result.outputs)
     }
 }
 


### PR DESCRIPTION
Closes #4316.

## Summary

- Adds `environmentOutputs ? null` parameter to `buildenv.nix`. When provided, it overrides the manifest-derived output list so the derivation only declares the specified outputs.
- Updates `builder.pl` to filter `@outputData` against `$nix_attrs->{"outputs"}` before iterating, so build-* entries are silently skipped when they were not declared as derivation outputs.
- `call_buildenv_nix` passes `--arg environmentOutputs '[ "run" "dev" ]'` when `out_link_prefix` is set (all env-rendering / mutation-op builds). Builds without an out-link prefix (`flox build`, which needs `manifest_build_runtimes`) omit the argument and continue to produce all outputs.
- Removes `remove_build_output_symlinks` and `remove_build_output_symlinks_by_scan` — no longer needed.

## Why

`nix build --out-link <prefix>` previously created `<prefix>-build-<id>` symlinks for every manifest build output, which were immediately deleted because they are not part of the activation interface. This introduced a brief window of stale GC roots and required cleanup logic that duplicated the output naming convention. By restricting the declared outputs to `run` and `dev` for env-rendering builds, nix never creates the unwanted symlinks in the first place.

## Release Notes

No user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)