### PR TITLE
revert: don't serialize InvocationType with underscores

### DIFF
--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -326,7 +326,7 @@ mod tests {
             export _activate_d=/interpreter/activate.d;
             export _flox_activations=/flox_activations;
             export _flox_activate_tracer=TRACER;
-            _FLOX_INVOCATION_TYPE=in_place;
+            _FLOX_INVOCATION_TYPE=inplace;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             eval "$('/flox_activations' set-env-dirs --shell bash --flox-env "/flox_env" --env-dirs "${FLOX_ENV_DIRS:-}")";
             eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")";

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -309,7 +309,7 @@ mod tests {
             set -gx _activate_d /interpreter/activate.d;
             set -gx _flox_activations /flox_activations;
             set -gx _flox_activate_tracer TRACER;
-            set -g _FLOX_INVOCATION_TYPE in_place;
+            set -g _FLOX_INVOCATION_TYPE inplace;
             if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
             set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);
             /flox_activations set-env-dirs --shell fish --flox-env "/flox_env" --env-dirs "$FLOX_ENV_DIRS" | source;

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -322,7 +322,7 @@ mod tests {
             setenv _activate_d /interpreter/activate.d;
             setenv _flox_activations /flox_activations;
             setenv _flox_activate_tracer TRACER;
-            set _FLOX_INVOCATION_TYPE = in_place;
+            set _FLOX_INVOCATION_TYPE = inplace;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
             if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";
             eval "`'/flox_activations' set-env-dirs --shell tcsh --flox-env '/flox_env' --env-dirs $FLOX_ENV_DIRS:q`";

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -272,7 +272,7 @@ mod tests {
             export QUOTED_VAR='QUOTED'\''VALUE';
             unset DELETED_VAR;
             source /interpreter/activate.d/zsh;
-            typeset -g _FLOX_INVOCATION_TYPE=in_place;
+            typeset -g _FLOX_INVOCATION_TYPE=inplace;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
         "#]]

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -133,7 +133,7 @@ pub enum AutoActivateFishMode {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 pub enum InvocationType {
     InPlace,
     Interactive,
@@ -165,8 +165,8 @@ impl std::fmt::Display for InvocationType {
 }
 
 #[derive(Clone, Copy, Debug, derive_more::Display, derive_more::FromStr, Eq, PartialEq)]
-#[display(rename_all = "snake_case")]
-#[from_str(rename_all = "snake_case")]
+#[display(rename_all = "lowercase")]
+#[from_str(rename_all = "lowercase")]
 pub enum InvocationKind {
     InPlace,
     Interactive,


### PR DESCRIPTION
We temporarily added InvocationType to state.json and then changed how
it's serialized to include underscores, so if we currently try to attach
to a CLI 1.12.2 activation, we error with:
```
✘ ERROR: Failed to parse state.json: unknown variant `inplace`, expected one of `in_place`, `interactive`, `shell_command`, `exec_command` at line 5 column 34
```

We should probably re-apply this change later.
