### PR TITLE
feat: add and respect disable_hook option

### DIFF
--- a/cli/flox-activations/src/attach.rs
+++ b/cli/flox-activations/src/attach.rs
@@ -136,6 +136,9 @@ pub(crate) fn startup_ctx(
 
     let set_prompt = ctx.attach_ctx.set_prompt;
 
+    // Respect both the feature flag and the config option
+    let register_hook = ctx.auto_activate && !ctx.disable_hook;
+
     let args = match ctx.shell {
         ShellWithPath::Bash(_) => ShellStartupArgs::Bash(BashStartupArgs {
             flox_activate_tracelevel: subsystem_verbosity,
@@ -147,7 +150,7 @@ pub(crate) fn startup_ctx(
             flox_activate_tracer: activate_tracer.to_string(),
             flox_activations,
             clean_up,
-            auto_activate: ctx.auto_activate,
+            register_hook,
             flox_bin: ctx.flox_bin.clone(),
             set_prompt,
         }),
@@ -160,7 +163,7 @@ pub(crate) fn startup_ctx(
             flox_activate_tracer: activate_tracer.to_string(),
             flox_activations,
             clean_up,
-            auto_activate: ctx.auto_activate,
+            register_hook,
             flox_bin: ctx.flox_bin.clone(),
             auto_activate_fish_mode: ctx.auto_activate_fish_mode,
             set_prompt,
@@ -174,7 +177,7 @@ pub(crate) fn startup_ctx(
             flox_activate_tracer: activate_tracer.to_string(),
             flox_activations,
             clean_up,
-            auto_activate: ctx.auto_activate,
+            register_hook,
             flox_bin: ctx.flox_bin.clone(),
             set_prompt,
         }),
@@ -183,7 +186,7 @@ pub(crate) fn startup_ctx(
             activate_d: ctx.attach_ctx.interpreter_path.join("activate.d"),
             invocation_type,
             clean_up,
-            auto_activate: ctx.auto_activate,
+            register_hook,
             flox_bin: ctx.flox_bin.clone(),
             set_prompt,
         }),

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -24,7 +24,7 @@ pub struct BashStartupArgs {
     pub flox_activate_tracer: String,
     pub flox_sourcing_rc: bool,
     pub flox_activations: PathBuf,
-    pub auto_activate: bool,
+    pub register_hook: bool,
     pub flox_bin: String,
     pub set_prompt: bool,
 }
@@ -244,7 +244,7 @@ pub fn generate_bash_profile_commands(
     // Auto-activate hook registration
     match action {
         Action::Activate { args, .. } => {
-            if args.auto_activate
+            if args.register_hook
                 && matches!(
                     args.invocation_type,
                     InvocationType::Interactive | InvocationType::InPlace

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -23,7 +23,7 @@ pub struct FishStartupArgs {
     pub flox_sourcing_rc: bool,
     pub flox_activate_tracer: String,
     pub flox_activations: PathBuf,
-    pub auto_activate: bool,
+    pub register_hook: bool,
     pub flox_bin: String,
     pub auto_activate_fish_mode: Option<AutoActivateFishMode>,
     pub set_prompt: bool,
@@ -226,7 +226,7 @@ pub fn generate_fish_profile_commands(
     // Auto-activate hook registration
     match action {
         Action::Activate { args, .. } => {
-            if args.auto_activate
+            if args.register_hook
                 && matches!(
                     args.invocation_type,
                     InvocationType::Interactive | InvocationType::InPlace

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -116,6 +116,7 @@ pub(crate) mod test_helpers {
             remove_after_reading: false,
             metrics_uuid: None,
             auto_activate: false,
+            disable_hook: false,
             flox_bin: "/flox".to_string(),
             auto_activate_fish_mode: None,
         };

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -22,7 +22,7 @@ pub struct TcshStartupArgs {
     pub flox_activate_tracer: String,
     pub flox_sourcing_rc: bool,
     pub flox_activations: PathBuf,
-    pub auto_activate: bool,
+    pub register_hook: bool,
     pub flox_bin: String,
     pub set_prompt: bool,
 }
@@ -247,7 +247,7 @@ pub fn generate_tcsh_profile_commands(
     // Auto-activate hook registration
     match action {
         Action::Activate { args, .. } => {
-            if args.auto_activate
+            if args.register_hook
                 && matches!(
                     args.invocation_type,
                     InvocationType::Interactive | InvocationType::InPlace

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -18,7 +18,7 @@ pub struct ZshStartupArgs {
     pub activate_d: PathBuf,
     pub invocation_type: InvocationType,
     pub clean_up: Option<PathBuf>,
-    pub auto_activate: bool,
+    pub register_hook: bool,
     pub flox_bin: String,
     pub set_prompt: bool,
 }
@@ -244,7 +244,7 @@ pub fn generate_zsh_profile_commands(
     // Auto-activate hook registration
     match action {
         Action::Activate { args, .. } => {
-            if args.auto_activate
+            if args.register_hook
                 && matches!(
                     args.invocation_type,
                     InvocationType::Interactive | InvocationType::InPlace

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -105,6 +105,10 @@ pub struct ActivateCtx {
     #[serde(default)]
     pub auto_activate: bool,
 
+    /// Passthrough for config.disable_hook.unwrap_or(false)
+    #[serde(default)]
+    pub disable_hook: bool,
+
     /// Path to the flox binary, used for generating hook code.
     #[serde(default)]
     pub flox_bin: String,

--- a/cli/flox/doc-auto-activate/flox-config.md
+++ b/cli/flox/doc-auto-activate/flox-config.md
@@ -108,6 +108,11 @@ flox config --set 'trusted_environments."owner/name"' trust
 :   Directory where Flox should store persistent data
     (default: `$XDG_DATA_HOME/flox`).
 
+`disable_hook`
+:   Don't setup the Flox prompt hook as part of activation.
+    This disables auto-activation as well as features like `flox deactivate`
+    without `--print-script` (default: false)
+
 `disable_metrics`
 :   Disable collecting and sending usage metrics.
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -548,6 +548,7 @@ impl ActivateOptions {
             remove_after_reading: true,
             metrics_uuid: flox.metrics_device_uuid,
             auto_activate: flox.features.auto_activate,
+            disable_hook: config.flox.disable_hook.unwrap_or(false),
             flox_bin: std::env::current_exe()
                 .ok()
                 .and_then(|p| p.to_str().map(String::from))

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -132,6 +132,11 @@ pub struct FloxConfig {
     /// Maps absolute paths to explicit allow/deny decisions.
     #[serde(default)]
     pub auto_activate_environments: HashMap<PathBuf, AutoActivationPreference>,
+
+    /// Don't setup the Flox prompt hook as part of activation.
+    /// This disables auto-activation as well as features like `flox deactivate`
+    /// without `--print-script` (default: false)
+    pub disable_hook: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Adds `disable_hook` to config. When true, skips installing the prompt
hook, which will disable auto-activation as well as `flox deactivate`
without `--print-script`
