### PR TITLE
 fix(publish): Trim trailing newline from branch

### DIFF
--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -41,6 +41,7 @@ pub struct BranchInfo {
     pub description: String,
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct StatusInfo {
     pub ref_: Option<String>,
     pub rev: String,
@@ -1657,18 +1658,26 @@ pub mod tests {
         let ct = repo.rev_count("HEAD").unwrap();
         let date = repo.rev_date("HEAD").unwrap();
 
+        let expected = StatusInfo {
+            ref_: Some("refs/heads/branch_1\n".to_string()),
+            rev: hash_1,
+            rev_count: ct,
+            rev_date: date,
+            is_dirty: false,
+        };
+
         let status = repo.status().unwrap();
-        assert_eq!(status.rev, hash_1);
-        assert_eq!(status.rev_count, ct);
-        assert_eq!(status.rev_date, date);
-        assert_eq!(status.is_dirty, false);
+        assert_eq!(status, expected);
 
         // touch a file
         let new_file_path = repo.path.join(new_filename);
         fs::write(&new_file_path, "new content").unwrap();
 
         let status = repo.status().unwrap();
-        assert_eq!(status.is_dirty, true);
+        assert_eq!(status, StatusInfo {
+            is_dirty: true,
+            ..expected
+        });
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/git.rs
+++ b/cli/flox-rust-sdk/src/providers/git.rs
@@ -988,7 +988,7 @@ impl GitProvider for GitCommandProvider {
             command.arg("HEAD");
             let ref_output_result = GitCommandProvider::run_command(&mut command);
             match ref_output_result {
-                Ok(ref_) => Some(ref_.to_string_lossy().into_owned()),
+                Ok(ref_) => Some(ref_.to_string_lossy().trim().to_string()),
                 Err(GitCommandError::BadExit(128, _, stderr))
                     if stderr == "fatal: ref HEAD is not a symbolic ref" =>
                 {
@@ -1659,7 +1659,7 @@ pub mod tests {
         let date = repo.rev_date("HEAD").unwrap();
 
         let expected = StatusInfo {
-            ref_: Some("refs/heads/branch_1\n".to_string()),
+            ref_: Some("refs/heads/branch_1".to_string()),
             rev: hash_1,
             rev_count: ct,
             rev_date: date,


### PR DESCRIPTION
## Proposed Changes

`GitCommandProvider::status` captured `git symbolic-ref HEAD` output
without trimming, so `StatusInfo.ref_` kept the trailing newline
(`refs/heads/master\n`). That newline flowed into the publish
"no upstream remote configured" error, splitting the branch name and
the suggested command across lines:

    % flox publish hello --stability stable
    ✘ ERROR: The environment is in an unsupported state for publishing: Current branch 'master
    ' has no upstream remote configured.
    Set one with 'git branch --set-upstream-to=origin/master
    '

The sibling `rev` and `is_dirty` fields already trim their command
output; `ref_` was the outlier. Trim it the same way, and update the
`test_status` expectation from `refs/heads/branch_1\n` to the
newline-free `refs/heads/branch_1`.

## Release Notes

N/A