### PR TITLE
chore(activations): remove invocation_type from Attachment and state.json

### DIFF
--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -137,12 +137,7 @@ impl ActivateArgs {
         let mut last_warning: Option<Instant> = None;
 
         loop {
-            match self.try_start_or_attach(
-                context,
-                invocation_type,
-                subsystem_verbosity,
-                vars_from_env,
-            )? {
+            match self.try_start_or_attach(context, subsystem_verbosity, vars_from_env)? {
                 StartOrAttachResult::Start { start_id, .. } => {
                     if *invocation_type == InvocationType::Interactive {
                         updated(
@@ -194,7 +189,6 @@ impl ActivateArgs {
     fn try_start_or_attach(
         &self,
         context: &ActivateCtx,
-        invocation_type: &InvocationType,
         subsystem_verbosity: u32,
         vars_from_env: &VarsFromEnvironment,
     ) -> Result<StartOrAttachResult, anyhow::Error> {
@@ -238,11 +232,7 @@ impl ActivateArgs {
         }
 
         let pid = std::process::id() as i32;
-        match activations.start_or_attach(
-            pid,
-            &context.flox_activate_store_path,
-            invocation_type.clone(),
-        ) {
+        match activations.start_or_attach(pid, &context.flox_activate_store_path) {
             StartOrAttachResult::Start { start_id } => start(
                 context,
                 subsystem_verbosity,

--- a/cli/flox-activations/src/cli/attach.rs
+++ b/cli/flox-activations/src/cli/attach.rs
@@ -99,7 +99,6 @@ mod test {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
-    use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::*;
     use flox_core::activations::{ActivationState, StartOrAttachResult, activation_state_dir_path};
@@ -121,7 +120,7 @@ mod test {
         // Create an activation with a PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(pid, &store_path);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -167,7 +166,7 @@ mod test {
         // Create an activation with the old PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(old_pid, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(old_pid, &store_path);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -65,7 +65,6 @@ impl DetachArgs {
 
 #[cfg(test)]
 mod test {
-    use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::{read_activation_state, write_activation_state};
     use flox_core::activations::{
@@ -92,7 +91,7 @@ mod test {
         );
         state.set_executive_pid(1);
         let start_id = StartIdentifier::new("/nix/store/test");
-        state.start_or_attach(pid, &start_id.store_path, InvocationType::InPlace);
+        state.start_or_attach(pid, &start_id.store_path);
         write_activation_state(tmp.path(), &dot_flox_path, state);
         let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
         let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
@@ -128,8 +127,7 @@ mod test {
             dot_flox_path.join("run/default"),
         );
         state.set_executive_pid(1);
-        let StartOrAttachResult::Start { start_id } =
-            state.start_or_attach(pid, "/nix/store/test", InvocationType::InPlace)
+        let StartOrAttachResult::Start { start_id } = state.start_or_attach(pid, "/nix/store/test")
         else {
             panic!("expected Start for pid");
         };

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -484,7 +484,6 @@ fn cleanup_all(
 mod test {
     use std::collections::BTreeMap;
 
-    use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::{read_activation_state, write_activation_state};
     use flox_core::activations::{ActivationState, StartOrAttachResult, activation_state_dir_path};
@@ -533,7 +532,7 @@ mod test {
         // Create an ActivationState with one PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(pid, &store_path);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -589,7 +588,7 @@ mod test {
         // Create an ActivationState with one PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(pid, &store_path);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -667,7 +666,7 @@ mod test {
         // Create an ActivationState with pid1 attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid1, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(pid1, &store_path);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -766,7 +765,7 @@ mod test {
         // Create state with this PID attached
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(pid, &store_path);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
@@ -834,7 +833,7 @@ mod test {
         // the last PID while the process is still running).
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(1, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(1, &store_path);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -75,7 +75,6 @@ pub mod test {
     use std::process::{Child, Command};
     use std::time::Duration;
 
-    use flox_core::activate::context::InvocationType;
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::write_activation_state;
     use flox_core::activations::{StartOrAttachResult, activation_state_dir_path, state_json_path};
@@ -152,12 +151,12 @@ pub mod test {
         // Create an ActivationState with two PIDs attached to the same start_id
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid1, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(pid1, &store_path);
         let StartOrAttachResult::Start { start_id, .. } = result else {
             panic!("Expected Start")
         };
         state.set_ready(&start_id);
-        let result = state.start_or_attach(pid2, &store_path, InvocationType::Interactive);
+        let result = state.start_or_attach(pid2, &store_path);
         assert!(matches!(result, StartOrAttachResult::Attach { .. }));
 
         write_activation_state(runtime_dir.path(), &dot_flox_path, state);
@@ -199,7 +198,7 @@ pub mod test {
         // Start and set ready for store_path_1
         let mut state =
             ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
-        let result = state.start_or_attach(pid1, &store_path_1, InvocationType::Interactive);
+        let result = state.start_or_attach(pid1, &store_path_1);
         let StartOrAttachResult::Start {
             start_id: start_id_1,
             ..
@@ -210,7 +209,7 @@ pub mod test {
         state.set_ready(&start_id_1);
 
         // Start and set ready for store_path_2
-        let result = state.start_or_attach(pid2, &store_path_2, InvocationType::Interactive);
+        let result = state.start_or_attach(pid2, &store_path_2);
         let StartOrAttachResult::Start {
             start_id: start_id_2,
             ..

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -11,7 +11,6 @@ use serde_json::{Value, json};
 use time::OffsetDateTime;
 use tracing::{debug, trace};
 
-use crate::activate::context::InvocationType;
 use crate::activate::mode::ActivateMode;
 use crate::proc_status::pid_is_running;
 use crate::{Version, path_hash};
@@ -347,11 +346,6 @@ impl StartIdentifier {
 pub struct Attachment {
     start_id: StartIdentifier,
     expiration: Option<OffsetDateTime>,
-    // Optional until the V4 schema bump ships alongside the consumer
-    // (DEV-82); a missing field deserializes to `None` so old state.json
-    // files written before this field existed round-trip cleanly.
-    #[serde(default)]
-    invocation_type: Option<InvocationType>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -427,7 +421,6 @@ impl ActivationState {
                 let Attachment {
                     expiration,
                     start_id,
-                    invocation_type: _,
                 } = attachment;
                 acc.entry(start_id.clone())
                     .or_default()
@@ -464,7 +457,6 @@ impl ActivationState {
         &mut self,
         pid: Pid,
         store_path: impl AsRef<Path>,
-        invocation_type: InvocationType,
     ) -> StartOrAttachResult {
         if let Ready::Starting(starting_pid, ref start_id) = self.ready
             && pid_is_running(starting_pid)
@@ -481,12 +473,11 @@ impl ActivationState {
                 self.attach(pid, Attachment {
                     start_id: start_id.clone(),
                     expiration: None,
-                    invocation_type: Some(invocation_type),
                 });
                 StartOrAttachResult::Attach { start_id }
             },
             Ready::False | Ready::True(_) | Ready::Starting(_, _) => {
-                let start_id = self.start(pid, &store_path, invocation_type);
+                let start_id = self.start(pid, &store_path);
                 StartOrAttachResult::Start { start_id }
             },
         }
@@ -603,17 +594,11 @@ impl ActivationState {
         }
     }
 
-    fn start(
-        &mut self,
-        pid: Pid,
-        store_path: impl AsRef<Path>,
-        invocation_type: InvocationType,
-    ) -> StartIdentifier {
+    fn start(&mut self, pid: Pid, store_path: impl AsRef<Path>) -> StartIdentifier {
         let start_id = StartIdentifier::new(store_path);
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: None,
-            invocation_type: Some(invocation_type),
         };
 
         debug!(pid, ?start_id, "starting new activation");
@@ -718,7 +703,6 @@ impl ActivationState {
         let new_attachment = Attachment {
             start_id,
             expiration,
-            invocation_type: old_attachment.invocation_type,
         };
 
         self.attached_pids.insert(new_pid, new_attachment);
@@ -920,7 +904,6 @@ mod tests {
         Attachment {
             start_id,
             expiration: None,
-            invocation_type: Some(InvocationType::Interactive),
         }
     }
 
@@ -987,11 +970,7 @@ mod tests {
             let store_path = PathBuf::from("/nix/store/test");
 
             // Start activation with first PID
-            let result = activations.start_or_attach(
-                proc_running.id() as i32,
-                &store_path,
-                InvocationType::Interactive,
-            );
+            let result = activations.start_or_attach(proc_running.id() as i32, &store_path);
             let start_id = match result {
                 StartOrAttachResult::Start { start_id, .. } => start_id,
                 _ => panic!("Expected Start"),
@@ -1001,11 +980,7 @@ mod tests {
             activations.set_ready(&start_id);
 
             // Attach second PID
-            activations.start_or_attach(
-                proc_stopped.id() as i32,
-                &store_path,
-                InvocationType::Interactive,
-            );
+            activations.start_or_attach(proc_stopped.id() as i32, &store_path);
 
             stop_process(proc_stopped);
 
@@ -1026,8 +1001,7 @@ mod tests {
             let store_path2 = PathBuf::from("/nix/store/path2");
 
             // Start activation with first store path
-            let result =
-                activations.start_or_attach(100, &store_path1, InvocationType::Interactive);
+            let result = activations.start_or_attach(100, &store_path1);
             let start_id1 = match result {
                 StartOrAttachResult::Start { start_id, .. } => start_id,
                 _ => panic!("Expected Start"),
@@ -1037,11 +1011,10 @@ mod tests {
             activations.set_ready(&start_id1);
 
             // Attach second PID to same start_id
-            activations.start_or_attach(200, &store_path1, InvocationType::Interactive);
+            activations.start_or_attach(200, &store_path1);
 
             // Start activation with second store path (creates new start_id)
-            let result =
-                activations.start_or_attach(300, &store_path2, InvocationType::Interactive);
+            let result = activations.start_or_attach(300, &store_path2);
             let start_id2 = match result {
                 StartOrAttachResult::Start { start_id, .. } => start_id,
                 _ => panic!("Expected Start"),
@@ -1068,7 +1041,7 @@ mod tests {
             let mut activations = make_activations(Ready::False);
 
             let pid = 123;
-            let result = activations.start_or_attach(pid, &store_path, InvocationType::Interactive);
+            let result = activations.start_or_attach(pid, &store_path);
 
             let start_id = match result {
                 StartOrAttachResult::Start { start_id } => start_id,
@@ -1094,8 +1067,7 @@ mod tests {
             let mut activations = make_activations(Ready::True(start_id.clone()));
 
             let pid = 123;
-            let result =
-                activations.start_or_attach(pid, &start_id.store_path, InvocationType::Interactive);
+            let result = activations.start_or_attach(pid, &start_id.store_path);
 
             match result {
                 StartOrAttachResult::Attach { start_id: id } => {
@@ -1118,7 +1090,7 @@ mod tests {
             let mut activations = make_activations(Ready::True(existing));
 
             let pid = 123;
-            let result = activations.start_or_attach(pid, &new_path, InvocationType::Interactive);
+            let result = activations.start_or_attach(pid, &new_path);
 
             let start_id = match result {
                 StartOrAttachResult::Start { start_id } => start_id,
@@ -1145,8 +1117,7 @@ mod tests {
             let start_id = StartIdentifier::new("/nix/store/path1");
             let mut activations = make_activations(Ready::Starting(pid, start_id.clone()));
 
-            let result =
-                activations.start_or_attach(123, &start_id.store_path, InvocationType::Interactive);
+            let result = activations.start_or_attach(123, &start_id.store_path);
 
             match result {
                 StartOrAttachResult::AlreadyStarting {
@@ -1179,11 +1150,7 @@ mod tests {
                 make_activations(Ready::Starting(stopped_pid, old_start_id.clone()));
 
             let pid = 123;
-            let result = activations.start_or_attach(
-                pid,
-                &old_start_id.store_path,
-                InvocationType::Interactive,
-            );
+            let result = activations.start_or_attach(pid, &old_start_id.store_path);
 
             let new_start_id = match result {
                 StartOrAttachResult::Start { start_id } => start_id,
@@ -1209,11 +1176,7 @@ mod tests {
             let mut activations = make_activations(Ready::True(start_id.clone()));
 
             for pid in [100, 200, 300].iter() {
-                let result = activations.start_or_attach(
-                    *pid,
-                    &start_id.store_path,
-                    InvocationType::Interactive,
-                );
+                let result = activations.start_or_attach(*pid, &start_id.store_path);
                 match result {
                     StartOrAttachResult::Attach { start_id: id } => {
                         assert_eq!(id, start_id);
@@ -1242,7 +1205,7 @@ mod tests {
             let store_path = PathBuf::from("/nix/store/path1");
 
             let pid = 123;
-            let result = activations.start_or_attach(pid, &store_path, InvocationType::Interactive);
+            let result = activations.start_or_attach(pid, &store_path);
             let start_id = match result {
                 StartOrAttachResult::Start { start_id, .. } => start_id,
                 _ => panic!("Expected Start"),
@@ -1255,8 +1218,7 @@ mod tests {
             activations.set_ready(&start_id);
 
             // Attach same PID again - should replace existing attachment
-            let result =
-                activations.start_or_attach(pid, &start_id.store_path, InvocationType::Interactive);
+            let result = activations.start_or_attach(pid, &start_id.store_path);
 
             match result {
                 StartOrAttachResult::Attach { start_id: id } => {
@@ -1285,7 +1247,6 @@ mod tests {
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: Some(expiration),
-            invocation_type: Some(InvocationType::Interactive),
         };
         activations.attach(pid, attachment);
 
@@ -1308,7 +1269,6 @@ mod tests {
         let attachment = Attachment {
             start_id: start_id.clone(),
             expiration: Some(expiration),
-            invocation_type: Some(InvocationType::Interactive),
         };
         activations.attach(pid, attachment);
 
@@ -1487,75 +1447,20 @@ mod tests {
     mod invocation_type {
         use super::*;
 
+        /// Confirms that state.json files written by CLI 1.12.2 (which included
+        /// `invocation_type`) still deserialize cleanly after the field was
+        /// removed. Serde ignores unknown fields by default; this test is a
+        /// regression guard against accidentally adding `deny_unknown_fields`.
         #[test]
-        fn replace_attachment_preserves_invocation_type_with_expiration() {
-            let start_id = StartIdentifier::new("/nix/store/path1");
-            let mut activations = make_activations(Ready::True(start_id.clone()));
-            let pid = 123;
-            activations.attach(pid, Attachment {
-                start_id: start_id.clone(),
-                expiration: None,
-                invocation_type: Some(InvocationType::ExecCommand(vec!["ls".to_string()])),
-            });
-
-            let now = OffsetDateTime::now_utc();
-            let expiration = now + Duration::from_secs(60);
-            activations
-                .replace_attachment(start_id.clone(), pid, pid, Some(expiration))
-                .unwrap();
-
-            let expected = Attachment {
-                start_id,
-                expiration: Some(expiration),
-                invocation_type: Some(InvocationType::ExecCommand(vec!["ls".to_string()])),
-            };
-            assert_eq!(activations.attached_pids, BTreeMap::from([(pid, expected)]));
-        }
-
-        #[test]
-        fn replace_attachment_preserves_invocation_type_on_pid_swap() {
-            let start_id = StartIdentifier::new("/nix/store/path1");
-            let mut activations = make_activations(Ready::True(start_id.clone()));
-            let old_pid = 123;
-            let new_pid = 456;
-            activations.attach(old_pid, Attachment {
-                start_id: start_id.clone(),
-                expiration: None,
-                invocation_type: Some(InvocationType::InPlace),
-            });
-
-            activations
-                .replace_attachment(start_id.clone(), old_pid, new_pid, None)
-                .unwrap();
-
-            let expected = Attachment {
-                start_id,
-                expiration: None,
-                invocation_type: Some(InvocationType::InPlace),
-            };
-            assert_eq!(
-                activations.attached_pids,
-                BTreeMap::from([(new_pid, expected)])
-            );
-        }
-
-        /// Forward-compat with V3 state.json written by older flox binaries
-        /// (pre-DEV-78) that did not include `invocation_type` on attachments.
-        /// Delete this test when the V4 schema bump lands and the field becomes
-        /// required.
-        #[test]
-        fn deserialize_attachment_without_invocation_type_yields_none() {
-            let json = json!({
-                "start_id": {
-                    "store_path": "/nix/store/path1",
-                    "timestamp": 0,
-                },
+        fn deserialize_attachment_with_legacy_invocation_type_field() {
+            let json = serde_json::json!({
+                "start_id": { "store_path": "/nix/store/path1", "timestamp": 0 },
                 "expiration": null,
+                "invocation_type": "interactive",
             })
             .to_string();
-
-            let attachment: Attachment = serde_json::from_str(&json).unwrap();
-            assert_eq!(attachment.invocation_type, None);
+            // Must not error — unknown fields are silently ignored
+            let _: Attachment = serde_json::from_str(&json).unwrap();
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

`invocation_type` was added to the `Attachment` struct in PR #4248 (DEV-78)
so it would be persisted in `state.json`. However, it was never read back
at runtime — activation always receives it as a live parameter from the
CLI, and `_FLOX_INVOCATION_TYPE` is available via the shell env during
deactivate. Persisting the field served no purpose. PR #4329 already
reverted the underscore serialization format change; this completes the
cleanup by dropping the field entirely.

**Backward compat:** No `#[serde(deny_unknown_fields)]` attribute exists
anywhere in the deserialization chain, so `serde` silently ignores unknown
fields. Existing `state.json` files from CLI 1.12.2 that contain
`invocation_type` continue to parse cleanly. No schema version bump needed.

Changes:
- Remove `invocation_type: Option<InvocationType>` from `Attachment`
- Remove `invocation_type` parameter from `start_or_attach` and private `start`
- Remove `invocation_type` from `attachments_by_start_id` destructure,
  `replace_attachment`, and all struct literals
- Update all call sites in `flox-activations` (activate, attach, detach,
  executive, watcher) — remove now-unused `InvocationType` imports
- Replace the old invocation_type test block with a single regression test
  that deserializes a legacy JSON blob containing the field and asserts it
  succeeds — guarding against accidental addition of `deny_unknown_fields`

## Release Notes

N/A

Fixes DEV-110

---
*Via Forge (implementation-worker) • d059ee66*