### PR TITLE
fix(deactivate): exit interactive tcsh activations via a hook flag (DEV-122)

### DIFF
--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -354,8 +354,8 @@ mod tests {
             unset verbose;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
             setenv _FLOX_PROMPT_HOOK_VERSION 1;
-            alias precmd 'set _flox_invocation_type=inplace; if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE"; eval "`/flox hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`"; unset _flox_invocation_type';
-            alias cwdcmd 'set _flox_invocation_type=inplace; if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE"; eval "`/flox hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`"; unset _flox_invocation_type';
+            alias precmd 'set _flox_invocation_type=inplace; if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE"; eval "`/flox hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`"; unset _flox_invocation_type; if ( $?_flox_exit ) exit';
+            alias cwdcmd 'set _flox_invocation_type=inplace; if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE"; eval "`/flox hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`"; unset _flox_invocation_type; if ( $?_flox_exit ) exit';
         "#]].assert_eq(&output);
     }
 
@@ -393,8 +393,8 @@ mod tests {
             unset verbose;
             /nix/store/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-coreutils-9.10/bin/rm /path/to/rc/file;
             setenv _FLOX_PROMPT_HOOK_VERSION 1;
-            alias precmd 'set _flox_invocation_type=inplace; if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE"; eval "`/flox hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`"; unset _flox_invocation_type';
-            alias cwdcmd 'set _flox_invocation_type=inplace; if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE"; eval "`/flox hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`"; unset _flox_invocation_type';
+            alias precmd 'set _flox_invocation_type=inplace; if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE"; eval "`/flox hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`"; unset _flox_invocation_type; if ( $?_flox_exit ) exit';
+            alias cwdcmd 'set _flox_invocation_type=inplace; if ( $?_FLOX_INVOCATION_TYPE ) set _flox_invocation_type="$_FLOX_INVOCATION_TYPE"; eval "`/flox hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`"; unset _flox_invocation_type; if ( $?_flox_exit ) exit';
         "#]].assert_eq(&output);
     }
 

