### PR TITLE
feat(managed-env): instant rollback — no rebuild when generation link exists (2/3)

### DIFF
--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -705,7 +705,18 @@ impl GenerationsExt for ManagedEnvironment {
         // update the rendered environment
         self.lock_pointer()?;
         self.reset_local_env_to_current_generation(flox)?;
-        self.build(flox)?;
+
+        // Instant rollback: if this generation's GC-root link already exists on
+        // this host, its build already ran here — flip the activation pointer
+        // to it with no `nix build`. Otherwise build it (e.g. the first switch
+        // to this generation on this host) — `build` targets the current
+        // generation, which is now `generation`.
+        let generation_link = self.rendered_env_links.generation_link(generation);
+        if generation_link.exists() {
+            self.flip_to_generation(&generation_link)?;
+        } else {
+            self.build(flox)?;
+        }
 
         Ok(())
     }
@@ -734,19 +745,6 @@ impl GenerationsExt for ManagedEnvironment {
         flox: &Flox,
         generation: GenerationId,
     ) -> Result<RenderedEnvironmentLinks, EnvironmentError> {
-        let mut generations = self.generations();
-        let generation_rw = generations
-            .writable(
-                &flox.temp_dir,
-                &flox.system_user_name,
-                &flox.system_hostname,
-                &flox.argv,
-            )
-            .map_err(ManagedEnvironmentError::Generations)?;
-
-        let mut core_environment =
-            generation_rw.get_generation(*generation, self.include_fetcher.clone());
-
         let run_dir = &self.path.join(GCROOTS_DIR_NAME);
         if !run_dir.exists() {
             std::fs::create_dir_all(run_dir).map_err(ManagedEnvironmentError::CreateLinksDir)?;
@@ -754,10 +752,9 @@ impl GenerationsExt for ManagedEnvironment {
 
         let base_dir = CanonicalPath::new(run_dir).expect("run dir is checked to exist");
 
-        // Activating a specific generation builds (if necessary) and resolves
-        // directly to that generation's GC-root link, without flipping the
-        // current pointer — `--generation N` must not change which generation
-        // is current.
+        // Activating a specific generation resolves directly to that
+        // generation's GC-root link, without flipping the current pointer —
+        // `--generation N` must not change which generation is current.
         let generation_link = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
             &base_dir,
             self.name().as_ref(),
@@ -765,7 +762,25 @@ impl GenerationsExt for ManagedEnvironment {
         )
         .generation_link(generation);
 
-        core_environment.build(flox, Some(generation_link.out_link_prefix()))?;
+        // Instant activation: build only if this generation's GC-root link is
+        // not already present on this host. The link is immutable once built,
+        // so its presence means the build already ran here (flox#4332).
+        if !generation_link.exists() {
+            let mut generations = self.generations();
+            let generation_rw = generations
+                .writable(
+                    &flox.temp_dir,
+                    &flox.system_user_name,
+                    &flox.system_hostname,
+                    &flox.argv,
+                )
+                .map_err(ManagedEnvironmentError::Generations)?;
+
+            let mut core_environment =
+                generation_rw.get_generation(*generation, self.include_fetcher.clone());
+
+            core_environment.build(flox, Some(generation_link.out_link_prefix()))?;
+        }
 
         Ok(generation_link.activation_links())
     }
@@ -2629,6 +2644,64 @@ mod test {
             std::fs::read_link(pointer_dev).unwrap(),
             Path::new(generation_dev.file_name().unwrap()),
             "activation pointer should redirect to the generation GC-root link"
+        );
+    }
+
+    /// Rolling back to a generation whose GC-root link already exists retains
+    /// that link and flips the activation pointer to it (instant rollback;
+    /// flox#4332 F2).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rollback_retains_and_flips_to_prior_generation_link() {
+        let owner = "owner".parse().unwrap();
+        let (mut flox, temp_dir) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        flox.catalog_client =
+            catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
+
+        let mut env = mock_managed_environment_in(&flox, "version = 1", owner, &temp_dir, None);
+
+        // Build generation 1 so its GC-root link exists on this host.
+        env.build(&flox).unwrap();
+        let gen1 = env
+            .rendered_env_links
+            .generation_link(GenerationId::from(1usize));
+        assert!(gen1.exists(), "generation 1 link built");
+
+        // Install -> generation 2; generation 1's link must be retained.
+        let packages = [PackageToInstall::Catalog(
+            CatalogPackage::from_str("hello").unwrap(),
+        )];
+        env.install(&packages, &flox).unwrap();
+        assert_eq!(
+            env.generations_metadata().unwrap().current_gen().as_deref(),
+            Some(&2),
+            "install creates generation 2"
+        );
+        assert!(
+            gen1.exists(),
+            "prior generation's GC-root link retained after mutation"
+        );
+
+        // Roll back to generation 1: the pointer flips to its retained link.
+        env.switch_generation(&flox, GenerationId::from(1usize))
+            .unwrap();
+        assert_eq!(
+            env.generations_metadata().unwrap().current_gen().as_deref(),
+            Some(&1),
+            "rolled back to generation 1"
+        );
+        let expected_target = format!(
+            "{}-dev",
+            gen1.out_link_prefix()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+        );
+        assert_eq!(
+            std::fs::read_link(env.rendered_env_links.dev.as_path()).unwrap(),
+            Path::new(&expected_target),
+            "activation pointer flipped to generation 1's GC-root link"
         );
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -517,13 +517,22 @@ impl GenerationLink {
         RenderedEnvironmentLinks::new_unchecked(self.out_link_prefix.clone())
     }
 
-    /// Whether this generation's GC-root links already exist on this host.
+    /// Whether this generation's GC-root links are present on this host and
+    /// resolve to their built store paths.
     ///
     /// When they do, the `nix build` for this generation has already run here,
     /// so switching to or activating it is a pointer flip with no build —
     /// instant rollback (flox#4332).
+    ///
+    /// Both the dev and run links must be symlinks that resolve: a **dangling**
+    /// GC-root link (its store path removed out-of-band, or the link present on
+    /// a host that lacks the store path) does not count, so callers rebuild
+    /// rather than activate a broken environment. The links are only ever
+    /// written by `nix build --out-link`, so a resolving link is a store path.
     pub fn exists(&self) -> bool {
-        self.dev.as_path().is_symlink() && self.run.as_path().is_symlink()
+        [self.dev.as_path(), self.run.as_path()]
+            .into_iter()
+            .all(|link| link.is_symlink() && link.exists())
     }
 }
 
