### PR TITLE
feat(hook-env): pop the whole auto-activated stack in one prompt (DEV-111)

### DIFF
--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
-use anyhow::{Context, anyhow};
+use anyhow::Context;
 use clap::Args;
 use flox_core::activations::{read_activations_json, state_json_path, write_activations_json};
+use tracing::debug;
 
 use crate::Error;
 
@@ -36,11 +37,18 @@ impl DetachArgs {
             })?;
 
         let Some(mut state) = activation_state_opt else {
-            return Err(anyhow!(
-                "No activation state found at '{}'; cannot detach PID {}",
-                activations_json_path.display(),
-                self.pid
-            ));
+            // The activation's executive removes the whole state directory as
+            // soon as the last PID detaches. The prompt hook emits this `detach`
+            // unconditionally and races that async cleanup, so a missing state
+            // file means the work is already done — the PID is no longer
+            // attached. Treat it as a no-op rather than surfacing a spurious
+            // error on the user's prompt.
+            debug!(
+                pid = self.pid,
+                path = %activations_json_path.display(),
+                "no activation state to detach from; assuming already cleaned up"
+            );
+            return Ok(());
         };
 
         let empty_start_id = state.detach(self.pid)?;
@@ -108,6 +116,24 @@ mod test {
             updated.attached_pids_is_empty(),
             "PID should be removed from state.json after detach"
         );
+    }
+
+    /// Detaching when the state file is already gone (the executive cleaned it
+    /// up first) is a no-op success, not an error — the prompt hook races that
+    /// async cleanup.
+    #[test]
+    fn detach_with_missing_state_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = tmp.path().join(".flox");
+        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+        // No state.json is ever written.
+
+        let args = DetachArgs {
+            activation_state_dir,
+            pid: 12345,
+        };
+        args.handle()
+            .expect("detach should be a no-op when state is missing");
     }
 
     /// When the last PID overall detaches, its start state dir is removed

--- a/cli/flox-activations/src/deactivate.rs
+++ b/cli/flox-activations/src/deactivate.rs
@@ -43,10 +43,40 @@ pub fn generate_deactivate_script(
     flox_env: &Path,
     flox_activate_tracelevel: u32,
 ) -> Result<()> {
-    let activate_d = interpreter_path.as_ref().join("activate.d");
     let encoded_diff = env::var(FLOX_HOOK_DIFF_VAR)
         .context(format!("{} not set in environment", FLOX_HOOK_DIFF_VAR))?;
-    let restore_diff = DiffSerializer::decode(&encoded_diff)
+    generate_deactivate_script_with_diff(
+        shell,
+        writer,
+        interpreter_path,
+        flox_activations_bin,
+        activation_state_dir,
+        flox_env,
+        flox_activate_tracelevel,
+        &encoded_diff,
+    )
+}
+
+/// Like [`generate_deactivate_script`], but for an explicitly provided encoded
+/// diff rather than the caller's `_FLOX_HOOK_DIFF`.
+///
+/// Used by the prompt hook to pop several stacked in-place activations in one
+/// run: the shell's `_FLOX_HOOK_DIFF` only ever holds the front layer's diff,
+/// and deeper layers' diffs are obtained by walking the chain with
+/// [`embedded_hook_diff`].
+#[allow(clippy::too_many_arguments)]
+pub fn generate_deactivate_script_with_diff(
+    shell: ShellWithPath,
+    writer: &mut impl Write,
+    interpreter_path: impl AsRef<Path>,
+    flox_activations_bin: &Path,
+    activation_state_dir: &Path,
+    flox_env: &Path,
+    flox_activate_tracelevel: u32,
+    encoded_diff: &str,
+) -> Result<()> {
+    let activate_d = interpreter_path.as_ref().join("activate.d");
+    let restore_diff = DiffSerializer::decode(encoded_diff)
         .context(format!("Failed to decode {}", FLOX_HOOK_DIFF_VAR))?;
     let ctx = DeactivateCtx {
         activate_d,
@@ -90,4 +120,20 @@ pub fn generate_deactivate_script(
     )?;
 
     Ok(())
+}
+
+/// The next (outer) layer's encoded `_FLOX_HOOK_DIFF`, as captured inside
+/// `encoded_diff`.
+///
+/// In-place activations track `_FLOX_HOOK_DIFF` in their diff (see
+/// `AttachDiff`), so a nested layer's diff records the previous layer's
+/// encoded value under `modified`. Decoding one layer's diff therefore yields
+/// the diff of the layer beneath it, forming a chain from the front of the
+/// activation stack to the outermost in-place layer. Returns `None` for the
+/// outermost layer (the variable had no previous value, so it is in `added`)
+/// and for non-in-place activations (which don't track the variable at all).
+pub fn embedded_hook_diff(encoded_diff: &str) -> Result<Option<String>> {
+    let diff = DiffSerializer::decode(encoded_diff)
+        .context(format!("Failed to decode {}", FLOX_HOOK_DIFF_VAR))?;
+    Ok(diff.modified.get(FLOX_HOOK_DIFF_VAR).cloned())
 }

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -118,6 +118,7 @@ impl Deactivate {
             &target.activation_state_dir,
             &target.flox_env,
             flox_activate_tracelevel(),
+            None,
             &mut writer,
         )
     }
