### PR TITLE
feat(managed-env): two-level GC-root symlinks — atomic generation switch (1/3)

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -118,6 +118,16 @@ impl<S> Generations<S> {
         read_metadata(&self.repo, &self.branch)
     }
 
+    /// The [GenerationId] that the next [`Generations::add_generation`] will
+    /// assign.
+    ///
+    /// Lets the mutation flow name the upcoming generation's GC-root links
+    /// (`nix build --out-link` targets) before the generation is committed to
+    /// floxmeta. Stable as long as no generation is added in between.
+    pub fn next_generation_id(&self) -> Result<GenerationId, GenerationsError> {
+        Ok(self.metadata()?.next_generation_id())
+    }
+
     /// Read the manifest of a given generation and return its contents as a string
     pub fn manifest_contents(&self, generation: usize) -> Result<String, GenerationsError> {
         let metadata = self.metadata()?;
@@ -331,7 +341,7 @@ impl Generations<ReadWrite<'_>> {
         &mut self,
         environment: &mut CoreEnvironment,
         change_kind: HistoryKind,
-    ) -> Result<(), GenerationsError> {
+    ) -> Result<GenerationId, GenerationsError> {
         // add metadata
         // this returns a free generation id to store the env files under
         let mut metadata = self.metadata()?;
@@ -372,7 +382,7 @@ impl Generations<ReadWrite<'_>> {
             .push("origin", false)
             .map_err(GenerationsError::CompleteTransaction)?;
 
-        Ok(())
+        Ok(generation)
     }
 
     /// Switch to a provided generation to either roll backwards or forwards.
