### PR TITLE
feat(upgrade): upgrade output clarity (DEV-95)

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -756,8 +756,9 @@ fn notify_package_upgrades(
         .to_flags()
         .map(|flags| format!(" {}", flags.join(" ")))
         .unwrap_or("".to_string());
-    let (version_changes, rebuilds) = super::upgrade::count_upgrade_categories(&diff_for_system);
-    let summary = super::upgrade::format_upgrade_summary(version_changes, rebuilds);
+    let (version_changes, rebuilds) =
+        crate::utils::upgrade_output::count_upgrade_categories(&diff_for_system);
+    let summary = crate::utils::upgrade_output::format_upgrade_summary(version_changes, rebuilds);
     let message = formatdoc! {"
         {summary} available in {description}.
         Use 'flox upgrade --dry-run{flags}' for details.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -62,6 +62,7 @@ use crate::config::{AutoActivationPreference, Config, EnvironmentPromptConfig};
 use crate::utils::detect_shell::{detect_shell_for_in_place, detect_shell_for_subshell};
 use crate::utils::errors::format_diverged_metadata;
 use crate::utils::message;
+use crate::utils::upgrade_output::{count_upgrade_categories, format_upgrade_summary};
 use crate::{Exit, environment_subcommand_metric, subcommand_metric, utils};
 
 #[derive(Debug, Clone, Bpaf)]
@@ -756,9 +757,8 @@ fn notify_package_upgrades(
         .to_flags()
         .map(|flags| format!(" {}", flags.join(" ")))
         .unwrap_or("".to_string());
-    let (version_changes, rebuilds) =
-        crate::utils::upgrade_output::count_upgrade_categories(&diff_for_system);
-    let summary = crate::utils::upgrade_output::format_upgrade_summary(version_changes, rebuilds);
+    let (version_changes, rebuilds) = count_upgrade_categories(&diff_for_system);
+    let summary = format_upgrade_summary(version_changes, rebuilds);
     let message = formatdoc! {"
         {summary} available in {description}.
         Use 'flox upgrade --dry-run{flags}' for details.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -746,12 +746,14 @@ fn notify_package_upgrades(
         debug!("Not notifying user of upgrade, no changes in lockfile");
         return Ok(());
     }
+    let description = environment_description(environment)?;
     let diff_for_system = upgrade_result.diff_for_system(&flox.system);
     if diff_for_system.is_empty() {
-        debug!("Not notifying user of upgrade, no changes for this system");
+        message::verbose(formatdoc! {"
+            Upgrades available for {description} on other systems.
+            Use 'flox upgrade --dry-run' for details."});
         return Ok(());
     }
-    let description = environment_description(environment)?;
     // TODO: this doesn't capture the environment chosen by the user if we prompted
     let flags = environment_select
         .to_flags()

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -745,14 +745,21 @@ fn notify_package_upgrades(
         debug!("Not notifying user of upgrade, no changes in lockfile");
         return Ok(());
     }
+    let diff_for_system = upgrade_result.diff_for_system(&flox.system);
+    if diff_for_system.is_empty() {
+        debug!("Not notifying user of upgrade, no changes for this system");
+        return Ok(());
+    }
     let description = environment_description(environment)?;
     // TODO: this doesn't capture the environment chosen by the user if we prompted
     let flags = environment_select
         .to_flags()
         .map(|flags| format!(" {}", flags.join(" ")))
         .unwrap_or("".to_string());
+    let (version_changes, rebuilds) = super::upgrade::count_upgrade_categories(&diff_for_system);
+    let summary = super::upgrade::format_upgrade_summary(version_changes, rebuilds);
     let message = formatdoc! {"
-        Upgrades are available for packages in {description}.
+        {summary} available in {description}.
         Use 'flox upgrade --dry-run{flags}' for details.
     "};
     message::info(message);
@@ -1116,7 +1123,7 @@ mod upgrade_notification_tests {
         let printed = writer.to_string();
 
         assert_eq!(printed, formatdoc! {"
-            ℹ Upgrades are available for packages in 'name'.
+            ℹ 1 rebuild available in 'name'.
             Use 'flox upgrade --dry-run' for details.
 
         "});

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -102,7 +102,6 @@ impl Upgrade {
         let diff_for_system = result.diff_for_system(&flox.system);
 
         let rendered_diff = render_diff(&diff_for_system);
-        let num_changes_for_system = diff_for_system.len(); // used in non-dry-run path
 
         if self.dry_run {
             if diff_for_system.is_empty() {
@@ -140,8 +139,10 @@ impl Upgrade {
             Upgrades were not available for this system, but upgrades were applied for other
             systems supported by this environment."});
         } else {
+            let (version_changes, rebuilds) = count_upgrade_categories(&diff_for_system);
+            let summary = format_upgrade_summary(version_changes, rebuilds);
             message::plain(formatdoc! {"
-            {icon} Upgraded {num_changes_for_system} package(s) in {description}:
+            {icon} Upgraded {summary} in {description}:
             {rendered_diff}
             "});
         }
@@ -446,9 +447,7 @@ mod tests {
             let mut diff = SingleSystemUpgradeDiff::new();
             diff.insert("curl".to_string(), (before_curl, after_curl));
             diff.insert("terraform-docs".to_string(), (before_tf, after_tf));
-            let (version_changes, rebuilds) = count_upgrade_categories(&diff);
-            assert_eq!(version_changes, 1);
-            assert_eq!(rebuilds, 1);
+            assert_eq!(count_upgrade_categories(&diff), (1, 1));
         }
     }
 

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -201,7 +201,6 @@ fn rebuild_detail(before: &LockedPackage, after: &LockedPackage) -> Option<Strin
     None
 }
 
-
 #[cfg(test)]
 mod tests {
     use flox_manifest::raw::PackageToInstall;
@@ -492,15 +491,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn dry_run_shows_version_change_summary() {
-        assert_eq!(
-            run_dry_run_with_version_change().await,
-            indoc! {"
+        assert_eq!(run_dry_run_with_version_change().await, indoc! {"
             Dry run: 1 version change in 'name':
             - hello: 2.10.1 -> 2.12.3
 
             To apply these changes, run upgrade without the '--dry-run' flag.
 
-            "}
-        );
+            "});
     }
 }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -180,7 +180,10 @@ fn render_diff(diff: &SingleSystemUpgradeDiff) -> String {
 /// Tries rev_date first (formatted as YYYY-MM-DD), then rev hash (7 chars).
 /// Returns `None` if no rev info is available (e.g. flake packages).
 fn rebuild_detail(before: &LockedPackage, after: &LockedPackage) -> Option<String> {
-    let (old, new) = (before.as_catalog_package_ref()?, after.as_catalog_package_ref()?);
+    let (old, new) = (
+        before.as_catalog_package_ref()?,
+        after.as_catalog_package_ref()?,
+    );
 
     let old_date = old.rev_date.format("%Y-%m-%d");
     let new_date = new.rev_date.format("%Y-%m-%d");
@@ -425,11 +428,16 @@ mod tests {
         #[test]
         fn rebuild_same_date_different_rev() {
             let date = chrono::Utc.with_ymd_and_hms(2025, 1, 15, 0, 0, 0).unwrap();
-            let before = make_catalog_package("jq", "1.7.1", "/nix/store/old", "abc1234def567", date);
-            let after = make_catalog_package("jq", "1.7.1", "/nix/store/new", "fff9999aaa000", date);
+            let before =
+                make_catalog_package("jq", "1.7.1", "/nix/store/old", "abc1234def567", date);
+            let after =
+                make_catalog_package("jq", "1.7.1", "/nix/store/new", "fff9999aaa000", date);
             let mut diff = SingleSystemUpgradeDiff::new();
             diff.insert("jq".to_string(), (before, after));
-            assert_eq!(render_diff(&diff), "- jq: 1.7.1 (rebuild, rev abc1234 -> fff9999)");
+            assert_eq!(
+                render_diff(&diff),
+                "- jq: 1.7.1 (rebuild, rev abc1234 -> fff9999)"
+            );
         }
 
         #[test]
@@ -446,8 +454,13 @@ mod tests {
         fn count_categories_mixed() {
             let before_curl =
                 make_catalog_package("curl", "8.9.0", "/nix/store/old", "aaa", chrono::Utc::now());
-            let after_curl =
-                make_catalog_package("curl", "8.10.1", "/nix/store/new", "bbb", chrono::Utc::now());
+            let after_curl = make_catalog_package(
+                "curl",
+                "8.10.1",
+                "/nix/store/new",
+                "bbb",
+                chrono::Utc::now(),
+            );
             let before_tf = make_catalog_package(
                 "terraform-docs",
                 "0.21.0",
@@ -496,12 +509,18 @@ mod tests {
 
         #[test]
         fn mixed() {
-            assert_eq!(format_upgrade_summary(2, 1), "2 version changes and 1 rebuild");
+            assert_eq!(
+                format_upgrade_summary(2, 1),
+                "2 version changes and 1 rebuild"
+            );
         }
 
         #[test]
         fn mixed_plural() {
-            assert_eq!(format_upgrade_summary(3, 5), "3 version changes and 5 rebuilds");
+            assert_eq!(
+                format_upgrade_summary(3, 5),
+                "3 version changes and 5 rebuilds"
+            );
         }
 
         #[test]

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use bpaf::Bpaf;
 use crossterm::style::Stylize;
+use flox_manifest::lockfile::LockedPackage;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{Environment, SingleSystemUpgradeDiff};
 use indoc::formatdoc;
@@ -100,7 +101,7 @@ impl Upgrade {
         let diff_for_system = result.diff_for_system(&flox.system);
 
         let rendered_diff = render_diff(&diff_for_system);
-        let num_changes_for_system = diff_for_system.len();
+        let num_changes_for_system = diff_for_system.len(); // used in non-dry-run path
 
         if self.dry_run {
             if diff_for_system.is_empty() {
@@ -115,8 +116,10 @@ impl Upgrade {
                 }
                 return Ok(());
             }
+            let (version_changes, rebuilds) = count_upgrade_categories(&diff_for_system);
+            let summary = format_upgrade_summary(version_changes, rebuilds);
             message::plain(formatdoc! {"
-                Dry run: Upgrades available for {num_changes_for_system} package(s) in {description}:
+                Dry run: {summary} in {description}:
                 {rendered_diff}
 
                 To apply these changes, run upgrade without the '--dry-run' flag.
@@ -148,7 +151,11 @@ impl Upgrade {
     }
 }
 
-/// Render a diff of locked packages before and after an upgrade
+/// Render a diff of locked packages before and after an upgrade.
+///
+/// Version changes show: `- pkg: 1.0 -> 2.0`
+/// Rebuilds show: `- pkg: 1.0 (rebuild, rev DATE -> DATE)` with fallback to
+/// rev hash or bare `(rebuild)` when rev info is unavailable.
 fn render_diff(diff: &SingleSystemUpgradeDiff) -> String {
     diff.iter()
         .map(|(_, (before, after))| {
@@ -156,13 +163,71 @@ fn render_diff(diff: &SingleSystemUpgradeDiff) -> String {
             let old_version = before.version().unwrap_or("unknown");
             let new_version = after.version().unwrap_or("unknown");
 
-            if new_version == old_version {
-                format!("- {install_id}: {old_version}")
-            } else {
-                format!("- {install_id}: {old_version} -> {new_version}")
+            if new_version != old_version {
+                return format!("- {install_id}: {old_version} -> {new_version}");
+            }
+
+            match rebuild_detail(before, after) {
+                Some(detail) => format!("- {install_id}: {old_version} (rebuild, {detail})"),
+                None => format!("- {install_id}: {old_version} (rebuild)"),
             }
         })
         .join("\n")
+}
+
+/// Extract a human-readable detail string for build-only changes.
+///
+/// Tries rev_date first (formatted as YYYY-MM-DD), then rev hash (7 chars).
+/// Returns `None` if no rev info is available (e.g. flake packages).
+fn rebuild_detail(before: &LockedPackage, after: &LockedPackage) -> Option<String> {
+    let (old, new) = (before.as_catalog_package_ref()?, after.as_catalog_package_ref()?);
+
+    let old_date = old.rev_date.format("%Y-%m-%d");
+    let new_date = new.rev_date.format("%Y-%m-%d");
+    if old_date.to_string() != new_date.to_string() {
+        return Some(format!("rev {old_date} -> {new_date}"));
+    }
+
+    let old_rev = &old.rev[..7.min(old.rev.len())];
+    let new_rev = &new.rev[..7.min(new.rev.len())];
+    if old_rev != new_rev {
+        return Some(format!("rev {old_rev} -> {new_rev}"));
+    }
+
+    None
+}
+
+/// Count version changes vs rebuilds in a diff.
+pub(crate) fn count_upgrade_categories(diff: &SingleSystemUpgradeDiff) -> (usize, usize) {
+    diff.values().fold((0, 0), |(vc, rb), (before, after)| {
+        let old_version = before.version().unwrap_or("unknown");
+        let new_version = after.version().unwrap_or("unknown");
+        if new_version != old_version {
+            (vc + 1, rb)
+        } else {
+            (vc, rb + 1)
+        }
+    })
+}
+
+/// Format a human-readable summary like "2 version changes and 1 rebuild".
+pub(crate) fn format_upgrade_summary(version_changes: usize, rebuilds: usize) -> String {
+    let version_part = match version_changes {
+        0 => None,
+        1 => Some("1 version change".to_string()),
+        n => Some(format!("{n} version changes")),
+    };
+    let rebuild_part = match rebuilds {
+        0 => None,
+        1 => Some("1 rebuild".to_string()),
+        n => Some(format!("{n} rebuilds")),
+    };
+    match (version_part, rebuild_part) {
+        (Some(v), Some(b)) => format!("{v} and {b}"),
+        (Some(v), None) => v,
+        (None, Some(b)) => b,
+        (None, None) => "Upgrades".to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -270,5 +335,178 @@ mod tests {
             available for other systems supported by this environment.
             "}
         );
+    }
+
+    mod render_diff_tests {
+        use std::collections::BTreeMap;
+
+        use chrono::TimeZone;
+        use flox_manifest::lockfile::{LockedPackage, LockedPackageCatalog};
+
+        use super::super::*;
+
+        fn make_catalog_package(
+            install_id: &str,
+            version: &str,
+            derivation: &str,
+            rev: &str,
+            rev_date: chrono::DateTime<chrono::Utc>,
+        ) -> LockedPackage {
+            LockedPackage::Catalog(LockedPackageCatalog {
+                attr_path: format!("legacyPackages.x86_64-linux.{install_id}"),
+                broken: None,
+                derivation: derivation.to_string(),
+                description: None,
+                install_id: install_id.to_string(),
+                license: None,
+                locked_url: "https://github.com/NixOS/nixpkgs".to_string(),
+                name: install_id.to_string(),
+                pname: install_id.to_string(),
+                rev: rev.to_string(),
+                rev_count: 1,
+                rev_date,
+                scrape_date: chrono::Utc::now(),
+                stabilities: None,
+                unfree: None,
+                version: version.to_string(),
+                outputs_to_install: None,
+                outputs: BTreeMap::new(),
+                system: "x86_64-linux".to_string(),
+                group: "toplevel".to_string(),
+                priority: 5,
+            })
+        }
+
+        #[test]
+        fn version_change_shows_arrow() {
+            let before = make_catalog_package(
+                "curl",
+                "8.9.0",
+                "/nix/store/old",
+                "aaa1111",
+                chrono::Utc.with_ymd_and_hms(2025, 1, 15, 0, 0, 0).unwrap(),
+            );
+            let after = make_catalog_package(
+                "curl",
+                "8.10.1",
+                "/nix/store/new",
+                "bbb2222",
+                chrono::Utc.with_ymd_and_hms(2025, 2, 10, 0, 0, 0).unwrap(),
+            );
+            let mut diff = SingleSystemUpgradeDiff::new();
+            diff.insert("curl".to_string(), (before, after));
+            assert_eq!(render_diff(&diff), "- curl: 8.9.0 -> 8.10.1");
+        }
+
+        #[test]
+        fn rebuild_with_different_rev_dates() {
+            let before = make_catalog_package(
+                "terraform-docs",
+                "0.21.0",
+                "/nix/store/old",
+                "aaa1111",
+                chrono::Utc.with_ymd_and_hms(2025, 1, 15, 0, 0, 0).unwrap(),
+            );
+            let after = make_catalog_package(
+                "terraform-docs",
+                "0.21.0",
+                "/nix/store/new",
+                "bbb2222",
+                chrono::Utc.with_ymd_and_hms(2025, 2, 10, 0, 0, 0).unwrap(),
+            );
+            let mut diff = SingleSystemUpgradeDiff::new();
+            diff.insert("terraform-docs".to_string(), (before, after));
+            assert_eq!(
+                render_diff(&diff),
+                "- terraform-docs: 0.21.0 (rebuild, rev 2025-01-15 -> 2025-02-10)"
+            );
+        }
+
+        #[test]
+        fn rebuild_same_date_different_rev() {
+            let date = chrono::Utc.with_ymd_and_hms(2025, 1, 15, 0, 0, 0).unwrap();
+            let before = make_catalog_package("jq", "1.7.1", "/nix/store/old", "abc1234def567", date);
+            let after = make_catalog_package("jq", "1.7.1", "/nix/store/new", "fff9999aaa000", date);
+            let mut diff = SingleSystemUpgradeDiff::new();
+            diff.insert("jq".to_string(), (before, after));
+            assert_eq!(render_diff(&diff), "- jq: 1.7.1 (rebuild, rev abc1234 -> fff9999)");
+        }
+
+        #[test]
+        fn rebuild_same_date_same_rev_shows_bare() {
+            let date = chrono::Utc.with_ymd_and_hms(2025, 1, 15, 0, 0, 0).unwrap();
+            let before = make_catalog_package("hello", "2.12.1", "/nix/store/old", "abc1234", date);
+            let after = make_catalog_package("hello", "2.12.1", "/nix/store/new", "abc1234", date);
+            let mut diff = SingleSystemUpgradeDiff::new();
+            diff.insert("hello".to_string(), (before, after));
+            assert_eq!(render_diff(&diff), "- hello: 2.12.1 (rebuild)");
+        }
+
+        #[test]
+        fn count_categories_mixed() {
+            let before_curl =
+                make_catalog_package("curl", "8.9.0", "/nix/store/old", "aaa", chrono::Utc::now());
+            let after_curl =
+                make_catalog_package("curl", "8.10.1", "/nix/store/new", "bbb", chrono::Utc::now());
+            let before_tf = make_catalog_package(
+                "terraform-docs",
+                "0.21.0",
+                "/nix/store/old",
+                "ccc",
+                chrono::Utc::now(),
+            );
+            let after_tf = make_catalog_package(
+                "terraform-docs",
+                "0.21.0",
+                "/nix/store/new",
+                "ddd",
+                chrono::Utc::now(),
+            );
+            let mut diff = SingleSystemUpgradeDiff::new();
+            diff.insert("curl".to_string(), (before_curl, after_curl));
+            diff.insert("terraform-docs".to_string(), (before_tf, after_tf));
+            let (version_changes, rebuilds) = count_upgrade_categories(&diff);
+            assert_eq!(version_changes, 1);
+            assert_eq!(rebuilds, 1);
+        }
+    }
+
+    mod format_summary_tests {
+        use super::super::format_upgrade_summary;
+
+        #[test]
+        fn version_change_singular() {
+            assert_eq!(format_upgrade_summary(1, 0), "1 version change");
+        }
+
+        #[test]
+        fn version_changes_plural() {
+            assert_eq!(format_upgrade_summary(3, 0), "3 version changes");
+        }
+
+        #[test]
+        fn rebuild_singular() {
+            assert_eq!(format_upgrade_summary(0, 1), "1 rebuild");
+        }
+
+        #[test]
+        fn rebuilds_plural() {
+            assert_eq!(format_upgrade_summary(0, 4), "4 rebuilds");
+        }
+
+        #[test]
+        fn mixed() {
+            assert_eq!(format_upgrade_summary(2, 1), "2 version changes and 1 rebuild");
+        }
+
+        #[test]
+        fn mixed_plural() {
+            assert_eq!(format_upgrade_summary(3, 5), "3 version changes and 5 rebuilds");
+        }
+
+        #[test]
+        fn fallback_when_zero() {
+            assert_eq!(format_upgrade_summary(0, 0), "Upgrades");
+        }
     }
 }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -350,7 +350,7 @@ mod tests {
         }
 
         #[test]
-        fn version_change_shows_arrow() {
+        fn upgrade_with_different_versions() {
             let before = make_catalog_package(
                 "curl",
                 "8.9.0",
@@ -417,6 +417,41 @@ mod tests {
             let mut diff = SingleSystemUpgradeDiff::new();
             diff.insert("hello".to_string(), (before, after));
             assert_eq!(render_diff(&diff), "- hello: 2.12.1 (rebuild)");
+        }
+
+        #[test]
+        fn dry_run_summary_with_rebuild() {
+            let date = chrono::Utc.with_ymd_and_hms(2025, 1, 15, 0, 0, 0).unwrap();
+            let before = make_catalog_package("hello", "2.12.1", "/nix/store/old", "abc1234", date);
+            let after = make_catalog_package("hello", "2.12.1", "/nix/store/new", "abc1234", date);
+            let mut diff = SingleSystemUpgradeDiff::new();
+            diff.insert("hello".to_string(), (before, after));
+            let (vc, rb) = count_upgrade_categories(&diff);
+            assert_eq!(format_upgrade_summary(vc, rb), "1 rebuild");
+            assert_eq!(render_diff(&diff), "- hello: 2.12.1 (rebuild)");
+        }
+
+        #[test]
+        fn dry_run_summary_with_version_change_and_rebuild() {
+            let date = chrono::Utc.with_ymd_and_hms(2025, 1, 15, 0, 0, 0).unwrap();
+            let before_curl = make_catalog_package("curl", "8.9.0", "/nix/store/old", "aaa", date);
+            let after_curl = make_catalog_package("curl", "8.10.1", "/nix/store/new", "bbb", date);
+            let before_hello =
+                make_catalog_package("hello", "2.12.1", "/nix/store/old", "abc1234", date);
+            let after_hello =
+                make_catalog_package("hello", "2.12.1", "/nix/store/new", "abc1234", date);
+            let mut diff = SingleSystemUpgradeDiff::new();
+            diff.insert("curl".to_string(), (before_curl, after_curl));
+            diff.insert("hello".to_string(), (before_hello, after_hello));
+            let (vc, rb) = count_upgrade_categories(&diff);
+            assert_eq!(
+                format_upgrade_summary(vc, rb),
+                "1 version change and 1 rebuild"
+            );
+            assert_eq!(
+                render_diff(&diff),
+                "- curl: 8.9.0 -> 8.10.1\n- hello: 2.12.1 (rebuild)"
+            );
         }
 
         #[test]

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -12,6 +12,7 @@ use super::services::warn_manifest_changes_for_services;
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::{ensure_auth, environment_description};
 use crate::utils::message::{self, stderr_supports_color};
+use crate::utils::upgrade_output::{count_upgrade_categories, format_upgrade_summary};
 use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Upgrade packages in an environment
@@ -200,38 +201,6 @@ fn rebuild_detail(before: &LockedPackage, after: &LockedPackage) -> Option<Strin
     None
 }
 
-/// Count version changes vs rebuilds in a diff.
-pub(crate) fn count_upgrade_categories(diff: &SingleSystemUpgradeDiff) -> (usize, usize) {
-    diff.values().fold((0, 0), |(vc, rb), (before, after)| {
-        let old_version = before.version().unwrap_or("unknown");
-        let new_version = after.version().unwrap_or("unknown");
-        if new_version != old_version {
-            (vc + 1, rb)
-        } else {
-            (vc, rb + 1)
-        }
-    })
-}
-
-/// Format a human-readable summary like "2 version changes and 1 rebuild".
-pub(crate) fn format_upgrade_summary(version_changes: usize, rebuilds: usize) -> String {
-    let version_part = match version_changes {
-        0 => None,
-        1 => Some("1 version change".to_string()),
-        n => Some(format!("{n} version changes")),
-    };
-    let rebuild_part = match rebuilds {
-        0 => None,
-        1 => Some("1 rebuild".to_string()),
-        n => Some(format!("{n} rebuilds")),
-    };
-    match (version_part, rebuild_part) {
-        (Some(v), Some(b)) => format!("{v} and {b}"),
-        (Some(v), None) => v,
-        (None, Some(b)) => b,
-        (None, None) => "Upgrades".to_string(),
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -484,48 +453,54 @@ mod tests {
         }
     }
 
-    mod format_summary_tests {
-        use super::super::format_upgrade_summary;
+    /// Run a dry-run upgrade of an environment that has a version change on this system
+    async fn run_dry_run_with_version_change() -> String {
+        let (mut flox, _tempdir) = flox_instance();
+        let (subscriber, writer) = test_subscriber_message_only();
 
-        #[test]
-        fn version_change_singular() {
-            assert_eq!(format_upgrade_summary(1, 0), "1 version change");
-        }
+        let mut environment = new_named_path_environment(&flox, "version = 1", "name");
 
-        #[test]
-        fn version_changes_plural() {
-            assert_eq!(format_upgrade_summary(3, 0), "3 version changes");
-        }
+        // Use the fixture that has an older version for THIS system
+        let response_path = if cfg!(target_os = "macos") {
+            "resolve/old_darwin_hello.yaml"
+        } else {
+            "resolve/old_linux_hello.yaml"
+        };
+        flox.catalog_client = catalog_replay_client(GENERATED_DATA.join(response_path)).await;
 
-        #[test]
-        fn rebuild_singular() {
-            assert_eq!(format_upgrade_summary(0, 1), "1 rebuild");
-        }
+        environment
+            .install(
+                &[PackageToInstall::parse(&flox.system, "hello").unwrap()],
+                &flox,
+            )
+            .unwrap();
 
-        #[test]
-        fn rebuilds_plural() {
-            assert_eq!(format_upgrade_summary(0, 4), "4 rebuilds");
+        flox.catalog_client =
+            catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
+        Upgrade {
+            environment: EnvironmentSelect::Dir(environment.parent_path().unwrap()),
+            dry_run: true,
+            groups_or_iids: Vec::new(),
         }
+        .handle(flox)
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
 
-        #[test]
-        fn mixed() {
-            assert_eq!(
-                format_upgrade_summary(2, 1),
-                "2 version changes and 1 rebuild"
-            );
-        }
+        writer.to_string()
+    }
 
-        #[test]
-        fn mixed_plural() {
-            assert_eq!(
-                format_upgrade_summary(3, 5),
-                "3 version changes and 5 rebuilds"
-            );
-        }
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dry_run_shows_version_change_summary() {
+        assert_eq!(
+            run_dry_run_with_version_change().await,
+            indoc! {"
+            Dry run: 1 version change in 'name':
+            - hello: 2.10.1 -> 2.12.3
 
-        #[test]
-        fn fallback_when_zero() {
-            assert_eq!(format_upgrade_summary(0, 0), "Upgrades");
-        }
+            To apply these changes, run upgrade without the '--dry-run' flag.
+
+            "}
+        );
     }
 }

--- a/cli/flox/src/utils/init/logger.rs
+++ b/cli/flox/src/utils/init/logger.rs
@@ -28,7 +28,9 @@ pub(crate) fn init_logger(verbosity: Option<Verbosity>) {
         // Only show warnings, and user facing messages
         Verbosity::Verbose(0) => "warn,flox::utils::message=info",
         // Show internal info logs
-        Verbosity::Verbose(1) => "warn,flox=info,flox-rust-sdk=info,flox-core=info",
+        Verbosity::Verbose(1) => {
+            "warn,flox=info,flox-rust-sdk=info,flox-core=info,flox::utils::message=debug"
+        },
         // Show debug logs from our libraries
         Verbosity::Verbose(2) => "warn,flox=debug,flox-rust-sdk=debug,flox-core=debug",
         // Show trace logs from our libraries

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -12,7 +12,7 @@ use flox_manifest::parsed::latest::SelectedOutputs;
 use flox_manifest::raw::PackageToInstall;
 use indoc::formatdoc;
 use minus::{ExitStrategy, Pager, page_all};
-use tracing::info;
+use tracing::{debug, info};
 
 /// Write a message to stderr.
 ///
@@ -51,6 +51,10 @@ pub(crate) fn deleted(v: impl Display) {
 }
 pub(crate) fn updated(v: impl Display) {
     print_message(format_updated(v));
+}
+/// Shown only at `-v` verbosity (`flox::utils::message=debug` filter).
+pub(crate) fn verbose(v: impl Display) {
+    debug!("{v}");
 }
 /// double width character, add an additional space for alignment
 pub(crate) fn info(v: impl Display) {

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -18,6 +18,7 @@ pub mod openers;
 pub mod search;
 pub mod tracing;
 pub mod update_notifications;
+pub mod upgrade_output;
 
 pub static TERMINAL_STDERR: LazyLock<Mutex<Stderr>> =
     LazyLock::new(|| Mutex::new(std::io::stderr()));

--- a/cli/flox/src/utils/upgrade_output.rs
+++ b/cli/flox/src/utils/upgrade_output.rs
@@ -1,0 +1,80 @@
+use flox_rust_sdk::models::environment::SingleSystemUpgradeDiff;
+
+/// Count version changes vs rebuilds in a diff.
+pub(crate) fn count_upgrade_categories(diff: &SingleSystemUpgradeDiff) -> (usize, usize) {
+    diff.values().fold((0, 0), |(vc, rb), (before, after)| {
+        let old_version = before.version().unwrap_or("unknown");
+        let new_version = after.version().unwrap_or("unknown");
+        if new_version != old_version {
+            (vc + 1, rb)
+        } else {
+            (vc, rb + 1)
+        }
+    })
+}
+
+/// Format a human-readable summary like "2 version changes and 1 rebuild".
+pub(crate) fn format_upgrade_summary(version_changes: usize, rebuilds: usize) -> String {
+    let version_part = match version_changes {
+        0 => None,
+        1 => Some("1 version change".to_string()),
+        n => Some(format!("{n} version changes")),
+    };
+    let rebuild_part = match rebuilds {
+        0 => None,
+        1 => Some("1 rebuild".to_string()),
+        n => Some(format!("{n} rebuilds")),
+    };
+    match (version_part, rebuild_part) {
+        (Some(v), Some(b)) => format!("{v} and {b}"),
+        (Some(v), None) => v,
+        (None, Some(b)) => b,
+        (None, None) => "Upgrades".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_change_singular() {
+        assert_eq!(format_upgrade_summary(1, 0), "1 version change");
+    }
+
+    #[test]
+    fn version_changes_plural() {
+        assert_eq!(format_upgrade_summary(3, 0), "3 version changes");
+    }
+
+    #[test]
+    fn rebuild_singular() {
+        assert_eq!(format_upgrade_summary(0, 1), "1 rebuild");
+    }
+
+    #[test]
+    fn rebuilds_plural() {
+        assert_eq!(format_upgrade_summary(0, 4), "4 rebuilds");
+    }
+
+    #[test]
+    fn mixed() {
+        assert_eq!(
+            format_upgrade_summary(2, 1),
+            "2 version changes and 1 rebuild"
+        );
+    }
+
+    #[test]
+    fn mixed_plural() {
+        assert_eq!(
+            format_upgrade_summary(3, 5),
+            "3 version changes and 5 rebuilds"
+        );
+    }
+
+    #[test]
+    fn fallback_when_zero() {
+        assert_eq!(format_upgrade_summary(0, 0), "Upgrades");
+    }
+}

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -84,7 +84,7 @@ function old_hello_response_version() {
     run "$FLOX_BIN" upgrade
   assert_success
   assert_output \
-"✔ Upgraded 1 package(s) in 'test':
+"✔ Upgraded 1 version change in 'test':
 - hello: $(old_hello_response_version) -> $(hello_response_version)"
 
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
@@ -104,7 +104,7 @@ function old_hello_response_version() {
     run "$FLOX_BIN" upgrade toplevel
   assert_success
   assert_output \
-"✔ Upgraded 1 package(s) in 'test':
+"✔ Upgraded 1 version change in 'test':
 - hello: $(old_hello_response_version) -> $(hello_response_version)"
 
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
@@ -124,7 +124,7 @@ function old_hello_response_version() {
     run "$FLOX_BIN" upgrade hello
   assert_success
   assert_output \
-"✔ Upgraded 1 package(s) in 'test':
+"✔ Upgraded 1 version change in 'test':
 - hello: $(old_hello_response_version) -> $(hello_response_version)"
 
   hello_locked_drv=$(jq -r '.packages.[0].derivation' "$LOCK_PATH")
@@ -202,7 +202,7 @@ To apply these changes, run upgrade without the '--dry-run' flag."
   assert_success
 
   assert_output \
-"✔ Upgraded 1 package(s) in 'test':
+"✔ Upgraded 1 version change in 'test':
 - hello: $old_version -> $new_version"
 }
 

--- a/cli/tests/upgrade.bats
+++ b/cli/tests/upgrade.bats
@@ -174,7 +174,7 @@ function old_hello_response_version() {
     run "$FLOX_BIN" upgrade --dry-run
   assert_success
   assert_output \
-"Dry run: Upgrades available for 1 package(s) in 'test':
+"Dry run: 1 version change in 'test':
 - hello: $(old_hello_response_version) -> $(hello_response_version)
 
 To apply these changes, run upgrade without the '--dry-run' flag."


### PR DESCRIPTION
## Summary

- Version changes now display `old -> new` (e.g., `cargo: 1.89.0 -> 1.92.0`)
- Same-version rebuilds display `(rebuild, rev DATE -> DATE)` with fallback to rev hash or bare `(rebuild)`
- Summary lines use "N version changes and M rebuilds" terminology in both `--dry-run` output and activation notifications
- Notification in `notify_package_upgrades` is now system-aware (skips if no changes for the current system)

### Example output

**`flox upgrade --dry-run`:**
```
Dry run: 9 version changes and 2 rebuilds in 'rust':
- cargo: 1.89.0 -> 1.92.0
- cargo-watch: 8.5.3 (rebuild, rev 2025-11-02 -> 2026-02-13)
- rustc: 1.89.0 -> 1.92.0
```

**Activation notification:**
```
ℹ 9 version changes and 2 rebuilds available in default.
Use 'flox upgrade --dry-run' for details.
```

Closes DEV-95. Fresh implementation from main; supersedes the abandoned #3999 (no `--detail` flag, no catalog API changes, no file splitting — AC-scoped only).

## Release Notes

`flox upgrade` output is now clearer about what changed and why:

- **Version changes** show the old and new version: `curl: 8.9.0 -> 8.10.1`
- **Rebuilds** (same version, different derivation) are labeled explicitly: `terraform-docs: 0.21.0 (rebuild, rev 2025-01-15 -> 2026-02-10)`
- **Summary lines** use plain English counts: `9 version changes and 2 rebuilds` instead of `9 package(s)`
- The activation notification when upgrades are available uses the same summary format

---
> 🤖 [Forge](https://github.com/flox/forge) `$(forge_sha 2>/dev/null || git -C /Users/stephen/Sites/forge rev-parse --short HEAD)`