### PR TITLE
feat(sandbox): interactive prompt broker for the virtual sandbox (Phase 2)

### DIFF
--- a/cli/flox-manifest/src/parsed/v1_13_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_13_0/mod.rs
@@ -236,9 +236,10 @@ impl SkipSerializing for Build {
 /// Sandbox mode for a build.
 ///
 /// This is a version-specific copy of `common::BuildSandbox` because V1_13_0
-/// adds the local `warn` and `enforce` modes. Keeping the new variants out of
-/// the common enum is what stops older schema versions (whose `BuildDescriptor`
-/// uses `common::BuildSandbox`) from accepting `sandbox = "warn" | "enforce"`.
+/// adds the local `warn`, `enforce`, and `prompt` modes. Keeping the new
+/// variants out of the common enum is what stops older schema versions (whose
+/// `BuildDescriptor` uses `common::BuildSandbox`) from accepting
+/// `sandbox = "warn" | "enforce" | "prompt"`.
 #[derive(
     Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, derive_more::Display, JsonSchema,
 )]
@@ -250,6 +251,10 @@ pub enum BuildSandbox {
     Warn,
     /// Local build; out-of-closure file access is denied (the build fails).
     Enforce,
+    /// Local build; out-of-closure file access is referred to an interactive
+    /// prompt (and otherwise denied, as enforce). A transitional mode for
+    /// building up a `sandbox-allow` list.
+    Prompt,
     Pure,
 }
 

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -214,6 +214,14 @@ pub struct FloxBuildMk<'args> {
     // are inherited from the current process.
     stdout_buffer: Option<&'args mut String>,
     stderr_buffer: Option<&'args mut String>,
+
+    // Interactive sandbox prompt broker (Phase 2). When set, the build is run
+    // with FLOX_SANDBOX_PROMPT_SOCKET pointing at the broker so libsandbox refers
+    // out-of-closure accesses to it. `force_prompt` additionally passes
+    // FLOX_SANDBOX_OVERRIDE=prompt so the build runs in prompt mode regardless of
+    // the manifest's sandbox value (used by `flox build --sandbox-prompt`).
+    prompt_socket: Option<PathBuf>,
+    force_prompt: bool,
 }
 
 impl FloxBuildMk<'_> {
@@ -231,7 +239,19 @@ impl FloxBuildMk<'_> {
             built_environments,
             stdout_buffer: None,
             stderr_buffer: None,
+            prompt_socket: None,
+            force_prompt: false,
         }
+    }
+
+    /// Attach an interactive sandbox prompt broker: the build runs with
+    /// `FLOX_SANDBOX_PROMPT_SOCKET` set to `socket`. When `force_prompt` is true
+    /// (the `--sandbox-prompt` flag) it also forces prompt mode regardless of the
+    /// manifest's per-build sandbox value.
+    pub fn with_sandbox_prompt(mut self, socket: PathBuf, force_prompt: bool) -> Self {
+        self.prompt_socket = Some(socket);
+        self.force_prompt = force_prompt;
+        self
     }
 
     /// Create a new instance with std{out,err} piped into buffers
@@ -254,6 +274,8 @@ impl FloxBuildMk<'_> {
             built_environments,
             stdout_buffer: Some(stdout),
             stderr_buffer: Some(stderr),
+            prompt_socket: None,
+            force_prompt: false,
         }
     }
 
