### PR TITLE
feat(managed-env): prune aged generation GC-root links via flox gc (3a/3)

### DIFF
--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -358,9 +358,9 @@ enum Ready {
 
 /// Information about the activated environment.
 ///
-/// This is only intended for humans to debug the serialized state.
-/// Fields should be promoted to the top-level if they are later needed
-/// programmatically.
+/// `dot_flox_path` is intended for humans to debug the serialized state.
+/// `flox_env` is also read programmatically (via [`ActivationState::flox_env`])
+/// by generation-link pruning to protect links that live activations depend on.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 struct EnvironmentInfo {
     /// Path to the activated environment's .flox directory (None for containers)
@@ -444,6 +444,16 @@ impl ActivationState {
     /// Returns the current activation mode
     pub fn mode(&self) -> &ActivateMode {
         &self.mode
+    }
+
+    /// Path to the activated environment's `.flox/run/{symlink}` (the rendered
+    /// env link that appears in the activation's `PATH`).
+    ///
+    /// Used by generation-link pruning to protect the links that live
+    /// activations depend on: this exact path must not be removed while a
+    /// process referencing it is running (flox#4332).
+    pub fn flox_env(&self) -> &Path {
+        &self.info.flox_env
     }
 
     /// Check if the activation state has running processes.

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1270,10 +1270,16 @@ impl ManagedEnvironment {
                 if !link.dev().is_symlink() && !link.run().is_symlink() {
                     return None;
                 }
+                // Canonicalize both links: an activation protects the
+                // mode-specific store path (run-mode resolves to the run link).
+                let store_paths = [link.dev(), link.run()]
+                    .into_iter()
+                    .filter_map(|link| fs::canonicalize(link).ok())
+                    .collect();
                 Some(PrunableGeneration {
                     generation,
                     last_live: generation_metadata.last_live,
-                    store_path: fs::canonicalize(link.dev()).ok(),
+                    store_paths,
                     link,
                 })
             })

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1264,16 +1264,19 @@ impl ManagedEnvironment {
             .into_iter()
             .filter_map(|(generation, generation_metadata)| {
                 let link = self.rendered_env_links.generation_link(generation);
-                // Only generations whose link is materialized on this host are
-                // prunable; a dangling link (symlink present, target gone) is
-                // included so it gets cleaned up.
-                if !link.dev().is_symlink() && !link.run().is_symlink() {
+                let legacy_links = self.rendered_env_links.legacy_generation_links(generation);
+                // Only generations with a link (new or legacy) materialized on
+                // this host are prunable; a dangling link (symlink present,
+                // target gone) is included so it gets cleaned up.
+                let has_new_link = link.dev().is_symlink() || link.run().is_symlink();
+                if !has_new_link && legacy_links.is_empty() {
                     return None;
                 }
-                // Canonicalize both links: an activation protects the
+                // Canonicalize all links: an activation protects the
                 // mode-specific store path (run-mode resolves to the run link).
                 let store_paths = [link.dev(), link.run()]
                     .into_iter()
+                    .chain(legacy_links.iter().map(PathBuf::as_path))
                     .filter_map(|link| fs::canonicalize(link).ok())
                     .collect();
                 Some(PrunableGeneration {
@@ -1281,6 +1284,7 @@ impl ManagedEnvironment {
                     last_live: generation_metadata.last_live,
                     store_paths,
                     link,
+                    legacy_links,
                 })
             })
             .collect();
@@ -1306,7 +1310,10 @@ impl ManagedEnvironment {
 
         let mut removed = Vec::new();
         for generation in to_prune {
-            for link in [generation.link.dev(), generation.link.run()] {
+            let links = [generation.link.dev(), generation.link.run()]
+                .into_iter()
+                .chain(generation.legacy_links.iter().map(PathBuf::as_path));
+            for link in links {
                 match fs::remove_file(link) {
                     Ok(()) => removed.push(link.to_path_buf()),
                     Err(err) if err.kind() == io::ErrorKind::NotFound => {},
@@ -2813,12 +2820,23 @@ mod test {
             "both generation links built"
         );
 
+        // A legacy-named link for the non-current generation must be pruned by
+        // the same policy (flox#4332 transitional cleanup).
+        let prefix = env.rendered_env_links.out_link_prefix();
+        let legacy_link = PathBuf::from(format!("{}.gen1-dev", prefix.display()));
+        std::os::unix::fs::symlink(gen1.dev(), &legacy_link).unwrap();
+        assert!(legacy_link.is_symlink(), "legacy link created");
+
         // No live activations -> all non-live: generation 1 pruned, current (2) kept.
         let removed = env
             .prune_generation_links(PrunePolicy::AllNonLive, &std::collections::HashSet::new())
             .unwrap();
         assert!(!removed.is_empty(), "generation 1 links removed");
         assert!(!gen1.exists(), "non-current generation link pruned");
+        assert!(
+            !legacy_link.is_symlink(),
+            "legacy non-current generation link pruned"
+        );
         assert!(gen2.exists(), "current generation link kept");
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1,7 +1,9 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fs, io};
 
+use chrono::Utc;
 use flox_core::data::environment_ref::{EnvironmentName, EnvironmentOwner, RemoteEnvironmentRef};
 use flox_manifest::interfaces::{AsLatestSchema, AsWritableManifest, ContentsMatch, WriteManifest};
 use flox_manifest::lockfile::{LOCKFILE_FILENAME, Lockfile};
@@ -9,7 +11,7 @@ use flox_manifest::parsed::common::IncludeDescriptor;
 use flox_manifest::raw::{CatalogPackage, FlakePackage, PackageToInstall, StorePath};
 use flox_manifest::{Manifest, ManifestError, Migrated, Validated};
 use thiserror::Error;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use super::core_environment::{CoreEnvironment, UpgradeResult};
 use super::fetcher::IncludeFetcher;
@@ -40,8 +42,11 @@ use super::{
     LOG_DIR_NAME,
     ManagedPointer,
     PathPointer,
+    PrunableGeneration,
+    PrunePolicy,
     RenderedEnvironmentLinks,
     UninstallationAttempt,
+    generation_links_to_prune,
     path_hash,
     services_socket_path,
 };
@@ -1239,6 +1244,74 @@ impl ManagedEnvironment {
         );
         self.lock_pointer()?;
         self.flip_to_generation(built_link)
+    }
+
+    /// The current generation plus a prune candidate for every generation that
+    /// has a GC-root link materialized on disk for this host.
+    fn prunable_generations(
+        &self,
+    ) -> Result<(GenerationId, Vec<PrunableGeneration>), EnvironmentError> {
+        let metadata = self
+            .generations()
+            .metadata()
+            .map_err(ManagedEnvironmentError::Generations)?;
+        let current = metadata
+            .current_gen()
+            .expect("managed environment always has a current generation");
+
+        let candidates = metadata
+            .generations()
+            .into_iter()
+            .filter_map(|(generation, generation_metadata)| {
+                let link = self.rendered_env_links.generation_link(generation);
+                // Only generations whose link is materialized on this host are
+                // prunable; a dangling link (symlink present, target gone) is
+                // included so it gets cleaned up.
+                if !link.dev().is_symlink() && !link.run().is_symlink() {
+                    return None;
+                }
+                Some(PrunableGeneration {
+                    generation,
+                    last_live: generation_metadata.last_live,
+                    store_path: fs::canonicalize(link.dev()).ok(),
+                    link,
+                })
+            })
+            .collect();
+
+        Ok((current, candidates))
+    }
+
+    /// Prune this environment's generation GC-root links according to `policy`,
+    /// never removing the current generation or links referenced by live
+    /// activations (`protected`, canonical store paths from
+    /// [`live_activation_store_paths`](super::live_activation_store_paths)).
+    ///
+    /// Best-effort: removing a link failing is logged, not fatal. Returns the
+    /// link paths that were removed.
+    pub fn prune_generation_links(
+        &self,
+        policy: PrunePolicy,
+        protected: &HashSet<PathBuf>,
+    ) -> Result<Vec<PathBuf>, EnvironmentError> {
+        let (current, candidates) = self.prunable_generations()?;
+        let to_prune =
+            generation_links_to_prune(&candidates, current, protected, policy, Utc::now());
+
+        let mut removed = Vec::new();
+        for generation in to_prune {
+            for link in [generation.link.dev(), generation.link.run()] {
+                match fs::remove_file(link) {
+                    Ok(()) => removed.push(link.to_path_buf()),
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => {},
+                    Err(err) => {
+                        warn!(path = %link.display(), %err, "failed to remove aged generation link");
+                    },
+                }
+            }
+        }
+
+        Ok(removed)
     }
 
     /// Returns the environment owner
@@ -2703,6 +2776,44 @@ mod test {
             Path::new(&expected_target),
             "activation pointer flipped to generation 1's GC-root link"
         );
+    }
+
+    /// `prune_generation_links` removes non-current generation links and keeps
+    /// the current generation's link (flox#4332 F3).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prune_generation_links_removes_non_current_links() {
+        let owner = "owner".parse().unwrap();
+        let (mut flox, temp_dir) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        flox.catalog_client =
+            catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
+
+        let mut env = mock_managed_environment_in(&flox, "version = 1", owner, &temp_dir, None);
+
+        // Generation 1 link, then install -> generation 2 (current); both links present.
+        env.build(&flox).unwrap();
+        let gen1 = env
+            .rendered_env_links
+            .generation_link(GenerationId::from(1usize));
+        let packages = [PackageToInstall::Catalog(
+            CatalogPackage::from_str("hello").unwrap(),
+        )];
+        env.install(&packages, &flox).unwrap();
+        let gen2 = env
+            .rendered_env_links
+            .generation_link(GenerationId::from(2usize));
+        assert!(
+            gen1.exists() && gen2.exists(),
+            "both generation links built"
+        );
+
+        // No live activations -> all non-live: generation 1 pruned, current (2) kept.
+        let removed = env
+            .prune_generation_links(PrunePolicy::AllNonLive, &std::collections::HashSet::new())
+            .unwrap();
+        assert!(!removed.is_empty(), "generation 1 links removed");
+        assert!(!gen1.exists(), "non-current generation link pruned");
+        assert!(gen2.exists(), "current generation link kept");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -425,6 +425,31 @@ impl RenderedEnvironmentLinks {
         GenerationLink::from_prefix(prefix)
     }
 
+    /// Legacy per-generation GC-root links from before the
+    /// `<prefix>-N-link-{dev,run}` naming: `<prefix>.gen{N}{-,.}{dev,run}`,
+    /// covering both the dash and dot separators older Flox versions used.
+    /// Returns the variants that currently exist on disk (a dangling one still
+    /// counts, so it gets cleaned up).
+    ///
+    /// Pruning ages these out by the same policy as their renamed counterparts.
+    /// TODO(flox#4332): remove this legacy sweep once old links have aged out
+    /// (target ~2026-12, roughly 6 months after introduction).
+    pub fn legacy_generation_links(&self, generation: GenerationId) -> Vec<PathBuf> {
+        let mut links = Vec::new();
+        for separator in ['-', '.'] {
+            for mode in ["dev", "run"] {
+                let path = append_output_suffix(
+                    &self.out_link_prefix,
+                    &format!(".gen{generation}{separator}{mode}"),
+                );
+                if path.is_symlink() {
+                    links.push(path);
+                }
+            }
+        }
+        links
+    }
+
     /// Atomically repoint the current activation links at `generation`'s
     /// GC-root links.
     ///
@@ -588,6 +613,11 @@ pub struct PrunableGeneration {
     /// mode-specific (`dev` or `run`) path — a run-mode activation references
     /// the run store path, not the dev one.
     pub store_paths: Vec<PathBuf>,
+    /// Legacy-named GC-root links for this generation
+    /// (`<system>.<name>.gen{N}{-,.}{dev,run}`) that exist on disk, pruned by
+    /// the same policy as the renamed `-N-link-{dev,run}` links.
+    /// TODO(flox#4332): drop once these have aged out (~2026-12, 6 months on).
+    pub legacy_links: Vec<PathBuf>,
 }
 
 /// Decide which generation GC-root links are safe to prune.
@@ -1785,6 +1815,7 @@ mod test {
                 link: pointer.generation_link(GenerationId::from(n)),
                 last_live,
                 store_paths: stores.iter().map(PathBuf::from).collect(),
+                legacy_links: vec![],
             };
 
         let candidates = vec![

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Duration, Utc};
 use enum_dispatch::enum_dispatch;
 use flox_catalog::ResolveError;
 use flox_core::activate::mode::ActivateMode;
+use flox_core::activations::{read_activations_json, state_json_path};
 use flox_core::data::environment_ref::{
     ActivateEnvironmentRef,
     EnvironmentName,
@@ -508,6 +509,16 @@ impl GenerationLink {
         &self.out_link_prefix
     }
 
+    /// The dev GC-root link path (`<prefix>-dev`).
+    pub fn dev(&self) -> &Path {
+        self.dev.as_path()
+    }
+
+    /// The run GC-root link path (`<prefix>-run`).
+    pub fn run(&self) -> &Path {
+        self.run.as_path()
+    }
+
     /// Activation links that resolve directly to this generation's GC-root
     /// links (its own `dev`/`run`).
     ///
@@ -608,6 +619,37 @@ pub fn generation_links_to_prune<'a>(
                 .is_some_and(|last_live| now - last_live > max_age),
         })
         .collect()
+}
+
+/// Canonical store paths of every live activation on this host.
+///
+/// Scans the runtime activations directory, keeps activations that still have
+/// running processes, and resolves each one's `flox_env` (the `.flox/run/…`
+/// link in the running process's `PATH`) to its store path. Generation-link
+/// pruning passes this as the protected set so it never removes a link a live
+/// activation depends on (flox#4332). Best-effort: unreadable or stale entries
+/// are skipped.
+pub fn live_activation_store_paths(runtime_dir: &Path) -> HashSet<PathBuf> {
+    let mut protected = HashSet::new();
+
+    let Ok(entries) = fs::read_dir(runtime_dir.join("activations")) else {
+        return protected; // nothing has been activated
+    };
+
+    for activation_dir in entries.flatten().map(|entry| entry.path()) {
+        let Ok((Some(state), _lock)) = read_activations_json(state_json_path(&activation_dir))
+        else {
+            continue;
+        };
+        if state.running_processes().is_none() {
+            continue; // not live; its links may be pruned
+        }
+        if let Ok(store_path) = fs::canonicalize(state.flox_env()) {
+            protected.insert(store_path);
+        }
+    }
+
+    protected
 }
 
 /// A pointer to an environment, either managed or path.
@@ -1745,10 +1787,22 @@ mod test {
 
         let candidates = vec![
             candidate(5, None, Some("/nix/store/gen5")), // current
-            candidate(4, Some(now - chrono::Duration::days(30)), Some("/nix/store/gen4")), // aged but protected
-            candidate(3, Some(now - chrono::Duration::days(20)), Some("/nix/store/gen3")), // aged
-            candidate(2, Some(now - chrono::Duration::days(2)), Some("/nix/store/gen2")),  // recent
-            candidate(1, Some(now - chrono::Duration::days(20)), None),                    // aged, dangling
+            candidate(
+                4,
+                Some(now - chrono::Duration::days(30)),
+                Some("/nix/store/gen4"),
+            ), // aged but protected
+            candidate(
+                3,
+                Some(now - chrono::Duration::days(20)),
+                Some("/nix/store/gen3"),
+            ), // aged
+            candidate(
+                2,
+                Some(now - chrono::Duration::days(2)),
+                Some("/nix/store/gen2"),
+            ), // recent
+            candidate(1, Some(now - chrono::Duration::days(20)), None), // aged, dangling
         ];
         let protected: HashSet<PathBuf> = [PathBuf::from("/nix/store/gen4")].into_iter().collect();
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
+use chrono::{DateTime, Duration, Utc};
 use enum_dispatch::enum_dispatch;
 use flox_catalog::ResolveError;
 use flox_core::activate::mode::ActivateMode;
@@ -534,6 +535,79 @@ impl GenerationLink {
             .into_iter()
             .all(|link| link.is_symlink() && link.exists())
     }
+}
+
+/// The default age-out window for generation GC-root links: a generation that
+/// has not been the current generation for longer than this is eligible for
+/// pruning (flox#4332).
+pub const DEFAULT_GENERATION_LINK_MAX_AGE_DAYS: i64 = 10;
+
+/// Which generation GC-root links a prune pass removes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrunePolicy {
+    /// Remove links whose generation ceased to be the current generation
+    /// longer ago than `max_age` (the opportunistic aging policy).
+    AgedOut { max_age: Duration },
+    /// Remove every generation link that is neither current nor in use, like
+    /// `nix-collect-garbage -d`.
+    AllNonLive,
+}
+
+impl PrunePolicy {
+    /// The default age-out policy ([`DEFAULT_GENERATION_LINK_MAX_AGE_DAYS`]).
+    pub fn default_aged_out() -> Self {
+        PrunePolicy::AgedOut {
+            max_age: chrono::Duration::days(DEFAULT_GENERATION_LINK_MAX_AGE_DAYS),
+        }
+    }
+}
+
+/// A generation's GC-root link plus the metadata needed to decide whether it
+/// can be pruned. See [`generation_links_to_prune`].
+#[derive(Clone, Debug)]
+pub struct PrunableGeneration {
+    pub generation: GenerationId,
+    pub link: GenerationLink,
+    /// When this generation last ceased to be the current generation; `None`
+    /// while it is current (the current generation is never pruned).
+    pub last_live: Option<DateTime<Utc>>,
+    /// The canonical store path the link resolves to, or `None` if it dangles.
+    /// Compared against the protected set to keep links that live activations
+    /// depend on.
+    pub store_path: Option<PathBuf>,
+}
+
+/// Decide which generation GC-root links are safe to prune.
+///
+/// A generation is never pruned when it is the `current` generation, nor when
+/// its link resolves to a store path in `protected_store_paths` — the canonical
+/// store paths that live activations reference, whose links appear in running
+/// processes' `PATH` and must stay live. Of the rest, [`PrunePolicy::AllNonLive`]
+/// prunes all, and [`PrunePolicy::AgedOut`] prunes only those whose `last_live`
+/// is older than the window.
+pub fn generation_links_to_prune<'a>(
+    candidates: &'a [PrunableGeneration],
+    current: GenerationId,
+    protected_store_paths: &HashSet<PathBuf>,
+    policy: PrunePolicy,
+    now: DateTime<Utc>,
+) -> Vec<&'a PrunableGeneration> {
+    candidates
+        .iter()
+        .filter(|candidate| candidate.generation != current)
+        .filter(|candidate| {
+            !candidate
+                .store_path
+                .as_deref()
+                .is_some_and(|path| protected_store_paths.contains(path))
+        })
+        .filter(|candidate| match policy {
+            PrunePolicy::AllNonLive => true,
+            PrunePolicy::AgedOut { max_age } => candidate
+                .last_live
+                .is_some_and(|last_live| now - last_live > max_age),
+        })
+        .collect()
 }
 
 /// A pointer to an environment, either managed or path.
@@ -1646,6 +1720,64 @@ mod test {
             !generation.exists(),
             "dangling links must not count as built"
         );
+    }
+
+    /// The prune decision never removes the current generation or one a live
+    /// activation depends on; `AgedOut` removes only links older than the
+    /// window, `AllNonLive` removes the rest.
+    #[test]
+    fn prune_decision_respects_current_protected_and_age() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = CanonicalPath::new(dir.path()).unwrap();
+        let system: System = "x86_64-linux".to_string();
+        let pointer = RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &base, "default", &system,
+        );
+
+        let now = Utc::now();
+        let candidate =
+            |n: usize, last_live: Option<DateTime<Utc>>, store: Option<&str>| PrunableGeneration {
+                generation: GenerationId::from(n),
+                link: pointer.generation_link(GenerationId::from(n)),
+                last_live,
+                store_path: store.map(PathBuf::from),
+            };
+
+        let candidates = vec![
+            candidate(5, None, Some("/nix/store/gen5")), // current
+            candidate(4, Some(now - chrono::Duration::days(30)), Some("/nix/store/gen4")), // aged but protected
+            candidate(3, Some(now - chrono::Duration::days(20)), Some("/nix/store/gen3")), // aged
+            candidate(2, Some(now - chrono::Duration::days(2)), Some("/nix/store/gen2")),  // recent
+            candidate(1, Some(now - chrono::Duration::days(20)), None),                    // aged, dangling
+        ];
+        let protected: HashSet<PathBuf> = [PathBuf::from("/nix/store/gen4")].into_iter().collect();
+
+        let pruned_ids = |policy| {
+            let mut ids: Vec<usize> = generation_links_to_prune(
+                &candidates,
+                GenerationId::from(5),
+                &protected,
+                policy,
+                now,
+            )
+            .iter()
+            .map(|candidate| *candidate.generation)
+            .collect::<Vec<_>>();
+            ids.sort_unstable();
+            ids
+        };
+
+        // Aged-out (10 days): only the aged, unprotected generations (3 and the
+        // dangling 1); current (5), protected (4) and recent (2) are kept.
+        assert_eq!(
+            pruned_ids(PrunePolicy::AgedOut {
+                max_age: chrono::Duration::days(10)
+            }),
+            vec![1, 3]
+        );
+
+        // All-non-live: everything except current (5) and protected (4).
+        assert_eq!(pruned_ids(PrunePolicy::AllNonLive), vec![1, 2, 3]);
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -582,20 +582,22 @@ pub struct PrunableGeneration {
     /// When this generation last ceased to be the current generation; `None`
     /// while it is current (the current generation is never pruned).
     pub last_live: Option<DateTime<Utc>>,
-    /// The canonical store path the link resolves to, or `None` if it dangles.
-    /// Compared against the protected set to keep links that live activations
-    /// depend on.
-    pub store_path: Option<PathBuf>,
+    /// The canonical store paths the dev and run links resolve to (a dangling
+    /// link contributes nothing). A generation is protected when *any* of these
+    /// is referenced by a live activation, because `flox_env` resolves to the
+    /// mode-specific (`dev` or `run`) path — a run-mode activation references
+    /// the run store path, not the dev one.
+    pub store_paths: Vec<PathBuf>,
 }
 
 /// Decide which generation GC-root links are safe to prune.
 ///
 /// A generation is never pruned when it is the `current` generation, nor when
