### PR TITLE
test: migrate assert!(matches!(…)) to assert_matches!

### DIFF
--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -482,6 +482,7 @@ fn cleanup_all(
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches::assert_matches;
     use std::collections::BTreeMap;
 
     use flox_core::activate::mode::ActivateMode;
@@ -791,7 +792,7 @@ mod test {
             &project.flox_services_socket,
             &activation_state_directory,
         );
-        assert!(matches!(result, Ok(false)), "first call should succeed");
+        assert_matches!(result, Ok(false), "first call should succeed");
 
         // Second call: loop_guard.allow_remonitor(pid) returns false (count=2 >= limit=2)
         // The re-monitoring should be skipped
@@ -804,7 +805,7 @@ mod test {
             &project.flox_services_socket,
             &activation_state_directory,
         );
-        assert!(matches!(result, Ok(false)), "second call should succeed");
+        assert_matches!(result, Ok(false), "second call should succeed");
 
         // Verify the guard state: calling allow_remonitor again should return false
         // since we've hit the limit

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -70,6 +70,7 @@ pub fn cleanup_pid(
 
 #[cfg(test)]
 pub mod test {
+    use std::assert_matches::assert_matches;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::process::{Child, Command};
@@ -157,7 +158,7 @@ pub mod test {
         };
         state.set_ready(&start_id);
         let result = state.start_or_attach(pid2, &store_path);
-        assert!(matches!(result, StartOrAttachResult::Attach { .. }));
+        assert_matches!(result, StartOrAttachResult::Attach { .. });
 
         write_activation_state(runtime_dir.path(), &dot_flox_path, state);
 

--- a/cli/flox-core/src/data/flox_version.rs
+++ b/cli/flox-core/src/data/flox_version.rs
@@ -253,6 +253,8 @@ impl fmt::Display for FloxVersion {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
+
     use super::*;
 
     #[test]
@@ -349,10 +351,10 @@ mod tests {
 
     #[test]
     fn test_parse_version_with_wrong_git_describe_format() {
-        assert!(matches!(
+        assert_matches!(
             "1.2.3-21".parse::<FloxVersion>(),
             Err(VersionParseError::InvalidFormat),
-        ));
+        );
     }
 
     #[test]
@@ -376,10 +378,10 @@ mod tests {
 
     #[test]
     fn test_parse_version_with_pre_release_and_commits() {
-        assert!(matches!(
+        assert_matches!(
             "1.2.3-rc.1-10-gb91c3f1".parse::<FloxVersion>(),
             Err(VersionParseError::InvalidFormat),
-        ));
+        );
     }
 
     #[test]

--- a/cli/flox-core/src/version.rs
+++ b/cli/flox-core/src/version.rs
@@ -80,6 +80,8 @@ mod tests {
         },
     }
 
+    use std::assert_matches::assert_matches;
+
     use serde_json::json;
 
     use super::*;
@@ -92,14 +94,14 @@ mod tests {
         }))
         .expect("Should parse explicit V1");
 
-        assert!(matches!(bla, Bla::V1 { .. }));
+        assert_matches!(bla, Bla::V1 { .. });
 
         let bla = serde_json::from_value::<Bla>(json!({
             "hello": "world",
         }))
         .expect("Should parse implicit V1");
 
-        assert!(matches!(bla, Bla::V1 { .. }));
+        assert_matches!(bla, Bla::V1 { .. });
 
         serde_json::from_value::<Bla>(json!({
             "hello": "world",
@@ -116,7 +118,7 @@ mod tests {
         }))
         .expect("Should parse explicit V2");
 
-        assert!(matches!(bla, Bla::V2 { .. }));
+        assert_matches!(bla, Bla::V2 { .. });
 
         serde_json::from_value::<Bla>(json!({
             "foo": "bar",

--- a/cli/flox-manifest/src/parsed/latest.rs
+++ b/cli/flox-manifest/src/parsed/latest.rs
@@ -104,6 +104,7 @@ impl ManifestLatest {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::path::PathBuf;
 
     use flox_core::data::environment_ref::RemoteEnvironmentRef;
@@ -599,7 +600,7 @@ mod tests {
         let result = manifest_mock
             .resolve_install_id("dotted.package", &None)
             .unwrap_err();
-        assert!(matches!(result, ManifestError::MultiplePackagesMatch(_, _)));
+        assert_matches!(result, ManifestError::MultiplePackagesMatch(_, _));
     }
 
     #[test]
@@ -609,7 +610,7 @@ mod tests {
         let result = manifest_mock
             .resolve_install_id("invalid.packageName", &None)
             .unwrap_err();
-        assert!(matches!(result, ManifestError::PackageNotFound(_)));
+        assert_matches!(result, ManifestError::PackageNotFound(_));
     }
 
     #[test]

--- a/cli/flox-manifest/src/raw/mod.rs
+++ b/cli/flox-manifest/src/raw/mod.rs
@@ -97,6 +97,8 @@ pub(crate) fn get_json_schema_version_kind(
 
 #[cfg(test)]
 mod schema_version_tests {
+    use std::assert_matches::assert_matches;
+
     use super::*;
 
     fn parse_toml(s: impl AsRef<str>) -> DocumentMut {
@@ -107,14 +109,14 @@ mod schema_version_tests {
     fn missing_schema() {
         let toml = parse_toml("foo = 1");
         let err = get_schema_version_kind(&toml).err().unwrap();
-        assert!(matches!(err, ManifestError::MissingSchemaVersion));
+        assert_matches!(err, ManifestError::MissingSchemaVersion);
     }
 
     #[test]
     fn version_wrong_type() {
         let toml = parse_toml("version = true");
         let err = get_schema_version_kind(&toml).err().unwrap();
-        assert!(matches!(err, ManifestError::Other(_)));
+        assert_matches!(err, ManifestError::Other(_));
     }
 
     #[test]
@@ -130,7 +132,7 @@ mod schema_version_tests {
     fn schema_version_wrong_type() {
         let toml = parse_toml("schema-version = 42");
         let err = get_schema_version_kind(&toml).err().unwrap();
-        assert!(matches!(err, ManifestError::Other(_)));
+        assert_matches!(err, ManifestError::Other(_));
     }
 
     #[test]
@@ -1522,6 +1524,8 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches::assert_matches;
+
     use expect_test::expect;
     use pretty_assertions::assert_eq;
     use proptest::prelude::*;
@@ -1633,7 +1637,7 @@ mod test {
         ];
         let manifest = dummy_manifest();
         let removal = manifest.modify_packages(&test_packages);
-        assert!(matches!(removal, Err(ManifestError::PackageNotFound(_))));
+        assert_matches!(removal, Err(ManifestError::PackageNotFound(_)));
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/data/flox_version.rs
+++ b/cli/flox-rust-sdk/src/data/flox_version.rs
@@ -253,6 +253,8 @@ impl fmt::Display for FloxVersion {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
+
     use super::*;
 
     #[test]
@@ -349,10 +351,10 @@ mod tests {
 
     #[test]
     fn test_parse_version_with_wrong_git_describe_format() {
-        assert!(matches!(
+        assert_matches!(
             "1.2.3-21".parse::<FloxVersion>(),
             Err(VersionParseError::InvalidFormat),
-        ));
+        );
     }
 
     #[test]
@@ -376,10 +378,10 @@ mod tests {
 
     #[test]
     fn test_parse_version_with_pre_release_and_commits() {
-        assert!(matches!(
+        assert_matches!(
             "1.2.3-rc.1-10-gb91c3f1".parse::<FloxVersion>(),
             Err(VersionParseError::InvalidFormat),
-        ));
+        );
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/environment/core_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/core_environment.rs
@@ -1305,6 +1305,7 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
@@ -1414,7 +1415,7 @@ mod tests {
         let result = env_view
             .edit(&flox, same_manifest.to_string(), None)
             .unwrap();
-        assert!(matches!(result, EditResult::Changed { .. }));
+        assert_matches!(result, EditResult::Changed { .. });
     }
 
     /// Trying to build a manifest with a system other than the current one
@@ -1475,7 +1476,7 @@ mod tests {
             catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
         let result = env_view.edit(&flox, new_env_str.to_string(), None).unwrap();
 
-        assert!(matches!(result, EditResult::Changed { .. }));
+        assert_matches!(result, EditResult::Changed { .. });
         assert!(!result.reactivate_required().unwrap());
     }
 
@@ -1543,7 +1544,7 @@ mod tests {
             .replace_with(temp_env)
             .expect_err("Should fail if backup exists");
 
-        assert!(matches!(err, CoreEnvironmentError::PriorTransaction(_)));
+        assert_matches!(err, CoreEnvironmentError::PriorTransaction(_));
     }
 
     /// creating backup should fail if env is readonly
@@ -1766,12 +1767,12 @@ mod tests {
             .unwrap()
             .shutdown = None;
         let res = env.transact_with_manifest(&manifest, &flox, None);
-        assert!(matches!(
+        assert_matches!(
             res,
             Err(EnvironmentError::ManifestError(
                 ManifestError::InvalidServiceConfig(_)
             ))
-        ));
+        );
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs
+++ b/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs
@@ -737,6 +737,7 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
@@ -976,10 +977,10 @@ mod tests {
         let result =
             ensure_generation_locked(&remote_branch, &local_branch, &floxmeta, Some(input_lock));
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(FloxmetaBranchError::LocalRevDoesNotExist)
-        ));
+        );
     }
 
     /// Test that when ensure_generation_locked has input state of:
@@ -1076,7 +1077,7 @@ mod tests {
         let result =
             ensure_generation_locked(&remote_branch, &local_branch, &floxmeta, Some(input_lock));
 
-        assert!(matches!(result, Err(FloxmetaBranchError::RevDoesNotExist)));
+        assert_matches!(result, Err(FloxmetaBranchError::RevDoesNotExist));
     }
 
     /// Test that when ensure_generation_locked has input state of:
@@ -1158,7 +1159,7 @@ mod tests {
         let result =
             ensure_generation_locked(&remote_branch, &local_branch, &floxmeta, Some(input_lock));
 
-        assert!(matches!(result, Err(FloxmetaBranchError::RevDoesNotExist)));
+        assert_matches!(result, Err(FloxmetaBranchError::RevDoesNotExist));
     }
 
     /// Test that ensure_branch is a no-op with input state:

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1743,6 +1743,7 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches::assert_matches;
     use std::str::FromStr;
 
     use flox_core::Version;
@@ -2202,10 +2203,10 @@ mod test {
         let reg_path = env_registry_path(&flox);
         assert!(reg_path.exists());
         let reg = read_environment_registry(&reg_path).unwrap().unwrap();
-        assert!(matches!(
+        assert_matches!(
             reg.entries[0].envs[0].pointer,
             EnvironmentPointer::Managed(_)
-        ));
+        );
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1093,6 +1093,7 @@ pub fn create_dot_flox_gitignore(dot_flox_path: impl AsRef<Path>) -> Result<(), 
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches::assert_matches;
     use std::str::FromStr;
     use std::sync::LazyLock;
     use std::time::Duration;
@@ -1203,10 +1204,10 @@ mod test {
         let temp_dir = tempfile::tempdir().unwrap();
         let actual_dot_flox = temp_dir.path().join(DOT_FLOX);
         std::fs::create_dir_all(actual_dot_flox).unwrap();
-        assert!(matches!(
+        assert_matches!(
             find_dot_flox(temp_dir.path()),
             Err(EnvironmentError::InvalidDotFlox { .. })
-        ))
+        )
     }
 
     #[test]
@@ -1397,10 +1398,10 @@ mod test {
         let (mut flox, _temp_dir_handle) = flox_instance();
         flox.runtime_dir = flox.runtime_dir.join("X".repeat(100));
         let err = services_socket_path("1", &flox).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             EnvironmentError::ServicesSocketPathTooLong(_)
-        ));
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -1409,10 +1410,10 @@ mod test {
         let (mut flox, _temp_dir_handle) = flox_instance();
         flox.runtime_dir = flox.runtime_dir.join("X".repeat(100));
         let err = services_socket_path("1", &flox).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             EnvironmentError::ServicesSocketPathTooLong(_)
-        ));
+        );
     }
 
     /// The dev and run links are the `--out-link` prefix with the nix output
@@ -1436,6 +1437,8 @@ mod test {
 
 #[cfg(test)]
 mod migration_tests {
+    use std::assert_matches::assert_matches;
+
     use expect_test::expect;
     use flox_manifest::interfaces::{AsWritableManifest, SchemaVersion, WriteManifest};
     use flox_manifest::parsed::common::KnownSchemaVersion;
@@ -1788,7 +1791,7 @@ mod migration_tests {
         // flox activate will unnecessarily re-lock the environment.
         assert!(composer.lockfile_up_to_date().unwrap());
         let second_lock = composer.lockfile(&flox).unwrap();
-        assert!(matches!(second_lock, LockResult::Unchanged(_)));
+        assert_matches!(second_lock, LockResult::Unchanged(_));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -741,6 +741,7 @@ pub mod test_helpers {
 #[cfg(test)]
 pub mod tests {
 
+    use std::assert_matches::assert_matches;
     use std::fs::{self, OpenOptions};
     use std::io::Write;
 
@@ -889,10 +890,10 @@ pub mod tests {
         let reg_path = env_registry_path(&flox);
         assert!(reg_path.exists());
         let reg = read_environment_registry(&reg_path).unwrap().unwrap();
-        assert!(matches!(
+        assert_matches!(
             reg.entries[0].envs[0].pointer,
             EnvironmentPointer::Path(_)
-        ));
+        );
     }
 
     #[test]
@@ -914,10 +915,10 @@ pub mod tests {
         std::fs::remove_file(&reg_path).unwrap();
         let _env = PathEnvironment::open(&flox, ptr, env.path).unwrap();
         let reg = read_environment_registry(&reg_path).unwrap().unwrap();
-        assert!(matches!(
+        assert_matches!(
             reg.entries[0].envs[0].pointer,
             EnvironmentPointer::Path(_)
-        ));
+        );
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1462,6 +1462,8 @@ mod test_helpers {
 #[cfg(test)]
 mod realise_nixpkgs_tests {
 
+    use std::assert_matches::assert_matches;
+
     use flox_manifest::lockfile::test_helpers::{
         locked_package_catalog_from_mock,
         locked_published_package,
@@ -1562,7 +1564,7 @@ mod realise_nixpkgs_tests {
             &Semaphore::new(1, 1),
         );
         let err = result.expect_err("realising nixpkgs#AAAAAASomeThingsFailToEvaluate should fail");
-        assert!(matches!(err, BuildEnvError::Realise2 { .. }));
+        assert_matches!(err, BuildEnvError::Realise2 { .. });
     }
 
     /// Ensure that we can build, or (attempt to build) a package from the catalog,
@@ -1668,10 +1670,10 @@ mod realise_nixpkgs_tests {
             &Semaphore::new(1, 1),
         );
         eprintln!("RESULT: {subst_resp:?}");
-        assert!(matches!(
+        assert_matches!(
             subst_resp,
             Err(BuildEnvError::NoPackageStoreLocation(_))
-        ));
+        );
     }
 
     #[test]
@@ -1748,7 +1750,7 @@ mod realise_nixpkgs_tests {
             &Semaphore::new(1, 1),
         );
         let err = result.unwrap_err();
-        assert!(matches!(err, BuildEnvError::BuildPublishedPackage { .. }));
+        assert_matches!(err, BuildEnvError::BuildPublishedPackage { .. });
         assert_eq!(err.to_string(), indoc! {r#"
             Couldn't download package 'hello' from the following locations
 
@@ -1779,6 +1781,7 @@ mod realise_nixpkgs_tests {
 
 #[cfg(test)]
 mod realise_flakes_tests {
+    use std::assert_matches::assert_matches;
     use std::fs;
 
     use flox_manifest::parsed::latest::PackageDescriptorFlake;
@@ -1937,7 +1940,7 @@ mod realise_flakes_tests {
             .build();
         let result = BuildEnvNix::<NixAuth>::realise_flake(&locked_package);
         let err = result.expect_err("realising flake should fail");
-        assert!(matches!(err, BuildEnvError::Realise2 { .. }));
+        assert_matches!(err, BuildEnvError::Realise2 { .. });
     }
 
     /// Realising a flake should fail if the output is not valid and the source cannot be evaluated.
@@ -1956,7 +1959,7 @@ mod realise_flakes_tests {
 
         let result = BuildEnvNix::<NixAuth>::realise_flake(&locked_package);
         let err = result.expect_err("realising flake should fail");
-        assert!(matches!(err, BuildEnvError::Realise2 { .. }));
+        assert_matches!(err, BuildEnvError::Realise2 { .. });
     }
 
     /// Evaluation (and build) are skipped if the store path is already valid.
@@ -1983,6 +1986,8 @@ mod realise_flakes_tests {
 
 #[cfg(test)]
 mod realise_store_path_tests {
+    use std::assert_matches::assert_matches;
+
     use flox_manifest::parsed::common::DEFAULT_PRIORITY;
 
     use super::*;
@@ -2024,7 +2029,7 @@ mod realise_store_path_tests {
         let result =
             BuildEnvNix::<NixAuth>::realise_single_store_path(&locked, span, &Semaphore::new(1, 1))
                 .expect_err("invalid store path should fail to realise");
-        assert!(matches!(result, BuildEnvError::Realise2 { .. }));
+        assert_matches!(result, BuildEnvError::Realise2 { .. });
     }
 }
 
@@ -2760,6 +2765,7 @@ mod join_realise_results_tests {
 
 #[cfg(test)]
 mod materialise_retry_tests {
+    use std::assert_matches::assert_matches;
     use std::cell::Cell;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -2959,7 +2965,7 @@ mod materialise_retry_tests {
                 Ok(fake_outputs())
             },
         );
-        assert!(matches!(result.unwrap_err(), BuildEnvError::Build(_)));
+        assert_matches!(result.unwrap_err(), BuildEnvError::Build(_));
         assert!(
             !build_called.get(),
             "build_env must not be called if realise fails"

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -1413,6 +1413,7 @@ pub mod test_helpers {
 #[cfg(test)]
 pub mod tests {
 
+    use std::assert_matches::assert_matches;
     use std::collections::HashMap;
     use std::fs;
 
@@ -1569,10 +1570,10 @@ pub mod tests {
         let subdirectory = path.join("subdirectory");
         std::fs::create_dir(&subdirectory).unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             GitCommandProvider::open(subdirectory),
             Err(GitCommandOpenError::Subdirectory),
-        ));
+        );
     }
 
     // test opening a subdirectory of a bare repo fails
@@ -1584,22 +1585,22 @@ pub mod tests {
         // of having successfully created a bare repository. We previously
         // tested for the existence of "branches", but that directory stopped
         // being created in a recent update of the GitCommandProvider.
-        assert!(matches!(
+        assert_matches!(
             GitCommandProvider::open(tempdir_handle.path().join("hooks")),
             Err(GitCommandOpenError::Subdirectory),
-        ));
+        );
     }
 
     #[test]
     fn test_open_nonexistent() {
         let a = GitCommandProvider::open(PathBuf::from("/does-not-exist"));
         println!("{:?}", a);
-        assert!(matches!(
+        assert_matches!(
             GitCommandProvider::open(PathBuf::from("/does-not-exist")),
             Err(GitCommandOpenError::Discover(
                 GitCommandDiscoverError::Command(GitCommandError::BadExit(128, _, _))
             )),
-        ));
+        );
     }
 
     #[test]
@@ -1848,10 +1849,10 @@ pub mod tests {
             GitCommandProvider::clone_branch(&repo.path, tempdir_handle_2.path(), "branch_1", true)
                 .unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             repo_2.fetch_ref("origin", "does-not-exist"),
             Err(GitRemoteCommandError::RefNotFound(_))
-        ));
+        );
     }
 
     #[test]
@@ -1909,7 +1910,7 @@ pub mod tests {
         repo.checkout("branch_1", true).unwrap();
         commit_file(&repo, "dummy");
         let err = repo.push("origin", false).unwrap_err();
-        assert!(matches!(dbg!(err), GitRemoteCommandError::AccessDenied));
+        assert_matches!(dbg!(err), GitRemoteCommandError::AccessDenied);
     }
 
     /// Test that we pushing to a read only repo fails with [GitRemoteCommandError::AccessDenied]
@@ -1930,7 +1931,7 @@ pub mod tests {
 
         let err = repo.fetch().unwrap_err();
 
-        assert!(matches!(dbg!(err), GitRemoteCommandError::AccessDenied));
+        assert_matches!(dbg!(err), GitRemoteCommandError::AccessDenied);
     }
 
     /// Test that we pushing to a read only repo fails with [GitRemoteCommandError::AccessDenied]
@@ -1955,7 +1956,7 @@ pub mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(dbg!(err), GitRemoteCommandError::AccessDenied));
+        assert_matches!(dbg!(err), GitRemoteCommandError::AccessDenied);
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/lock_manifest.rs
+++ b/cli/flox-rust-sdk/src/providers/lock_manifest.rs
@@ -1353,6 +1353,7 @@ fn format_multiple_resolution_failures(failures: &[ResolutionFailure]) -> String
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::sync::LazyLock;
 
     use flox_core::data::environment_ref::RemoteEnvironmentRef;
@@ -3057,7 +3058,7 @@ mod tests {
         manifest.options.allow.unfree = Some(false);
 
         let client = MockClient::new();
-        assert!(matches!(
+        assert_matches!(
             LockManifest::resolve_manifest(
                 &manifest,
                 Some(&locked),
@@ -3067,7 +3068,7 @@ mod tests {
             .await
             .unwrap_err(),
             ResolveError::UnfreeNotAllowed { .. }
-        ));
+        );
     }
 
     /// [Lockfile::lock_manifest] returns an error if the server
@@ -3095,7 +3096,7 @@ mod tests {
             GENERATED_DATA.join("resolve/hello_buggy_unfree_server_response.yaml"),
         )
         .await;
-        assert!(matches!(
+        assert_matches!(
             LockManifest::resolve_manifest(
                 manifest.as_latest_schema(),
                 None,
@@ -3105,7 +3106,7 @@ mod tests {
             .await
             .unwrap_err(),
             ResolveError::UnfreeNotAllowed { .. }
-        ));
+        );
     }
 
     /// [Lockfile::check_packages_are_allowed] returns an error
@@ -3115,14 +3116,14 @@ mod tests {
         let (_, _, mut foo_locked) = fake_catalog_package_lock("foo", None);
         foo_locked.license = Some("disallowed".to_string());
 
-        assert!(matches!(
+        assert_matches!(
             LockManifest::check_packages_are_allowed(&vec![foo_locked], &Allows {
                 unfree: None,
                 broken: None,
                 licenses: Some(vec!["allowed".to_string()])
             }),
             Err(ResolveError::LicenseNotAllowed { .. })
-        ));
+        );
     }
 
     /// [Lockfile::check_packages_are_allowed] does not error when
@@ -3166,14 +3167,14 @@ mod tests {
         let (_, _, mut foo_locked) = fake_catalog_package_lock("foo", None);
         foo_locked.broken = Some(true);
 
-        assert!(matches!(
+        assert_matches!(
             LockManifest::check_packages_are_allowed(&vec![foo_locked], &Allows {
                 unfree: None,
                 broken: None,
                 licenses: None
             }),
             Err(ResolveError::BrokenNotAllowed { .. })
-        ));
+        );
     }
 
     /// [Lockfile::check_packages_are_allowed] does not error for a
@@ -3200,14 +3201,14 @@ mod tests {
         let (_, _, mut foo_locked) = fake_catalog_package_lock("foo", None);
         foo_locked.broken = Some(true);
 
-        assert!(matches!(
+        assert_matches!(
             LockManifest::check_packages_are_allowed(&vec![foo_locked], &Allows {
                 unfree: None,
                 broken: Some(false),
                 licenses: None
             }),
             Err(ResolveError::BrokenNotAllowed { .. })
-        ));
+        );
     }
 
     /// [Lockfile::check_packages_are_allowed] does not error for
@@ -3251,14 +3252,14 @@ mod tests {
         let (_, _, mut foo_locked) = fake_catalog_package_lock("foo", None);
         foo_locked.unfree = Some(true);
 
-        assert!(matches!(
+        assert_matches!(
             LockManifest::check_packages_are_allowed(&vec![foo_locked], &Allows {
                 unfree: Some(false),
                 broken: None,
                 licenses: None
             }),
             Err(ResolveError::UnfreeNotAllowed { .. })
-        ));
+        );
     }
 
     #[test]

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -443,6 +443,7 @@ impl Edit {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::fs;
 
     use flox_rust_sdk::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
@@ -825,7 +826,7 @@ mod tests {
             .downcast::<ManagedEnvironmentError>()
             .expect("should be a ManagedEnvironmentError");
 
-        assert!(matches!(err, ManagedEnvironmentError::CheckoutOutOfSync));
+        assert_matches!(err, ManagedEnvironmentError::CheckoutOutOfSync);
     }
 
     /// If a manifest file or contents are provided, edit succeeds despite local changes.

--- a/cli/flox/src/commands/gc.rs
+++ b/cli/flox/src/commands/gc.rs
@@ -335,6 +335,8 @@ fn run_store_gc() -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
+
     use super::*;
 
     fn state_sequence(lines: &[&str]) -> Vec<GcProgress> {
@@ -372,26 +374,26 @@ mod tests {
         let states = state_sequence(&lines);
         assert!(!states.is_empty());
         let mut states = states.into_iter();
-        assert!(matches!(states.next().unwrap(), GcProgress::Init));
-        assert!(matches!(states.next().unwrap(), GcProgress::FindingRoots));
-        assert!(matches!(states.next().unwrap(), GcProgress::RemovingLinks));
-        assert!(matches!(states.next().unwrap(), GcProgress::Scanning));
-        assert!(matches!(
+        assert_matches!(states.next().unwrap(), GcProgress::Init);
+        assert_matches!(states.next().unwrap(), GcProgress::FindingRoots);
+        assert_matches!(states.next().unwrap(), GcProgress::RemovingLinks);
+        assert_matches!(states.next().unwrap(), GcProgress::Scanning);
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
+        );
         assert!(states.next().is_none());
     }
 
@@ -414,21 +416,21 @@ mod tests {
         let states = state_sequence(&lines);
         assert!(!states.is_empty());
         let mut states = states.into_iter();
-        assert!(matches!(states.next().unwrap(), GcProgress::Init));
-        assert!(matches!(states.next().unwrap(), GcProgress::FindingRoots));
-        assert!(matches!(states.next().unwrap(), GcProgress::Scanning));
-        assert!(matches!(
+        assert_matches!(states.next().unwrap(), GcProgress::Init);
+        assert_matches!(states.next().unwrap(), GcProgress::FindingRoots);
+        assert_matches!(states.next().unwrap(), GcProgress::Scanning);
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
+        );
         assert!(states.next().is_none());
     }
 
@@ -447,20 +449,20 @@ mod tests {
         let states = state_sequence(&lines);
         assert!(!states.is_empty());
         let mut states = states.into_iter();
-        assert!(matches!(states.next().unwrap(), GcProgress::Init));
-        assert!(matches!(states.next().unwrap(), GcProgress::FindingRoots));
-        assert!(matches!(
+        assert_matches!(states.next().unwrap(), GcProgress::Init);
+        assert_matches!(states.next().unwrap(), GcProgress::FindingRoots);
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             states.next().unwrap(),
             GcProgress::DeletingStorePaths(_)
-        ));
+        );
         assert!(states.next().is_none());
     }
 }

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -524,6 +524,7 @@ fn mk_environment(envs: &mut Vec<(String, String)>, prefix: &str) -> Environment
 #[cfg(test)]
 mod tests {
 
+    use std::assert_matches::assert_matches;
     use std::num::NonZero;
 
     use indoc::{formatdoc, indoc};
@@ -754,7 +755,7 @@ mod tests {
     fn test_writing_invalid() {
         let config_content =
             Config::write_to(None, &Key::parse("does_not_exist").unwrap(), Some("true"));
-        assert!(matches!(config_content, Err(ReadWriteError::InvalidKey(_))));
+        assert_matches!(config_content, Err(ReadWriteError::InvalidKey(_)));
     }
 
     #[test]
@@ -785,10 +786,10 @@ mod tests {
             &Key::parse("invalid").unwrap(),
             None::<()>,
         );
-        assert!(matches!(
+        assert_matches!(
             config_content,
             Err(ReadWriteError::NotAUserValue(_))
-        ));
+        );
     }
 
     #[test]
@@ -800,10 +801,10 @@ mod tests {
             &Key::parse("git_base_url").unwrap(),
             None::<()>,
         );
-        assert!(matches!(
+        assert_matches!(
             config_content,
             Err(ReadWriteError::NotAUserValue(_))
-        ));
+        );
     }
 
     #[test]
@@ -815,10 +816,10 @@ mod tests {
             &Key::parse("trusted_environments.\"foo/bar\"").unwrap(),
             None::<()>,
         );
-        assert!(matches!(
+        assert_matches!(
             config_content,
             Err(ReadWriteError::NotAUserValue(_))
-        ));
+        );
     }
 
     #[test]


### PR DESCRIPTION
Rust 1.96 stabilized `std::assert_matches::assert_matches`, so this replaces the 74 `assert!(matches!(…))` assertions across the test suites with the dedicated macro for clearer intent and better failure output. Each touched test module gains a `use std::assert_matches::assert_matches;` import (it is not in the prelude). `assert!(!matches!(…))` and bare `matches!` calls are left untouched.

Stacked on #4368 (the 1.96 toolchain bump) — `assert_matches!` does not compile until that lands, so the toolchain commits appear in this diff and will drop out once #4368 merges. No behavioral change; test-only.

Note: nix/cargo were not available in the authoring sandbox, so `cargo fmt`/`clippy`/tests were not run locally — relying on CI to verify.
