### PR TITLE
fix(vars): render [vars] in dependency order

### DIFF
--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -8,6 +8,9 @@
   manifestLock,
   name ? "environment",
   serviceConfigYaml ? null,
+  # JSON array of `[vars]` names giving the order in which to render them,
+  # so a value referencing another entry is exported after it.
+  varsOrder,
 }:
 let
   outdentScript = (import ./buildenvLib/default.nix).outdentText;
@@ -52,16 +55,13 @@ let
   profileSection = if (builtins.hasAttr "profile" manifest) then manifest.profile else { };
   vars =
     if (builtins.hasAttr "vars" manifest) then
+      let
+        varNames = builtins.fromJSON varsOrder;
+      in
       (builtins.toFile "envrc-vars" (
         builtins.concatStringsSep "" (
-          builtins.map (n: "export ${n}=\"${builtins.getAttr n manifest.vars}\"\n") (
-            builtins.attrNames manifest.vars
-          )
+          builtins.map (n: "export ${n}=\"${builtins.getAttr n manifest.vars}\"\n") varNames
         )
-        # alternative ... worth it?
-        #      foldlAttrs (
-        #        acc: n: v: acc + "export ${n}=\"${v}\"\n"
-        #      ) "" manifestData.vars
       ))
     else
       null;

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -19,6 +19,7 @@ use flox_manifest::lockfile::{
     Lockfile,
     PackageToList,
 };
+use flox_manifest::parsed::Inner;
 use flox_manifest::parsed::latest::SelectedOutputs;
 use floxhub_client::{CatalogClientTrait, FloxhubClientError, StoreInfo};
 use pollster::FutureExt as _;
@@ -29,6 +30,7 @@ use tracing::{Span, debug, info_span, instrument, trace, warn};
 
 use super::nix::nix_base_command;
 use super::nix_auth::{AuthError, AuthProvider};
+use super::vars_order;
 use crate::data::System;
 use crate::models::nix_plugins::NIX_PLUGINS;
 use crate::providers::nix_auth::{catalog_auth_to_envs, store_needs_auth};
@@ -123,6 +125,12 @@ pub enum BuildEnvError {
         "Lockfile is not compatible with the current system\n\
         Supported systems: {0}", systems.join(", "))]
     LockfileIncompatible { systems: Vec<String> },
+
+    #[error(
+        "Found a reference cycle in the '[vars]' section: {cycle}.\n\
+        Remove one of these references so the variables no longer form a loop."
+    )]
+    VarsCycle { cycle: String },
 
     /// An error that occurred while creating GC roots via `create_gc_root_in`.
     #[error("Failed to link environment: {0}")]
@@ -969,6 +977,7 @@ where
         &self,
         lockfile_path: &Path,
         service_config_path: Option<PathBuf>,
+        vars_order: &[String],
         out_link_prefix: Option<&Path>,
     ) -> Result<BuildEnvOutputs, BuildEnvError> {
         let mut nix_build_command = base_command();
@@ -983,6 +992,10 @@ where
             .arg("--argstr")
             .arg("manifestLock")
             .arg(lockfile_path);
+        nix_build_command
+            .arg("--argstr")
+            .arg("varsOrder")
+            .arg(serde_json::to_string(vars_order).expect("var names serialize to JSON"));
         if let Some(service_config_path) = &service_config_path {
             nix_build_command
                 .arg("--argstr")
@@ -1434,6 +1447,13 @@ where
             });
         }
 
+        // Reject `[vars]` reference cycles before any build work rather than
+        // letting bash fail opaquely at activation time.
+        let vars_order = vars_order::render_order(manifest.as_latest_schema().vars.inner())
+            .map_err(|cycle| BuildEnvError::VarsCycle {
+                cycle: cycle.to_string(),
+            })?;
+
         // Realise the packages in the lockfile, for the current system.
         // "Realising" a package means to check if the associated store paths are valid
         // and otherwise building the package to _create_ valid store paths.
@@ -1479,7 +1499,14 @@ where
                     .collect()
             },
             || all_env_paths.clone(),
-            || self.call_buildenv_nix(lockfile_path, service_config_path.clone(), out_link_prefix),
+            || {
+                self.call_buildenv_nix(
+                    lockfile_path,
+                    service_config_path.clone(),
+                    &vars_order,
+                    out_link_prefix,
+                )
+            },
         )
     }
 }
