### PR TITLE
feat(deactivate): support plain `flox deactivate` via the prompt hook (DEV-84)

### DIFF
--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
+use flox_core::hook_actions::PROMPT_HOOK_VERSION_ENV;
 use shell_gen::{GenerateShell, Shell, source_file};
 
 use crate::attach_diff::{todo_drop_set_exported_unexpanded, todo_drop_unset};
@@ -118,6 +119,15 @@ pub fn generate_bash_profile_commands(
         Action::Deactivate(_) => {
             // Handled by the activation diff (added → unset, modified → restore).
         },
+    }
+
+    // The prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration (see
+    // hook.rs) so a subprocess like `flox deactivate` can detect a compatible
+    // hook. It is set shell-side, so it isn't part of the env-var diff; unset it
+    // on deactivation so it doesn't leak into the restored environment.
+    // Unconditional: a no-op when no hook was registered.
+    if let Action::Deactivate(_) = action {
+        stmts.push(todo_drop_unset(PROMPT_HOOK_VERSION_ENV));
     }
 
     // Source set-prompt.bash if we're in an interactive shell
@@ -289,6 +299,7 @@ mod tests {
         strip_volatile_deactivate,
         test_deactivate_ctx,
         test_startup_ctx,
+        test_startup_ctx_hook,
     };
 
     // NOTE: For these `expect!` tests, run unit tests with `UPDATE_EXPECT=1`
@@ -310,6 +321,30 @@ mod tests {
         generate_bash_profile_commands(&action, &mut buf).expect("generator should succeed");
         let output = String::from_utf8(buf).expect("output should be utf-8");
         strip_volatile_deactivate(&output)
+    }
+
+    // The auto-activation prompt hook (the `_flox_hook` function and its
+    // PROMPT_COMMAND registration) is emitted only when auto-activation is on
+    // and `disable_hook` is not set. This replaces an integration test that
+    // activated a real shell to check the same gating.
+    #[test]
+    fn disable_hook_suppresses_prompt_hook_registration() {
+        let shell = ShellWithPath::Bash(PathBuf::from("/bin/bash"));
+
+        // Auto-activation on, hook not disabled: the hook is registered.
+        let with_hook =
+            render_normalized(&test_startup_ctx_hook(shell.clone(), false, true, false));
+        assert!(
+            with_hook.contains("_flox_hook"),
+            "expected the prompt hook to be registered:\n{with_hook}"
+        );
+
+        // disable_hook = true: no hook is registered, even with auto-activation on.
+        let without_hook = render_normalized(&test_startup_ctx_hook(shell, false, true, true));
+        assert!(
+            !without_hook.contains("_flox_hook"),
+            "expected no prompt hook when disable_hook is set:\n{without_hook}"
+        );
     }
 
     #[test]
@@ -397,6 +432,7 @@ mod tests {
             unset _flox_activations;
             export MODIFIED_VAR=MODIFIED_ORIGINAL;
             export DELETED_VAR=DELETED_ORIGINAL;
+            unset _FLOX_PROMPT_HOOK_VERSION;
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             eval "$('/flox_activations' profile-scripts-deactivate --shell bash --env '/flox_env' --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}")";
             unset _activate_d _flox_activate_tracer;

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -5,9 +5,10 @@ use std::path::PathBuf;
 use anyhow::Result;
 use flox_core::activate::context::{AutoActivateFishMode, InvocationType};
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
+use flox_core::hook_actions::PROMPT_HOOK_VERSION_ENV;
 use shell_gen::{GenerateShell, Shell};
 
-use crate::attach_diff::todo_drop_set_exported_unexpanded;
+use crate::attach_diff::{todo_drop_set_exported_unexpanded, todo_drop_unset};
 use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating fish startup commands
@@ -102,6 +103,15 @@ pub fn generate_fish_profile_commands(
         Action::Deactivate(_) => {
             // Handled by the activation diff (added → unset, modified → restore).
         },
+    }
+
+    // The prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration (see
+    // hook.rs) so a subprocess like `flox deactivate` can detect a compatible
+    // hook. It is set shell-side, so it isn't part of the env-var diff; unset it
+    // on deactivation so it doesn't leak into the restored environment.
+    // Unconditional: a no-op when no hook was registered.
+    if let Action::Deactivate(_) = action {
+        stmts.push(todo_drop_unset(PROMPT_HOOK_VERSION_ENV));
     }
 
     // Source set-prompt.fish if we're in an interactive shell