@@ -1606,10 +1615,11 @@ mod test {
     }
 
     /// `GenerationLink::exists` is true only once both the dev and run GC-root
-    /// links are present — the signal that a generation's build already ran
-    /// here and a switch to it needs no rebuild.
+    /// links are present and resolve — the signal that a generation's build
+    /// already ran here and a switch to it needs no rebuild. A dangling link
+    /// (store path gone) must not count.
     #[test]
-    fn generation_link_exists_requires_both_dev_and_run() {
+    fn generation_link_exists_requires_both_links_to_resolve() {
         let dir = tempfile::tempdir().unwrap();
         let base = CanonicalPath::new(dir.path()).unwrap();
         let system: System = "x86_64-linux".to_string();
@@ -1627,7 +1637,15 @@ mod test {
         assert!(!generation.exists(), "only the dev link is present");
 
         std::os::unix::fs::symlink(&store, generation.run.as_path()).unwrap();
-        assert!(generation.exists(), "both links present");
+        assert!(generation.exists(), "both links present and resolve");
+
+        // Remove the store path out-of-band: the links now dangle, so the
+        // generation must be treated as not built (callers rebuild).
+        std::fs::remove_file(&store).unwrap();
+        assert!(
+            !generation.exists(),
+            "dangling links must not count as built"
+        );
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -516,6 +516,15 @@ impl GenerationLink {
     pub fn activation_links(&self) -> RenderedEnvironmentLinks {
         RenderedEnvironmentLinks::new_unchecked(self.out_link_prefix.clone())
     }
+
+    /// Whether this generation's GC-root links already exist on this host.
+    ///
+    /// When they do, the `nix build` for this generation has already run here,
+    /// so switching to or activating it is a pointer flip with no build —
+    /// instant rollback (flox#4332).
+    pub fn exists(&self) -> bool {
+        self.dev.as_path().is_symlink() && self.run.as_path().is_symlink()
+    }
 }
 
 /// A pointer to an environment, either managed or path.
@@ -1594,6 +1603,31 @@ mod test {
         // Flipping again over existing pointers succeeds (atomic replace).
         pointer.flip_to(&generation).unwrap();
         assert!(pointer.dev.as_path().is_symlink());
+    }
+
+    /// `GenerationLink::exists` is true only once both the dev and run GC-root
+    /// links are present — the signal that a generation's build already ran
+    /// here and a switch to it needs no rebuild.
+    #[test]
+    fn generation_link_exists_requires_both_dev_and_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = CanonicalPath::new(dir.path()).unwrap();
+        let system: System = "x86_64-linux".to_string();
+
+        let pointer = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &base, "default", &system,
+        );
+        let generation = pointer.generation_link(GenerationId::from(1usize));
+
+        assert!(!generation.exists(), "no links yet");
+
+        let store = dir.path().join("store");
+        std::fs::write(&store, "").unwrap();
+        std::os::unix::fs::symlink(&store, generation.dev.as_path()).unwrap();
+        assert!(!generation.exists(), "only the dev link is present");
+
+        std::os::unix::fs::symlink(&store, generation.run.as_path()).unwrap();
+        assert!(generation.exists(), "both links present");
     }
 }
 

