### PR TITLE
feat(dev): enable matched rust-analyzer LSP for Claude Code (official plugin)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "enabledPlugins": {
+    "rust-analyzer-lsp@claude-plugins-official": true
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,24 @@ section refers to settings from that plugin.
    "shellformat.useEditorConfig": true,
   ```
 
+#### Claude Code Rust LSP
+
+The dev shell now provides `rust-analyzer` pinned to the same `fenix.stable`
+toolchain as `rustc`, and the repository enables the official
+`rust-analyzer-lsp` Claude Code plugin at project scope (see
+`.claude/settings.json`). To get Rust code intelligence in Claude Code:
+
+- Start Claude Code with the dev environment loaded, either by running
+  `direnv allow` (the repo's `.envrc` runs `use flake`) or by launching from
+  inside `nix develop`. This puts the pinned `rust-analyzer` first on `PATH`.
+- Accept the workspace trust dialog. Project-scope plugins, including LSP
+  servers, only start after the workspace is trusted.
+
+The plugin invokes whatever `rust-analyzer` is first on `PATH`; loading the dev
+environment at launch is what keeps it matched to the workspace toolchain. The
+`extra-tests` cargo feature is not enabled through this plugin, so code behind
+`#[cfg(feature = "extra-tests")]` may show as inactive.
+
 ### Activation scripts
 
 Flox activations invoke a series of scripts

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -11,6 +11,7 @@
   just,
   krb5,
   lib,
+  rust-toolchain,
   rustPlatform,
   mkShell,
   nix-unit,
@@ -46,6 +47,9 @@ let
       podman
       procps
       pstree
+      # Pin `rust-analyzer` to the same `fenix.stable` toolchain as `rustc`,
+      # so editor/LSP code intelligence matches the workspace toolchain.
+      rust-toolchain.rust-analyzer
       shfmt
       treefmt
       yamlfmt


### PR DESCRIPTION
# feat(dev): enable matched rust-analyzer LSP for Claude Code (official plugin)

## Approach A+B — official `rust-analyzer-lsp` plugin

This is **one of two alternative implementations** for giving Claude Code Rust
code intelligence. See the sibling PR for the custom in-tree plugin approach
(A+C). Reviewers should pick one.

### What this PR does
1. **devShell (`shells/default/default.nix`)** — adds `rust-analyzer` to the dev
   shell, pinned to the same `fenix.stable` toolchain that already pins `rustc`.
   This is the correctness linchpin: the analyzer is version-matched to the
   compiler by construction.
2. **Project settings (`.claude/settings.json`)** — enables the official
   `rust-analyzer-lsp@claude-plugins-official` plugin at project scope, so it is
   on for every contributor from a clean clone (after they accept the workspace
   trust dialog).
3. **Docs (`CONTRIBUTING.md`)** — documents launching with the env loaded and
   the trust requirement.

### How it works
The official plugin's config is just `{ "command": "rust-analyzer" }` — pure
`PATH` resolution, no toolchain pinning, no feature flags. It therefore runs
whatever `rust-analyzer` is first on `PATH`. Change #1 ensures the matched one
is on `PATH` whenever the dev env is loaded (`.envrc` runs `use flake`).

### Comparison to the custom approach (sibling PR)
| Dimension | This PR (official) | Sibling PR (custom) |
|---|---|---|
| Maintenance | Zero — Anthropic ships it | In-tree artifact to maintain |
| Startup latency | Minimal (direct exec) | Higher (`nix develop -c` wrapper) |
| Toolchain pinning | Depends on launch env | Enforced by wrapper |
| `extra-tests` feature | Not set | Enabled |
| Robust to bare-shell launch | No | Yes |

### Testing
1. `git switch feat/rust-lsp-official-plugin`
2. Verify the matched analyzer:
   ```
   nix develop -c rust-analyzer --version   # expect 1.94.x
   nix develop -c rustc --version           # same version/commit
   ```
3. `direnv allow` (or launch from `nix develop`), start Claude Code at the repo
   root, accept the trust dialog, open a `.rs` file.
4. Confirm via `/plugin` that `rust-analyzer-lsp` is running with no
   `Executable not found in $PATH` error; try go-to-definition / hover.

### Known limitation
Code behind `#[cfg(feature = "extra-tests")]` shows as inactive (the official
plugin cannot pass `cargo.features`). The sibling PR addresses this.
