### PR TITLE
feat(managed-env): periodic background prune of generation links via the executive (3b/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,7 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
+ "close_fds",
  "dirs",
  "expect-test",
  "flate2",

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
+close_fds.workspace = true
 flate2.workspace = true
 clap = { version = "4.5.56", default-features = false, features = [
     "std",

--- a/cli/flox-activations/src/cli/executive/log_gc.rs
+++ b/cli/flox-activations/src/cli/executive/log_gc.rs
@@ -48,6 +48,8 @@ pub(super) fn spawn_logs_gc_threads(dir: impl AsRef<Path>) {
                 KEEP_LAST_N_PROCESSES,
             )
             .unwrap_or_else(|err| error!(%err, "failed to delete upgrade-check logs"));
+            gc_logs_per_process(&dir, "generation-prune.*.log", KEEP_LAST_N_PROCESSES)
+                .unwrap_or_else(|err| error!(%err, "failed to delete generation-prune logs"));
 
             std::thread::sleep(EXECUTIVE_GC_INTERVAL);
         }

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -13,6 +13,7 @@ use log_gc::{spawn_heartbeat_log, spawn_logs_gc_threads};
 use nix::sys::signal::Signal::SIGUSR1;
 use nix::sys::signal::kill;
 use nix::unistd::{Pid, getpgid, getpid, setsid};
+use prune::spawn_generation_prune_thread;
 use reaper::reap_orphaned_children;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, debug_span, error, info, instrument};
@@ -25,6 +26,7 @@ use crate::process_compose::{process_compose_down, start_process_compose_no_serv
 
 mod event_coordinator;
 mod log_gc;
+mod prune;
 mod reaper;
 mod watcher;
 
@@ -42,6 +44,15 @@ pub struct ExecutiveCtx {
     /// When None, metrics are disabled and Sentry is not initialized.
     #[serde(default)]
     pub metrics_uuid: Option<Uuid>,
+
+    /// Path to the `flox` CLI binary, used to periodically spawn the
+    /// generation-link prune in the background (flox#4332).
+    ///
+    /// design-debt: the executive has to shell out to the `flox` CLI to run the
+    /// prune because the executive is a separate binary that cannot link
+    /// flox-rust-sdk. Were the executive the same binary as the CLI, it could
+    /// call the prune directly instead.
+    pub flox_bin: String,
 }
 
 #[derive(Debug, Args)]
@@ -67,6 +78,7 @@ impl ExecutiveArgs {
             activation_state_dir,
             parent_pid,
             metrics_uuid,
+            flox_bin,
         } = serde_json::from_str(&contents)?;
         if !std::env::var(NO_REMOVE_ACTIVATION_FILES).is_ok_and(|val| val == "true") {
             fs::remove_file(&self.executive_ctx)?;
@@ -120,6 +132,7 @@ impl ExecutiveArgs {
         // Step 8: Spawn non-essential GC threads
         spawn_heartbeat_log();
         spawn_logs_gc_threads(&log_dir);
+        spawn_generation_prune_thread(flox_bin, log_dir.clone());
 
         // Step 9: Enter the monitoring loop
         info!("starting monitoring loop");

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -52,6 +52,12 @@ pub struct ExecutiveCtx {
     /// prune because the executive is a separate binary that cannot link
     /// flox-rust-sdk. Were the executive the same binary as the CLI, it could
     /// call the prune directly instead.
+    ///
+    /// `#[serde(default)]` so a context file written by an older
+    /// `flox-activations` (without this field) still deserializes during an
+    /// upgrade; an empty value just disables the background prune for that
+    /// activation.
+    #[serde(default)]
     pub flox_bin: String,
 }
 

--- a/cli/flox-activations/src/cli/executive/prune.rs
+++ b/cli/flox-activations/src/cli/executive/prune.rs
@@ -11,13 +11,14 @@
 //! executive the same binary as the CLI, this would be a direct function call.
 
 use std::fs::{self, File};
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::{sleep, spawn};
 use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
-use tracing::error;
+use tracing::{debug, error};
 
 /// How often the executive fires a generation-link prune.
 const GENERATION_PRUNE_INTERVAL: Duration = Duration::from_secs(3600);
@@ -25,7 +26,17 @@ const GENERATION_PRUNE_INTERVAL: Duration = Duration::from_secs(3600);
 /// Starts a background thread that periodically prunes aged generation GC-root
 /// links by spawning `<flox_bin> prune-generation-links`. Best-effort: failures
 /// are logged and the thread keeps looping until the executive exits.
+///
+/// A no-op when `flox_bin` is empty, which happens only when the executive
+/// context was written by an older `flox-activations` that did not record it.
 pub(super) fn spawn_generation_prune_thread(flox_bin: String, log_dir: PathBuf) {
+    if flox_bin.is_empty() {
+        debug!(
+            "no flox binary path in executive context; skipping background generation-link prune"
+        );
+        return;
+    }
+
     spawn(move || {
         loop {
             // Wait first so the prune never competes with activation startup.
@@ -47,14 +58,35 @@ fn spawn_prune_process(flox_bin: &str, log_dir: &Path) -> Result<()> {
 
     fs::create_dir_all(log_dir)?;
     let log_file = File::create(log_dir.join(format!("generation-prune.{timestamp}.log")))?;
+    let log_file_fd = log_file.as_raw_fd();
 
-    Command::new(flox_bin)
+    let mut command = Command::new(flox_bin);
+    command
         .arg("prune-generation-links")
         .arg("-vv") // enable debug logging into the log file
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(log_file)
-        .spawn()?;
+        .stderr(log_file);
+
+    // Close inherited file descriptors (except the log file) and detach into a
+    // new session before exec, mirroring the check-for-upgrades background
+    // process. The executive inherits fds from the activation chain (e.g.
+    // direnv's fd-4); leaking them into this subprocess would hold them open
+    // until it exits and can block shells (see flox/flox#2716). Limiting the
+    // unsafe work to closing fds + setsid keeps `pre_exec` safe.
+    let keep_fds = [log_file_fd];
+    unsafe {
+        use std::os::unix::process::CommandExt as _;
+        command.pre_exec(move || {
+            close_fds::CloseFdsBuilder::new()
+                .keep_fds(&keep_fds)
+                .cloexecfrom(3);
+            nix::unistd::setsid()?;
+            Ok(())
+        });
+    }
+
+    command.spawn()?;
 
     Ok(())
 }

--- a/cli/flox-activations/src/cli/executive/prune.rs
+++ b/cli/flox-activations/src/cli/executive/prune.rs
@@ -1,0 +1,60 @@
+//! Periodic background pruning of managed-environment generation GC-root links.
+//!
+//! The activation executive is a long-running per-user process (users activate
+//! their default environment on login), so it is a natural place to drive the
+//! opportunistic generation-link prune on a timer (flox#4332). The worker
+//! self-locks, so multiple executives firing it concurrently is harmless.
+//!
+//! design-debt: the executive has to shell out to the `flox` CLI's hidden
+//! `prune-generation-links` worker because the executive is a separate binary
+//! that cannot link `flox-rust-sdk` to run the prune directly. Were the
+//! executive the same binary as the CLI, this would be a direct function call.
+
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread::{sleep, spawn};
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+use tracing::error;
+
+/// How often the executive fires a generation-link prune.
+const GENERATION_PRUNE_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// Starts a background thread that periodically prunes aged generation GC-root
+/// links by spawning `<flox_bin> prune-generation-links`. Best-effort: failures
+/// are logged and the thread keeps looping until the executive exits.
+pub(super) fn spawn_generation_prune_thread(flox_bin: String, log_dir: PathBuf) {
+    spawn(move || {
+        loop {
+            // Wait first so the prune never competes with activation startup.
+            sleep(GENERATION_PRUNE_INTERVAL);
+            if let Err(err) = spawn_prune_process(&flox_bin, &log_dir) {
+                error!(%err, "failed to spawn generation-link prune");
+            }
+        }
+    });
+}
+
+/// Fire-and-forget a `flox prune-generation-links` subprocess, redirecting its
+/// output to a per-process log file rather than the executive's std streams.
+fn spawn_prune_process(flox_bin: &str, log_dir: &Path) -> Result<()> {
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    fs::create_dir_all(log_dir)?;
+    let log_file = File::create(log_dir.join(format!("generation-prune.{timestamp}.log")))?;
+
+    Command::new(flox_bin)
+        .arg("prune-generation-links")
+        .arg("-vv") // enable debug logging into the log file
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(log_file)
+        .spawn()?;
+
+    Ok(())
+}

--- a/cli/flox-activations/src/start.rs
+++ b/cli/flox-activations/src/start.rs
@@ -71,6 +71,7 @@ pub fn start(
                 &context.activation_state_dir,
                 &start_state_dir,
                 context.metrics_uuid,
+                &context.flox_bin,
             )?;
             activations.set_executive_pid(exec_pid.as_raw());
             Some((exec_pid, signals))
@@ -188,6 +189,7 @@ fn spawn_executive(
     activation_state_dir: &Path,
     start_state_dir: &Path,
     metrics_uuid: Option<Uuid>,
+    flox_bin: &str,
 ) -> Result<Pid, anyhow::Error> {
     let parent_pid = getpid();
 
@@ -197,6 +199,7 @@ fn spawn_executive(
         activation_state_dir: activation_state_dir.to_path_buf(),
         parent_pid: parent_pid.as_raw(),
         metrics_uuid,
+        flox_bin: flox_bin.to_string(),
     };
 
     let temp_file = tempfile::NamedTempFile::with_prefix_in("executive_ctx_", start_state_dir)?;

--- a/cli/flox/src/commands/gc.rs
+++ b/cli/flox/src/commands/gc.rs
@@ -65,16 +65,12 @@ use std::process::{Child, ChildStderr, ChildStdout, Stdio};
 use anyhow::{Context, Result, anyhow};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::env_registry::{self, env_registry_path, read_environment_registry};
-use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
-use flox_rust_sdk::models::environment::{
-    EnvironmentPointer,
-    PrunePolicy,
-    live_activation_store_paths,
-};
+use flox_rust_sdk::models::env_registry;
+use flox_rust_sdk::models::environment::PrunePolicy;
 use flox_rust_sdk::providers::nix::nix_base_command;
 use tracing::{Span, debug, info_span, instrument, trace};
 
+use super::prune_generation_links::prune_registered_environments;
 use crate::{message, subcommand_metric};
 
 #[derive(Bpaf, Debug, Clone)]
@@ -101,60 +97,13 @@ impl Gc {
         } else {
             PrunePolicy::default_aged_out()
         };
-        prune_generation_links(&flox, policy);
+        prune_registered_environments(&flox, policy);
 
         let freed = run_store_gc()?;
         drop(_guard);
         message::info(freed);
         message::updated("Garbage collection complete");
         Ok(())
-    }
-}
-
-/// Synchronously prune managed-environment generation GC-root links across all
-/// registered environments, protecting links that live activations depend on.
-///
-/// Best-effort: failing to read the registry, open an environment, or remove a
-/// link is logged and skipped — it must never abort garbage collection
-/// (flox#4332).
-fn prune_generation_links(flox: &Flox, policy: PrunePolicy) {
-    let protected = live_activation_store_paths(&flox.runtime_dir);
-
-    let registry = match read_environment_registry(env_registry_path(flox)) {
-        Ok(Some(registry)) => registry,
-        Ok(None) => return,
-        Err(err) => {
-            debug!(%err, "failed to read environment registry for generation-link pruning");
-            return;
-        },
-    };
-
-    for entry in &registry.entries {
-        let Some(registered) = entry.latest_env() else {
-            continue;
-        };
-        // Only managed environments have generations / generation links.
-        let EnvironmentPointer::Managed(pointer) = &registered.pointer else {
-            continue;
-        };
-
-        let env = match ManagedEnvironment::open(flox, pointer.clone(), &entry.path, None) {
-            Ok(env) => env,
-            Err(err) => {
-                debug!(path = %entry.path.display(), %err, "skipping environment for generation-link pruning");
-                continue;
-            },
-        };
-
-        match env.prune_generation_links(policy, &protected) {
-            Ok(removed) if !removed.is_empty() => {
-                debug!(count = removed.len(), path = %entry.path.display(), "pruned generation links");
-            },
-            Ok(_) => {},
-            Err(err) => {
-                debug!(path = %entry.path.display(), %err, "failed to prune generation links");
-            },
-        }
     }
 }
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -18,6 +18,7 @@ mod init;
 mod install;
 mod list;
 mod lock_manifest;
+mod prune_generation_links;
 mod publish;
 mod pull;
 mod push;
@@ -810,6 +811,13 @@ enum InternalCommands {
         check_for_upgrades::CheckForUpgrades,
     ),
 
+    /// Prune aged managed-environment generation GC-root links
+    #[bpaf(command("prune-generation-links"), hide)]
+    PruneGenerationLinks(
+        #[bpaf(external(prune_generation_links::prune_generation_links))]
+        prune_generation_links::PruneGenerationLinks,
+    ),
+
     /// Print information for how to exit environment
     // TODO: when we flip features.auto_activate we should update this help
     // message
@@ -841,6 +849,7 @@ impl InternalCommands {
             InternalCommands::Upload(args) => args.handle(flox).await?,
             InternalCommands::LockManifest(args) => args.handle(flox).await?,
             InternalCommands::CheckForUpgrades(args) => args.handle(flox).await?,
+            InternalCommands::PruneGenerationLinks(args) => args.handle(flox)?,
             InternalCommands::Deactivate(args) => args.handle(config, flox)?,
             InternalCommands::ActivationState(args) => args.handle(flox).await?,
             InternalCommands::ServicesSocket(args) => args.handle(flox).await?,

--- a/cli/flox/src/commands/prune_generation_links.rs
+++ b/cli/flox/src/commands/prune_generation_links.rs
@@ -1,0 +1,101 @@
+//! Pruning of managed-environment generation GC-root links (flox#4332).
+//!
+//! Shared by two callers:
+//! - `flox gc` (interactive), which prunes synchronously before running the
+//!   nix store GC — see [`prune_registered_environments`].
+//! - the hidden `prune-generation-links` worker ([`PruneGenerationLinks`]),
+//!   which the activation executive fires periodically in the background and
+//!   which does **not** run the nix store GC.
+
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::env_registry::{env_registry_path, read_environment_registry};
+use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
+use flox_rust_sdk::models::environment::{
+    EnvironmentPointer,
+    PrunePolicy,
+    live_activation_store_paths,
+};
+use fslock::LockFile;
+use tracing::{debug, instrument};
+
+use crate::subcommand_metric;
+
+/// Hidden worker: prune aged generation GC-root links across all registered
+/// managed environments, **without** running the nix store GC.
+///
+/// The activation executive fires this periodically (see the executive's
+/// background prune). The interactive `flox gc` instead calls
+/// [`prune_registered_environments`] directly and then runs the store GC.
+#[derive(Bpaf, Clone, Debug)]
+pub struct PruneGenerationLinks {}
+
+impl PruneGenerationLinks {
+    #[instrument(name = "prune-generation-links", skip_all)]
+    pub fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("prune-generation-links");
+
+        // Multiple executives may fire this concurrently. The prune is
+        // idempotent, but take a non-blocking lock so they don't race to remove
+        // the same links; if another prune already holds it, this run would be
+        // redundant, so just exit.
+        let lock_path = flox.runtime_dir.join("generation-prune.lock");
+        let mut lock = LockFile::open(&lock_path)?;
+        if !lock.try_lock()? {
+            debug!("another generation-link prune is in progress; skipping");
+            return Ok(());
+        }
+
+        prune_registered_environments(&flox, PrunePolicy::default_aged_out());
+        // The lock is released when `lock` is dropped.
+        Ok(())
+    }
+}
+
+/// Prune managed-environment generation GC-root links across all registered
+/// environments according to `policy`, protecting links that live activations
+/// depend on ([`live_activation_store_paths`]).
+///
+/// Best-effort throughout: failing to read the registry, open an environment,
+/// or remove a link is logged and skipped so it never aborts the caller.
+pub fn prune_registered_environments(flox: &Flox, policy: PrunePolicy) {
+    let protected = live_activation_store_paths(&flox.runtime_dir);
+
+    let registry = match read_environment_registry(env_registry_path(flox)) {
+        Ok(Some(registry)) => registry,
+        Ok(None) => return,
+        Err(err) => {
+            debug!(%err, "failed to read environment registry for generation-link pruning");
+            return;
+        },
+    };
+
+    for entry in &registry.entries {
+        let Some(registered) = entry.latest_env() else {
+            continue;
+        };
+        // Only managed environments have generations / generation links.
+        let EnvironmentPointer::Managed(pointer) = &registered.pointer else {
+            continue;
+        };
+
+        let env = match ManagedEnvironment::open(flox, pointer.clone(), &entry.path, None) {
+            Ok(env) => env,
+            Err(err) => {
+                debug!(path = %entry.path.display(), %err, "skipping environment for generation-link pruning");
+                continue;
+            },
+        };
+
+        match env.prune_generation_links(policy, &protected) {
+            Ok(removed) if !removed.is_empty() => {
+                debug!(count = removed.len(), path = %entry.path.display(), "pruned generation links");
+            },
+            Ok(_) => {},
+            Err(err) => {
+                debug!(path = %entry.path.display(), %err, "failed to prune generation links");
+            },
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Background half of the generation-link aging policy (flox#4332 F3). The activation **executive** — a long-running per-user process (users activate their default environment on login) — periodically prunes aged generation GC-root links, so they don't accumulate without an interactive `flox gc`.

> **Stacked on #4369 (3a/3)** → #4366 → #4361. Base is `managed-env-prune-generation-links`; review the stack in order.

## Design

The executive fires the prune on a timer rather than gating a per-`flox`-invocation background job behind a timestamp file: an executive is essentially always running, multiple executives doing the same idempotent work is fine, and the timer *is* the cadence (no timestamp file needed).

- **`flox prune-generation-links`** — a hidden, prune-only worker: it runs the same prune as `flox gc` but **not** `nix store gc`. It takes a non-blocking lock so concurrent executives don't race to delete the same links.
- **Executive** spawns an hourly thread that fire-and-forgets `<flox> prune-generation-links`, logging to a per-process file under its log dir (GC'd alongside its other logs). The `flox` CLI path is threaded from `ActivateCtx` (which already carries it) into `ExecutiveCtx`.

### design-debt note

The executive has to shell out to the `flox` CLI to run the prune because it is a **separate binary** that cannot link `flox-rust-sdk`. Were the executive the same binary as the CLI, it would call the prune directly. This is recorded at the relevant sites and is the kind of friction that argues for unifying the executive and CLI binaries.

## Behavior

- Pruning runs whenever ≥1 executive is live (i.e. an environment is active). `flox gc` (#4369) covers the no-activation case.
- Links a live activation depends on are protected (#4369); the cross-platform GC-root-for-active-store-paths gap is tracked in #4367.

## Release Notes

Managed-environment generation GC-root links are now pruned automatically in the background by the activation executive (default: links kept ≥10 days since they stopped being current, never the current generation or one in use), in addition to `flox gc`.

## Test plan

- [x] Builds + clippy clean across flox, flox-activations, flox-core.
- [x] flox-activations unit suite passes (the lone `successful_detach_removes_pid` failure is a known macOS flake, unrelated — passes on retry).
- [x] Prune logic itself unit-covered in #4369; the executive thread is thin fire-and-forget glue (mirrors the existing `spawn_logs_gc_threads`).