### PR TITLE
feat(deactivate): suggest 'flox deactivate' in the activation banner

### DIFF
--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -136,13 +136,19 @@ impl ActivateArgs {
         let warning_interval = Duration::from_secs(5);
         let mut last_warning: Option<Instant> = None;
 
+        let deactivate_hint = if context.auto_activate {
+            "To stop using this environment, run 'flox deactivate'"
+        } else {
+            "To stop using this environment, type 'exit'"
+        };
+
         loop {
             match self.try_start_or_attach(context, subsystem_verbosity, vars_from_env)? {
                 StartOrAttachResult::Start { start_id, .. } => {
                     if *invocation_type == InvocationType::Interactive {
                         updated(
                             formatdoc! {"You are now using the environment '{env_description}'
-                                     To stop using this environment, type 'exit'
+                                     {deactivate_hint}
                                      ",
                             env_description = context.attach_ctx.env_description,
                             },
@@ -154,7 +160,7 @@ impl ActivateArgs {
                     if *invocation_type == InvocationType::Interactive {
                         updated(
                             formatdoc! {"Attached to existing activation of environment '{env_description}'
-                                     To stop using this environment, type 'exit'
+                                     {deactivate_hint}
                                      ",
                             env_description = context.attach_ctx.env_description,
                             },


### PR DESCRIPTION
## What

The interactive activation banner ("You are now using…" / "Attached to existing activation…") told users to `type 'exit'` to leave. With the auto-activate feature enabled, `flox deactivate` is the right way out: it works for both interactive and in-place activations (where `exit` would close the whole terminal).

This gates the "how to leave" line on `context.auto_activate` (itself gated behind `FLOX_FEATURES_AUTO_ACTIVATE`):

- **Flag off** (default): `To stop using this environment, type 'exit'` — unchanged.
- **Flag on**: `To stop using this environment, run 'flox deactivate'`

`exit` still works in interactive subshell activations, but we show `flox deactivate` for both start and attach banners for consistency.

## Notes

- The change is fully behind the `FLOX_FEATURES_AUTO_ACTIVATE` flag, so no release notes are needed.
- No test added: this is temporary wording that goes away when the feature flag is removed (planned this week). Verified manually that the flag-off banner shows `type 'exit'` and the flag-on banner shows `run 'flox deactivate'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)