### PR TITLE
fix(hook-env): suppress advisory preamble output (DEV-128)

### DIFF
--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -67,12 +67,7 @@ impl DetachArgs {
 mod test {
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::{read_activation_state, write_activation_state};
-    use flox_core::activations::{
-        ActivationState,
-        StartIdentifier,
-        StartOrAttachResult,
-        activation_state_dir_path,
-    };
+    use flox_core::activations::{ActivationState, StartOrAttachResult, activation_state_dir_path};
     use tempfile::TempDir;
 
     use super::DetachArgs;
@@ -90,14 +85,17 @@ mod test {
             dot_flox_path.join("run/default"),
         );
         state.set_executive_pid(1);
-        let start_id = StartIdentifier::new("/nix/store/test");
-        state.start_or_attach(pid, &start_id.store_path);
+        // Use the identifier minted by start_or_attach: StartIdentifier is
+        // timestamped, so a locally constructed one names a different start
+        // state dir whenever the millisecond ticks in between.
+        let StartOrAttachResult::Start { start_id } = state.start_or_attach(pid, "/nix/store/test")
+        else {
+            panic!("expected Start for pid");
+        };
         write_activation_state(tmp.path(), &dot_flox_path, state);
         let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
         let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
         std::fs::create_dir_all(&start_state_dir).unwrap();
-
-        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
 
         let args = DetachArgs {
             activation_state_dir,

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -252,11 +252,13 @@ impl FloxArgs {
 
         let git_url_override = {
             if let Ok(env_set_host) = std::env::var("_FLOX_FLOXHUB_GIT_URL") {
-                message::warning(formatdoc! {"
-                    Using {env_set_host} as FloxHub host
-                    '$_FLOX_FLOXHUB_GIT_URL' is used for testing purposes only,
-                    alternative FloxHub hosts are not yet supported!
-                "});
+                if !self.is_prompt_hook_flow() {
+                    message::warning(formatdoc! {"
+                        Using {env_set_host} as FloxHub host
+                        '$_FLOX_FLOXHUB_GIT_URL' is used for testing purposes only,
+                        alternative FloxHub hosts are not yet supported!
+                    "});
+                }
                 Some(Url::parse(&env_set_host)?)
             } else {
                 None
@@ -384,6 +386,23 @@ impl FloxArgs {
         result
     }
 
+    /// Whether this invocation is part of the prompt-hook flow:
+    /// `flox hook-env`, which the shell prompt hook runs on every prompt
+    /// inside a command substitution that captures only stdout, or
+    /// `flox deactivate`, which hands the deactivation off to that hook
+    /// (and in `--print-script` mode is itself invoked by the emitted
+    /// script). Anything the preamble prints to stderr appears above every
+    /// prompt for `hook-env` and once more on the way out for `deactivate`,
+    /// so advisory messages are suppressed for these commands and left for
+    /// the next user-invoked command to surface.
+    fn is_prompt_hook_flow(&self) -> bool {
+        matches!(
+            self.command,
+            Some(Commands::Internal(InternalCommands::HookEnv(_)))
+                | Some(Commands::Use(UseCommands::Deactivate(_)))
+        )
+    }
+
     /// Parse and validate the configured `floxhub_token`, returning `None` and
     /// emitting any user-facing warnings as a side effect.
     ///
@@ -391,6 +410,9 @@ impl FloxArgs {
     /// the token (e.g. Kerberos) — in that case the token in `flox.toml` is
     /// not consumed by the auth pipeline, so warning about its state — or
     /// rewriting the user's config — would be misleading.
+    ///
+    /// For `flox hook-env` the token state is reported by the next
+    /// user-invoked command instead; see [Self::is_prompt_hook_flow].
     fn resolve_floxhub_token(&self, config: &Config) -> Option<FloxhubToken> {
         if !matches!(config.flox.floxhub_authn_mode, AuthnMode::Auth0) {
             return None;
@@ -411,6 +433,12 @@ impl FloxArgs {
 
         match parsed {
             Err(FloxhubTokenError::InvalidToken(token_error)) => {
+                // The prompt hook must neither print nor rewrite the user's
+                // config; the next user-invoked command surfaces and removes
+                // the invalid token.
+                if self.is_prompt_hook_flow() {
+                    return None;
+                }
                 message::error(formatdoc! {"
                     Your FloxHub token is invalid: {token_error}
                     You may need to log in again.
@@ -423,10 +451,11 @@ impl FloxArgs {
                 None
             },
             Ok(Some(token)) if token.is_expired() => {
-                if !matches!(
+                let reauthenticating = matches!(
                     self.command,
                     Some(Commands::Admin(AdminCommands::Auth(auth::Auth::Login)))
-                ) {
+                );
+                if !reauthenticating && !self.is_prompt_hook_flow() {
                     message::warning(
                         "Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.",
                     );

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -56,6 +56,79 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------- #
+# hook-env / deactivate: advisory preamble output is suppressed
+# ---------------------------------------------------------------------------- #
+
+# Same shape as the floxhub_setup() token but with an `exp` claim in the past
+# (2001-09-09). The CLI decodes tokens without verifying the signature, so the
+# signature is arbitrary.
+#   { "https://flox.dev/handle": "test", "exp": 1000000000 }
+EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjEwMDAwMDAwMDB9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74"
+
+# The prompt hook runs `flox hook-env` on every prompt inside a command
+# substitution that captures only stdout, so anything the CLI preamble prints
+# to stderr appears above every prompt — and anything it printed to stdout
+# would be eval'd by the shell.
+# bats test_tags=hook:hook-env
+@test "'flox hook-env' suppresses advisory preamble output" {
+  # With the flag set, hook-env legitimately emits an export to stdout.
+  unset FLOX_FEATURES_AUTO_ACTIVATE
+  _FLOX_FLOXHUB_GIT_URL="https://git.example.invalid/" \
+    FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
+    run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$" --invocation-type inplace
+  assert_success
+  assert_equal "$stderr" ""
+  assert_output ""
+}
+
+# An invalid token is normally surfaced and removed from the user's config;
+# both must be deferred to the next user-invoked command rather than printing
+# and rewriting config on every prompt.
+# bats test_tags=hook:hook-env
+@test "'flox hook-env' defers invalid token cleanup to user-invoked commands" {
+  mkdir -p "$FLOX_CONFIG_DIR"
+  echo 'floxhub_token = "not-a-jwt"' >> "$FLOX_CONFIG_DIR/flox.toml"
+
+  run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$" --invocation-type inplace
+  assert_success
+  assert_equal "$stderr" ""
+  run grep floxhub_token "$FLOX_CONFIG_DIR/flox.toml"
+  assert_success
+
+  run --separate-stderr "$FLOX_BIN" config
+  assert_success
+  assert_regex "$stderr" "Your FloxHub token is invalid"
+  run grep floxhub_token "$FLOX_CONFIG_DIR/flox.toml"
+  assert_failure
+}
+
+# 'flox deactivate' hands the deactivation off to the prompt hook, so its
+# preamble advisories are suppressed like hook-env's. Without an active
+# environment the command prints "No environment active!", but the advisories
+# must not print either way.
+# bats test_tags=hook:hook-env
+@test "'flox deactivate' suppresses advisory preamble output" {
+  _FLOX_FLOXHUB_GIT_URL="https://git.example.invalid/" \
+    FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
+    run --separate-stderr "$FLOX_BIN" deactivate
+  assert_success
+  refute_regex "$stderr" "as FloxHub host"
+  refute_regex "$stderr" "token has expired"
+}
+
+# Pin that the suppression is scoped to the prompt-hook flow: user-invoked
+# commands still print both advisories.
+# bats test_tags=hook:hook-env
+@test "user-invoked commands still print advisory preamble output" {
+  _FLOX_FLOXHUB_GIT_URL="https://git.example.invalid/" \
+    FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
+    run --separate-stderr "$FLOX_BIN" config
+  assert_success
+  assert_regex "$stderr" "Using https://git.example.invalid/ as FloxHub host"
+  assert_regex "$stderr" "Your FloxHub token has expired"
+}
+
+# ---------------------------------------------------------------------------- #
 # Hook fires: verify _FLOX_HOOK_FIRED is set per shell
 # ---------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Summary

Since the prompt hook shipped ungated (DEV-116, #4370), `flox hook-env` runs on every shell prompt and goes through the same CLI preamble as every other subcommand. The prompt hook's command substitution captures only stdout, so anything the preamble printed to stderr appeared above every prompt:

- the `$_FLOX_FLOXHUB_GIT_URL` testing-override warning (the reported symptom, dev setups only)
- the FloxHub token-expiry reminder (would have hit every user with an expired token)
- the invalid-token error, which also rewrote the user's `flox.toml` from the prompt hook

This PR adds `FloxArgs::is_prompt_hook_flow()` and gates those three advisories on it, deferring them to the next user-invoked command. The predicate covers the whole prompt-hook flow:

- `flox hook-env` — run by the hook on every prompt
- `flox deactivate` — hands the deactivation off to the prompt hook (and in `--print-script` mode is itself invoked by the emitted script); the advisories otherwise printed one more time on the way out of an environment, where they aren't actionable

Genuine errors still print, and other user-invoked commands behave exactly as before (message text unchanged).

Once auto-activation lands (DEV-119), activation still runs as an emitted `eval "$(flox activate --dir …)"` child process whose stderr reaches the terminal, so this suppression does not hide activation-time output.

## Tests

Four bats regression tests in `hook.bats`:
- `flox hook-env` produces empty stderr **and** empty stdout with both advisories armed (stdout matters because the shell evals it)
- invalid-token surfacing and config cleanup are deferred to the next user-invoked command (pinned by checking `flox.toml` before and after)
- `flox deactivate` prints no advisories
- scope guard: a user-invoked command still prints both advisories

## Known follow-ups (out of scope, noted on DEV-128)

- The first-run metrics consent notice prints from `main.rs` before arg parsing and is reachable from `hook-env` once on fresh installs
- `take_hook_actions` IO errors don't consume the action file, producing a per-prompt error loop while the condition persists
- The update notification is suppressed for `hook-env` only incidentally (stdout-TTY check in `Dialog::can_prompt`), not by the new gate

No release notes: this fixes a regression introduced after v1.12.2 that has not shipped in any release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)