--- a/cli/flox-activations/src/hook.rs
+++ b/cli/flox-activations/src/hook.rs
@@ -134,6 +134,14 @@ pub fn fish_hook(flox_bin: &str) -> String {
 // it from `_FLOX_INVOCATION_TYPE` only when that is set, pass it, then unset it
 // so it doesn't linger. `inplace` is the right default because the prompt hook
 // only ever deactivates in place.
+//
+// Exiting from the hook is also awkward: if `exit` unwinds out of the eval'd
+// `hook-env` output, tcsh treats the special alias as broken, prints
+// "Faulty alias 'precmd' removed.", deletes the alias, and does NOT exit. An
+// `exit` at the alias-body top level is fine, so for an interactive
+// deactivation `hook-env` emits `set _flox_exit=1` (see
+// `emit_deactivate_script` in the `flox` crate) and the alias body checks the
+// flag after the eval completes.
 pub fn tcsh_hook(flox_bin: &str) -> String {
     // A tcsh alias body must be a single line, so assemble the statements here
     // and join them with "; " rather than writing one long string literal.
@@ -144,6 +152,7 @@ pub fn tcsh_hook(flox_bin: &str) -> String {
             r#"eval "`{flox_bin} hook-env --shell tcsh --shell-pid $$ --invocation-type "$_flox_invocation_type"`""#
         ),
         "unset _flox_invocation_type".to_string(),
+        "if ( $?_flox_exit ) exit".to_string(),
     ]
     .join("; ");
     formatdoc!(

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -32,7 +32,8 @@ pub struct Deactivate {
     ///
     /// When provided, emits a deactivation script to stdout. The value
     /// determines the exit strategy:
-    /// - `"interactive"` → emit `exit;` (subshell will exit and clean up)
+    /// - `"interactive"` → emit an exit (subshell will exit and clean up);
+    ///   see [`emit_deactivate_script`] for the tcsh-specific form
     /// - anything else   → emit in-place env-var restoration + detach command
     #[bpaf(long("print-script"), argument("INVOCATION_TYPE"), optional, hide)]
     pub print_script: Option<String>,
@@ -206,8 +207,14 @@ pub(crate) fn flox_activate_tracelevel() -> u32 {
 /// Emit a deactivation script for `invocation_kind` to `writer`.
 ///
 /// Shared by `flox deactivate --print-script` and `flox hook-env`:
-/// - `Interactive` → `exit;` (the subshell exits and the executive cleans up
-///   state.json when the PID goes away).
+/// - `Interactive` → an exit (the subshell exits and the executive cleans up
+///   state.json when the PID goes away). For most shells this is a literal
+///   `exit;`, but tcsh removes a special alias (`precmd`/`cwdcmd`) — printing
+///   "Faulty alias 'precmd' removed." — without exiting the shell when `exit`
+///   unwinds out of an `eval` inside it. The tcsh prompt hook evals this
+///   script from exactly that position, so for tcsh emit a flag the alias
+///   body checks after the eval, exiting at the alias top level instead
+///   (see `tcsh_hook` in `flox-activations`).
 /// - `InPlace`/`ShellCommand` → restore env vars, then emit a
 ///   `flox-activations detach` command so state.json is updated once the caller
 ///   eval's the script.
@@ -222,7 +229,10 @@ pub(crate) fn emit_deactivate_script(
 ) -> Result<()> {
     match invocation_kind {
         InvocationKind::Interactive => {
-            write!(writer, "exit;")?;
+            match shell {
+                ShellWithPath::Tcsh(_) => write!(writer, "set _flox_exit=1;")?,
+                _ => write!(writer, "exit;")?,
+            }
             Ok(())
         },
         InvocationKind::InPlace | InvocationKind::ShellCommand => {
@@ -240,5 +250,40 @@ pub(crate) fn emit_deactivate_script(
         InvocationKind::ExecCommand => {
             bail!("cannot deactivate an exec command activation");
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn interactive_deactivate_script(shell: ShellWithPath) -> String {
+        let mut buf = Vec::new();
+        emit_deactivate_script(
+            shell,
+            InvocationKind::Interactive,
+            Path::new("/activation_state_dir"),
+            Path::new("/flox_env"),
+            0,
+            &mut buf,
+        )
+        .unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn interactive_deactivate_emits_exit_for_bash() {
+        let script = interactive_deactivate_script(ShellWithPath::Bash("bash".into()));
+        assert_eq!(script, "exit;");
+    }
+
+    #[test]
+    fn interactive_deactivate_emits_exit_flag_for_tcsh() {
+        // The tcsh prompt hook evals this script inside the precmd/cwdcmd alias
+        // body; an `exit` there makes tcsh remove the alias ("Faulty alias
+        // 'precmd' removed.") without exiting, so the script sets a flag the
+        // alias checks after the eval instead.
+        let script = interactive_deactivate_script(ShellWithPath::Tcsh("tcsh".into()));
+        assert_eq!(script, "set _flox_exit=1;");
     }
 }

--- a/cli/tests/activate/interactive-deactivate.exp
+++ b/cli/tests/activate/interactive-deactivate.exp
@@ -1,0 +1,26 @@
+# Activate a project environment interactively, run a plain `flox deactivate`
+# at the prompt, and expect the activation subshell to exit on the next prompt.
+
+set dir [lindex $argv 0]
+set flox $env(FLOX_BIN)
+set timeout 10
+set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
+
+spawn $flox activate --dir $dir
+expect_after {
+  timeout { exit 1 }
+  "*\n" { exp_continue }
+  "*\r" { exp_continue }
+}
+
+expect "You are now using the environment"
+expect $env(KNOWN_PROMPT)
+
+# Plain `flox deactivate` records a prompt-hook action; the next prompt's hook
+# consumes it and exits the subshell, so the session must end without any
+# further input. A timeout here means the shell survived the deactivation
+# (e.g. tcsh's "Faulty alias 'precmd' removed." regression).
+send "$flox deactivate\n"
+expect eof

--- a/cli/tests/deactivate.bats
+++ b/cli/tests/deactivate.bats
@@ -1091,6 +1091,21 @@ EOF
 }
 
 # bats test_tags=activate,deactivate
+@test "interactive deactivate exits the subshell via the prompt hook (tcsh)" {
+  project_setup
+
+  # Unlike the env-diff tests above, deactivate at the TOP-LEVEL interactive
+  # prompt: the next prompt's hook consumes the action and exits the subshell.
+  # Regression test: tcsh used to print "Faulty alias 'precmd' removed." and
+  # stay in the subshell, because an `exit` unwinding out of the eval inside
+  # the auto-fired precmd alias removes the alias instead of exiting (the
+  # deactivation script now sets a flag the alias body acts on).
+  FLOX_SHELL="tcsh" run -0 \
+    flox_cold_start expect "$TESTS_DIR/activate/interactive-deactivate.exp" "$PROJECT_DIR"
+  refute_output --partial "Faulty alias"
+}
+
+# bats test_tags=activate,deactivate
 @test "interactive deactivate env diff (zsh)" {
   project_setup
   "$FLOX_BIN" edit -f "$BATS_TEST_DIRNAME/activate/deactivate-vars.toml"

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -244,6 +244,36 @@ EOF
   assert_output --partial "after:original"
 }
 
+# bats test_tags=hook:deactivate:tcsh
+@test "tcsh: interactive-type deactivate exits via the auto-fired prompt hook" {
+  project_setup
+
+  # tcsh's faulty-alias handling only applies to auto-fired special aliases:
+  # an `exit` unwinding out of the eval'd `hook-env` output inside precmd makes
+  # tcsh print "Faulty alias 'precmd' removed." and delete the alias WITHOUT
+  # exiting the shell. The interactive deactivation script therefore sets
+  # `_flox_exit` for the alias body to act on after the eval. Unlike the test
+  # above, `precmd` must not be invoked manually here — a manual call is
+  # ordinary alias expansion and bypasses the faulty-alias handling under test;
+  # `tcsh -i` auto-fires precmd before each prompt even with stdin piped.
+  #
+  # The activation is in place; _FLOX_INVOCATION_TYPE is overridden to
+  # `interactive` so the hook requests the interactive (exit) deactivation
+  # script, as it would inside a real `flox activate` subshell.
+  SESSION="$BATS_TEST_TMPDIR/interactive-deactivate.tcsh"
+  cat > "$SESSION" <<EOF
+eval "\`$FLOX_BIN activate -d $PROJECT_DIR\`"
+setenv _FLOX_INVOCATION_TYPE interactive
+$FLOX_BIN deactivate
+echo SHOULD_NOT_PRINT: the shell exits at the next prompt, before this line
+EOF
+
+  run tcsh -i < "$SESSION"
+  assert_success
+  refute_output --partial "Faulty alias"
+  refute_output --partial "SHOULD_NOT_PRINT"
+}
+
 # ---------------------------------------------------------------------------- #
 # Plain `flox deactivate` errors when no compatible prompt hook will consume it
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes DEV-122.

## Summary

Plain `flox deactivate` inside an interactive tcsh activation failed with `Faulty alias 'precmd' removed.` and left the user stuck in the subshell, with the prompt hook deleted — repeating `flox deactivate` could never recover; only a manual `exit` escaped. bash, zsh, and fish are unaffected.

## Root cause

For the interactive invocation type the deactivation script was a shell-agnostic `exit;`, which the tcsh prompt hook evals **inside the auto-fired `precmd` alias**. tcsh treats an `exit` unwinding out of an `eval` in a special alias (`precmd`, `cwdcmd`, …) as the alias misbehaving: it prints `Faulty alias 'precmd' removed.`, deletes the alias, and does not exit. (Verified against bare tcsh 6.21/6.24 with no flox involved; an `exit` at the alias-body top level is handled fine.)

## Fix

- `emit_deactivate_script` is now shell-aware: for tcsh the interactive deactivation script emits `set _flox_exit=1;` instead of `exit;`.
- The tcsh `precmd`/`cwdcmd` alias body ends with `if ( $?_flox_exit ) exit`, so the exit happens at the alias-body top level after the eval completes.
- `PROMPT_HOOK_VERSION` intentionally stays at 1: the prompt hook is unreleased (this branch stack is what enables it), so no released flox has registered a hook the new emission could mismatch.

## Tests

- New `hook.bats` test pipes a session into `tcsh -i`, where special aliases auto-fire — the existing tests called `precmd` manually, which bypasses tcsh's faulty-alias handling and is why CI never caught this.
- New `deactivate.bats` test drives a full interactive session via a new `interactive-deactivate.exp` (activate, type `flox deactivate`, expect the session to end on its own).
- Both verified red against the old emission and green with the fix; repeated runs (8×, both tests) show no flakiness.
- Updated gen_rc tcsh snapshots and added unit tests pinning the per-shell interactive emission.

## Release Notes
-

🤖 Generated with [Claude Code](https://claude.com/claude-code)