--- a/cli/tests/generations.bats
+++ b/cli/tests/generations.bats
@@ -83,6 +83,18 @@ teardown() {
   assert_line "Command:    flox generations switch 1"
 }
 
+# Instant rollback (flox#4332): switching to a generation whose GC-root link
+# was already built on this host is a pointer flip with no 'nix build'.
+@test "generations switch: rollback to a built generation needs no nix build" {
+  create_environment_with_generations
+
+  # Current generation is 3; generation 2 was built and its GC-root link is
+  # retained. _FLOX_TESTING_NO_BUILD makes any build attempt fail, so success
+  # here proves the switch flipped the pointer without rebuilding.
+  run env _FLOX_TESTING_NO_BUILD=true "$FLOX_BIN" generations switch 2
+  assert_success
+}
+
 @test "activate --generation: works with managed and remote envs" {
   create_environment_with_generations
 


### PR DESCRIPTION
## Summary

Second of three PRs for the two-level GC-root model (flox#4332). Delivers **instant rollback**: switching to or activating a generation whose GC-root link already exists on this host is a pointer flip with **no `nix build`** and no refetch.

> **Stacked on #4361 (1/3).** Base is `managed-env-two-level-gc-roots`; will retarget to `main` once #4361 merges. Review #4361 first.

Generation GC-root links (`<sys>.<name>-N-link-{dev,run}`) are immutable once built, so their presence is a sufficient signal that the build already ran here.

## Changes

- `GenerationLink::exists()` — both dev and run GC-root links present.
- `switch_generation` (`flox generations rollback` / `switch`) — flips the activation pointer to the target generation's link when it exists; builds only otherwise (first switch to it on this host).
- `rendered_env_links_for_generation` (`flox activate --generation N`) — skips the build *and* the floxmeta checkout when the link is already present, resolving directly to it.

## Follow-up

- F3 — GC-root aging policy (`last_live` in floxmeta + opportunistic cleanup). Until F3 lands, generation links accumulate in `.flox/run/`.

## Release Notes

Rolling back to a previously-built generation of a managed environment (`flox generations rollback` / `flox generations switch`) is now instant — it reuses the retained GC-root link with no rebuild or network access, on any host where that generation was previously built.

## Test plan

- [x] Unit: `GenerationLink::exists()`; rollback retains and flips to the prior generation's link
- [x] `generations.bats`: a rollback to a built generation performs no `nix build` (verified under `_FLOX_TESTING_NO_BUILD`)
- [x] clippy clean; managed + generations unit suites pass