### PR TITLE
fix(activate): quote tcsh backtick evals in tests and document the rule in AGENTS.md (DEV-115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,16 @@ nix build
 FLOX_ACTIVATE_TRACE=1 result/bin/flox activate [args]
 ```
 
+## Generating shell code for tcsh
+
+**Any tcsh code consumed via `eval` of a command substitution MUST double-quote
+the backticks.** Use the quoted form, never the bare form:
+
+```tcsh
+eval "`flox activate`"   # correct
+eval `flox activate`     # WRONG — output is word-split and brace-expanded
+```
+
 ## Pull Requests
 
 When opening a PR, consider if the PR has user-facing changes that aren't behind a feature flag.

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2048,12 +2048,10 @@ EOF
 
 # bats test_tags=activate,activate:cwd_braces,activate:cwd_braces:tcsh
 @test "tcsh: tolerates cwd containing braces" {
-  skip "Apparently regressed in 1.4.3, now failing with Missing '}', due to quoting in _FLOX_ACTIVE_ENVIRONMENTS (#3173)"
   project_setup
   setup_cwd_with_braces
   activation_cmd="$(cat <<'EOF'
-    "$FLOX_BIN" activate --print-script
-    eval `"$FLOX_BIN" activate`
+    eval "`$FLOX_BIN activate`"
 EOF
 )"
   run tcsh -c "$activation_cmd"

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -114,7 +114,7 @@ teardown() {
 
   run tcsh -c "
     setenv FLOX_FEATURES_AUTO_ACTIVATE true
-    eval \`$FLOX_BIN activate -d $PROJECT_DIR\`
+    eval \"\`$FLOX_BIN activate -d $PROJECT_DIR\`\"
     precmd
     printenv _FLOX_HOOK_FIRED
   "


### PR DESCRIPTION
## Summary

In tcsh, a **bare** `` eval `...` `` word-splits and brace-expands the output of
the backtick substitution, unlike the bash/zsh/fish hooks (which
capture-then-`eval "$var"`) and the rest of the tcsh activation code, which all
use the double-quoted form `` eval "`...`" ``. A `{...}` in the captured output —
e.g. the JSON in `_FLOX_ACTIVE_ENVIRONMENTS` — is otherwise mangled into tokens
like `["environment":"type":"dot-flox"]` plus `... : Command not found.` stderr
noise.

This PR documents the rule and fixes the affected tcsh tests.

Fixes [DEV-115](https://linear.app/floxdotdev/issue/DEV-115).

## Changes

- `AGENTS.md` — document the tcsh double-quoted-backtick rule so it stops
  recurring.
- `cli/tests/activate.bats` — un-skip `tcsh: tolerates cwd containing braces`
  (#3173) and switch to the quoted form.
- `cli/tests/hook.bats` — the tcsh hook test uses the quoted form (removes the
  brace-expansion noise).

## Production hook fix lives in #4345

The `hook.rs` `tcsh_hook` change originally in this PR was dropped. #4345
(DEV-84) rewrote `tcsh_hook` with `--invocation-type` and quotes the eval there,
so keeping a competing fix here against main's older form only created a merge
conflict. The production fix is owned by #4345; this PR is now docs + tests only.

## Testing

- `just integ-tests activate.bats -- --filter 'tcsh: tolerates cwd containing braces'` ✅ (previously skipped)
- `just integ-tests hook.bats -- --filter 'tcsh: hook fires'` ✅

No `## Release Notes`: this PR is docs- and test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
