### PR TITLE
build: update cli rust toolchain to 1.96.0

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -539,7 +539,7 @@ impl ClientSideCatalogStoreConfig {
             );
             let output_nar_infos =
                 Self::get_nar_info(source_url, &output.store_path, auth_netrc_path)?;
-            nar_infos.extend(output_nar_infos.0.into_iter());
+            nar_infos.extend(output_nar_infos.0);
         }
         Ok(nar_infos.into())
     }

--- a/cli/flox-test-utils/src/proptest.rs
+++ b/cli/flox-test-utils/src/proptest.rs
@@ -198,16 +198,16 @@ pub fn btree_maps_overlapping_keys<T: Arbitrary>(
             )| {
                 let mut map1 = BTreeMap::new();
                 let mut map2 = BTreeMap::new();
-                for (k, v) in keys_map1.clone().into_iter().zip(vals_map1.into_iter()) {
+                for (k, v) in keys_map1.clone().into_iter().zip(vals_map1) {
                     map1.insert(k, v);
                 }
-                for (k, v) in keys_dup.clone().into_iter().zip(vals_dup_map1.into_iter()) {
+                for (k, v) in keys_dup.clone().into_iter().zip(vals_dup_map1) {
                     map1.insert(k, v);
                 }
-                for (k, v) in keys_map2.clone().into_iter().zip(vals_map2.into_iter()) {
+                for (k, v) in keys_map2.clone().into_iter().zip(vals_map2) {
                     map2.insert(k, v);
                 }
-                for (k, v) in keys_dup.clone().into_iter().zip(vals_dup_map2.into_iter()) {
+                for (k, v) in keys_dup.clone().into_iter().zip(vals_dup_map2) {
                     map2.insert(k, v);
                 }
                 OverlappingMaps {

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1774857716,
-        "narHash": "sha256-z05BKQ6F9/6H2/ecIYEXuq54JCUEiOpdYXTQIijB/wM=",
+        "lastModified": 1780999471,
+        "narHash": "sha256-rY4yNlSzDY3OoYBdgjwlpVKWY/oUeOb65709i/tJbns=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "9ad9c53e902485e006c07ae54a7dd4ad55a8c4d8",
+        "rev": "db976d430cbb6b0d6b300b4e22cbb28462841af2",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774787924,
-        "narHash": "sha256-Cbpmf0+1pqi/zbpub2vkp5lTPx3QdVtDkkagDwQzHHg=",
+        "lastModified": 1780924205,
+        "narHash": "sha256-5s6nPSNU1Mo/Qy90XxCTNj6/rB70zgX8VqleTdLoESA=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "f1297b21119565c626320c1ffc248965fffb2527",
+        "rev": "4fde9dd9822df453dc6f20149b8e375efbbe66c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'fenix':
    'github:nix-community/fenix/9ad9c53e902485e006c07ae54a7dd4ad55a8c4d8?narHash=sha256-z05BKQ6F9/6H2/ecIYEXuq54JCUEiOpdYXTQIijB/wM%3D' (2026-03-30)
  → 'github:nix-community/fenix/db976d430cbb6b0d6b300b4e22cbb28462841af2?narHash=sha256-rY4yNlSzDY3OoYBdgjwlpVKWY/oUeOb65709i/tJbns%3D' (2026-06-09)
• Updated input 'fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/f1297b21119565c626320c1ffc248965fffb2527?narHash=sha256-Cbpmf0%2B1pqi/zbpub2vkp5lTPx3QdVtDkkagDwQzHHg%3D' (2026-03-29)
  → 'github:rust-lang/rust-analyzer/4fde9dd9822df453dc6f20149b8e375efbbe66c0?narHash=sha256-5s6nPSNU1Mo/Qy90XxCTNj6/rB70zgX8VqleTdLoESA%3D' (2026-06-08)