@@ -351,6 +373,19 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         let build_cache = build_cache.unwrap_or(true);
         if !build_cache {
             command.arg("DISABLE_BUILDCACHE=true");
+        }
+
+        // Interactive sandbox prompt broker wiring (Phase 2). flox-build.mk
+        // forwards FLOX_SANDBOX_PROMPT_SOCKET into the build-script injection and
+        // honors FLOX_SANDBOX_OVERRIDE above the manifest's sandbox value.
+        if let Some(prompt_socket) = &self.prompt_socket {
+            command.arg(format!(
+                "FLOX_SANDBOX_PROMPT_SOCKET={}",
+                prompt_socket.display()
+            ));
+        }
+        if self.force_prompt {
+            command.arg("FLOX_SANDBOX_OVERRIDE=prompt");
         }
 
         if self.stdout_buffer.is_some() {

--- a/cli/flox-rust-sdk/src/providers/mod.rs
+++ b/cli/flox-rust-sdk/src/providers/mod.rs
@@ -10,5 +10,6 @@ pub mod manifest_init;
 pub mod nix;
 pub mod nix_auth;
 pub mod publish;
+pub mod sandbox_prompt;
 pub mod services;
 pub mod upgrade_checks;

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -917,12 +917,18 @@ pub fn check_build_metadata(
 }
 
 /// Returns `true` when `pkg` is a manifest build that runs locally, in situ:
-/// sandbox `off` (or unset, which defaults to off), `warn`, or `enforce`. Only
-/// `pure` builds hermetically from a clean checkout, so it is the sole mode
-/// that returns `false`.
+/// sandbox `off` (or unset, which defaults to off), `warn`, `enforce`, or
+/// `prompt`. Only `pure` builds hermetically from a clean checkout, so it is the
+/// sole mode that returns `false`.
 fn sandbox_is_local(pkg: &PackageTarget) -> bool {
     matches!(pkg.kind(), PackageTargetKind::ManifestBuild {
-        sandbox: None | Some(BuildSandbox::Off | BuildSandbox::Warn | BuildSandbox::Enforce)
+        sandbox: None
+            | Some(
+                BuildSandbox::Off
+                    | BuildSandbox::Warn
+                    | BuildSandbox::Enforce
+                    | BuildSandbox::Prompt
+            )
     })
 }
 

--- a/cli/flox-rust-sdk/src/providers/sandbox_prompt.rs
+++ b/cli/flox-rust-sdk/src/providers/sandbox_prompt.rs
@@ -1,0 +1,447 @@
+//! Interactive prompt broker for the build-time virtual sandbox (Phase 2).
+//!
+//! When a manifest build runs under `sandbox = "warn"`/`"enforce"`, libsandbox
+//! (the `LD_PRELOAD`/`DYLD` shim) refers each out-of-closure file access that is
+//! not already permitted to a broker over an `AF_UNIX` socket, instead of just
+//! warning or blocking. This module is that broker: the `flox` side of the
+//! control channel.
+//!
+//! Responsibilities handled here (increment 2):
+//!   - own the socket and hand its path to the build (via
+//!     `FLOX_SANDBOX_PROMPT_SOCKET`),
+//!   - **serialize** requests — connections are accepted and answered one at a
+//!     time, so prompts from parallel build processes (`make -j`, `npm`, …)
+//!     never interleave,
+//!   - **remember** accepted patterns and auto-answer any later request already
+//!     covered by one, so the user is asked at most once per pattern even across
+//!     many build processes,
+//!   - delegate the actual allow/deny decision for a *new* access to a
+//!     [`PromptResolver`] — the seam where the interactive UI (increment 3)
+//!     plugs in.
+//!
+//! The wire protocol mirrors what libsandbox speaks: one request and one reply
+//! per connection, newline-terminated text.
+//!
+//!   -> `<realpath>\n`
+//!   <- `allow\n`                 allow this access (once)
+//!   <- `allow-glob <pattern>\n`  allow, and remember `<pattern>`
+//!   <- `deny\n`                  deny this access
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+use tempfile::TempDir;
+use tracing::{debug, warn};
+
+/// Environment variable libsandbox reads to find the broker socket.
+pub const PROMPT_SOCKET_ENV: &str = "FLOX_SANDBOX_PROMPT_SOCKET";
+
+/// What to do about an out-of-closure access that is not yet covered by an
+/// accepted pattern. Returned by a [`PromptResolver`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptDecision {
+    /// Allow this exact path (remembered so the same path is not asked again).
+    Allow,
+    /// Allow and remember a glob pattern (e.g. `~/.npm/**`); future accesses
+    /// matching it are auto-allowed, and the pattern can be written back to the
+    /// manifest's `sandbox-allow`.
+    AllowGlob(String),
+    /// Deny this access (libsandbox turns it into `EACCES`).
+    Deny,
+}
+
+/// Decides what to do about a *new* out-of-closure access (one not already
+/// covered by a previously accepted pattern). The broker owns the resolver and
+/// calls it on its serving thread, so it may block (e.g. to prompt the user);
+/// the single-threaded accept loop guarantees one prompt at a time.
+///
+/// This is the extension point for increment 3's interactive UI. Implementations
+/// must be `Send` because the resolver moves onto the broker thread.
+pub trait PromptResolver: Send {
+    fn resolve(&mut self, path: &Path) -> PromptDecision;
+}
+
+/// A [`PromptResolver`] that denies everything. Useful as a safe default and in
+/// tests; with it the broker behaves like plain `enforce`.
+#[derive(Debug, Default, Clone)]
+pub struct DenyAll;
+
+impl PromptResolver for DenyAll {
+    fn resolve(&mut self, _path: &Path) -> PromptDecision {
+        PromptDecision::Deny
+    }
+}
+
+/// The set of exceptions accepted so far during a build. Shared between the
+/// serving thread (which appends as the user accepts) and the owner (which reads
+/// `globs` afterwards to offer a `sandbox-allow` write-back).
+#[derive(Debug, Default)]
+struct Accepted {
+    /// Glob patterns the user accepted (`AllowGlob`).
+    globs: Vec<String>,
+    /// Exact realpaths the user accepted (`Allow`).
+    exacts: Vec<String>,
+    /// `$HOME`, captured once, for expanding a leading `~/` in patterns the same
+    /// way libsandbox does.
+    home: Option<String>,
+}
+
+impl Accepted {
+    /// If `path` is already covered by an accepted glob, return that glob.
+    fn matching_glob(&self, path: &str) -> Option<&str> {
+        self.globs
+            .iter()
+            .find(|g| glob_matches(g, path, self.home.as_deref()))
+            .map(String::as_str)
+    }
+
+    fn covered_exactly(&self, path: &str) -> bool {
+        self.exacts.iter().any(|p| p == path)
+    }
+}
+
+/// A running prompt broker. Dropping it shuts the serving thread down and
+/// removes the socket.
+pub struct SandboxPromptBroker {
+    socket_path: PathBuf,
+    // Kept so the temp dir (and the socket inside it) lives as long as the
+    // broker; dropped last.
+    _tempdir: TempDir,
+    accepted: Arc<Mutex<Accepted>>,
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl SandboxPromptBroker {
+    /// Create a broker listening on a fresh socket, serving requests with
+    /// `resolver`. The serving thread starts immediately.
+    pub fn new(resolver: Box<dyn PromptResolver>) -> std::io::Result<Self> {
+        let tempdir = tempfile::Builder::new()
+            .prefix("flox-sandbox-prompt")
+            .tempdir()?;
+        let socket_path = tempdir.path().join("prompt.sock");
+        let listener = UnixListener::bind(&socket_path)?;
+
+        let accepted = Arc::new(Mutex::new(Accepted {
+            home: std::env::var("HOME").ok(),
+            ..Default::default()
+        }));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let handle = {
+            let accepted = Arc::clone(&accepted);
+            let stop = Arc::clone(&stop);
+            std::thread::Builder::new()
+                .name("flox-sandbox-prompt-broker".into())
+                .spawn(move || serve(listener, resolver, accepted, stop))?
+        };
+
+        Ok(Self {
+            socket_path,
+            _tempdir: tempdir,
+            accepted,
+            stop,
+            handle: Some(handle),
+        })
+    }
+
+    /// Path of the broker socket; set as `FLOX_SANDBOX_PROMPT_SOCKET` in the
+    /// build's environment.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Glob patterns the user accepted so far. Increment 4 offers to write these
+    /// back to the manifest's `sandbox-allow`.
+    pub fn accepted_globs(&self) -> Vec<String> {
+        self.accepted
+            .lock()
+            .expect("broker mutex poisoned")
+            .globs
+            .clone()
+    }
+
+    /// Stop the serving thread and wait for it. Idempotent; also run by `Drop`.
+    pub fn shutdown(&mut self) {
+        if self.stop.swap(true, Ordering::SeqCst) {
+            return; // already stopping
+        }
+        // Wake the blocking accept() by making a throwaway connection; the loop
+        // observes `stop` and exits without serving it.
+        let _ = UnixStream::connect(&self.socket_path);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for SandboxPromptBroker {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// The serving thread: accept one connection at a time and answer it. Because
+/// the loop is single-threaded and handles each connection fully before
+/// accepting the next, prompts are inherently serialized.
+fn serve(
+    listener: UnixListener,
+    mut resolver: Box<dyn PromptResolver>,
+    accepted: Arc<Mutex<Accepted>>,
+    stop: Arc<AtomicBool>,
+) {
+    for stream in listener.incoming() {
+        if stop.load(Ordering::SeqCst) {
+            break;
+        }
+        match stream {
+            Ok(stream) => {
+                if let Err(err) = handle_connection(stream, resolver.as_mut(), &accepted) {
+                    debug!(%err, "sandbox prompt: connection error");
+                }
+            },
+            Err(err) => {
+                warn!(%err, "sandbox prompt: accept failed");
+                break;
+            },
+        }
+    }
+}
+
+/// Read one request, decide, and write one reply.
+fn handle_connection(
+    stream: UnixStream,
+    resolver: &mut dyn PromptResolver,
+    accepted: &Arc<Mutex<Accepted>>,
+) -> std::io::Result<()> {
+    // The listener may be non-blocking after a wake; ensure normal blocking I/O.
+    stream.set_nonblocking(false)?;
+    let mut reader = BufReader::new(&stream);
+    let mut line = String::new();
+    if reader.read_line(&mut line)? == 0 {
+        return Ok(()); // peer closed without a request (e.g. shutdown wake)
+    }
+    let path = line.trim_end_matches(['\n', '\r']);
+    if path.is_empty() {
+        return Ok(());
+    }
+
+    let reply = decide(path, resolver, accepted);
+    debug!(path, reply = reply.trim_end(), "sandbox prompt: answered");
+    (&stream).write_all(reply.as_bytes())
+}
+
+/// Produce the wire reply for `path`: an already-accepted glob auto-answers with
+/// that glob (so the client caches it too), an already-accepted exact path
+/// auto-answers `allow`, and anything else is referred to `resolver`.
+fn decide(
+    path: &str,
+    resolver: &mut dyn PromptResolver,
+    accepted: &Arc<Mutex<Accepted>>,
+) -> String {
+    {
+        let acc = accepted.lock().expect("broker mutex poisoned");
+        if let Some(glob) = acc.matching_glob(path) {
+            return format!("allow-glob {glob}\n");
+        }
+        if acc.covered_exactly(path) {
+            return "allow\n".to_string();
+        }
+    }
+    // Not yet covered: ask the resolver (this may block to prompt the user). The
+    // lock is released across the call so reads of `accepted` don't stall.
+    match resolver.resolve(Path::new(path)) {
+        PromptDecision::AllowGlob(glob) => {
+            accepted
+                .lock()
+                .expect("broker mutex poisoned")
+                .globs
+                .push(glob.clone());
+            format!("allow-glob {glob}\n")
+        },
+        PromptDecision::Allow => {
+            accepted
+                .lock()
+                .expect("broker mutex poisoned")
+                .exacts
+                .push(path.to_string());
+            "allow\n".to_string()
+        },
+        PromptDecision::Deny => "deny\n".to_string(),
+    }
+}
+
+/// Match `path` against `pattern` the way libsandbox does: `fnmatch` with no
+/// `FNM_PATHNAME`, so `*`/`**` cross `/`, plus a leading `~/` expanded to
+/// `$HOME/`. Used only to decide whether to re-prompt; the actual enforcement is
+/// libsandbox's, so a mismatch merely costs an extra prompt.
+fn glob_matches(pattern: &str, path: &str, home: Option<&str>) -> bool {
+    let expanded;
+    let pattern = match (home, pattern.strip_prefix("~/")) {
+        (Some(home), Some(rest)) => {
+            expanded = format!("{home}/{rest}");
+            expanded.as_str()
+        },
+        _ => pattern,
+    };
+    wildcard_match(pattern, path)
+}
+
+/// Classic backtracking wildcard match supporting `*` (any run, including `/`)
+/// and `?` (any single character). Bracket expressions are not handled — accepted
+/// `sandbox-allow` patterns are plain path globs, and an unhandled pattern just
+/// means we prompt again rather than auto-allowing.
+fn wildcard_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    // Position to backtrack to on a `*`, and the text index it last consumed up
+    // to.
+    let mut star: Option<usize> = None;
+    let mut star_ti = 0usize;
+    while ti < t.len() {
+        if pi < p.len() && (p[pi] == '?' || p[pi] == t[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            star = Some(pi);
+            star_ti = ti;
+            pi += 1;
+        } else if let Some(star_pi) = star {
+            // Last `*` absorbs one more character of text and we retry.
+            pi = star_pi + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use super::*;
+
+    /// A resolver scripted with a fixed sequence of decisions; records how many
+    /// times it was asked so tests can assert auto-answers did NOT call it.
+    struct ScriptedResolver {
+        decisions: Vec<PromptDecision>,
+        next: usize,
+        asked: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl PromptResolver for ScriptedResolver {
+        fn resolve(&mut self, path: &Path) -> PromptDecision {
+            self.asked
+                .lock()
+                .unwrap()
+                .push(path.to_string_lossy().into_owned());
+            let d = self.decisions[self.next.min(self.decisions.len() - 1)].clone();
+            self.next += 1;
+            d
+        }
+    }
+
+    /// Send one request over a fresh connection and return the broker's reply,
+    /// mimicking libsandbox's one-shot-per-connection protocol.
+    fn query(socket: &Path, path: &str) -> String {
+        let mut stream = UnixStream::connect(socket).unwrap();
+        stream.write_all(format!("{path}\n").as_bytes()).unwrap();
+        let mut reply = String::new();
+        stream.read_to_string(&mut reply).unwrap();
+        reply
+    }
+
+    fn broker_with(
+        decisions: Vec<PromptDecision>,
+    ) -> (SandboxPromptBroker, Arc<Mutex<Vec<String>>>) {
+        let asked = Arc::new(Mutex::new(Vec::new()));
+        let resolver = ScriptedResolver {
+            decisions,
+            next: 0,
+            asked: Arc::clone(&asked),
+        };
+        let broker = SandboxPromptBroker::new(Box::new(resolver)).unwrap();
+        (broker, asked)
+    }
+
+    #[test]
+    fn deny_is_relayed() {
+        let (broker, asked) = broker_with(vec![PromptDecision::Deny]);
+        assert_eq!(query(broker.socket_path(), "/etc/hosts"), "deny\n");
+        assert_eq!(*asked.lock().unwrap(), vec!["/etc/hosts".to_string()]);
+    }
+
+    #[test]
+    fn allow_is_relayed_and_caches_exact_path() {
+        let (broker, asked) = broker_with(vec![PromptDecision::Allow]);
+        assert_eq!(query(broker.socket_path(), "/etc/hosts"), "allow\n");
+        // Second request for the same path is auto-allowed without re-asking.
+        assert_eq!(query(broker.socket_path(), "/etc/hosts"), "allow\n");
+        assert_eq!(*asked.lock().unwrap(), vec!["/etc/hosts".to_string()]);
+    }
+
+    #[test]
+    fn allow_glob_caches_and_auto_answers_siblings() {
+        let (broker, asked) = broker_with(vec![PromptDecision::AllowGlob(
+            "/home/u/.npm/**".to_string(),
+        )]);
+        assert_eq!(
+            query(broker.socket_path(), "/home/u/.npm/foo"),
+            "allow-glob /home/u/.npm/**\n"
+        );
+        // A sibling under the accepted glob auto-answers with the same glob and
+        // does not consult the resolver again.
+        assert_eq!(
+            query(broker.socket_path(), "/home/u/.npm/bar/baz"),
+            "allow-glob /home/u/.npm/**\n"
+        );
+        assert_eq!(broker.accepted_globs(), vec!["/home/u/.npm/**".to_string()]);
+        assert_eq!(*asked.lock().unwrap(), vec!["/home/u/.npm/foo".to_string()]);
+    }
+
+    #[test]
+    fn unrelated_path_after_glob_is_prompted() {
+        let (broker, asked) = broker_with(vec![
+            PromptDecision::AllowGlob("/home/u/.npm/**".to_string()),
+            PromptDecision::Deny,
+        ]);
+        assert_eq!(
+            query(broker.socket_path(), "/home/u/.npm/foo"),
+            "allow-glob /home/u/.npm/**\n"
+        );
+        // /etc/hosts is not under the glob, so the resolver is asked again.
+        assert_eq!(query(broker.socket_path(), "/etc/hosts"), "deny\n");
+        assert_eq!(asked.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn wildcard_match_semantics() {
+        assert!(wildcard_match("/a/**", "/a/b/c"));
+        assert!(wildcard_match("/a/*", "/a/b/c")); // '*' crosses '/'
+        assert!(wildcard_match("/a/?", "/a/b"));
+        assert!(!wildcard_match("/a/?", "/a/bc"));
+        assert!(!wildcard_match("/a/b", "/a/c"));
+        assert!(wildcard_match("*", "anything/at/all"));
+    }
+
+    #[test]
+    fn glob_matches_expands_home() {
+        assert!(glob_matches("~/.npm/**", "/home/u/.npm/x", Some("/home/u")));
+        assert!(!glob_matches(
+            "~/.npm/**",
+            "/home/u/.cache/x",
+            Some("/home/u")
+        ));
+    }
+}

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -7,6 +7,7 @@ use bpaf::Bpaf;
 use flox_catalog::{BaseCatalogUrl, ClientTrait};
 use flox_core::data::CanonicalPath;
 use flox_manifest::lockfile::Lockfile;
+use flox_manifest::parsed::latest::BuildSandbox;
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
@@ -23,6 +24,7 @@ use flox_rust_sdk::providers::build::{
 use flox_rust_sdk::providers::catalog::base_catalog_url_for_stability_arg;
 use flox_rust_sdk::providers::git::{GitCommandProvider, GitProvider};
 use flox_rust_sdk::providers::nix;
+use flox_rust_sdk::providers::sandbox_prompt::SandboxPromptBroker;
 use flox_rust_sdk::utils::{CommandExt, FLOX_INTERPRETER};
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -34,7 +36,46 @@ use url::Url;
 
 use super::{DirEnvironmentSelect, dir_environment_select};
 use crate::utils::message;
+use crate::utils::sandbox_prompt::InteractivePromptResolver;
 use crate::{environment_subcommand_metric, subcommand_metric};
+
+/// After a prompted build, guide the user through recording the exceptions they
+/// accepted into the manifest's `sandbox-allow`, so the next build is silent and
+/// can run under plain `enforce`. (A guided, copy-paste-ready summary rather than
+/// an automatic edit, since a build may have several targets and the user should
+/// see exactly what is being permitted.)
+fn guide_sandbox_allow_writeback(targets: &[PackageTarget], accepted: &[String]) {
+    if accepted.is_empty() {
+        return;
+    }
+
+    // Name the build to attach to when a single manifest build was built;
+    // otherwise use a placeholder the user fills in.
+    let manifest_builds: Vec<String> = targets
+        .iter()
+        .filter(|target| target.kind().is_manifest_build())
+        .map(|target| target.name().as_ref().to_string())
+        .collect();
+    let build_name = match manifest_builds.as_slice() {
+        [single] => single.clone(),
+        _ => "<name>".to_string(),
+    };
+
+    let allow_lines = accepted
+        .iter()
+        .map(|pattern| format!("      \"{pattern}\","))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    message::info(format!(
+        "Accepted {count} sandbox exception(s) during this build.\n\
+         To keep them, add to [build.{build_name}] in your manifest \
+         (e.g. with 'flox edit'):\n\n\
+         \x20   sandbox-allow = [\n{allow_lines}\n\x20   ]\n\n\
+         Then set sandbox = \"enforce\" for a reproducible build that no longer prompts.",
+        count = accepted.len(),
+    ));
+}
 
 #[derive(Debug, Clone, Bpaf)]
 pub enum BaseCatalogUrlSelect {
@@ -127,6 +168,14 @@ enum SubcommandOrBuildTargets {
         #[bpaf(external(system_override))]
         system_override: SystemOverride,
 
+        /// Interactively resolve out-of-closure file access during the build.
+        /// Runs the build in the 'prompt' sandbox mode regardless of the
+        /// manifest's sandbox setting, prompting to allow or deny each new
+        /// access, then guides you through recording the accepted paths in the
+        /// manifest's 'sandbox-allow'.
+        #[bpaf(long("sandbox-prompt"))]
+        sandbox_prompt: bool,
+
         /// The package to build.
         /// Corresponds to entries in the 'build' table in the environment's manifest.toml.
         /// If not specified, all packages are built.
@@ -166,6 +215,7 @@ impl Build {
                 targets,
                 base_catalog_url_select,
                 system_override,
+                sandbox_prompt,
             } => {
                 let env = self
                     .environment
@@ -178,6 +228,7 @@ impl Build {
                     targets,
                     base_catalog_url_select,
                     system_override.into_inner(),
+                    sandbox_prompt,
                 )
                 .await
             },
@@ -226,6 +277,7 @@ impl Build {
         packages: Vec<String>,
         nixpkgs_url_select: Option<BaseCatalogUrlSelect>,
         system_override: Option<String>,
+        sandbox_prompt: bool,
     ) -> Result<()> {
         match &env {
             ConcreteEnvironment::Path(_) => (),
@@ -291,7 +343,39 @@ impl Build {
             "has_manifest_build" = has_manifest_build
         );
 
-        let builder = FloxBuildMk::new(&flox, &base_dir, &expression_ref, &built_environments);
+        // Interactive sandbox prompt (Phase 2). Prompting applies when the user
+        // passed --sandbox-prompt or any manifest build is in `prompt` mode.
+        let any_prompt_mode = packages_to_build.iter().any(|target| {
+            matches!(target.kind(), PackageTargetKind::ManifestBuild {
+                sandbox: Some(BuildSandbox::Prompt)
+            })
+        });
+        if sandbox_prompt
+            && let Some(pure) = packages_to_build.iter().find(|target| {
+                matches!(target.kind(), PackageTargetKind::ManifestBuild {
+                    sandbox: Some(BuildSandbox::Pure)
+                })
+            })
+        {
+            bail!(
+                "Cannot use '--sandbox-prompt' with the 'pure' build '{}'.\nA pure build runs in the Nix sandbox, which has no interactive escape hatch.",
+                pure.name()
+            );
+        }
+
+        let mut builder = FloxBuildMk::new(&flox, &base_dir, &expression_ref, &built_environments);
+        // The broker must outlive the build; it serves prompts on a background
+        // thread while make runs.
+        let prompt_broker = if sandbox_prompt || any_prompt_mode {
+            let broker = SandboxPromptBroker::new(Box::new(InteractivePromptResolver::new()))
+                .context("could not start the sandbox prompt broker")?;
+            builder =
+                builder.with_sandbox_prompt(broker.socket_path().to_path_buf(), sandbox_prompt);
+            Some(broker)
+        } else {
+            None
+        };
+
         let results = builder.build(
             &base_nixpkgs_url,
             &FLOX_INTERPRETER,
@@ -299,6 +383,14 @@ impl Build {
             None,
             system_override,
         )?;
+
+        // Surface any exceptions the user accepted during the build and guide
+        // them through recording them in the manifest's sandbox-allow.
+        if let Some(broker) = prompt_broker {
+            let accepted = broker.accepted_globs();
+            drop(broker); // shut the serving thread down
+            guide_sandbox_allow_writeback(&packages_to_build, &accepted);
+        }
 
         let current_dir = env::current_dir()
             .context("could not get current directory")?

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -15,6 +15,7 @@ pub mod init;
 pub mod message;
 pub mod metrics;
 pub mod openers;
+pub mod sandbox_prompt;
 pub mod search;
 pub mod tracing;
 pub mod update_notifications;

--- a/cli/flox/src/utils/sandbox_prompt.rs
+++ b/cli/flox/src/utils/sandbox_prompt.rs
@@ -1,0 +1,405 @@
+//! Interactive resolver for the build-time virtual sandbox prompt broker
+//! (Phase 2, increment 3).
+//!
+//! The broker ([`flox_rust_sdk::providers::sandbox_prompt`]) calls a
+//! [`PromptResolver`] for each genuinely-new out-of-closure access. This module
+//! provides the interactive one: a full-screen "Flox sandbox" page drawn on
+//! `/dev/tty` with an arrow-navigable menu offering
+//!
+//!   - Allow once (this exact file)
+//!   - Allow `<dir>/**` at one of several nesting levels (the rollup that
+//!     silences a flood and can be written back to `sandbox-allow`)
+//!   - Deny (this access)
+//!   - Deny all (stop prompting for the rest of the build)
+//!
+//! Rendering on `/dev/tty` (rather than stdout) means the prompt works even when
+//! the build's stdout/stderr are redirected, and crossterm reads key events from
+//! the controlling terminal. When there is no usable tty the resolver denies
+//! (and a later audit phase can recommend a `sandbox-allow` block instead).
+//!
+//! Box-drawing glyphs are written with `\u{...}` escapes so the source stays
+//! ASCII and the bytes emitted are unambiguous UTF-8.
+
+// Nothing constructs InteractivePromptResolver yet — it is wired into the
+// `flox build` path in increment 4, at which point this allow is removed.
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, read};
+use crossterm::style::{Attribute, Print, SetAttribute};
+use crossterm::terminal::{
+    Clear,
+    ClearType,
+    EnterAlternateScreen,
+    LeaveAlternateScreen,
+    disable_raw_mode,
+    enable_raw_mode,
+    size,
+};
+use crossterm::{cursor, execute, queue};
+use flox_rust_sdk::providers::sandbox_prompt::{PromptDecision, PromptResolver};
+
+// Box-drawing and UI glyphs (escaped to keep the source ASCII).
+const TOP_LEFT: char = '\u{250C}'; // top-left corner
+const TOP_RIGHT: char = '\u{2510}'; // top-right corner
+const BOTTOM_LEFT: char = '\u{2514}'; // bottom-left corner
+const BOTTOM_RIGHT: char = '\u{2518}'; // bottom-right corner
+const VERTICAL: char = '\u{2502}'; // vertical edge
+const HORIZONTAL: char = '\u{2500}'; // horizontal edge
+const CURSOR: char = '\u{25B8}'; // selected-row marker
+const ELLIPSIS: char = '\u{2026}'; // truncation marker
+const HINT: &str = "  \u{2191}/\u{2193} move \u{00B7} \u{21B5} select \u{00B7} Esc deny";
+
+/// What a single menu entry maps to once chosen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Choice {
+    AllowOnce,
+    AllowGlob(String),
+    Deny,
+    DenyAll,
+}
+
+/// A rendered menu entry: the label shown and the choice it selects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MenuItem {
+    label: String,
+    choice: Choice,
+}
+
+/// Express `dir` relative to `$HOME` as `~/...` when it lives under it, matching
+/// how the patterns are written in `sandbox-allow` (and expanded by libsandbox).
+fn home_relative(dir: &str, home: Option<&str>) -> String {
+    if let Some(home) = home {
+        if dir == home {
+            return "~".to_string();
+        }
+        if let Some(rest) = dir.strip_prefix(&format!("{home}/")) {
+            return format!("~/{rest}");
+        }
+    }
+    dir.to_string()
+}
+
+/// Build the `<dir>/**` rollup patterns offered for `path`, from the immediate
+/// parent directory upward. Patterns under `$HOME` are written `~/...`; the walk
+/// stops just below `$HOME` (never offering the whole home directory) and at the
+/// filesystem root, and is capped so the menu stays manageable for deep paths.
+fn ancestor_globs(path: &Path, home: Option<&str>) -> Vec<String> {
+    const MAX_LEVELS: usize = 8;
+    let mut globs = Vec::new();
+    let mut current = path.parent();
+    while let Some(dir) = current {
+        let dir_str = dir.to_string_lossy();
+        if dir_str.is_empty() || dir_str == "/" {
+            break;
+        }
+        let relative = home_relative(&dir_str, home);
+        // `~` means we've reached $HOME itself: `~/**` (all of home) is too broad
+        // to offer, so stop here.
+        if relative == "~" {
+            break;
+        }
+        globs.push(format!("{relative}/**"));
+        if globs.len() >= MAX_LEVELS {
+            break;
+        }
+        current = dir.parent();
+    }
+    globs
+}
+
+/// Assemble the full menu for an access to `path`.
+fn build_menu(path: &Path, home: Option<&str>) -> Vec<MenuItem> {
+    let mut items = vec![MenuItem {
+        label: "Allow once (this file)".to_string(),
+        choice: Choice::AllowOnce,
+    }];
+    for glob in ancestor_globs(path, home) {
+        items.push(MenuItem {
+            label: format!("Allow {glob}"),
+            choice: Choice::AllowGlob(glob),
+        });
+    }
+    items.push(MenuItem {
+        label: "Deny".to_string(),
+        choice: Choice::Deny,
+    });
+    items.push(MenuItem {
+        label: "Deny all (stop prompting)".to_string(),
+        choice: Choice::DenyAll,
+    });
+    items
+}
+
+/// Map a chosen [`Choice`] to a [`PromptDecision`], updating `deny_all` when the
+/// user asks to stop prompting. `None` (cancelled / no tty) denies.
+fn decision_for(choice: Option<&Choice>, deny_all: &mut bool) -> PromptDecision {
+    match choice {
+        Some(Choice::AllowOnce) => PromptDecision::Allow,
+        Some(Choice::AllowGlob(glob)) => PromptDecision::AllowGlob(glob.clone()),
+        Some(Choice::Deny) | None => PromptDecision::Deny,
+        Some(Choice::DenyAll) => {
+            *deny_all = true;
+            PromptDecision::Deny
+        },
+    }
+}
+
+/// The interactive [`PromptResolver`]. Stateful: once the user picks "Deny all",
+/// every later access is denied without prompting.
+pub struct InteractivePromptResolver {
+    home: Option<String>,
+    deny_all: bool,
+}
+
+impl Default for InteractivePromptResolver {
+    fn default() -> Self {
+        Self {
+            home: std::env::var("HOME").ok(),
+            deny_all: false,
+        }
+    }
+}
+
+impl InteractivePromptResolver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl PromptResolver for InteractivePromptResolver {
+    fn resolve(&mut self, path: &Path) -> PromptDecision {
+        if self.deny_all {
+            return PromptDecision::Deny;
+        }
+        let menu = build_menu(path, self.home.as_deref());
+        // A missing/erroring tty (non-interactive) yields None: fail closed by
+        // denying. A later audit phase can recommend a sandbox-allow block.
+        let selected = prompt_on_tty(path, &menu).unwrap_or_default();
+        decision_for(selected.map(|i| &menu[i].choice), &mut self.deny_all)
+    }
+}
+
+/// Draw the menu full-screen on `/dev/tty` and return the index the user
+/// selected, or `None` if they cancelled (Esc / Ctrl-C / `q`). Errors only when
+/// `/dev/tty` or raw mode is unavailable (non-interactive), which the caller
+/// treats as "deny".
+fn prompt_on_tty(path: &Path, menu: &[MenuItem]) -> std::io::Result<Option<usize>> {
+    // Render to /dev/tty so the prompt is visible even with stdout/stderr
+    // redirected. crossterm reads key events from the controlling terminal.
+    let mut tty = File::options().read(true).write(true).open("/dev/tty")?;
+
+    enable_raw_mode()?;
+    execute!(tty, EnterAlternateScreen, cursor::Hide)?;
+
+    // Restore the terminal no matter how we leave (selection, cancel, error).
+    let result = run_menu_loop(&mut tty, path, menu);
+
+    let _ = execute!(tty, cursor::Show, LeaveAlternateScreen);
+    let _ = disable_raw_mode();
+    result
+}
+
+/// The render + key-handling loop, factored out so `prompt_on_tty` can always
+/// restore the terminal afterward.
+fn run_menu_loop(tty: &mut File, path: &Path, menu: &[MenuItem]) -> std::io::Result<Option<usize>> {
+    let mut selected = 0usize;
+    loop {
+        draw(tty, path, menu, selected)?;
+        let Event::Key(key) = read()? else {
+            continue;
+        };
+        // crossterm reports press and release on some platforms; act on press.
+        if key.kind == KeyEventKind::Release {
+            continue;
+        }
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                selected = selected.checked_sub(1).unwrap_or(menu.len() - 1);
+            },
+            KeyCode::Down | KeyCode::Char('j') => {
+                selected = (selected + 1) % menu.len();
+            },
+            KeyCode::Enter => return Ok(Some(selected)),
+            KeyCode::Esc | KeyCode::Char('q') => return Ok(None),
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                return Ok(None);
+            },
+            _ => {},
+        }
+    }
+}
+
+/// Draw the bordered "Flox sandbox" box with the access path and the menu, the
+/// `selected` row highlighted.
+fn draw(tty: &mut File, path: &Path, menu: &[MenuItem], selected: usize) -> std::io::Result<()> {
+    let (term_cols, _) = size().unwrap_or((80, 24));
+    let max_inner = (term_cols as usize).saturating_sub(4).max(20);
+
+    let path_display = truncate(&path.to_string_lossy(), max_inner.saturating_sub(2));
+    // Content rows (without the box edges); menu rows reserve a 2-col cursor
+    // gutter.
+    let header_rows = 3; // title-row content, path, blank
+    let mut rows: Vec<String> = vec![
+        "Out-of-closure access:".to_string(),
+        format!("  {path_display}"),
+        String::new(),
+    ];
+    for item in menu {
+        rows.push(format!(
+            "  {}",
+            truncate(&item.label, max_inner.saturating_sub(2))
+        ));
+    }
+
+    let title = " Flox sandbox ";
+    let inner = rows
+        .iter()
+        .map(|r| r.chars().count())
+        .chain(std::iter::once(title.chars().count() + 1))
+        .max()
+        .unwrap_or(20)
+        .min(max_inner);
+
+    queue!(tty, Clear(ClearType::All), cursor::MoveTo(0, 0))?;
+
+    // Top border with the embedded title.
+    let dashes = inner
+        .saturating_sub(title.chars().count())
+        .saturating_sub(1);
+    queue!(
+        tty,
+        Print(format!(
+            "{TOP_LEFT}{HORIZONTAL}{title}{}{TOP_RIGHT}\r\n",
+            HORIZONTAL.to_string().repeat(dashes)
+        ))
+    )?;
+
+    for (i, row) in rows.iter().enumerate() {
+        let menu_index = i.checked_sub(header_rows);
+        let is_selected = menu_index == Some(selected);
+        // The selected menu row gets the cursor marker and reverse video.
+        let body = match menu_index {
+            Some(_) if is_selected => format!("{CURSOR} {}", row.trim_start()),
+            Some(_) => format!("  {}", row.trim_start()),
+            None => row.clone(),
+        };
+        let padded = pad(&body, inner);
+        queue!(tty, Print(format!("{VERTICAL} ")))?;
+        if is_selected {
+            queue!(
+                tty,
+                SetAttribute(Attribute::Reverse),
+                Print(&padded),
+                SetAttribute(Attribute::Reset)
+            )?;
+        } else {
+            queue!(tty, Print(&padded))?;
+        }
+        queue!(tty, Print(format!(" {VERTICAL}\r\n")))?;
+    }
+
+    queue!(
+        tty,
+        Print(format!(
+            "{BOTTOM_LEFT}{}{BOTTOM_RIGHT}\r\n",
+            HORIZONTAL.to_string().repeat(inner + 2)
+        )),
+        Print(format!("{HINT}\r\n"))
+    )?;
+    tty.flush()
+}
+
+/// Pad `s` with spaces to exactly `width` display columns (truncating if longer).
+fn pad(s: &str, width: usize) -> String {
+    let len = s.chars().count();
+    if len >= width {
+        truncate(s, width)
+    } else {
+        format!("{s}{}", " ".repeat(width - len))
+    }
+}
+
+/// Truncate `s` to at most `width` columns, ending with an ellipsis when
+/// shortened.
+fn truncate(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        return s.to_string();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    let kept: String = s.chars().take(width.saturating_sub(1)).collect();
+    format!("{kept}{ELLIPSIS}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ancestor_globs_under_home_are_tilde_relative_and_stop_below_home() {
+        let globs = ancestor_globs(
+            Path::new("/home/u/.npm/_cacache/index-v5/a1/b2"),
+            Some("/home/u"),
+        );
+        assert_eq!(globs, vec![
+            "~/.npm/_cacache/index-v5/a1/**".to_string(),
+            "~/.npm/_cacache/index-v5/**".to_string(),
+            "~/.npm/_cacache/**".to_string(),
+            "~/.npm/**".to_string(),
+        ]);
+        // Never offers all of $HOME.
+        assert!(!globs.iter().any(|g| g == "~/**"));
+    }
+
+    #[test]
+    fn ancestor_globs_outside_home_stop_at_root() {
+        let globs = ancestor_globs(Path::new("/etc/hosts"), Some("/home/u"));
+        assert_eq!(globs, vec!["/etc/**".to_string()]);
+    }
+
+    #[test]
+    fn build_menu_has_allow_once_rollups_then_deny_choices() {
+        let menu = build_menu(Path::new("/home/u/.npm/x"), Some("/home/u"));
+        assert_eq!(menu.first().unwrap().choice, Choice::AllowOnce);
+        assert_eq!(menu[menu.len() - 2].choice, Choice::Deny);
+        assert_eq!(menu[menu.len() - 1].choice, Choice::DenyAll);
+        assert_eq!(menu[1].choice, Choice::AllowGlob("~/.npm/**".to_string()));
+    }
+
+    #[test]
+    fn decision_for_maps_choices() {
+        let mut deny_all = false;
+        assert_eq!(
+            decision_for(Some(&Choice::AllowOnce), &mut deny_all),
+            PromptDecision::Allow
+        );
+        assert_eq!(
+            decision_for(Some(&Choice::AllowGlob("~/.npm/**".into())), &mut deny_all),
+            PromptDecision::AllowGlob("~/.npm/**".into())
+        );
+        assert_eq!(
+            decision_for(Some(&Choice::Deny), &mut deny_all),
+            PromptDecision::Deny
+        );
+        assert_eq!(decision_for(None, &mut deny_all), PromptDecision::Deny);
+        assert!(!deny_all);
+        // Deny all flips the latch.
+        assert_eq!(
+            decision_for(Some(&Choice::DenyAll), &mut deny_all),
+            PromptDecision::Deny
+        );
+        assert!(deny_all);
+    }
+
+    #[test]
+    fn truncate_adds_ellipsis() {
+        assert_eq!(truncate("abcdef", 10), "abcdef");
+        assert_eq!(truncate("abcdef", 4), format!("abc{ELLIPSIS}"));
+        assert_eq!(truncate("abcdef", 0), "");
+    }
+}

--- a/cli/flox/src/utils/sandbox_prompt.rs
+++ b/cli/flox/src/utils/sandbox_prompt.rs
@@ -20,10 +20,6 @@
 //! Box-drawing glyphs are written with `\u{...}` escapes so the source stays
 //! ASCII and the bytes emitted are unambiguous UTF-8.
 
-// Nothing constructs InteractivePromptResolver yet — it is wired into the
-// `flox build` path in increment 4, at which point this allow is removed.
-#![allow(dead_code)]
-
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -615,7 +615,7 @@
           "type": "string"
         },
         "BuildSandbox2": {
-          "description": "Sandbox mode for a build.\n\nThis is a version-specific copy of `common::BuildSandbox` because V1_13_0\nadds the local `warn` and `enforce` modes. Keeping the new variants out of\nthe common enum is what stops older schema versions (whose `BuildDescriptor`\nuses `common::BuildSandbox`) from accepting `sandbox = \"warn\" | \"enforce\"`.",
+          "description": "Sandbox mode for a build.\n\nThis is a version-specific copy of `common::BuildSandbox` because V1_13_0\nadds the local `warn`, `enforce`, and `prompt` modes. Keeping the new\nvariants out of the common enum is what stops older schema versions (whose\n`BuildDescriptor` uses `common::BuildSandbox`) from accepting\n`sandbox = \"warn\" | \"enforce\" | \"prompt\"`.",
           "oneOf": [
             {
               "enum": [
@@ -632,6 +632,11 @@
             {
               "const": "enforce",
               "description": "Local build; out-of-closure file access is denied (the build fails).",
+              "type": "string"
+            },
+            {
+              "const": "prompt",
+              "description": "Local build; out-of-closure file access is referred to an interactive\nprompt (and otherwise denied, as enforce). A transitional mode for\nbuilding up a `sandbox-allow` list.",
               "type": "string"
             }
           ]

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -218,7 +218,7 @@
       "type": "string"
     },
     "BuildSandbox2": {
-      "description": "Sandbox mode for a build.\n\nThis is a version-specific copy of `common::BuildSandbox` because V1_13_0\nadds the local `warn` and `enforce` modes. Keeping the new variants out of\nthe common enum is what stops older schema versions (whose `BuildDescriptor`\nuses `common::BuildSandbox`) from accepting `sandbox = \"warn\" | \"enforce\"`.",
+      "description": "Sandbox mode for a build.\n\nThis is a version-specific copy of `common::BuildSandbox` because V1_13_0\nadds the local `warn`, `enforce`, and `prompt` modes. Keeping the new\nvariants out of the common enum is what stops older schema versions (whose\n`BuildDescriptor` uses `common::BuildSandbox`) from accepting\n`sandbox = \"warn\" | \"enforce\" | \"prompt\"`.",
       "oneOf": [
         {
           "enum": [
@@ -235,6 +235,11 @@
         {
           "const": "enforce",
           "description": "Local build; out-of-closure file access is denied (the build fails).",
+          "type": "string"
+        },
+        {
+          "const": "prompt",
+          "description": "Local build; out-of-closure file access is referred to an interactive\nprompt (and otherwise denied, as enforce). A transitional mode for\nbuilding up a `sandbox-allow` list.",
           "type": "string"
         }
       ]

--- a/package-builder/.gitignore
+++ b/package-builder/.gitignore
@@ -5,3 +5,4 @@
 /libsandbox.dylib
 /tests/threadtest
 /tests/sandbox_probe
+/tests/mock_prompt_broker

--- a/package-builder/Makefile
+++ b/package-builder/Makefile
@@ -52,9 +52,14 @@ tests/threadtest: tests/threadtest.c closure.c closure.h
 tests/sandbox_probe: tests/sandbox_probe.c
 	$(CC) -pthread -O2 -Wall -o $@ $<
 
+# mock_prompt_broker is a fixed-reply AF_UNIX server standing in for the Phase 2
+# prompt broker, so run-tests.sh can exercise libsandbox's prompt client.
+tests/mock_prompt_broker: tests/mock_prompt_broker.c
+	$(CC) -O2 -Wall -o $@ $<
+
 # Run the full sandbox test suite (thread-safety oracle + interception
 # semantics + threaded interception storm). Depends on the injected library and
-# both test binaries.
+# the test binaries.
 .PHONY: tests
-tests: $(SANDBOX_LIB) tests/threadtest tests/sandbox_probe
+tests: $(SANDBOX_LIB) tests/threadtest tests/sandbox_probe tests/mock_prompt_broker
 	bash tests/run-tests.sh

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -454,7 +454,7 @@ define BUILD_local_template =
 	  $(FLOX_INTERPRETER)/activate --env $$($(_pvarname)_develop_copy_env) \
 	    --mode build --skip-hook-on-activate --env-project $(PWD) -- \
 	    $(_t3) $($(_pvarname)_logfile) -- \
-	    $(if $(_virtualSandbox),$(_env) $(PRELOAD_VARS) FLOX_SRC_DIR=$(PWD) FLOX_SANDBOX_ALLOW_DIRS="$(__bashInteractive) $$($(_pvarname)_buildDeps)" FLOX_SANDBOX_ALLOW=$(_sandbox_allow) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
+	    $(if $(_virtualSandbox),$(_env) $(PRELOAD_VARS) FLOX_SRC_DIR=$(PWD) FLOX_SANDBOX_ALLOW_DIRS="$(__bashInteractive) $$($(_pvarname)_buildDeps)" FLOX_SANDBOX_ALLOW=$(_sandbox_allow) FLOX_SANDBOX_PROMPT_SOCKET="$(FLOX_SANDBOX_PROMPT_SOCKET)" FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \
 	    $(_bash) -e $$<
 	@#
 	@# Finally, rewrite references to temporary build wrapper in "out",
@@ -764,13 +764,22 @@ endef
 #                                          wiring. (off/null leave it empty, so
 #                                          the preload is not applied.)
 #
+#   prompt               -> local       : like enforce, but out-of-closure
+#                                          access is referred to an interactive
+#                                          broker (FLOX_SANDBOX_PROMPT_SOCKET);
+#                                          with no broker it behaves as enforce.
+#
 # Only "pure" routes away from the local build; every other value (including an
 # unrecognized one) builds locally, and libsandbox itself ignores any
-# FLOX_VIRTUAL_SANDBOX value outside (off|warn|enforce|pure).
+# FLOX_VIRTUAL_SANDBOX value outside (off|warn|enforce|prompt|pure).
+#
+# FLOX_SANDBOX_OVERRIDE, when set, replaces the manifest's per-build sandbox
+# value for this invocation. `flox build --sandbox-prompt` uses it to force
+# prompt mode without editing the manifest.
 $(foreach build,$(MANIFEST_BUILDS), \
   $(eval _pname = $(notdir $(build))) \
-  $(eval _sandbox = $(shell \
-    $(_jq) -r '.manifest.build."$(_pname)".sandbox' $(MANIFEST_LOCK))) \
+  $(eval _sandbox = $(or $(FLOX_SANDBOX_OVERRIDE),$(shell \
+    $(_jq) -r '.manifest.build."$(_pname)".sandbox' $(MANIFEST_LOCK)))) \
   $(eval _sandbox_allow = $(shell \
     $(_jq) -r '(.manifest.build."$(_pname)"."sandbox-allow" // []) | join(" ") | @sh' $(MANIFEST_LOCK))) \
   $(eval _version = $(shell $(shell \

--- a/package-builder/glibc-bindings.h
+++ b/package-builder/glibc-bindings.h
@@ -28,7 +28,9 @@
 #error "Unsupported architecture"
 #endif
 
+__asm__(".symver close,close@" GLIBC_MIN_VERSION);
 __asm__(".symver closedir,closedir@" GLIBC_MIN_VERSION);
+__asm__(".symver connect,connect@" GLIBC_MIN_VERSION);
 __asm__(".symver __cxa_finalize,__cxa_finalize@" GLIBC_MIN_VERSION);
 __asm__(".symver dlsym,dlsym@" GLIBC_MIN_VERSION);
 __asm__(".symver __errno_location,__errno_location@" GLIBC_MIN_VERSION);
@@ -41,6 +43,7 @@ __asm__(".symver __fprintf_chk,__fprintf_chk@" ALT_GLIBC_MIN_VERSION);
 __asm__(".symver fwrite,fwrite@" GLIBC_MIN_VERSION);
 __asm__(".symver getenv,getenv@" GLIBC_MIN_VERSION);
 __asm__(".symver getpid,getpid@" GLIBC_MIN_VERSION);
+__asm__(".symver memset,memset@" GLIBC_MIN_VERSION);
 __asm__(".symver opendir,opendir@" GLIBC_MIN_VERSION);
 __asm__(".symver perror,perror@" GLIBC_MIN_VERSION);
 // pthread_once is the core of the thread-safety fix. On glibc < 2.34 it lives
@@ -55,8 +58,10 @@ __asm__(".symver pthread_once,pthread_once@" GLIBC_MIN_VERSION);
 // minimum so the library does not silently require GLIBC_2.34.
 __asm__(".symver pthread_mutex_lock,pthread_mutex_lock@" GLIBC_MIN_VERSION);
 __asm__(".symver pthread_mutex_unlock,pthread_mutex_unlock@" GLIBC_MIN_VERSION);
+__asm__(".symver read,read@" GLIBC_MIN_VERSION);
 __asm__(".symver __realpath_chk,__realpath_chk@" ALT_ALT_GLIBC_MIN_VERSION);
 __asm__(".symver __snprintf_chk,__snprintf_chk@" ALT_GLIBC_MIN_VERSION);
+__asm__(".symver socket,socket@" GLIBC_MIN_VERSION);
 __asm__(".symver __stack_chk_fail,__stack_chk_fail@" ALT_ALT_GLIBC_MIN_VERSION);
 __asm__(".symver __stack_chk_guard,__stack_chk_guard@" GLIBC_MIN_VERSION);
 __asm__(".symver stderr,stderr@" GLIBC_MIN_VERSION);
@@ -72,5 +77,6 @@ __asm__(".symver strtok_r,strtok_r@" GLIBC_MIN_VERSION);
 // wrapper, which only exists from glibc 2.30; syscall() has existed since the
 // baseline, so binding it here keeps the minimum glibc at the target.
 __asm__(".symver syscall,syscall@" GLIBC_MIN_VERSION);
+__asm__(".symver write,write@" GLIBC_MIN_VERSION);
 
 #endif // GLIBC_BINDINGS_H

--- a/package-builder/sandbox.c
+++ b/package-builder/sandbox.c
@@ -153,14 +153,21 @@ static atomic_int warn_count = 0;
 static char home_real[PATH_MAX];
 static size_t home_real_len = 0;
 
-// Interactive prompt broker (Phase 2). When FLOX_SANDBOX_PROMPT_SOCKET names an
-// AF_UNIX socket, an out-of-closure access — instead of being warned/blocked
-// outright — is referred to that broker (the flox process driving the build),
-// which prompts the user and replies allow / deny / allow-glob. prompt_enabled
-// gates the (otherwise lock-free) glob-list reads, since the broker path can
-// append to the list at runtime; see allow_globs_add.
+// Interactive prompt broker (Phase 2). In "prompt" mode an out-of-closure
+// access — instead of being blocked outright — is referred to a broker (the
+// flox process driving the build) at FLOX_SANDBOX_PROMPT_SOCKET, which prompts
+// the user and replies allow / deny / allow-glob.
+//
+// prompt_mode is true only when FLOX_VIRTUAL_SANDBOX == "prompt"; it gates the
+// broker consultation, so an enforce-mode build that happens to share the
+// process-wide socket env (a mixed `flox build`) never prompts. prompt_enabled
+// is true when a socket path is set; it gates the (otherwise lock-free)
+// glob-list reads, since the broker path can append to the list at runtime (see
+// allow_globs_add). With prompt_mode but no socket — a non-interactive build —
+// prompt_broker errors and the access falls through to enforce.
 static char prompt_socket_path[PATH_MAX];
 static int prompt_enabled = 0;
+static int prompt_mode = 0;
 
 // Perform various initialization, which includes loading the original
 // glibc functions to be wrapped using dlsym().
@@ -200,6 +207,7 @@ void sandbox_init() {
     // blocked. With no broker — e.g. a non-interactive build — it is therefore
     // just enforce.
     sandbox_level = 2;
+    prompt_mode = 1;
   } else if (strcmp(flox_virtual_sandbox_value, "pure") == 0) {
     // Pure mode is just like enforce, but invoked within the Nix sandbox.
     sandbox_level = 3;
@@ -844,11 +852,13 @@ bool sandbox_check_path(const char *pathname) {
     }
     return true;
   }
-  // If an interactive prompt broker is configured, let it resolve this access
-  // (allow / allow-glob / deny) before the default warn/enforce policy applies.
-  // An allow is remembered so the same path/pattern is not asked again; a
-  // broker error falls through to the default policy below.
-  if (prompt_enabled) {
+  // In prompt mode, let the broker resolve this access (allow / allow-glob /
+  // deny) before the default enforce policy applies. Gated on prompt_mode (not
+  // merely the socket) so an enforce-mode build sharing the process-wide socket
+  // env never prompts. An allow is remembered so the same path/pattern is not
+  // asked again; a broker error (e.g. no socket) falls through to enforce
+  // below.
+  if (prompt_mode) {
     int decision = prompt_broker(real_path);
     if (decision == PROMPT_ALLOW)
       return true;

--- a/package-builder/sandbox.c
+++ b/package-builder/sandbox.c
@@ -193,12 +193,19 @@ void sandbox_init() {
     sandbox_level = 1;
   } else if (strcmp(flox_virtual_sandbox_value, "enforce") == 0) {
     sandbox_level = 2;
+  } else if (strcmp(flox_virtual_sandbox_value, "prompt") == 0) {
+    // Prompt mode is enforce with an interactive escape hatch: out-of-closure
+    // accesses are referred to the prompt broker (when
+    // FLOX_SANDBOX_PROMPT_SOCKET is set; see prompt_broker) and otherwise
+    // blocked. With no broker — e.g. a non-interactive build — it is therefore
+    // just enforce.
+    sandbox_level = 2;
   } else if (strcmp(flox_virtual_sandbox_value, "pure") == 0) {
     // Pure mode is just like enforce, but invoked within the Nix sandbox.
     sandbox_level = 3;
   } else {
-    warn_once(
-        "FLOX_VIRTUAL_SANDBOX must be (off|warn|enforce|pure) ... ignoring");
+    warn_once("FLOX_VIRTUAL_SANDBOX must be (off|warn|enforce|prompt|pure) ... "
+              "ignoring");
     sandbox_level = 0;
   }
   debug("sandbox_level=%d", sandbox_level);
@@ -501,17 +508,20 @@ static bool check_allowed_globs(const char *real_path) {
 }
 
 // Decision values returned by prompt_broker().
-#define PROMPT_ERROR (-1) // no broker, or the exchange failed: use default policy
-#define PROMPT_DENY 0     // user/broker denied this access
-#define PROMPT_ALLOW 1    // user/broker allowed this access
+#define PROMPT_ERROR                                                           \
+  (-1)                 // no broker, or the exchange failed: use default policy
+#define PROMPT_DENY 0  // user/broker denied this access
+#define PROMPT_ALLOW 1 // user/broker allowed this access
 
 // Refer an out-of-closure access to the interactive prompt broker over the
 // AF_UNIX socket named by FLOX_SANDBOX_PROMPT_SOCKET. The wire protocol is one
 // request and one reply per connection, newline-terminated text:
 //
 //   -> "<realpath>\n"
-//   <- "allow\n"                 allow this access (remembered for the exact path)
-//   <- "allow-glob <pattern>\n"  allow, and remember <pattern> for future matches
+//   <- "allow\n"                 allow this access (remembered for the exact
+//   path)
+//   <- "allow-glob <pattern>\n"  allow, and remember <pattern> for future
+//   matches
 //   <- "deny\n"                  deny this access
 //
 // One connection per query keeps the client simple and lets the broker
@@ -570,7 +580,8 @@ static int prompt_broker(const char *real_path) {
     debug("prompt broker denied '%s'", real_path);
     return PROMPT_DENY;
   }
-  debug("prompt broker gave unrecognized reply '%s' for '%s'", reply, real_path);
+  debug("prompt broker gave unrecognized reply '%s' for '%s'", reply,
+        real_path);
   return PROMPT_ERROR;
 }
 

--- a/package-builder/sandbox.c
+++ b/package-builder/sandbox.c
@@ -28,9 +28,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/un.h>
 #include <unistd.h>
 
 // Declare version bindings to work with minimum supported GLIBC versions.
@@ -151,6 +153,15 @@ static atomic_int warn_count = 0;
 static char home_real[PATH_MAX];
 static size_t home_real_len = 0;
 
+// Interactive prompt broker (Phase 2). When FLOX_SANDBOX_PROMPT_SOCKET names an
+// AF_UNIX socket, an out-of-closure access — instead of being warned/blocked
+// outright — is referred to that broker (the flox process driving the build),
+// which prompts the user and replies allow / deny / allow-glob. prompt_enabled
+// gates the (otherwise lock-free) glob-list reads, since the broker path can
+// append to the list at runtime; see allow_globs_add.
+static char prompt_socket_path[PATH_MAX];
+static int prompt_enabled = 0;
+
 // Perform various initialization, which includes loading the original
 // glibc functions to be wrapped using dlsym().
 void sandbox_init() {
@@ -163,6 +174,15 @@ void sandbox_init() {
   const char *home = getenv("HOME");
   if (home != NULL && realpath(home, home_real) != NULL)
     home_real_len = strlen(home_real);
+
+  // Note the interactive prompt broker socket, if any.
+  const char *prompt_socket = getenv("FLOX_SANDBOX_PROMPT_SOCKET");
+  if (prompt_socket != NULL && prompt_socket[0] != '\0' &&
+      strlen(prompt_socket) < sizeof(prompt_socket_path)) {
+    strncpy(prompt_socket_path, prompt_socket, sizeof(prompt_socket_path) - 1);
+    prompt_socket_path[sizeof(prompt_socket_path) - 1] = '\0';
+    prompt_enabled = 1;
+  }
 
   // Derive audit level from FLOX_VIRTUAL_SANDBOX environment variable.
   const char *flox_virtual_sandbox_value = getenv("FLOX_VIRTUAL_SANDBOX");
@@ -396,9 +416,31 @@ bool check_allowed_basenames(const char *pathname) {
 #define FLOX_SANDBOX_ALLOW_MAXLEN (16 * 1024)
 static pthread_once_t allow_globs_once = PTHREAD_ONCE_INIT;
 static char allow_globs_buf[FLOX_SANDBOX_ALLOW_MAXLEN];
-// Read-only after init (tokens inside allow_globs_buf), so `const char *`.
+// Entries point either into allow_globs_buf (manifest entries, parsed once) or
+// at strdup()'d strings appended at runtime by allow_globs_add() when the
+// prompt broker accepts a pattern; either way they are never freed or mutated,
+// so `const char *`.
 static const char *allow_globs[FLOX_SANDBOX_ALLOW_MAXENTRIES];
 static int allow_globs_count = 0;
+// Guards allow_globs[]/allow_globs_count against concurrent runtime appends
+// (allow_globs_add) racing reads (check_allowed_globs). Only engaged when the
+// prompt broker is active; without it the list is built once and read-only, so
+// the default build path takes no lock. PTHREAD_MUTEX_INITIALIZER is correct on
+// both platforms (unlike the removed zero-initialized mutex).
+static pthread_mutex_t allow_globs_lock = PTHREAD_MUTEX_INITIALIZER;
+
+// Append a pattern to the allow-globs list at runtime (used when the prompt
+// broker returns allow/allow-glob). Thread-safe. The pattern is strdup()'d and
+// intentionally never freed: it must live for the rest of the process.
+static void allow_globs_add(const char *pattern) {
+  pthread_mutex_lock(&allow_globs_lock);
+  if (allow_globs_count < FLOX_SANDBOX_ALLOW_MAXENTRIES) {
+    char *copy = strdup(pattern);
+    if (copy != NULL)
+      allow_globs[allow_globs_count++] = copy;
+  }
+  pthread_mutex_unlock(&allow_globs_lock);
+}
 
 static void allow_globs_init(void) {
   const char *env = getenv("FLOX_SANDBOX_ALLOW");
@@ -432,6 +474,11 @@ static void allow_globs_init(void) {
 // directory separators, giving simple recursive patterns like "~/.npm/**".
 static bool check_allowed_globs(const char *real_path) {
   pthread_once(&allow_globs_once, allow_globs_init);
+  // The list is immutable after init unless the prompt broker is active and may
+  // append to it, so only then do we take the lock around the scan.
+  if (prompt_enabled)
+    pthread_mutex_lock(&allow_globs_lock);
+  bool matched = false;
   for (int i = 0; i < allow_globs_count; i++) {
     const char *pattern = allow_globs[i];
     // Expand a leading "~/" to "$HOME/" (into a local buffer) so manifest
@@ -444,10 +491,87 @@ static bool check_allowed_globs(const char *real_path) {
     }
     if (fnmatch(pattern, real_path, 0) == 0) {
       debug("%s matches sandbox-allow pattern '%s'", real_path, allow_globs[i]);
-      return true;
+      matched = true;
+      break;
     }
   }
-  return false;
+  if (prompt_enabled)
+    pthread_mutex_unlock(&allow_globs_lock);
+  return matched;
+}
+
+// Decision values returned by prompt_broker().
+#define PROMPT_ERROR (-1) // no broker, or the exchange failed: use default policy
+#define PROMPT_DENY 0     // user/broker denied this access
+#define PROMPT_ALLOW 1    // user/broker allowed this access
+
+// Refer an out-of-closure access to the interactive prompt broker over the
+// AF_UNIX socket named by FLOX_SANDBOX_PROMPT_SOCKET. The wire protocol is one
+// request and one reply per connection, newline-terminated text:
+//
+//   -> "<realpath>\n"
+//   <- "allow\n"                 allow this access (remembered for the exact path)
+//   <- "allow-glob <pattern>\n"  allow, and remember <pattern> for future matches
+//   <- "deny\n"                  deny this access
+//
+// One connection per query keeps the client simple and lets the broker
+// serialize prompts (it accepts and handles connections one at a time). Socket
+// calls are not themselves interposed, so there is no re-entrancy here. Returns
+// a PROMPT_* value; PROMPT_ERROR means fall back to the normal warn/enforce
+// policy.
+static int prompt_broker(const char *real_path) {
+  if (!prompt_enabled)
+    return PROMPT_ERROR;
+
+  int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0)
+    return PROMPT_ERROR;
+
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, prompt_socket_path, sizeof(addr.sun_path) - 1);
+  if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+    close(fd);
+    return PROMPT_ERROR;
+  }
+
+  // Send the realpath being queried.
+  char request[PATH_MAX + 2];
+  int request_len = snprintf(request, sizeof(request), "%s\n", real_path);
+  if (request_len < 0 || (size_t)request_len >= sizeof(request) ||
+      write(fd, request, (size_t)request_len) != request_len) {
+    close(fd);
+    return PROMPT_ERROR;
+  }
+
+  // Read the single reply line. The broker writes one short line and we read
+  // once; that is sufficient for the small fixed vocabulary above.
+  char reply[PATH_MAX + 32];
+  ssize_t reply_len = read(fd, reply, sizeof(reply) - 1);
+  close(fd);
+  if (reply_len <= 0)
+    return PROMPT_ERROR;
+  reply[reply_len] = '\0';
+  reply[strcspn(reply, "\n")] = '\0';
+
+  if (strncmp(reply, "allow-glob ", 11) == 0) {
+    allow_globs_add(reply + 11);
+    debug("prompt broker allowed '%s' via glob '%s'", real_path, reply + 11);
+    return PROMPT_ALLOW;
+  }
+  if (strcmp(reply, "allow") == 0) {
+    // Remember the exact path so the same file is not queried again.
+    allow_globs_add(real_path);
+    debug("prompt broker allowed '%s'", real_path);
+    return PROMPT_ALLOW;
+  }
+  if (strcmp(reply, "deny") == 0) {
+    debug("prompt broker denied '%s'", real_path);
+    return PROMPT_DENY;
+  }
+  debug("prompt broker gave unrecognized reply '%s' for '%s'", reply, real_path);
+  return PROMPT_ERROR;
 }
 
 // Returns true if `path` (an already-resolved realpath) is a hidden entry
@@ -708,6 +832,19 @@ bool sandbox_check_path(const char *pathname) {
       home_dotfile_hint();
     }
     return true;
+  }
+  // If an interactive prompt broker is configured, let it resolve this access
+  // (allow / allow-glob / deny) before the default warn/enforce policy applies.
+  // An allow is remembered so the same path/pattern is not asked again; a
+  // broker error falls through to the default policy below.
+  if (prompt_enabled) {
+    int decision = prompt_broker(real_path);
+    if (decision == PROMPT_ALLOW)
+      return true;
+    if (decision == PROMPT_DENY) {
+      warn("%s denied by sandbox prompt", display);
+      return false; // the interceptor turns this into EACCES
+    }
   }
   if (sandbox_level == 1) {
     // warn mode: report the out-of-closure read, but only once per path —

--- a/package-builder/tests/mock_prompt_broker.c
+++ b/package-builder/tests/mock_prompt_broker.c
@@ -1,0 +1,68 @@
+/*
+ * mock_prompt_broker.c — a minimal stand-in for the Phase 2 prompt broker,
+ * used by run-tests.sh to exercise libsandbox's prompt client without the real
+ * (interactive) flox broker.
+ *
+ * It listens on the AF_UNIX socket path given as argv[1] and replies with a
+ * fixed decision (argv[2], one of "allow", "deny", or an "allow-glob <pattern>"
+ * line) to every query, following the same one-request/one-reply-per-connection
+ * newline-terminated protocol libsandbox speaks. It prints "READY" once the
+ * socket is listening so the test can wait for it, then serves forever until
+ * killed.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  if (argc < 3) {
+    fprintf(stderr, "usage: %s <socket-path> <reply>\n", argv[0]);
+    return 2;
+  }
+  const char *path = argv[1];
+  const char *reply = argv[2];
+
+  unlink(path); /* a stale socket file would make bind() fail */
+
+  int listener = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (listener < 0) {
+    perror("socket");
+    return 1;
+  }
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+  if (bind(listener, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+    perror("bind");
+    return 1;
+  }
+  if (listen(listener, 16) != 0) {
+    perror("listen");
+    return 1;
+  }
+
+  /* Tell the test we are ready to accept connections. */
+  printf("READY\n");
+  fflush(stdout);
+
+  for (;;) {
+    int conn = accept(listener, NULL, NULL);
+    if (conn < 0) {
+      continue;
+    }
+    char request[4096];
+    (void)read(conn, request, sizeof(request)); /* discard the queried path */
+    char response[4200];
+    int n = snprintf(response, sizeof(response), "%s\n", reply);
+    if (n > 0) {
+      (void)write(conn, response, (size_t)n);
+    }
+    close(conn);
+  }
+  return 0;
+}

--- a/package-builder/tests/run-tests.sh
+++ b/package-builder/tests/run-tests.sh
@@ -336,7 +336,7 @@ fi
 # fixed-reply mock broker and check both decisions under enforce.
 # ----------------------------------------------------------------------------
 
-# Run a probe under enforce with the mock broker replying $1, opening $out_file
+# Run a probe in prompt mode with the mock broker replying $1, opening $out_file
 # (out of closure). Echoes "<rc>|<stdout+stderr>".
 run_with_broker() {
   local reply="$1"
@@ -347,7 +347,7 @@ run_with_broker() {
   for _ in $(seq 1 50); do [[ -S "$sock" ]] && break; sleep 0.05; done
   local out rc
   out="$(env "$preload_var=$sandbox_lib" FLOX_ENV="$fixture" \
-      FLOX_SANDBOX_ALLOW_DIRS="$allow_dirs" FLOX_VIRTUAL_SANDBOX=enforce \
+      FLOX_SANDBOX_ALLOW_DIRS="$allow_dirs" FLOX_VIRTUAL_SANDBOX=prompt \
       FLOX_SANDBOX_PROMPT_SOCKET="$sock" \
       "$root/tests/sandbox_probe" open "$out_file" 2>&1)"; rc=$?
   kill "$broker_pid" 2>/dev/null; wait "$broker_pid" 2>/dev/null
@@ -355,21 +355,32 @@ run_with_broker() {
   printf '%s|%s' "$rc" "$out"
 }
 
-# Broker "allow": the out-of-closure read is permitted, no error, build the
-# probe succeeds even under enforce.
+# Broker "allow": the out-of-closure read is permitted, no error, the probe
+# succeeds.
 res="$(run_with_broker allow)"; rc="${res%%|*}"; out="${res#*|}"
 if [[ "$rc" -eq 0 && "$out" == *"OPEN_OK"* && "$out" != *"not in the sandbox"* ]]; then
-  pass "enforce: prompt broker 'allow' permits an out-of-closure file"
+  pass "prompt: broker 'allow' permits an out-of-closure file"
 else
-  fail "enforce: broker 'allow' should permit the access (rc=$rc)" "$out"
+  fail "prompt: broker 'allow' should permit the access (rc=$rc)" "$out"
 fi
 
 # Broker "deny": the access is refused (EACCES), so the probe's open() fails.
 res="$(run_with_broker deny)"; rc="${res%%|*}"; out="${res#*|}"
 if [[ "$rc" -ne 0 && "$out" == *"OPEN_FAIL"* && "$out" == *"denied by sandbox prompt"* ]]; then
-  pass "enforce: prompt broker 'deny' refuses an out-of-closure file"
+  pass "prompt: broker 'deny' refuses an out-of-closure file"
 else
-  fail "enforce: broker 'deny' should refuse the access (rc=$rc)" "$out"
+  fail "prompt: broker 'deny' should refuse the access (rc=$rc)" "$out"
+fi
+
+# No broker configured: prompt mode falls back to plain enforce (the access is
+# fatal), which is what a non-interactive build gets.
+out="$(env "$preload_var=$sandbox_lib" FLOX_ENV="$fixture" \
+    FLOX_SANDBOX_ALLOW_DIRS="$allow_dirs" FLOX_VIRTUAL_SANDBOX=prompt \
+    "$root/tests/sandbox_probe" open "$out_file" 2>&1)"; rc=$?
+if [[ "$rc" -ne 0 && "$out" == *"is not in the sandbox"* ]]; then
+  pass "prompt: with no broker, falls back to enforce (blocks)"
+else
+  fail "prompt: no-broker should behave as enforce (rc=$rc)" "$out"
 fi
 
 # ----------------------------------------------------------------------------

--- a/package-builder/tests/run-tests.sh
+++ b/package-builder/tests/run-tests.sh
@@ -383,6 +383,25 @@ else
   fail "prompt: no-broker should behave as enforce (rc=$rc)" "$out"
 fi
 
+# Mode gating: an enforce-mode build that happens to share the process-wide
+# prompt socket env must NOT consult the broker (it would say allow); only
+# prompt mode prompts. Start an allow-broker but run under enforce: the access
+# is still blocked.
+sock="$(mktemp -u "${TMPDIR:-/tmp}/flox-prompt.XXXXXX.sock")"
+"$root/tests/mock_prompt_broker" "$sock" allow >/dev/null 2>&1 &
+broker_pid=$!
+for _ in $(seq 1 50); do [[ -S "$sock" ]] && break; sleep 0.05; done
+out="$(env "$preload_var=$sandbox_lib" FLOX_ENV="$fixture" \
+    FLOX_SANDBOX_ALLOW_DIRS="$allow_dirs" FLOX_VIRTUAL_SANDBOX=enforce \
+    FLOX_SANDBOX_PROMPT_SOCKET="$sock" \
+    "$root/tests/sandbox_probe" open "$out_file" 2>&1)"; rc=$?
+kill "$broker_pid" 2>/dev/null; wait "$broker_pid" 2>/dev/null; rm -f "$sock"
+if [[ "$rc" -ne 0 && "$out" == *"is not in the sandbox"* ]]; then
+  pass "enforce: ignores the prompt socket (only prompt mode consults the broker)"
+else
+  fail "enforce: must not consult the broker (rc=$rc)" "$out"
+fi
+
 # ----------------------------------------------------------------------------
 # Layer 3: threaded interception storm (stability of the real interceptors).
 # The OLD library crashed here on macOS (uninitialized mutex + shared buffers);

--- a/package-builder/tests/run-tests.sh
+++ b/package-builder/tests/run-tests.sh
@@ -330,6 +330,49 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+# Layer 2c: interactive prompt broker (Phase 2). With FLOX_SANDBOX_PROMPT_SOCKET
+# set, an out-of-closure access is referred to the broker instead of being
+# warned/blocked outright. We drive the libsandbox prompt client against the
+# fixed-reply mock broker and check both decisions under enforce.
+# ----------------------------------------------------------------------------
+
+# Run a probe under enforce with the mock broker replying $1, opening $out_file
+# (out of closure). Echoes "<rc>|<stdout+stderr>".
+run_with_broker() {
+  local reply="$1"
+  local sock; sock="$(mktemp -u "${TMPDIR:-/tmp}/flox-prompt.XXXXXX.sock")"
+  "$root/tests/mock_prompt_broker" "$sock" "$reply" >/dev/null 2>&1 &
+  local broker_pid=$!
+  # Wait (briefly) for the socket to appear.
+  for _ in $(seq 1 50); do [[ -S "$sock" ]] && break; sleep 0.05; done
+  local out rc
+  out="$(env "$preload_var=$sandbox_lib" FLOX_ENV="$fixture" \
+      FLOX_SANDBOX_ALLOW_DIRS="$allow_dirs" FLOX_VIRTUAL_SANDBOX=enforce \
+      FLOX_SANDBOX_PROMPT_SOCKET="$sock" \
+      "$root/tests/sandbox_probe" open "$out_file" 2>&1)"; rc=$?
+  kill "$broker_pid" 2>/dev/null; wait "$broker_pid" 2>/dev/null
+  rm -f "$sock"
+  printf '%s|%s' "$rc" "$out"
+}
+
+# Broker "allow": the out-of-closure read is permitted, no error, build the
+# probe succeeds even under enforce.
+res="$(run_with_broker allow)"; rc="${res%%|*}"; out="${res#*|}"
+if [[ "$rc" -eq 0 && "$out" == *"OPEN_OK"* && "$out" != *"not in the sandbox"* ]]; then
+  pass "enforce: prompt broker 'allow' permits an out-of-closure file"
+else
+  fail "enforce: broker 'allow' should permit the access (rc=$rc)" "$out"
+fi
+
+# Broker "deny": the access is refused (EACCES), so the probe's open() fails.
+res="$(run_with_broker deny)"; rc="${res%%|*}"; out="${res#*|}"
+if [[ "$rc" -ne 0 && "$out" == *"OPEN_FAIL"* && "$out" == *"denied by sandbox prompt"* ]]; then
+  pass "enforce: prompt broker 'deny' refuses an out-of-closure file"
+else
+  fail "enforce: broker 'deny' should refuse the access (rc=$rc)" "$out"
+fi
+
+# ----------------------------------------------------------------------------
 # Layer 3: threaded interception storm (stability of the real interceptors).
 # The OLD library crashed here on macOS (uninitialized mutex + shared buffers);
 # the fixed library must run to completion. Mixed in/out/nonexistent paths


### PR DESCRIPTION
> **Draft / stacked on #4351 (merged).** The below-CLI plumbing and all logic
> are unit/integration tested, but the live interactive flow (crossterm TUI +
> broker-during-build on `/dev/tty`) has **not yet been exercised end-to-end** on
> a real tty — see [Status](#status). Opening as a draft for review of the
> architecture while that validation is done.

## Release Notes

Manifest builds gain an interactive `sandbox` mode for discovering and recording
out-of-closure dependencies:

- `sandbox = "prompt"` in a `[build.<name>]` section (requires
  `schema-version = "1.13.0"`): when the build reads a file outside its package
  closure, Flox pauses and asks what to do — **allow this file**, **allow a
  `<dir>/**` rollup**, **deny**, or **deny all** — on an interactive menu. With
  no interactive terminal it behaves exactly like `enforce` (fail-closed).
- `flox build --sandbox-prompt` forces prompt mode for a single invocation
  without editing the manifest (errors if the build is `pure`).
- After a prompted build, Flox prints a copy-paste-ready
  `sandbox-allow = [...]` block of everything you allowed, plus a nudge toward
  `sandbox = "enforce"` for a reproducible build.

`prompt` is a transitional aid: prompt once, capture the exceptions into
`sandbox-allow`, then graduate to `enforce`.

## Summary

This is **Phase 2** of the build-time virtual sandbox, stacked on #4351 (the
thread-safe engine + `warn`/`enforce` modes, now merged). It adds an
**interactive exceptions broker**: instead of warning or failing on an
out-of-closure access, a `prompt`-mode build refers the access to the user live,
remembers the answer, and offers to record it as `sandbox-allow`.

It's built as a control channel between the build process and the driving `flox`
process, in four increments (one per commit pair):

## Architecture

**1 — libsandbox prompt client (`package-builder/sandbox.c`).** When
`FLOX_SANDBOX_PROMPT_SOCKET` names an `AF_UNIX` socket, an out-of-closure access
is referred to that broker over a one-request/one-reply, newline-terminated
protocol (`<realpath>` → `allow` / `allow-glob <pattern>` / `deny`). `allow(-glob)`
decisions are cached in-process (so the same path/pattern is never asked twice),
`deny` yields `EACCES`, and a broker error falls through to the normal
warn/enforce policy. The allow-globs list is guarded by a properly-initialized
mutex engaged **only** when the broker is active, so the default (non-prompt)
build path stays lock-free. New libc symbols (`socket`, `connect`, `read`,
`write`, `close`, …) are bound to the minimum GLIBC.

**2 — Rust prompt broker (`flox-rust-sdk/.../sandbox_prompt.rs`).**
`SandboxPromptBroker` owns the socket and a serving thread that (a) accepts and
answers connections **one at a time**, so prompts from parallel build processes
(`make -j`, `npm`, …) never interleave; (b) **auto-answers** any later request
already covered by an accepted pattern, so the user is asked at most once per
pattern even across many processes; and (c) delegates a genuinely new access to a
`PromptResolver` trait (the seam for the UI; `DenyAll` is the safe default/test
stub). `accepted_globs()` exposes the answers for the write-back. Glob matching
mirrors libsandbox's (`*`/`**` cross `/`, leading `~/` → `$HOME`), no new
dependency.

**3 — Interactive UI (`flox/src/utils/sandbox_prompt.rs`).**
`InteractivePromptResolver` draws a full-screen bordered "Flox sandbox" page on
`/dev/tty` (crossterm) with an arrow menu: *Allow once* / *Allow `<dir>/**`* at
each nesting level from the parent up to (not including) `$HOME` / *Deny* /
*Deny all* (latches). Going through `/dev/tty` means it works even when the
build's stdout/stderr are redirected; **no tty → deny (fail-closed)**. The
menu-building and decision logic are pure and unit-tested.

**4 — `flox build` wiring (`build.rs`, `flox-build.mk`).** `prompt` is routed to
the local build with the preload (it's neither `pure` nor `off`);
`FLOX_SANDBOX_PROMPT_SOCKET` is forwarded into the build-script injection, and
`FLOX_SANDBOX_OVERRIDE` lets `--sandbox-prompt` force the mode for one run. The
command starts the broker + resolver before the build and shuts it down after.
The broker consultation is gated on `prompt_mode` (not merely the socket being
present), so in a mixed build an `enforce` package sharing the process-wide
socket env never prompts. Afterward, `guide_sandbox_allow_writeback` prints the
accepted patterns as a paste-ready block — a **guided summary, not an automatic
edit**, so the user sees exactly what is being permitted.

## Manifest schema

`BuildSandbox::Prompt` is added to the **version-specific `v1_13_0::BuildSandbox`**
(alongside `warn`/`enforce`), not the common enum — so `sandbox = "prompt"`
requires `schema-version = "1.13.0"` and is rejected under older schemas, the
same gating established for `warn`/`enforce` in #4351. `publish` treats `prompt`
as a local build. Schemas regenerated.

## Tests

- **`package-builder` (`make tests`, 23/23 on macOS):** the four `prompt` cases —
  broker `allow` permits, broker `deny` blocks, **no broker → falls back to
  enforce**, and **enforce ignores the prompt socket** (only `prompt` mode
  consults the broker) — driven through real `DYLD`/`LD_PRELOAD` interception
  against a dependency-free C `mock_prompt_broker`.
- **`flox-rust-sdk` broker (6):** allow/deny relay, exact-path and glob caching
  (auto-answer without re-prompting), prompting for uncovered paths, matcher
  semantics.
- **`flox` resolver (5):** ancestor `<dir>/**` rollups, `$HOME`-relativization,
  deny-all latch, truncation.
- **`flox-manifest` (119):** proptest roundtrips include the new `Prompt` value.
- clippy / rustfmt / treefmt / clang-format clean.

## Status

**Done & validated below the TUI.** The one thing left before this leaves draft:
a real `flox build --sandbox-prompt` on a machine with a tty to exercise the
crossterm rendering, the broker-during-build path, and a prompt on `/dev/tty`
(the resolver's pure logic is unit-tested, but the live page render is not). A
non-tty `--sandbox-prompt` integration test (resolver denies → enforce-like
fail) is a good first automated cover for that path.

## Commits

Six commits, by increment:

1. `feat(sandbox): libsandbox interactive prompt client` — the control-channel client.
2. `feat(sandbox): Rust prompt broker` — socket owner + serving thread + resolver seam.
3. `feat(sandbox): interactive prompt UI` — the crossterm `/dev/tty` resolver.
4. `feat(sandbox): prompt mode plumbing` (4a/4b) — `prompt` mode end-to-end below the CLI.
5. `feat(sandbox): prompt-mode gating + FloxBuildMk broker wiring` (4c·1).
6. `feat(sandbox): flox build --sandbox-prompt + guided write-back` (4c/4d/4e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