@@ -383,6 +393,7 @@ mod tests {
             set -e _flox_activations;
             set -gx MODIFIED_VAR MODIFIED_ORIGINAL;
             set -gx DELETED_VAR DELETED_ORIGINAL;
+            set -e _FLOX_PROMPT_HOOK_VERSION;
             if isatty 1; source '/interpreter/activate.d/set-prompt.fish'; end;
             /flox_activations profile-scripts-deactivate --shell fish --env '/flox_env' --already-sourced-env-dirs (if set -q _FLOX_SOURCED_PROFILE_SCRIPTS; echo "$_FLOX_SOURCED_PROFILE_SCRIPTS"; else; echo ""; end) | source;
             set -e _activate_d _flox_activate_tracer;

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -81,7 +81,22 @@ pub(crate) mod test_helpers {
     /// Fills every `AttachCtx` / `AttachProjectCtx` / `ActivateCtx`
     /// field with stable test values so snapshot output is
     /// reproducible across shells.
+    ///
+    /// Auto-activation is off, so no prompt hook is registered. Use
+    /// [`test_startup_ctx_hook`] to control that.
     pub fn test_startup_ctx(shell: ShellWithPath, is_in_place: bool) -> StartupCtx {
+        test_startup_ctx_hook(shell, is_in_place, false, false)
+    }
+
+    /// Like [`test_startup_ctx`] but with control over the auto-activation
+    /// inputs, for tests that exercise prompt-hook registration. The hook is
+    /// emitted when `auto_activate` is set and `disable_hook` is not.
+    pub fn test_startup_ctx_hook(
+        shell: ShellWithPath,
+        is_in_place: bool,
+        auto_activate: bool,
+        disable_hook: bool,
+    ) -> StartupCtx {
         let invocation_type = if is_in_place {
             InvocationType::InPlace
         } else {
@@ -119,8 +134,8 @@ pub(crate) mod test_helpers {
             invocation_type: Some(invocation_type.clone()),
             remove_after_reading: false,
             metrics_uuid: None,
-            auto_activate: false,
-            disable_hook: false,
+            auto_activate,
+            disable_hook,
             flox_bin: "/flox".to_string(),
             auto_activate_fish_mode: None,
         };

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
+use flox_core::hook_actions::PROMPT_HOOK_VERSION_ENV;
 use shell_gen::{GenerateShell, Shell};
 
 use crate::attach_diff::todo_drop_set_exported_unexpanded;
@@ -96,6 +97,16 @@ pub fn generate_tcsh_profile_commands(
         Action::Deactivate(_) => {
             // Handled by the activation diff (added → unset, modified → restore).
         },
+    }
+
+    // The prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration (see
+    // hook.rs) so a subprocess like `flox deactivate` can detect a compatible
+    // hook. It is set shell-side, so it isn't part of the env-var diff; unset it
+    // on deactivation so it doesn't leak into the restored environment.
+    // Unconditional: a no-op when no hook was registered. The marker is exported
+    // (`setenv`), so tear it down with `unsetenv`.
+    if let Action::Deactivate(_) = action {
+        stmts.push(format!("unsetenv {PROMPT_HOOK_VERSION_ENV};").to_stmt());
     }
 
     // Source set-prompt.tcsh if we're in an interactive shell
@@ -404,6 +415,7 @@ mod tests {
             unsetenv _flox_activations;
             setenv MODIFIED_VAR MODIFIED_ORIGINAL;
             setenv DELETED_VAR DELETED_ORIGINAL;
+            unsetenv _FLOX_PROMPT_HOOK_VERSION;
             if ( $?tty ) then; source '/interpreter/activate.d/set-prompt.tcsh'; endif;
             set _already_sourced_args = ();
             if ($?_FLOX_SOURCED_PROFILE_SCRIPTS) set _already_sourced_args = ( --already-sourced-env-dirs `echo $_FLOX_SOURCED_PROFILE_SCRIPTS:q` );

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -5,10 +5,11 @@ use std::path::PathBuf;
 use anyhow::Result;
 use flox_core::activate::context::InvocationType;
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
+use flox_core::hook_actions::PROMPT_HOOK_VERSION_ENV;
 use indoc::{formatdoc, indoc};
 use shell_gen::{GenerateShell, Shell, set_unexported_unexpanded, source_file};
 
-use crate::attach_diff::todo_drop_set_exported_unexpanded;
+use crate::attach_diff::{todo_drop_set_exported_unexpanded, todo_drop_unset};
 use crate::gen_rc::{Action, RM};
 
 /// Arguments for generating zsh startup commands
@@ -204,6 +205,15 @@ pub fn generate_zsh_profile_commands(
         Action::Deactivate(_) => {
             // Handled by the activation diff (added → unset, modified → restore).
         },
+    }
+
+    // The prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration (see
+    // hook.rs) so a subprocess like `flox deactivate` can detect a compatible
+    // hook. It is set shell-side, so it isn't part of the env-var diff; unset it
+    // on deactivation so it doesn't leak into the restored environment.
+    // Unconditional: a no-op when no hook was registered.
+    if let Action::Deactivate(_) = action {
+        stmts.push(todo_drop_unset(PROMPT_HOOK_VERSION_ENV));
     }
 
     // Source set-prompt.zsh if we're in an interactive shell
@@ -425,6 +435,7 @@ mod tests {
                 unset _FLOX_HOOK_SAVE_FPATH _FLOX_HOOK_SAVE_COMPINIT_DUMPFILE;
             fi;
             eval "$('/flox_activations' profile-scripts-deactivate --shell zsh --env '/flox_env' --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}")";
+            unset _FLOX_PROMPT_HOOK_VERSION;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
             unset _activate_d _flox_activate_tracer _flox_activate_tracelevel;
         "#]]
@@ -460,6 +471,7 @@ mod tests {
                 unset _flox_deactivate_old_fpath;
             fi;
             eval "$('/flox_activations' profile-scripts-deactivate --shell zsh --env '/flox_env' --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}")";
+            unset _FLOX_PROMPT_HOOK_VERSION;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
             unset _activate_d _flox_activate_tracer _flox_activate_tracelevel;
         "#]]

--- a/cli/flox-activations/src/hook.rs
+++ b/cli/flox-activations/src/hook.rs
@@ -4,16 +4,35 @@
 //! on every prompt, matching the behavior of direnv. The hook only
 //! fires in interactive shells (via PROMPT_COMMAND, precmd, fish_prompt),
 //! so it naturally does not trigger in non-interactive (e.g. `bash -c`) contexts.
+//!
+//! Each hook passes the interactive shell's PID (`$$` / `$fish_pid`) so
+//! `hook-env` can find this shell's prompt-hook action file, and the invocation
+//! type so `hook-env` can emit the right deactivation script.
+//! `_FLOX_INVOCATION_TYPE` is a shell-local set during activation and unset on
+//! deactivation, so the hook — which keeps firing afterwards — defaults it to
+//! `inplace` when it is unset. bash and zsh express that default inline; fish
+//! factors it into the `_flox_invocation_type` helper function; tcsh can't
+//! reference a possibly-unset variable without erroring, so it guards with `$?`
+//! and a throwaway variable (see `tcsh_hook`). `--invocation-type` is still
+//! optional on `hook-env` as a defensive measure.
+//!
+//! Each hook also exports [`PROMPT_HOOK_VERSION_ENV`] =
+//! [`PROMPT_HOOK_VERSION`] at registration time (top level, so it is set
+//! before the first prompt). It is exported, unlike `_FLOX_INVOCATION_TYPE`, so
+//! a subprocess such as `flox deactivate` can confirm a compatible hook is set
+//! up before writing an action file the hook would otherwise never consume.
 
+use flox_core::hook_actions::{PROMPT_HOOK_VERSION, PROMPT_HOOK_VERSION_ENV};
 use indoc::formatdoc;
 
 pub fn bash_hook(flox_bin: &str) -> String {
     formatdoc!(
         r#"
+        export {PROMPT_HOOK_VERSION_ENV}={PROMPT_HOOK_VERSION};
         _flox_hook() {{
           local _prev_exit=$?;
           local _flox_vars;
-          _flox_vars="$("{flox_bin}" hook-env --shell bash)";
+          _flox_vars="$("{flox_bin}" hook-env --shell bash --shell-pid $$ --invocation-type "${{_FLOX_INVOCATION_TYPE:-inplace}}")";
           trap -- '' SIGINT;
           eval "$_flox_vars";
           trap - SIGINT;
@@ -35,9 +54,10 @@ pub fn bash_hook(flox_bin: &str) -> String {
 pub fn zsh_hook(flox_bin: &str) -> String {
     formatdoc!(
         r#"
+        export {PROMPT_HOOK_VERSION_ENV}={PROMPT_HOOK_VERSION};
         _flox_hook() {{
           local _flox_vars;
-          _flox_vars="$("{flox_bin}" hook-env --shell zsh)";
+          _flox_vars="$("{flox_bin}" hook-env --shell zsh --shell-pid $$ --invocation-type "${{_FLOX_INVOCATION_TYPE:-inplace}}")";
           trap -- '' SIGINT;
           eval "$_flox_vars";
           trap - SIGINT;
@@ -75,8 +95,12 @@ pub fn fish_hook(flox_bin: &str) -> String {
     //   - disable_arrow: no PWD reaction; only prompt-based evaluation.
     formatdoc!(
         r#"
+        set -gx {PROMPT_HOOK_VERSION_ENV} {PROMPT_HOOK_VERSION};
+        function _flox_invocation_type;
+            test -n "$_FLOX_INVOCATION_TYPE"; and echo $_FLOX_INVOCATION_TYPE; or echo inplace;
+        end;
         function _flox_hook --on-event fish_prompt;
-            "{flox_bin}" hook-env --shell fish | source;
+            "{flox_bin}" hook-env --shell fish --shell-pid $fish_pid --invocation-type (_flox_invocation_type) | source;
             if test "$FLOX_AUTO_ACTIVATE_FISH_MODE" != "disable_arrow";
                 set -g _flox_pwd_hook_active 1;
             end;
@@ -86,14 +110,14 @@ pub fn fish_hook(flox_bin: &str) -> String {
                 if test "$FLOX_AUTO_ACTIVATE_FISH_MODE" = "eval_after_arrow";
                     set -g _flox_env_again 0;
                 else;
-                    "{flox_bin}" hook-env --shell fish | source;
+                    "{flox_bin}" hook-env --shell fish --shell-pid $fish_pid --invocation-type (_flox_invocation_type) | source;
                 end;
             end;
         end;
         function _flox_hook_preexec --on-event fish_preexec;
             if set -q _flox_env_again;
                 set -e _flox_env_again;
-                "{flox_bin}" hook-env --shell fish | source;
+                "{flox_bin}" hook-env --shell fish --shell-pid $fish_pid --invocation-type (_flox_invocation_type) | source;
             end;
             set -e _flox_pwd_hook_active;
         end;
@@ -101,12 +125,32 @@ pub fn fish_hook(flox_bin: &str) -> String {
     )
 }
 
-// Set both precmd and cwdcmd so we get pushd/popd behavior similar to what we have for zsh
+// Set both precmd and cwdcmd so we get pushd/popd behavior similar to what we have for zsh.
+//
+// Passing --invocation-type in tcsh is awkward: referencing an unset variable is
+// a hard error, so a possibly-unset `_FLOX_INVOCATION_TYPE` can't be expanded
+// directly the way bash/zsh/fish do with a default. Guard it with `$?` instead:
+// seed a throwaway `_flox_invocation_type` with the `inplace` default, overwrite
+// it from `_FLOX_INVOCATION_TYPE` only when that is set, pass it, then unset it
+// so it doesn't linger. `inplace` is the right default because the prompt hook
+// only ever deactivates in place.
 pub fn tcsh_hook(flox_bin: &str) -> String {
+    // A tcsh alias body must be a single line, so assemble the statements here
+    // and join them with "; " rather than writing one long string literal.
+    let hook = [
+        "set _flox_invocation_type=inplace".to_string(),
+        r#"if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE""#.to_string(),
+        format!(
+            r#"eval "`{flox_bin} hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`""#
+        ),
+        "unset _flox_invocation_type".to_string(),
+    ]
+    .join("; ");
     formatdoc!(
         r#"
-        alias precmd 'eval `{flox_bin} hook-env --shell tcsh`';
-        alias cwdcmd 'eval `{flox_bin} hook-env --shell tcsh`';
+        setenv {PROMPT_HOOK_VERSION_ENV} {PROMPT_HOOK_VERSION};
+        alias precmd '{hook}';
+        alias cwdcmd '{hook}';
         "#
     )
 }

--- a/cli/flox-core/src/hook_actions.rs
+++ b/cli/flox-core/src/hook_actions.rs
@@ -1,0 +1,311 @@
+//! A small file that lets a `flox` command ask the prompt hook to act.
+//!
+//! `flox hook-env` runs on every shell prompt (and on directory changes). A
+//! command such as `flox deactivate` runs in a subprocess and so cannot modify
+//! its parent shell directly; instead it writes a [`HookActionsFile`] describing
+//! what the prompt hook should do, and `flox hook-env` consumes it on the next
+//! prompt.
+//!
+//! The file deliberately serializes a closed [`HookAction`] enum carrying
+//! only structured data — never shell code — so a non-`flox` writer cannot use
+//! the prompt hook to inject arbitrary commands or environment variables into
+//! the shell. It lives under the runtime dir (user-only), like activation
+//! `state.json`, and is keyed by the shell's PID.
+//!
+//! Note the runtime dir's backing store isn't uniform. On systemd Linux it is
+//! `XDG_RUNTIME_DIR` (`/run/user/<uid>`), a tmpfs, so this file is RAM-backed;
+//! on macOS (and on Linux when `XDG_RUNTIME_DIR` is unset) flox falls back to a
+//! disk-backed cache dir, so reads and writes here are real filesystem
+//! operations rather than memory-speed ones.
+
+use std::fs::DirBuilder;
+use std::io::ErrorKind;
+use std::os::unix::fs::DirBuilderExt;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::{Version, WriteError, traceable_path, write_atomically};
+
+/// An action for `flox hook-env` to perform on the next prompt.
+///
+/// Intentionally a closed enum that carries only structured data, so the prompt
+/// hook cannot be tricked by a non-`flox` writer into injecting arbitrary
+/// commands or environment variables into the shell.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum HookAction {
+    /// Emit an in-place deactivation script. The environment-variable diff to
+    /// restore is read from the shell's `_FLOX_HOOK_DIFF` at hook time; this
+    /// carries the activation state dir needed for the `flox-activations detach`
+    /// call and the rendered env link (`flox_env`) the generated script restores
+    /// `$FLOX_ENV` from.
+    Deactivate {
+        activation_state_dir: PathBuf,
+        flox_env: PathBuf,
+    },
+}
+
+/// The current prompt-hook protocol version.
+///
+/// This is the single source of truth shared by both sides of the protocol, so
+/// they can't drift: it is the `version` of the on-disk [`HookActionsFile`] *and*
+/// the value the shell hook exports as [`PROMPT_HOOK_VERSION_ENV`]. Before
+/// writing a file the hook must read, `flox deactivate` checks the exported
+/// value against this. Bump it (and follow the version-compatibility note on
+/// [`HookActionsFile`]) on any shape change to the file or the protocol.
+pub const PROMPT_HOOK_VERSION: u8 = 1;
+
+/// Environment variable the shell hook exports to advertise that a prompt hook
+/// speaking version [`PROMPT_HOOK_VERSION`] is registered in this shell.
+///
+/// It is exported (unlike `_FLOX_INVOCATION_TYPE`) precisely so a subprocess
+/// like `flox deactivate` can read it to confirm the hook is set up and
+/// compatible before writing an action file the hook would otherwise never
+/// consume.
+pub const PROMPT_HOOK_VERSION_ENV: &str = "_FLOX_PROMPT_HOOK_VERSION";
+
+/// Versioned on-disk form of the prompt-hook action file.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HookActionsFile {
+    version: Version<PROMPT_HOOK_VERSION>,
+    pub actions: Vec<HookAction>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HookActionsError {
+    #[error("failed to create prompt-hook directory")]
+    CreateDir(#[source] std::io::Error),
+    #[error("failed to serialize prompt-hook actions")]
+    Serialize(#[source] serde_json::Error),
+    #[error("failed to write prompt-hook actions")]
+    Write(#[source] WriteError),
+    #[error("failed to read prompt-hook actions")]
+    Read(#[source] std::io::Error),
+    #[error("failed to remove prompt-hook actions file")]
+    Remove(#[source] std::io::Error),
+}
+
+/// Path to the prompt-hook action file for a given shell PID.
+///
+/// A single directory keyed only by shell PID — no environment component — so
+/// the hook checks exactly one path per prompt even when environments are
+/// layered.
+pub fn hook_actions_path(runtime_dir: &Path, shell_pid: i32) -> PathBuf {
+    runtime_dir
+        .join("prompt-hook-actions")
+        .join(format!("{shell_pid}.json"))
+}
+
+/// Write `actions` to the prompt-hook action file for `shell_pid`.
+///
+/// This runs once per writing command (e.g. `flox deactivate`), which is a
+/// foreground, user-initiated action — so write-path performance barely matters
+/// here, and the atomic write's small extra cost is worth it. Optimize the read
+/// path ([`take_hook_actions`]) instead: it runs on every shell prompt.
+pub fn write_hook_actions(
+    runtime_dir: &Path,
+    shell_pid: i32,
+    actions: Vec<HookAction>,
+) -> Result<(), HookActionsError> {
+    let path = hook_actions_path(runtime_dir, shell_pid);
+    let dir = path.parent().expect("actions path has a parent");
+
+    // The prompt hook evaluates whatever this file resolves to, so no other
+    // user may write it. XDG_RUNTIME_DIR is already user-only, but set 0o700
+    // explicitly (mirrors acquire_activations_json_lock).
+    DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+        .map_err(HookActionsError::CreateDir)?;
+
+    let file = HookActionsFile {
+        version: Version,
+        actions,
+    };
+    let contents = serde_json::to_vec_pretty(&file).map_err(HookActionsError::Serialize)?;
+    write_atomically(&path, contents).map_err(HookActionsError::Write)
+}
+
+/// Read and remove the prompt-hook action file for `shell_pid`, returning the
+/// actions it contained (or an empty vec if there is no file).
+///
+/// This is the hot path: it runs on every shell prompt, almost always with no
+/// file present, so the miss case is kept to a single failing `open` and the
+/// file is removed (not emptied) after a hit to preserve that. Keep it cheap.
+///
+/// ## Why there is no lock here
+///
+/// This is called by `flox hook-env` from the shell's prompt / directory-change
+/// hook; the file is written by another `flox` command (`flox deactivate`).
+/// There is deliberately no file lock, and none is needed:
+///
+/// - A shell runs its `precmd`/`chpwd` (and fish prompt/PWD/preexec) hooks
+///   synchronously and *blocks* on the `$(flox hook-env ...)` subprocess, so two
+///   `hook-env` invocations from the same shell never overlap. Even when a
+///   single `cd` fires both a directory-change hook and the prompt hook, they
+///   run one after the other and read-once handles the second (it finds no
+///   file).
+/// - The writer (`flox deactivate`) is a foreground command that finishes before
+///   any hook fires.
+/// - The file is keyed by shell PID, so different shells never share a file.
+/// - Async prompt frameworks don't change this: powerlevel10k only asyncs its
+///   own `gitstatusd` query (its precmd hook still runs synchronously in the
+///   main shell), and zsh-async only runs functions explicitly submitted via
+///   `async_job` in a worker — neither relocates our plain hook entry into a
+///   worker, and our hook template never submits `hook-env` via `async_job`.
+///
+/// The no-lock reasoning above is about concurrency, and it is *not* why the
+/// writer uses `write_atomically`: with no overlapping reader, a torn read can't
+/// happen anyway. The atomic write instead guards against a single, *interrupted*
+/// writer — if `flox deactivate` is killed (Ctrl-C / SIGKILL / OOM) between
+/// opening the file and finishing the write, the rename-into-place guarantees
+/// the target path holds either the previous file or the complete new one, never
+/// a half. And as a backstop this reader tolerates a partial or otherwise
+/// unparseable file regardless (it consumes and ignores it — see below), so the
+/// atomicity is defense-in-depth, not load-bearing. Please don't "fix" the
+/// absent lock by adding one.
+pub fn take_hook_actions(
+    runtime_dir: &Path,
+    shell_pid: i32,
+) -> Result<Vec<HookAction>, HookActionsError> {
+    let path = hook_actions_path(runtime_dir, shell_pid);
+
+    let contents = match std::fs::read(&path) {
+        Ok(contents) => contents,
+        // The common, every-prompt case: no pending actions.
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(HookActionsError::Read(err)),
+    };
+
+    // Remove the file rather than emptying it so the steady state is "no file":
+    // every subsequent prompt then hits the cheap miss path above (a single
+    // failing `open`) instead of having to open, read, and parse a lingering
+    // empty file. We consume it even when it doesn't parse, so a malformed or
+    // wrong-version file can't make every prompt fail.
+    std::fs::remove_file(&path).map_err(HookActionsError::Remove)?;
+
+    match serde_json::from_slice::<HookActionsFile>(&contents) {
+        Ok(file) => Ok(file.actions),
+        Err(err) => {
+            warn!(
+                %err,
+                path = traceable_path(&path),
+                "ignoring unparseable prompt-hook action file"
+            );
+            Ok(Vec::new())
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const PID: i32 = 1234;
+
+    #[test]
+    fn hook_actions_file_serializes_with_version_and_tagged_action() {
+        let file = HookActionsFile {
+            version: Version,
+            actions: vec![HookAction::Deactivate {
+                activation_state_dir: PathBuf::from("/run/flox/activations/abc-proj"),
+                flox_env: PathBuf::from("/run/flox/abc-proj/run"),
+            }],
+        };
+
+        assert_eq!(
+            serde_json::to_value(&file).unwrap(),
+            json!({
+                "version": 1,
+                "actions": [
+                    {
+                        "type": "deactivate",
+                        "activation_state_dir": "/run/flox/activations/abc-proj",
+                        "flox_env": "/run/flox/abc-proj/run",
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn hook_actions_file_round_trips() {
+        let file = HookActionsFile {
+            version: Version,
+            actions: vec![HookAction::Deactivate {
+                activation_state_dir: PathBuf::from("/run/flox/activations/abc-proj"),
+                flox_env: PathBuf::from("/run/flox/abc-proj/run"),
+            }],
+        };
+
+        let json = serde_json::to_string(&file).unwrap();
+        let parsed: HookActionsFile = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed, file);
+    }
+
+    #[test]
+    fn actions_path_is_pid_keyed_single_dir() {
+        let runtime_dir = Path::new("/run/flox");
+        assert_eq!(
+            hook_actions_path(runtime_dir, PID),
+            PathBuf::from("/run/flox/prompt-hook-actions/1234.json")
+        );
+    }
+
+    #[test]
+    fn write_then_take_returns_actions_and_consumes_file() {
+        let runtime = tempdir().unwrap();
+        let actions = vec![HookAction::Deactivate {
+            activation_state_dir: PathBuf::from("/run/flox/activations/abc-proj"),
+            flox_env: PathBuf::from("/run/flox/abc-proj/run"),
+        }];
+
+        write_hook_actions(runtime.path(), PID, actions.clone()).unwrap();
+        assert!(hook_actions_path(runtime.path(), PID).exists());
+
+        assert_eq!(take_hook_actions(runtime.path(), PID).unwrap(), actions);
+        // read-once: the file is gone afterwards.
+        assert!(!hook_actions_path(runtime.path(), PID).exists());
+    }
+
+    #[test]
+    fn second_take_after_consuming_returns_empty() {
+        // Mirrors a chpwd hook then a prompt hook firing for a single `cd`:
+        // the first consumes the action, the second finds nothing.
+        let runtime = tempdir().unwrap();
+        write_hook_actions(runtime.path(), PID, vec![HookAction::Deactivate {
+            activation_state_dir: PathBuf::from("/run/flox/activations/abc-proj"),
+            flox_env: PathBuf::from("/run/flox/abc-proj/run"),
+        }])
+        .unwrap();
+
+        take_hook_actions(runtime.path(), PID).unwrap();
+        assert_eq!(take_hook_actions(runtime.path(), PID).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn take_with_no_file_returns_empty() {
+        let runtime = tempdir().unwrap();
+        assert_eq!(take_hook_actions(runtime.path(), PID).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn take_ignores_and_consumes_unparseable_file() {
+        let runtime = tempdir().unwrap();
+        let path = hook_actions_path(runtime.path(), PID);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Wrong version — Version<1> deserialization rejects it.
+        std::fs::write(&path, br#"{"version": 99, "actions": []}"#).unwrap();
+
+        assert_eq!(take_hook_actions(runtime.path(), PID).unwrap(), Vec::new());
+        // Even an unparseable file is consumed so it can't fail every prompt.
+        assert!(!path.exists());
+    }
+}

--- a/cli/flox-core/src/lib.rs
+++ b/cli/flox-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod activate;
 pub mod activations;
 pub mod canonical_path;
 pub mod data;
+pub mod hook_actions;
 #[cfg(feature = "proc_status")]
 pub mod proc_status;
 pub mod process_compose;

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -1,4 +1,5 @@
 use std::io::{BufWriter, Write, stdout};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -6,13 +7,22 @@ use bpaf::Bpaf;
 use flox_core::activate::context::InvocationKind;
 use flox_core::activate::vars::FLOX_ACTIVATIONS_BIN;
 use flox_core::activations::activation_state_dir_path;
+use flox_core::hook_actions::{
+    HookAction,
+    PROMPT_HOOK_VERSION,
+    PROMPT_HOOK_VERSION_ENV,
+    write_hook_actions,
+};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
 use flox_rust_sdk::utils::FLOX_INTERPRETER;
 use indoc::{formatdoc, indoc};
+use shell_gen::ShellWithPath;
 
 use super::{activated_environments, uninitialized_environment_description};
+use crate::config::Config;
 use crate::subcommand_metric;
+use crate::utils::active_environments::ActiveEnvironment;
 use crate::utils::detect_shell::detect_shell_for_in_place;
 use crate::utils::message;
 
@@ -29,7 +39,7 @@ pub struct Deactivate {
 }
 
 impl Deactivate {
-    pub fn handle(self, flox: Flox) -> Result<()> {
+    pub fn handle(self, config: Config, flox: Flox) -> Result<()> {
         if !flox.features.auto_activate {
             return self.old_exit(flox);
         }
@@ -40,11 +50,19 @@ impl Deactivate {
             return self.handle_print_script(flox, invocation_type);
         }
 
-        // Interactive mode - print instructions
-        let active_environments = activated_environments();
-        let last_active = active_environments.last_active();
+        self.handle_request_deactivate(config, flox)
+    }
 
-        let Some(last_active) = last_active else {
+    /// Handle a plain `flox deactivate` (no `--print-script`).
+    ///
+    /// `flox deactivate` runs in a subprocess and can't modify its parent
+    /// shell, so it writes a prompt-hook action file that the shell's prompt
+    /// hook (`flox hook-env`) reads on the next prompt and turns into an
+    /// in-place deactivation. The file is keyed by the shell's PID:
+    /// `flox deactivate` is a direct child of the interactive shell, so its
+    /// parent PID is the shell that will read the file.
+    fn handle_request_deactivate(self, config: Config, flox: Flox) -> Result<()> {
+        let Some(active) = activated_environments().last_active_full() else {
             message::info(indoc! {"
                 No environment active!
                 Exit active environments by typing 'exit' to exit your current shell or close your terminal.
@@ -54,9 +72,20 @@ impl Deactivate {
             return Ok(());
         };
 
-        message::info(formatdoc! {"
-            Exit the currently active environment {} by typing 'exit' to exit your current shell or close your terminal.
-        ", uninitialized_environment_description(&last_active)?});
+        // The action file we are about to write is only useful if this shell has
+        // a compatible prompt hook to consume it. Fail loudly otherwise, rather
+        // than printing a success message for a deactivation that never happens.
+        ensure_prompt_hook_available(&config)?;
+
+        let target = open_deactivation_target(&flox, active)?;
+
+        write_hook_actions(&flox.runtime_dir, nix::unistd::getppid().as_raw(), vec![
+            HookAction::Deactivate {
+                activation_state_dir: target.activation_state_dir,
+                flox_env: target.flox_env,
+            },
+        ])
+        .context("failed to record deactivation request")?;
 
         Ok(())
     }
@@ -73,31 +102,10 @@ impl Deactivate {
     fn handle_print_script(self, flox: Flox, invocation_type: String) -> Result<()> {
         let shell = detect_shell_for_in_place()?;
 
-        // Open the concrete environment for the env at the front of the
-        // active-environment stack — the one being torn down. Managed and
-        // remote envs are supported here, not just local path envs.
-        let last_active = activated_environments()
+        let active = activated_environments()
             .last_active_full()
             .ok_or_else(|| anyhow!("No environment active."))?;
-        let mode = last_active.mode;
-        let mut concrete_env = last_active
-            .environment
-            .into_concrete_environment(&flox, None)
-            .context("failed to open active environment for deactivation")?;
-        let dot_flox_path = concrete_env.dot_flox_path().to_path_buf();
-        // Use the same rendered-env link the activate path used to set
-        // `$FLOX_ENV` — picking it from the active-stack entry rather than
-        // reading `$FLOX_ENV` at runtime is what lets us deactivate an env
-        // that isn't the most recently activated one.
-        let flox_env = concrete_env
-            .rendered_env_links(&flox)
-            .context("failed to read rendered env links for active environment")?
-            .for_mode(&mode)
-            .to_path_buf();
-
-        let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
-
-        let mut writer = BufWriter::new(stdout());
+        let target = open_deactivation_target(&flox, active)?;
 
         if invocation_type.is_empty() {
             bail!("cannot deactivate for empty INVOCATION_TYPE")
@@ -106,39 +114,15 @@ impl Deactivate {
         let invocation_kind = InvocationKind::from_str(&invocation_type)
             .context("could not determine invocation type".to_string())?;
 
-        match invocation_kind {
-            InvocationKind::Interactive => {
-                // Interactive subshell: just emit `exit;`. The shell exits and the
-                // executive monitors the PID, cleaning up state.json when it goes
-                // away.
-                write!(writer, "exit;")?;
-                Ok(())
-            },
-            InvocationKind::InPlace | InvocationKind::ShellCommand => {
-                let flox_activate_tracelevel = std::env::var("_FLOX_SUBSYSTEM_VERBOSITY")
-                    .ok()
-                    .and_then(|v| v.parse().ok())
-                    .unwrap_or(0);
-
-                // In-place activation: restore env vars first, then emit a shell
-                // command that calls `flox-activations detach` so state.json is
-                // updated after the script is eval'd by the caller.
-                flox_activations::deactivate::generate_deactivate_script(
-                    shell,
-                    &mut writer,
-                    &*FLOX_INTERPRETER,
-                    &FLOX_ACTIVATIONS_BIN,
-                    &activation_state_dir,
-                    &flox_env,
-                    flox_activate_tracelevel,
-                )
-                .context("failed to generate deactivation script")
-            },
-            InvocationKind::ExecCommand => {
-                // This should be unreachable because we shouldn't set _FLOX_INVOCATION_TYPE to exec_command
-                bail!("cannot deactivate an exec command activation");
-            },
-        }
+        let mut writer = BufWriter::new(stdout());
+        emit_deactivate_script(
+            shell,
+            invocation_kind,
+            &target.activation_state_dir,
+            &target.flox_env,
+            flox_activate_tracelevel(),
+            &mut writer,
+        )
     }
 
     pub fn old_exit(self, _flox: Flox) -> Result<()> {
@@ -162,5 +146,126 @@ impl Deactivate {
         ", uninitialized_environment_description(&last_active)?});
 
         Ok(())
+    }
+}
+
+/// Verify that this shell has a prompt hook able to service a plain
+/// `flox deactivate`, returning a descriptive error if not.
+///
+/// `flox deactivate` records its request in a file the shell's prompt hook reads
+/// on the next prompt; with no compatible hook registered, that file is never
+/// consumed and the command would be a silent no-op. Two ways it can be missing:
+/// - `disable_hook = true` in the config turns the prompt hook off entirely.
+/// - The hook exports [`PROMPT_HOOK_VERSION_ENV`] at activation: an unset value
+///   means no hook is set up (or it predates this marker), and a non-matching
+///   value means it was set up by an incompatible version of Flox.
+fn ensure_prompt_hook_available(config: &Config) -> Result<()> {
+    if config.flox.disable_hook.unwrap_or(false) {
+        bail!(formatdoc! {"
+            The Flox prompt hook is disabled ('disable_hook = true'), so 'flox deactivate' cannot take effect on the next prompt.
+            Re-enable it with 'flox config --delete disable_hook', then deactivate again.
+        "});
+    }
+
+    match std::env::var(PROMPT_HOOK_VERSION_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u8>().ok())
+    {
+        Some(version) if version == PROMPT_HOOK_VERSION => Ok(()),
+        Some(_) => bail!(formatdoc! {"
+            This shell's Flox prompt hook was set up by an incompatible version of Flox.
+            Restart your shell to pick up the current version, then deactivate again.
+        "}),
+        None => bail!(formatdoc! {"
+            The Flox prompt hook is not set up in this shell, so 'flox deactivate' cannot take effect on the next prompt.
+            Restart your shell to activate with the prompt hook, then deactivate again.
+        "}),
+    }
+}
+
+/// The data needed to deactivate the front-of-stack active environment.
+struct DeactivationTarget {
+    /// Activation state dir, for the `flox-activations detach` call.
+    activation_state_dir: PathBuf,
+    /// Rendered env link (`$FLOX_ENV`) the activate path used, needed to restore
+    /// the prompt and PATH on an in-place deactivation.
+    flox_env: PathBuf,
+}
+
+/// Resolve an active-stack entry into the data needed to deactivate it.
+///
+/// Opens the concrete environment so managed and remote environments are also
+/// supported (not just local path environments). The rendered env link is
+/// resolved via the entry's activation `mode` rather than read from `$FLOX_ENV`
+/// at runtime, which is what lets an env that isn't the most recently activated
+/// one be torn down. This is also where a future `flox deactivate <ENV>`
+/// argument would resolve a specific environment rather than the last-active
+/// one.
+fn open_deactivation_target(flox: &Flox, active: ActiveEnvironment) -> Result<DeactivationTarget> {
+    let mode = active.mode;
+    let mut concrete_env = active
+        .environment
+        .into_concrete_environment(flox, None)
+        .context("failed to open active environment for deactivation")?;
+    let dot_flox_path = concrete_env.dot_flox_path().to_path_buf();
+    let flox_env = concrete_env
+        .rendered_env_links(flox)
+        .context("failed to read rendered env links for active environment")?
+        .for_mode(&mode)
+        .to_path_buf();
+    let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
+
+    Ok(DeactivationTarget {
+        activation_state_dir,
+        flox_env,
+    })
+}
+
+/// The subsystem verbosity to thread into a generated deactivation script, read
+/// from `_FLOX_SUBSYSTEM_VERBOSITY` (0 when unset or unparseable).
+pub(crate) fn flox_activate_tracelevel() -> u32 {
+    std::env::var("_FLOX_SUBSYSTEM_VERBOSITY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Emit a deactivation script for `invocation_kind` to `writer`.
+///
+/// Shared by `flox deactivate --print-script` and `flox hook-env`:
+/// - `Interactive` → `exit;` (the subshell exits and the executive cleans up
+///   state.json when the PID goes away).
+/// - `InPlace`/`ShellCommand` → restore env vars, then emit a
+///   `flox-activations detach` command so state.json is updated once the caller
+///   eval's the script.
+/// - `ExecCommand` → unreachable; `_FLOX_INVOCATION_TYPE` is never `exec_command`.
+pub(crate) fn emit_deactivate_script(
+    shell: ShellWithPath,
+    invocation_kind: InvocationKind,
+    activation_state_dir: &Path,
+    flox_env: &Path,
+    flox_activate_tracelevel: u32,
+    writer: &mut impl Write,
+) -> Result<()> {
+    match invocation_kind {
+        InvocationKind::Interactive => {
+            write!(writer, "exit;")?;
+            Ok(())
+        },
+        InvocationKind::InPlace | InvocationKind::ShellCommand => {
+            flox_activations::deactivate::generate_deactivate_script(
+                shell,
+                writer,
+                &*FLOX_INTERPRETER,
+                &FLOX_ACTIVATIONS_BIN,
+                activation_state_dir,
+                flox_env,
+                flox_activate_tracelevel,
+            )
+            .context("failed to generate deactivation script")
+        },
+        InvocationKind::ExecCommand => {
+            bail!("cannot deactivate an exec command activation");
+        },
     }
 }

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -1,10 +1,14 @@
 use std::borrow::Cow;
+use std::io::{BufWriter, Write, stdout};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
+use flox_core::activate::context::InvocationKind;
+use flox_core::hook_actions::{HookAction, take_hook_actions};
 use flox_rust_sdk::flox::Flox;
-use shell_gen::Shell;
+use shell_gen::{Shell, ShellWithPath};
 
+use super::deactivate::{emit_deactivate_script, flox_activate_tracelevel};
 use crate::subcommand_metric;
 
 #[derive(Debug, Clone, Bpaf)]
@@ -12,6 +16,24 @@ pub struct HookEnv {
     /// Shell to emit hook-env code for (bash, zsh, fish, tcsh)
     #[bpaf(long("shell"), argument("SHELL"))]
     shell: Shell,
+
+    /// PID of the calling interactive shell ($$ / $fish_pid).
+    ///
+    /// The shell expands this before invoking `hook-env`, so it identifies the
+    /// interactive shell even though `hook-env` itself runs in a command
+    /// substitution subshell. It keys the prompt-hook action file this shell
+    /// reads.
+    #[bpaf(long("shell-pid"), argument("PID"))]
+    shell_pid: i32,
+
+    /// Invocation type of the activation the hook is running in
+    /// (`$_FLOX_INVOCATION_TYPE`), used when emitting a deactivation script.
+    ///
+    /// Optional as a defensive measure. Every shell hook passes it (tcsh guards
+    /// a possibly-unset value with `$?`); when a deactivate action is pending but
+    /// none was provided, the hook falls back to `inplace`.
+    #[bpaf(long("invocation-type"), argument("INVOCATION_TYPE"), optional)]
+    invocation_kind: Option<InvocationKind>,
 }
 
 impl HookEnv {
@@ -28,15 +50,47 @@ impl HookEnv {
         // instead of recording every single run of this command.
         subcommand_metric!("hook-env");
 
+        let mut writer = BufWriter::new(stdout());
+
+        // Consume any actions another flox command (e.g. `flox deactivate`) left
+        // for this shell and emit the corresponding script. The common case is
+        // no pending actions.
+        let actions = take_hook_actions(&flox.runtime_dir, self.shell_pid)
+            .context("failed to read prompt-hook actions")?;
+        for action in actions {
+            match action {
+                HookAction::Deactivate {
+                    activation_state_dir,
+                    flox_env,
+                } => {
+                    // Default to in-place when the shell didn't pass an
+                    // invocation type. Every shell hook passes it today; this is
+                    // a defensive fallback, and the prompt hook only ever
+                    // deactivates in place.
+                    let invocation_kind = self.invocation_kind.unwrap_or(InvocationKind::InPlace);
+                    emit_deactivate_script(
+                        ShellWithPath::from(self.shell),
+                        invocation_kind,
+                        &activation_state_dir,
+                        &flox_env,
+                        flox_activate_tracelevel(),
+                        &mut writer,
+                    )?;
+                },
+            }
+        }
+
         // Temporary: set _FLOX_HOOK_FIRED so we can verify the hook fires.
         // This will be replaced by real environment activation logic.
         let cwd = std::env::current_dir()?.to_string_lossy().to_string();
         let escaped_cwd = shell_escape::escape(Cow::Borrowed(&cwd));
         match self.shell {
-            Shell::Bash | Shell::Zsh => println!("export _FLOX_HOOK_FIRED={escaped_cwd};"),
-            Shell::Fish => println!("set -gx _FLOX_HOOK_FIRED {escaped_cwd};"),
-            Shell::Tcsh => println!("setenv _FLOX_HOOK_FIRED {escaped_cwd};"),
+            Shell::Bash | Shell::Zsh => writeln!(writer, "export _FLOX_HOOK_FIRED={escaped_cwd};")?,
+            Shell::Fish => writeln!(writer, "set -gx _FLOX_HOOK_FIRED {escaped_cwd};")?,
+            Shell::Tcsh => writeln!(writer, "setenv _FLOX_HOOK_FIRED {escaped_cwd};")?,
         }
+
+        writer.flush()?;
         Ok(())
     }
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -330,7 +330,7 @@ impl FloxArgs {
                 Commands::Modify(args) => args.handle(config, flox).await,
                 Commands::Share(args) => args.handle(config, flox).await,
                 Commands::Admin(args) => args.handle(config, flox).await,
-                Commands::Internal(args) => args.handle(flox).await,
+                Commands::Internal(args) => args.handle(config, flox).await,
                 Commands::Beta(args) => {
                     if !flox.features.beta {
                         bail!(indoc! {"
@@ -835,13 +835,13 @@ enum InternalCommands {
 }
 
 impl InternalCommands {
-    async fn handle(self, flox: Flox) -> Result<()> {
+    async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
             InternalCommands::ResetMetrics(args) => args.handle(flox).await?,
             InternalCommands::Upload(args) => args.handle(flox).await?,
             InternalCommands::LockManifest(args) => args.handle(flox).await?,
             InternalCommands::CheckForUpgrades(args) => args.handle(flox).await?,
-            InternalCommands::Deactivate(args) => args.handle(flox)?,
+            InternalCommands::Deactivate(args) => args.handle(config, flox)?,
             InternalCommands::ActivationState(args) => args.handle(flox).await?,
             InternalCommands::ServicesSocket(args) => args.handle(flox).await?,
             InternalCommands::HookEnv(args) => args.handle(flox)?,

--- a/cli/shell_gen/src/lib.rs
+++ b/cli/shell_gen/src/lib.rs
@@ -105,6 +105,22 @@ impl From<ShellWithPath> for Shell {
     }
 }
 
+impl From<Shell> for ShellWithPath {
+    /// Build a [ShellWithPath] from a bare [Shell], using the shell's name as
+    /// the (non-absolute) executable path. Useful when only the shell kind is
+    /// known (e.g. from a `--shell` argument) and the absolute path isn't
+    /// needed.
+    fn from(value: Shell) -> Self {
+        let path = PathBuf::from(value.to_string());
+        match value {
+            Shell::Bash => ShellWithPath::Bash(path),
+            Shell::Zsh => ShellWithPath::Zsh(path),
+            Shell::Tcsh => ShellWithPath::Tcsh(path),
+            Shell::Fish => ShellWithPath::Fish(path),
+        }
+    }
+}
+
 impl Display for Shell {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -48,7 +48,7 @@ teardown() {
 # bats test_tags=hook:hook-env
 @test "'flox hook-env' fails without auto_activate feature flag" {
   unset FLOX_FEATURES_AUTO_ACTIVATE
-  run "$FLOX_BIN" hook-env --shell bash
+  run "$FLOX_BIN" hook-env --shell bash --shell-pid "$$" --invocation-type inplace
   assert_failure
   assert_output --partial "auto_activate feature flag"
 }
@@ -149,4 +149,162 @@ EOF
   local count
   count=$(sed 's/^[[:space:]]*//;s/[[:space:]]*$//' <<< "$output" | grep -cFx "$expected")
   assert_equal "$count" "3"
+}
+
+# ---------------------------------------------------------------------------- #
+# Plain `flox deactivate` is serviced by the prompt hook
+# ---------------------------------------------------------------------------- #
+#
+# `flox deactivate` (no `--print-script`) writes a prompt-hook action file; the
+# next time the prompt hook runs `flox hook-env`, it restores the environment in
+# place. We fire `_flox_hook` manually to stand in for the next prompt.
+
+set_test_var_manifest() {
+  cat << "EOF" | "$FLOX_BIN" edit -f -
+version = 1
+
+[vars]
+TEST_VAR = "modified"
+EOF
+}
+
+# bats test_tags=hook:deactivate:bash
+@test "bash: plain 'flox deactivate' restores env via the prompt hook" {
+  project_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  set_test_var_manifest
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    export TEST_VAR=original
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    echo \"during:\$TEST_VAR\"
+    $FLOX_BIN deactivate
+    _flox_hook
+    echo \"after:\$TEST_VAR\"
+  "
+  assert_success
+  assert_output --partial "during:modified"
+  assert_output --partial "after:original"
+}
+
+# bats test_tags=hook:deactivate:zsh
+@test "zsh: plain 'flox deactivate' restores env via the prompt hook" {
+  project_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  set_test_var_manifest
+
+  run --separate-stderr zsh -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which zsh)
+    export TEST_VAR=original
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    echo \"during:\$TEST_VAR\"
+    $FLOX_BIN deactivate
+    _flox_hook
+    echo \"after:\$TEST_VAR\"
+  "
+  assert_success
+  assert_output --partial "during:modified"
+  assert_output --partial "after:original"
+}
+
+# bats test_tags=hook:deactivate:fish
+@test "fish: plain 'flox deactivate' restores env via the prompt hook" {
+  project_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  set_test_var_manifest
+
+  run --separate-stderr fish -c "
+    set -gx FLOX_FEATURES_AUTO_ACTIVATE true
+    set -gx TEST_VAR original
+    eval ($FLOX_BIN activate -d $PROJECT_DIR)
+    echo \"during:\$TEST_VAR\"
+    $FLOX_BIN deactivate
+    _flox_hook
+    echo \"after:\$TEST_VAR\"
+  "
+  assert_success
+  assert_output --partial "during:modified"
+  assert_output --partial "after:original"
+}
+
+# bats test_tags=hook:deactivate:tcsh
+@test "tcsh: plain 'flox deactivate' restores env via the prompt hook" {
+  project_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  set_test_var_manifest
+
+  run --separate-stderr tcsh -c "
+    setenv FLOX_FEATURES_AUTO_ACTIVATE true
+    setenv TEST_VAR original
+    eval \"\`$FLOX_BIN activate -d $PROJECT_DIR\`\"
+    echo \"during:\$TEST_VAR\"
+    $FLOX_BIN deactivate
+    precmd
+    echo \"after:\$TEST_VAR\"
+  "
+  assert_success
+  assert_output --partial "during:modified"
+  assert_output --partial "after:original"
+}
+
+# ---------------------------------------------------------------------------- #
+# Plain `flox deactivate` errors when no compatible prompt hook will consume it
+# ---------------------------------------------------------------------------- #
+#
+# Writing the action file is only useful if this shell has a compatible prompt
+# hook to read it. `flox deactivate` checks the exported _FLOX_PROMPT_HOOK_VERSION
+# (and the disable_hook config) and errors rather than claiming success for a
+# deactivation that would never happen.
+
+# bats test_tags=hook:deactivate:not-set-up
+@test "plain 'flox deactivate' errors when the prompt hook is not set up" {
+  project_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  # Activate (which exports the version marker), then clear the marker to
+  # simulate a shell with no prompt hook registered.
+  run bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    unset _FLOX_PROMPT_HOOK_VERSION
+    $FLOX_BIN deactivate
+  "
+  assert_failure
+  assert_output --partial "is not set up in this shell"
+}
+
+# bats test_tags=hook:deactivate:incompatible
+@test "plain 'flox deactivate' errors when the prompt hook version is incompatible" {
+  project_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  run bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    export _FLOX_PROMPT_HOOK_VERSION=99
+    $FLOX_BIN deactivate
+  "
+  assert_failure
+  assert_output --partial "incompatible version of Flox"
+}
+
+# bats test_tags=hook:deactivate:disabled
+@test "plain 'flox deactivate' errors when the prompt hook is disabled in config" {
+  project_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  "$FLOX_BIN" config --set disable_hook true
+
+  run bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    $FLOX_BIN deactivate
+  "
+  assert_failure
+  assert_output --partial "prompt hook is disabled"
 }


### PR DESCRIPTION
Wires up a plain `flox deactivate` (no `eval` / `--print-script`) by recording
the request and deactivating on the next shell prompt via the Flox prompt hook.

## Summary

Previously only `eval "$(flox deactivate --print-script ...)"` could deactivate
in place. A plain `flox deactivate` runs in a subprocess and can't modify its
parent shell, so it now writes a small, closed-format action file that
`flox hook-env` reads on the next prompt and turns into the same in-place
deactivation script.

## Changes

- **Prompt-hook action file** (`flox-core::hook_actions`): a versioned file
  serializing a closed `Vec<HookAction>` (never shell code), keyed by the
  shell's PID. Written atomically and read once per prompt, so it stays cheap
  even with layered environments.
- **Register / tear down the prompt hook across shells** (bash, zsh, fish,
  tcsh). Activation exports `_FLOX_PROMPT_HOOK_VERSION` so a plain
  `flox deactivate` can confirm a compatible hook is present.
- **Fail loudly instead of silently doing nothing.** When the request can't be
  serviced, `flox deactivate` explains why and how to fix it:
  - the prompt hook isn't set up in this shell (restart the shell),
  - it was set up by an incompatible version of Flox (restart the shell), or
  - it's disabled via `disable_hook = true` (re-enable it).
- **Shared deactivate dispatch** between `flox deactivate --print-script` and
  `flox hook-env`, plus a small refactor pulling out the repeated
  invocation-type handling.
- **tcsh**: quote the prompt-hook eval, and unskip the tcsh deactivate test.
- **Tests**: cover a plain `flox deactivate` driven through the prompt hook.

## Release Notes

`flox deactivate` now works on its own, without needing
`eval "$(flox deactivate --print-script ...)"`. It takes effect on the next
shell prompt. The environment must have been activated with a compatible
version of Flox and the prompt hook enabled; otherwise `flox deactivate`
explains what to fix rather than doing nothing.
