### PR TITLE
feat(dev): add in-tree flox-rust-lsp Claude Code plugin (custom)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "enabledPlugins": {
+    "flox-rust-lsp@skills-dir": true
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/.claude/skills/flox-rust-lsp/.claude-plugin/plugin.json
+++ b/.claude/skills/flox-rust-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "flox-rust-lsp",
+  "description": "Rust LSP for Claude Code, launched inside the Flox/Nix dev shell with the extra-tests cargo feature enabled.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Flox"
+  },
+  "lspServers": {
+    "rust-analyzer": {
+      "command": "bash",
+      "args": [
+        "-lc",
+        "cd \"$CLAUDE_PROJECT_DIR\" && if [ -n \"$IN_NIX_SHELL\" ]; then exec rust-analyzer; else exec nix develop -c rust-analyzer; fi"
+      ],
+      "extensionToLanguage": {
+        ".rs": "rust"
+      },
+      "settings": {
+        "rust-analyzer": {
+          "cargo": {
+            "features": ["extra-tests"]
+          },
+          "check": {
+            "command": "clippy"
+          }
+        }
+      },
+      "startupTimeout": 180000
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,24 @@ section refers to settings from that plugin.
    "shellformat.useEditorConfig": true,
   ```
 
+#### Claude Code Rust LSP
+
+The repository ships an in-tree Claude Code LSP plugin at
+`.claude/skills/flox-rust-lsp` that launches `rust-analyzer` inside the dev
+shell (`nix develop -c rust-analyzer`) with the `extra-tests` cargo feature and
+`clippy` checks enabled. Because the server is launched through `nix develop`,
+it always uses the workspace's pinned `fenix.stable` toolchain regardless of how
+Claude Code itself was started. To use it:
+
+- Launch Claude Code from the repository root so the project-scope plugin is
+  discovered, and accept the workspace trust dialog (LSP servers only start
+  after the workspace is trusted).
+- The first launch is slow while `nix develop` evaluates; the configured
+  `startupTimeout` accounts for this.
+
+This plugin replaces the official `rust-analyzer-lsp` plugin, which is disabled
+at project scope in `.claude/settings.json` to avoid running two servers.
+
 ### Activation scripts
 
 Flox activations invoke a series of scripts


### PR DESCRIPTION
# feat(dev): add in-tree flox-rust-lsp Claude Code plugin (custom)

## Approach A+C — custom in-tree LSP plugin

This is **one of two alternative implementations** for giving Claude Code Rust
code intelligence. See the sibling PR for the official-plugin approach (A+B).
Reviewers should pick one.

### What this PR does
1. **devShell (`shells/default/default.nix`)** — adds `rust-analyzer` to the dev
   shell, pinned to the same `fenix.stable` toolchain as `rustc` (same neutral
   change as the sibling PR).
2. **In-tree plugin (`.claude/skills/flox-rust-lsp/.claude-plugin/plugin.json`)**
   — a project-scope `@skills-dir` Claude Code LSP plugin that launches
   `rust-analyzer` via `nix develop -c rust-analyzer`, with `cargo.features =
   ["extra-tests"]` and `check.command = "clippy"`.
3. **Project settings (`.claude/settings.json`)** — enables the in-tree plugin
   and **disables** the official `rust-analyzer-lsp` plugin at project scope so
   only one server runs.
4. **Docs (`CONTRIBUTING.md`)** — documents the in-tree plugin, the trust
   requirement, and the first-launch latency.

### How it works
Because the server is launched through `nix develop -c`, it always uses the
workspace's pinned toolchain regardless of how Claude Code itself was started —
no reliance on launch-time `PATH`. The plugin also injects rust-analyzer
`settings`, which the official plugin cannot do, enabling the `extra-tests`
feature and clippy checks.

### Comparison to the official approach (sibling PR)
| Dimension | This PR (custom) | Sibling PR (official) |
|---|---|---|
| Maintenance | In-tree artifact to maintain | Zero — Anthropic ships it |
| Startup latency | Higher (`nix develop -c` wrapper) | Minimal (direct exec) |
| Toolchain pinning | Enforced by wrapper | Depends on launch env |
| `extra-tests` feature | Enabled | Not set |
| Robust to bare-shell launch | Yes | No |

### Testing
1. `git switch feat/rust-lsp-custom-plugin`
2. Verify the matched analyzer:
   ```
   nix develop -c rust-analyzer --version   # expect 1.94.x
   ```
3. Start Claude Code **at the repo root** (`@skills-dir` project plugins don't
   walk up from subdirs), accept the trust dialog, open a `.rs` file.
4. Confirm via `/plugin` that `flox-rust-lsp` is running (and the official
   plugin is not); the first launch is slow while `nix develop` evaluates.
5. Confirm code behind `#[cfg(feature = "extra-tests")]` is now analyzed
   (not greyed out), and clippy diagnostics appear.

### Trade-off to weigh
Stronger correctness guarantees and `extra-tests` support, at the cost of a
maintained in-tree artifact and slower LSP startup.