@@ -732,6 +742,17 @@ pub struct SwitchGenerationOptions {
 }
 
 impl AllGenerationsMetadata {
+    /// The [GenerationId] that the next [Self::add_generation] will assign.
+    ///
+    /// Generations are numbered consecutively, so the next id is one past the
+    /// highest ever allocated (`total_generations`). Reading it does not mutate
+    /// metadata, so callers can name per-generation artifacts (e.g. GC-root
+    /// links) for the upcoming generation before it is committed. The value is
+    /// stable until the next `add_generation` (or other mutation).
+    pub fn next_generation_id(&self) -> GenerationId {
+        GenerationId(self.total_generations + 1)
+    }
+
     /// Add metadata for a new generation, as well as consistent history.
     /// The return provides the [GenerationId] of the added generation metadata,
     /// that should **subsequently** be used
@@ -753,7 +774,7 @@ impl AllGenerationsMetadata {
         // generation if you're currently on e.g. 2, but the latest is 5.
         //
         // Keys should all be numbers, but if they aren't we provide a default value.
-        let next_generation = GenerationId(self.total_generations + 1);
+        let next_generation = self.next_generation_id();
         let current_generation = self.current_gen();
 
         let history_spec = HistorySpec {
@@ -1448,6 +1469,24 @@ mod tests {
             assert_eq!(history.previous_generation, None);
             assert_eq!(history.kind, options.kind);
             assert_eq!(history.timestamp, options.timestamp);
+        }
+
+        #[test]
+        fn next_generation_id_matches_subsequent_add() {
+            let mut metadata = AllGenerationsMetadata::default();
+
+            // The peeked id must equal what add_generation actually assigns,
+            // both for the first generation and after one already exists, so the
+            // mutation flow can name GC-root links before committing.
+            let peeked_first = metadata.next_generation_id();
+            let (added_first, _) = metadata.add_generation(default_add_generation_options());
+            assert_eq!(peeked_first, added_first);
+            assert_eq!(peeked_first, GenerationId(1));
+
+            let peeked_second = metadata.next_generation_id();
+            let (added_second, _) = metadata.add_generation(default_add_generation_options());
+            assert_eq!(peeked_second, added_second);
+            assert_eq!(peeked_second, GenerationId(2));
         }
 
         #[test]

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -35,6 +35,7 @@ use super::{
     EnvironmentError,
     EnvironmentPointer,
     GCROOTS_DIR_NAME,
+    GenerationLink,
     InstallationAttempt,
     LOG_DIR_NAME,
     ManagedPointer,
@@ -164,6 +165,9 @@ pub enum ManagedEnvironmentError {
 
     #[error("could not commit generation")]
     CommitGeneration(#[source] GenerationsError),
+
+    #[error("could not update activation links")]
+    FlipActivationLinks(#[source] std::io::Error),
 
     #[error("could not build environment")]
     Build(#[source] CoreEnvironmentError),
@@ -317,17 +321,19 @@ impl Environment for ManagedEnvironment {
             })
             .collect();
 
-        let out_link_prefix = self.rendered_env_links.out_link_prefix();
-        let result = local_checkout.install(packages, flox, Some(out_link_prefix))?;
+        let generation_id = generations
+            .next_generation_id()
+            .map_err(ManagedEnvironmentError::Generations)?;
+        let generation_link = self.rendered_env_links.generation_link(generation_id);
+        let result =
+            local_checkout.install(packages, flox, Some(generation_link.out_link_prefix()))?;
         if !result.modifications.is_empty() {
             let change = HistoryKind::Install { targets };
             generations
                 .add_generation(&mut local_checkout, change)
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
             self.lock_pointer()?;
-        }
-        if result.built_environments.is_some() {
-            self.rendered_env_links.replace_legacy_links();
+            self.flip_to_generation(&generation_link)?;
         }
 
         Ok(result)
@@ -360,8 +366,12 @@ impl Environment for ManagedEnvironment {
         }
 
         let targets: Vec<String> = specs.iter().map(|s| s.package_ref.clone()).collect();
-        let out_link_prefix = self.rendered_env_links.out_link_prefix();
-        let result = local_checkout.uninstall(specs, flox, Some(out_link_prefix))?;
+        let generation_id = generations
+            .next_generation_id()
+            .map_err(ManagedEnvironmentError::Generations)?;
+        let generation_link = self.rendered_env_links.generation_link(generation_id);
+        let result =
+            local_checkout.uninstall(specs, flox, Some(generation_link.out_link_prefix()))?;
         let change = HistoryKind::Uninstall { targets };
 
         // It's an error to uninstall a package that isn't installed so if we
@@ -370,9 +380,7 @@ impl Environment for ManagedEnvironment {
             .add_generation(&mut local_checkout, change)
             .map_err(ManagedEnvironmentError::CommitGeneration)?;
         self.lock_pointer()?;
-        if result.built_environment_store_paths.is_some() {
-            self.rendered_env_links.replace_legacy_links();
-        }
+        self.flip_to_generation(&generation_link)?;
 
         Ok(result)
     }
@@ -393,8 +401,12 @@ impl Environment for ManagedEnvironment {
 
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
 
-        let out_link_prefix = self.rendered_env_links.out_link_prefix();
-        let result = local_checkout.edit(flox, contents, Some(out_link_prefix))?;
+        let generation_id = generations
+            .next_generation_id()
+            .map_err(ManagedEnvironmentError::Generations)?;
+        let generation_link = self.rendered_env_links.generation_link(generation_id);
+        let result =
+            local_checkout.edit(flox, contents, Some(generation_link.out_link_prefix()))?;
 
         match &result {
             EditResult::Changed { .. } => {
@@ -402,7 +414,7 @@ impl Environment for ManagedEnvironment {
                     .add_generation(&mut local_checkout, HistoryKind::Edit)
                     .map_err(ManagedEnvironmentError::CommitGeneration)?;
                 self.lock_pointer()?;
-                self.rendered_env_links.replace_legacy_links();
+                self.flip_to_generation(&generation_link)?;
             },
             EditResult::Unchanged => {},
         }
@@ -448,8 +460,16 @@ impl Environment for ManagedEnvironment {
             ))?
         }
 
-        let out_link_prefix = self.rendered_env_links.out_link_prefix();
-        let result = local_checkout.upgrade(flox, groups_or_iids, true, Some(out_link_prefix))?;
+        let generation_id = generations
+            .next_generation_id()
+            .map_err(ManagedEnvironmentError::Generations)?;
+        let generation_link = self.rendered_env_links.generation_link(generation_id);
+        let result = local_checkout.upgrade(
+            flox,
+            groups_or_iids,
+            true,
+            Some(generation_link.out_link_prefix()),
+        )?;
         if !result.diff().is_empty() {
             let change = HistoryKind::Upgrade {
                 targets: result.packages().collect(),
@@ -459,9 +479,7 @@ impl Environment for ManagedEnvironment {
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
 
             self.lock_pointer()?;
-        }
-        if result.store_path.is_some() {
-            self.rendered_env_links.replace_legacy_links();
+            self.flip_to_generation(&generation_link)?;
         }
         Ok(result)
     }
@@ -492,9 +510,15 @@ impl Environment for ManagedEnvironment {
             ))?
         }
 
-        let out_link_prefix = self.rendered_env_links.out_link_prefix();
-        let result =
-            local_checkout.include_upgrade(flox, to_upgrade.clone(), Some(out_link_prefix))?;
+        let generation_id = generations
+            .next_generation_id()
+            .map_err(ManagedEnvironmentError::Generations)?;
+        let generation_link = self.rendered_env_links.generation_link(generation_id);
+        let result = local_checkout.include_upgrade(
+            flox,
+            to_upgrade.clone(),
+            Some(generation_link.out_link_prefix()),
+        )?;
         if result.store_path.is_some() {
             let change = HistoryKind::IncludeUpgrade {
                 targets: to_upgrade,
@@ -504,7 +528,7 @@ impl Environment for ManagedEnvironment {
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
 
             self.lock_pointer()?;
-            self.rendered_env_links.replace_legacy_links();
+            self.flip_to_generation(&generation_link)?;
         }
 
         Ok(result)
@@ -554,12 +578,19 @@ impl Environment for ManagedEnvironment {
     }
 
     fn build(&mut self, flox: &Flox) -> Result<BuildEnvOutputs, EnvironmentError> {
-        let out_link_prefix = self.rendered_env_links.out_link_prefix();
+        let current_generation = self
+            .generations()
+            .metadata()
+            .map_err(ManagedEnvironmentError::Generations)?
+            .current_gen()
+            .expect("managed environment always has a current generation");
+        let generation_link = self.rendered_env_links.generation_link(current_generation);
+
         let mut local_checkout = self.local_env_or_copy_current_generation(flox)?;
         // todo: ensure lockfile exists?
 
-        let store_paths = local_checkout.build(flox, Some(out_link_prefix))?;
-        self.rendered_env_links.replace_legacy_links();
+        let store_paths = local_checkout.build(flox, Some(generation_link.out_link_prefix()))?;
+        self.flip_to_generation(&generation_link)?;
         Ok(store_paths)
     }
 
@@ -730,19 +761,20 @@ impl GenerationsExt for ManagedEnvironment {
 
         let base_dir = CanonicalPath::new(run_dir).expect("run dir is checked to exist");
 
-        let rendered_env_links =
-            RenderedEnvironmentLinks::new_in_base_dir_with_name_system_and_generation(
-                &base_dir,
-                self.name().as_ref(),
-                &flox.system,
-                generation,
-            );
+        // Activating a specific generation builds (if necessary) and resolves
+        // directly to that generation's GC-root link, without flipping the
+        // current pointer — `--generation N` must not change which generation
+        // is current.
+        let generation_link = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &base_dir,
+            self.name().as_ref(),
+            &flox.system,
+        )
+        .generation_link(generation);
 
-        let out_link_prefix = rendered_env_links.out_link_prefix();
-        core_environment.build(flox, Some(out_link_prefix))?;
-        rendered_env_links.replace_legacy_links();
+        core_environment.build(flox, Some(generation_link.out_link_prefix()))?;
 
-        Ok(rendered_env_links)
+        Ok(generation_link.activation_links())
     }
 
     fn remote_generations_metadata(
@@ -862,7 +894,12 @@ impl ManagedEnvironment {
         write_generation_lock(&lock_path, &validated_lock)
             .map_err(ManagedEnvironmentError::from)?;
 
-        // Setup rendered_env_links
+        // Setup rendered_env_links.
+        //
+        // This always tracks the *current* generation's activation pointer, even
+        // for a pinned-generation view: pinned activation is served separately by
+        // `rendered_env_links_for_generation`, and current-generation operations
+        // (e.g. `build`) derive the per-generation GC-root link from this pointer.
         let rendered_env_links = {
             let run_dir = dot_flox_path.join(GCROOTS_DIR_NAME);
             if !run_dir.exists() {
@@ -872,20 +909,11 @@ impl ManagedEnvironment {
 
             let base_dir = CanonicalPath::new(run_dir).expect("run dir is checked to exist");
 
-            if let Some(generation) = generation {
-                RenderedEnvironmentLinks::new_in_base_dir_with_name_system_and_generation(
-                    &base_dir,
-                    pointer.name.as_ref(),
-                    &flox.system,
-                    generation,
-                )
-            } else {
-                RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
-                    &base_dir,
-                    pointer.name.as_ref(),
-                    &flox.system,
-                )
-            }
+            RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+                &base_dir,
+                pointer.name.as_ref(),
+                &flox.system,
+            )
         };
 
         let parent_directory = dot_flox_path
@@ -1162,6 +1190,20 @@ impl ManagedEnvironment {
         let lock = self.floxmeta_branch.generation_lock()?;
 
         write_generation_lock(lock_path, &lock)?;
+        Ok(())
+    }
+
+    /// Atomically point the activation links at a freshly built generation's
+    /// GC-root links, then refresh legacy compatibility links.
+    ///
+    /// This is the final, user-visible step of a managed-environment mutation
+    /// and must run only after the generation has been committed to floxmeta
+    /// (flox#4332).
+    fn flip_to_generation(&self, generation_link: &GenerationLink) -> Result<(), EnvironmentError> {
+        self.rendered_env_links
+            .flip_to(generation_link)
+            .map_err(ManagedEnvironmentError::FlipActivationLinks)?;
+        self.rendered_env_links.replace_legacy_links();
         Ok(())
     }
 
@@ -2523,6 +2565,51 @@ mod test {
             env.generations_metadata().unwrap().current_gen().as_deref(),
             Some(&2),
             "installing the same package should not change the generation"
+        );
+    }
+
+    /// After a managed mutation the activation pointer is a relative symlink to
+    /// the new generation's GC-root link (`-N-link`), not a direct store path —
+    /// the two-level model from flox#4332.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mutation_points_activation_link_at_generation_gc_root() {
+        let owner = "owner".parse().unwrap();
+        let (mut flox, temp_dir) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        flox.catalog_client =
+            catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
+
+        let mut env = mock_managed_environment_in(&flox, "version = 1", owner, &temp_dir, None);
+        let packages = [PackageToInstall::Catalog(
+            CatalogPackage::from_str("hello").unwrap(),
+        )];
+        env.install(&packages, &flox).unwrap();
+
+        let generation = env
+            .generations_metadata()
+            .unwrap()
+            .current_gen()
+            .expect("environment has a current generation");
+        let generation_link = env.rendered_env_links.generation_link(generation);
+        let generation_dev = PathBuf::from(format!(
+            "{}-dev",
+            generation_link.out_link_prefix().display()
+        ));
+
+        // The generation GC-root link exists and keeps the store path live.
+        assert!(
+            generation_dev.is_symlink(),
+            "generation GC-root link should exist: {}",
+            generation_dev.display()
+        );
+
+        // The activation pointer is a relative symlink to that generation link.
+        let pointer_dev = env.rendered_env_links.dev.as_path();
+        assert!(pointer_dev.is_symlink(), "activation pointer should exist");
+        assert_eq!(
+            std::fs::read_link(pointer_dev).unwrap(),
+            Path::new(generation_dev.file_name().unwrap()),
+            "activation pointer should redirect to the generation GC-root link"
         );
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -329,11 +329,10 @@ impl Environment for ManagedEnvironment {
             local_checkout.install(packages, flox, Some(generation_link.out_link_prefix()))?;
         if !result.modifications.is_empty() {
             let change = HistoryKind::Install { targets };
-            generations
+            let committed = generations
                 .add_generation(&mut local_checkout, change)
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
-            self.lock_pointer()?;
-            self.flip_to_generation(&generation_link)?;
+            self.flip_to_committed_generation(committed, generation_id, &generation_link)?;
         }
 
         Ok(result)
@@ -376,11 +375,10 @@ impl Environment for ManagedEnvironment {
 
         // It's an error to uninstall a package that isn't installed so if we
         // got this far then we need a new generation.
-        generations
+        let committed = generations
             .add_generation(&mut local_checkout, change)
             .map_err(ManagedEnvironmentError::CommitGeneration)?;
-        self.lock_pointer()?;
-        self.flip_to_generation(&generation_link)?;
+        self.flip_to_committed_generation(committed, generation_id, &generation_link)?;
 
         Ok(result)
     }
@@ -410,11 +408,10 @@ impl Environment for ManagedEnvironment {
 
         match &result {
             EditResult::Changed { .. } => {
-                generations
+                let committed = generations
                     .add_generation(&mut local_checkout, HistoryKind::Edit)
                     .map_err(ManagedEnvironmentError::CommitGeneration)?;
-                self.lock_pointer()?;
-                self.flip_to_generation(&generation_link)?;
+                self.flip_to_committed_generation(committed, generation_id, &generation_link)?;
             },
             EditResult::Unchanged => {},
         }
@@ -474,12 +471,10 @@ impl Environment for ManagedEnvironment {
             let change = HistoryKind::Upgrade {
                 targets: result.packages().collect(),
             };
-            generations
+            let committed = generations
                 .add_generation(&mut local_checkout, change)
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
-
-            self.lock_pointer()?;
-            self.flip_to_generation(&generation_link)?;
+            self.flip_to_committed_generation(committed, generation_id, &generation_link)?;
         }
         Ok(result)
     }
@@ -523,12 +518,10 @@ impl Environment for ManagedEnvironment {
             let change = HistoryKind::IncludeUpgrade {
                 targets: to_upgrade,
             };
-            generations
+            let committed = generations
                 .add_generation(&mut local_checkout, change)
                 .map_err(ManagedEnvironmentError::CommitGeneration)?;
-
-            self.lock_pointer()?;
-            self.flip_to_generation(&generation_link)?;
+            self.flip_to_committed_generation(committed, generation_id, &generation_link)?;
         }
 
         Ok(result)
@@ -1065,12 +1058,11 @@ impl ManagedEnvironment {
         let generation_link = self.rendered_env_links.generation_link(generation_id);
         local_checkout.build(flox, Some(generation_link.out_link_prefix()))?;
 
-        generations
+        let committed = generations
             .add_generation(&mut local_checkout, HistoryKind::Edit)
             .map_err(ManagedEnvironmentError::CommitGeneration)?;
 
-        self.lock_pointer()?;
-        self.flip_to_generation(&generation_link)?;
+        self.flip_to_committed_generation(committed, generation_id, &generation_link)?;
         Ok(SyncToGenerationResult::Synced)
     }
 
@@ -1209,6 +1201,29 @@ impl ManagedEnvironment {
             .map_err(ManagedEnvironmentError::FlipActivationLinks)?;
         self.rendered_env_links.replace_legacy_links();
         Ok(())
+    }
+
+    /// Commit-time pointer flip for a freshly committed mutation: write the
+    /// generation lock and flip the activation pointer to `built_link`.
+    ///
+    /// `built_link` was built for `built_for` (the id predicted by
+    /// `next_generation_id`), which must equal the `committed` id returned by
+    /// `add_generation` — both are read from the same floxmeta snapshot, so
+    /// they always match. The assertion guards against ever flipping the
+    /// activation pointer to a generation link that was never built (e.g. if a
+    /// future change reintroduced a window between predicting and committing).
+    fn flip_to_committed_generation(
+        &self,
+        committed: GenerationId,
+        built_for: GenerationId,
+        built_link: &GenerationLink,
+    ) -> Result<(), EnvironmentError> {
+        assert_eq!(
+            committed, built_for,
+            "committed generation {committed} does not match the built generation link {built_for}"
+        );
+        self.lock_pointer()?;
+        self.flip_to_generation(built_link)
     }
 
     /// Returns the environment owner

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1047,11 +1047,6 @@ impl ManagedEnvironment {
         // but we don't need to support pushing old manifests.
         local_checkout.lock(flox)?;
 
-        // Ensure the created generation is valid
-        let out_link_prefix = self.rendered_env_links.out_link_prefix();
-        local_checkout.build(flox, Some(out_link_prefix))?;
-        self.rendered_env_links.replace_legacy_links();
-
         let mut generations = self.generations();
         let mut generations = generations
             .writable(
@@ -1062,11 +1057,20 @@ impl ManagedEnvironment {
             )
             .map_err(ManagedEnvironmentError::CreateFloxmetaDir)?;
 
+        // Build the new generation to its GC-root link (which also validates
+        // that it builds), commit it, then flip the activation pointer to it.
+        let generation_id = generations
+            .next_generation_id()
+            .map_err(ManagedEnvironmentError::Generations)?;
+        let generation_link = self.rendered_env_links.generation_link(generation_id);
+        local_checkout.build(flox, Some(generation_link.out_link_prefix()))?;
+
         generations
             .add_generation(&mut local_checkout, HistoryKind::Edit)
             .map_err(ManagedEnvironmentError::CommitGeneration)?;
 
         self.lock_pointer()?;
+        self.flip_to_generation(&generation_link)?;
         Ok(SyncToGenerationResult::Synced)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -342,19 +342,6 @@ impl RenderedEnvironmentLinks {
         Self::new_unchecked(prefix)
     }
 
-    pub fn new_in_base_dir_with_name_system_and_generation(
-        base_dir: &CanonicalPath,
-        name: impl AsRef<str>,
-        system: &System,
-        generation: GenerationId,
-    ) -> Self {
-        let prefix = base_dir.join(format!(
-            "{system}.{name}.gen{generation}",
-            name = name.as_ref()
-        ));
-        Self::new_unchecked(prefix)
-    }
-
     /// Returns the `--out-link` prefix for `nix build`.
     ///
     /// With outputs named `"dev"` and `"run"`, nix creates `<prefix>-dev` and
@@ -511,6 +498,16 @@ impl GenerationLink {
     /// links.
     pub fn out_link_prefix(&self) -> &Path {
         &self.out_link_prefix
+    }
+
+    /// Activation links that resolve directly to this generation's GC-root
+    /// links (its own `dev`/`run`).
+    ///
+    /// Used to activate a *specific* generation without flipping the current
+    /// pointer — e.g. `flox activate --generation N`, which must not change
+    /// which generation is current.
+    pub fn activation_links(&self) -> RenderedEnvironmentLinks {
+        RenderedEnvironmentLinks::new_unchecked(self.out_link_prefix.clone())
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -418,12 +418,99 @@ impl RenderedEnvironmentLinks {
         }
     }
 
+    /// The GC-root link for `generation`, derived from this activation
+    /// pointer's prefix as `<pointer-prefix>-<generation>-link-{dev,run}`.
+    ///
+    /// Managed environments build a new generation to this link, then
+    /// [`Self::flip_to`] it; the two-level indirection keeps prior generations'
+    /// store paths live for instant rollback (flox#4332).
+    pub fn generation_link(&self, generation: GenerationId) -> GenerationLink {
+        let prefix = append_output_suffix(&self.out_link_prefix, &format!("-{generation}-link"));
+        GenerationLink::from_prefix(prefix)
+    }
+
+    /// Atomically repoint the current activation links at `generation`'s
+    /// GC-root links.
+    ///
+    /// Each pointer (`dev`, `run`) becomes a relative symlink to the matching
+    /// generation link in the same directory, installed via `rename()` so a
+    /// concurrent `flox activate` observes either the old or the new target,
+    /// never a missing or half-written link.
+    ///
+    /// This is the only user-visible step of a managed-environment mutation and
+    /// must run **only after** the new generation has been committed to
+    /// floxmeta (flox#4332).
+    pub fn flip_to(&self, generation: &GenerationLink) -> Result<(), std::io::Error> {
+        flip_pointer(self.dev.as_path(), generation.dev.as_path())?;
+        flip_pointer(self.run.as_path(), generation.run.as_path())?;
+        Ok(())
+    }
+
     /// Returns the built environment path for an activation mode.
     pub fn for_mode(self, mode: &ActivateMode) -> RenderedEnvironmentLink {
         match mode {
             ActivateMode::Dev => self.dev,
             ActivateMode::Run => self.run,
         }
+    }
+}
+
+/// Atomically replace the symlink at `pointer` with a relative symlink to
+/// `target`, which must live in the same directory.
+///
+/// Writes a temporary symlink alongside `pointer` and `rename()`s it into
+/// place; the rename is atomic within a directory on POSIX, so readers never
+/// see `pointer` missing.
+fn flip_pointer(pointer: &Path, target: &Path) -> Result<(), std::io::Error> {
+    let target_name = target.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "generation link has no file name",
+        )
+    })?;
+    let tmp = append_output_suffix(pointer, ".flip-tmp");
+    // A leftover temp from an interrupted flip would block symlink creation.
+    let _ = std::fs::remove_file(&tmp);
+    std::os::unix::fs::symlink(target_name, &tmp)?;
+    std::fs::rename(&tmp, pointer)
+}
+
+/// The immutable nix GC-root link for a single managed-environment generation.
+///
+/// Created once at build time as a `nix build --out-link` target named
+/// `<system>.<name>-<N>-link-{dev,run}` and never modified afterward. It keeps
+/// that generation's store paths live and is the target the current activation
+/// pointer ([RenderedEnvironmentLinks]) is flipped to as the final step of a
+/// mutation. Generation links persist until aged out by the cleanup policy.
+///
+/// Only managed environments use this two-level model; path and remote
+/// environments build directly to their single activation link.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationLink {
+    out_link_prefix: PathBuf,
+    dev: RenderedEnvironmentLink,
+    run: RenderedEnvironmentLink,
+}
+
+impl GenerationLink {
+    /// Construct from a `--out-link` prefix, deriving the `-dev` / `-run` links
+    /// the same way `nix build` names outputs. Construct via
+    /// [`RenderedEnvironmentLinks::generation_link`] rather than directly, so the
+    /// prefix is always derived from the activation pointer.
+    fn from_prefix(out_link_prefix: PathBuf) -> Self {
+        let dev = append_output_suffix(&out_link_prefix, "-dev");
+        let run = append_output_suffix(&out_link_prefix, "-run");
+        Self {
+            out_link_prefix,
+            dev: RenderedEnvironmentLink(dev),
+            run: RenderedEnvironmentLink(run),
+        }
+    }
+
+    /// The `--out-link` prefix `nix build` uses to write this generation's
+    /// links.
+    pub fn out_link_prefix(&self) -> &Path {
+        &self.out_link_prefix
     }
 }
 
@@ -1431,6 +1518,78 @@ mod test {
             links.run.as_path(),
             Path::new("/base/x86_64-linux.name-run")
         );
+    }
+
+    /// A generation GC-root link is named `<system>.<name>-<N>-link`, with nix
+    /// deriving `-dev` / `-run` from that prefix.
+    #[test]
+    fn generation_link_names_match_nix_output_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = CanonicalPath::new(dir.path()).unwrap();
+        let system: System = "x86_64-linux".to_string();
+
+        let pointer = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &base, "default", &system,
+        );
+        let link = pointer.generation_link(GenerationId::from(33usize));
+
+        assert_eq!(
+            link.out_link_prefix(),
+            base.join("x86_64-linux.default-33-link").as_path()
+        );
+        assert_eq!(
+            link.dev.as_path(),
+            base.join("x86_64-linux.default-33-link-dev").as_path()
+        );
+        assert_eq!(
+            link.run.as_path(),
+            base.join("x86_64-linux.default-33-link-run").as_path()
+        );
+    }
+
+    /// `flip_to` repoints the activation links at a generation's GC-root links
+    /// as relative symlinks, and is idempotent (atomically replaces existing
+    /// pointers).
+    #[test]
+    fn flip_to_points_activation_links_at_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = CanonicalPath::new(dir.path()).unwrap();
+        let system: System = "x86_64-linux".to_string();
+
+        let pointer = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &base, "default", &system,
+        );
+        let generation = pointer.generation_link(GenerationId::from(1usize));
+
+        // Materialize the generation links as a build would, pointing at
+        // (stand-in) store paths.
+        let store_dev = dir.path().join("store-dev");
+        let store_run = dir.path().join("store-run");
+        std::fs::write(&store_dev, "").unwrap();
+        std::fs::write(&store_run, "").unwrap();
+        std::os::unix::fs::symlink(&store_dev, generation.dev.as_path()).unwrap();
+        std::os::unix::fs::symlink(&store_run, generation.run.as_path()).unwrap();
+
+        pointer.flip_to(&generation).unwrap();
+
+        // Pointers are relative symlinks to the generation link file names ...
+        assert_eq!(
+            std::fs::read_link(pointer.dev.as_path()).unwrap(),
+            Path::new("x86_64-linux.default-1-link-dev")
+        );
+        assert_eq!(
+            std::fs::read_link(pointer.run.as_path()).unwrap(),
+            Path::new("x86_64-linux.default-1-link-run")
+        );
+        // ... and resolve through the generation link to the store path.
+        assert_eq!(
+            std::fs::canonicalize(pointer.dev.as_path()).unwrap(),
+            std::fs::canonicalize(&store_dev).unwrap()
+        );
+
+        // Flipping again over existing pointers succeeds (atomic replace).
+        pointer.flip_to(&generation).unwrap();
+        assert!(pointer.dev.as_path().is_symlink());
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -362,6 +362,13 @@ impl RenderedEnvironmentLinks {
     ///
     /// Errors are logged at debug level and do not propagate; this is a
     /// best-effort compatibility shim and must not fail the build.
+    ///
+    /// Under the two-level GC-root model (flox#4332) this still operates only on
+    /// the current activation pointer (`self.dev` / `self.run`), whose names are
+    /// unchanged — the pointer is now itself a redirect to a `-N-link`
+    /// generation link, so the legacy `.dev` / `.run` redirect resolves through
+    /// it. It is never called on a generation GC-root link, so the
+    /// `-{dev,run}`-suffix matching cannot misfire on the `-N-link` layer.
     pub fn replace_legacy_links(&self) {
         for (new_link, suffix) in [(self.dev.as_path(), "dev"), (self.run.as_path(), "run")] {
             let Some(parent) = new_link.parent() else {

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -406,9 +406,13 @@ impl ActivateOptions {
                 .unwrap_or_default(),
         );
         let mode_link_path = rendered_env_path.clone().for_mode(&mode);
-        let store_path = fs::read_link(&mode_link_path).with_context(|| {
+        // Fully resolve to the nix store path: for managed environments the
+        // activation link is a two-level symlink (pointer -> generation GC-root
+        // link -> store), so a single `read_link` would yield the relative
+        // generation-link name rather than the store path.
+        let store_path = fs::canonicalize(&mode_link_path).with_context(|| {
             format!(
-                "a symlink at {} was just created and should still exist",
+                "a symlink at {} was just created and should still resolve",
                 mode_link_path.display()
             )
         })?;

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -212,7 +212,11 @@ impl ServicesEnvironment {
 
         let rendered_link = rendered_env_links.for_mode(mode);
         let link_path: &Path = rendered_link.as_ref();
-        let Ok(current_store_path) = std::fs::read_link(link_path) else {
+        // Fully resolve the (possibly two-level) activation link to the nix
+        // store path, matching `flox_activate_store_path` set at activation
+        // time. A single `read_link` would yield the relative generation-link
+        // name for managed environments.
+        let Ok(current_store_path) = std::fs::canonicalize(link_path) else {
             return ProcessComposeState::NotCurrent;
         };
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -343,6 +343,7 @@ pub fn format_managed_error(err: &ManagedEnvironmentError) -> String {
         "},
         ManagedEnvironmentError::ReverseLink(_) => display_chain(err),
         ManagedEnvironmentError::CreateLinksDir(_) => display_chain(err),
+        ManagedEnvironmentError::FlipActivationLinks(_) => display_chain(err),
         ManagedEnvironmentError::CreateLocalEnvironmentView(err) => formatdoc! {"
             Failed to create the local environment from the current generation: {err}
 


### PR DESCRIPTION
## Summary

First of three PRs implementing the two-level GC-root symlink model for managed environments (flox#4332; design in the Forge effort, flox/forge#1085). This PR delivers the **atomicity correctness fix**; instant rollback (F2) and the GC-root aging policy (F3) follow in later PRs.

Previously a single symlink (`<sys>.<name>-{dev,run}`) was *both* the activation pointer and the nix GC root, and a mutation updated it **during** `nix build` — before `add_generation`/`lock_pointer` committed to floxmeta. A failure midway left activation pointing at a store path with no corresponding generation record.

Now there are two levels:

```
.flox/run/x86_64-linux.default-run            (current pointer)
    -> x86_64-linux.default-33-link-run        (generation GC-root link)
    -> /nix/store/…-environment-run
```

- **Generation GC-root links** (`<sys>.<name>-N-link-{dev,run}`): immutable, written once at build time as `nix build --out-link` targets; keep that generation's store paths live.
- **Current pointer** (`<sys>.<name>-{dev,run}`): flipped to the new generation link via an atomic `rename()` as the **last** step, only after the generation is committed.

A failure before the flip leaves the pointer on the prior generation; a build that is never committed leaves only a harmless orphan GC-root link. (This is why the in-place transaction + lock explored in the now-closed flox#4339 are unnecessary.)

## What's in this PR

- **P2** — `Generations::next_generation_id()` (reserve the id before building); `add_generation` returns the committed `GenerationId`.
- **P1** — `GenerationLink` + `RenderedEnvironmentLinks::generation_link(N)` + atomic `flip_to`.
- **F1** — rewire the 5 managed mutations (install/uninstall/edit/upgrade/include_upgrade) and `build()` to *build → commit → flip last*. `build()`/`switch_generation` are now flip-based. Activating a specific generation (`--generation N`) resolves directly to that generation's GC-root link without touching the current pointer. Naming unified on `-N-link` (old `.gen{N}` constructor removed).
- **F4** — `replace_legacy_links` confirmed to need no behavioral change (only ever operates on the current pointer); documented.

Path and remote environments are unchanged (single-level).

## Follow-ups

- F2 — instant rollback (flip with no rebuild when the `-N-link` already exists locally)
- F3 — GC-root aging policy (`last_live` in floxmeta + opportunistic cleanup)

## Release Notes

Managed environments now record a per-generation nix GC-root link under `.flox/run/` (`<system>.<name>-<N>-link-{dev,run}`), and the activation symlink is flipped atomically only after a generation is committed. This makes the activation pointer and the committed generation always consistent. (Instant rollback across these retained generations lands in a follow-up.)

## Test plan

- [x] Unit tests for `next_generation_id`, `generation_link`/`flip_to`, and the two-level on-disk structure after a mutation
- [x] `cargo clippy` clean; managed-environment + generations suites pass
