### PR TITLE
test(deactivate): treat tcsh REMOTEHOST as env-diff noise

### DIFF
--- a/cli/tests/deactivate.bats
+++ b/cli/tests/deactivate.bats
@@ -605,6 +605,7 @@ diff_env_dumps() {
         LOGNAME
         NIX_SSL_CERT_FILE
         PATH_LOCALE
+        REMOTEHOST
         _flox_activate_tracer
       )
       ;;
@@ -617,6 +618,7 @@ diff_env_dumps() {
         LOGNAME
         LS_COLORS
         NIX_SSL_CERT_FILE
+        REMOTEHOST
         SSL_CERT_FILE
         _flox_activate_tracer
       )


### PR DESCRIPTION
## Problem

The `interactive deactivate env diff (tcsh)` test (`cli/tests/deactivate.bats`)
spawns an interactive `tcsh` via `expect` and asserts the exact set of
environment variables that leak across an activate/deactivate round-trip.

On the self-hosted `remote (aarch64-linux, !containerize)` CI runners — which
are reached over SSH/Tailscale — interactive `tcsh` sets its `REMOTEHOST`
built-in at startup. That surfaces as an unexpected `REMOTEHOST` entry in the
env diff and fails the assertion. The variable is absent from the `BEFORE`
snapshot (captured under `env`/bash) and present in the `AFTER` snapshot
(captured under tcsh), so it reads as a leak even though flox never touches it.

This intermittently fails the merge queue: it bounced PR #4342 out of the
queue three times on `remote (aarch64-linux, !containerize)`, always on this
same test. Only the interactive tcsh test is affected — the non-interactive
`tcsh -c` tests and the containerized job never trigger it (no SSH session
inside the container).

## Fix

Filter `REMOTEHOST` as noise in `diff_env_dumps`. It is a tcsh built-in, not a
flox leak, and whether it appears depends on the connection rather than the OS,
so it is added unconditionally after the per-OS `noise` lists. `REMOTEHOST` is
not referenced anywhere else in the tests, so filtering it cannot mask a real
regression.

Test-only change; no release notes.
