### PR TITLE
fix(deactivate): keep the prompt-hook marker set across inner deactivations (DEV-129)

### DIFF
--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -123,10 +123,13 @@ pub fn generate_bash_profile_commands(
 
     // The prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration (see
     // hook.rs) so a subprocess like `flox deactivate` can detect a compatible
-    // hook. It is set shell-side, so it isn't part of the env-var diff; unset it
-    // on deactivation so it doesn't leak into the restored environment.
-    // Unconditional: a no-op when no hook was registered.
-    if let Action::Deactivate(_) = action {
+    // hook. It is set shell-side, so it isn't part of the env-var diff. Only the
+    // outermost deactivate clears it: the prompt hook stays registered while any
+    // activation remains on the stack, so unsetting it on an inner deactivate
+    // would make the next `flox deactivate` wrongly report the hook missing.
+    if let Action::Deactivate(ctx) = action
+        && ctx.restore_diff.is_outermost_deactivate()
+    {
         stmts.push(todo_drop_unset(PROMPT_HOOK_VERSION_ENV));
     }
 

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -107,10 +107,13 @@ pub fn generate_fish_profile_commands(
 
     // The prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration (see
     // hook.rs) so a subprocess like `flox deactivate` can detect a compatible
-    // hook. It is set shell-side, so it isn't part of the env-var diff; unset it
-    // on deactivation so it doesn't leak into the restored environment.
-    // Unconditional: a no-op when no hook was registered.
-    if let Action::Deactivate(_) = action {
+    // hook. It is set shell-side, so it isn't part of the env-var diff. Only the
+    // outermost deactivate clears it: the prompt hook stays registered while any
+    // activation remains on the stack, so unsetting it on an inner deactivate
+    // would make the next `flox deactivate` wrongly report the hook missing.
+    if let Action::Deactivate(ctx) = action
+        && ctx.restore_diff.is_outermost_deactivate()
+    {
         stmts.push(todo_drop_unset(PROMPT_HOOK_VERSION_ENV));
     }
 

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -101,11 +101,14 @@ pub fn generate_tcsh_profile_commands(
 
     // The prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration (see
     // hook.rs) so a subprocess like `flox deactivate` can detect a compatible
-    // hook. It is set shell-side, so it isn't part of the env-var diff; unset it
-    // on deactivation so it doesn't leak into the restored environment.
-    // Unconditional: a no-op when no hook was registered. The marker is exported
-    // (`setenv`), so tear it down with `unsetenv`.
-    if let Action::Deactivate(_) = action {
+    // hook. It is set shell-side, so it isn't part of the env-var diff. Only the
+    // outermost deactivate clears it: the prompt hook stays registered while any
+    // activation remains on the stack, so unsetting it on an inner deactivate
+    // would make the next `flox deactivate` wrongly report the hook missing. The
+    // marker is exported (`setenv`), so tear it down with `unsetenv`.
+    if let Action::Deactivate(ctx) = action
+        && ctx.restore_diff.is_outermost_deactivate()
+    {
         stmts.push(format!("unsetenv {PROMPT_HOOK_VERSION_ENV};").to_stmt());
     }
 

--- a/cli/flox-activations/src/gen_rc/zsh.rs
+++ b/cli/flox-activations/src/gen_rc/zsh.rs
@@ -209,10 +209,13 @@ pub fn generate_zsh_profile_commands(
 
     // The prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration (see
     // hook.rs) so a subprocess like `flox deactivate` can detect a compatible
-    // hook. It is set shell-side, so it isn't part of the env-var diff; unset it
-    // on deactivation so it doesn't leak into the restored environment.
-    // Unconditional: a no-op when no hook was registered.
-    if let Action::Deactivate(_) = action {
+    // hook. It is set shell-side, so it isn't part of the env-var diff. Only the
+    // outermost deactivate clears it: the prompt hook stays registered while any
+    // activation remains on the stack, so unsetting it on an inner deactivate
+    // would make the next `flox deactivate` wrongly report the hook missing.
+    if let Action::Deactivate(ctx) = action
+        && ctx.restore_diff.is_outermost_deactivate()
+    {
         stmts.push(todo_drop_unset(PROMPT_HOOK_VERSION_ENV));
     }
 
@@ -503,7 +506,6 @@ mod tests {
                 unset _flox_deactivate_old_fpath;
             fi;
             eval "$('/flox_activations' profile-scripts-deactivate --shell zsh --env '/flox_env' --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}")";
-            unset _FLOX_PROMPT_HOOK_VERSION;
             if [[ -o interactive ]]; then source '/interpreter/activate.d/set-prompt.zsh'; fi;
             unset _activate_d _flox_activate_tracer _flox_activate_tracelevel;
         "#]]


### PR DESCRIPTION
## Problem

When more than one environment is active (a nested/stacked activation), running `flox deactivate` to pop an inner layer leaves the shell unable to deactivate the next layer:

```
✘ ERROR: The Flox prompt hook is not set up in this shell, so 'flox deactivate' cannot take effect on the next prompt.
Restart your shell to activate with the prompt hook, then deactivate again.
```

Reproduction (plain nested in-place activations — no auto-activation needed):

```bash
eval "$(flox activate -d outer)"
eval "$(flox activate -d inner)"
flox deactivate            # pops inner, OK
flox deactivate            # ERROR: prompt hook is not set up
```

It is easiest to hit via auto-activation, which creates nested stacks by `cd`-ing into nested project directories.

## Root cause

The shell-side prompt hook exports `_FLOX_PROMPT_HOOK_VERSION` at registration; a subprocess `flox deactivate` reads it to confirm a compatible hook will consume its action file. The deactivation script generated in `cli/flox-activations/src/gen_rc/{bash,fish,tcsh,zsh}.rs` unset that marker **unconditionally on every deactivation**, including inner ones — even though the prompt hook stays registered and other environments remain active. The next `flox deactivate` then finds no marker and aborts.

Introduced in DEV-84 (`fad46220a`), so it is a pre-existing bug on `main`, independent of the auto-activate PoC (DEV-119) / multi-pop (DEV-111) work, which only make nested stacks trivial to create. This PR sits at the base of that stack.

## Fix

Only the outermost deactivation (the one that empties `_FLOX_ACTIVE_ENVIRONMENTS`) clears the marker, gated on `restore_diff.is_outermost_deactivate()` — the same signal that already gates per-shell teardown (hashing, FPATH, precmd-hook removal). Inner deactivations keep the marker set, so every layer of a nested stack can be deactivated in turn.

The zsh inner-deactivate snapshot test is updated to reflect the marker no longer being unset on an inner deactivate. An end-to-end bats regression test (nested stack, deactivate each layer) lives in the stacked DEV-111 branch where the nested-project test helpers exist.

## Release Notes

Fixed `flox deactivate` failing with "The Flox prompt hook is not set up in this shell" when deactivating one of several stacked environments.

Closes DEV-129.