-/// its link resolves to a store path in `protected_store_paths` — the canonical
-/// store paths that live activations reference, whose links appear in running
-/// processes' `PATH` and must stay live. Of the rest, [`PrunePolicy::AllNonLive`]
-/// prunes all, and [`PrunePolicy::AgedOut`] prunes only those whose `last_live`
-/// is older than the window.
+/// any of its links resolves to a store path in `protected_store_paths` — the
+/// canonical store paths that live activations reference, whose links appear in
+/// running processes' `PATH` and must stay live. Of the rest,
+/// [`PrunePolicy::AllNonLive`] prunes all, and [`PrunePolicy::AgedOut`] prunes
+/// only those whose `last_live` is older than the window.
 pub fn generation_links_to_prune<'a>(
     candidates: &'a [PrunableGeneration],
     current: GenerationId,
@@ -608,9 +610,9 @@ pub fn generation_links_to_prune<'a>(
         .filter(|candidate| candidate.generation != current)
         .filter(|candidate| {
             !candidate
-                .store_path
-                .as_deref()
-                .is_some_and(|path| protected_store_paths.contains(path))
+                .store_paths
+                .iter()
+                .any(|path| protected_store_paths.contains(path))
         })
         .filter(|candidate| match policy {
             PrunePolicy::AllNonLive => true,
@@ -1778,33 +1780,31 @@ mod test {
 
         let now = Utc::now();
         let candidate =
-            |n: usize, last_live: Option<DateTime<Utc>>, store: Option<&str>| PrunableGeneration {
+            |n: usize, last_live: Option<DateTime<Utc>>, stores: &[&str]| PrunableGeneration {
                 generation: GenerationId::from(n),
                 link: pointer.generation_link(GenerationId::from(n)),
                 last_live,
-                store_path: store.map(PathBuf::from),
+                store_paths: stores.iter().map(PathBuf::from).collect(),
             };
 
         let candidates = vec![
-            candidate(5, None, Some("/nix/store/gen5")), // current
-            candidate(
-                4,
-                Some(now - chrono::Duration::days(30)),
-                Some("/nix/store/gen4"),
-            ), // aged but protected
-            candidate(
-                3,
-                Some(now - chrono::Duration::days(20)),
-                Some("/nix/store/gen3"),
-            ), // aged
-            candidate(
-                2,
-                Some(now - chrono::Duration::days(2)),
-                Some("/nix/store/gen2"),
-            ), // recent
-            candidate(1, Some(now - chrono::Duration::days(20)), None), // aged, dangling
+            candidate(5, None, &["/nix/store/gen5-dev", "/nix/store/gen5-run"]), // current
+            // Aged, but a live run-mode activation references its *run* path, so
+            // it must be protected even though the dev path differs.
+            candidate(4, Some(now - chrono::Duration::days(30)), &[
+                "/nix/store/gen4-dev",
+                "/nix/store/gen4-run",
+            ]),
+            candidate(3, Some(now - chrono::Duration::days(20)), &[
+                "/nix/store/gen3-dev",
+            ]), // aged
+            candidate(2, Some(now - chrono::Duration::days(2)), &[
+                "/nix/store/gen2-dev",
+            ]), // recent
+            candidate(1, Some(now - chrono::Duration::days(20)), &[]), // aged, dangling
         ];
-        let protected: HashSet<PathBuf> = [PathBuf::from("/nix/store/gen4")].into_iter().collect();
+        let protected: HashSet<PathBuf> =
+            [PathBuf::from("/nix/store/gen4-run")].into_iter().collect();
 
         let pruned_ids = |policy| {
             let mut ids: Vec<usize> = generation_links_to_prune(

--- a/cli/flox/src/commands/gc.rs
+++ b/cli/flox/src/commands/gc.rs
@@ -65,14 +65,25 @@ use std::process::{Child, ChildStderr, ChildStdout, Stdio};
 use anyhow::{Context, Result, anyhow};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::env_registry;
+use flox_rust_sdk::models::env_registry::{self, env_registry_path, read_environment_registry};
+use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
+use flox_rust_sdk::models::environment::{
+    EnvironmentPointer,
+    PrunePolicy,
+    live_activation_store_paths,
+};
 use flox_rust_sdk::providers::nix::nix_base_command;
 use tracing::{Span, debug, info_span, instrument, trace};
 
 use crate::{message, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
-pub struct Gc {}
+pub struct Gc {
+    /// Remove all managed-environment generation GC-root links that are not in
+    /// use, not just aged-out ones — like 'nix-collect-garbage -d'.
+    #[bpaf(long, short('d'))]
+    all_generations: bool,
+}
 
 impl Gc {
     #[instrument(skip_all)]
@@ -82,11 +93,68 @@ impl Gc {
         let span = info_span!("collecting_garbage", progress = "Collecting garbage");
         let _guard = span.enter();
         env_registry::garbage_collect(&flox)?;
+
+        // Prune managed-environment generation GC-root links before the store
+        // GC so the freed store paths become collectable.
+        let policy = if self.all_generations {
+            PrunePolicy::AllNonLive
+        } else {
+            PrunePolicy::default_aged_out()
+        };
+        prune_generation_links(&flox, policy);
+
         let freed = run_store_gc()?;
         drop(_guard);
         message::info(freed);
         message::updated("Garbage collection complete");
         Ok(())
+    }
+}
+
+/// Synchronously prune managed-environment generation GC-root links across all
+/// registered environments, protecting links that live activations depend on.
+///
+/// Best-effort: failing to read the registry, open an environment, or remove a
+/// link is logged and skipped — it must never abort garbage collection
+/// (flox#4332).
+fn prune_generation_links(flox: &Flox, policy: PrunePolicy) {
+    let protected = live_activation_store_paths(&flox.runtime_dir);
+
+    let registry = match read_environment_registry(env_registry_path(flox)) {
+        Ok(Some(registry)) => registry,
+        Ok(None) => return,
+        Err(err) => {
+            debug!(%err, "failed to read environment registry for generation-link pruning");
+            return;
+        },
+    };
+
+    for entry in &registry.entries {
+        let Some(registered) = entry.latest_env() else {
+            continue;
+        };
+        // Only managed environments have generations / generation links.
+        let EnvironmentPointer::Managed(pointer) = &registered.pointer else {
+            continue;
+        };
+
+        let env = match ManagedEnvironment::open(flox, pointer.clone(), &entry.path, None) {
+            Ok(env) => env,
+            Err(err) => {
+                debug!(path = %entry.path.display(), %err, "skipping environment for generation-link pruning");
+                continue;
+            },
+        };
+
+        match env.prune_generation_links(policy, &protected) {
+            Ok(removed) if !removed.is_empty() => {
+                debug!(count = removed.len(), path = %entry.path.display(), "pruned generation links");
+            },
+            Ok(_) => {},
+            Err(err) => {
+                debug!(path = %entry.path.display(), %err, "failed to prune generation links");
+            },
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Interactive half of the generation-link aging policy (flox#4332 F3). `flox gc` now prunes managed-environment generation GC-root links (`<sys>.<name>-N-link-{dev,run}`) before running the nix store GC, so links retained for instant rollback don't accumulate forever.

> **Stacked on #4366 (2/3)** → #4361 (1/3). Base is `managed-env-rollback-no-build`; will retarget as the stack merges. Review #4361 and #4366 first.

The background, fire-and-forget prune (on any `flox` invocation, rate-limited, logged to a per-user file) is the separate follow-up **PR3b**.

## Changes

- **`ActivationState::flox_env()`** — promotes the recorded `.flox/run/{symlink}` path (the link in a running activation's `PATH`) to a programmatic accessor.
- **Prune decision** (`generation_links_to_prune`, `PrunePolicy`, `PrunableGeneration`, `DEFAULT_GENERATION_LINK_MAX_AGE_DAYS = 10`) — pure logic: never prune the current generation or one a live activation references; `AgedOut` prunes links older than the window, `AllNonLive` prunes all the rest.
- **`live_activation_store_paths`** — the protected set: canonical store paths of all live activations (running processes), resolved from their `flox_env`.
- **`ManagedEnvironment::prune_generation_links`** — enumerates on-disk generation links (with `last_live` from floxmeta), applies the decision, removes links best-effort.
- **`flox gc`** — prunes across all registered managed environments before `nix store gc`; `--all-generations` (`-d`) prunes all non-live links.

## Safety

A generation link in a live activation's `PATH` must not be removed (the store path must stay live for the running process). The protected set guards this by canonical store path, covering both `--generation N` (the link itself in `PATH`) and current (the pointer) activations. The cross-platform GC-root-for-active-activations gap (required on Darwin) is tracked separately in #4367.

## Follow-up

- **PR3b** — background fire-and-forget prune (rate-limited, per-user log file).
- #4367 — temporary GC roots for the lifetime of active activations (Darwin).

## Release Notes

`flox gc` now removes old managed-environment generation GC-root links (default: not the current generation of any environment, kept for ≥10 days) before collecting the Nix store, and `flox gc -d` removes all generation links that are not in use. Links that a running activation depends on are never removed.

## Test plan

- [x] Unit: prune decision (current/protected/aged/all-non-live); `prune_generation_links` removes non-current links and keeps the current one; `GenerationLink::exists` requires resolving links.
- [x] clippy clean; env-model + managed + generations unit suites pass.