### PR TITLE
feat(factory): add hidden `flox factory` status and list verbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "crossterm 0.29.0",
  "derive_more",
  "dirs",
+ "factory-api-v1",
  "flox-activations",
  "flox-core",
  "flox-manifest",

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -62,6 +62,7 @@ nef-lock-catalog.workspace = true
 flox-manifest.workspace = true
 
 [dev-dependencies]
+factory-api-v1.workspace = true
 floxhub-client = { workspace = true, features = ["tests"] }
 pretty_assertions.workspace = true
 proptest.workspace = true

--- a/cli/flox/src/commands/factory/list.rs
+++ b/cli/flox/src/commands/factory/list.rs
@@ -1,0 +1,242 @@
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::Result;
+use bpaf::Bpaf;
+use floxhub_client::{BuildResponse, FactoryClientTrait, FactoryStatus};
+use serde::Serialize;
+use tracing::instrument;
+
+use super::{effective_status, effective_updated_at};
+use crate::subcommand_metric;
+use crate::utils::message::page_output;
+
+/// CLI-boundary filter for `--status`, extending the seven wire `Status`
+/// values with the server-side keyword `undispatched` (builds where
+/// `task_id IS NULL`).
+///
+/// `undispatched` is accepted by the GET /builds query parameter but is NOT
+/// a value of the `Status` enum. It is the mechanism for filtering builds
+/// the CLI renders as "pending (not dispatched)". The richer list-query
+/// contract — including effective-status matching semantics and what
+/// `undispatched` precisely means — is owned by ECO-97.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StatusFilter {
+    /// One of the seven task lifecycle statuses on the wire.
+    Status(FactoryStatus),
+    /// Server-side keyword: builds with no dispatched task (`task_id IS NULL`).
+    Undispatched,
+}
+
+impl FromStr for StatusFilter {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "undispatched" {
+            return Ok(StatusFilter::Undispatched);
+        }
+        FactoryStatus::from_str(s)
+            .map(StatusFilter::Status)
+            .map_err(|_| {
+                format!("Invalid status '{s}'; valid values are: queued, dispatching, running, completed, failed, timed_out, cancelled, undispatched.")
+            })
+    }
+}
+
+impl fmt::Display for StatusFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StatusFilter::Status(s) => fmt::Display::fmt(s, f),
+            StatusFilter::Undispatched => f.write_str("undispatched"),
+        }
+    }
+}
+
+/// List Flox Factory builds.
+#[derive(Debug, Clone, PartialEq, Bpaf)]
+pub struct List {
+    /// Filter by build status.
+    /// Valid values: queued, dispatching, running, completed, failed,
+    /// timed_out, cancelled, undispatched.
+    /// Use "undispatched" to show builds that have not yet been sent
+    /// to Build Coordinator (displayed as "pending (not dispatched)").
+    #[bpaf(long)]
+    pub status: Option<StatusFilter>,
+
+    /// Display output as JSON
+    #[bpaf(long)]
+    pub json: bool,
+
+    /// Disable interactive pager
+    #[bpaf(long)]
+    pub no_pager: bool,
+}
+
+impl List {
+    #[instrument(name = "list", skip_all)]
+    pub async fn handle(self, client: &impl FactoryClientTrait) -> Result<()> {
+        subcommand_metric!("factory::list");
+
+        // Convert the validated filter to its wire string. The seven Status
+        // values use their own Display ("running", etc.); "undispatched" is
+        // forwarded as the literal keyword the server accepts.
+        let status_str = self.status.as_ref().map(|f| f.to_string());
+
+        // Depage the full result set, mirroring `flox generations list`: the
+        // operator sees every matching build at once and scrolls with the
+        // pager, rather than stepping server-side pages by hand.
+        let builds = client
+            .list_builds(status_str.as_deref())
+            .await
+            .map_err(|e| super::user_facing_error(e, None))?;
+
+        let output = render(builds.results, self.json)?;
+
+        // JSON is for scripting: never route it through the pager, even on a
+        // TTY. The human table is paged unless `--no-pager` is given.
+        if self.json || self.no_pager {
+            print!("{output}");
+            return Ok(());
+        }
+
+        page_output(output)
+    }
+}
+
+/// Render the builds as either pretty-printed JSON or a table.
+///
+/// The depaging client returns every matching build, so the JSON form is the
+/// full array of builds, with no pagination envelope to report.
+fn render(builds: Vec<BuildResponse>, json: bool) -> Result<String> {
+    if json {
+        Ok(format!("{}\n", serde_json::to_string_pretty(&builds)?))
+    } else {
+        Ok(BuildListDisplay::from(builds).to_string())
+    }
+}
+
+/// Human-readable build list table row.
+#[derive(Clone, Debug, Serialize)]
+struct BuildRowDisplay {
+    build_id: i64,
+    attr_path: String,
+    system: String,
+    status: String,
+    updated_at: String,
+}
+
+impl From<BuildResponse> for BuildRowDisplay {
+    fn from(b: BuildResponse) -> Self {
+        let status = effective_status(&b);
+        let updated_at = effective_updated_at(&b);
+
+        BuildRowDisplay {
+            build_id: b.build_id,
+            attr_path: b.attr_path,
+            system: b.system,
+            status,
+            updated_at,
+        }
+    }
+}
+
+/// Human-readable build list table.
+#[derive(Clone, Debug)]
+struct BuildListDisplay {
+    rows: Vec<BuildRowDisplay>,
+}
+
+impl From<Vec<BuildResponse>> for BuildListDisplay {
+    fn from(builds: Vec<BuildResponse>) -> Self {
+        BuildListDisplay {
+            rows: builds.into_iter().map(BuildRowDisplay::from).collect(),
+        }
+    }
+}
+
+impl fmt::Display for BuildListDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.rows.is_empty() {
+            writeln!(f, "No builds found.")?;
+            return Ok(());
+        }
+
+        // Column widths with minimums sized to header labels.
+        let id_width = "BUILD ID".len().max(
+            self.rows
+                .iter()
+                .map(|r| r.build_id.to_string().len())
+                .max()
+                .unwrap_or(0),
+        );
+        let attr_width = "ATTR PATH".len().max(
+            self.rows
+                .iter()
+                .map(|r| r.attr_path.len())
+                .max()
+                .unwrap_or(0),
+        );
+        let system_width = "SYSTEM"
+            .len()
+            .max(self.rows.iter().map(|r| r.system.len()).max().unwrap_or(0));
+        let status_width = "STATUS"
+            .len()
+            .max(self.rows.iter().map(|r| r.status.len()).max().unwrap_or(0));
+
+        writeln!(
+            f,
+            "{:<id_width$}  {:<attr_width$}  {:<system_width$}  {:<status_width$}  UPDATED",
+            "BUILD ID", "ATTR PATH", "SYSTEM", "STATUS",
+        )?;
+
+        for row in &self.rows {
+            writeln!(
+                f,
+                "{:<id_width$}  {:<attr_width$}  {:<system_width$}  {:<status_width$}  {}",
+                row.build_id, row.attr_path, row.system, row.status, row.updated_at,
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::commands::factory::test_helpers::make_build;
+
+    #[test]
+    fn status_filter_parses_undispatched_keyword() {
+        let f: StatusFilter = "undispatched".parse().unwrap();
+        assert_eq!(f, StatusFilter::Undispatched);
+    }
+
+    #[test]
+    fn status_filter_rejects_invalid_value_with_named_values() {
+        let err = "garbage".parse::<StatusFilter>().unwrap_err();
+        assert_eq!(
+            err,
+            "Invalid status 'garbage'; valid values are: queued, dispatching, running, completed, failed, timed_out, cancelled, undispatched."
+        );
+    }
+
+    #[test]
+    fn list_display_renders_table_exactly() {
+        // A dispatched build shows its task's updated_at; an undispatched build
+        // has no task, so UPDATED falls back to the build's created_at.
+        let builds = vec![
+            make_build(1, "x86_64-linux", "hello", Some("running")),
+            make_build(2, "aarch64-darwin", "ripgrep", None),
+        ];
+        let display = BuildListDisplay::from(builds);
+        assert_eq!(display.to_string(), indoc! {"
+            BUILD ID  ATTR PATH  SYSTEM          STATUS                    UPDATED
+            1         hello      x86_64-linux    running                   2025-01-01T00:00:01+00:00
+            2         ripgrep    aarch64-darwin  pending (not dispatched)  2025-01-01T00:00:00+00:00
+        "});
+    }
+}

--- a/cli/flox/src/commands/factory/mod.rs
+++ b/cli/flox/src/commands/factory/mod.rs
@@ -1,0 +1,266 @@
+//! `flox factory` command namespace: read-only build inspection for operators.
+//!
+//! Hidden from `flox --help`; discoverable via the operator runbook. `Logs`
+//! (ECO-99) and `Cancel` (ECO-100) are future verbs.
+
+mod list;
+mod status;
+
+use anyhow::{Result, anyhow};
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use floxhub_client::{BuildResponse, FactoryClientError};
+use indoc::indoc;
+use tracing::instrument;
+
+use crate::commands::display_help;
+
+/// The label shown for an undispatched build's effective status.
+///
+/// A build with no task has never been dispatched to Build Coordinator, so it
+/// has no task lifecycle status. `pending` is synthesized by the CLI — it is
+/// NOT a value of the API `Status` enum (`queued`, `dispatching`, `running`,
+/// `completed`, `failed`, `timed_out`, `cancelled`), so the "(not dispatched)"
+/// suffix keeps a user from typing it as a `--status` filter and getting an
+/// empty result or 422.
+const UNDISPATCHED_STATUS_LABEL: &str = "pending (not dispatched)";
+
+/// Compute the effective status string for a build.
+///
+/// Returns the task's lifecycle status when the build has been dispatched
+/// (a task exists), otherwise the synthesized undispatched label. An
+/// undispatched build always reads as pending — never as a terminal status —
+/// because no task lifecycle has begun.
+fn effective_status(build: &BuildResponse) -> String {
+    build
+        .task
+        .as_ref()
+        .map(|task| task.status.clone())
+        .unwrap_or_else(|| UNDISPATCHED_STATUS_LABEL.to_string())
+}
+
+/// Compute the effective "last updated" timestamp for a build, as an RFC 3339
+/// string.
+///
+/// A dispatched build reports its task's `updated_at`, which tracks lifecycle
+/// progress. An undispatched build has no task, so it falls back to the
+/// build's own `created_at`. This is the "updated, or created if never
+/// updated" value shown in the `UPDATED` column.
+fn effective_updated_at(build: &BuildResponse) -> String {
+    build
+        .task
+        .as_ref()
+        .map(|task| task.updated_at)
+        .unwrap_or(build.created_at)
+        .to_rfc3339()
+}
+
+/// Rewrite a [`FactoryClientError`] as a product-level error, so an operator
+/// never sees raw client or transport output.
+///
+/// The transport case is verb-independent. The not-found case is not: the
+/// client does not know what the caller asked for, so `not_found` carries the
+/// verb-specific message. A verb that cannot meaningfully 404 passes `None`.
+fn user_facing_error(err: FactoryClientError, not_found: Option<String>) -> anyhow::Error {
+    match err {
+        FactoryClientError::Transport(_) => anyhow!(indoc! {"
+            Could not reach the Flox Factory.
+            Check your network connection and try again."}),
+        FactoryClientError::NotFound => match not_found {
+            Some(message) => anyhow!(message),
+            None => anyhow!("The requested Flox Factory resource was not found."),
+        },
+        other => other.into(),
+    }
+}
+
+// The verbs are thin wrappers over the `factory-api-v1` client. The namespace
+// is hidden from top-level help via `#[bpaf(hide)]` on the hosting
+// `Commands::Factory` variant; see the module docs above. These notes are kept
+// as plain comments rather than a `///` doc comment because bpaf renders the
+// enum's doc comment into `flox factory --help`, where implementation detail
+// does not belong.
+/// Operator subcommands for inspecting Flox Factory builds.
+#[derive(Debug, Clone, Bpaf)]
+pub enum FactoryCommands {
+    /// Print help information
+    #[bpaf(command, hide)]
+    Help,
+
+    /// Show the status of a single Flox Factory build
+    #[bpaf(command)]
+    Status(#[bpaf(external(status::status))] status::Status),
+
+    /// List Flox Factory builds
+    #[bpaf(command)]
+    List(#[bpaf(external(list::list))] list::List),
+    // ECO-99 will add: Logs(#[bpaf(external(logs::logs))] logs::Logs),
+    // ECO-100 will add: Cancel(#[bpaf(external(cancel::cancel))] cancel::Cancel),
+}
+
+impl FactoryCommands {
+    #[instrument(name = "factory", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        // The factory client shares its base URL with the catalog client, so
+        // `FLOX_CATALOG_URL` already repoints both for local development; no
+        // factory-specific override is needed.
+        match self {
+            FactoryCommands::Help => {
+                display_help(Some("factory".to_string()));
+                Ok(())
+            },
+            FactoryCommands::Status(args) => args.handle(&flox.floxhub_client).await,
+            FactoryCommands::List(args) => args.handle(&flox.floxhub_client).await,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    //! Shared test fixtures for the `status` and `list` verb handler tests.
+
+    use chrono::TimeZone;
+    use factory_api_v1::types::TaskResponse;
+    use floxhub_client::{
+        BuildResponse,
+        FactoryByteStream,
+        FactoryClientError,
+        FactoryClientTrait,
+    };
+
+    /// Construct a `BuildResponse` fixture. A `Some(task_status)` attaches a
+    /// dispatch task with that lifecycle status; `None` leaves the build
+    /// undispatched (no task).
+    pub fn make_build(
+        id: i64,
+        system: &str,
+        attr_path: &str,
+        task_status: Option<&str>,
+    ) -> BuildResponse {
+        let task = task_status.map(|s| TaskResponse {
+            task_id: id,
+            task_type: "dispatch_build".to_string(),
+            status: s.to_string(),
+            created_at: chrono::Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
+            updated_at: chrono::Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 1).unwrap(),
+            completed_at: None,
+            error_class: None,
+            error_message: None,
+            started_at: None,
+        });
+
+        BuildResponse {
+            build_id: id,
+            system: system.to_string(),
+            attr_path: attr_path.to_string(),
+            catalog_name: "my-catalog".to_string(),
+            build_type: "nixpkgs".to_string(),
+            source_repo_url: "https://github.com/example/repo".to_string(),
+            source_commit_sha: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2".to_string(),
+            nixpkgs_revision: "deadbeef1234567890deadbeef1234567890dead".to_string(),
+            created_at: chrono::Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
+            exit_code: None,
+            task,
+        }
+    }
+
+    /// In-test stub implementing [`FactoryClientTrait`], used to drive the
+    /// `status` handler down its not-found path without a live service.
+    pub struct StubFactoryClient {
+        not_found: bool,
+    }
+
+    impl StubFactoryClient {
+        pub fn with_not_found() -> Self {
+            Self { not_found: true }
+        }
+    }
+
+    impl FactoryClientTrait for StubFactoryClient {
+        async fn list_builds(
+            &self,
+            _status: Option<&str>,
+        ) -> Result<floxhub_client::ResultsPage<BuildResponse>, FactoryClientError> {
+            if self.not_found {
+                return Err(FactoryClientError::NotFound);
+            }
+            Ok(floxhub_client::ResultsPage {
+                results: vec![],
+                count: Some(0),
+            })
+        }
+
+        async fn get_build(&self, _build_id: i64) -> Result<BuildResponse, FactoryClientError> {
+            if self.not_found {
+                return Err(FactoryClientError::NotFound);
+            }
+            Ok(make_build(1, "x86_64-linux", "hello", Some("running")))
+        }
+
+        async fn get_build_logs(
+            &self,
+            _build_id: i64,
+        ) -> Result<FactoryByteStream, FactoryClientError> {
+            unimplemented!("StubFactoryClient does not implement get_build_logs")
+        }
+    }
+}
+
+#[cfg(test)]
+mod parser_tests {
+    //! Guard the one `bpaf` footgun in this namespace: a positional declared
+    //! before a flag parses fine but panics when help is rendered, taking down
+    //! every verb at once. Rendering the namespace help builds each verb's meta,
+    //! so this catches the misordering for all current and future verbs.
+
+    use bpaf::ParseFailure;
+
+    use crate::commands::flox_cli;
+
+    #[test]
+    fn factory_help_renders_instead_of_panicking() {
+        match flox_cli().run_inner(&["factory", "--help"]) {
+            Err(ParseFailure::Stdout(..)) => {},
+            Err(other) => panic!("expected factory help output, got error {other:?}"),
+            Ok(_) => panic!("expected factory help output, parsed a command instead"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod error_tests {
+    use floxhub_client::{FactoryApiError, FactoryClientError};
+    use indoc::indoc;
+
+    use super::user_facing_error;
+
+    #[test]
+    fn not_found_renders_the_verb_message() {
+        let err = user_facing_error(
+            FactoryClientError::NotFound,
+            Some("No Flox Factory build found with ID 7.".to_string()),
+        );
+        assert_eq!(err.to_string(), "No Flox Factory build found with ID 7.");
+    }
+
+    #[tokio::test]
+    async fn transport_renders_the_unreachable_message() {
+        // A deterministic transport failure: port 0 is never a valid
+        // connection target, so the request always fails at the transport
+        // layer, with no reliance on a particular port being closed.
+        let transport_err = reqwest::get("http://127.0.0.1:0").await.unwrap_err();
+        let err = user_facing_error(FactoryClientError::Transport(transport_err), None);
+        assert_eq!(err.to_string(), indoc! {"
+            Could not reach the Flox Factory.
+            Check your network connection and try again."});
+    }
+
+    #[test]
+    fn other_errors_keep_the_client_rendering() {
+        let err = user_facing_error(
+            FactoryClientError::APIError(FactoryApiError::InvalidRequest("boom".to_string())),
+            None,
+        );
+        assert_eq!(err.to_string(), "Invalid Request: boom");
+    }
+}

--- a/cli/flox/src/commands/factory/status.rs
+++ b/cli/flox/src/commands/factory/status.rs
@@ -1,0 +1,146 @@
+use std::num::NonZeroU64;
+
+use anyhow::Result;
+use bpaf::Bpaf;
+use floxhub_client::{BuildResponse, FactoryClientTrait};
+use indoc::formatdoc;
+use serde::Serialize;
+use tracing::instrument;
+
+use super::effective_status;
+use crate::subcommand_metric;
+
+/// Show the status of a single Flox Factory build.
+#[derive(Debug, Clone, PartialEq, Bpaf)]
+pub struct Status {
+    /// Display output as JSON
+    #[bpaf(long)]
+    pub json: bool,
+
+    /// Build ID to query
+    #[bpaf(positional("ID"))]
+    pub id: NonZeroU64,
+}
+
+impl Status {
+    #[instrument(name = "status", skip_all)]
+    pub async fn handle(self, client: &impl FactoryClientTrait) -> Result<()> {
+        subcommand_metric!("factory::status");
+
+        let build = client.get_build(self.id.get() as i64).await.map_err(|e| {
+            super::user_facing_error(
+                e,
+                Some(formatdoc! {"
+                    No Flox Factory build found with ID {id}.
+                    Use 'flox factory list' to see existing builds.",
+                    id = self.id,
+                }),
+            )
+        })?;
+
+        print!("{}", render(build, self.json)?);
+        Ok(())
+    }
+}
+
+/// Render a single build as either raw JSON or a human-readable table.
+///
+/// The JSON form is intentionally the bare [`BuildResponse`] object, with no
+/// surrounding envelope: a single build has no pagination to report, unlike the
+/// `list` verb whose JSON form carries the page envelope.
+fn render(build: BuildResponse, json: bool) -> Result<String> {
+    if json {
+        Ok(format!("{}\n", serde_json::to_string_pretty(&build)?))
+    } else {
+        Ok(BuildStatusDisplay::from(build).to_string())
+    }
+}
+
+/// Human-readable single-build status table.
+#[derive(Clone, Debug, Serialize)]
+struct BuildStatusDisplay {
+    build_id: i64,
+    system: String,
+    attr_path: String,
+    catalog_name: String,
+    status: String,
+    created_at: String,
+}
+
+impl From<BuildResponse> for BuildStatusDisplay {
+    fn from(b: BuildResponse) -> Self {
+        let status = effective_status(&b);
+
+        BuildStatusDisplay {
+            build_id: b.build_id,
+            system: b.system,
+            attr_path: b.attr_path,
+            catalog_name: b.catalog_name,
+            status,
+            created_at: b.created_at.to_rfc3339(),
+        }
+    }
+}
+
+impl std::fmt::Display for BuildStatusDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{:<14} {}", "Build ID:", self.build_id)?;
+        writeln!(f, "{:<14} {}", "System:", self.system)?;
+        writeln!(f, "{:<14} {}", "Attr path:", self.attr_path)?;
+        writeln!(f, "{:<14} {}", "Catalog:", self.catalog_name)?;
+        writeln!(f, "{:<14} {}", "Status:", self.status)?;
+        writeln!(f, "{:<14} {}", "Created:", self.created_at)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::commands::factory::test_helpers::{StubFactoryClient, make_build};
+
+    #[tokio::test]
+    async fn status_renders_not_found_message() {
+        let client = StubFactoryClient::with_not_found();
+        let args = Status {
+            id: NonZeroU64::new(42).unwrap(),
+            json: false,
+        };
+
+        let err = args.handle(&client).await.unwrap_err();
+        assert_eq!(err.to_string(), indoc! {"
+            No Flox Factory build found with ID 42.
+            Use 'flox factory list' to see existing builds."});
+    }
+
+    #[test]
+    fn status_table_uses_task_status_when_dispatched() {
+        let build = make_build(42, "x86_64-linux", "hello", Some("running"));
+        assert_eq!(render(build, false).unwrap(), indoc! {"
+            Build ID:      42
+            System:        x86_64-linux
+            Attr path:     hello
+            Catalog:       my-catalog
+            Status:        running
+            Created:       2025-01-01T00:00:00+00:00
+        "});
+    }
+
+    #[test]
+    fn status_table_marks_undispatched_build_distinctly() {
+        let build = make_build(42, "x86_64-linux", "hello", None);
+        assert_eq!(render(build, false).unwrap(), indoc! {"
+            Build ID:      42
+            System:        x86_64-linux
+            Attr path:     hello
+            Catalog:       my-catalog
+            Status:        pending (not dispatched)
+            Created:       2025-01-01T00:00:00+00:00
+        "});
+    }
+}

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod deactivate;
 mod delete;
 mod edit;
 mod envs;
+mod factory;
 mod gc;
 mod general;
 mod generations;
@@ -341,6 +342,7 @@ impl FloxArgs {
                     }
                     args.handle(flox).await
                 },
+                Commands::Factory(args) => args.handle(flox).await,
             };
 
             // This will print the update notification after output from a successful
@@ -526,6 +528,16 @@ enum Commands {
     Internal(#[bpaf(external(internal_commands))] InternalCommands),
 
     Beta(#[bpaf(external(beta::beta_commands))] beta::BetaCommands),
+
+    /// Flox Factory operator commands (hidden; see operator runbook)
+    #[bpaf(command, hide)]
+    Factory(
+        #[bpaf(
+            external(factory::factory_commands),
+            fallback(factory::FactoryCommands::Help)
+        )]
+        factory::FactoryCommands,
+    ),
 }
 
 #[derive(Debug, Bpaf, Clone)]

--- a/cli/floxhub-client/src/factory.rs
+++ b/cli/floxhub-client/src/factory.rs
@@ -26,6 +26,21 @@ pub type ApiErrorResponseValue = ResponseValue<ApiErrorResponse>;
 /// Common error type for factory API operations.
 #[derive(Debug, thiserror::Error)]
 pub enum FactoryClientError {
+    /// The requested build was not found (HTTP 404).
+    ///
+    /// Deliberately carries no detail: the calling verb knows what it asked
+    /// for and renders the user-facing message.
+    #[error("not found")]
+    NotFound,
+
+    /// The Flox Factory service could not be reached (transport failure).
+    ///
+    /// progenitor renders this case with the request URL in the message; this
+    /// variant lets callers show a product-level message without that detail.
+    #[error("could not reach the Flox Factory")]
+    Transport(#[source] reqwest::Error),
+
+    /// Any other factory API error, rendered from the generated error type.
     #[error("{}", fmt_api_error(.0))]
     APIError(APIError<ErrorResponse>),
 }
@@ -44,11 +59,14 @@ impl<T: Send> MapApiErrorExt<T> for Result<T, APIError<ErrorResponse>> {
             Err(err) => err,
         };
 
-        if let APIError::UnexpectedResponse(resp) = err {
-            return parse_api_error(resp).await;
+        match err {
+            // progenitor renders a transport failure with the request URL in
+            // the message; classify it so the caller can show a product-level
+            // message without that detail.
+            APIError::CommunicationError(source) => Err(FactoryClientError::Transport(source)),
+            APIError::UnexpectedResponse(resp) => parse_api_error(resp).await,
+            other => Err(FactoryClientError::APIError(other)),
         }
-
-        Err(FactoryClientError::APIError(err))
     }
 }
 
@@ -83,6 +101,25 @@ fn fmt_api_error(api_error: &APIError<ErrorResponse>) -> String {
             format!("{status}")
         },
         _ => format!("{api_error}"),
+    }
+}
+
+/// Reclassify a 404 from a resource-specific endpoint as
+/// [`FactoryClientError::NotFound`].
+///
+/// Only callers where a 404 unambiguously means the requested resource does
+/// not exist (such as [`FactoryClientTrait::get_build`]) should apply this. A
+/// 404 from a listing endpoint or from a misconfigured base URL is a route or
+/// configuration error, not a missing resource, and is left as the underlying
+/// API error so the message describes what is actually wrong.
+fn not_found_on_404(err: FactoryClientError) -> FactoryClientError {
+    match err {
+        FactoryClientError::APIError(api)
+            if api.status() == Some(reqwest::StatusCode::NOT_FOUND) =>
+        {
+            FactoryClientError::NotFound
+        },
+        other => other,
     }
 }
 
@@ -143,12 +180,16 @@ impl FactoryClientTrait for crate::FloxhubClient {
     }
 
     async fn get_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError> {
+        // A 404 on this resource-specific endpoint means the build ID does not
+        // exist; reclassify it so the caller can say so. Other endpoints leave
+        // a 404 as the underlying API error.
         Ok(self
             .factory
             .get_build_api_v1_factory_builds_build_id_get(build_id)
             .await
             .map_api_error()
-            .await?
+            .await
+            .map_err(not_found_on_404)?
             .into_inner())
     }
 
@@ -226,6 +267,37 @@ pub mod tests {
         };
         let client = crate::FloxhubClient::new(config).unwrap();
         let result = client.list_builds(None).await.unwrap();
+
+        mock.assert();
+        assert_eq!(result, ResultsPage {
+            results: vec![],
+            count: Some(0),
+        });
+    }
+
+    /// Verify `list_builds` forwards the `status` filter as a query param.
+    #[tokio::test]
+    async fn list_builds_forwards_status_filter() {
+        let server = MockServer::start_async().await;
+
+        let mock = server.mock(|when, then| {
+            when.method("GET")
+                .path("/api/v1/factory/builds")
+                .query_param("status", "running");
+            then.status(200).json_body(json!({
+                "builds": [],
+                "page": 0,
+                "page_size": 50,
+                "total": 0
+            }));
+        });
+
+        let config = FloxhubClientConfig {
+            base_url: server.base_url(),
+            ..client_config(&server.base_url())
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        let result = client.list_builds(Some("running")).await.unwrap();
 
         mock.assert();
         assert_eq!(result, ResultsPage {
@@ -339,6 +411,106 @@ pub mod tests {
         let result: Result<(), APIError<ErrorResponse>> = Err(APIError::UnexpectedResponse(resp));
         let err = result.map_api_error().await.unwrap_err();
         assert_eq!(err.to_string(), "403 Forbidden");
+    }
+
+    #[tokio::test]
+    async fn map_api_error_does_not_collapse_404_error_response() {
+        // The shared funnel no longer treats a 404 as a missing resource; only
+        // resource-specific callers (get_build) do that. A 404 here stays an
+        // APIError carrying the server detail.
+        let status = StatusCode::NOT_FOUND;
+        let error_body = ErrorResponse {
+            detail: "Build not found".to_string(),
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        let resp_val = ResponseValue::new(error_body, status, headers);
+
+        let result: Result<(), APIError<ErrorResponse>> = Err(APIError::ErrorResponse(resp_val));
+        let err = result.map_api_error().await.unwrap_err();
+        assert_eq!(err.to_string(), "404 Not Found: Build not found");
+    }
+
+    #[tokio::test]
+    async fn map_api_error_does_not_collapse_404_unexpected_response() {
+        let status = StatusCode::NOT_FOUND;
+        let resp = http::Response::builder()
+            .status(status)
+            .body("Build not found".to_string())
+            .unwrap()
+            .into();
+
+        let result: Result<(), APIError<ErrorResponse>> = Err(APIError::UnexpectedResponse(resp));
+        let err = result.map_api_error().await.unwrap_err();
+        assert_eq!(err.to_string(), "404 Not Found");
+    }
+
+    #[tokio::test]
+    async fn map_api_error_communication_error_is_transport() {
+        // A deterministic transport failure: port 0 is never a valid
+        // connection target, so the request always fails at the transport
+        // layer, with no reliance on a particular port being closed.
+        let transport_err = reqwest::get("http://127.0.0.1:0").await.unwrap_err();
+
+        let result: Result<(), APIError<ErrorResponse>> =
+            Err(APIError::CommunicationError(transport_err));
+        let err = result.map_api_error().await.unwrap_err();
+        assert!(
+            matches!(err, FactoryClientError::Transport(_)),
+            "expected Transport, got {err:?}"
+        );
+        // The classification drops progenitor's URL-bearing transport text.
+        assert_eq!(err.to_string(), "could not reach the Flox Factory");
+    }
+
+    #[tokio::test]
+    async fn get_build_maps_404_to_not_found() {
+        // On a resource-specific endpoint a 404 unambiguously means the build
+        // does not exist, so get_build classifies it as NotFound.
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("GET").path("/api/v1/factory/builds/7");
+            then.status(404)
+                .json_body(json!({ "detail": "Build not found" }));
+        });
+
+        let config = FloxhubClientConfig {
+            base_url: server.base_url(),
+            ..client_config(&server.base_url())
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        let err = client.get_build(7).await.unwrap_err();
+
+        mock.assert();
+        assert!(
+            matches!(err, FactoryClientError::NotFound),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_builds_404_is_not_collapsed_to_not_found() {
+        // A 404 on the listing endpoint is a route or configuration error, not
+        // a missing resource, so it is left as the underlying API error rather
+        // than reported as NotFound.
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method("GET").path("/api/v1/factory/builds");
+            then.status(404).json_body(json!({ "detail": "Not Found" }));
+        });
+
+        let config = FloxhubClientConfig {
+            base_url: server.base_url(),
+            ..client_config(&server.base_url())
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        let err = client.list_builds(None).await.unwrap_err();
+
+        assert!(
+            matches!(err, FactoryClientError::APIError(_)),
+            "expected APIError, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -66,7 +66,11 @@ pub use factory::{
     FactoryClientTrait,
     MapApiErrorExt as FactoryMapApiErrorExt,
 };
-pub use factory_api_v1::types::{BuildResponse, ErrorResponse as FactoryErrorResponse};
+pub use factory_api_v1::types::{
+    BuildResponse,
+    ErrorResponse as FactoryErrorResponse,
+    Status as FactoryStatus,
+};
 // Re-export factory-api-v1 types for consumers.
 pub use factory_api_v1::{
     ByteStream as FactoryByteStream,


### PR DESCRIPTION
## Summary

Adds a hidden `flox factory` command namespace that gives operators read-only visibility into Flox Factory builds, as thin wrappers over the `factory-api-v1` client. `flox factory status <ID>` shows one build as a table, or as JSON under `--json`; `flox factory list` lists builds the same way and takes `--status` to filter (the seven wire statuses plus `undispatched`). The list output is depaged and shown through the interactive pager, like `flox generations list`, with `--no-pager` to disable it.

The namespace is hidden from `flox --help` and discoverable through the operator runbook; it is registered as a top-level command, like `Services`. A build with no dispatch task is shown as `pending (not dispatched)`, distinct from the wire statuses. Because the factory client shares its base URL with the catalog, `FLOX_CATALOG_URL` repoints it for local development. `Logs` and `Cancel` are out of scope (ECO-99, ECO-100).

Closes [ECO-80](https://linear.app/floxdotdev/issue/ECO-80).

### Test plan

- [x] `just unit-tests`
- [x] `cargo clippy --all --all-targets -- --deny warnings`
