### PR TITLE
feat(hook-env): auto-activate environments via the prompt hook (DEV-119)

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/set-prompt.bash
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.bash
@@ -1,6 +1,8 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2154
-"$_flox_activate_tracer" "$_activate_d/set-prompt.bash" START
+# A previous in-place deactivation in this shell unsets the tracer, so default
+# to a no-op rather than executing an empty command when sourced again.
+"${_flox_activate_tracer:-true}" "${_activate_d:-}/set-prompt.bash" START
 
 # Tweak the (already customized) prompt: add a flox indicator.
 _flox_set_prompt() {
@@ -49,4 +51,4 @@ elif [ -n "${FLOX_SAVE_BASH_PS1:-}" ]; then
 fi
 unset -f _flox_set_prompt
 
-"$_flox_activate_tracer" "$_activate_d/set-prompt.bash" END
+"${_flox_activate_tracer:-true}" "${_activate_d:-}/set-prompt.bash" END

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.fish
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.fish
@@ -1,3 +1,9 @@
+# A previous in-place deactivation in this shell unsets the tracer, so default
+# to a no-op rather than executing an empty command when sourced again.
+if not set -q _flox_activate_tracer; or test -z "$_flox_activate_tracer"
+    set -g _flox_activate_tracer true
+end
+
 "$_flox_activate_tracer" "$_activate_d/set-prompt.fish" START
 
 if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS"

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.tcsh
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.tcsh
@@ -1,3 +1,10 @@
+# A previous in-place deactivation in this shell unsets the tracer and
+# _activate_d; default them so the unset-variable references below don't
+# abort this script when it is sourced again.
+if ( ! $?_flox_activate_tracer ) set _flox_activate_tracer = true
+if ( "$_flox_activate_tracer" == "" ) set _flox_activate_tracer = true
+if ( ! $?_activate_d ) set _activate_d = ""
+
 $_flox_activate_tracer $_activate_d/set-prompt.tcsh START
 
 # Tweak the (already customized) prompt: add a flox indicator.

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.zsh
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.zsh
@@ -1,4 +1,6 @@
-"$_flox_activate_tracer" "$_activate_d/set-prompt.zsh" START
+# A previous in-place deactivation in this shell unsets the tracer, so default
+# to a no-op rather than executing an empty command when sourced again.
+"${_flox_activate_tracer:-true}" "${_activate_d:-}/set-prompt.zsh" START
 
 # Tweak the (already customized) prompt: add a flox indicator.
 _flox_set_prompt() {
@@ -37,4 +39,4 @@ elif [ -n "${FLOX_SAVE_ZSH_PS1:-}" ]; then
 fi
 unset -f _flox_set_prompt
 
-"$_flox_activate_tracer" "$_activate_d/set-prompt.zsh" END
+"${_flox_activate_tracer:-true}" "${_activate_d:-}/set-prompt.zsh" END

--- a/cli/flox-core/src/activate/vars.rs
+++ b/cli/flox-core/src/activate/vars.rs
@@ -8,9 +8,35 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
+/// The environments active in this shell, as a JSON array of serialized
+/// environment metadata (`UninitializedEnvironment` in `flox-rust-sdk`), most
+/// recently activated first. Set by `flox activate`; read wherever an active
+/// environment must be reopened (e.g. `flox deactivate`, the prompt hook) and
+/// printed to users by `flox envs`.
 pub const FLOX_ACTIVE_ENVIRONMENTS_VAR: &str = "_FLOX_ACTIVE_ENVIRONMENTS";
+
+/// Numeric log verbosity for the `flox-activations` binary, exported by the
+/// CLI from its own verbosity so subprocess logging matches `flox -v` levels.
+/// Overridden by `RUST_LOG` when both are set.
 pub const FLOX_ACTIVATIONS_VERBOSITY_VAR: &str = "_FLOX_ACTIVATIONS_VERBOSITY";
+
+/// Numeric log verbosity for the executive subsystem's log file, deliberately
+/// separate from [`FLOX_ACTIVATIONS_VERBOSITY_VAR`] so that `flox activate -v`
+/// does not change what the long-lived executive process records.
 pub const FLOX_EXECUTIVE_VERBOSITY_VAR: &str = "_FLOX_EXECUTIVE_VERBOSITY";
+
+/// Project directories whose environments the prompt hook auto-activated in
+/// this shell, as a JSON array of absolute paths, outermost-first. Maintained
+/// by the script `flox hook-env` emits; used to decide which environments to
+/// auto-deactivate when the shell leaves their directory.
+pub const FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR: &str = "_FLOX_AUTO_ACTIVATED_ENVIRONMENTS";
+
+/// Project directories the prompt hook must not auto-(re)activate while the
+/// shell remains inside them, as a JSON array of absolute paths. An entry is
+/// added when an environment is deactivated while the shell is still inside
+/// its directory (e.g. by 'flox deactivate') and removed once the shell
+/// leaves that directory, so a later re-entry auto-activates again.
+pub const FLOX_SUPPRESSED_ENVIRONMENTS_VAR: &str = "_FLOX_SUPPRESSED_ENVIRONMENTS";
 
 pub static FLOX_ACTIVATIONS_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
     PathBuf::from(

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -10,6 +10,7 @@ use flox_core::data::environment_ref::{
     EnvironmentOwner,
     RemoteEnvironmentRef,
 };
+use flox_core::traceable_path;
 pub use flox_core::{Version, path_hash};
 use flox_manifest::lockfile::{LockedInclude, Lockfile, LockfileError};
 use flox_manifest::raw::{PackageToInstall, PackageToModify};
@@ -1036,6 +1037,44 @@ pub fn find_dot_flox(initial_dir: &Path) -> Result<Option<DotFlox>, EnvironmentE
     Ok(None)
 }
 
+/// Searches for all `.flox` directories from `initial_dir` up to the
+/// filesystem root, for auto-activation.
+///
+/// Unlike [`find_dot_flox`] the search does not stop at a git repository
+/// boundary: auto-activation should see every environment an interactive
+/// shell is "inside", regardless of how the directories are version
+/// controlled.
+///
+/// A `.flox` directory that cannot be parsed is skipped with a debug log
+/// rather than failing discovery, so one broken environment can't break every
+/// shell prompt.
+///
+/// Environments are returned outermost-first (closest to the filesystem root
+/// first), which is the order they should be activated in so that the
+/// innermost environment ends up on top of the activation stack.
+pub fn find_all_dot_flox(initial_dir: &Path) -> Result<Vec<DotFlox>, EnvironmentError> {
+    let path = CanonicalPath::new(initial_dir).map_err(EnvironmentError::StartDiscoveryDir)?;
+
+    let mut found = Vec::new();
+    for ancestor in path.ancestors() {
+        let tentative_dot_flox = ancestor.join(DOT_FLOX);
+        if !tentative_dot_flox.exists() {
+            continue;
+        }
+        match DotFlox::open_in(ancestor) {
+            Ok(dot_flox) => found.push(dot_flox),
+            Err(err) => debug!(
+                path = traceable_path(&tentative_dot_flox),
+                %err,
+                "skipping invalid .flox during auto-activation discovery"
+            ),
+        }
+    }
+    // `ancestors()` yields innermost-first; activation order is outermost-first.
+    found.reverse();
+    Ok(found)
+}
+
 /// Return a path to the services socket given a unique identifier
 ///
 /// Socket paths cannot exceed 104 characters on macOS
@@ -1357,6 +1396,123 @@ mod test {
 
         let found_environment = find_dot_flox(&start_path).unwrap();
         assert_eq!(found_environment, None);
+    }
+
+    /// All environments in the ancestor chain are found, outermost-first,
+    /// without requiring a git repo.
+    ///
+    /// .
+    /// ├── .flox
+    /// │   └── env.json
+    /// └── foo
+    ///     ├── .flox
+    ///     │   └── env.json
+    ///     └── bar
+    #[test]
+    fn discovers_all_dot_flox_upwards_outermost_first() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path();
+        let outer_dot_flox = path.join(DOT_FLOX);
+        let foo = path.join("foo");
+        let inner_dot_flox = foo.join(DOT_FLOX);
+        let start_path = foo.join("bar");
+        std::fs::create_dir_all(&outer_dot_flox).unwrap();
+        std::fs::create_dir_all(&inner_dot_flox).unwrap();
+        std::fs::create_dir_all(&start_path).unwrap();
+        for dot_flox in [&outer_dot_flox, &inner_dot_flox] {
+            fs::write(
+                dot_flox.join(ENVIRONMENT_POINTER_FILENAME),
+                serde_json::to_string_pretty(&*MANAGED_ENV_POINTER).unwrap(),
+            )
+            .unwrap();
+        }
+
+        let found_environments = find_all_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environments, vec![
+            DotFlox {
+                path: outer_dot_flox.canonicalize().unwrap(),
+                pointer: (*MANAGED_ENV_POINTER).clone()
+            },
+            DotFlox {
+                path: inner_dot_flox.canonicalize().unwrap(),
+                pointer: (*MANAGED_ENV_POINTER).clone()
+            },
+        ]);
+    }
+
+    /// Discovery for auto-activation does not stop at a git repository
+    /// boundary.
+    ///
+    /// .
+    /// ├── .flox
+    /// │   └── env.json
+    /// └── foo
+    ///     ├── .git
+    ///     └── bar
+    #[test]
+    fn discovers_all_dot_flox_above_git_repo() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path();
+        let actual_dot_flox = path.join(DOT_FLOX);
+        let foo = path.join("foo");
+        let start_path = foo.join("bar");
+        std::fs::create_dir_all(&actual_dot_flox).unwrap();
+        std::fs::create_dir_all(&start_path).unwrap();
+        fs::write(
+            actual_dot_flox.join(ENVIRONMENT_POINTER_FILENAME),
+            serde_json::to_string_pretty(&*MANAGED_ENV_POINTER).unwrap(),
+        )
+        .unwrap();
+
+        GitCommandProvider::init(&foo, false).unwrap();
+
+        let found_environments = find_all_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environments, vec![DotFlox {
+            path: actual_dot_flox.canonicalize().unwrap(),
+            pointer: (*MANAGED_ENV_POINTER).clone()
+        }]);
+    }
+
+    /// An invalid `.flox` directory is skipped without failing discovery of
+    /// other environments.
+    ///
+    /// .
+    /// ├── .flox
+    /// │   └── env.json
+    /// └── foo
+    ///     ├── .flox        (empty, invalid)
+    ///     └── bar
+    #[test]
+    fn skips_invalid_dot_flox_during_discovery() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path();
+        let outer_dot_flox = path.join(DOT_FLOX);
+        let foo = path.join("foo");
+        let invalid_dot_flox = foo.join(DOT_FLOX);
+        let start_path = foo.join("bar");
+        std::fs::create_dir_all(&outer_dot_flox).unwrap();
+        std::fs::create_dir_all(&invalid_dot_flox).unwrap();
+        std::fs::create_dir_all(&start_path).unwrap();
+        fs::write(
+            outer_dot_flox.join(ENVIRONMENT_POINTER_FILENAME),
+            serde_json::to_string_pretty(&*MANAGED_ENV_POINTER).unwrap(),
+        )
+        .unwrap();
+
+        let found_environments = find_all_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environments, vec![DotFlox {
+            path: outer_dot_flox.canonicalize().unwrap(),
+            pointer: (*MANAGED_ENV_POINTER).clone()
+        }]);
+    }
+
+    #[test]
+    fn finds_no_dot_flox_in_plain_ancestry() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let start_path = temp_dir.path().join("foo").join("bar");
+        std::fs::create_dir_all(&start_path).unwrap();
+        let found_environments = find_all_dot_flox(&start_path).unwrap();
+        assert_eq!(found_environments, Vec::new());
     }
 
     #[test]

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -158,12 +158,12 @@ fn ensure_prompt_hook_available(config: &Config) -> Result<()> {
 }
 
 /// The data needed to deactivate the front-of-stack active environment.