@@ -2495,6 +2522,50 @@ mod buildenv_tests {
             assert!(content.contains(r#"export singlequotes="'bar'""#));
             assert!(content.contains(r#"export singlequoteescaped="\'baz""#));
         }
+    }
+
+    /// A variable that references another `[vars]` entry must be exported after
+    /// the entry it references, even when it sorts alphabetically before it.
+    #[test]
+    fn renders_vars_in_dependency_order() {
+        let buildenv = buildenv_instance();
+        let lockfile_path = MANUALLY_GENERATED.join("buildenv/lockfiles/vars_order/manifest.lock");
+        let client = MockClient::new();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
+
+        let runtime = result.run.as_ref();
+        let develop = result.dev.as_ref();
+
+        for envrc_path in [
+            runtime.join("activate.d/envrc"),
+            develop.join("activate.d/envrc"),
+        ] {
+            let content = std::fs::read_to_string(&envrc_path).unwrap();
+            let omega = content
+                .find(r#"export omega="base""#)
+                .expect("omega is exported");
+            let alpha = content
+                .find(r#"export alpha="${omega}-x""#)
+                .expect("alpha is exported");
+            assert!(
+                omega < alpha,
+                "omega must be exported before alpha:\n{content}"
+            );
+        }
+    }
+
+    /// A reference cycle in `[vars]` is rejected before any build work, with a
+    /// dedicated error rather than an opaque activation-time failure.
+    #[test]
+    fn rejects_vars_reference_cycle() {
+        let buildenv = buildenv_instance();
+        let lockfile_path = MANUALLY_GENERATED.join("buildenv/lockfiles/vars_cycle/manifest.lock");
+        let client = MockClient::new();
+        let result = buildenv.build(&client, &lockfile_path, None, None);
+        assert!(
+            matches!(result, Err(BuildEnvError::VarsCycle { .. })),
+            "expected a vars cycle error, got: {result:?}"
+        );
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -12,3 +12,4 @@ pub mod nix_auth;
 pub mod publish;
 pub mod services;
 pub mod upgrade_checks;
+pub(crate) mod vars_order;

--- a/cli/flox-rust-sdk/src/providers/vars_order.rs
+++ b/cli/flox-rust-sdk/src/providers/vars_order.rs
@@ -1,0 +1,345 @@
+//! Ordering of `[vars]` entries for the activation `envrc`.
+//!
+//! `[vars]` are rendered to the activation script as a sequence of
+//! `export NAME="VALUE"` lines that bash sources in order. Because bash
+//! expands each value as it is sourced, a value that references another
+//! `[vars]` entry only resolves when the referenced entry has already been
+//! exported. The entries are stored in a [`BTreeMap`], so without
+//! reordering the emission order is alphabetical — whether one variable can
+//! reference another then depends on the accident of their names.
+//!
+//! [`render_order`] fixes that by emitting each variable after the `[vars]`
+//! entries it references. It does not rewrite values; bash still performs the
+//! expansion. The parsing here serves only to order the entries and to reject
+//! reference cycles, which bash would otherwise surface as an opaque
+//! `unbound variable` failure at activation time.
+//!
+//! Reference detection is deliberately conservative: an edge is added only
+//! when a value clearly references another entry's exact name, and anything
+//! ambiguous adds no edge. The costs are asymmetric. A spurious edge could
+//! reject a valid manifest with a false cycle error, while a missed edge only
+//! leaves the entry at its alphabetical position, where at worst the
+//! reference fails to resolve at activation.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// A reference cycle among `[vars]` entries, as the chain of names that
+/// forms the loop (e.g. `["foo", "bar", "foo"]`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VarsCycle(pub Vec<String>);
+
+impl fmt::Display for VarsCycle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.join(" → "))
+    }
+}
+
+impl std::error::Error for VarsCycle {}
+
+/// Order the `[vars]` keys so that each variable is emitted after every
+/// `[vars]` entry it references.
+///
+/// This reordering is stable with respect to independent vars: a variable keeps
+/// its alphabetical position unless a reference forces it later, so a manifest
+/// with no cross-references renders in the same order as before. Returns
+/// [`VarsCycle`] if the references form a cycle.
+pub(crate) fn render_order(vars: &BTreeMap<String, String>) -> Result<Vec<String>, VarsCycle> {
+    let keys: BTreeSet<String> = vars.keys().cloned().collect();
+
+    // For each variable, the set of other `[vars]` keys it references. These
+    // are its dependencies: it must be emitted after all of them.
+    let dependencies: BTreeMap<String, BTreeSet<String>> = vars
+        .iter()
+        .map(|(name, value)| (name.clone(), referenced_keys(value, &keys, name)))
+        .collect();
+
+    // Reverse edges and in-degrees for Kahn's algorithm.
+    let mut dependents: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut indegree: BTreeMap<String, usize> = BTreeMap::new();
+    for (name, referenced_names) in &dependencies {
+        indegree.insert(name.clone(), referenced_names.len());
+        for reference in referenced_names {
+            dependents
+                .entry(reference.clone())
+                .or_default()
+                .insert(name.clone());
+        }
+    }
+
+    let mut ready: BTreeSet<String> = indegree
+        .iter()
+        .filter(|&(_, &count)| count == 0)
+        .map(|(name, _)| name.clone())
+        .collect();
+    let mut order = Vec::with_capacity(dependencies.len());
+    while let Some(name) = ready.pop_first() {
+        for dependent in dependents.get(&name).into_iter().flatten() {
+            let count = indegree.get_mut(dependent).expect("dependent is a key");
+            *count -= 1;
+            if *count == 0 {
+                ready.insert(dependent.clone());
+            }
+        }
+        order.push(name);
+    }
+
+    if order.len() != dependencies.len() {
+        return Err(VarsCycle(find_cycle(&dependencies, &order)));
+    }
+    Ok(order)
+}
+
+/// The `[vars]` keys referenced by `value`, excluding `self_name`.
+///
+/// Mirrors bash expansion inside `export NAME="<value>"`: `$name` and
+/// `${name...}` are expansions, and a `$` preceded by a backslash is a literal
+/// dollar. Only names that are exactly another `[vars]` key are returned;
+/// environment variables, command substitutions, and undefined names impose no
+/// ordering constraint and are ignored. A variable's reference to its own name
+/// reads the ambient value (the `PATH = "${PATH}:/x"` idiom) and is not a
+/// dependency.
+fn referenced_keys(value: &str, keys: &BTreeSet<String>, self_name: &str) -> BTreeSet<String> {
+    let bytes = value.as_bytes();
+    let mut deps = BTreeSet::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            // A backslash escapes the next byte.
+            b'\\' => i += 2,
+            // The name must appear immediately after `$`/`${`, but the closing
+            // brace is accepted anywhere later in the value. This detects
+            // references inside parameter expansions like `${FOO:-default}`
+            // without parsing the operator or nested expansions. An
+            // unterminated `${` adds no edge and is left to fail as a syntax
+            // error at activation time.
+            b'$' => {
+                let mut j = i + 1;
+                let braced = j < bytes.len() && bytes[j] == b'{';
+                if braced {
+                    j += 1;
+                }
+                let name_start = j;
+                while j < bytes.len() && is_name_byte(bytes[j], j == name_start) {
+                    j += 1;
+                }
+                let closed = !braced || value[j..].contains('}');
+                if j > name_start && closed {
+                    let name = &value[name_start..j];
+                    if name != self_name && keys.contains(name) {
+                        deps.insert(name.to_string());
+                    }
+                }
+                // `j` is past the `$`, so scanning resumes and always advances.
+                i = j;
+            },
+            _ => i += 1,
+        }
+    }
+    deps
+}
+
+/// Whether `b` may appear in a shell variable name. The first byte may not be
+/// a digit, which excludes positional parameters like `${1}`.
+fn is_name_byte(b: u8, first: bool) -> bool {
+    match b {
+        b'a'..=b'z' | b'A'..=b'Z' | b'_' => true,
+        b'0'..=b'9' => !first,
+        _ => false,
+    }
+}
+
+/// Recover one reference cycle from the entries left unemitted by the
+/// topological sort, as the chain of names that closes the loop.
+fn find_cycle(deps: &BTreeMap<String, BTreeSet<String>>, order: &[String]) -> Vec<String> {
+    let emitted: BTreeSet<&String> = order.iter().collect();
+    let remaining: BTreeSet<&String> = deps.keys().filter(|k| !emitted.contains(*k)).collect();
+
+    let Some(start) = remaining.first().copied() else {
+        return Vec::new();
+    };
+
+    // Every unemitted entry references at least one other unemitted entry, so
+    // following those references eventually revisits a name. That repeat closes
+    // the cycle.
+    let mut path = vec![start.clone()];
+    loop {
+        let next = deps[path.last().expect("path is never empty")]
+            .iter()
+            .find(|reference| remaining.contains(reference))
+            .expect("an unemitted entry references another unemitted entry")
+            .clone();
+        if let Some(start_idx) = path.iter().position(|name| *name == next) {
+            path.push(next);
+            return path.split_off(start_idx);
+        }
+        path.push(next);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn refs(value: &str, keys: &[&str], self_name: &str) -> Vec<String> {
+        let keys: BTreeSet<String> = keys.iter().map(|k| k.to_string()).collect();
+        referenced_keys(value, &keys, self_name)
+            .into_iter()
+            .collect()
+    }
+
+    #[test]
+    fn no_references_preserves_alphabetical_order() {
+        let order = render_order(&vars(&[("b", "2"), ("a", "1"), ("c", "3")])).unwrap();
+        assert_eq!(order, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn dependency_emitted_before_dependent() {
+        let order = render_order(&vars(&[("a", "${z}"), ("z", "1")])).unwrap();
+        assert_eq!(order, vec!["z", "a"]);
+    }
+
+    #[test]
+    fn reference_to_alphabetically_later_var_is_reordered() {
+        let order = render_order(&vars(&[("aaa", "${zzz}"), ("zzz", "v")])).unwrap();
+        assert_eq!(order, vec!["zzz", "aaa"]);
+    }
+
+    #[test]
+    fn only_forced_entries_move() {
+        // Constraint is z < a; `m` is unconstrained and keeps its slot.
+        let order = render_order(&vars(&[("a", "${z}"), ("m", "x"), ("z", "1")])).unwrap();
+        assert_eq!(order, vec!["m", "z", "a"]);
+    }
+
+    #[test]
+    fn self_reference_is_not_a_cycle() {
+        let order = render_order(&vars(&[("PATH", "${PATH}:/x")])).unwrap();
+        assert_eq!(order, vec!["PATH"]);
+    }
+
+    #[test]
+    fn self_reference_with_additional_dependency() {
+        let order = render_order(&vars(&[("PATH", "${PATH}:${bin}"), ("bin", "/b")])).unwrap();
+        assert_eq!(order, vec!["bin", "PATH"]);
+    }
+
+    #[test]
+    fn bare_dollar_reference_creates_edge() {
+        let order = render_order(&vars(&[("a", "$z"), ("z", "1")])).unwrap();
+        assert_eq!(order, vec!["z", "a"]);
+    }
+
+    #[test]
+    fn environment_reference_adds_no_edge() {
+        // `USER` is not a `[vars]` key; bash resolves it from the environment.
+        let order = render_order(&vars(&[("greeting", "${USER}")])).unwrap();
+        assert_eq!(order, vec!["greeting"]);
+        assert_eq!(
+            refs("${USER}", &["greeting"], "greeting"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn command_substitution_inner_reference_creates_edge() {
+        let order = render_order(&vars(&[("a", "$(echo ${b})"), ("b", "1")])).unwrap();
+        assert_eq!(order, vec!["b", "a"]);
+    }
+
+    #[test]
+    fn nested_reference_creates_edge() {
+        let order = render_order(&vars(&[("a", "${x:-${y}}"), ("x", "1"), ("y", "2")])).unwrap();
+        assert_eq!(order, vec!["x", "y", "a"]);
+    }
+
+    #[test]
+    fn escaped_dollar_is_not_a_reference() {
+        assert_eq!(refs(r"\${b}", &["b"], "a"), Vec::<String>::new());
+        let order = render_order(&vars(&[("a", r"\${b}"), ("b", "1")])).unwrap();
+        assert_eq!(order, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn reference_matches_whole_name_only() {
+        // `${ab}` references `ab`, not the shorter key `a`.
+        assert_eq!(refs("${ab}", &["a", "ab"], "x"), vec!["ab".to_string()]);
+        assert_eq!(refs("$ab", &["a", "ab"], "x"), vec!["ab".to_string()]);
+    }
+
+    #[test]
+    fn parameter_expansion_with_operator_creates_edge() {
+        assert_eq!(refs("${b:-default}", &["b"], "a"), vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn positional_parameter_is_not_a_reference() {
+        assert_eq!(refs("${1}", &["a"], "a"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn unclosed_brace_is_not_a_reference() {
+        // `${foo` is a bash syntax error, not a reference; adding no edge keeps
+        // a malformed value from reordering anything.
+        assert_eq!(refs("${foo", &["foo"], "bar"), Vec::<String>::new());
+        let order = render_order(&vars(&[("bar", "${foo"), ("foo", "x")])).unwrap();
+        assert_eq!(order, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn unclosed_brace_does_not_create_false_cycle() {
+        // `bar`'s value is malformed and imposes no ordering, so `foo`'s
+        // reference to `bar` is the only edge and there is no cycle.
+        let order = render_order(&vars(&[("bar", "${foo"), ("foo", "${bar}")])).unwrap();
+        assert_eq!(order, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn mutual_cycle_is_detected() {
+        let err = render_order(&vars(&[("foo", "${bar}"), ("bar", "${foo}")])).unwrap_err();
+        assert_eq!(
+            err,
+            VarsCycle(vec![
+                "bar".to_string(),
+                "foo".to_string(),
+                "bar".to_string(),
+            ])
+        );
+        assert_eq!(err.to_string(), "bar → foo → bar");
+    }
+
+    #[test]
+    fn three_way_cycle_is_detected() {
+        let err = render_order(&vars(&[("a", "${b}"), ("b", "${c}"), ("c", "${a}")])).unwrap_err();
+        assert_eq!(
+            err,
+            VarsCycle(vec![
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string(),
+                "a".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn self_reference_alone_does_not_form_cycle() {
+        assert!(render_order(&vars(&[("a", "${a}")])).is_ok());
+    }
+
+    #[test]
+    fn empty_vars_yield_empty_order() {
+        assert_eq!(
+            render_order(&BTreeMap::new()).unwrap(),
+            Vec::<String>::new()
+        );
+    }
+}

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -354,7 +354,9 @@ impl Edit {
             | Err(e @ EnvironmentError::Core(CoreEnvironmentError::DeserializeManifest(_)))
             | Err(
                 e @ EnvironmentError::Core(CoreEnvironmentError::BuildEnv(
-                    BuildEnvError::Realise2 { .. } | BuildEnvError::Build(_),
+                    BuildEnvError::Realise2 { .. }
+                    | BuildEnvError::Build(_)
+                    | BuildEnvError::VarsCycle { .. },
                 )),
             )
             | Err(
@@ -508,6 +510,20 @@ mod tests {
     fn test_recover_edit_loop_result_locking() {
         let result = Err(EnvironmentError::Core(CoreEnvironmentError::Resolve(
             ResolveError::ResolutionFailed(ResolutionFailures(vec![])),
+        )));
+
+        Edit::make_interactively_recoverable(result)
+            .expect("should be recoverable")
+            .expect_err("should return recoverable err");
+    }
+
+    /// a `[vars]` reference cycle is recoverable, so editing drops back into the editor
+    #[test]
+    fn test_recover_edit_loop_result_vars_cycle() {
+        let result = Err(EnvironmentError::Core(CoreEnvironmentError::BuildEnv(
+            BuildEnvError::VarsCycle {
+                cycle: "foo → bar → foo".to_string(),
+            },
         )));
 
         Edit::make_interactively_recoverable(result)

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -519,9 +519,12 @@ impl Pull {
                 }
             },
 
-            // Failed to _build_ the environment due to an incompatible package
+            // Failed to _build_ the environment, e.g. due to an incompatible
+            // package or a `[vars]` reference cycle
             EnvironmentError::Core(
-                ref core_err @ CoreEnvironmentError::BuildEnv(BuildEnvError::Realise2 { .. }),
+                ref core_err @ CoreEnvironmentError::BuildEnv(
+                    BuildEnvError::Realise2 { .. } | BuildEnvError::VarsCycle { .. },
+                ),
             ) => {
                 debug!(
                     "Failed to build environment: {err}",
@@ -765,6 +768,14 @@ mod tests {
         )))
     }
 
+    fn vars_cycle_result() -> Result<(), EnvironmentError> {
+        Err(EnvironmentError::Core(CoreEnvironmentError::BuildEnv(
+            BuildEnvError::VarsCycle {
+                cycle: "foo → bar → foo".to_string(),
+            },
+        )))
+    }
+
     #[test]
     fn ensure_valid_mock_incompatible_system_result() {
         match incompatible_system_result() {
@@ -931,6 +942,31 @@ mod tests {
         Pull::handle_pull_result(
             &flox,
             incompatible_package_result(),
+            &dot_flox_path,
+            false,
+            &mut unusable_mock_managed_environment(),
+            Some(QueryFunctions {
+                query_add_system: |_| panic!(),
+                query_ignore_build_errors: || Ok(true),
+            }),
+        )
+        .unwrap();
+
+        assert!(dot_flox_path.exists());
+    }
+
+    /// Pulling an environment with a `[vars]` reference cycle should prompt to
+    /// ignore the build error like any other build failure.
+    /// When answering yes, the environment should not be removed.
+    #[test]
+    fn handle_pull_result_vars_cycle_is_recoverable() {
+        let (flox, _temp_dir_handle) = flox_instance();
+
+        let dot_flox_path = tempdir_in(&flox.temp_dir).unwrap().keep();
+
+        Pull::handle_pull_result(
+            &flox,
+            vars_cycle_result(),
             &dot_flox_path,
             false,
             &mut unusable_mock_managed_environment(),

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -112,6 +112,24 @@ foo = "baz"
 EOF
 )
 
+# `alpha` references `omega`, which sorts after it. The reference must resolve
+# regardless of the entries' alphabetical order.
+export VARS_INTERPOLATED=$(
+  cat <<'EOF'
+[vars]
+alpha = "${omega}-suffix"
+omega = "base"
+EOF
+)
+
+export VARS_CYCLE=$(
+  cat <<'EOF'
+[vars]
+foo = "${bar}"
+bar = "${foo}"
+EOF
+)
+
 export HELLO_PROFILE_SCRIPT=$(
   cat <<-EOF
 [profile]
@@ -1084,6 +1102,26 @@ EOF
   FLOX_SHELL="zsh" NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -c 'echo "$foo"'
   assert_success
   assert_output --partial "baz"
+}
+
+# bats test_tags=activate,activate:envVar:order
+@test "bash: vars resolve regardless of definition order" {
+  project_setup
+  sed -i -e "s/^\[vars\]/${VARS_INTERPOLATED//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+
+  FLOX_SHELL="bash" NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -c 'echo "$alpha"'
+  assert_success
+  assert_output --partial "base-suffix"
+}
+
+# bats test_tags=activate,activate:envVar:cycle
+@test "vars reference cycle fails with a clear error" {
+  project_setup
+  sed -i -e "s/^\[vars\]/${VARS_CYCLE//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+
+  NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -c true
+  assert_failure
+  assert_output --partial "reference cycle in the '[vars]' section"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/test_data/manually_generated/buildenv/lockfiles/vars_cycle/manifest.lock
+++ b/test_data/manually_generated/buildenv/lockfiles/vars_cycle/manifest.lock
@@ -1,0 +1,25 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "vars": {
+      "foo": "${bar}",
+      "bar": "${foo}"
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "x86_64-darwin",
+        "aarch64-linux",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": []
+}

--- a/test_data/manually_generated/buildenv/lockfiles/vars_order/manifest.lock
+++ b/test_data/manually_generated/buildenv/lockfiles/vars_order/manifest.lock
@@ -1,0 +1,25 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "vars": {
+      "alpha": "${omega}-x",
+      "omega": "base"
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "x86_64-darwin",
+        "aarch64-linux",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": []
+}


### PR DESCRIPTION
## Proposed Changes

A `[vars]` value that references another `[vars]` entry only resolved when the referenced entry happened to sort earlier alphabetically. The entries are rendered to the activation `envrc` as `export NAME="VALUE"` lines that bash sources in order, expanding each value as it is sourced, and emission order was alphabetical. Under `set -u`, a reference to an entry sorting later aborted activation.

The build provider now computes a dependency order for the entries and passes it to `buildenv.nix`, which renders them in that order. Values are not rewritten, so bash still performs the expansion. A reference cycle fails before any build work with a dedicated error, which `flox edit` and `flox pull` treat as a recoverable build failure. The commit messages carry the safety argument for existing manifests and the reason `varsOrder` is a required argument of `buildenv.nix`.

## Release Notes

`[vars]` entries that reference other entries with `${name}` now resolve in dependency order, so a reference works regardless of where the entries appear in the manifest. A reference cycle between entries fails with a clear error instead of aborting activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