@@ -222,12 +223,18 @@ pub(crate) fn flox_activate_tracelevel() -> u32 {
 ///   `flox-activations detach` command so state.json is updated once the caller
 ///   eval's the script.
 /// - `ExecCommand` → unreachable; `_FLOX_INVOCATION_TYPE` is never `exec_command`.
+///
+/// `encoded_diff` selects which layer's diff to restore: `None` restores the
+/// front of the stack from this process's `_FLOX_HOOK_DIFF`; `Some` restores
+/// an explicitly provided diff, which is how the prompt hook pops several
+/// stacked layers in one run (see `embedded_hook_diff`).
 pub(crate) fn emit_deactivate_script(
     shell: ShellWithPath,
     invocation_kind: InvocationKind,
     activation_state_dir: &Path,
     flox_env: &Path,
     flox_activate_tracelevel: u32,
+    encoded_diff: Option<&str>,
     writer: &mut impl Write,
 ) -> Result<()> {
     match invocation_kind {
@@ -238,8 +245,20 @@ pub(crate) fn emit_deactivate_script(
             }
             Ok(())
         },
-        InvocationKind::InPlace | InvocationKind::ShellCommand => {
-            flox_activations::deactivate::generate_deactivate_script(
+        InvocationKind::InPlace | InvocationKind::ShellCommand => match encoded_diff {
+            Some(encoded_diff) => {
+                flox_activations::deactivate::generate_deactivate_script_with_diff(
+                    shell,
+                    writer,
+                    &*FLOX_INTERPRETER,
+                    &FLOX_ACTIVATIONS_BIN,
+                    activation_state_dir,
+                    flox_env,
+                    flox_activate_tracelevel,
+                    encoded_diff,
+                )
+            },
+            None => flox_activations::deactivate::generate_deactivate_script(
                 shell,
                 writer,
                 &*FLOX_INTERPRETER,
@@ -247,9 +266,9 @@ pub(crate) fn emit_deactivate_script(
                 activation_state_dir,
                 flox_env,
                 flox_activate_tracelevel,
-            )
-            .context("failed to generate deactivation script")
-        },
+            ),
+        }
+        .context("failed to generate deactivation script"),
         InvocationKind::ExecCommand => {
             bail!("cannot deactivate an exec command activation");
         },
@@ -268,6 +287,7 @@ mod tests {
             Path::new("/activation_state_dir"),
             Path::new("/flox_env"),
             0,
+            None,
             &mut buf,
         )
         .unwrap();

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -2,8 +2,10 @@ use std::borrow::Cow;
 use std::io::{BufWriter, Write, stdout};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
+use flox_activations::attach_diff::diff_serializer::FLOX_HOOK_DIFF_VAR;
+use flox_activations::deactivate::embedded_hook_diff;
 use flox_core::activate::context::InvocationKind;
 use flox_core::activate::vars::{
     FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR,
@@ -76,6 +78,7 @@ impl HookEnv {
                         activation_state_dir,
                         flox_env,
                         flox_activate_tracelevel(),
+                        None,
                         &mut writer,
                     )?;
                 },
@@ -103,28 +106,72 @@ impl HookEnv {
         // `hook-env` runs on every shell prompt, and recording the common
         // nothing-to-do case would be noise.
         if !actions.is_empty()
-            || plan.deactivate_front
+            || !plan.deactivate.is_empty()
             || !plan.activate.is_empty()
             || !plan.abandoned.is_empty()
         {
             subcommand_metric!("hook-env");
         }
 
-        if plan.deactivate_front {
-            let active = activated_environments()
-                .last_active_full()
-                .context("no active environment to auto-deactivate")?;
-            let target = open_deactivation_target(&flox, active)?;
-            // Auto-activations are always in-place, so the matching
-            // deactivation is too.
-            emit_deactivate_script(
-                ShellWithPath::from(self.shell),
-                InvocationKind::InPlace,
-                &target.activation_state_dir,
-                &target.flox_env,
-                flox_activate_tracelevel(),
-                &mut writer,
-            )?;
+        if !plan.deactivate.is_empty() {
+            // Auto-activations are always in-place, so each layer recorded
+            // the previous value of `_FLOX_HOOK_DIFF` in its own diff. The
+            // shell's variable holds the front layer's diff; walking the
+            // embedded chain yields one diff per deeper layer, which is what
+            // lets a single run pop several layers.
+            let mut encoded_diff = std::env::var(FLOX_HOOK_DIFF_VAR).ok();
+            let stack = activated_environments();
+            let mut layers = stack.iter_full();
+            for (layer_idx, project_dir) in plan.deactivate.iter().enumerate() {
+                let layer = layers.next().with_context(|| {
+                    format!(
+                        "no active environment to auto-deactivate for '{}'",
+                        project_dir.display()
+                    )
+                })?;
+                let layer_dir = layer.environment.path().and_then(Path::parent);
+                if layer_dir != Some(project_dir.as_path()) {
+                    bail!(
+                        "activation stack does not match the auto-deactivation plan (expected '{}')",
+                        project_dir.display()
+                    );
+                }
+                let Some(diff) = encoded_diff.take() else {
+                    // This layer has no chained diff: its activation predates
+                    // the prompt hook (or `_FLOX_HOOK_DIFF` was lost), so the
+                    // walk can go no deeper. This layer and every tracked
+                    // leaver still queued behind it are dropped from tracking
+                    // below, so warn for each one here; otherwise they would
+                    // be silently stranded, still active but no longer
+                    // auto-managed. They can each still be unwound with
+                    // 'flox deactivate'.
+                    message::warning(formatdoc! {"
+                        Did not auto-deactivate the environment in '{}' because its activation predates the prompt hook.
+                        Run 'flox deactivate' to deactivate it.",
+                        project_dir.display()
+                    });
+                    for buried in &plan.deactivate[layer_idx + 1..] {
+                        message::warning(format!(
+                            "Did not auto-deactivate the environment in '{}' because an environment above it could not be auto-deactivated.",
+                            buried.display()
+                        ));
+                    }
+                    break;
+                };
+                let target = open_deactivation_target(&flox, layer.clone())?;
+                // Auto-activations are always in-place, so the matching
+                // deactivation is too.
+                emit_deactivate_script(
+                    ShellWithPath::from(self.shell),
+                    InvocationKind::InPlace,
+                    &target.activation_state_dir,
+                    &target.flox_env,
+                    flox_activate_tracelevel(),
+                    Some(&diff),
+                    &mut writer,
+                )?;
+                encoded_diff = embedded_hook_diff(&diff)?;
+            }
         }
 
         for path in &plan.abandoned {
@@ -186,8 +233,8 @@ struct AutoActivateContext {
 struct AutoActivatePlan {
     /// Project directories to activate, outermost-first.
     activate: Vec<PathBuf>,
-    /// Deactivate the front-of-stack environment.
-    deactivate_front: bool,
+    /// Project directories to deactivate, front of stack first.
+    deactivate: Vec<PathBuf>,
     /// Auto-activated environments that should be deactivated but are buried
     /// under other activations. Tearing down the middle of the stack is
     /// not yet supported, so these are dropped from tracking with a warning.
@@ -201,12 +248,16 @@ struct AutoActivatePlan {
 /// Decide what the prompt hook should do given the shell's current location
 /// and activation state.
 ///
-/// At most one environment is deactivated per run: the generated deactivation
-/// script restores the next layer's `_FLOX_HOOK_DIFF` only once the shell has
-/// applied it, so a deeper stack unwinds across consecutive prompts rather
-/// than in a single run. While such an unwind is in progress, newly
+/// All tracked leaver layers at the front of the activation stack pop in a
+/// single run: each in-place activation's diff embeds the previous value of
+/// `_FLOX_HOOK_DIFF`, so one run can emit a deactivation script per
+/// layer and they restore state correctly when evaluated in order. The walk
+/// stops at the first layer that is not a tracked leaver, because tearing
+/// down the middle of the stack is deferred; leavers buried beneath
+/// such a layer are abandoned with a warning once nothing in front of them
+/// can pop. While any tracked layer the shell has left remains active, newly
 /// discovered environments are not activated yet — they would bury the
-/// still-unwinding layers and force them to be abandoned.
+/// still-unwinding layers.
 fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
     let inside = |path: &Path| ctx.cwd.starts_with(path);
     let is_active = |path: &PathBuf| ctx.active.iter().flatten().any(|active| active == path);
@@ -250,7 +301,7 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
         }
         return AutoActivatePlan {
             activate: Vec::new(),
-            deactivate_front: false,
+            deactivate: Vec::new(),
             abandoned: Vec::new(),
             auto_activated,
             suppressed,
@@ -258,8 +309,9 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
     }
 
     // Auto-deactivate environments whose directory the shell has left,
-    // popping at most one layer per run (see the function docs).
-    let mut deactivate_front = false;
+    // popping every tracked leaver at the front of the stack in one run
+    // (see the function docs).
+    let mut deactivate = Vec::new();
     let mut abandoned = Vec::new();
     let leavers: Vec<PathBuf> = auto_activated
         .iter()
@@ -267,16 +319,20 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
         .cloned()
         .collect();
     if !leavers.is_empty() {
-        match ctx.active.first() {
-            Some(Some(front)) if leavers.contains(front) => {
-                deactivate_front = true;
-                auto_activated.retain(|path| path != front);
-                // Any remaining leavers unwind on subsequent prompts.
-            },
-            _ => {
-                abandoned = leavers;
-                auto_activated.retain(|path| inside(path));
-            },
+        for layer in &ctx.active {
+            match layer {
+                Some(path) if leavers.contains(path) => deactivate.push(path.clone()),
+                _ => break,
+            }
+        }
+        auto_activated.retain(|path| !deactivate.contains(path));
+        if deactivate.is_empty() {
+            // Every leaver is buried under a layer that can't pop: drop them
+            // from tracking with a warning. (When something did pop, buried
+            // leavers stay tracked; they are abandoned on a later run once
+            // the front of the stack settles.)
+            abandoned = leavers;
+            auto_activated.retain(|path| inside(path));
         }
     }
 
@@ -299,7 +355,7 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
 
     AutoActivatePlan {
         activate,
-        deactivate_front,
+        deactivate,
         abandoned,
         auto_activated,
         suppressed,
@@ -439,7 +495,7 @@ mod tests {
     fn noop_plan() -> AutoActivatePlan {
         AutoActivatePlan {
             activate: Vec::new(),
-            deactivate_front: false,
+            deactivate: Vec::new(),
             abandoned: Vec::new(),
             auto_activated: Vec::new(),
             suppressed: Vec::new(),
@@ -515,13 +571,13 @@ mod tests {
             ..empty_ctx("/home/user/elsewhere")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
-            deactivate_front: true,
+            deactivate: paths(&["/home/user/proj"]),
             ..noop_plan()
         });
     }
 
     #[test]
-    fn pops_one_layer_per_run() {
+    fn pops_all_leaver_layers_in_one_run() {
         let ctx = AutoActivateContext {
             // Front of stack is the innermost env.
             active: vec![
@@ -532,9 +588,8 @@ mod tests {
             ..empty_ctx("/home/user/elsewhere")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
-            deactivate_front: true,
-            // The outer env unwinds on the next prompt.
-            auto_activated: paths(&["/home/user/outer"]),
+            // Front-of-stack (innermost) first, the whole stack in one run.
+            deactivate: paths(&["/home/user/outer/inner", "/home/user/outer"]),
             ..noop_plan()
         });
     }
@@ -549,17 +604,17 @@ mod tests {
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
             activate: paths(&["/home/user/proj_b"]),
-            deactivate_front: true,
+            deactivate: paths(&["/home/user/proj_a"]),
             auto_activated: paths(&["/home/user/proj_b"]),
             ..noop_plan()
         });
     }
 
     #[test]
-    fn defers_activation_while_stack_unwinds() {
-        // Leaving /tmp/a/b for /tmp/z: the front pops this run, but /tmp/a is
-        // still unwinding, so /tmp/z is not activated yet — activating it now
-        // would bury /tmp/a and force an abandon on a later run.
+    fn pops_whole_stack_and_activates_replacement_in_one_run() {
+        // Leaving a nested stack for a different project unwinds every
+        // tracked layer and activates the replacement in the same run, so
+        // the shell never shows a stale stack or buries an unwinding layer.
         let ctx = AutoActivateContext {
             discovered: paths(&["/tmp/z"]),
             active: vec![
@@ -570,26 +625,54 @@ mod tests {
             ..empty_ctx("/tmp/z")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
-            deactivate_front: true,
+            activate: paths(&["/tmp/z"]),
+            deactivate: paths(&["/tmp/a/b", "/tmp/a"]),
+            auto_activated: paths(&["/tmp/z"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn defers_activation_while_buried_leaver_unwinds() {
+        // Leaving /tmp/a/b for /tmp/z with a manual activation between the
+        // tracked layers: the front pops this run, but /tmp/a is buried and
+        // still unwinding, so /tmp/z is not activated yet — activating it
+        // now would bury /tmp/a even deeper.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/tmp/z"]),
+            active: vec![
+                Some(PathBuf::from("/tmp/a/b")),
+                Some(PathBuf::from("/tmp/manual")),
+                Some(PathBuf::from("/tmp/a")),
+            ],
+            auto_activated: paths(&["/tmp/a", "/tmp/a/b"]),
+            ..empty_ctx("/tmp/z")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            deactivate: paths(&["/tmp/a/b"]),
             auto_activated: paths(&["/tmp/a"]),
             ..noop_plan()
         });
     }
 
     #[test]
-    fn unwinds_fully_then_activates_in_final_run() {
-        // Continuation of defers_activation_while_stack_unwinds, with the
-        // previous plan applied by the shell: the next hook run pops the last
-        // unwinding layer and activates the new environment in the same run.
+    fn abandons_buried_leaver_then_activates_in_next_run() {
+        // Continuation of defers_activation_while_buried_leaver_unwinds, with
+        // the previous plan applied by the shell: nothing in front of /tmp/a
+        // can pop, so it is abandoned with a warning and the new environment
+        // activates in the same run.
         let ctx = AutoActivateContext {
             discovered: paths(&["/tmp/z"]),
-            active: vec![Some(PathBuf::from("/tmp/a"))],
+            active: vec![
+                Some(PathBuf::from("/tmp/manual")),
+                Some(PathBuf::from("/tmp/a")),
+            ],
             auto_activated: paths(&["/tmp/a"]),
             ..empty_ctx("/tmp/z")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
             activate: paths(&["/tmp/z"]),
-            deactivate_front: true,
+            abandoned: paths(&["/tmp/a"]),
             auto_activated: paths(&["/tmp/z"]),
             ..noop_plan()
         });
@@ -771,7 +854,7 @@ mod tests {
             ..empty_ctx("/home/user/proj2")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
-            deactivate_front: true,
+            deactivate: paths(&["/home/user/proj"]),
             ..noop_plan()
         });
     }

--- a/cli/flox/src/utils/active_environments.rs
+++ b/cli/flox/src/utils/active_environments.rs
@@ -118,6 +118,15 @@ impl ActiveEnvironments {
     pub fn iter(&self) -> impl Iterator<Item = &UninitializedEnvironment> {
         self.0.iter().map(|active| &active.environment)
     }
+
+    /// Iterate over the active environments with their activation metadata
+    /// (mode, generation), most recently activated first. Needed when callers
+    /// must know how an env was activated, e.g. to pick the matching
+    /// rendered-env link when deactivating layers below the front of the
+    /// stack.
+    pub fn iter_full(&self) -> impl Iterator<Item = &ActiveEnvironment> {
+        self.0.iter()
+    }
 }
 
 impl Display for ActiveEnvironments {

--- a/cli/tests/activate/hook-nested-cd.exp
+++ b/cli/tests/activate/hook-nested-cd.exp
@@ -1,0 +1,47 @@
+# Drive an interactive bash through nested auto-activation: cd into a nested
+# project stack, then to a sibling project. The prompt hook must unwind the
+# whole stack and activate the sibling in a single prompt, with no leftover
+# variables from the popped layers.
+#
+# Verification beyond the expect matches below is the caller's job: the bats
+# test asserts on the captured output (e.g. no abandon warning, no tracer
+# noise from consecutive deactivations).
+
+set dir [lindex $argv 0]
+set child [lindex $argv 1]
+set sibling [lindex $argv 2]
+set flox $env(FLOX_BIN)
+# Auto-activation may lock and build environments on first use.
+set timeout 60
+set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
+
+spawn $flox activate --dir $dir
+expect_after {
+  timeout { exit 1 }
+  eof { exit 2 }
+  "*\n" { exp_continue }
+  "*\r" { exp_continue }
+}
+
+expect "You are now using the environment"
+expect $env(KNOWN_PROMPT)
+
+# Entering the nested child activates parent then child before this prompt.
+send "cd $child\n"
+expect $env(KNOWN_PROMPT)
+send "echo S1: v2=\${TEST_VAR2:-unset} v3=\${TEST_VAR3:-unset}\n"
+expect "S1: v2=auto2 v3=auto3"
+expect $env(KNOWN_PROMPT)
+
+# Switching to the sibling pops both nested layers and activates the sibling
+# in the same prompt run.
+send "cd $sibling\n"
+expect $env(KNOWN_PROMPT)
+send "echo S2: v2=\${TEST_VAR2:-unset} v3=\${TEST_VAR3:-unset} vz=\${TEST_VARZ:-unset}\n"
+expect "S2: v2=unset v3=unset vz=autoz"
+expect $env(KNOWN_PROMPT)
+
+send "exit\n"
+expect eof

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -60,6 +60,21 @@ project3_setup() {
   set_vars_manifest "$PROJECT3_DIR" TEST_VAR3 auto3
 }
 
+# A sibling project with an observable var, as a target for switching away
+# from a nested stack.
+projectz_setup() {
+  export PROJECTZ_DIR="${BATS_TEST_TMPDIR?}/projectz-${BATS_TEST_NUMBER?}"
+  rm -rf "$PROJECTZ_DIR"
+  mkdir -p "$PROJECTZ_DIR"
+  "$FLOX_BIN" init -d "$PROJECTZ_DIR"
+  set_vars_manifest "$PROJECTZ_DIR" TEST_VARZ autoz
+}
+
+projectz_teardown() {
+  rm -rf "${PROJECTZ_DIR?}"
+  unset PROJECTZ_DIR
+}
+
 setup() {
   common_test_setup
   setup_isolated_flox
@@ -67,6 +82,9 @@ setup() {
 }
 
 teardown() {
+  if [ -n "${PROJECTZ_DIR:-}" ]; then
+    projectz_teardown
+  fi
   if [ -n "${PROJECT2_DIR:-}" ]; then
     project2_teardown
   fi
@@ -326,12 +344,12 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 }
 
 # ---------------------------------------------------------------------------- #
-# Stacked auto-activation: nested projects activate outermost-first and
-# unwind one layer per prompt
+# Stacked auto-activation: nested projects activate outermost-first and the
+# whole stack unwinds in a single hook run on leaving
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=hook:auto-activate:nested
-@test "bash: nested projects activate as a stack and unwind one layer per prompt" {
+@test "bash: nested projects activate as a stack and unwind together on leaving" {
   project_setup
   project2_setup
   project3_setup
@@ -346,15 +364,14 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
     echo \"in: v2:\$TEST_VAR2 v3:\$TEST_VAR3\"
     cd $BATS_TEST_TMPDIR
     _flox_hook
-    echo \"one: v2:\${TEST_VAR2:-unset} v3:\${TEST_VAR3:-unset}\"
-    _flox_hook
-    echo \"two: v2:\${TEST_VAR2:-unset} v3:\${TEST_VAR3:-unset}\"
+    echo \"out: v2:\${TEST_VAR2:-unset} v3:\${TEST_VAR3:-unset}\"
+    echo \"tracked:\${_FLOX_AUTO_ACTIVATED_ENVIRONMENTS:-unset}\"
   "
   assert_success
   assert_output --partial "in: v2:auto2 v3:auto3"
-  # One layer pops per prompt: the inner (most recent) env first.
-  assert_output --partial "one: v2:auto2 v3:unset"
-  assert_output --partial "two: v2:unset v3:unset"
+  # Both layers pop in the single hook run after leaving.
+  assert_output --partial "out: v2:unset v3:unset"
+  assert_output --partial "tracked:unset"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -419,6 +436,32 @@ EOF
 
   FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/hook-cd.exp" "$PROJECT_DIR" "$PROJECT2_DIR" 'echo TEST_VAR2="$TEST_VAR2"'
   assert_output --partial 'TEST_VAR2=auto2'
+}
+
+# bats test_tags=hook:auto-fires:nested
+@test "bash: interactive hook unwinds a nested stack and switches projects in one prompt" {
+  project_setup
+  project2_setup
+  project3_setup
+  projectz_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  # Set up a .bashrc so the interactive shell has a known prompt
+  export KNOWN_PROMPT="hooktest> "
+  cat >"$HOME/.bashrc" <<EOF
+export PS1="$KNOWN_PROMPT"
+EOF
+  cat >"$HOME/.inputrc" <<EOF
+set enable-bracketed-paste off
+EOF
+
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/hook-nested-cd.exp" "$PROJECT_DIR" "$PROJECT3_DIR" "$PROJECTZ_DIR"
+  # The whole stack pops in the prompt run that switches projects, so no
+  # layer is buried and abandoned ...
+  refute_output --partial "Did not auto-deactivate"
+  # ... and the consecutive deactivations must not leave tracer noise from
+  # re-sourcing set-prompt after a previous pop unset the tracer.
+  refute_output --partial "command not found"
 }
 
 # ---------------------------------------------------------------------------- #
@@ -535,6 +578,68 @@ EOF
   assert_success
   refute_output --partial "Faulty alias"
   refute_output --partial "SHOULD_NOT_PRINT"
+}
+
+# ---------------------------------------------------------------------------- #
+# Plain `flox deactivate` works for every layer of a nested stack
+# ---------------------------------------------------------------------------- #
+#
+# Each in-place deactivation used to unconditionally unset the exported
+# `_FLOX_PROMPT_HOOK_VERSION` marker, even when inner layers remained active and
+# the prompt hook was still registered. The next `flox deactivate` then found no
+# marker and wrongly aborted with "is not set up in this shell". Only the
+# outermost deactivation (the whole stack torn down) should clear the marker, so
+# every layer of a nested stack can be deactivated in turn.
+
+# bats test_tags=hook:deactivate:nested
+@test "bash: plain 'flox deactivate' works for each layer of a nested stack" {
+  project2_setup
+  project3_setup
+
+  run --separate-stderr bash -c "
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT2_DIR)\"
+    eval \"\$($FLOX_BIN activate -d $PROJECT3_DIR)\"
+    # Pop the inner layer; the prompt hook services the request.
+    $FLOX_BIN deactivate
+    _flox_hook
+    echo \"after-inner:marker=[\${_FLOX_PROMPT_HOOK_VERSION:-UNSET}]\"
+    # The outer layer is still active and the prompt hook is still set up, so
+    # this must be accepted rather than aborting.
+    $FLOX_BIN deactivate || echo SECOND_DEACTIVATE_FAILED
+    _flox_hook
+    echo \"after-outer:[\$FLOX_PROMPT_ENVIRONMENTS]\"
+  "
+  assert_success
+  # The marker survives the inner deactivation (the regression).
+  assert_output --partial "after-inner:marker=[1]"
+  refute_output --partial "is not set up in this shell"
+  refute_output --partial "SECOND_DEACTIVATE_FAILED"
+  # The outer deactivation tore the whole stack down.
+  assert_output --partial "after-outer:[]"
+}
+
+# bats test_tags=hook:deactivate:nested
+@test "zsh: plain 'flox deactivate' works for each layer of a nested stack" {
+  project2_setup
+  project3_setup
+
+  run --separate-stderr zsh -c "
+    export FLOX_SHELL=\$(which zsh)
+    eval \"\$($FLOX_BIN activate -d $PROJECT2_DIR)\"
+    eval \"\$($FLOX_BIN activate -d $PROJECT3_DIR)\"
+    $FLOX_BIN deactivate
+    _flox_hook
+    echo \"after-inner:marker=[\${_FLOX_PROMPT_HOOK_VERSION:-UNSET}]\"
+    $FLOX_BIN deactivate || echo SECOND_DEACTIVATE_FAILED
+    _flox_hook
+    echo \"after-outer:[\$FLOX_PROMPT_ENVIRONMENTS]\"
+  "
+  assert_success
+  assert_output --partial "after-inner:marker=[1]"
+  refute_output --partial "is not set up in this shell"
+  refute_output --partial "SECOND_DEACTIVATE_FAILED"
+  assert_output --partial "after-outer:[]"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Implements [DEV-111](https://linear.app/floxdotdev/issue/DEV-111/preserve-flox-hook-diff-across-stacked-activatedeactivate) on top of #4365, per the review discussion there: verify the auto-activate architecture accommodates multi-pop with minimal tweaks.

## What

Each in-place activation's diff already records the previous value of `_FLOX_HOOK_DIFF`, so the encoded diffs form a chain from the front of the activation stack to the outermost in-place layer (the preservation DEV-111 asks for landed with the DEV-86 work). This PR consumes that chain in `flox hook-env`:

- `flox-activations`: split `generate_deactivate_script` so the encoded diff can be passed explicitly, and add `embedded_hook_diff()` to extract the next layer's diff from a decoded one.
- The auto-activation plan replaces `deactivate_front: bool` with a list of layers to pop, front of stack first. The walk stops at the first layer that isn't a tracked leaver; mid-stack teardown remains deferred (DEV-85), and such buried leavers are still abandoned with a warning once nothing in front of them can pop.
- Leaving a nested stack for another project now unwinds every layer and activates the replacement in the same prompt — no stale stack in the prompt while unwinding, no stranded buried layers when switching projects.

Everything is behind the `auto_activate` feature flag.

## Validation

The previously misbehaving interactive transcript (nested `a/b` stack → sibling `z`, which used to abandon `a/b` with a warning and leave `[b a]` in the prompt indefinitely) is now covered end-to-end by `cli/tests/activate/hook-nested-cd.exp` + the `hook:auto-fires:nested` bats test: the switch completes in one prompt with no abandon warning and no tracer noise from consecutive deactivations. Unit tests cover the planner changes, including the buried-leaver defer/abandon sequence.

## Note on the diff

The first four commits (set-prompt tracer guard, defer-while-unwinding, vars docs, suppression test) belong to #4365 and appear here only until that branch is updated; review them there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)