-struct DeactivationTarget {
+pub(crate) struct DeactivationTarget {
     /// Activation state dir, for the `flox-activations detach` call.
-    activation_state_dir: PathBuf,
+    pub(crate) activation_state_dir: PathBuf,
     /// Rendered env link (`$FLOX_ENV`) the activate path used, needed to restore
     /// the prompt and PATH on an in-place deactivation.
-    flox_env: PathBuf,
+    pub(crate) flox_env: PathBuf,
 }
 
 /// Resolve an active-stack entry into the data needed to deactivate it.
@@ -175,7 +175,10 @@ struct DeactivationTarget {
 /// one be torn down. This is also where a future `flox deactivate <ENV>`
 /// argument would resolve a specific environment rather than the last-active
 /// one.
-fn open_deactivation_target(flox: &Flox, active: ActiveEnvironment) -> Result<DeactivationTarget> {
+pub(crate) fn open_deactivation_target(
+    flox: &Flox,
+    active: ActiveEnvironment,
+) -> Result<DeactivationTarget> {
     let mode = active.mode;
     let mut concrete_env = active
         .environment

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -1,15 +1,29 @@
 use std::borrow::Cow;
 use std::io::{BufWriter, Write, stdout};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use bpaf::Bpaf;
 use flox_core::activate::context::InvocationKind;
+use flox_core::activate::vars::{
+    FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR,
+    FLOX_SUPPRESSED_ENVIRONMENTS_VAR,
+};
 use flox_core::hook_actions::{HookAction, take_hook_actions};
 use flox_rust_sdk::flox::Flox;
-use shell_gen::{Shell, ShellWithPath};
+use flox_rust_sdk::models::environment::find_all_dot_flox;
+use indoc::formatdoc;
+use shell_gen::{GenerateShell, SetVar, Shell, ShellWithPath, UnsetVar};
+use tracing::debug;
 
-use super::deactivate::{emit_deactivate_script, flox_activate_tracelevel};
+use super::activated_environments;
+use super::deactivate::{
+    emit_deactivate_script,
+    flox_activate_tracelevel,
+    open_deactivation_target,
+};
 use crate::subcommand_metric;
+use crate::utils::message;
 
 #[derive(Debug, Clone, Bpaf)]
 pub struct HookEnv {
@@ -45,17 +59,7 @@ impl HookEnv {
         // no pending actions.
         let actions = take_hook_actions(&flox.runtime_dir, self.shell_pid)
             .context("failed to read prompt-hook actions")?;
-
-        // This command runs on every prompt; only record a metric when it
-        // actually does something so metric volume tracks deactivations, not
-        // prompts.
-        // TODO: when we add auto-activation logic, consider counting unique
-        // environments or something instead of recording every consumed action.
-        if !actions.is_empty() {
-            subcommand_metric!("hook-env");
-        }
-
-        for action in actions {
+        for action in &actions {
             match action {
                 HookAction::Deactivate {
                     activation_state_dir,
@@ -69,8 +73,8 @@ impl HookEnv {
                     emit_deactivate_script(
                         ShellWithPath::from(self.shell),
                         invocation_kind,
-                        &activation_state_dir,
-                        &flox_env,
+                        activation_state_dir,
+                        flox_env,
                         flox_activate_tracelevel(),
                         &mut writer,
                     )?;
@@ -78,23 +82,757 @@ impl HookEnv {
             }
         }
 
-        // Temporary: set _FLOX_HOOK_FIRED so we can verify the hook fires.
-        // This is the placeholder for auto-activation logic and stays gated
-        // behind the auto_activate feature flag, unlike the deactivate-action
-        // handling above.
-        if flox.features.auto_activate {
-            let cwd = std::env::current_dir()?.to_string_lossy().to_string();
-            let escaped_cwd = shell_escape::escape(Cow::Borrowed(&cwd));
-            match self.shell {
-                Shell::Bash | Shell::Zsh => {
-                    writeln!(writer, "export _FLOX_HOOK_FIRED={escaped_cwd};")?
-                },
-                Shell::Fish => writeln!(writer, "set -gx _FLOX_HOOK_FIRED {escaped_cwd};")?,
-                Shell::Tcsh => writeln!(writer, "setenv _FLOX_HOOK_FIRED {escaped_cwd};")?,
+        // The deactivate-action handling above runs unconditionally; the
+        // auto-activation logic below stays gated behind the auto_activate
+        // feature flag.
+        if !flox.features.auto_activate {
+            // Only record a metric when this run actually does something;
+            // `hook-env` runs on every shell prompt, and recording the common
+            // nothing-to-do case would be noise.
+            if !actions.is_empty() {
+                subcommand_metric!("hook-env");
             }
+            writer.flush()?;
+            return Ok(());
         }
+
+        let ctx = gather_auto_activate_context(!actions.is_empty())?;
+        let plan = plan_auto_activation(&ctx);
+
+        // Only record a metric when this run actually does something;
+        // `hook-env` runs on every shell prompt, and recording the common
+        // nothing-to-do case would be noise.
+        if !actions.is_empty()
+            || plan.deactivate_front
+            || !plan.activate.is_empty()
+            || !plan.abandoned.is_empty()
+        {
+            subcommand_metric!("hook-env");
+        }
+
+        if plan.deactivate_front {
+            let active = activated_environments()
+                .last_active_full()
+                .context("no active environment to auto-deactivate")?;
+            let target = open_deactivation_target(&flox, active)?;
+            // Auto-activations are always in-place, so the matching
+            // deactivation is too.
+            emit_deactivate_script(
+                ShellWithPath::from(self.shell),
+                InvocationKind::InPlace,
+                &target.activation_state_dir,
+                &target.flox_env,
+                flox_activate_tracelevel(),
+                &mut writer,
+            )?;
+        }
+
+        for path in &plan.abandoned {
+            message::warning(formatdoc! {"
+                Did not auto-deactivate the environment in '{}' because other environments are layered on top.
+                Run 'flox deactivate' to deactivate them in order.",
+                path.display()
+            });
+        }
+
+        for path in &plan.activate {
+            write_activate_command(self.shell, path, &mut writer)?;
+        }
+
+        write_path_list_update(
+            self.shell,
+            FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR,
+            &ctx.auto_activated,
+            &plan.auto_activated,
+            &mut writer,
+        )?;
+        write_path_list_update(
+            self.shell,
+            FLOX_SUPPRESSED_ENVIRONMENTS_VAR,
+            &ctx.suppressed,
+            &plan.suppressed,
+            &mut writer,
+        )?;
 
         writer.flush()?;
         Ok(())
+    }
+}
+
+/// Inputs to [`plan_auto_activation`].
+///
+/// Gathered from the runtime environment by [`gather_auto_activate_context`]
+/// so the planning logic itself is pure and unit-testable.
+#[derive(Clone, Debug, PartialEq)]
+struct AutoActivateContext {
+    /// Canonicalized working directory of the interactive shell.
+    cwd: PathBuf,
+    /// Project directories with a discoverable `.flox`, outermost-first.
+    discovered: Vec<PathBuf>,
+    /// Project directories of active environments, most recently activated
+    /// first. `None` for environments without a local directory (remote).
+    active: Vec<Option<PathBuf>>,
+    /// Project directories auto-activated by the hook in this shell.
+    auto_activated: Vec<PathBuf>,
+    /// Project directories suppressed from auto-activation in this shell.
+    suppressed: Vec<PathBuf>,
+    /// Whether this run consumed pending prompt-hook deactivation actions.
+    pending_deactivations: bool,
+}
+
+/// What the prompt hook should do this run, plus the new values of the
+/// auto-activation state variables.
+#[derive(Clone, Debug, PartialEq)]
+struct AutoActivatePlan {
+    /// Project directories to activate, outermost-first.
+    activate: Vec<PathBuf>,
+    /// Deactivate the front-of-stack environment.
+    deactivate_front: bool,
+    /// Auto-activated environments that should be deactivated but are buried
+    /// under other activations. Tearing down the middle of the stack is
+    /// not yet supported, so these are dropped from tracking with a warning.
+    abandoned: Vec<PathBuf>,
+    /// New value for [`FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR`].
+    auto_activated: Vec<PathBuf>,
+    /// New value for [`FLOX_SUPPRESSED_ENVIRONMENTS_VAR`].
+    suppressed: Vec<PathBuf>,
+}
+
+/// Decide what the prompt hook should do given the shell's current location
+/// and activation state.
+///
+/// At most one environment is deactivated per run: the generated deactivation
+/// script restores the next layer's `_FLOX_HOOK_DIFF` only once the shell has
+/// applied it, so a deeper stack unwinds across consecutive prompts rather
+/// than in a single run. While such an unwind is in progress, newly
+/// discovered environments are not activated yet — they would bury the
+/// still-unwinding layers and force them to be abandoned.
+fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
+    let inside = |path: &Path| ctx.cwd.starts_with(path);
+    let is_active = |path: &PathBuf| ctx.active.iter().flatten().any(|active| active == path);
+
+    // Reconcile tracked state with the actual activation stack. A suppressed
+    // environment stays suppressed only while the shell remains inside its
+    // directory. A tracked auto-activation that is no longer active was
+    // deactivated out-of-band (or failed to activate): suppress it while
+    // still inside so it isn't immediately re-activated, otherwise forget it.
+    // Filter to entries the shell is still inside, fully de-duplicating while
+    // preserving order: this is treated as a set, and a corrupted or
+    // hand-edited state variable could contain non-adjacent duplicates that
+    // `Vec::dedup` (consecutive-only) would miss and keep re-emitting.
+    let mut suppressed: Vec<PathBuf> = Vec::new();
+    for path in &ctx.suppressed {
+        if inside(path) && !suppressed.contains(path) {
+            suppressed.push(path.clone());
+        }
+    }
+    let mut auto_activated = Vec::new();
+    for path in &ctx.auto_activated {
+        if is_active(path) {
+            if !auto_activated.contains(path) {
+                auto_activated.push(path.clone());
+            }
+        } else if inside(path) && !suppressed.contains(path) {
+            suppressed.push(path.clone());
+        }
+    }
+
+    // A pending deactivation consumed this run targets the front of the
+    // stack. Suppress it while the shell is still inside its directory so the
+    // next prompt doesn't undo the deactivation the user just asked for, and
+    // take no further action this run; the next prompt sees settled state.
+    if ctx.pending_deactivations {
+        if let Some(Some(front)) = ctx.active.first() {
+            if inside(front) && !suppressed.contains(front) {
+                suppressed.push(front.clone());
+            }
+            auto_activated.retain(|path| path != front);
+        }
+        return AutoActivatePlan {
+            activate: Vec::new(),
+            deactivate_front: false,
+            abandoned: Vec::new(),
+            auto_activated,
+            suppressed,
+        };
+    }
+
+    // Auto-deactivate environments whose directory the shell has left,
+    // popping at most one layer per run (see the function docs).
+    let mut deactivate_front = false;
+    let mut abandoned = Vec::new();
+    let leavers: Vec<PathBuf> = auto_activated
+        .iter()
+        .filter(|path| !inside(path))
+        .cloned()
+        .collect();
+    if !leavers.is_empty() {
+        match ctx.active.first() {
+            Some(Some(front)) if leavers.contains(front) => {
+                deactivate_front = true;
+                auto_activated.retain(|path| path != front);
+                // Any remaining leavers unwind on subsequent prompts.
+            },
+            _ => {
+                abandoned = leavers;
+                auto_activated.retain(|path| inside(path));
+            },
+        }
+    }
+
+    // Activate discovered environments that aren't already active or
+    // suppressed, outermost-first so the innermost ends up on top. Defer
+    // while tracked environments the shell has left are still unwinding:
+    // activating now would stack the new environment on top of them, and a
+    // buried environment can't be popped (it would be abandoned instead).
+    let unwinding = auto_activated.iter().any(|path| !inside(path));
+    let mut activate = Vec::new();
+    if !unwinding {
+        for path in &ctx.discovered {
+            if is_active(path) || suppressed.contains(path) || activate.contains(path) {
+                continue;
+            }
+            activate.push(path.clone());
+            auto_activated.push(path.clone());
+        }
+    }
+
+    AutoActivatePlan {
+        activate,
+        deactivate_front,
+        abandoned,
+        auto_activated,
+        suppressed,
+    }
+}
+
+/// Gather the runtime inputs for [`plan_auto_activation`]: the shell's
+/// working directory, the environments discoverable from it, the activation
+/// stack, and the hook's tracked state variables.
+fn gather_auto_activate_context(pending_deactivations: bool) -> Result<AutoActivateContext> {
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+    let discovered = find_all_dot_flox(&cwd)
+        .context("failed to discover environments for auto-activation")?
+        .into_iter()
+        .filter_map(|dot_flox| dot_flox.path.parent().map(Path::to_path_buf))
+        .collect();
+    // `find_all_dot_flox` canonicalized the same starting path, so reuse its
+    // canonicalization rules for the containment checks.
+    let cwd = cwd
+        .canonicalize()
+        .context("failed to canonicalize current directory")?;
+    // Active environments are recorded into `_FLOX_ACTIVE_ENVIRONMENTS` from
+    // the opened `ConcreteEnvironment`, whose `.flox` path is a `CanonicalPath`
+    // (activation can't open an environment without canonicalizing it). So
+    // these paths are already canonical and comparable to `discovered` and the
+    // state variables without re-canonicalizing here.
+    let active = activated_environments()
+        .iter()
+        .map(|env| env.path().and_then(Path::parent).map(Path::to_path_buf))
+        .collect();
+    Ok(AutoActivateContext {
+        cwd,
+        discovered,
+        active,
+        auto_activated: read_path_list_var(FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR),
+        suppressed: read_path_list_var(FLOX_SUPPRESSED_ENVIRONMENTS_VAR),
+        pending_deactivations,
+    })
+}
+
+/// Read a JSON array of paths from an environment variable, treating an
+/// unset, empty, or unparseable value as empty so a corrupted state variable
+/// can't fail every shell prompt.
+fn read_path_list_var(var: &str) -> Vec<PathBuf> {
+    let Ok(value) = std::env::var(var) else {
+        return Vec::new();
+    };
+    if value.is_empty() {
+        return Vec::new();
+    }
+    match serde_json::from_str(&value) {
+        Ok(paths) => paths,
+        Err(err) => {
+            debug!(%err, var, "ignoring unparseable auto-activation state variable");
+            Vec::new()
+        },
+    }
+}
+
+/// Emit a command that activates the environment in `project_dir` in place.
+///
+/// The emitted command is itself evaluated by the shell's prompt hook, and
+/// runs `flox activate` with stdout captured — which selects in-place mode —
+/// so this reuses the full activation path (hooks, services, attach
+/// semantics) of `eval "$(flox activate)"`.
+fn write_activate_command(shell: Shell, project_dir: &Path, writer: &mut impl Write) -> Result<()> {
+    let flox_bin = std::env::current_exe().context("failed to determine flox executable path")?;
+    let flox_bin = flox_bin.to_string_lossy().to_string();
+    let escaped_bin = shell_escape::escape(Cow::Borrowed(&*flox_bin));
+    let dir = project_dir.to_string_lossy().to_string();
+    let escaped_dir = shell_escape::escape(Cow::Borrowed(&*dir));
+    match shell {
+        Shell::Bash | Shell::Zsh => {
+            writeln!(
+                writer,
+                r#"eval "$({escaped_bin} activate --dir {escaped_dir})";"#
+            )?;
+        },
+        Shell::Fish => {
+            writeln!(
+                writer,
+                "{escaped_bin} activate --dir {escaped_dir} | source;"
+            )?;
+        },
+        Shell::Tcsh => {
+            writeln!(
+                writer,
+                r#"eval "`{escaped_bin} activate --dir {escaped_dir}`";"#
+            )?;
+        },
+    }
+    Ok(())
+}
+
+/// Emit a state-variable update when `new` differs from `old`: an export of
+/// the JSON-encoded list, or an unset when the list becomes empty.
+fn write_path_list_update(
+    shell: Shell,
+    var: &str,
+    old: &[PathBuf],
+    new: &[PathBuf],
+    writer: &mut impl Write,
+) -> Result<()> {
+    if old == new {
+        return Ok(());
+    }
+    if new.is_empty() {
+        UnsetVar::new(var).generate_with_newline(shell, writer)?;
+        return Ok(());
+    }
+    let value = serde_json::to_string(new)
+        .with_context(|| format!("failed to serialize state variable {var}"))?;
+    SetVar::exported_no_expansion(var, value).generate_with_newline(shell, writer)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A context with nothing discovered, nothing active, and no state.
+    fn empty_ctx(cwd: &str) -> AutoActivateContext {
+        AutoActivateContext {
+            cwd: PathBuf::from(cwd),
+            discovered: Vec::new(),
+            active: Vec::new(),
+            auto_activated: Vec::new(),
+            suppressed: Vec::new(),
+            pending_deactivations: false,
+        }
+    }
+
+    fn paths(values: &[&str]) -> Vec<PathBuf> {
+        values.iter().map(PathBuf::from).collect()
+    }
+
+    fn noop_plan() -> AutoActivatePlan {
+        AutoActivatePlan {
+            activate: Vec::new(),
+            deactivate_front: false,
+            abandoned: Vec::new(),
+            auto_activated: Vec::new(),
+            suppressed: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn nothing_to_do_in_plain_directory() {
+        let ctx = empty_ctx("/home/user/plain");
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn activates_discovered_env() {
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/home/user/proj"]),
+            auto_activated: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn activates_stack_outermost_first() {
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            ..empty_ctx("/home/user/outer/inner")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            auto_activated: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn does_not_reactivate_active_env() {
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            auto_activated: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/proj/subdir")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            auto_activated: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn activates_missing_inner_env_on_top_of_active_outer() {
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            active: vec![Some(PathBuf::from("/home/user/outer"))],
+            auto_activated: paths(&["/home/user/outer"]),
+            ..empty_ctx("/home/user/outer/inner")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/home/user/outer/inner"]),
+            auto_activated: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn pops_front_env_after_leaving_its_directory() {
+        let ctx = AutoActivateContext {
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            auto_activated: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            deactivate_front: true,
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn pops_one_layer_per_run() {
+        let ctx = AutoActivateContext {
+            // Front of stack is the innermost env.
+            active: vec![
+                Some(PathBuf::from("/home/user/outer/inner")),
+                Some(PathBuf::from("/home/user/outer")),
+            ],
+            auto_activated: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            deactivate_front: true,
+            // The outer env unwinds on the next prompt.
+            auto_activated: paths(&["/home/user/outer"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn pops_and_activates_in_one_run_when_switching_projects() {
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj_b"]),
+            active: vec![Some(PathBuf::from("/home/user/proj_a"))],
+            auto_activated: paths(&["/home/user/proj_a"]),
+            ..empty_ctx("/home/user/proj_b")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/home/user/proj_b"]),
+            deactivate_front: true,
+            auto_activated: paths(&["/home/user/proj_b"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn defers_activation_while_stack_unwinds() {
+        // Leaving /tmp/a/b for /tmp/z: the front pops this run, but /tmp/a is
+        // still unwinding, so /tmp/z is not activated yet — activating it now
+        // would bury /tmp/a and force an abandon on a later run.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/tmp/z"]),
+            active: vec![
+                Some(PathBuf::from("/tmp/a/b")),
+                Some(PathBuf::from("/tmp/a")),
+            ],
+            auto_activated: paths(&["/tmp/a", "/tmp/a/b"]),
+            ..empty_ctx("/tmp/z")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            deactivate_front: true,
+            auto_activated: paths(&["/tmp/a"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn unwinds_fully_then_activates_in_final_run() {
+        // Continuation of defers_activation_while_stack_unwinds, with the
+        // previous plan applied by the shell: the next hook run pops the last
+        // unwinding layer and activates the new environment in the same run.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/tmp/z"]),
+            active: vec![Some(PathBuf::from("/tmp/a"))],
+            auto_activated: paths(&["/tmp/a"]),
+            ..empty_ctx("/tmp/z")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/tmp/z"]),
+            deactivate_front: true,
+            auto_activated: paths(&["/tmp/z"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn settled_state_is_a_noop() {
+        // A hook run with nothing to do (e.g. zsh fires the hook from both
+        // chpwd and precmd, so a second run often sees the first run's plan
+        // already applied) must plan no further changes.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/tmp/z"]),
+            active: vec![Some(PathBuf::from("/tmp/z"))],
+            auto_activated: paths(&["/tmp/z"]),
+            ..empty_ctx("/tmp/z")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            auto_activated: paths(&["/tmp/z"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn abandons_env_buried_under_manual_activation() {
+        let ctx = AutoActivateContext {
+            // A manually activated env (not tracked) sits on top of the
+            // auto-activated one the shell has left.
+            active: vec![
+                Some(PathBuf::from("/home/user/manual")),
+                Some(PathBuf::from("/home/user/proj")),
+            ],
+            auto_activated: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            abandoned: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn abandons_env_buried_under_remote_activation() {
+        let ctx = AutoActivateContext {
+            // `None` is a remote env (no local directory) sitting on top of
+            // the auto-activated one the shell has left.
+            active: vec![None, Some(PathBuf::from("/home/user/proj"))],
+            auto_activated: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            abandoned: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn pending_deactivation_suppresses_front_and_skips_activation() {
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            auto_activated: paths(&["/home/user/proj"]),
+            pending_deactivations: true,
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            suppressed: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn pending_deactivation_outside_directory_does_not_suppress() {
+        let ctx = AutoActivateContext {
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            auto_activated: paths(&["/home/user/proj"]),
+            pending_deactivations: true,
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn pending_deactivation_of_manual_activation_suppresses_reactivation() {
+        // The user manually activated the discovered env, then ran
+        // 'flox deactivate' while still inside the project directory. The
+        // next prompt must not auto-activate it again.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            pending_deactivations: true,
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            suppressed: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn suppressed_env_is_not_reactivated_while_inside() {
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            suppressed: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            suppressed: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn suppression_is_cleared_after_leaving_the_directory() {
+        let ctx = AutoActivateContext {
+            suppressed: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn tracked_env_that_is_no_longer_active_is_suppressed_while_inside() {
+        // The activation failed (or was deactivated out-of-band): tracked as
+        // auto-activated but absent from the stack. Suppress instead of
+        // retrying on every prompt.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            auto_activated: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            suppressed: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn tracked_env_that_is_no_longer_active_is_forgotten_after_leaving() {
+        let ctx = AutoActivateContext {
+            auto_activated: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn reentry_after_suppression_cleared_reactivates() {
+        // The suppression entry was pruned on a previous prompt (outside the
+        // directory); coming back in looks like a fresh discovery.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/home/user/proj"]),
+            auto_activated: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn manually_activated_env_is_not_popped_on_leave() {
+        // Active but never tracked as auto-activated: leaving its directory
+        // must not deactivate it.
+        let ctx = AutoActivateContext {
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn sibling_directory_is_not_inside() {
+        // Path containment must compare whole components: /home/user/proj2
+        // is not inside /home/user/proj.
+        let ctx = AutoActivateContext {
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            auto_activated: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/proj2")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            deactivate_front: true,
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn activate_command_is_shell_escaped() {
+        // A smoke test that the directory is passed through `shell_escape` and
+        // the `eval "$(...)"` wrapping stays intact; a space is the canonical
+        // needs-quoting case. The full range of shell-significant characters
+        // (`&`, `;`, `$`, quotes, globs, ...) is exercised by the
+        // `shell-escape` crate's own tests, not re-tested here.
+        let mut buf = Vec::new();
+        write_activate_command(Shell::Bash, Path::new("/home/user/my proj"), &mut buf).unwrap();
+        let script = String::from_utf8(buf).unwrap();
+        assert!(
+            script.contains("activate --dir '/home/user/my proj'"),
+            "{script}"
+        );
+        assert!(script.starts_with(r#"eval "$("#), "{script}");
+    }
+
+    #[test]
+    fn state_var_update_emitted_only_on_change() {
+        let unchanged = paths(&["/home/user/proj"]);
+        let mut buf = Vec::new();
+        write_path_list_update(
+            Shell::Bash,
+            FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR,
+            &unchanged,
+            &unchanged,
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "");
+
+        let mut buf = Vec::new();
+        write_path_list_update(
+            Shell::Bash,
+            FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR,
+            &[],
+            &unchanged,
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "export _FLOX_AUTO_ACTIVATED_ENVIRONMENTS='[\"/home/user/proj\"]';\n"
+        );
+
+        let mut buf = Vec::new();
+        write_path_list_update(
+            Shell::Bash,
+            FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR,
+            &unchanged,
+            &[],
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "unset _FLOX_AUTO_ACTIVATED_ENVIRONMENTS;\n"
+        );
     }
 }

--- a/cli/tests/activate/hook-cd.exp
+++ b/cli/tests/activate/hook-cd.exp
@@ -1,0 +1,32 @@
+# Activate a project environment using --dir, then cd to a second directory
+# and verify the prompt hook fires (auto-activating any environment there)
+# before the next prompt.
+
+set dir [lindex $argv 0]
+set target [lindex $argv 1]
+set command [lindex $argv 2]
+set flox $env(FLOX_BIN)
+# Auto-activation may lock and build an environment on first use.
+set timeout 30
+set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
+
+spawn $flox activate --dir $dir
+expect_after {
+  timeout { exit 1 }
+  eof { exit 2 }
+  "*\n" { exp_continue }
+  "*\r" { exp_continue }
+}
+
+expect "You are now using the environment"
+expect $env(KNOWN_PROMPT)
+
+send "cd $target\n"
+# The prompt hook runs before this prompt is drawn, so by the time we see it
+# any auto-activation has been applied.
+expect $env(KNOWN_PROMPT)
+
+send "$command && exit\n"
+expect eof

--- a/cli/tests/deactivate.bats
+++ b/cli/tests/deactivate.bats
@@ -543,9 +543,15 @@ FLOX_COLD_START_UNSET=(
   # as spurious env-diff records.
   -u _FLOX_PROMPT_HOOK_VERSION
   -u _FLOX_INVOCATION_TYPE
-  # A leaked auto-activate flag makes the prompt hook set _FLOX_HOOK_FIRED
-  # inside interactive test sessions, which also surfaces in the env diff.
+  # A leaked auto-activate flag makes the prompt hook auto-activate inside
+  # interactive test sessions, which also surfaces in the env diff.
   -u FLOX_FEATURES_AUTO_ACTIVATE
+  # State vars maintained by the prompt hook in any outer shell that
+  # activated with auto-activate enabled (e.g. a developer's own terminal).
+  # _FLOX_HOOK_FIRED is only set by older flox versions but can still leak
+  # from an outer shell running one.
+  -u _FLOX_AUTO_ACTIVATED_ENVIRONMENTS
+  -u _FLOX_SUPPRESSED_ENVIRONMENTS
   -u _FLOX_HOOK_FIRED
 )
 
@@ -861,7 +867,6 @@ EOF
   if [[ "$OSTYPE" == darwin* ]]; then
     assert_output - <<EOF
 FLOX_ORIG_HOME
-FLOX_SAVE_TCSH_PROMPT
 FLOX_TCSH_INIT_SCRIPT
 GROUP
 HOST
@@ -878,7 +883,6 @@ EOF
   else
     assert_output - <<EOF
 FLOX_ORIG_HOME
-FLOX_SAVE_TCSH_PROMPT
 FLOX_TCSH_INIT_SCRIPT
 GROUP
 HOST
@@ -1055,11 +1059,11 @@ EOF
 
   output=$(diff_env_dumps "$BEFORE" "$AFTER"); status=$?
   assert_success
-  # FLOX_SAVE_TCSH_PROMPT is a macOS-only tcsh interactive leak.
+  # macOS and Linux differ only in the SSL cert var (SSL_CERT_FILE vs
+  # SSL_CERT_DIR).
   if [[ "$OSTYPE" == darwin* ]]; then
     assert_output - <<EOF
 FLOX_ORIG_HOME
-FLOX_SAVE_TCSH_PROMPT
 FLOX_TCSH_INIT_SCRIPT
 GROUP
 HOST
@@ -1079,7 +1083,6 @@ EOF
   else
     assert_output - <<EOF
 FLOX_ORIG_HOME
-FLOX_SAVE_TCSH_PROMPT
 FLOX_TCSH_INIT_SCRIPT
 GROUP
 HOST

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -27,6 +27,39 @@ project_teardown() {
   unset PROJECT_DIR
 }
 
+# Set a `[vars]` manifest for the project at $1 defining $2 = "$3".
+set_vars_manifest() {
+  cat << EOF | "$FLOX_BIN" edit -d "$1" -f -
+version = 1
+
+[vars]
+$2 = "$3"
+EOF
+}
+
+# A second project with an observable var, as a target for auto-activation.
+project2_setup() {
+  export PROJECT2_DIR="${BATS_TEST_TMPDIR?}/project2-${BATS_TEST_NUMBER?}"
+  rm -rf "$PROJECT2_DIR"
+  mkdir -p "$PROJECT2_DIR"
+  "$FLOX_BIN" init -d "$PROJECT2_DIR"
+  set_vars_manifest "$PROJECT2_DIR" TEST_VAR2 auto2
+}
+
+project2_teardown() {
+  rm -rf "${PROJECT2_DIR?}"
+  unset PROJECT2_DIR
+}
+
+# A project nested inside PROJECT2_DIR, for stacked auto-activation.
+# Cleaned up by project2_teardown.
+project3_setup() {
+  export PROJECT3_DIR="${PROJECT2_DIR?}/nested"
+  mkdir -p "$PROJECT3_DIR"
+  "$FLOX_BIN" init -d "$PROJECT3_DIR"
+  set_vars_manifest "$PROJECT3_DIR" TEST_VAR3 auto3
+}
+
 setup() {
   common_test_setup
   setup_isolated_flox
@@ -34,6 +67,9 @@ setup() {
 }
 
 teardown() {
+  if [ -n "${PROJECT2_DIR:-}" ]; then
+    project2_teardown
+  fi
   if [ -n "${PROJECT_DIR:-}" ]; then
     project_teardown
   fi
@@ -45,14 +81,16 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 # Deactivate-action handling in hook-env is not gated, but the auto-activation
-# placeholder (_FLOX_HOOK_FIRED) still is.
+# logic still is: without the flag the hook emits nothing, even with a
+# discoverable environment in the working directory.
 # TODO: Remove this test when the auto_activate feature flag is removed.
 # bats test_tags=hook:hook-env
 @test "'flox hook-env' succeeds without auto_activate feature flag but doesn't auto-activate" {
+  project_setup
   unset FLOX_FEATURES_AUTO_ACTIVATE
-  run "$FLOX_BIN" hook-env --shell bash --shell-pid "$$" --invocation-type inplace
+  run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$" --invocation-type inplace
   assert_success
-  refute_output --partial "_FLOX_HOOK_FIRED"
+  assert_output ""
 }
 
 # ---------------------------------------------------------------------------- #
@@ -129,72 +167,235 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 }
 
 # ---------------------------------------------------------------------------- #
-# Hook fires: verify _FLOX_HOOK_FIRED is set per shell
+# Auto-activation: cd into a project activates its environment
 # ---------------------------------------------------------------------------- #
-
+#
+# Each test activates PROJECT_DIR to install the prompt hook, then cd's into
+# a second project and fires the hook manually to stand in for the next
+# prompt. The hook should activate the second project's environment in place.
+#
 # Each test has the shell call `flox activate` directly (not pre-captured in
 # a bats variable) to avoid quoting issues across shells.
 
-# bats test_tags=hook:fires:bash
-@test "bash: hook fires and sets _FLOX_HOOK_FIRED to cwd" {
+# bats test_tags=hook:auto-activate:bash
+@test "bash: hook auto-activates a discovered environment on cd" {
   project_setup
+  project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
 
-  run bash -c "
+  run --separate-stderr bash -c "
     export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
     _flox_hook
-    printenv _FLOX_HOOK_FIRED
+    echo \"var2:\$TEST_VAR2\"
+    printenv _FLOX_AUTO_ACTIVATED_ENVIRONMENTS
   "
   assert_success
-  assert_output --partial "$PWD"
+  assert_output --partial "var2:auto2"
+  assert_output --partial "$(realpath "$PROJECT2_DIR")"
 }
 
-# bats test_tags=hook:fires:zsh
-@test "zsh: hook fires and sets _FLOX_HOOK_FIRED to cwd" {
+# bats test_tags=hook:auto-activate:zsh
+@test "zsh: hook auto-activates a discovered environment on cd" {
   project_setup
+  project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
 
-  run zsh -c "
+  run --separate-stderr zsh -c "
     export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which zsh)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
     _flox_hook
-    printenv _FLOX_HOOK_FIRED
+    echo \"var2:\$TEST_VAR2\"
+    printenv _FLOX_AUTO_ACTIVATED_ENVIRONMENTS
   "
   assert_success
-  assert_output --partial "$PWD"
+  assert_output --partial "var2:auto2"
+  assert_output --partial "$(realpath "$PROJECT2_DIR")"
 }
 
-# bats test_tags=hook:fires:fish
-@test "fish: hook fires and sets _FLOX_HOOK_FIRED to cwd" {
+# bats test_tags=hook:auto-activate:fish
+@test "fish: hook auto-activates a discovered environment on cd" {
   project_setup
+  project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
 
-  run fish -c "
+  run --separate-stderr fish -c "
     set -gx FLOX_FEATURES_AUTO_ACTIVATE true
     eval ($FLOX_BIN activate -d $PROJECT_DIR)
+    cd $PROJECT2_DIR
     _flox_hook
-    printenv _FLOX_HOOK_FIRED
+    echo \"var2:\$TEST_VAR2\"
+    printenv _FLOX_AUTO_ACTIVATED_ENVIRONMENTS
   "
   assert_success
-  assert_output --partial "$PWD"
+  assert_output --partial "var2:auto2"
+  assert_output --partial "$(realpath "$PROJECT2_DIR")"
 }
 
-# bats test_tags=hook:fires:tcsh
-@test "tcsh: hook fires and sets _FLOX_HOOK_FIRED to cwd" {
+# bats test_tags=hook:auto-activate:tcsh
+@test "tcsh: hook auto-activates a discovered environment on cd" {
   project_setup
+  project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
 
-  run tcsh -c "
+  run --separate-stderr tcsh -c "
     setenv FLOX_FEATURES_AUTO_ACTIVATE true
     eval \"\`$FLOX_BIN activate -d $PROJECT_DIR\`\"
+    cd $PROJECT2_DIR
     precmd
-    printenv _FLOX_HOOK_FIRED
+    echo \"var2:\$TEST_VAR2\"
+    printenv _FLOX_AUTO_ACTIVATED_ENVIRONMENTS
   "
   assert_success
-  assert_output --partial "$PWD"
+  assert_output --partial "var2:auto2"
+  assert_output --partial "$(realpath "$PROJECT2_DIR")"
+}
+
+# ---------------------------------------------------------------------------- #
+# Auto-deactivation: leaving the project directory deactivates the environment
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=hook:auto-deactivate:bash
+@test "bash: auto-activated environment deactivates after leaving its directory" {
+  project_setup
+  project2_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"during:\$TEST_VAR2\"
+    cd $BATS_TEST_TMPDIR
+    _flox_hook
+    echo \"after:\${TEST_VAR2:-unset}\"
+    echo \"tracked:\${_FLOX_AUTO_ACTIVATED_ENVIRONMENTS:-unset}\"
+  "
+  assert_success
+  assert_output --partial "during:auto2"
+  assert_output --partial "after:unset"
+  assert_output --partial "tracked:unset"
+}
+
+# bats test_tags=hook:auto-deactivate:manual
+@test "bash: manually activated environment is not deactivated on leaving" {
+  project_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  set_vars_manifest "$PROJECT_DIR" TEST_VAR manual
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $BATS_TEST_TMPDIR
+    _flox_hook
+    echo \"after:\${TEST_VAR:-unset}\"
+  "
+  assert_success
+  assert_output --partial "after:manual"
+}
+
+# bats test_tags=hook:auto-activate:reentry
+@test "bash: re-entering a project after leaving re-activates it" {
+  project_setup
+  project2_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    cd $BATS_TEST_TMPDIR
+    _flox_hook
+    echo \"out:\${TEST_VAR2:-unset}\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"back:\$TEST_VAR2\"
+  "
+  assert_success
+  assert_output --partial "out:unset"
+  assert_output --partial "back:auto2"
+}
+
+# ---------------------------------------------------------------------------- #
+# Stacked auto-activation: nested projects activate outermost-first and
+# unwind one layer per prompt
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=hook:auto-activate:nested
+@test "bash: nested projects activate as a stack and unwind one layer per prompt" {
+  project_setup
+  project2_setup
+  project3_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT3_DIR
+    _flox_hook
+    echo \"in: v2:\$TEST_VAR2 v3:\$TEST_VAR3\"
+    cd $BATS_TEST_TMPDIR
+    _flox_hook
+    echo \"one: v2:\${TEST_VAR2:-unset} v3:\${TEST_VAR3:-unset}\"
+    _flox_hook
+    echo \"two: v2:\${TEST_VAR2:-unset} v3:\${TEST_VAR3:-unset}\"
+  "
+  assert_success
+  assert_output --partial "in: v2:auto2 v3:auto3"
+  # One layer pops per prompt: the inner (most recent) env first.
+  assert_output --partial "one: v2:auto2 v3:unset"
+  assert_output --partial "two: v2:unset v3:unset"
+}
+
+# ---------------------------------------------------------------------------- #
+# Suppression: 'flox deactivate' inside the project must not be undone by
+# the next prompt
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=hook:suppress:bash
+@test "bash: 'flox deactivate' suppresses re-activation until the directory is left" {
+  project_setup
+  project2_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"during:\$TEST_VAR2\"
+    $FLOX_BIN deactivate
+    _flox_hook
+    echo \"after:\${TEST_VAR2:-unset}\"
+    _flox_hook
+    echo \"still:\${TEST_VAR2:-unset}\"
+    printenv _FLOX_SUPPRESSED_ENVIRONMENTS
+    cd $BATS_TEST_TMPDIR
+    _flox_hook
+    echo \"left:\${_FLOX_SUPPRESSED_ENVIRONMENTS:-unset}\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"back:\$TEST_VAR2\"
+  "
+  assert_success
+  assert_output --partial "during:auto2"
+  assert_output --partial "after:unset"
+  assert_output --partial "still:unset"
+  assert_output --partial "$(realpath "$PROJECT2_DIR")"
+  # Leaving the directory revokes the suppression; re-entering re-activates.
+  assert_output --partial "left:unset"
+  assert_output --partial "back:auto2"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -202,8 +403,9 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=hook:auto-fires
-@test "bash: hook auto-fires via PROMPT_COMMAND in interactive shell" {
+@test "bash: hook auto-activates via PROMPT_COMMAND in interactive shell" {
   project_setup
+  project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
 
   # Set up a .bashrc so the interactive shell has a known prompt
@@ -215,15 +417,8 @@ EOF
 set enable-bracketed-paste off
 EOF
 
-  mkdir -p "$PROJECT_DIR/subdir"
-
-  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/activate-command.exp" "$PROJECT_DIR" 'echo _FLOX_HOOK_FIRED="$_FLOX_HOOK_FIRED" && pushd subdir >/dev/null && echo _FLOX_HOOK_FIRED="$_FLOX_HOOK_FIRED" && popd >/dev/null && echo _FLOX_HOOK_FIRED="$_FLOX_HOOK_FIRED"'
-  # All three echos should show the project dir — the hook fired before the
-  # compound command and the value doesn't change mid-pipeline.
-  local expected="_FLOX_HOOK_FIRED=$(realpath "$PROJECT_DIR")"
-  local count
-  count=$(sed 's/^[[:space:]]*//;s/[[:space:]]*$//' <<< "$output" | grep -cFx "$expected")
-  assert_equal "$count" "3"
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/hook-cd.exp" "$PROJECT_DIR" "$PROJECT2_DIR" 'echo TEST_VAR2="$TEST_VAR2"'
+  assert_output --partial 'TEST_VAR2=auto2'
 }
 
 # ---------------------------------------------------------------------------- #
@@ -235,12 +430,7 @@ EOF
 # place. We fire `_flox_hook` manually to stand in for the next prompt.
 
 set_test_var_manifest() {
-  cat << "EOF" | "$FLOX_BIN" edit -f -
-version = 1
-
-[vars]
-TEST_VAR = "modified"
-EOF
+  set_vars_manifest "$PROJECT_DIR" TEST_VAR modified
 }
 
 # bats test_tags=hook:deactivate:bash


### PR DESCRIPTION
Proof of concept for auto-activation via the shell prompt hook ([DEV-119](https://linear.app/floxdotdev/issue/DEV-119/auto-activate-poc), parent [DEV-85](https://linear.app/floxdotdev/issue/DEV-85/add-auto-activation-hook-to-our-prompt-hook)). Everything is behind the `auto_activate` feature flag.

Replaces the placeholder `_FLOX_HOOK_FIRED` logic in `flox hook-env` with a working auto-activation loop. With the feature flag set and the prompt hook installed (any `eval "$(flox activate)"`), the shell now:

- **activates** environments discovered in the working directory's ancestor chain when you `cd` in (outermost-first, as a stack),
- **deactivates** auto-activated environments when you `cd` out, and
- **suppresses** re-activation after `flox deactivate` until you leave and re-enter the directory.

## How it works

On every prompt / directory change, `hook-env`:

1. Consumes pending prompt-hook actions (plain `flox deactivate`) and emits the corresponding deactivation script, as before.
2. Gathers runtime state: cwd, discovered `.flox` dirs (new `find_all_dot_flox()`), the active stack (`_FLOX_ACTIVE_ENVIRONMENTS`), and two new state variables it maintains itself.
3. Feeds all of that into a pure decision function, `plan_auto_activation()`, and renders the resulting plan as shell code: deactivation scripts, `eval "$(flox activate --dir <DIR>)"` lines (reusing the full in-place activation path), and state-variable updates.

## Approach taken for each DEV-85 TODO

**TODO: decide how to store suppressed environments.**
A new exported shell variable, `_FLOX_SUPPRESSED_ENVIRONMENTS` (JSON array of project dirs), maintained by the script `hook-env` emits. An entry is added when an environment is deactivated while the shell is still inside its directory — either by servicing a pending `flox deactivate` action, or by reconciliation when a tracked auto-activation is no longer in the active stack (which also stops a persistently failing activation from retrying on every prompt). Entries are pruned once the shell leaves the directory, so re-entry auto-activates again. Shell variables were chosen over PID-keyed runtime files because subshells inherit `_FLOX_ACTIVE_ENVIRONMENTS`; state stored by PID would diverge from the inherited stack, while inherited variables stay consistent with it.

**TODO: decide how to store which environments were auto-activated (and need deactivation on leaving).**
Same mechanism: `_FLOX_AUTO_ACTIVATED_ENVIRONMENTS`, a JSON array of project dirs the hook activated in this shell, outermost-first. On each prompt, any tracked entry whose directory no longer contains cwd is deactivated. Manually activated environments are never tracked, so they are never auto-deactivated.

**TODO: how do we handle changes to intermediate environments?**
Deferred, as the issue suggests, with a warning. Two consequences in this PoC:

- An auto-activated environment buried under another activation (e.g. a manual `flox activate` layered on top) is not torn down from the middle of the stack when you leave its directory. It is dropped from tracking with a warning telling the user to run `flox deactivate`.
- At most **one** stack layer is deactivated per prompt. The deactivation script restores the next layer's `_FLOX_HOOK_DIFF` only once the shell has applied it, so `hook-env` (which reads the diff from its own process environment) can only generate a correct script for the front of the stack. Deeper stacks unwind across consecutive prompts; an integration test pins this behavior. Full multi-pop in one prompt would need DEV-111. Detecting that an environment is out of date with manifest changes is not attempted at all yet.

**Other DEV-85 checklist items touched here:**

- *Discovery (1a):* new `find_all_dot_flox()` walks from cwd to the filesystem root. Unlike `find_dot_flox` it does not stop at git boundaries, and it skips unparseable `.flox` dirs with a debug log so one broken environment can't break every prompt.
- *Config (1b):* deliberately **not** consulted in this PoC — `flox activate allow`/`deny` and `auto_activate = "prompt"` have no effect yet. That's DEV-120.
- *Pending deactivations (1f) and merging into one action list (1g):* pending actions are serviced first and short-circuit the rest of the plan for that prompt (the next prompt sees settled state); otherwise the plan merges reconciliation, leave-deactivation, and activation into one ordered emission.
- *Unit testing (1h):* `plan_auto_activation()` is pure — suppressed environments, previously auto-activated environments, the active stack, and pending deactivations are all function arguments — with a thin wrapper injecting runtime values. 22 unit tests cover the decision logic; `hook.bats` covers the end-to-end loop (activation on cd for all four shells, leave-deactivation, re-entry, nested stack unwind, suppression, and an interactive PROMPT_COMMAND session via expect).
- *Factoring out activation emission (2) / emitting code per action (3):* activation lines are emitted by a small `write_activate_command()` per shell; deactivation reuses the existing `emit_deactivate_script()`.
- *direnv interaction (4):* not assessed yet.

## Known gaps (intentional for the PoC)

- `eval "$(flox deactivate --print-script)"` bypasses `hook-env`, so it does not trigger suppression; only plain `flox deactivate` does.
- If both an outer and inner environment are discovered but only the outer is missing, it activates on top of the inner rather than beneath it (stack-order repair is part of the deferred intermediate-environment work).
- No manifest-change detection, no config handling, no performance work (`find_all_dot_flox` stats the ancestor chain every prompt; DEV-90).
- `hook-env` now records a metric only when it actually does something, resolving the inline TODO about metric noise on every prompt.

The second commit fixes a test-harness issue this work surfaced: when the test suite runs from a terminal that itself activated an environment with auto-activate enabled, exported hook variables leak into the cold-start env-diff snapshots in `deactivate.bats` and fail them. They are now unset by `flox_cold_start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
